### PR TITLE
[tool] Coverage crash fix

### DIFF
--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -119,13 +119,20 @@ impl CliCommand<()> for SourceCoverage {
         let (coverage_map, package) = compile_coverage(self.move_options)?;
         let unit = package.get_module_by_name_from_root(&self.module_name)?;
         let source_path = &unit.source_path;
-        let (module, source_map) = match &unit.unit {
-            CompiledUnit::Module(NamedCompiledModule {
-                module, source_map, ..
-            }) => (module, source_map),
+        let source_map = match &unit.unit {
+            CompiledUnit::Module(NamedCompiledModule { source_map, .. }) => source_map,
             _ => panic!("Should all be modules"),
         };
-        let source_coverage = SourceCoverageBuilder::new(module, &coverage_map, source_map);
+        let root_modules: Vec<_> = package
+            .root_modules()
+            .map(|unit| match &unit.unit {
+                CompiledUnit::Module(NamedCompiledModule {
+                    module, source_map, ..
+                }) => (module, source_map),
+                _ => unreachable!("Should all be modules"),
+            })
+            .collect();
+        let source_coverage = SourceCoverageBuilder::new(&coverage_map, source_map, root_modules);
         let source_coverage = source_coverage.compute_source_coverage(source_path);
         let output_result =
             source_coverage.output_source_coverage(&mut std::io::stdout(), self.color, self.tag);
@@ -189,7 +196,7 @@ fn compile_coverage(
 
     let path = move_options.get_package_path()?;
     let coverage_map =
-        CoverageMap::from_binary_file(path.join(".coverage_map.mvcov")).map_err(|err| {
+        CoverageMap::from_binary_file(&path.join(".coverage_map.mvcov")).map_err(|err| {
             CliError::UnexpectedError(format!("Failed to retrieve coverage map {}", err))
         })?;
     let package = config

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -48,9 +48,8 @@ use codespan_reporting::{
 };
 pub use experiments::{Experiment, EXPERIMENTS};
 use log::{debug, info, log_enabled, Level};
-use move_binary_format::{binary_views::BinaryIndexedView, errors::VMError};
+use move_binary_format::errors::VMError;
 use move_bytecode_source_map::source_map::SourceMap;
-use move_command_line_common::files::FileHash;
 use move_compiler::{
     command_line,
     compiled_unit::{
@@ -62,7 +61,6 @@ use move_compiler::{
 };
 use move_core_types::vm_status::StatusType;
 use move_disassembler::disassembler::Disassembler;
-use move_ir_types::location;
 use move_model::{
     metadata::LanguageVersion,
     model::{GlobalEnv, Loc, MoveIrLoc},
@@ -515,14 +513,7 @@ pub fn bytecode_pipeline(env: &GlobalEnv) -> FunctionTargetPipeline {
 pub fn disassemble_compiled_units(units: &[CompiledUnit]) -> anyhow::Result<String> {
     let disassembled_units: anyhow::Result<Vec<_>> = units
         .iter()
-        .map(|unit| {
-            let view = match unit {
-                CompiledUnit::Module(module) => BinaryIndexedView::Module(&module.module),
-                CompiledUnit::Script(script) => BinaryIndexedView::Script(&script.script),
-            };
-            Disassembler::from_view(view, location::Loc::new(FileHash::empty(), 0, 0))
-                .and_then(|d| d.disassemble())
-        })
+        .map(|unit| Disassembler::from_unit(unit).disassemble())
         .collect();
     Ok(disassembled_units?.concat())
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
@@ -678,29 +678,29 @@ struct R has key {
 	data: vector<u64>
 }
 
-f(Arg0: u8, Arg1: &vector<u64>): u64 /* def_idx: 0 */ {
-L2:	loc0: &vector<u64>
+f(k: u8, d: &vector<u64>): u64 /* def_idx: 0 */ {
+L2:	v: &vector<u64>
 B0:
-	0: MoveLoc[0](Arg0: u8)
+	0: MoveLoc[0](k: u8)
 	1: LdU8(0)
 	2: Eq
 	3: BrFalse(15)
 B1:
-	4: MoveLoc[1](Arg1: &vector<u64>)
+	4: MoveLoc[1](d: &vector<u64>)
 	5: Pop
 	6: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
 	7: ImmBorrowGlobal[0](R)
 	8: ImmBorrowField[0](R.data: vector<u64>)
-	9: StLoc[2](loc0: &vector<u64>)
+	9: StLoc[2](v: &vector<u64>)
 B2:
-	10: MoveLoc[2](loc0: &vector<u64>)
+	10: MoveLoc[2](v: &vector<u64>)
 	11: LdU64(0)
 	12: VecImmBorrow(1)
 	13: ReadRef
 	14: Ret
 B3:
-	15: MoveLoc[1](Arg1: &vector<u64>)
-	16: StLoc[2](loc0: &vector<u64>)
+	15: MoveLoc[1](d: &vector<u64>)
+	16: StLoc[2](v: &vector<u64>)
 	17: Branch(10)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
@@ -2247,10 +2247,10 @@ script {
 
 
 main() /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: &mut u64
-L2:	loc2: vector<u8>
-L3:	loc3: &mut vector<u8>
+L0:	$t13: u64
+L1:	c: &mut u64
+L2:	$t16: vector<u8>
+L3:	b: &mut vector<u8>
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
@@ -2263,26 +2263,26 @@ B1:
 	7: BrFalse(43)
 B2:
 	8: LdU64(0)
-	9: StLoc[0](loc0: u64)
-	10: MutBorrowLoc[0](loc0: u64)
-	11: StLoc[1](loc1: &mut u64)
+	9: StLoc[0]($t13: u64)
+	10: MutBorrowLoc[0]($t13: u64)
+	11: StLoc[1](c: &mut u64)
 	12: LdU64(1)
-	13: CopyLoc[1](loc1: &mut u64)
+	13: CopyLoc[1](c: &mut u64)
 	14: WriteRef
 	15: LdConst[0](Vector(U8): [5, 104, 101, 108, 108, 111])
-	16: StLoc[2](loc2: vector<u8>)
-	17: MutBorrowLoc[2](loc2: vector<u8>)
-	18: StLoc[3](loc3: &mut vector<u8>)
+	16: StLoc[2]($t16: vector<u8>)
+	17: MutBorrowLoc[2]($t16: vector<u8>)
+	18: StLoc[3](b: &mut vector<u8>)
 	19: LdConst[1](Vector(U8): [3, 98, 121, 101])
-	20: CopyLoc[3](loc3: &mut vector<u8>)
+	20: CopyLoc[3](b: &mut vector<u8>)
 	21: WriteRef
-	22: MoveLoc[1](loc1: &mut u64)
+	22: MoveLoc[1](c: &mut u64)
 	23: ReadRef
 	24: LdU64(1)
 	25: Eq
 	26: BrFalse(39)
 B3:
-	27: MoveLoc[3](loc3: &mut vector<u8>)
+	27: MoveLoc[3](b: &mut vector<u8>)
 	28: ReadRef
 	29: LdConst[1](Vector(U8): [3, 98, 121, 101])
 	30: Eq
@@ -2299,7 +2299,7 @@ B7:
 	37: LdU64(42)
 	38: Abort
 B8:
-	39: MoveLoc[3](loc3: &mut vector<u8>)
+	39: MoveLoc[3](b: &mut vector<u8>)
 	40: Pop
 	41: LdU64(42)
 	42: Abort

--- a/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
@@ -448,22 +448,22 @@ struct R has key {
 	f: u64
 }
 
-public f(Arg0: R): R * u64 /* def_idx: 0 */ {
+public f(r: R): R * u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: R)
+	0: MoveLoc[0](r: R)
 	1: LdU64(0)
 	2: Ret
 }
-public g(Arg0: &signer) /* def_idx: 1 */ {
-L1:	loc0: R
+public g(s: &signer) /* def_idx: 1 */ {
+L1:	r: R
 B0:
 	0: LdU64(1)
 	1: Pack[0](R)
 	2: Call f(R): R * u64
 	3: Pop
-	4: StLoc[1](loc0: R)
-	5: MoveLoc[0](Arg0: &signer)
-	6: MoveLoc[1](loc0: R)
+	4: StLoc[1](r: R)
+	5: MoveLoc[0](s: &signer)
+	6: MoveLoc[1](r: R)
 	7: MoveTo[0](R)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/dead_but_borrowed.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/dead_but_borrowed.exp
@@ -195,11 +195,11 @@ module 42.explicate_drop {
 
 
 test0(): u8 /* def_idx: 0 */ {
-L0:	loc0: u8
+L0:	$t2: u8
 B0:
 	0: LdU8(42)
-	1: StLoc[0](loc0: u8)
-	2: ImmBorrowLoc[0](loc0: u8)
+	1: StLoc[0]($t2: u8)
+	2: ImmBorrowLoc[0]($t2: u8)
 	3: ReadRef
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
@@ -404,22 +404,22 @@ fun m::g() {
 module 42.m {
 
 
-f(Arg0: &mut u64): &mut u64 /* def_idx: 0 */ {
+f(r: &mut u64): &mut u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[0](r: &mut u64)
 	1: Ret
 }
 g() /* def_idx: 1 */ {
-L0:	loc0: u64
-L1:	loc1: &mut u64
-L2:	loc2: &u64
+L0:	v: u64
+L1:	r: &mut u64
+L2:	_r: &u64
 B0:
 	0: LdU64(22)
-	1: StLoc[0](loc0: u64)
-	2: MutBorrowLoc[0](loc0: u64)
+	1: StLoc[0](v: u64)
+	2: MutBorrowLoc[0](v: u64)
 	3: Call f(&mut u64): &mut u64
 	4: Pop
-	5: ImmBorrowLoc[0](loc0: u64)
+	5: ImmBorrowLoc[0](v: u64)
 	6: Pop
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
@@ -833,30 +833,30 @@ module 42.m {
 
 
 drop_after_loop() /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: &mut u64
-L2:	loc2: bool
+L0:	l: u64
+L1:	r: &mut u64
+L2:	c: bool
 B0:
 	0: LdU64(1)
-	1: StLoc[0](loc0: u64)
-	2: MutBorrowLoc[0](loc0: u64)
-	3: StLoc[1](loc1: &mut u64)
+	1: StLoc[0](l: u64)
+	2: MutBorrowLoc[0](l: u64)
+	3: StLoc[1](r: &mut u64)
 	4: LdTrue
-	5: StLoc[2](loc2: bool)
+	5: StLoc[2](c: bool)
 B1:
-	6: MoveLoc[2](loc2: bool)
+	6: MoveLoc[2](c: bool)
 	7: BrFalse(14)
 B2:
 	8: LdU64(2)
-	9: CopyLoc[1](loc1: &mut u64)
+	9: CopyLoc[1](r: &mut u64)
 	10: WriteRef
 	11: LdFalse
-	12: StLoc[2](loc2: bool)
+	12: StLoc[2](c: bool)
 	13: Branch(6)
 B3:
-	14: MoveLoc[1](loc1: &mut u64)
+	14: MoveLoc[1](r: &mut u64)
 	15: Pop
-	16: MoveLoc[0](loc0: u64)
+	16: MoveLoc[0](l: u64)
 	17: LdU64(2)
 	18: Eq
 	19: BrFalse(21)

--- a/third_party/move/move-compiler-v2/tests/ability-transform/drop_at_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/drop_at_branch.exp
@@ -258,20 +258,20 @@ fun explicate_drop::drop_at_branch($t0: bool): u8 {
 module 42.explicate_drop {
 
 
-drop_at_branch(Arg0: bool): u8 /* def_idx: 0 */ {
-L1:	loc0: u8
+drop_at_branch(x: bool): u8 /* def_idx: 0 */ {
+L1:	return: u8
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](x: bool)
 	1: BrFalse(6)
 B1:
 	2: LdU8(1)
-	3: StLoc[1](loc0: u8)
+	3: StLoc[1](return: u8)
 B2:
-	4: MoveLoc[1](loc0: u8)
+	4: MoveLoc[1](return: u8)
 	5: Ret
 B3:
 	6: LdU8(0)
-	7: StLoc[1](loc0: u8)
+	7: StLoc[1](return: u8)
 	8: Branch(4)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
@@ -1157,44 +1157,44 @@ module 42.m {
 
 
 test_for_each_mut() /* def_idx: 0 */ {
-L0:	loc0: vector<u64>
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: &mut vector<u64>
-L4:	loc4: u64
-L5:	loc5: &mut u64
+L0:	v: vector<u64>
+L1:	i: u64
+L2:	len: u64
+L3:	vr: &mut vector<u64>
+L4:	$t6: u64
+L5:	x: &mut u64
 B0:
 	0: LdConst[0](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	1: StLoc[0](loc0: vector<u64>)
+	1: StLoc[0](v: vector<u64>)
 	2: LdU64(0)
-	3: StLoc[1](loc1: u64)
-	4: ImmBorrowLoc[0](loc0: vector<u64>)
+	3: StLoc[1](i: u64)
+	4: ImmBorrowLoc[0](v: vector<u64>)
 	5: VecLen(1)
-	6: StLoc[2](loc2: u64)
-	7: MutBorrowLoc[0](loc0: vector<u64>)
-	8: StLoc[3](loc3: &mut vector<u64>)
+	6: StLoc[2](len: u64)
+	7: MutBorrowLoc[0](v: vector<u64>)
+	8: StLoc[3](vr: &mut vector<u64>)
 B1:
-	9: CopyLoc[1](loc1: u64)
-	10: CopyLoc[2](loc2: u64)
+	9: CopyLoc[1](i: u64)
+	10: CopyLoc[2](len: u64)
 	11: Lt
 	12: BrFalse(25)
 B2:
-	13: CopyLoc[3](loc3: &mut vector<u64>)
-	14: CopyLoc[1](loc1: u64)
+	13: CopyLoc[3](vr: &mut vector<u64>)
+	14: CopyLoc[1](i: u64)
 	15: VecMutBorrow(1)
-	16: StLoc[5](loc5: &mut u64)
+	16: StLoc[5](x: &mut u64)
 	17: LdU64(2)
-	18: MoveLoc[5](loc5: &mut u64)
+	18: MoveLoc[5](x: &mut u64)
 	19: WriteRef
-	20: MoveLoc[1](loc1: u64)
+	20: MoveLoc[1](i: u64)
 	21: LdU64(1)
 	22: Add
-	23: StLoc[1](loc1: u64)
+	23: StLoc[1](i: u64)
 	24: Branch(9)
 B3:
-	25: MoveLoc[3](loc3: &mut vector<u64>)
+	25: MoveLoc[3](vr: &mut vector<u64>)
 	26: Pop
-	27: MoveLoc[0](loc0: vector<u64>)
+	27: MoveLoc[0](v: vector<u64>)
 	28: LdConst[1](Vector(U64): [3, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0, 0])
 	29: Eq
 	30: BrFalse(32)

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
@@ -307,20 +307,20 @@ fun m::g<#0>($t0: &mut vector<#0>) {
 module c0ffee.m {
 
 
-public singleton<Ty0>(Arg0: Ty0): vector<Ty0> /* def_idx: 0 */ {
-L1:	loc0: vector<Ty0>
+public singleton<Element>(e: Element): vector<Element> /* def_idx: 0 */ {
+L1:	v: vector<Element>
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
+	0: MoveLoc[0](e: Element)
 	1: VecPack(0, 1)
-	2: StLoc[1](loc0: vector<Ty0>)
-	3: MutBorrowLoc[1](loc0: vector<Ty0>)
-	4: Call g<Ty0>(&mut vector<Ty0>)
-	5: MoveLoc[1](loc0: vector<Ty0>)
+	2: StLoc[1](v: vector<Element>)
+	3: MutBorrowLoc[1](v: vector<Element>)
+	4: Call g<Element>(&mut vector<Element>)
+	5: MoveLoc[1](v: vector<Element>)
 	6: Ret
 }
-g<Ty0>(Arg0: &mut vector<Ty0>) /* def_idx: 1 */ {
+g<A>(_v: &mut vector<A>) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	0: MoveLoc[0](_v: &mut vector<A>)
 	1: Pop
 	2: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
@@ -481,21 +481,21 @@ struct Scalar has copy, drop, store {
 	data: vector<u8>
 }
 
-public new_scalar_from_u8(Arg0: u8): Scalar /* def_idx: 0 */ {
-L1:	loc0: Scalar
-L2:	loc1: &mut u8
+public new_scalar_from_u8(byte: u8): Scalar /* def_idx: 0 */ {
+L1:	s: Scalar
+L2:	byte_zero: &mut u8
 B0:
 	0: Call scalar_zero(): Scalar
-	1: StLoc[1](loc0: Scalar)
-	2: MutBorrowLoc[1](loc0: Scalar)
+	1: StLoc[1](s: Scalar)
+	2: MutBorrowLoc[1](s: Scalar)
 	3: MutBorrowField[0](Scalar.data: vector<u8>)
 	4: LdU64(0)
 	5: VecMutBorrow(0)
-	6: StLoc[2](loc1: &mut u8)
-	7: MoveLoc[0](Arg0: u8)
-	8: MoveLoc[2](loc1: &mut u8)
+	6: StLoc[2](byte_zero: &mut u8)
+	7: MoveLoc[0](byte: u8)
+	8: MoveLoc[2](byte_zero: &mut u8)
 	9: WriteRef
-	10: MoveLoc[1](loc0: Scalar)
+	10: MoveLoc[1](s: Scalar)
 	11: Ret
 }
 public scalar_zero(): Scalar /* def_idx: 1 */ {

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/assign.exp
@@ -108,39 +108,39 @@ struct S has drop {
 	g: T
 }
 
-assign_field(Arg0: &mut S, Arg1: u64) /* def_idx: 0 */ {
-L2:	loc0: &mut u64
+assign_field(s: &mut S, f: u64) /* def_idx: 0 */ {
+L2:	$t2: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[2](loc0: &mut u64)
-	3: MoveLoc[1](Arg1: u64)
-	4: MoveLoc[2](loc0: &mut u64)
+	2: StLoc[2]($t2: &mut u64)
+	3: MoveLoc[1](f: u64)
+	4: MoveLoc[2]($t2: &mut u64)
 	5: WriteRef
 	6: Ret
 }
-assign_int(Arg0: &mut u64) /* def_idx: 1 */ {
+assign_int(x: &mut u64) /* def_idx: 1 */ {
 B0:
 	0: LdU64(42)
-	1: MoveLoc[0](Arg0: &mut u64)
+	1: MoveLoc[0](x: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-assign_pattern(Arg0: S, Arg1: u64, Arg2: u64): u64 /* def_idx: 2 */ {
+assign_pattern(s: S, f: u64, h: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: S)
+	0: MoveLoc[0](s: S)
 	1: Unpack[1](S)
 	2: Unpack[0](T)
 	3: Add
 	4: Ret
 }
-assign_struct(Arg0: &mut S) /* def_idx: 3 */ {
+assign_struct(s: &mut S) /* def_idx: 3 */ {
 B0:
 	0: LdU64(42)
 	1: LdU64(42)
 	2: Pack[0](T)
 	3: Pack[1](S)
-	4: MoveLoc[0](Arg0: &mut S)
+	4: MoveLoc[0](s: &mut S)
 	5: WriteRef
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow.exp
@@ -178,65 +178,65 @@ struct S {
 	f: u64
 }
 
-field(Arg0: &S): u64 /* def_idx: 0 */ {
+field(s: &S): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](s: &S)
 	1: ImmBorrowField[0](S.f: u64)
 	2: ReadRef
 	3: Ret
 }
-local(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
+local(param: u64): u64 /* def_idx: 1 */ {
+L1:	$t3: u64
 B0:
 	0: LdU64(33)
-	1: StLoc[1](loc0: u64)
-	2: ImmBorrowLoc[1](loc0: u64)
+	1: StLoc[1]($t3: u64)
+	2: ImmBorrowLoc[1]($t3: u64)
 	3: ReadRef
 	4: Ret
 }
-param(Arg0: u64): u64 /* def_idx: 2 */ {
+param(param: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
+	0: ImmBorrowLoc[0](param: u64)
 	1: ReadRef
 	2: Ret
 }
-mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: &mut u64
+mut_field(s: &mut S): u64 /* def_idx: 3 */ {
+L1:	r: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[1](loc0: &mut u64)
+	2: StLoc[1](r: &mut u64)
 	3: LdU64(22)
-	4: CopyLoc[1](loc0: &mut u64)
+	4: CopyLoc[1](r: &mut u64)
 	5: WriteRef
-	6: MoveLoc[1](loc0: &mut u64)
+	6: MoveLoc[1](r: &mut u64)
 	7: ReadRef
 	8: Ret
 }
-mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+mut_local(param: u64): u64 /* def_idx: 4 */ {
+L1:	local: u64
+L2:	r: &mut u64
 B0:
 	0: LdU64(33)
-	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[1](loc0: u64)
-	3: StLoc[2](loc1: &mut u64)
+	1: StLoc[1](local: u64)
+	2: MutBorrowLoc[1](local: u64)
+	3: StLoc[2](r: &mut u64)
 	4: LdU64(22)
-	5: CopyLoc[2](loc1: &mut u64)
+	5: CopyLoc[2](r: &mut u64)
 	6: WriteRef
-	7: MoveLoc[2](loc1: &mut u64)
+	7: MoveLoc[2](r: &mut u64)
 	8: ReadRef
 	9: Ret
 }
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: &mut u64
+mut_param(param: u64): u64 /* def_idx: 5 */ {
+L1:	r: &mut u64
 B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: &mut u64)
+	0: MutBorrowLoc[0](param: u64)
+	1: StLoc[1](r: &mut u64)
 	2: LdU64(22)
-	3: CopyLoc[1](loc0: &mut u64)
+	3: CopyLoc[1](r: &mut u64)
 	4: WriteRef
-	5: MoveLoc[1](loc0: &mut u64)
+	5: MoveLoc[1](r: &mut u64)
 	6: ReadRef
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow_deref_optimize.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/borrow_deref_optimize.exp
@@ -148,30 +148,30 @@ struct X has copy, drop, key {
 }
 
 no_optimize_resource(): bool /* def_idx: 0 */ {
-L0:	loc0: X
+L0:	$t2: X
 B0:
 	0: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
 	1: ImmBorrowGlobal[0](X)
 	2: ReadRef
-	3: StLoc[0](loc0: X)
-	4: MutBorrowLoc[0](loc0: X)
+	3: StLoc[0]($t2: X)
+	4: MutBorrowLoc[0]($t2: X)
 	5: ImmBorrowField[0](X.value: bool)
 	6: ReadRef
 	7: Ret
 }
 no_optimize_vector() /* def_idx: 1 */ {
-L0:	loc0: vector<vector<u64>>
-L1:	loc1: vector<u64>
-L2:	loc2: &mut u64
+L0:	$t5: vector<vector<u64>>
+L1:	$t2: vector<u64>
+L2:	$t0: &mut u64
 B0:
 	0: LdConst[1](Vector(Vector(U64)): [1, 2, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0])
-	1: StLoc[0](loc0: vector<vector<u64>>)
-	2: ImmBorrowLoc[0](loc0: vector<vector<u64>>)
+	1: StLoc[0]($t5: vector<vector<u64>>)
+	2: ImmBorrowLoc[0]($t5: vector<vector<u64>>)
 	3: LdU64(0)
 	4: VecImmBorrow(3)
 	5: ReadRef
-	6: StLoc[1](loc1: vector<u64>)
-	7: MutBorrowLoc[1](loc1: vector<u64>)
+	6: StLoc[1]($t2: vector<u64>)
+	7: MutBorrowLoc[1]($t2: vector<u64>)
 	8: LdU64(1)
 	9: VecMutBorrow(4)
 	10: Pop
@@ -186,12 +186,12 @@ B0:
 	4: Ret
 }
 optimize_vector() /* def_idx: 3 */ {
-L0:	loc0: vector<vector<u64>>
-L1:	loc1: &mut u64
+L0:	x: vector<vector<u64>>
+L1:	$t1: &mut u64
 B0:
 	0: LdConst[1](Vector(Vector(U64)): [1, 2, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0])
-	1: StLoc[0](loc0: vector<vector<u64>>)
-	2: MutBorrowLoc[0](loc0: vector<vector<u64>>)
+	1: StLoc[0](x: vector<vector<u64>>)
+	2: MutBorrowLoc[0](x: vector<vector<u64>>)
 	3: LdU64(0)
 	4: VecMutBorrow(3)
 	5: LdU64(1)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14300_update_variant_select.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14300_update_variant_select.exp
@@ -198,103 +198,103 @@ enum CommonFields has drop {
 }
 
 update_common_field(): u64 /* def_idx: 0 */ {
-L0:	loc0: CommonFields
+L0:	common: CommonFields
 B0:
 	0: LdU64(30)
 	1: LdU8(40)
 	2: LdU32(50)
 	3: PackVariant[0](CommonFields/Bar)
-	4: StLoc[0](loc0: CommonFields)
+	4: StLoc[0](common: CommonFields)
 	5: LdU64(15)
-	6: MutBorrowLoc[0](loc0: CommonFields)
+	6: MutBorrowLoc[0](common: CommonFields)
 	7: MutBorrowVariantField[0](Foo.x|Bar.x: u64)
 	8: WriteRef
-	9: ImmBorrowLoc[0](loc0: CommonFields)
+	9: ImmBorrowLoc[0](common: CommonFields)
 	10: ImmBorrowVariantField[0](Foo.x|Bar.x: u64)
 	11: ReadRef
 	12: Ret
 }
 update_common_field_different_offset(): u8 /* def_idx: 1 */ {
-L0:	loc0: CommonFields
-L1:	loc1: u8
-L2:	loc2: &mut CommonFields
-L3:	loc3: &mut u8
-L4:	loc4: &CommonFields
-L5:	loc5: &u8
+L0:	common: CommonFields
+L1:	$t3: u8
+L2:	$t7: &mut CommonFields
+L3:	$t6: &mut u8
+L4:	$t9: &CommonFields
+L5:	$t10: &u8
 B0:
 	0: LdU64(30)
 	1: LdU8(40)
 	2: LdU32(50)
 	3: PackVariant[0](CommonFields/Bar)
-	4: StLoc[0](loc0: CommonFields)
+	4: StLoc[0](common: CommonFields)
 	5: LdU8(15)
-	6: StLoc[1](loc1: u8)
-	7: MutBorrowLoc[0](loc0: CommonFields)
-	8: StLoc[2](loc2: &mut CommonFields)
-	9: CopyLoc[2](loc2: &mut CommonFields)
+	6: StLoc[1]($t3: u8)
+	7: MutBorrowLoc[0](common: CommonFields)
+	8: StLoc[2]($t7: &mut CommonFields)
+	9: CopyLoc[2]($t7: &mut CommonFields)
 	10: TestVariant[1](CommonFields/Foo)
 	11: BrFalse(39)
 B1:
 	12: Branch(13)
 B2:
-	13: MoveLoc[2](loc2: &mut CommonFields)
+	13: MoveLoc[2]($t7: &mut CommonFields)
 	14: MutBorrowVariantField[1](Foo.y|Bar.y: u8)
-	15: StLoc[3](loc3: &mut u8)
+	15: StLoc[3]($t6: &mut u8)
 B3:
-	16: MoveLoc[1](loc1: u8)
-	17: MoveLoc[3](loc3: &mut u8)
+	16: MoveLoc[1]($t3: u8)
+	17: MoveLoc[3]($t6: &mut u8)
 	18: WriteRef
-	19: ImmBorrowLoc[0](loc0: CommonFields)
-	20: StLoc[4](loc4: &CommonFields)
-	21: CopyLoc[4](loc4: &CommonFields)
+	19: ImmBorrowLoc[0](common: CommonFields)
+	20: StLoc[4]($t9: &CommonFields)
+	21: CopyLoc[4]($t9: &CommonFields)
 	22: TestVariant[1](CommonFields/Foo)
 	23: BrFalse(31)
 B4:
 	24: Branch(25)
 B5:
-	25: MoveLoc[4](loc4: &CommonFields)
+	25: MoveLoc[4]($t9: &CommonFields)
 	26: ImmBorrowVariantField[1](Foo.y|Bar.y: u8)
-	27: StLoc[5](loc5: &u8)
+	27: StLoc[5]($t10: &u8)
 B6:
-	28: MoveLoc[5](loc5: &u8)
+	28: MoveLoc[5]($t10: &u8)
 	29: ReadRef
 	30: Ret
 B7:
-	31: CopyLoc[4](loc4: &CommonFields)
+	31: CopyLoc[4]($t9: &CommonFields)
 	32: TestVariant[0](CommonFields/Bar)
 	33: BrFalse(35)
 B8:
 	34: Branch(25)
 B9:
-	35: MoveLoc[4](loc4: &CommonFields)
+	35: MoveLoc[4]($t9: &CommonFields)
 	36: ImmBorrowVariantField[2](Baz.y: u8)
-	37: StLoc[5](loc5: &u8)
+	37: StLoc[5]($t10: &u8)
 	38: Branch(28)
 B10:
-	39: CopyLoc[2](loc2: &mut CommonFields)
+	39: CopyLoc[2]($t7: &mut CommonFields)
 	40: TestVariant[0](CommonFields/Bar)
 	41: BrFalse(43)
 B11:
 	42: Branch(13)
 B12:
-	43: MoveLoc[2](loc2: &mut CommonFields)
+	43: MoveLoc[2]($t7: &mut CommonFields)
 	44: MutBorrowVariantField[2](Baz.y: u8)
-	45: StLoc[3](loc3: &mut u8)
+	45: StLoc[3]($t6: &mut u8)
 	46: Branch(16)
 }
 update_non_common_field(): u32 /* def_idx: 2 */ {
-L0:	loc0: CommonFields
+L0:	common: CommonFields
 B0:
 	0: LdU64(30)
 	1: LdU8(40)
 	2: LdU32(50)
 	3: PackVariant[0](CommonFields/Bar)
-	4: StLoc[0](loc0: CommonFields)
+	4: StLoc[0](common: CommonFields)
 	5: LdU32(15)
-	6: MutBorrowLoc[0](loc0: CommonFields)
+	6: MutBorrowLoc[0](common: CommonFields)
 	7: MutBorrowVariantField[3](Bar.z: u32)
 	8: WriteRef
-	9: ImmBorrowLoc[0](loc0: CommonFields)
+	9: ImmBorrowLoc[0](common: CommonFields)
 	10: ImmBorrowVariantField[3](Bar.z: u32)
 	11: ReadRef
 	12: Ret

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14300_variant_select_autoref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14300_variant_select_autoref.exp
@@ -68,13 +68,13 @@ enum Positional has drop {
 }
 
 test_common_access(): u8 /* def_idx: 0 */ {
-L0:	loc0: Positional
+L0:	x: Positional
 B0:
 	0: LdU8(42)
 	1: PackVariant[0](Positional/A)
-	2: StLoc[0](loc0: Positional)
+	2: StLoc[0](x: Positional)
 	3: LdU8(19)
-	4: MutBorrowLoc[0](loc0: Positional)
+	4: MutBorrowLoc[0](x: Positional)
 	5: MutBorrowVariantField[0](A._0|B._0: u8)
 	6: WriteRef
 	7: LdU8(20)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14471_receiver_inference.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14471_receiver_inference.exp
@@ -112,52 +112,52 @@ module 815.m {
 struct MyMap has key {
 	table: Table<address, ValueWrap>
 }
-struct Table<Ty0, Ty1> has store {
-	x: Ty0,
-	y: Ty1
+struct Table<T1, T2> has store {
+	x: T1,
+	y: T2
 }
 struct ValueWrap has drop, store {
 	val: u64
 }
 
-contains<Ty0: drop, Ty1: drop>(Arg0: &Table<Ty0, Ty1>, Arg1: Ty0): bool /* def_idx: 0 */ {
+contains<T1: drop, T2: drop>(self: &Table<T1, T2>, _key: T1): bool /* def_idx: 0 */ {
 B0:
 	0: LdTrue
-	1: MoveLoc[0](Arg0: &Table<Ty0, Ty1>)
+	1: MoveLoc[0](self: &Table<T1, T2>)
 	2: Pop
 	3: Ret
 }
-add<Ty0: drop, Ty1: drop>(Arg0: &mut Table<Ty0, Ty1>, Arg1: Ty0, Arg2: Ty1) /* def_idx: 1 */ {
+add<T1: drop, T2: drop>(self: &mut Table<T1, T2>, _key: T1, _val: T2) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut Table<Ty0, Ty1>)
+	0: MoveLoc[0](self: &mut Table<T1, T2>)
 	1: Pop
 	2: Ret
 }
-public add_when_missing(Arg0: address, Arg1: u64) /* def_idx: 2 */ {
-L2:	loc0: &mut MyMap
-L3:	loc1: ValueWrap
+public add_when_missing(key: address, val: u64) /* def_idx: 2 */ {
+L2:	my_map: &mut MyMap
+L3:	wrap: ValueWrap
 B0:
 	0: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 8, 21])
 	1: MutBorrowGlobal[0](MyMap)
-	2: StLoc[2](loc0: &mut MyMap)
-	3: CopyLoc[2](loc0: &mut MyMap)
+	2: StLoc[2](my_map: &mut MyMap)
+	3: CopyLoc[2](my_map: &mut MyMap)
 	4: ImmBorrowField[0](MyMap.table: Table<address, ValueWrap>)
-	5: CopyLoc[0](Arg0: address)
+	5: CopyLoc[0](key: address)
 	6: Call contains<address, ValueWrap>(&Table<address, ValueWrap>, address): bool
 	7: BrTrue(17)
 B1:
-	8: MoveLoc[1](Arg1: u64)
+	8: MoveLoc[1](val: u64)
 	9: Pack[2](ValueWrap)
-	10: StLoc[3](loc1: ValueWrap)
-	11: MoveLoc[2](loc0: &mut MyMap)
+	10: StLoc[3](wrap: ValueWrap)
+	11: MoveLoc[2](my_map: &mut MyMap)
 	12: MutBorrowField[0](MyMap.table: Table<address, ValueWrap>)
-	13: MoveLoc[0](Arg0: address)
-	14: MoveLoc[3](loc1: ValueWrap)
+	13: MoveLoc[0](key: address)
+	14: MoveLoc[3](wrap: ValueWrap)
 	15: Call add<address, ValueWrap>(&mut Table<address, ValueWrap>, address, ValueWrap)
 B2:
 	16: Ret
 B3:
-	17: MoveLoc[2](loc0: &mut MyMap)
+	17: MoveLoc[2](my_map: &mut MyMap)
 	18: Pop
 	19: Branch(16)
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14629.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_14629.exp
@@ -77,11 +77,11 @@ fun M::t0_u128() {
 ============ disassembled file-format ==================
 // Move bytecode v8
 module 8675309.M {
-struct R<Ty0: key> {
-	r: Ty0
+struct R<T: key> {
+	r: T
 }
-struct X<Ty0> has drop, key {
-	r: Ty0
+struct X<T> has drop, key {
+	r: T
 }
 
 t0() /* def_idx: 0 */ {

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/conditional_borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/conditional_borrow.exp
@@ -428,201 +428,201 @@ B0:
 	4: Add
 	5: Ret
 }
-test1(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: &mut u64
-L4:	loc3: u64
-L5:	loc4: u64
-L6:	loc5: u64
-L7:	loc6: u64
-L8:	loc7: u64
+test1(r: u64): u64 /* def_idx: 1 */ {
+L1:	$t3: u64
+L2:	$t5: u64
+L3:	tref: &mut u64
+L4:	y: u64
+L5:	$t15: u64
+L6:	$t23: u64
+L7:	$t28: u64
+L8:	$t33: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](r: u64)
 	1: LdU64(4)
 	2: Lt
 	3: BrFalse(67)
 B1:
-	4: CopyLoc[0](Arg0: u64)
-	5: StLoc[1](loc0: u64)
+	4: CopyLoc[0](r: u64)
+	5: StLoc[1]($t3: u64)
 B2:
-	6: MutBorrowLoc[1](loc0: u64)
-	7: StLoc[3](loc2: &mut u64)
+	6: MutBorrowLoc[1]($t3: u64)
+	7: StLoc[3](tref: &mut u64)
 	8: LdU64(10)
-	9: MoveLoc[3](loc2: &mut u64)
+	9: MoveLoc[3](tref: &mut u64)
 	10: WriteRef
-	11: MoveLoc[0](Arg0: u64)
-	12: StLoc[4](loc3: u64)
-	13: MutBorrowLoc[4](loc3: u64)
-	14: StLoc[3](loc2: &mut u64)
-	15: CopyLoc[3](loc2: &mut u64)
+	11: MoveLoc[0](r: u64)
+	12: StLoc[4](y: u64)
+	13: MutBorrowLoc[4](y: u64)
+	14: StLoc[3](tref: &mut u64)
+	15: CopyLoc[3](tref: &mut u64)
 	16: ReadRef
 	17: LdU64(1)
 	18: Add
-	19: MoveLoc[3](loc2: &mut u64)
+	19: MoveLoc[3](tref: &mut u64)
 	20: WriteRef
-	21: MoveLoc[4](loc3: u64)
-	22: StLoc[2](loc1: u64)
-	23: CopyLoc[2](loc1: u64)
+	21: MoveLoc[4](y: u64)
+	22: StLoc[2]($t5: u64)
+	23: CopyLoc[2]($t5: u64)
 	24: LdU64(0)
 	25: Add
-	26: StLoc[5](loc4: u64)
-	27: MutBorrowLoc[5](loc4: u64)
-	28: StLoc[3](loc2: &mut u64)
-	29: CopyLoc[3](loc2: &mut u64)
+	26: StLoc[5]($t15: u64)
+	27: MutBorrowLoc[5]($t15: u64)
+	28: StLoc[3](tref: &mut u64)
+	29: CopyLoc[3](tref: &mut u64)
 	30: ReadRef
 	31: LdU64(2)
 	32: Add
-	33: MoveLoc[3](loc2: &mut u64)
+	33: MoveLoc[3](tref: &mut u64)
 	34: WriteRef
-	35: CopyLoc[2](loc1: u64)
-	36: StLoc[6](loc5: u64)
-	37: MutBorrowLoc[6](loc5: u64)
-	38: StLoc[3](loc2: &mut u64)
-	39: CopyLoc[3](loc2: &mut u64)
+	35: CopyLoc[2]($t5: u64)
+	36: StLoc[6]($t23: u64)
+	37: MutBorrowLoc[6]($t23: u64)
+	38: StLoc[3](tref: &mut u64)
+	39: CopyLoc[3](tref: &mut u64)
 	40: ReadRef
 	41: LdU64(4)
 	42: Add
-	43: MoveLoc[3](loc2: &mut u64)
+	43: MoveLoc[3](tref: &mut u64)
 	44: WriteRef
-	45: CopyLoc[2](loc1: u64)
-	46: StLoc[7](loc6: u64)
-	47: MutBorrowLoc[7](loc6: u64)
-	48: StLoc[3](loc2: &mut u64)
-	49: CopyLoc[3](loc2: &mut u64)
+	45: CopyLoc[2]($t5: u64)
+	46: StLoc[7]($t28: u64)
+	47: MutBorrowLoc[7]($t28: u64)
+	48: StLoc[3](tref: &mut u64)
+	49: CopyLoc[3](tref: &mut u64)
 	50: ReadRef
 	51: LdU64(8)
 	52: Add
-	53: MoveLoc[3](loc2: &mut u64)
+	53: MoveLoc[3](tref: &mut u64)
 	54: WriteRef
-	55: CopyLoc[2](loc1: u64)
-	56: StLoc[8](loc7: u64)
-	57: MutBorrowLoc[8](loc7: u64)
-	58: StLoc[3](loc2: &mut u64)
-	59: CopyLoc[3](loc2: &mut u64)
+	55: CopyLoc[2]($t5: u64)
+	56: StLoc[8]($t33: u64)
+	57: MutBorrowLoc[8]($t33: u64)
+	58: StLoc[3](tref: &mut u64)
+	59: CopyLoc[3](tref: &mut u64)
 	60: ReadRef
 	61: LdU64(16)
 	62: Add
-	63: MoveLoc[3](loc2: &mut u64)
+	63: MoveLoc[3](tref: &mut u64)
 	64: WriteRef
-	65: MoveLoc[2](loc1: u64)
+	65: MoveLoc[2]($t5: u64)
 	66: Ret
 B3:
 	67: LdU64(3)
-	68: StLoc[1](loc0: u64)
+	68: StLoc[1]($t3: u64)
 	69: Branch(6)
 }
-test1b(Arg0: S): u64 /* def_idx: 2 */ {
-L1:	loc0: S
-L2:	loc1: S
-L3:	loc2: &mut S
-L4:	loc3: S
-L5:	loc4: S
-L6:	loc5: S
-L7:	loc6: S
-L8:	loc7: S
-L9:	loc8: &mut u64
-L10:	loc9: S
-L11:	loc10: u64
-L12:	loc11: u64
-L13:	loc12: u64
+test1b(r: S): u64 /* def_idx: 2 */ {
+L1:	x: S
+L2:	$t5: S
+L3:	tref: &mut S
+L4:	$t13: S
+L5:	y: S
+L6:	$t19: S
+L7:	$t24: S
+L8:	z: S
+L9:	$t12: &mut u64
+L10:	a: S
+L11:	$t34: u64
+L12:	$t41: u64
+L13:	$t48: u64
 B0:
 	0: LdU64(3)
 	1: Pack[0](S)
-	2: StLoc[1](loc0: S)
-	3: ImmBorrowLoc[0](Arg0: S)
+	2: StLoc[1](x: S)
+	3: ImmBorrowLoc[0](r: S)
 	4: ImmBorrowField[0](S.f: u64)
 	5: ReadRef
 	6: LdU64(4)
 	7: Lt
 	8: BrFalse(91)
 B1:
-	9: CopyLoc[0](Arg0: S)
-	10: StLoc[2](loc1: S)
+	9: CopyLoc[0](r: S)
+	10: StLoc[2]($t5: S)
 B2:
-	11: MutBorrowLoc[2](loc1: S)
-	12: StLoc[3](loc2: &mut S)
+	11: MutBorrowLoc[2]($t5: S)
+	12: StLoc[3](tref: &mut S)
 	13: LdU64(10)
-	14: MoveLoc[3](loc2: &mut S)
+	14: MoveLoc[3](tref: &mut S)
 	15: ReadRef
-	16: StLoc[4](loc3: S)
-	17: MutBorrowLoc[4](loc3: S)
+	16: StLoc[4]($t13: S)
+	17: MutBorrowLoc[4]($t13: S)
 	18: MutBorrowField[0](S.f: u64)
 	19: WriteRef
-	20: MoveLoc[0](Arg0: S)
-	21: StLoc[5](loc4: S)
-	22: MutBorrowLoc[5](loc4: S)
-	23: StLoc[3](loc2: &mut S)
-	24: CopyLoc[3](loc2: &mut S)
+	20: MoveLoc[0](r: S)
+	21: StLoc[5](y: S)
+	22: MutBorrowLoc[5](y: S)
+	23: StLoc[3](tref: &mut S)
+	24: CopyLoc[3](tref: &mut S)
 	25: ReadRef
-	26: StLoc[6](loc5: S)
-	27: ImmBorrowLoc[6](loc5: S)
+	26: StLoc[6]($t19: S)
+	27: ImmBorrowLoc[6]($t19: S)
 	28: ImmBorrowField[0](S.f: u64)
 	29: ReadRef
 	30: LdU64(1)
 	31: Add
-	32: MoveLoc[3](loc2: &mut S)
+	32: MoveLoc[3](tref: &mut S)
 	33: ReadRef
-	34: StLoc[7](loc6: S)
-	35: MutBorrowLoc[7](loc6: S)
+	34: StLoc[7]($t24: S)
+	35: MutBorrowLoc[7]($t24: S)
 	36: MutBorrowField[0](S.f: u64)
 	37: WriteRef
-	38: MoveLoc[5](loc4: S)
-	39: StLoc[8](loc7: S)
-	40: MutBorrowLoc[8](loc7: S)
+	38: MoveLoc[5](y: S)
+	39: StLoc[8](z: S)
+	40: MutBorrowLoc[8](z: S)
 	41: MutBorrowField[0](S.f: u64)
-	42: StLoc[9](loc8: &mut u64)
-	43: CopyLoc[9](loc8: &mut u64)
+	42: StLoc[9]($t12: &mut u64)
+	43: CopyLoc[9]($t12: &mut u64)
 	44: ReadRef
 	45: LdU64(1)
 	46: Add
-	47: MoveLoc[9](loc8: &mut u64)
+	47: MoveLoc[9]($t12: &mut u64)
 	48: WriteRef
-	49: MoveLoc[8](loc7: S)
-	50: StLoc[10](loc9: S)
-	51: ImmBorrowLoc[10](loc9: S)
+	49: MoveLoc[8](z: S)
+	50: StLoc[10](a: S)
+	51: ImmBorrowLoc[10](a: S)
 	52: ImmBorrowField[0](S.f: u64)
 	53: ReadRef
-	54: StLoc[11](loc10: u64)
-	55: MutBorrowLoc[11](loc10: u64)
-	56: StLoc[9](loc8: &mut u64)
-	57: CopyLoc[9](loc8: &mut u64)
+	54: StLoc[11]($t34: u64)
+	55: MutBorrowLoc[11]($t34: u64)
+	56: StLoc[9]($t12: &mut u64)
+	57: CopyLoc[9]($t12: &mut u64)
 	58: ReadRef
 	59: LdU64(1)
 	60: Add
-	61: MoveLoc[9](loc8: &mut u64)
+	61: MoveLoc[9]($t12: &mut u64)
 	62: WriteRef
-	63: ImmBorrowLoc[10](loc9: S)
+	63: ImmBorrowLoc[10](a: S)
 	64: ImmBorrowField[0](S.f: u64)
 	65: ReadRef
-	66: StLoc[12](loc11: u64)
-	67: MutBorrowLoc[12](loc11: u64)
-	68: StLoc[9](loc8: &mut u64)
-	69: CopyLoc[9](loc8: &mut u64)
+	66: StLoc[12]($t41: u64)
+	67: MutBorrowLoc[12]($t41: u64)
+	68: StLoc[9]($t12: &mut u64)
+	69: CopyLoc[9]($t12: &mut u64)
 	70: ReadRef
 	71: LdU64(8)
 	72: Add
-	73: MoveLoc[9](loc8: &mut u64)
+	73: MoveLoc[9]($t12: &mut u64)
 	74: WriteRef
-	75: ImmBorrowLoc[10](loc9: S)
+	75: ImmBorrowLoc[10](a: S)
 	76: ImmBorrowField[0](S.f: u64)
 	77: ReadRef
-	78: StLoc[13](loc12: u64)
-	79: MutBorrowLoc[13](loc12: u64)
-	80: StLoc[9](loc8: &mut u64)
-	81: CopyLoc[9](loc8: &mut u64)
+	78: StLoc[13]($t48: u64)
+	79: MutBorrowLoc[13]($t48: u64)
+	80: StLoc[9]($t12: &mut u64)
+	81: CopyLoc[9]($t12: &mut u64)
 	82: ReadRef
 	83: LdU64(16)
 	84: Add
-	85: MoveLoc[9](loc8: &mut u64)
+	85: MoveLoc[9]($t12: &mut u64)
 	86: WriteRef
-	87: ImmBorrowLoc[10](loc9: S)
+	87: ImmBorrowLoc[10](a: S)
 	88: ImmBorrowField[0](S.f: u64)
 	89: ReadRef
 	90: Ret
 B3:
-	91: MoveLoc[1](loc0: S)
-	92: StLoc[2](loc1: S)
+	91: MoveLoc[1](x: S)
+	92: StLoc[2]($t5: S)
 	93: Branch(11)
 }
 public testb(): u64 /* def_idx: 3 */ {

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/escape_autoref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/escape_autoref.exp
@@ -131,9 +131,9 @@ B0:
 	0: LdU64(0)
 	1: Abort
 }
-owner_correct(Arg0: Object): address /* def_idx: 1 */ {
+owner_correct(o: Object): address /* def_idx: 1 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: Object)
+	0: ImmBorrowLoc[0](o: Object)
 	1: ImmBorrowField[0](Object.inner: address)
 	2: ReadRef
 	3: ImmBorrowGlobal[1](ObjectCore)
@@ -141,9 +141,9 @@ B0:
 	5: ReadRef
 	6: Ret
 }
-owner_read_ref_missing(Arg0: Object): address /* def_idx: 2 */ {
+owner_read_ref_missing(o: Object): address /* def_idx: 2 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: Object)
+	0: ImmBorrowLoc[0](o: Object)
 	1: ImmBorrowField[0](Object.inner: address)
 	2: ReadRef
 	3: ImmBorrowGlobal[1](ObjectCore)
@@ -152,11 +152,11 @@ B0:
 	6: Ret
 }
 will_autoref(): address /* def_idx: 3 */ {
-L0:	loc0: Object
+L0:	$t1: Object
 B0:
 	0: Call make(): Object
-	1: StLoc[0](loc0: Object)
-	2: ImmBorrowLoc[0](loc0: Object)
+	1: StLoc[0]($t1: Object)
+	2: ImmBorrowLoc[0]($t1: Object)
 	3: ImmBorrowField[0](Object.inner: address)
 	4: ReadRef
 	5: Ret

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/fields.exp
@@ -269,120 +269,120 @@ module 42.fields {
 struct T has drop {
 	h: u64
 }
-struct G<Ty0> has drop {
-	f: Ty0
+struct G<X> has drop {
+	f: X
 }
 struct S has drop {
 	f: u64,
 	g: T
 }
 
-read_generic_val(Arg0: G<u64>): u64 /* def_idx: 0 */ {
+read_generic_val(x: G<u64>): u64 /* def_idx: 0 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: G<u64>)
-	1: ImmBorrowFieldGeneric[0](G.f: Ty0)
+	0: ImmBorrowLoc[0](x: G<u64>)
+	1: ImmBorrowFieldGeneric[0](G.f: X)
 	2: ReadRef
 	3: Ret
 }
-read_ref(Arg0: &S): u64 /* def_idx: 1 */ {
+read_ref(x: &S): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](x: &S)
 	1: ImmBorrowField[1](S.g: T)
 	2: ImmBorrowField[2](T.h: u64)
 	3: ReadRef
 	4: Ret
 }
-read_val(Arg0: S): u64 /* def_idx: 2 */ {
+read_val(x: S): u64 /* def_idx: 2 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: S)
+	0: ImmBorrowLoc[0](x: S)
 	1: ImmBorrowField[1](S.g: T)
 	2: ImmBorrowField[2](T.h: u64)
 	3: ReadRef
 	4: Ret
 }
-write_generic_val(Arg0: &mut G<u64>, Arg1: u64) /* def_idx: 3 */ {
-L2:	loc0: &mut u64
+write_generic_val(x: &mut G<u64>, v: u64) /* def_idx: 3 */ {
+L2:	$t2: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut G<u64>)
-	1: MutBorrowFieldGeneric[0](G.f: Ty0)
-	2: StLoc[2](loc0: &mut u64)
-	3: MoveLoc[1](Arg1: u64)
-	4: MoveLoc[2](loc0: &mut u64)
+	0: MoveLoc[0](x: &mut G<u64>)
+	1: MutBorrowFieldGeneric[0](G.f: X)
+	2: StLoc[2]($t2: &mut u64)
+	3: MoveLoc[1](v: u64)
+	4: MoveLoc[2]($t2: &mut u64)
 	5: WriteRef
 	6: Ret
 }
 write_local_direct(): S /* def_idx: 4 */ {
-L0:	loc0: S
+L0:	x: S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[2](S)
-	4: StLoc[0](loc0: S)
+	4: StLoc[0](x: S)
 	5: LdU64(42)
-	6: MutBorrowLoc[0](loc0: S)
+	6: MutBorrowLoc[0](x: S)
 	7: MutBorrowField[1](S.g: T)
 	8: MutBorrowField[2](T.h: u64)
 	9: WriteRef
-	10: MoveLoc[0](loc0: S)
+	10: MoveLoc[0](x: S)
 	11: Ret
 }
 write_local_via_ref(): S /* def_idx: 5 */ {
-L0:	loc0: S
-L1:	loc1: &mut S
+L0:	x: S
+L1:	r: &mut S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[2](S)
-	4: StLoc[0](loc0: S)
-	5: MutBorrowLoc[0](loc0: S)
-	6: StLoc[1](loc1: &mut S)
+	4: StLoc[0](x: S)
+	5: MutBorrowLoc[0](x: S)
+	6: StLoc[1](r: &mut S)
 	7: LdU64(42)
-	8: MoveLoc[1](loc1: &mut S)
+	8: MoveLoc[1](r: &mut S)
 	9: MutBorrowField[1](S.g: T)
 	10: MutBorrowField[2](T.h: u64)
 	11: WriteRef
-	12: MoveLoc[0](loc0: S)
+	12: MoveLoc[0](x: S)
 	13: Ret
 }
 write_local_via_ref_2(): S /* def_idx: 6 */ {
-L0:	loc0: S
-L1:	loc1: u64
-L2:	loc2: &mut u64
+L0:	x: S
+L1:	$t2: u64
+L2:	r: &mut u64
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[2](S)
-	4: StLoc[0](loc0: S)
-	5: MutBorrowLoc[0](loc0: S)
+	4: StLoc[0](x: S)
+	5: MutBorrowLoc[0](x: S)
 	6: MutBorrowField[1](S.g: T)
 	7: MutBorrowField[2](T.h: u64)
-	8: StLoc[2](loc2: &mut u64)
+	8: StLoc[2](r: &mut u64)
 	9: LdU64(42)
-	10: MoveLoc[2](loc2: &mut u64)
+	10: MoveLoc[2](r: &mut u64)
 	11: WriteRef
-	12: MoveLoc[0](loc0: S)
+	12: MoveLoc[0](x: S)
 	13: Ret
 }
-write_param(Arg0: &mut S) /* def_idx: 7 */ {
+write_param(x: &mut S) /* def_idx: 7 */ {
 B0:
 	0: LdU64(42)
-	1: MoveLoc[0](Arg0: &mut S)
+	1: MoveLoc[0](x: &mut S)
 	2: MutBorrowField[1](S.g: T)
 	3: MutBorrowField[2](T.h: u64)
 	4: WriteRef
 	5: Ret
 }
-write_val(Arg0: S): S /* def_idx: 8 */ {
+write_val(x: S): S /* def_idx: 8 */ {
 B0:
 	0: LdU64(42)
-	1: MutBorrowLoc[0](Arg0: S)
+	1: MutBorrowLoc[0](x: S)
 	2: MutBorrowField[1](S.g: T)
 	3: MutBorrowField[2](T.h: u64)
 	4: WriteRef
-	5: MoveLoc[0](Arg0: S)
+	5: MoveLoc[0](x: S)
 	6: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
@@ -413,186 +413,186 @@ struct S has drop {
 	dummy_field: bool
 }
 
-public borrow_mut<Ty0>(Arg0: &mut vector<Ty0>): &Ty0 /* def_idx: 0 */ {
+public borrow_mut<Element>(map: &mut vector<Element>): &Element /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	0: MoveLoc[0](map: &mut vector<Element>)
 	1: LdU64(0)
 	2: VecMutBorrow(2)
 	3: FreezeRef
 	4: Ret
 }
-public borrow_mut2<Ty0>(Arg0: &mut Ty0): &Ty0 /* def_idx: 1 */ {
+public borrow_mut2<Element>(v: &mut Element): &Element /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut Ty0)
+	0: MoveLoc[0](v: &mut Element)
 	1: FreezeRef
 	2: Ret
 }
-public borrow_mut3<Ty0>(Arg0: &mut Ty0, Arg1: &Ty0): &Ty0 /* def_idx: 2 */ {
-L2:	loc0: &Ty0
+public borrow_mut3<Element>(v1: &mut Element, v2: &Element): &Element /* def_idx: 2 */ {
+L2:	return: &Element
 B0:
-	0: MoveLoc[1](Arg1: &Ty0)
+	0: MoveLoc[1](v2: &Element)
 	1: Pop
-	2: MoveLoc[0](Arg0: &mut Ty0)
+	2: MoveLoc[0](v1: &mut Element)
 	3: FreezeRef
-	4: StLoc[2](loc0: &Ty0)
+	4: StLoc[2](return: &Element)
 B1:
-	5: MoveLoc[2](loc0: &Ty0)
+	5: MoveLoc[2](return: &Element)
 	6: Ret
 B2:
-	7: MoveLoc[0](Arg0: &mut Ty0)
+	7: MoveLoc[0](v1: &mut Element)
 	8: Pop
-	9: MoveLoc[1](Arg1: &Ty0)
-	10: StLoc[2](loc0: &Ty0)
+	9: MoveLoc[1](v2: &Element)
+	10: StLoc[2](return: &Element)
 	11: Branch(5)
 }
-public borrow_mut4<Ty0>(Arg0: &mut Ty0): &Ty0 /* def_idx: 3 */ {
+public borrow_mut4<Element>(v: &mut Element): &Element /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut Ty0)
+	0: MoveLoc[0](v: &mut Element)
 	1: FreezeRef
 	2: Ret
 }
 t0() /* def_idx: 4 */ {
-L0:	loc0: u64
-L1:	loc1: &u64
+L0:	$t2: u64
+L1:	x: &u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
-	2: MutBorrowLoc[0](loc0: u64)
+	1: StLoc[0]($t2: u64)
+	2: MutBorrowLoc[0]($t2: u64)
 	3: FreezeRef
 	4: Pop
 	5: Ret
 }
-t1(Arg0: &mut S): &S /* def_idx: 5 */ {
+t1(s: &mut S): &S /* def_idx: 5 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](s: &mut S)
 	1: FreezeRef
 	2: Ret
 }
-t2(Arg0: &mut u64, Arg1: &mut u64): &u64 * &mut u64 /* def_idx: 6 */ {
-L2:	loc0: &u64
+t2(u1: &mut u64, u2: &mut u64): &u64 * &mut u64 /* def_idx: 6 */ {
+L2:	return[0]: &u64
 B0:
-	0: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[0](u1: &mut u64)
 	1: FreezeRef
-	2: MoveLoc[1](Arg1: &mut u64)
+	2: MoveLoc[1](u2: &mut u64)
 	3: Ret
 }
 public t4() /* def_idx: 7 */ {
-L0:	loc0: u64
-L1:	loc1: &u64
-L2:	loc2: u64
+L0:	$t4: u64
+L1:	$t2: &u64
+L2:	$t7: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
-	2: MutBorrowLoc[0](loc0: u64)
+	1: StLoc[0]($t4: u64)
+	2: MutBorrowLoc[0]($t4: u64)
 	3: FreezeRef
 	4: Pop
 	5: LdU64(0)
-	6: StLoc[2](loc2: u64)
-	7: MutBorrowLoc[2](loc2: u64)
+	6: StLoc[2]($t7: u64)
+	7: MutBorrowLoc[2]($t7: u64)
 	8: FreezeRef
 	9: Pop
 	10: Ret
 }
-public t5(Arg0: &mut G) /* def_idx: 8 */ {
-L1:	loc0: &mut u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: &mut u64
-L5:	loc4: &u64
-L6:	loc5: u64
-L7:	loc6: &mut u64
+public t5(s: &mut G) /* def_idx: 8 */ {
+L1:	f: &mut u64
+L2:	x: u64
+L3:	$t13: u64
+L4:	y: &mut u64
+L5:	$t18: &u64
+L6:	$t5: u64
+L7:	g: &mut u64
 B0:
 	0: LdU64(0)
 	1: LdU64(1)
 	2: Add
-	3: CopyLoc[0](Arg0: &mut G)
+	3: CopyLoc[0](s: &mut G)
 	4: MutBorrowField[0](G.f: u64)
-	5: StLoc[1](loc0: &mut u64)
+	5: StLoc[1](f: &mut u64)
 	6: LdU64(1)
 	7: Add
 	8: Pop
-	9: MoveLoc[0](Arg0: &mut G)
+	9: MoveLoc[0](s: &mut G)
 	10: MutBorrowField[0](G.f: u64)
 	11: LdU64(2)
-	12: StLoc[3](loc2: u64)
-	13: MutBorrowLoc[3](loc2: u64)
-	14: StLoc[4](loc3: &mut u64)
+	12: StLoc[3]($t13: u64)
+	13: MutBorrowLoc[3]($t13: u64)
+	14: StLoc[4](y: &mut u64)
 	15: LdU64(2)
 	16: LdU64(0)
-	17: MoveLoc[1](loc0: &mut u64)
+	17: MoveLoc[1](f: &mut u64)
 	18: WriteRef
-	19: MoveLoc[4](loc3: &mut u64)
+	19: MoveLoc[4](y: &mut u64)
 	20: FreezeRef
 	21: Pop
-	22: StLoc[6](loc5: u64)
-	23: StLoc[7](loc6: &mut u64)
-	24: MoveLoc[6](loc5: u64)
-	25: MoveLoc[7](loc6: &mut u64)
+	22: StLoc[6]($t5: u64)
+	23: StLoc[7](g: &mut u64)
+	24: MoveLoc[6]($t5: u64)
+	25: MoveLoc[7](g: &mut u64)
 	26: WriteRef
 	27: Ret
 }
-t6(Arg0: bool, Arg1: &mut S, Arg2: &S) /* def_idx: 9 */ {
-L3:	loc0: &S
+t6(cond: bool, s: &mut S, other: &S) /* def_idx: 9 */ {
+L3:	$t4: &S
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(10)
 B1:
-	2: MoveLoc[2](Arg2: &S)
+	2: MoveLoc[2](other: &S)
 	3: Pop
-	4: CopyLoc[1](Arg1: &mut S)
-	5: MoveLoc[1](Arg1: &mut S)
+	4: CopyLoc[1](s: &mut S)
+	5: MoveLoc[1](s: &mut S)
 	6: Pop
 	7: FreezeRef
 	8: Pop
 B2:
 	9: Ret
 B3:
-	10: MoveLoc[1](Arg1: &mut S)
+	10: MoveLoc[1](s: &mut S)
 	11: Pop
-	12: MoveLoc[2](Arg2: &S)
+	12: MoveLoc[2](other: &S)
 	13: Pop
 	14: Branch(9)
 }
-t7(Arg0: bool, Arg1: &mut S, Arg2: &S) /* def_idx: 10 */ {
-L3:	loc0: &S
-L4:	loc1: &S
+t7(cond: bool, s: &mut S, other: &S) /* def_idx: 10 */ {
+L3:	$t4: &S
+L4:	_x: &S
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(10)
 B1:
-	2: MoveLoc[2](Arg2: &S)
+	2: MoveLoc[2](other: &S)
 	3: Pop
-	4: MoveLoc[1](Arg1: &mut S)
+	4: MoveLoc[1](s: &mut S)
 	5: FreezeRef
-	6: StLoc[3](loc0: &S)
+	6: StLoc[3]($t4: &S)
 B2:
-	7: MoveLoc[3](loc0: &S)
+	7: MoveLoc[3]($t4: &S)
 	8: Pop
 	9: Ret
 B3:
-	10: MoveLoc[1](Arg1: &mut S)
+	10: MoveLoc[1](s: &mut S)
 	11: Pop
-	12: MoveLoc[2](Arg2: &S)
-	13: StLoc[3](loc0: &S)
+	12: MoveLoc[2](other: &S)
+	13: StLoc[3]($t4: &S)
 	14: Branch(7)
 }
-t8(Arg0: bool, Arg1: &mut S, Arg2: &S) /* def_idx: 11 */ {
-L3:	loc0: &S
+t8(cond: bool, s: &mut S, other: &S) /* def_idx: 11 */ {
+L3:	_x: &S
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(8)
 B1:
-	2: MoveLoc[2](Arg2: &S)
+	2: MoveLoc[2](other: &S)
 	3: Pop
-	4: MoveLoc[1](Arg1: &mut S)
+	4: MoveLoc[1](s: &mut S)
 	5: FreezeRef
 	6: Pop
 B2:
 	7: Ret
 B3:
-	8: MoveLoc[1](Arg1: &mut S)
+	8: MoveLoc[1](s: &mut S)
 	9: Pop
-	10: MoveLoc[2](Arg2: &S)
+	10: MoveLoc[2](other: &S)
 	11: Pop
 	12: Branch(7)
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
@@ -120,36 +120,36 @@ struct R has store, key {
 	f: u64
 }
 
-check(Arg0: address): bool /* def_idx: 0 */ {
+check(a: address): bool /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: Exists[0](R)
 	2: Ret
 }
-publish(Arg0: &signer) /* def_idx: 1 */ {
+publish(s: &signer) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &signer)
+	0: MoveLoc[0](s: &signer)
 	1: LdU64(1)
 	2: Pack[0](R)
 	3: MoveTo[0](R)
 	4: Ret
 }
-read(Arg0: address): u64 /* def_idx: 2 */ {
+read(a: address): u64 /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: ImmBorrowGlobal[0](R)
 	2: ImmBorrowField[0](R.f: u64)
 	3: ReadRef
 	4: Ret
 }
-write(Arg0: address, Arg1: u64): u64 /* def_idx: 3 */ {
-L2:	loc0: &mut R
+write(a: address, x: u64): u64 /* def_idx: 3 */ {
+L2:	r: &mut R
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: MutBorrowGlobal[0](R)
-	2: StLoc[2](loc0: &mut R)
+	2: StLoc[2](r: &mut R)
 	3: LdU64(2)
-	4: MoveLoc[2](loc0: &mut R)
+	4: MoveLoc[2](r: &mut R)
 	5: MutBorrowField[0](R.f: u64)
 	6: WriteRef
 	7: LdU64(9)

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/if_else.exp
@@ -101,61 +101,61 @@ fun if_else::if_else_nested($t0: bool, $t1: u64): u64 {
 module 42.if_else {
 
 
-if_else(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+if_else(cond: bool, x: u64): u64 /* def_idx: 0 */ {
+L2:	$t3: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(8)
 B1:
-	2: MoveLoc[1](Arg1: u64)
+	2: MoveLoc[1](x: u64)
 	3: LdU64(1)
 	4: Add
-	5: StLoc[2](loc0: u64)
+	5: StLoc[2]($t3: u64)
 B2:
-	6: MoveLoc[2](loc0: u64)
+	6: MoveLoc[2]($t3: u64)
 	7: Ret
 B3:
-	8: MoveLoc[1](Arg1: u64)
+	8: MoveLoc[1](x: u64)
 	9: LdU64(1)
 	10: Sub
-	11: StLoc[2](loc0: u64)
+	11: StLoc[2]($t3: u64)
 	12: Branch(6)
 }
-if_else_nested(Arg0: bool, Arg1: u64): u64 /* def_idx: 1 */ {
-L2:	loc0: u64
-L3:	loc1: u64
+if_else_nested(cond: bool, x: u64): u64 /* def_idx: 1 */ {
+L2:	$t5: u64
+L3:	$t6: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(21)
 B1:
-	2: CopyLoc[1](Arg1: u64)
+	2: CopyLoc[1](x: u64)
 	3: LdU64(1)
 	4: Add
-	5: StLoc[2](loc0: u64)
+	5: StLoc[2]($t5: u64)
 B2:
-	6: MoveLoc[2](loc0: u64)
+	6: MoveLoc[2]($t5: u64)
 	7: LdU64(10)
 	8: Gt
 	9: BrFalse(16)
 B3:
-	10: MoveLoc[1](Arg1: u64)
+	10: MoveLoc[1](x: u64)
 	11: LdU64(2)
 	12: Mul
-	13: StLoc[3](loc1: u64)
+	13: StLoc[3]($t6: u64)
 B4:
-	14: MoveLoc[3](loc1: u64)
+	14: MoveLoc[3]($t6: u64)
 	15: Ret
 B5:
-	16: MoveLoc[1](Arg1: u64)
+	16: MoveLoc[1](x: u64)
 	17: LdU64(2)
 	18: Div
-	19: StLoc[3](loc1: u64)
+	19: StLoc[3]($t6: u64)
 	20: Branch(14)
 B6:
-	21: CopyLoc[1](Arg1: u64)
+	21: CopyLoc[1](x: u64)
 	22: LdU64(1)
 	23: Sub
-	24: StLoc[2](loc0: u64)
+	24: StLoc[2]($t5: u64)
 	25: Branch(6)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/inline_specs.exp
@@ -85,19 +85,19 @@ module 42.inline_specs {
 
 
 specs(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	x: u64
 B0:
 	0: Nop
 	1: LdU64(0)
 	2: Call succ(u64): u64
-	3: StLoc[0](loc0: u64)
+	3: StLoc[0](x: u64)
 	4: Nop
-	5: MoveLoc[0](loc0: u64)
+	5: MoveLoc[0](x: u64)
 	6: Ret
 }
-succ(Arg0: u64): u64 /* def_idx: 1 */ {
+succ(x: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: LdU64(1)
 	2: Add
 	3: Ret

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/loop.exp
@@ -229,80 +229,80 @@ fun loops::while_loop_with_break_and_continue($t0: u64): u64 {
 module 42.loops {
 
 
-nested_loop(Arg0: u64): u64 /* def_idx: 0 */ {
+nested_loop(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(18)
 B1:
-	4: CopyLoc[0](Arg0: u64)
+	4: CopyLoc[0](x: u64)
 	5: LdU64(10)
 	6: Gt
 	7: BrTrue(9)
 B2:
 	8: Branch(13)
 B3:
-	9: MoveLoc[0](Arg0: u64)
+	9: MoveLoc[0](x: u64)
 	10: LdU64(1)
 	11: Sub
-	12: StLoc[0](Arg0: u64)
+	12: StLoc[0](x: u64)
 B4:
-	13: MoveLoc[0](Arg0: u64)
+	13: MoveLoc[0](x: u64)
 	14: LdU64(1)
 	15: Sub
-	16: StLoc[0](Arg0: u64)
+	16: StLoc[0](x: u64)
 	17: Branch(0)
 B5:
-	18: MoveLoc[0](Arg0: u64)
+	18: MoveLoc[0](x: u64)
 	19: Ret
 }
-while_loop(Arg0: u64): u64 /* def_idx: 1 */ {
+while_loop(x: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(9)
 B1:
-	4: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[0](x: u64)
 	5: LdU64(1)
 	6: Sub
-	7: StLoc[0](Arg0: u64)
+	7: StLoc[0](x: u64)
 	8: Branch(0)
 B2:
-	9: MoveLoc[0](Arg0: u64)
+	9: MoveLoc[0](x: u64)
 	10: Ret
 }
-while_loop_with_break_and_continue(Arg0: u64): u64 /* def_idx: 2 */ {
+while_loop_with_break_and_continue(x: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrTrue(5)
 B1:
 	4: Branch(10)
 B2:
-	5: CopyLoc[0](Arg0: u64)
+	5: CopyLoc[0](x: u64)
 	6: LdU64(42)
 	7: Eq
 	8: BrFalse(12)
 B3:
 	9: Branch(10)
 B4:
-	10: MoveLoc[0](Arg0: u64)
+	10: MoveLoc[0](x: u64)
 	11: Ret
 B5:
-	12: CopyLoc[0](Arg0: u64)
+	12: CopyLoc[0](x: u64)
 	13: LdU64(21)
 	14: Eq
 	15: BrFalse(17)
 B6:
 	16: Branch(0)
 B7:
-	17: MoveLoc[0](Arg0: u64)
+	17: MoveLoc[0](x: u64)
 	18: LdU64(1)
 	19: Sub
-	20: StLoc[0](Arg0: u64)
+	20: StLoc[0](x: u64)
 	21: Branch(0)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_refutable_err.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_refutable_err.exp
@@ -52,9 +52,9 @@ enum E {
  }
 }
 
-t(Arg0: E): u64 /* def_idx: 0 */ {
+t(self: E): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: E)
+	0: MoveLoc[0](self: E)
 	1: UnpackVariant[0](E/Some)
 	2: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/operators.exp
@@ -207,162 +207,162 @@ fun operators::order($t0: u64, $t1: u64): bool {
 module 42.operators {
 
 
-arithm(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+arithm(x: u64, y: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u64)
+	2: CopyLoc[0](x: u64)
+	3: CopyLoc[1](y: u64)
 	4: Sub
 	5: Div
-	6: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[1](y: u64)
 	7: Mul
-	8: MoveLoc[0](Arg0: u64)
+	8: MoveLoc[0](x: u64)
 	9: Mod
 	10: Add
 	11: Ret
 }
-bits(Arg0: u64, Arg1: u8): u64 /* def_idx: 1 */ {
+bits(x: u64, y: u8): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u8)
+	0: CopyLoc[0](x: u64)
+	1: MoveLoc[1](y: u8)
 	2: Shl
-	3: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[0](x: u64)
 	4: BitAnd
 	5: Ret
 }
-bools(Arg0: bool, Arg1: bool): bool /* def_idx: 2 */ {
-L2:	loc0: bool
-L3:	loc1: bool
-L4:	loc2: bool
-L5:	loc3: bool
+bools(x: bool, y: bool): bool /* def_idx: 2 */ {
+L2:	$t5: bool
+L3:	$t4: bool
+L4:	$t3: bool
+L5:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: bool)
+	0: CopyLoc[0](x: bool)
 	1: BrFalse(44)
 B1:
-	2: CopyLoc[1](Arg1: bool)
-	3: StLoc[2](loc0: bool)
+	2: CopyLoc[1](y: bool)
+	3: StLoc[2]($t5: bool)
 B2:
-	4: MoveLoc[2](loc0: bool)
+	4: MoveLoc[2]($t5: bool)
 	5: BrFalse(35)
 B3:
 	6: LdTrue
-	7: StLoc[3](loc1: bool)
+	7: StLoc[3]($t4: bool)
 B4:
-	8: MoveLoc[3](loc1: bool)
+	8: MoveLoc[3]($t4: bool)
 	9: BrFalse(27)
 B5:
 	10: LdTrue
-	11: StLoc[4](loc2: bool)
+	11: StLoc[4]($t3: bool)
 B6:
-	12: MoveLoc[4](loc2: bool)
+	12: MoveLoc[4]($t3: bool)
 	13: BrFalse(18)
 B7:
 	14: LdTrue
-	15: StLoc[5](loc3: bool)
+	15: StLoc[5](return: bool)
 B8:
-	16: MoveLoc[5](loc3: bool)
+	16: MoveLoc[5](return: bool)
 	17: Ret
 B9:
-	18: MoveLoc[0](Arg0: bool)
+	18: MoveLoc[0](x: bool)
 	19: BrTrue(24)
 B10:
-	20: MoveLoc[1](Arg1: bool)
+	20: MoveLoc[1](y: bool)
 	21: Not
-	22: StLoc[5](loc3: bool)
+	22: StLoc[5](return: bool)
 	23: Branch(16)
 B11:
 	24: LdFalse
-	25: StLoc[5](loc3: bool)
+	25: StLoc[5](return: bool)
 	26: Branch(16)
 B12:
-	27: CopyLoc[0](Arg0: bool)
+	27: CopyLoc[0](x: bool)
 	28: BrTrue(32)
 B13:
-	29: CopyLoc[1](Arg1: bool)
-	30: StLoc[4](loc2: bool)
+	29: CopyLoc[1](y: bool)
+	30: StLoc[4]($t3: bool)
 	31: Branch(12)
 B14:
 	32: LdFalse
-	33: StLoc[4](loc2: bool)
+	33: StLoc[4]($t3: bool)
 	34: Branch(12)
 B15:
-	35: CopyLoc[0](Arg0: bool)
+	35: CopyLoc[0](x: bool)
 	36: BrFalse(41)
 B16:
-	37: CopyLoc[1](Arg1: bool)
+	37: CopyLoc[1](y: bool)
 	38: Not
-	39: StLoc[3](loc1: bool)
+	39: StLoc[3]($t4: bool)
 	40: Branch(8)
 B17:
 	41: LdFalse
-	42: StLoc[3](loc1: bool)
+	42: StLoc[3]($t4: bool)
 	43: Branch(8)
 B18:
 	44: LdFalse
-	45: StLoc[2](loc0: bool)
+	45: StLoc[2]($t5: bool)
 	46: Branch(4)
 }
-equality<Ty0: drop>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 3 */ {
+equality<T: drop>(x: T, y: T): bool /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
-	1: MoveLoc[1](Arg1: Ty0)
+	0: MoveLoc[0](x: T)
+	1: MoveLoc[1](y: T)
 	2: Eq
 	3: Ret
 }
-inequality<Ty0: drop>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 4 */ {
+inequality<T: drop>(x: T, y: T): bool /* def_idx: 4 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
-	1: MoveLoc[1](Arg1: Ty0)
+	0: MoveLoc[0](x: T)
+	1: MoveLoc[1](y: T)
 	2: Neq
 	3: Ret
 }
-order(Arg0: u64, Arg1: u64): bool /* def_idx: 5 */ {
-L2:	loc0: bool
-L3:	loc1: bool
-L4:	loc2: bool
+order(x: u64, y: u64): bool /* def_idx: 5 */ {
+L2:	$t5: bool
+L3:	$t8: bool
+L4:	$t10: bool
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u64)
 	2: Lt
 	3: BrFalse(30)
 B1:
-	4: CopyLoc[0](Arg0: u64)
-	5: CopyLoc[1](Arg1: u64)
+	4: CopyLoc[0](x: u64)
+	5: CopyLoc[1](y: u64)
 	6: Le
-	7: StLoc[2](loc0: bool)
+	7: StLoc[2]($t5: bool)
 B2:
-	8: MoveLoc[2](loc0: bool)
+	8: MoveLoc[2]($t5: bool)
 	9: BrFalse(27)
 B3:
-	10: CopyLoc[0](Arg0: u64)
-	11: CopyLoc[1](Arg1: u64)
+	10: CopyLoc[0](x: u64)
+	11: CopyLoc[1](y: u64)
 	12: Gt
 	13: Not
-	14: StLoc[3](loc1: bool)
+	14: StLoc[3]($t8: bool)
 B4:
-	15: MoveLoc[3](loc1: bool)
+	15: MoveLoc[3]($t8: bool)
 	16: BrFalse(24)
 B5:
-	17: MoveLoc[0](Arg0: u64)
-	18: MoveLoc[1](Arg1: u64)
+	17: MoveLoc[0](x: u64)
+	18: MoveLoc[1](y: u64)
 	19: Ge
 	20: Not
-	21: StLoc[4](loc2: bool)
+	21: StLoc[4]($t10: bool)
 B6:
-	22: MoveLoc[4](loc2: bool)
+	22: MoveLoc[4]($t10: bool)
 	23: Ret
 B7:
 	24: LdFalse
-	25: StLoc[4](loc2: bool)
+	25: StLoc[4]($t10: bool)
 	26: Branch(22)
 B8:
 	27: LdFalse
-	28: StLoc[3](loc1: bool)
+	28: StLoc[3]($t8: bool)
 	29: Branch(15)
 B9:
 	30: LdFalse
-	31: StLoc[2](loc0: bool)
+	31: StLoc[2]($t5: bool)
 	32: Branch(8)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_order.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_order.exp
@@ -183,51 +183,51 @@ struct S {
 	f3: u8
 }
 
-pack1(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 0 */ {
+pack1(x: u8, y: u8, z: u8): S /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[2](Arg2: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[2](z: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack2(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 1 */ {
+pack2(x: u8, y: u8, z: u8): S /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[2](Arg2: u8)
-	2: MoveLoc[1](Arg1: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[2](z: u8)
+	2: MoveLoc[1](y: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack3(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 2 */ {
+pack3(x: u8, y: u8, z: u8): S /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[1](Arg1: u8)
-	1: MoveLoc[0](Arg0: u8)
-	2: MoveLoc[2](Arg2: u8)
+	0: MoveLoc[1](y: u8)
+	1: MoveLoc[0](x: u8)
+	2: MoveLoc[2](z: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack4(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 3 */ {
+pack4(x: u8, y: u8, z: u8): S /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[2](Arg2: u8)
-	1: MoveLoc[0](Arg0: u8)
-	2: MoveLoc[1](Arg1: u8)
+	0: MoveLoc[2](z: u8)
+	1: MoveLoc[0](x: u8)
+	2: MoveLoc[1](y: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack5(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 4 */ {
+pack5(x: u8, y: u8, z: u8): S /* def_idx: 4 */ {
 B0:
-	0: MoveLoc[1](Arg1: u8)
-	1: MoveLoc[2](Arg2: u8)
-	2: MoveLoc[0](Arg0: u8)
+	0: MoveLoc[1](y: u8)
+	1: MoveLoc[2](z: u8)
+	2: MoveLoc[0](x: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack6(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 5 */ {
+pack6(x: u8, y: u8, z: u8): S /* def_idx: 5 */ {
 B0:
-	0: MoveLoc[2](Arg2: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[0](Arg0: u8)
+	0: MoveLoc[2](z: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[0](x: u8)
 	3: Pack[0](S)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/pack_unpack.exp
@@ -76,19 +76,19 @@ struct S {
 	g: T
 }
 
-pack(Arg0: u64, Arg1: u64): S /* def_idx: 0 */ {
+pack(x: u64, y: u64): S /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: u64)
+	1: MoveLoc[1](y: u64)
 	2: Pack[0](T)
 	3: Pack[1](S)
 	4: Ret
 }
-unpack(Arg0: S): u64 * u64 /* def_idx: 1 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+unpack(s: S): u64 * u64 /* def_idx: 1 */ {
+L1:	h: u64
+L2:	f: u64
 B0:
-	0: MoveLoc[0](Arg0: S)
+	0: MoveLoc[0](s: S)
 	1: Unpack[1](S)
 	2: Unpack[0](T)
 	3: Ret

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/reference_conversion.exp
@@ -60,24 +60,24 @@ fun reference_conversion::use_it(): u64 {
 module 42.reference_conversion {
 
 
-deref(Arg0: &u64): u64 /* def_idx: 0 */ {
+deref(r: &u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &u64)
+	0: MoveLoc[0](r: &u64)
 	1: ReadRef
 	2: Ret
 }
 use_it(): u64 /* def_idx: 1 */ {
-L0:	loc0: u64
-L1:	loc1: &mut u64
+L0:	x: u64
+L1:	r: &mut u64
 B0:
 	0: LdU64(42)
-	1: StLoc[0](loc0: u64)
-	2: MutBorrowLoc[0](loc0: u64)
-	3: StLoc[1](loc1: &mut u64)
+	1: StLoc[0](x: u64)
+	2: MutBorrowLoc[0](x: u64)
+	3: StLoc[1](r: &mut u64)
 	4: LdU64(43)
-	5: CopyLoc[1](loc1: &mut u64)
+	5: CopyLoc[1](r: &mut u64)
 	6: WriteRef
-	7: MoveLoc[1](loc1: &mut u64)
+	7: MoveLoc[1](r: &mut u64)
 	8: FreezeRef
 	9: Call deref(&u64): u64
 	10: Ret

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/spec_construct.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/spec_construct.exp
@@ -53,9 +53,9 @@ struct S {
 	data: vector<E>
 }
 
-public foo(Arg0: &S): u8 /* def_idx: 0 */ {
+public foo(v: &S): u8 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](v: &S)
 	1: ImmBorrowField[0](S.data: vector<E>)
 	2: LdU64(0)
 	3: VecImmBorrow(2)

--- a/third_party/move/move-compiler-v2/tests/control-flow-simplification/bug-10253.off.exp
+++ b/third_party/move/move-compiler-v2/tests/control-flow-simplification/bug-10253.off.exp
@@ -4,40 +4,40 @@
 module cafe.vectors {
 
 
-entry public guess_flips(Arg0: vector<u8>) /* def_idx: 0 */ {
-L1:	loc0: &vector<u8>
-L2:	loc1: u64
+entry public guess_flips(flips: vector<u8>) /* def_idx: 0 */ {
+L1:	$t2: &vector<u8>
+L2:	i: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<u8>)
-	1: StLoc[1](loc0: &vector<u8>)
+	0: ImmBorrowLoc[0](flips: vector<u8>)
+	1: StLoc[1]($t2: &vector<u8>)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](i: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
-	5: CopyLoc[1](loc0: &vector<u8>)
+	4: CopyLoc[2](i: u64)
+	5: CopyLoc[1]($t2: &vector<u8>)
 	6: VecLen(2)
 	7: Lt
 	8: BrFalse(24)
 B2:
-	9: CopyLoc[1](loc0: &vector<u8>)
-	10: CopyLoc[2](loc1: u64)
+	9: CopyLoc[1]($t2: &vector<u8>)
+	10: CopyLoc[2](i: u64)
 	11: VecImmBorrow(2)
 	12: ReadRef
 	13: LdU8(0)
 	14: Neq
 	15: BrFalse(19)
 B3:
-	16: MoveLoc[1](loc0: &vector<u8>)
+	16: MoveLoc[1]($t2: &vector<u8>)
 	17: Pop
 	18: Branch(28)
 B4:
-	19: MoveLoc[2](loc1: u64)
+	19: MoveLoc[2](i: u64)
 	20: LdU64(1)
 	21: Add
-	22: StLoc[2](loc1: u64)
+	22: StLoc[2](i: u64)
 	23: Branch(27)
 B5:
-	24: MoveLoc[1](loc0: &vector<u8>)
+	24: MoveLoc[1]($t2: &vector<u8>)
 	25: Pop
 	26: Branch(28)
 B6:
@@ -45,20 +45,20 @@ B6:
 B7:
 	28: Ret
 }
-entry public guess_flips_directly(Arg0: vector<u8>) /* def_idx: 1 */ {
-L1:	loc0: u64
+entry public guess_flips_directly(flips: vector<u8>) /* def_idx: 1 */ {
+L1:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](i: u64)
 B1:
-	2: CopyLoc[1](loc0: u64)
-	3: ImmBorrowLoc[0](Arg0: vector<u8>)
+	2: CopyLoc[1](i: u64)
+	3: ImmBorrowLoc[0](flips: vector<u8>)
 	4: VecLen(2)
 	5: Lt
 	6: BrFalse(20)
 B2:
-	7: ImmBorrowLoc[0](Arg0: vector<u8>)
-	8: CopyLoc[1](loc0: u64)
+	7: ImmBorrowLoc[0](flips: vector<u8>)
+	8: CopyLoc[1](i: u64)
 	9: VecImmBorrow(2)
 	10: ReadRef
 	11: LdU8(0)
@@ -67,10 +67,10 @@ B2:
 B3:
 	14: Branch(22)
 B4:
-	15: MoveLoc[1](loc0: u64)
+	15: MoveLoc[1](i: u64)
 	16: LdU64(1)
 	17: Add
-	18: StLoc[1](loc0: u64)
+	18: StLoc[1](i: u64)
 	19: Branch(21)
 B5:
 	20: Branch(22)
@@ -79,29 +79,29 @@ B6:
 B7:
 	22: Ret
 }
-entry public guess_with_break_without_inline(Arg0: vector<u8>) /* def_idx: 2 */ {
+entry public guess_with_break_without_inline(flips: vector<u8>) /* def_idx: 2 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	0: ImmBorrowLoc[0](flips: vector<u8>)
 	1: Call loops_with_break_no_inline(&vector<u8>)
 	2: Ret
 }
-entry public guess_without_break_with_inline(Arg0: vector<u8>) /* def_idx: 3 */ {
-L1:	loc0: &vector<u8>
-L2:	loc1: u64
+entry public guess_without_break_with_inline(flips: vector<u8>) /* def_idx: 3 */ {
+L1:	$t2: &vector<u8>
+L2:	i: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<u8>)
-	1: StLoc[1](loc0: &vector<u8>)
+	0: ImmBorrowLoc[0](flips: vector<u8>)
+	1: StLoc[1]($t2: &vector<u8>)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](i: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
-	5: CopyLoc[1](loc0: &vector<u8>)
+	4: CopyLoc[2](i: u64)
+	5: CopyLoc[1]($t2: &vector<u8>)
 	6: VecLen(2)
 	7: Lt
 	8: BrFalse(26)
 B2:
-	9: CopyLoc[1](loc0: &vector<u8>)
-	10: CopyLoc[2](loc1: u64)
+	9: CopyLoc[1]($t2: &vector<u8>)
+	10: CopyLoc[2](i: u64)
 	11: VecImmBorrow(2)
 	12: ReadRef
 	13: LdU8(0)
@@ -110,18 +110,18 @@ B2:
 B3:
 	16: Branch(21)
 B4:
-	17: MoveLoc[1](loc0: &vector<u8>)
+	17: MoveLoc[1]($t2: &vector<u8>)
 	18: Pop
 	19: LdU64(3)
 	20: Abort
 B5:
-	21: MoveLoc[2](loc1: u64)
+	21: MoveLoc[2](i: u64)
 	22: LdU64(1)
 	23: Add
-	24: StLoc[2](loc1: u64)
+	24: StLoc[2](i: u64)
 	25: Branch(29)
 B6:
-	26: MoveLoc[1](loc0: &vector<u8>)
+	26: MoveLoc[1]($t2: &vector<u8>)
 	27: Pop
 	28: Branch(30)
 B7:
@@ -129,37 +129,37 @@ B7:
 B8:
 	30: Ret
 }
-loops_with_break_no_inline(Arg0: &vector<u8>) /* def_idx: 4 */ {
-L1:	loc0: u64
+loops_with_break_no_inline(flips: &vector<u8>) /* def_idx: 4 */ {
+L1:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](i: u64)
 B1:
-	2: CopyLoc[1](loc0: u64)
-	3: CopyLoc[0](Arg0: &vector<u8>)
+	2: CopyLoc[1](i: u64)
+	3: CopyLoc[0](flips: &vector<u8>)
 	4: VecLen(2)
 	5: Lt
 	6: BrFalse(22)
 B2:
-	7: CopyLoc[0](Arg0: &vector<u8>)
-	8: CopyLoc[1](loc0: u64)
+	7: CopyLoc[0](flips: &vector<u8>)
+	8: CopyLoc[1](i: u64)
 	9: VecImmBorrow(2)
 	10: ReadRef
 	11: LdU8(0)
 	12: Neq
 	13: BrFalse(17)
 B3:
-	14: MoveLoc[0](Arg0: &vector<u8>)
+	14: MoveLoc[0](flips: &vector<u8>)
 	15: Pop
 	16: Branch(26)
 B4:
-	17: MoveLoc[1](loc0: u64)
+	17: MoveLoc[1](i: u64)
 	18: LdU64(1)
 	19: Add
-	20: StLoc[1](loc0: u64)
+	20: StLoc[1](i: u64)
 	21: Branch(25)
 B5:
-	22: MoveLoc[0](Arg0: &vector<u8>)
+	22: MoveLoc[0](flips: &vector<u8>)
 	23: Pop
 	24: Branch(26)
 B6:

--- a/third_party/move/move-compiler-v2/tests/control-flow-simplification/bug-10253.on.exp
+++ b/third_party/move/move-compiler-v2/tests/control-flow-simplification/bug-10253.on.exp
@@ -244,60 +244,60 @@ fun vectors::test_guess_without_break() {
 module cafe.vectors {
 
 
-entry public guess_flips(Arg0: vector<u8>) /* def_idx: 0 */ {
-L1:	loc0: &vector<u8>
-L2:	loc1: u64
+entry public guess_flips(flips: vector<u8>) /* def_idx: 0 */ {
+L1:	$t2: &vector<u8>
+L2:	i: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<u8>)
-	1: StLoc[1](loc0: &vector<u8>)
+	0: ImmBorrowLoc[0](flips: vector<u8>)
+	1: StLoc[1]($t2: &vector<u8>)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](i: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
-	5: CopyLoc[1](loc0: &vector<u8>)
+	4: CopyLoc[2](i: u64)
+	5: CopyLoc[1]($t2: &vector<u8>)
 	6: VecLen(2)
 	7: Lt
 	8: BrFalse(24)
 B2:
-	9: CopyLoc[1](loc0: &vector<u8>)
-	10: CopyLoc[2](loc1: u64)
+	9: CopyLoc[1]($t2: &vector<u8>)
+	10: CopyLoc[2](i: u64)
 	11: VecImmBorrow(2)
 	12: ReadRef
 	13: LdU8(0)
 	14: Neq
 	15: BrFalse(19)
 B3:
-	16: MoveLoc[1](loc0: &vector<u8>)
+	16: MoveLoc[1]($t2: &vector<u8>)
 	17: Pop
 B4:
 	18: Ret
 B5:
-	19: MoveLoc[2](loc1: u64)
+	19: MoveLoc[2](i: u64)
 	20: LdU64(1)
 	21: Add
-	22: StLoc[2](loc1: u64)
+	22: StLoc[2](i: u64)
 	23: Branch(4)
 B6:
-	24: MoveLoc[1](loc0: &vector<u8>)
+	24: MoveLoc[1]($t2: &vector<u8>)
 	25: Pop
 	26: Branch(18)
 }
-entry public guess_flips_directly(Arg0: vector<u8>) /* def_idx: 1 */ {
-L1:	loc0: u64
+entry public guess_flips_directly(flips: vector<u8>) /* def_idx: 1 */ {
+L1:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](i: u64)
 B1:
-	2: CopyLoc[1](loc0: u64)
-	3: ImmBorrowLoc[0](Arg0: vector<u8>)
+	2: CopyLoc[1](i: u64)
+	3: ImmBorrowLoc[0](flips: vector<u8>)
 	4: VecLen(2)
 	5: Lt
 	6: BrTrue(8)
 B2:
 	7: Branch(16)
 B3:
-	8: ImmBorrowLoc[0](Arg0: vector<u8>)
-	9: CopyLoc[1](loc0: u64)
+	8: ImmBorrowLoc[0](flips: vector<u8>)
+	9: CopyLoc[1](i: u64)
 	10: VecImmBorrow(2)
 	11: ReadRef
 	12: LdU8(0)
@@ -308,88 +308,88 @@ B4:
 B5:
 	16: Ret
 B6:
-	17: MoveLoc[1](loc0: u64)
+	17: MoveLoc[1](i: u64)
 	18: LdU64(1)
 	19: Add
-	20: StLoc[1](loc0: u64)
+	20: StLoc[1](i: u64)
 	21: Branch(2)
 }
-entry public guess_with_break_without_inline(Arg0: vector<u8>) /* def_idx: 2 */ {
+entry public guess_with_break_without_inline(flips: vector<u8>) /* def_idx: 2 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<u8>)
+	0: ImmBorrowLoc[0](flips: vector<u8>)
 	1: Call loops_with_break_no_inline(&vector<u8>)
 	2: Ret
 }
-entry public guess_without_break_with_inline(Arg0: vector<u8>) /* def_idx: 3 */ {
-L1:	loc0: &vector<u8>
-L2:	loc1: u64
+entry public guess_without_break_with_inline(flips: vector<u8>) /* def_idx: 3 */ {
+L1:	$t2: &vector<u8>
+L2:	i: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<u8>)
-	1: StLoc[1](loc0: &vector<u8>)
+	0: ImmBorrowLoc[0](flips: vector<u8>)
+	1: StLoc[1]($t2: &vector<u8>)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](i: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
-	5: CopyLoc[1](loc0: &vector<u8>)
+	4: CopyLoc[2](i: u64)
+	5: CopyLoc[1]($t2: &vector<u8>)
 	6: VecLen(2)
 	7: Lt
 	8: BrFalse(25)
 B2:
-	9: CopyLoc[1](loc0: &vector<u8>)
-	10: CopyLoc[2](loc1: u64)
+	9: CopyLoc[1]($t2: &vector<u8>)
+	10: CopyLoc[2](i: u64)
 	11: VecImmBorrow(2)
 	12: ReadRef
 	13: LdU8(0)
 	14: Eq
 	15: BrFalse(21)
 B3:
-	16: MoveLoc[2](loc1: u64)
+	16: MoveLoc[2](i: u64)
 	17: LdU64(1)
 	18: Add
-	19: StLoc[2](loc1: u64)
+	19: StLoc[2](i: u64)
 	20: Branch(4)
 B4:
-	21: MoveLoc[1](loc0: &vector<u8>)
+	21: MoveLoc[1]($t2: &vector<u8>)
 	22: Pop
 	23: LdU64(3)
 	24: Abort
 B5:
-	25: MoveLoc[1](loc0: &vector<u8>)
+	25: MoveLoc[1]($t2: &vector<u8>)
 	26: Pop
 	27: Ret
 }
-loops_with_break_no_inline(Arg0: &vector<u8>) /* def_idx: 4 */ {
-L1:	loc0: u64
+loops_with_break_no_inline(flips: &vector<u8>) /* def_idx: 4 */ {
+L1:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](i: u64)
 B1:
-	2: CopyLoc[1](loc0: u64)
-	3: CopyLoc[0](Arg0: &vector<u8>)
+	2: CopyLoc[1](i: u64)
+	3: CopyLoc[0](flips: &vector<u8>)
 	4: VecLen(2)
 	5: Lt
 	6: BrFalse(22)
 B2:
-	7: CopyLoc[0](Arg0: &vector<u8>)
-	8: CopyLoc[1](loc0: u64)
+	7: CopyLoc[0](flips: &vector<u8>)
+	8: CopyLoc[1](i: u64)
 	9: VecImmBorrow(2)
 	10: ReadRef
 	11: LdU8(0)
 	12: Neq
 	13: BrFalse(17)
 B3:
-	14: MoveLoc[0](Arg0: &vector<u8>)
+	14: MoveLoc[0](flips: &vector<u8>)
 	15: Pop
 B4:
 	16: Ret
 B5:
-	17: MoveLoc[1](loc0: u64)
+	17: MoveLoc[1](i: u64)
 	18: LdU64(1)
 	19: Add
-	20: StLoc[1](loc0: u64)
+	20: StLoc[1](i: u64)
 	21: Branch(2)
 B6:
-	22: MoveLoc[0](Arg0: &vector<u8>)
+	22: MoveLoc[0](flips: &vector<u8>)
 	23: Pop
 	24: Branch(16)
 }

--- a/third_party/move/move-compiler-v2/tests/control-flow-simplification/jump-label.off.exp
+++ b/third_party/move/move-compiler-v2/tests/control-flow-simplification/jump-label.off.exp
@@ -7,58 +7,58 @@ use 0000000000000000000000000000000000000000000000000000000000000001::string;
 
 
 
-test<Ty0>(Arg0: vector<u8>): Ty0 /* def_idx: 0 */ {
-L1:	loc0: String
+test<T>(x: vector<u8>): T /* def_idx: 0 */ {
+L1:	y: String
 B0:
-	0: Call foo<Ty0>(): String
-	1: StLoc[1](loc0: String)
-	2: CopyLoc[1](loc0: String)
+	0: Call foo<T>(): String
+	1: StLoc[1](y: String)
+	2: CopyLoc[1](y: String)
 	3: LdConst[0](Vector(U8): [4, 98, 111, 111, 108])
 	4: Call string::utf8(vector<u8>): String
 	5: Eq
 	6: BrFalse(11)
 B1:
-	7: MoveLoc[0](Arg0: vector<u8>)
+	7: MoveLoc[0](x: vector<u8>)
 	8: Call baz<bool>(vector<u8>): bool
-	9: Call bar<Ty0>(bool): Ty0
+	9: Call bar<T>(bool): T
 	10: Ret
 B2:
-	11: CopyLoc[1](loc0: String)
+	11: CopyLoc[1](y: String)
 	12: LdConst[1](Vector(U8): [2, 117, 56])
 	13: Call string::utf8(vector<u8>): String
 	14: Eq
 	15: BrFalse(20)
 B3:
-	16: MoveLoc[0](Arg0: vector<u8>)
+	16: MoveLoc[0](x: vector<u8>)
 	17: Call baz<bool>(vector<u8>): bool
-	18: Call bar<Ty0>(bool): Ty0
+	18: Call bar<T>(bool): T
 	19: Ret
 B4:
-	20: MoveLoc[1](loc0: String)
+	20: MoveLoc[1](y: String)
 	21: LdConst[2](Vector(U8): [3, 117, 54, 52])
 	22: Call string::utf8(vector<u8>): String
 	23: Eq
 	24: BrFalse(29)
 B5:
-	25: MoveLoc[0](Arg0: vector<u8>)
+	25: MoveLoc[0](x: vector<u8>)
 	26: Call baz<bool>(vector<u8>): bool
-	27: Call bar<Ty0>(bool): Ty0
+	27: Call bar<T>(bool): T
 	28: Ret
 B6:
 	29: LdU64(0)
 	30: Abort
 }
-bar<Ty0>(Arg0: bool): Ty0 /* def_idx: 1 */ {
+bar<T>(_x: bool): T /* def_idx: 1 */ {
 B0:
 	0: LdU64(0)
 	1: Abort
 }
-baz<Ty0>(Arg0: vector<u8>): Ty0 /* def_idx: 2 */ {
+baz<T>(_x: vector<u8>): T /* def_idx: 2 */ {
 B0:
 	0: LdU64(0)
 	1: Abort
 }
-foo<Ty0>(): String /* def_idx: 3 */ {
+foo<T>(): String /* def_idx: 3 */ {
 B0:
 	0: LdU64(0)
 	1: Abort

--- a/third_party/move/move-compiler-v2/tests/control-flow-simplification/jump-label.on.exp
+++ b/third_party/move/move-compiler-v2/tests/control-flow-simplification/jump-label.on.exp
@@ -91,58 +91,58 @@ use 0000000000000000000000000000000000000000000000000000000000000001::string;
 
 
 
-test<Ty0>(Arg0: vector<u8>): Ty0 /* def_idx: 0 */ {
-L1:	loc0: String
+test<T>(x: vector<u8>): T /* def_idx: 0 */ {
+L1:	y: String
 B0:
-	0: Call foo<Ty0>(): String
-	1: StLoc[1](loc0: String)
-	2: CopyLoc[1](loc0: String)
+	0: Call foo<T>(): String
+	1: StLoc[1](y: String)
+	2: CopyLoc[1](y: String)
 	3: LdConst[0](Vector(U8): [4, 98, 111, 111, 108])
 	4: Call string::utf8(vector<u8>): String
 	5: Eq
 	6: BrFalse(11)
 B1:
-	7: MoveLoc[0](Arg0: vector<u8>)
+	7: MoveLoc[0](x: vector<u8>)
 	8: Call baz<bool>(vector<u8>): bool
-	9: Call bar<Ty0>(bool): Ty0
+	9: Call bar<T>(bool): T
 	10: Ret
 B2:
-	11: CopyLoc[1](loc0: String)
+	11: CopyLoc[1](y: String)
 	12: LdConst[1](Vector(U8): [2, 117, 56])
 	13: Call string::utf8(vector<u8>): String
 	14: Eq
 	15: BrFalse(20)
 B3:
-	16: MoveLoc[0](Arg0: vector<u8>)
+	16: MoveLoc[0](x: vector<u8>)
 	17: Call baz<bool>(vector<u8>): bool
-	18: Call bar<Ty0>(bool): Ty0
+	18: Call bar<T>(bool): T
 	19: Ret
 B4:
-	20: MoveLoc[1](loc0: String)
+	20: MoveLoc[1](y: String)
 	21: LdConst[2](Vector(U8): [3, 117, 54, 52])
 	22: Call string::utf8(vector<u8>): String
 	23: Eq
 	24: BrFalse(29)
 B5:
-	25: MoveLoc[0](Arg0: vector<u8>)
+	25: MoveLoc[0](x: vector<u8>)
 	26: Call baz<bool>(vector<u8>): bool
-	27: Call bar<Ty0>(bool): Ty0
+	27: Call bar<T>(bool): T
 	28: Ret
 B6:
 	29: LdU64(0)
 	30: Abort
 }
-bar<Ty0>(Arg0: bool): Ty0 /* def_idx: 1 */ {
+bar<T>(_x: bool): T /* def_idx: 1 */ {
 B0:
 	0: LdU64(0)
 	1: Abort
 }
-baz<Ty0>(Arg0: vector<u8>): Ty0 /* def_idx: 2 */ {
+baz<T>(_x: vector<u8>): T /* def_idx: 2 */ {
 B0:
 	0: LdU64(0)
 	1: Abort
 }
-foo<Ty0>(): String /* def_idx: 3 */ {
+foo<T>(): String /* def_idx: 3 */ {
 B0:
 	0: LdU64(0)
 	1: Abort

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/eager_load_03.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/eager_load_03.exp
@@ -86,25 +86,25 @@ fun m::one(): u64 {
 module c0ffee.m {
 
 
-bar(Arg0: &mut u64) /* def_idx: 0 */ {
+bar(_x: &mut u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[0](_x: &mut u64)
 	1: Pop
 	2: Ret
 }
-baz(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+baz(_x: u64, _y: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public foo(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
+public foo(x: u64) /* def_idx: 2 */ {
+L1:	t: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[0](Arg0: u64)
+	1: StLoc[1](t: u64)
+	2: MutBorrowLoc[0](x: u64)
 	3: Call bar(&mut u64)
-	4: MoveLoc[0](Arg0: u64)
-	5: MoveLoc[1](loc0: u64)
+	4: MoveLoc[0](x: u64)
+	5: MoveLoc[1](t: u64)
 	6: Call baz(u64, u64)
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_01.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_01.exp
@@ -120,15 +120,15 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
+public test(p: u64) /* def_idx: 2 */ {
+L1:	e: u64
 B0:
 	0: Call two(): u64
-	1: StLoc[1](loc0: u64)
-	2: MoveLoc[0](Arg0: u64)
+	1: StLoc[1](e: u64)
+	2: MoveLoc[0](p: u64)
 	3: Call one(): u64
 	4: Sub
-	5: MoveLoc[1](loc0: u64)
+	5: MoveLoc[1](e: u64)
 	6: Gt
 	7: BrTrue(9)
 B1:

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_02.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_02.exp
@@ -58,15 +58,15 @@ struct Wrap {
 	e: u64
 }
 
-public make(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: &S, Arg4: u64): Wrap /* def_idx: 0 */ {
+public make(a: u64, b: u64, c: u64, d: &S, e: u64): Wrap /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
-	2: MoveLoc[2](Arg2: u64)
-	3: MoveLoc[3](Arg3: &S)
+	0: MoveLoc[0](a: u64)
+	1: MoveLoc[1](b: u64)
+	2: MoveLoc[2](c: u64)
+	3: MoveLoc[3](d: &S)
 	4: ImmBorrowField[0](S.x: u64)
 	5: ReadRef
-	6: MoveLoc[4](Arg4: u64)
+	6: MoveLoc[4](e: u64)
 	7: Pack[1](Wrap)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_03.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_03.exp
@@ -80,20 +80,20 @@ struct Wrap {
 	f: u64
 }
 
-public make(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: address, Arg4: u64): Wrap /* def_idx: 0 */ {
-L5:	loc0: &S
+public make(a: u64, b: u64, c: u64, d: address, e: u64): Wrap /* def_idx: 0 */ {
+L5:	ref: &S
 B0:
-	0: MoveLoc[3](Arg3: address)
+	0: MoveLoc[3](d: address)
 	1: ImmBorrowGlobal[0](S)
-	2: StLoc[5](loc0: &S)
-	3: MoveLoc[0](Arg0: u64)
-	4: MoveLoc[1](Arg1: u64)
-	5: MoveLoc[2](Arg2: u64)
-	6: CopyLoc[5](loc0: &S)
+	2: StLoc[5](ref: &S)
+	3: MoveLoc[0](a: u64)
+	4: MoveLoc[1](b: u64)
+	5: MoveLoc[2](c: u64)
+	6: CopyLoc[5](ref: &S)
 	7: ImmBorrowField[0](S.x: u64)
 	8: ReadRef
-	9: MoveLoc[4](Arg4: u64)
-	10: MoveLoc[5](loc0: &S)
+	9: MoveLoc[4](e: u64)
+	10: MoveLoc[5](ref: &S)
 	11: ImmBorrowField[1](S.y: u64)
 	12: ReadRef
 	13: Pack[1](Wrap)

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_04.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_04.exp
@@ -107,22 +107,22 @@ struct Wrap has drop, key {
 	d: u64
 }
 
-bar(Arg0: &signer, Arg1: &mut u64, Arg2: Wrap) /* def_idx: 0 */ {
+bar(_x: &signer, _y: &mut u64, _w: Wrap) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &signer)
+	0: MoveLoc[0](_x: &signer)
 	1: Pop
-	2: MoveLoc[1](Arg1: &mut u64)
+	2: MoveLoc[1](_y: &mut u64)
 	3: Pop
 	4: Ret
 }
-public test(Arg0: signer, Arg1: address) /* def_idx: 1 */ {
-L2:	loc0: &mut Wrap
+public test(x: signer, a: address) /* def_idx: 1 */ {
+L2:	ref: &mut Wrap
 B0:
-	0: MoveLoc[1](Arg1: address)
+	0: MoveLoc[1](a: address)
 	1: MutBorrowGlobal[0](Wrap)
-	2: StLoc[2](loc0: &mut Wrap)
-	3: ImmBorrowLoc[0](Arg0: signer)
-	4: MoveLoc[2](loc0: &mut Wrap)
+	2: StLoc[2](ref: &mut Wrap)
+	3: ImmBorrowLoc[0](x: signer)
+	4: MoveLoc[2](ref: &mut Wrap)
 	5: MutBorrowField[0](Wrap.a: u64)
 	6: LdU64(0)
 	7: LdU64(0)
@@ -133,7 +133,7 @@ B0:
 	12: Call bar(&signer, &mut u64, Wrap)
 	13: Ret
 }
-zero(Arg0: u64): u64 /* def_idx: 2 */ {
+zero(_y: u64): u64 /* def_idx: 2 */ {
 B0:
 	0: LdU64(0)
 	1: Ret

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_05.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_05.exp
@@ -75,19 +75,19 @@ struct S has drop {
 	b: u64
 }
 
-foo(Arg0: &signer, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+foo(_x: &signer, _y: u64, _z: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &signer)
+	0: MoveLoc[0](_x: &signer)
 	1: Pop
 	2: Ret
 }
-public test(Arg0: &signer, Arg1: S) /* def_idx: 1 */ {
+public test(x: &signer, y: S) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &signer)
-	1: ImmBorrowLoc[1](Arg1: S)
+	0: MoveLoc[0](x: &signer)
+	1: ImmBorrowLoc[1](y: S)
 	2: ImmBorrowField[0](S.a: u64)
 	3: ReadRef
-	4: ImmBorrowLoc[1](Arg1: S)
+	4: ImmBorrowLoc[1](y: S)
 	5: ImmBorrowField[1](S.b: u64)
 	6: ReadRef
 	7: Call foo(&signer, u64, u64)

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_06.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_06.exp
@@ -164,61 +164,61 @@ struct S {
 	x: u64
 }
 
-bar(Arg0: &mut S, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: &mut u64
+bar(r: &mut S, i: u64): u64 /* def_idx: 0 */ {
+L2:	$t3: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](r: &mut S)
 	1: MutBorrowField[0](S.x: u64)
-	2: StLoc[2](loc0: &mut u64)
-	3: CopyLoc[1](Arg1: u64)
-	4: MoveLoc[2](loc0: &mut u64)
+	2: StLoc[2]($t3: &mut u64)
+	3: CopyLoc[1](i: u64)
+	4: MoveLoc[2]($t3: &mut u64)
 	5: WriteRef
-	6: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[1](i: u64)
 	7: Ret
 }
-destroy(Arg0: S) /* def_idx: 1 */ {
+destroy(s: S) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: S)
+	0: MoveLoc[0](s: S)
 	1: Unpack[0](S)
 	2: Pop
 	3: Ret
 }
-foo(Arg0: &mut S, Arg1: u64) /* def_idx: 2 */ {
-L2:	loc0: &mut u64
+foo(l: &mut S, i: u64) /* def_idx: 2 */ {
+L2:	$t2: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](l: &mut S)
 	1: MutBorrowField[0](S.x: u64)
-	2: StLoc[2](loc0: &mut u64)
-	3: MoveLoc[1](Arg1: u64)
-	4: MoveLoc[2](loc0: &mut u64)
+	2: StLoc[2]($t2: &mut u64)
+	3: MoveLoc[1](i: u64)
+	4: MoveLoc[2]($t2: &mut u64)
 	5: WriteRef
 	6: Ret
 }
-public test(Arg0: &mut S, Arg1: S) /* def_idx: 3 */ {
-L2:	loc0: u64
+public test(l: &mut S, r: S) /* def_idx: 3 */ {
+L2:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[2](loc0: u64)
+	1: StLoc[2](i: u64)
 B1:
-	2: CopyLoc[2](loc0: u64)
+	2: CopyLoc[2](i: u64)
 	3: LdU64(42)
 	4: Lt
 	5: BrFalse(16)
 B2:
-	6: CopyLoc[0](Arg0: &mut S)
-	7: MutBorrowLoc[1](Arg1: S)
-	8: CopyLoc[2](loc0: u64)
+	6: CopyLoc[0](l: &mut S)
+	7: MutBorrowLoc[1](r: S)
+	8: CopyLoc[2](i: u64)
 	9: Call bar(&mut S, u64): u64
 	10: Call foo(&mut S, u64)
-	11: MoveLoc[2](loc0: u64)
+	11: MoveLoc[2](i: u64)
 	12: LdU64(1)
 	13: Add
-	14: StLoc[2](loc0: u64)
+	14: StLoc[2](i: u64)
 	15: Branch(2)
 B3:
-	16: MoveLoc[0](Arg0: &mut S)
+	16: MoveLoc[0](l: &mut S)
 	17: Pop
-	18: MoveLoc[1](Arg1: S)
+	18: MoveLoc[1](r: S)
 	19: Call destroy(S)
 	20: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_07.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_07.exp
@@ -110,33 +110,33 @@ struct S {
 	y: u64
 }
 
-bar(Arg0: &mut u64, Arg1: u64) /* def_idx: 0 */ {
+bar(r: &mut u64, i: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[1](i: u64)
+	1: MoveLoc[0](r: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-foo(Arg0: &mut u64, Arg1: u64): &mut u64 /* def_idx: 1 */ {
+foo(l: &mut u64, i: u64): &mut u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: CopyLoc[0](Arg0: &mut u64)
+	0: MoveLoc[1](i: u64)
+	1: CopyLoc[0](l: &mut u64)
 	2: WriteRef
-	3: MoveLoc[0](Arg0: &mut u64)
+	3: MoveLoc[0](l: &mut u64)
 	4: Ret
 }
-public test(Arg0: &mut S, Arg1: u64) /* def_idx: 2 */ {
+public test(s: &mut S, i: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut S)
+	0: CopyLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.x: u64)
-	2: CopyLoc[1](Arg1: u64)
-	3: CopyLoc[0](Arg0: &mut S)
+	2: CopyLoc[1](i: u64)
+	3: CopyLoc[0](s: &mut S)
 	4: ImmBorrowField[1](S.y: u64)
 	5: ReadRef
 	6: Div
 	7: Call foo(&mut u64, u64): &mut u64
-	8: MoveLoc[1](Arg1: u64)
-	9: MoveLoc[0](Arg0: &mut S)
+	8: MoveLoc[1](i: u64)
+	9: MoveLoc[0](s: &mut S)
 	10: ImmBorrowField[1](S.y: u64)
 	11: ReadRef
 	12: Div

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_08.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_08.exp
@@ -106,29 +106,29 @@ struct S {
 	y: u64
 }
 
-bar(Arg0: &u64, Arg1: u64) /* def_idx: 0 */ {
+bar(_r: &u64, _i: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &u64)
+	0: MoveLoc[0](_r: &u64)
 	1: Pop
 	2: Ret
 }
-foo(Arg0: &u64, Arg1: u64): &u64 /* def_idx: 1 */ {
+foo(l: &u64, _i: u64): &u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &u64)
+	0: MoveLoc[0](l: &u64)
 	1: Ret
 }
-public test(Arg0: &S, Arg1: u64) /* def_idx: 2 */ {
+public test(s: &S, i: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](s: &S)
 	1: ImmBorrowField[0](S.x: u64)
-	2: CopyLoc[1](Arg1: u64)
-	3: CopyLoc[0](Arg0: &S)
+	2: CopyLoc[1](i: u64)
+	3: CopyLoc[0](s: &S)
 	4: ImmBorrowField[1](S.y: u64)
 	5: ReadRef
 	6: Div
 	7: Call foo(&u64, u64): &u64
-	8: MoveLoc[1](Arg1: u64)
-	9: MoveLoc[0](Arg0: &S)
+	8: MoveLoc[1](i: u64)
+	9: MoveLoc[0](s: &S)
 	10: ImmBorrowField[1](S.y: u64)
 	11: ReadRef
 	12: Div

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_09.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_09.exp
@@ -150,55 +150,55 @@ struct S {
 	y: u64
 }
 
-bar(Arg0: &mut u64, Arg1: u64): &mut u64 /* def_idx: 0 */ {
+bar(r: &mut u64, i: u64): &mut u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: CopyLoc[0](Arg0: &mut u64)
+	0: MoveLoc[1](i: u64)
+	1: CopyLoc[0](r: &mut u64)
 	2: WriteRef
-	3: MoveLoc[0](Arg0: &mut u64)
+	3: MoveLoc[0](r: &mut u64)
 	4: Ret
 }
-baz(Arg0: &mut u64, Arg1: u64) /* def_idx: 1 */ {
+baz(r: &mut u64, i: u64) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[1](i: u64)
+	1: MoveLoc[0](r: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-foo(Arg0: &u64): u64 /* def_idx: 2 */ {
+foo(l: &u64): u64 /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &u64)
+	0: MoveLoc[0](l: &u64)
 	1: ReadRef
 	2: Ret
 }
-public test(Arg0: &mut S, Arg1: u64) /* def_idx: 3 */ {
-L2:	loc0: u64
+public test(s: &mut S, v: u64) /* def_idx: 3 */ {
+L2:	n: u64
 B0:
-	0: CopyLoc[0](Arg0: &mut S)
+	0: CopyLoc[0](s: &mut S)
 	1: ImmBorrowField[0](S.x: u64)
 	2: Call foo(&u64): u64
-	3: StLoc[2](loc0: u64)
-	4: CopyLoc[0](Arg0: &mut S)
+	3: StLoc[2](n: u64)
+	4: CopyLoc[0](s: &mut S)
 	5: ImmBorrowField[0](S.x: u64)
 	6: ReadRef
-	7: CopyLoc[2](loc0: u64)
-	8: CopyLoc[0](Arg0: &mut S)
+	7: CopyLoc[2](n: u64)
+	8: CopyLoc[0](s: &mut S)
 	9: ImmBorrowField[1](S.y: u64)
 	10: ReadRef
 	11: Mul
 	12: Eq
 	13: BrFalse(21)
 B1:
-	14: MoveLoc[0](Arg0: &mut S)
+	14: MoveLoc[0](s: &mut S)
 	15: MutBorrowField[0](S.x: u64)
-	16: MoveLoc[2](loc0: u64)
+	16: MoveLoc[2](n: u64)
 	17: Call bar(&mut u64, u64): &mut u64
-	18: MoveLoc[1](Arg1: u64)
+	18: MoveLoc[1](v: u64)
 	19: Call baz(&mut u64, u64)
 B2:
 	20: Ret
 B3:
-	21: MoveLoc[0](Arg0: &mut S)
+	21: MoveLoc[0](s: &mut S)
 	22: Pop
 	23: Branch(20)
 }

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_10.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/framework_reduced_10.exp
@@ -159,51 +159,51 @@ struct S {
 	z: u64
 }
 
-bar(Arg0: &mut u64, Arg1: u64) /* def_idx: 0 */ {
+bar(r: &mut u64, i: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[1](i: u64)
+	1: MoveLoc[0](r: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-foo(Arg0: &u64): u64 /* def_idx: 1 */ {
+foo(l: &u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &u64)
+	0: MoveLoc[0](l: &u64)
 	1: ReadRef
 	2: Ret
 }
-public test(Arg0: &mut S, Arg1: u64) /* def_idx: 2 */ {
-L2:	loc0: u64
+public test(s: &mut S, i: u64) /* def_idx: 2 */ {
+L2:	$t4: u64
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: CopyLoc[0](Arg0: &mut S)
+	0: MoveLoc[1](i: u64)
+	1: CopyLoc[0](s: &mut S)
 	2: ImmBorrowField[0](S.x: u64)
 	3: ReadRef
 	4: Div
-	5: StLoc[1](Arg1: u64)
-	6: CopyLoc[0](Arg0: &mut S)
+	5: StLoc[1](i: u64)
+	6: CopyLoc[0](s: &mut S)
 	7: ImmBorrowField[1](S.y: u64)
 	8: Call foo(&u64): u64
-	9: StLoc[2](loc0: u64)
+	9: StLoc[2]($t4: u64)
 B1:
-	10: CopyLoc[1](Arg1: u64)
-	11: CopyLoc[2](loc0: u64)
+	10: CopyLoc[1](i: u64)
+	11: CopyLoc[2]($t4: u64)
 	12: Lt
 	13: BrFalse(25)
 B2:
-	14: CopyLoc[0](Arg0: &mut S)
+	14: CopyLoc[0](s: &mut S)
 	15: MutBorrowField[2](S.z: u64)
-	16: CopyLoc[1](Arg1: u64)
+	16: CopyLoc[1](i: u64)
 	17: LdU64(1)
 	18: Sub
 	19: Call bar(&mut u64, u64)
-	20: MoveLoc[1](Arg1: u64)
+	20: MoveLoc[1](i: u64)
 	21: LdU64(1)
 	22: Add
-	23: StLoc[1](Arg1: u64)
+	23: StLoc[1](i: u64)
 	24: Branch(10)
 B3:
-	25: MoveLoc[0](Arg0: &mut S)
+	25: MoveLoc[0](s: &mut S)
 	26: Pop
 	27: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/move_stdlib_reduced.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/move_stdlib_reduced.exp
@@ -120,30 +120,30 @@ fun m::one(): u64 {
 module c0ffee.m {
 
 
-bar(Arg0: &mut u64, Arg1: u64) /* def_idx: 0 */ {
+bar(x: &mut u64, i: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[1](Arg1: u64)
-	1: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[1](i: u64)
+	1: MoveLoc[0](x: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-public foo(Arg0: &mut u64, Arg1: u64) /* def_idx: 1 */ {
+public foo(x: &mut u64, len: u64) /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[1](len: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(12)
 B1:
-	4: CopyLoc[0](Arg0: &mut u64)
+	4: CopyLoc[0](x: &mut u64)
 	5: Call one(): u64
 	6: Call bar(&mut u64, u64)
-	7: MoveLoc[1](Arg1: u64)
+	7: MoveLoc[1](len: u64)
 	8: LdU64(1)
 	9: Sub
-	10: StLoc[1](Arg1: u64)
+	10: StLoc[1](len: u64)
 	11: Branch(0)
 B2:
-	12: MoveLoc[0](Arg0: &mut u64)
+	12: MoveLoc[0](x: &mut u64)
 	13: Pop
 	14: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/eager-pushes/txn_reduced_01.exp
+++ b/third_party/move/move-compiler-v2/tests/eager-pushes/txn_reduced_01.exp
@@ -136,50 +136,50 @@ public fun m::test($t0: &signer, $t1: vector<address>, $t2: vector<u64>) {
 module c0ffee.m {
 
 
-call_other(Arg0: &signer, Arg1: address, Arg2: u64) /* def_idx: 0 */ {
+call_other(_from: &signer, _to: address, _amount: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &signer)
+	0: MoveLoc[0](_from: &signer)
 	1: Pop
 	2: Ret
 }
-public test(Arg0: &signer, Arg1: vector<address>, Arg2: vector<u64>) /* def_idx: 1 */ {
-L3:	loc0: u64
-L4:	loc1: u64
-L5:	loc2: &address
-L6:	loc3: &u64
+public test(from: &signer, to_vec: vector<address>, amount_vec: vector<u64>) /* def_idx: 1 */ {
+L3:	len: u64
+L4:	i: u64
+L5:	to: &address
+L6:	amount: &u64
 B0:
-	0: ImmBorrowLoc[1](Arg1: vector<address>)
+	0: ImmBorrowLoc[1](to_vec: vector<address>)
 	1: VecLen(3)
-	2: StLoc[3](loc0: u64)
+	2: StLoc[3](len: u64)
 	3: LdU64(0)
-	4: StLoc[4](loc1: u64)
+	4: StLoc[4](i: u64)
 B1:
-	5: CopyLoc[4](loc1: u64)
-	6: CopyLoc[3](loc0: u64)
+	5: CopyLoc[4](i: u64)
+	6: CopyLoc[3](len: u64)
 	7: Lt
 	8: BrFalse(28)
 B2:
-	9: ImmBorrowLoc[1](Arg1: vector<address>)
-	10: CopyLoc[4](loc1: u64)
+	9: ImmBorrowLoc[1](to_vec: vector<address>)
+	10: CopyLoc[4](i: u64)
 	11: VecImmBorrow(3)
-	12: StLoc[5](loc2: &address)
-	13: ImmBorrowLoc[2](Arg2: vector<u64>)
-	14: CopyLoc[4](loc1: u64)
+	12: StLoc[5](to: &address)
+	13: ImmBorrowLoc[2](amount_vec: vector<u64>)
+	14: CopyLoc[4](i: u64)
 	15: VecImmBorrow(4)
-	16: StLoc[6](loc3: &u64)
-	17: CopyLoc[0](Arg0: &signer)
-	18: MoveLoc[5](loc2: &address)
+	16: StLoc[6](amount: &u64)
+	17: CopyLoc[0](from: &signer)
+	18: MoveLoc[5](to: &address)
 	19: ReadRef
-	20: MoveLoc[6](loc3: &u64)
+	20: MoveLoc[6](amount: &u64)
 	21: ReadRef
 	22: Call call_other(&signer, address, u64)
-	23: MoveLoc[4](loc1: u64)
+	23: MoveLoc[4](i: u64)
 	24: LdU64(1)
 	25: Add
-	26: StLoc[4](loc1: u64)
+	26: StLoc[4](i: u64)
 	27: Branch(5)
 B3:
-	28: MoveLoc[0](Arg0: &signer)
+	28: MoveLoc[0](from: &signer)
 	29: Pop
 	30: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.exp
@@ -10,43 +10,43 @@ struct S has drop {
 	g: T
 }
 
-assign_field(Arg0: &mut S, Arg1: u64) /* def_idx: 0 */ {
-L2:	loc0: &mut u64
+assign_field(s: &mut S, f: u64) /* def_idx: 0 */ {
+L2:	$t2: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[2](loc0: &mut u64)
-	3: MoveLoc[1](Arg1: u64)
-	4: MoveLoc[2](loc0: &mut u64)
+	2: StLoc[2]($t2: &mut u64)
+	3: MoveLoc[1](f: u64)
+	4: MoveLoc[2]($t2: &mut u64)
 	5: WriteRef
 	6: Ret
 }
-assign_int(Arg0: &mut u64) /* def_idx: 1 */ {
+assign_int(x: &mut u64) /* def_idx: 1 */ {
 B0:
 	0: LdU64(42)
-	1: MoveLoc[0](Arg0: &mut u64)
+	1: MoveLoc[0](x: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-assign_pattern(Arg0: S, Arg1: u64, Arg2: u64): u64 /* def_idx: 2 */ {
+assign_pattern(s: S, f: u64, h: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: S)
+	0: MoveLoc[0](s: S)
 	1: Unpack[1](S)
 	2: Unpack[0](T)
-	3: StLoc[2](Arg2: u64)
-	4: StLoc[1](Arg1: u64)
-	5: MoveLoc[1](Arg1: u64)
-	6: MoveLoc[2](Arg2: u64)
+	3: StLoc[2](h: u64)
+	4: StLoc[1](f: u64)
+	5: MoveLoc[1](f: u64)
+	6: MoveLoc[2](h: u64)
 	7: Add
 	8: Ret
 }
-assign_struct(Arg0: &mut S) /* def_idx: 3 */ {
+assign_struct(s: &mut S) /* def_idx: 3 */ {
 B0:
 	0: LdU64(42)
 	1: LdU64(42)
 	2: Pack[0](T)
 	3: Pack[1](S)
-	4: MoveLoc[0](Arg0: &mut S)
+	4: MoveLoc[0](s: &mut S)
 	5: WriteRef
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/assign.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/assign.opt.exp
@@ -10,39 +10,39 @@ struct S has drop {
 	g: T
 }
 
-assign_field(Arg0: &mut S, Arg1: u64) /* def_idx: 0 */ {
-L2:	loc0: &mut u64
+assign_field(s: &mut S, f: u64) /* def_idx: 0 */ {
+L2:	$t2: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[2](loc0: &mut u64)
-	3: MoveLoc[1](Arg1: u64)
-	4: MoveLoc[2](loc0: &mut u64)
+	2: StLoc[2]($t2: &mut u64)
+	3: MoveLoc[1](f: u64)
+	4: MoveLoc[2]($t2: &mut u64)
 	5: WriteRef
 	6: Ret
 }
-assign_int(Arg0: &mut u64) /* def_idx: 1 */ {
+assign_int(x: &mut u64) /* def_idx: 1 */ {
 B0:
 	0: LdU64(42)
-	1: MoveLoc[0](Arg0: &mut u64)
+	1: MoveLoc[0](x: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-assign_pattern(Arg0: S, Arg1: u64, Arg2: u64): u64 /* def_idx: 2 */ {
+assign_pattern(s: S, f: u64, h: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: S)
+	0: MoveLoc[0](s: S)
 	1: Unpack[1](S)
 	2: Unpack[0](T)
 	3: Add
 	4: Ret
 }
-assign_struct(Arg0: &mut S) /* def_idx: 3 */ {
+assign_struct(s: &mut S) /* def_idx: 3 */ {
 B0:
 	0: LdU64(42)
 	1: LdU64(42)
 	2: Pack[0](T)
 	3: Pack[1](S)
-	4: MoveLoc[0](Arg0: &mut S)
+	4: MoveLoc[0](s: &mut S)
 	5: WriteRef
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.exp
@@ -20,74 +20,74 @@ struct S {
 	f: u64
 }
 
-field(Arg0: &S): u64 /* def_idx: 0 */ {
+field(s: &S): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](s: &S)
 	1: ImmBorrowField[0](S.f: u64)
 	2: ReadRef
 	3: Ret
 }
-local(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
+local(param: u64): u64 /* def_idx: 1 */ {
+L1:	$t3: u64
 B0:
 	0: LdU64(33)
-	1: StLoc[1](loc0: u64)
-	2: ImmBorrowLoc[1](loc0: u64)
+	1: StLoc[1]($t3: u64)
+	2: ImmBorrowLoc[1]($t3: u64)
 	3: ReadRef
 	4: Ret
 }
-param(Arg0: u64): u64 /* def_idx: 2 */ {
+param(param: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
+	0: ImmBorrowLoc[0](param: u64)
 	1: ReadRef
 	2: Ret
 }
-mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+mut_field(s: &mut S): u64 /* def_idx: 3 */ {
+L1:	$t3: u64
+L2:	r: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
 	2: LdU64(22)
-	3: StLoc[1](loc0: u64)
-	4: StLoc[2](loc1: &mut u64)
-	5: MoveLoc[1](loc0: u64)
-	6: CopyLoc[2](loc1: &mut u64)
+	3: StLoc[1]($t3: u64)
+	4: StLoc[2](r: &mut u64)
+	5: MoveLoc[1]($t3: u64)
+	6: CopyLoc[2](r: &mut u64)
 	7: WriteRef
-	8: MoveLoc[2](loc1: &mut u64)
+	8: MoveLoc[2](r: &mut u64)
 	9: ReadRef
 	10: Ret
 }
-mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: &mut u64
+mut_local(param: u64): u64 /* def_idx: 4 */ {
+L1:	local: u64
+L2:	$t4: u64
+L3:	r: &mut u64
 B0:
 	0: LdU64(33)
-	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[1](loc0: u64)
+	1: StLoc[1](local: u64)
+	2: MutBorrowLoc[1](local: u64)
 	3: LdU64(22)
-	4: StLoc[2](loc1: u64)
-	5: StLoc[3](loc2: &mut u64)
-	6: MoveLoc[2](loc1: u64)
-	7: CopyLoc[3](loc2: &mut u64)
+	4: StLoc[2]($t4: u64)
+	5: StLoc[3](r: &mut u64)
+	6: MoveLoc[2]($t4: u64)
+	7: CopyLoc[3](r: &mut u64)
 	8: WriteRef
-	9: MoveLoc[3](loc2: &mut u64)
+	9: MoveLoc[3](r: &mut u64)
 	10: ReadRef
 	11: Ret
 }
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+mut_param(param: u64): u64 /* def_idx: 5 */ {
+L1:	$t3: u64
+L2:	r: &mut u64
 B0:
-	0: MutBorrowLoc[0](Arg0: u64)
+	0: MutBorrowLoc[0](param: u64)
 	1: LdU64(22)
-	2: StLoc[1](loc0: u64)
-	3: StLoc[2](loc1: &mut u64)
-	4: MoveLoc[1](loc0: u64)
-	5: CopyLoc[2](loc1: &mut u64)
+	2: StLoc[1]($t3: u64)
+	3: StLoc[2](r: &mut u64)
+	4: MoveLoc[1]($t3: u64)
+	5: CopyLoc[2](r: &mut u64)
 	6: WriteRef
-	7: MoveLoc[2](loc1: &mut u64)
+	7: MoveLoc[2](r: &mut u64)
 	8: ReadRef
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/borrow.opt.exp
@@ -20,65 +20,65 @@ struct S {
 	f: u64
 }
 
-field(Arg0: &S): u64 /* def_idx: 0 */ {
+field(s: &S): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](s: &S)
 	1: ImmBorrowField[0](S.f: u64)
 	2: ReadRef
 	3: Ret
 }
-local(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
+local(param: u64): u64 /* def_idx: 1 */ {
+L1:	$t3: u64
 B0:
 	0: LdU64(33)
-	1: StLoc[1](loc0: u64)
-	2: ImmBorrowLoc[1](loc0: u64)
+	1: StLoc[1]($t3: u64)
+	2: ImmBorrowLoc[1]($t3: u64)
 	3: ReadRef
 	4: Ret
 }
-param(Arg0: u64): u64 /* def_idx: 2 */ {
+param(param: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
+	0: ImmBorrowLoc[0](param: u64)
 	1: ReadRef
 	2: Ret
 }
-mut_field(Arg0: &mut S): u64 /* def_idx: 3 */ {
-L1:	loc0: &mut u64
+mut_field(s: &mut S): u64 /* def_idx: 3 */ {
+L1:	r: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: StLoc[1](loc0: &mut u64)
+	2: StLoc[1](r: &mut u64)
 	3: LdU64(22)
-	4: CopyLoc[1](loc0: &mut u64)
+	4: CopyLoc[1](r: &mut u64)
 	5: WriteRef
-	6: MoveLoc[1](loc0: &mut u64)
+	6: MoveLoc[1](r: &mut u64)
 	7: ReadRef
 	8: Ret
 }
-mut_local(Arg0: u64): u64 /* def_idx: 4 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+mut_local(param: u64): u64 /* def_idx: 4 */ {
+L1:	local: u64
+L2:	r: &mut u64
 B0:
 	0: LdU64(33)
-	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[1](loc0: u64)
-	3: StLoc[2](loc1: &mut u64)
+	1: StLoc[1](local: u64)
+	2: MutBorrowLoc[1](local: u64)
+	3: StLoc[2](r: &mut u64)
 	4: LdU64(22)
-	5: CopyLoc[2](loc1: &mut u64)
+	5: CopyLoc[2](r: &mut u64)
 	6: WriteRef
-	7: MoveLoc[2](loc1: &mut u64)
+	7: MoveLoc[2](r: &mut u64)
 	8: ReadRef
 	9: Ret
 }
-mut_param(Arg0: u64): u64 /* def_idx: 5 */ {
-L1:	loc0: &mut u64
+mut_param(param: u64): u64 /* def_idx: 5 */ {
+L1:	r: &mut u64
 B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: &mut u64)
+	0: MutBorrowLoc[0](param: u64)
+	1: StLoc[1](r: &mut u64)
 	2: LdU64(22)
-	3: CopyLoc[1](loc0: &mut u64)
+	3: CopyLoc[1](r: &mut u64)
 	4: WriteRef
-	5: MoveLoc[1](loc0: &mut u64)
+	5: MoveLoc[1](r: &mut u64)
 	6: ReadRef
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.exp
@@ -6,29 +6,29 @@ struct Struct0 has copy, drop {
 	x: bool
 }
 
-public function5(Arg0: bool, Arg1: bool) /* def_idx: 0 */ {
-L2:	loc0: &bool
-L3:	loc1: bool
-L4:	loc2: &bool
+public function5(var21: bool, var23: bool) /* def_idx: 0 */ {
+L2:	$t3: &bool
+L3:	$t5: bool
+L4:	$t4: &bool
 B0:
-	0: ImmBorrowLoc[0](Arg0: bool)
-	1: StLoc[2](loc0: &bool)
-	2: CopyLoc[0](Arg0: bool)
+	0: ImmBorrowLoc[0](var21: bool)
+	1: StLoc[2]($t3: &bool)
+	2: CopyLoc[0](var21: bool)
 	3: BrFalse(7)
 B1:
 	4: LdTrue
-	5: StLoc[3](loc1: bool)
+	5: StLoc[3]($t5: bool)
 	6: Branch(9)
 B2:
-	7: MoveLoc[1](Arg1: bool)
-	8: StLoc[3](loc1: bool)
+	7: MoveLoc[1](var23: bool)
+	8: StLoc[3]($t5: bool)
 B3:
-	9: ImmBorrowLoc[3](loc1: bool)
-	10: StLoc[4](loc2: &bool)
-	11: MoveLoc[2](loc0: &bool)
-	12: MoveLoc[4](loc2: &bool)
+	9: ImmBorrowLoc[3]($t5: bool)
+	10: StLoc[4]($t4: &bool)
+	11: MoveLoc[2]($t3: &bool)
+	12: MoveLoc[4]($t4: &bool)
 	13: Neq
-	14: MoveLoc[0](Arg0: bool)
+	14: MoveLoc[0](var21: bool)
 	15: Pack[0](Struct0)
 	16: Pop
 	17: Pop

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance.opt.exp
@@ -6,32 +6,32 @@ struct Struct0 has copy, drop {
 	x: bool
 }
 
-public function5(Arg0: bool, Arg1: bool) /* def_idx: 0 */ {
-L2:	loc0: &bool
-L3:	loc1: bool
-L4:	loc2: &bool
+public function5(var21: bool, var23: bool) /* def_idx: 0 */ {
+L2:	$t3: &bool
+L3:	$t5: bool
+L4:	$t4: &bool
 B0:
-	0: ImmBorrowLoc[0](Arg0: bool)
-	1: StLoc[2](loc0: &bool)
-	2: CopyLoc[0](Arg0: bool)
+	0: ImmBorrowLoc[0](var21: bool)
+	1: StLoc[2]($t3: &bool)
+	2: CopyLoc[0](var21: bool)
 	3: BrFalse(16)
 B1:
 	4: LdTrue
-	5: StLoc[3](loc1: bool)
+	5: StLoc[3]($t5: bool)
 B2:
-	6: ImmBorrowLoc[3](loc1: bool)
-	7: StLoc[4](loc2: &bool)
-	8: MoveLoc[2](loc0: &bool)
-	9: MoveLoc[4](loc2: &bool)
+	6: ImmBorrowLoc[3]($t5: bool)
+	7: StLoc[4]($t4: &bool)
+	8: MoveLoc[2]($t3: &bool)
+	9: MoveLoc[4]($t4: &bool)
 	10: Neq
 	11: Pop
-	12: MoveLoc[0](Arg0: bool)
+	12: MoveLoc[0](var21: bool)
 	13: Pack[0](Struct0)
 	14: Pop
 	15: Ret
 B3:
-	16: MoveLoc[1](Arg1: bool)
-	17: StLoc[3](loc1: bool)
+	16: MoveLoc[1](var23: bool)
+	17: StLoc[3]($t5: bool)
 	18: Branch(6)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance_regression.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance_regression.exp
@@ -16,75 +16,75 @@ enum Data has drop {
 }
 
 test_v1(): bool /* def_idx: 0 */ {
-L0:	loc0: Data
-L1:	loc1: bool
+L0:	d: Data
+L1:	return: bool
 B0:
 	0: LdU64(43)
 	1: PackVariant[0](Data/V1)
-	2: StLoc[0](loc0: Data)
-	3: ImmBorrowLoc[0](loc0: Data)
+	2: StLoc[0](d: Data)
+	3: ImmBorrowLoc[0](d: Data)
 	4: TestVariant[0](Data/V1)
-	5: StLoc[1](loc1: bool)
-	6: CopyLoc[1](loc1: bool)
+	5: StLoc[1](return: bool)
+	6: CopyLoc[1](return: bool)
 	7: BrFalse(9)
 B1:
 	8: Branch(9)
 B2:
-	9: MoveLoc[1](loc1: bool)
+	9: MoveLoc[1](return: bool)
 	10: Ret
 }
 test_v1v3(): bool /* def_idx: 1 */ {
-L0:	loc0: Data
-L1:	loc1: &Data
-L2:	loc2: bool
-L3:	loc3: Data
-L4:	loc4: &Data
-L5:	loc5: bool
+L0:	d: Data
+L1:	$t4: &Data
+L2:	t: bool
+L3:	d: Data
+L4:	$t6: &Data
+L5:	return: bool
 B0:
 	0: LdU64(43)
 	1: PackVariant[0](Data/V1)
-	2: StLoc[0](loc0: Data)
-	3: ImmBorrowLoc[0](loc0: Data)
-	4: StLoc[1](loc1: &Data)
-	5: CopyLoc[1](loc1: &Data)
+	2: StLoc[0](d: Data)
+	3: ImmBorrowLoc[0](d: Data)
+	4: StLoc[1]($t4: &Data)
+	5: CopyLoc[1]($t4: &Data)
 	6: TestVariant[0](Data/V1)
-	7: StLoc[2](loc2: bool)
-	8: CopyLoc[2](loc2: bool)
+	7: StLoc[2](t: bool)
+	8: CopyLoc[2](t: bool)
 	9: BrFalse(13)
 B1:
-	10: MoveLoc[1](loc1: &Data)
+	10: MoveLoc[1]($t4: &Data)
 	11: Pop
 	12: Branch(19)
 B2:
-	13: MoveLoc[1](loc1: &Data)
+	13: MoveLoc[1]($t4: &Data)
 	14: TestVariant[1](Data/V3)
-	15: StLoc[2](loc2: bool)
-	16: CopyLoc[2](loc2: bool)
+	15: StLoc[2](t: bool)
+	16: CopyLoc[2](t: bool)
 	17: BrFalse(19)
 B3:
 	18: Branch(19)
 B4:
 	19: PackVariant[1](Data/V3)
-	20: StLoc[3](loc3: Data)
-	21: MoveLoc[2](loc2: bool)
+	20: StLoc[3](d: Data)
+	21: MoveLoc[2](t: bool)
 	22: BrFalse(40)
 B5:
-	23: ImmBorrowLoc[3](loc3: Data)
-	24: StLoc[4](loc4: &Data)
-	25: CopyLoc[4](loc4: &Data)
+	23: ImmBorrowLoc[3](d: Data)
+	24: StLoc[4]($t6: &Data)
+	25: CopyLoc[4]($t6: &Data)
 	26: TestVariant[0](Data/V1)
-	27: StLoc[5](loc5: bool)
-	28: CopyLoc[5](loc5: bool)
+	27: StLoc[5](return: bool)
+	28: CopyLoc[5](return: bool)
 	29: BrFalse(33)
 B6:
-	30: MoveLoc[4](loc4: &Data)
+	30: MoveLoc[4]($t6: &Data)
 	31: Pop
 	32: Branch(39)
 B7:
-	33: MoveLoc[4](loc4: &Data)
+	33: MoveLoc[4]($t6: &Data)
 	34: TestVariant[1](Data/V3)
-	35: StLoc[5](loc5: bool)
-	36: CopyLoc[5](loc5: bool)
+	35: StLoc[5](return: bool)
+	36: CopyLoc[5](return: bool)
 	37: BrFalse(39)
 B8:
 	38: Branch(39)
@@ -92,9 +92,9 @@ B9:
 	39: Branch(42)
 B10:
 	40: LdFalse
-	41: StLoc[5](loc5: bool)
+	41: StLoc[5](return: bool)
 B11:
-	42: MoveLoc[5](loc5: bool)
+	42: MoveLoc[5](return: bool)
 	43: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance_regression.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_13952_stack_balance_regression.opt.exp
@@ -16,68 +16,68 @@ enum Data has drop {
 }
 
 test_v1(): bool /* def_idx: 0 */ {
-L0:	loc0: Data
+L0:	d: Data
 B0:
 	0: LdU64(43)
 	1: PackVariant[0](Data/V1)
-	2: StLoc[0](loc0: Data)
-	3: ImmBorrowLoc[0](loc0: Data)
+	2: StLoc[0](d: Data)
+	3: ImmBorrowLoc[0](d: Data)
 	4: TestVariant[0](Data/V1)
 	5: Ret
 }
 test_v1v3(): bool /* def_idx: 1 */ {
-L0:	loc0: Data
-L1:	loc1: &Data
-L2:	loc2: bool
-L3:	loc3: Data
-L4:	loc4: &Data
-L5:	loc5: bool
+L0:	d: Data
+L1:	$t4: &Data
+L2:	t: bool
+L3:	d: Data
+L4:	$t6: &Data
+L5:	return: bool
 B0:
 	0: LdU64(43)
 	1: PackVariant[0](Data/V1)
-	2: StLoc[0](loc0: Data)
-	3: ImmBorrowLoc[0](loc0: Data)
-	4: StLoc[1](loc1: &Data)
-	5: CopyLoc[1](loc1: &Data)
+	2: StLoc[0](d: Data)
+	3: ImmBorrowLoc[0](d: Data)
+	4: StLoc[1]($t4: &Data)
+	5: CopyLoc[1]($t4: &Data)
 	6: TestVariant[0](Data/V1)
-	7: StLoc[2](loc2: bool)
-	8: CopyLoc[2](loc2: bool)
+	7: StLoc[2](t: bool)
+	8: CopyLoc[2](t: bool)
 	9: BrFalse(34)
 B1:
-	10: MoveLoc[1](loc1: &Data)
+	10: MoveLoc[1]($t4: &Data)
 	11: Pop
 B2:
 	12: PackVariant[1](Data/V3)
-	13: StLoc[3](loc3: Data)
-	14: MoveLoc[2](loc2: bool)
+	13: StLoc[3](d: Data)
+	14: MoveLoc[2](t: bool)
 	15: BrFalse(31)
 B3:
-	16: ImmBorrowLoc[3](loc3: Data)
-	17: StLoc[4](loc4: &Data)
-	18: CopyLoc[4](loc4: &Data)
+	16: ImmBorrowLoc[3](d: Data)
+	17: StLoc[4]($t6: &Data)
+	18: CopyLoc[4]($t6: &Data)
 	19: TestVariant[0](Data/V1)
-	20: StLoc[5](loc5: bool)
-	21: CopyLoc[5](loc5: bool)
+	20: StLoc[5](return: bool)
+	21: CopyLoc[5](return: bool)
 	22: BrFalse(27)
 B4:
-	23: MoveLoc[4](loc4: &Data)
+	23: MoveLoc[4]($t6: &Data)
 	24: Pop
 B5:
-	25: MoveLoc[5](loc5: bool)
+	25: MoveLoc[5](return: bool)
 	26: Ret
 B6:
-	27: MoveLoc[4](loc4: &Data)
+	27: MoveLoc[4]($t6: &Data)
 	28: TestVariant[1](Data/V3)
-	29: StLoc[5](loc5: bool)
+	29: StLoc[5](return: bool)
 	30: Branch(25)
 B7:
 	31: LdFalse
-	32: StLoc[5](loc5: bool)
+	32: StLoc[5](return: bool)
 	33: Branch(25)
 B8:
-	34: MoveLoc[1](loc1: &Data)
+	34: MoveLoc[1]($t4: &Data)
 	35: TestVariant[1](Data/V3)
-	36: StLoc[2](loc2: bool)
+	36: StLoc[2](t: bool)
 	37: Branch(12)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14762.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14762.exp
@@ -17,55 +17,55 @@ struct S has copy, drop, store {
 	entries: vector<T>
 }
 
-test(Arg0: &mut S, Arg1: vector<u8>): Option<T> /* def_idx: 0 */ {
-L2:	loc0: &vector<T>
-L3:	loc1: bool
-L4:	loc2: u64
-L5:	loc3: u64
-L6:	loc4: u64
-L7:	loc5: u64
-L8:	loc6: bool
-L9:	loc7: Option<T>
+test(s: &mut S, issuer: vector<u8>): Option<T> /* def_idx: 0 */ {
+L2:	v: &vector<T>
+L3:	find: bool
+L4:	found_index: u64
+L5:	len: u64
+L6:	i: u64
+L7:	index: u64
+L8:	found: bool
+L9:	ret: Option<T>
 B0:
-	0: CopyLoc[0](Arg0: &mut S)
+	0: CopyLoc[0](s: &mut S)
 	1: ImmBorrowField[0](S.entries: vector<T>)
-	2: StLoc[2](loc0: &vector<T>)
+	2: StLoc[2](v: &vector<T>)
 	3: LdFalse
-	4: StLoc[3](loc1: bool)
+	4: StLoc[3](find: bool)
 	5: LdU64(0)
-	6: StLoc[4](loc2: u64)
+	6: StLoc[4](found_index: u64)
 	7: LdU64(0)
-	8: CopyLoc[2](loc0: &vector<T>)
+	8: CopyLoc[2](v: &vector<T>)
 	9: VecLen(2)
-	10: StLoc[5](loc3: u64)
-	11: StLoc[6](loc4: u64)
+	10: StLoc[5](len: u64)
+	11: StLoc[6](i: u64)
 B1:
-	12: CopyLoc[6](loc4: u64)
-	13: CopyLoc[5](loc3: u64)
+	12: CopyLoc[6](i: u64)
+	13: CopyLoc[5](len: u64)
 	14: Lt
 	15: BrFalse(35)
 B2:
-	16: CopyLoc[2](loc0: &vector<T>)
-	17: CopyLoc[6](loc4: u64)
+	16: CopyLoc[2](v: &vector<T>)
+	17: CopyLoc[6](i: u64)
 	18: VecImmBorrow(2)
 	19: ImmBorrowField[1](T.issuer: vector<u8>)
 	20: ReadRef
-	21: CopyLoc[1](Arg1: vector<u8>)
+	21: CopyLoc[1](issuer: vector<u8>)
 	22: Eq
 	23: BrFalse(30)
 B3:
 	24: LdTrue
-	25: StLoc[3](loc1: bool)
-	26: MoveLoc[6](loc4: u64)
-	27: StLoc[4](loc2: u64)
+	25: StLoc[3](find: bool)
+	26: MoveLoc[6](i: u64)
+	27: StLoc[4](found_index: u64)
 	28: Branch(37)
 B4:
 	29: Branch(30)
 B5:
-	30: MoveLoc[6](loc4: u64)
+	30: MoveLoc[6](i: u64)
 	31: LdU64(1)
 	32: Add
-	33: StLoc[6](loc4: u64)
+	33: StLoc[6](i: u64)
 	34: Branch(36)
 B6:
 	35: Branch(37)
@@ -73,29 +73,29 @@ B7:
 	36: Branch(12)
 B8:
 	37: Nop
-	38: MoveLoc[2](loc0: &vector<T>)
+	38: MoveLoc[2](v: &vector<T>)
 	39: Pop
-	40: MoveLoc[3](loc1: bool)
-	41: MoveLoc[4](loc2: u64)
-	42: StLoc[7](loc5: u64)
-	43: StLoc[8](loc6: bool)
-	44: MoveLoc[8](loc6: bool)
+	40: MoveLoc[3](find: bool)
+	41: MoveLoc[4](found_index: u64)
+	42: StLoc[7](index: u64)
+	43: StLoc[8](found: bool)
+	44: MoveLoc[8](found: bool)
 	45: BrFalse(53)
 B9:
-	46: MoveLoc[0](Arg0: &mut S)
+	46: MoveLoc[0](s: &mut S)
 	47: MutBorrowField[0](S.entries: vector<T>)
-	48: MoveLoc[7](loc5: u64)
+	48: MoveLoc[7](index: u64)
 	49: Call vector::remove<T>(&mut vector<T>, u64): T
 	50: Call option::some<T>(T): Option<T>
-	51: StLoc[9](loc7: Option<T>)
+	51: StLoc[9](ret: Option<T>)
 	52: Branch(57)
 B10:
-	53: MoveLoc[0](Arg0: &mut S)
+	53: MoveLoc[0](s: &mut S)
 	54: Pop
 	55: Call option::none<T>(): Option<T>
-	56: StLoc[9](loc7: Option<T>)
+	56: StLoc[9](ret: Option<T>)
 B11:
-	57: MoveLoc[9](loc7: Option<T>)
+	57: MoveLoc[9](ret: Option<T>)
 	58: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14762.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14762.opt.exp
@@ -17,77 +17,77 @@ struct S has copy, drop, store {
 	entries: vector<T>
 }
 
-test(Arg0: &mut S, Arg1: vector<u8>): Option<T> /* def_idx: 0 */ {
-L2:	loc0: &vector<T>
-L3:	loc1: bool
-L4:	loc2: u64
-L5:	loc3: u64
-L6:	loc4: u64
-L7:	loc5: u64
-L8:	loc6: Option<T>
+test(s: &mut S, issuer: vector<u8>): Option<T> /* def_idx: 0 */ {
+L2:	v: &vector<T>
+L3:	find: bool
+L4:	found_index: u64
+L5:	i: u64
+L6:	len: u64
+L7:	$t12: u64
+L8:	ret: Option<T>
 B0:
-	0: CopyLoc[0](Arg0: &mut S)
+	0: CopyLoc[0](s: &mut S)
 	1: ImmBorrowField[0](S.entries: vector<T>)
-	2: StLoc[2](loc0: &vector<T>)
+	2: StLoc[2](v: &vector<T>)
 	3: LdFalse
-	4: StLoc[3](loc1: bool)
+	4: StLoc[3](find: bool)
 	5: LdU64(0)
-	6: StLoc[4](loc2: u64)
+	6: StLoc[4](found_index: u64)
 	7: LdU64(0)
-	8: StLoc[5](loc3: u64)
-	9: CopyLoc[2](loc0: &vector<T>)
+	8: StLoc[5](i: u64)
+	9: CopyLoc[2](v: &vector<T>)
 	10: VecLen(2)
-	11: StLoc[6](loc4: u64)
+	11: StLoc[6](len: u64)
 B1:
-	12: CopyLoc[5](loc3: u64)
-	13: CopyLoc[6](loc4: u64)
+	12: CopyLoc[5](i: u64)
+	13: CopyLoc[6](len: u64)
 	14: Lt
 	15: BrTrue(17)
 B2:
 	16: Branch(29)
 B3:
-	17: CopyLoc[2](loc0: &vector<T>)
-	18: CopyLoc[5](loc3: u64)
+	17: CopyLoc[2](v: &vector<T>)
+	18: CopyLoc[5](i: u64)
 	19: VecImmBorrow(2)
 	20: ImmBorrowField[1](T.issuer: vector<u8>)
 	21: ReadRef
-	22: CopyLoc[1](Arg1: vector<u8>)
+	22: CopyLoc[1](issuer: vector<u8>)
 	23: Eq
 	24: BrFalse(49)
 B4:
 	25: LdTrue
-	26: StLoc[3](loc1: bool)
-	27: MoveLoc[5](loc3: u64)
-	28: StLoc[4](loc2: u64)
+	26: StLoc[3](find: bool)
+	27: MoveLoc[5](i: u64)
+	28: StLoc[4](found_index: u64)
 B5:
 	29: Nop
-	30: MoveLoc[2](loc0: &vector<T>)
+	30: MoveLoc[2](v: &vector<T>)
 	31: Pop
-	32: MoveLoc[3](loc1: bool)
-	33: MoveLoc[4](loc2: u64)
-	34: StLoc[7](loc5: u64)
+	32: MoveLoc[3](find: bool)
+	33: MoveLoc[4](found_index: u64)
+	34: StLoc[7]($t12: u64)
 	35: BrFalse(44)
 B6:
-	36: MoveLoc[0](Arg0: &mut S)
+	36: MoveLoc[0](s: &mut S)
 	37: MutBorrowField[0](S.entries: vector<T>)
-	38: MoveLoc[7](loc5: u64)
+	38: MoveLoc[7]($t12: u64)
 	39: Call vector::remove<T>(&mut vector<T>, u64): T
 	40: Call option::some<T>(T): Option<T>
-	41: StLoc[8](loc6: Option<T>)
+	41: StLoc[8](ret: Option<T>)
 B7:
-	42: MoveLoc[8](loc6: Option<T>)
+	42: MoveLoc[8](ret: Option<T>)
 	43: Ret
 B8:
-	44: MoveLoc[0](Arg0: &mut S)
+	44: MoveLoc[0](s: &mut S)
 	45: Pop
 	46: Call option::none<T>(): Option<T>
-	47: StLoc[8](loc6: Option<T>)
+	47: StLoc[8](ret: Option<T>)
 	48: Branch(42)
 B9:
-	49: MoveLoc[5](loc3: u64)
+	49: MoveLoc[5](i: u64)
 	50: LdU64(1)
 	51: Add
-	52: StLoc[5](loc3: u64)
+	52: StLoc[5](i: u64)
 	53: Branch(12)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -177,9 +177,9 @@ B0:
 	32: Pop
 	33: Ret
 }
-u<Ty0>(Arg0: Ty0): Ty0 /* def_idx: 1 */ {
+u<T>(x: T): T /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
+	0: MoveLoc[0](x: T)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
@@ -177,9 +177,9 @@ B0:
 	32: Pop
 	33: Ret
 }
-u<Ty0>(Arg0: Ty0): Ty0 /* def_idx: 1 */ {
+u<T>(x: T): T /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
+	0: MoveLoc[0](x: T)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-bar(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+bar(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -13,9 +13,9 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: u64) /* def_idx: 2 */ {
+public test(x: u64) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call one(): u64
 	2: Call one(): u64
 	3: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.opt.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-bar(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+bar(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -13,9 +13,9 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: u64) /* def_idx: 2 */ {
+public test(x: u64) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call one(): u64
 	2: Call one(): u64
 	3: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_02.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_02.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-test(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+test(x: u64, y: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
-	2: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: MoveLoc[1](y: u64)
+	2: MoveLoc[0](x: u64)
 	3: Mul
 	4: Add
 	5: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_02.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_02.opt.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-test(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+test(x: u64, y: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
-	2: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: MoveLoc[1](y: u64)
+	2: MoveLoc[0](x: u64)
 	3: Mul
 	4: Add
 	5: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.exp
@@ -10,80 +10,80 @@ struct S has drop {
 	g: T
 }
 
-read_ref(Arg0: &S): u64 /* def_idx: 0 */ {
+read_ref(x: &S): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](x: &S)
 	1: ImmBorrowField[0](S.g: T)
 	2: ImmBorrowField[1](T.h: u64)
 	3: ReadRef
 	4: Ret
 }
-read_val(Arg0: S): u64 /* def_idx: 1 */ {
+read_val(x: S): u64 /* def_idx: 1 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: S)
+	0: ImmBorrowLoc[0](x: S)
 	1: ImmBorrowField[0](S.g: T)
 	2: ImmBorrowField[1](T.h: u64)
 	3: ReadRef
 	4: Ret
 }
 write_local_direct(): S /* def_idx: 2 */ {
-L0:	loc0: S
+L0:	x: S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[1](S)
-	4: StLoc[0](loc0: S)
+	4: StLoc[0](x: S)
 	5: LdU64(42)
-	6: MutBorrowLoc[0](loc0: S)
+	6: MutBorrowLoc[0](x: S)
 	7: MutBorrowField[0](S.g: T)
 	8: MutBorrowField[1](T.h: u64)
 	9: WriteRef
-	10: MoveLoc[0](loc0: S)
+	10: MoveLoc[0](x: S)
 	11: Ret
 }
 write_local_via_ref(): S /* def_idx: 3 */ {
-L0:	loc0: S
-L1:	loc1: u64
-L2:	loc2: &mut S
-L3:	loc3: &mut u64
+L0:	x: S
+L1:	$t6: u64
+L2:	r: &mut S
+L3:	$t7: &mut u64
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[1](S)
-	4: StLoc[0](loc0: S)
-	5: MutBorrowLoc[0](loc0: S)
+	4: StLoc[0](x: S)
+	5: MutBorrowLoc[0](x: S)
 	6: LdU64(42)
-	7: StLoc[1](loc1: u64)
-	8: StLoc[2](loc2: &mut S)
-	9: MoveLoc[2](loc2: &mut S)
+	7: StLoc[1]($t6: u64)
+	8: StLoc[2](r: &mut S)
+	9: MoveLoc[2](r: &mut S)
 	10: MutBorrowField[0](S.g: T)
 	11: MutBorrowField[1](T.h: u64)
-	12: StLoc[3](loc3: &mut u64)
-	13: MoveLoc[1](loc1: u64)
-	14: MoveLoc[3](loc3: &mut u64)
+	12: StLoc[3]($t7: &mut u64)
+	13: MoveLoc[1]($t6: u64)
+	14: MoveLoc[3]($t7: &mut u64)
 	15: WriteRef
-	16: MoveLoc[0](loc0: S)
+	16: MoveLoc[0](x: S)
 	17: Ret
 }
-write_param(Arg0: &mut S) /* def_idx: 4 */ {
+write_param(x: &mut S) /* def_idx: 4 */ {
 B0:
 	0: LdU64(42)
-	1: MoveLoc[0](Arg0: &mut S)
+	1: MoveLoc[0](x: &mut S)
 	2: MutBorrowField[0](S.g: T)
 	3: MutBorrowField[1](T.h: u64)
 	4: WriteRef
 	5: Ret
 }
-write_val(Arg0: S): S /* def_idx: 5 */ {
+write_val(x: S): S /* def_idx: 5 */ {
 B0:
 	0: LdU64(42)
-	1: MutBorrowLoc[0](Arg0: S)
+	1: MutBorrowLoc[0](x: S)
 	2: MutBorrowField[0](S.g: T)
 	3: MutBorrowField[1](T.h: u64)
 	4: WriteRef
-	5: MoveLoc[0](Arg0: S)
+	5: MoveLoc[0](x: S)
 	6: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/fields.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/fields.opt.exp
@@ -10,74 +10,74 @@ struct S has drop {
 	g: T
 }
 
-read_ref(Arg0: &S): u64 /* def_idx: 0 */ {
+read_ref(x: &S): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](x: &S)
 	1: ImmBorrowField[0](S.g: T)
 	2: ImmBorrowField[1](T.h: u64)
 	3: ReadRef
 	4: Ret
 }
-read_val(Arg0: S): u64 /* def_idx: 1 */ {
+read_val(x: S): u64 /* def_idx: 1 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: S)
+	0: ImmBorrowLoc[0](x: S)
 	1: ImmBorrowField[0](S.g: T)
 	2: ImmBorrowField[1](T.h: u64)
 	3: ReadRef
 	4: Ret
 }
 write_local_direct(): S /* def_idx: 2 */ {
-L0:	loc0: S
+L0:	x: S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[1](S)
-	4: StLoc[0](loc0: S)
+	4: StLoc[0](x: S)
 	5: LdU64(42)
-	6: MutBorrowLoc[0](loc0: S)
+	6: MutBorrowLoc[0](x: S)
 	7: MutBorrowField[0](S.g: T)
 	8: MutBorrowField[1](T.h: u64)
 	9: WriteRef
-	10: MoveLoc[0](loc0: S)
+	10: MoveLoc[0](x: S)
 	11: Ret
 }
 write_local_via_ref(): S /* def_idx: 3 */ {
-L0:	loc0: S
-L1:	loc1: &mut S
+L0:	x: S
+L1:	r: &mut S
 B0:
 	0: LdU64(0)
 	1: LdU64(0)
 	2: Pack[0](T)
 	3: Pack[1](S)
-	4: StLoc[0](loc0: S)
-	5: MutBorrowLoc[0](loc0: S)
-	6: StLoc[1](loc1: &mut S)
+	4: StLoc[0](x: S)
+	5: MutBorrowLoc[0](x: S)
+	6: StLoc[1](r: &mut S)
 	7: LdU64(42)
-	8: MoveLoc[1](loc1: &mut S)
+	8: MoveLoc[1](r: &mut S)
 	9: MutBorrowField[0](S.g: T)
 	10: MutBorrowField[1](T.h: u64)
 	11: WriteRef
-	12: MoveLoc[0](loc0: S)
+	12: MoveLoc[0](x: S)
 	13: Ret
 }
-write_param(Arg0: &mut S) /* def_idx: 4 */ {
+write_param(x: &mut S) /* def_idx: 4 */ {
 B0:
 	0: LdU64(42)
-	1: MoveLoc[0](Arg0: &mut S)
+	1: MoveLoc[0](x: &mut S)
 	2: MutBorrowField[0](S.g: T)
 	3: MutBorrowField[1](T.h: u64)
 	4: WriteRef
 	5: Ret
 }
-write_val(Arg0: S): S /* def_idx: 5 */ {
+write_val(x: S): S /* def_idx: 5 */ {
 B0:
 	0: LdU64(42)
-	1: MutBorrowLoc[0](Arg0: S)
+	1: MutBorrowLoc[0](x: S)
 	2: MutBorrowField[0](S.g: T)
 	3: MutBorrowField[1](T.h: u64)
 	4: WriteRef
-	5: MoveLoc[0](Arg0: S)
+	5: MoveLoc[0](x: S)
 	6: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.exp
@@ -7,70 +7,70 @@ struct S {
 	g: u64
 }
 
-bar(Arg0: &mut S): u64 * u64 /* def_idx: 0 */ {
+bar(_r: &mut S): u64 * u64 /* def_idx: 0 */ {
 B0:
 	0: LdU64(1)
-	1: MoveLoc[0](Arg0: &mut S)
+	1: MoveLoc[0](_r: &mut S)
 	2: Pop
 	3: LdU64(1)
 	4: Ret
 }
-f1(Arg0: &mut S, Arg1: u64, Arg2: address): &mut S * address * u64 /* def_idx: 1 */ {
+f1(a: &mut S, b: u64, c: address): &mut S * address * u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
-	1: MoveLoc[2](Arg2: address)
-	2: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](a: &mut S)
+	1: MoveLoc[2](c: address)
+	2: MoveLoc[1](b: u64)
 	3: Ret
 }
-f2(Arg0: address, Arg1: &mut S, Arg2: address, Arg3: u64, Arg4: &mut S) /* def_idx: 2 */ {
+f2(_r1: address, _r2: &mut S, _r3: address, _r4: u64, _r5: &mut S) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[1](Arg1: &mut S)
+	0: MoveLoc[1](_r2: &mut S)
 	1: Pop
-	2: MoveLoc[4](Arg4: &mut S)
+	2: MoveLoc[4](_r5: &mut S)
 	3: Pop
 	4: Ret
 }
-f3(Arg0: u64, Arg1: &u64) /* def_idx: 3 */ {
+f3(_r1: u64, _r2: &u64) /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[1](Arg1: &u64)
+	0: MoveLoc[1](_r2: &u64)
 	1: Pop
 	2: Ret
 }
-foo(Arg0: address, Arg1: &mut S, Arg2: &mut S): u64 /* def_idx: 4 */ {
-L3:	loc0: u64
-L4:	loc1: address
-L5:	loc2: address
-L6:	loc3: &mut S
-L7:	loc4: u64
-L8:	loc5: address
-L9:	loc6: &mut S
+foo(a: address, ref1: &mut S, ref2: &mut S): u64 /* def_idx: 4 */ {
+L3:	c: u64
+L4:	b: address
+L5:	$t9: address
+L6:	r1: &mut S
+L7:	$t12: u64
+L8:	$t11: address
+L9:	$t10: &mut S
 B0:
-	0: MoveLoc[1](Arg1: &mut S)
+	0: MoveLoc[1](ref1: &mut S)
 	1: LdU64(1)
-	2: MoveLoc[0](Arg0: address)
+	2: MoveLoc[0](a: address)
 	3: Call f1(&mut S, u64, address): &mut S * address * u64
-	4: StLoc[3](loc0: u64)
-	5: StLoc[4](loc1: address)
-	6: CopyLoc[4](loc1: address)
-	7: StLoc[5](loc2: address)
-	8: StLoc[6](loc3: &mut S)
-	9: CopyLoc[6](loc3: &mut S)
-	10: MoveLoc[4](loc1: address)
-	11: CopyLoc[3](loc0: u64)
-	12: StLoc[7](loc4: u64)
-	13: StLoc[8](loc5: address)
-	14: StLoc[9](loc6: &mut S)
-	15: MoveLoc[5](loc2: address)
-	16: MoveLoc[9](loc6: &mut S)
-	17: MoveLoc[8](loc5: address)
-	18: MoveLoc[7](loc4: u64)
-	19: MoveLoc[2](Arg2: &mut S)
+	4: StLoc[3](c: u64)
+	5: StLoc[4](b: address)
+	6: CopyLoc[4](b: address)
+	7: StLoc[5]($t9: address)
+	8: StLoc[6](r1: &mut S)
+	9: CopyLoc[6](r1: &mut S)
+	10: MoveLoc[4](b: address)
+	11: CopyLoc[3](c: u64)
+	12: StLoc[7]($t12: u64)
+	13: StLoc[8]($t11: address)
+	14: StLoc[9]($t10: &mut S)
+	15: MoveLoc[5]($t9: address)
+	16: MoveLoc[9]($t10: &mut S)
+	17: MoveLoc[8]($t11: address)
+	18: MoveLoc[7]($t12: u64)
+	19: MoveLoc[2](ref2: &mut S)
 	20: Call f2(address, &mut S, address, u64, &mut S)
-	21: CopyLoc[3](loc0: u64)
-	22: MoveLoc[6](loc3: &mut S)
+	21: CopyLoc[3](c: u64)
+	22: MoveLoc[6](r1: &mut S)
 	23: ImmBorrowField[0](S.g: u64)
 	24: Call f3(u64, &u64)
-	25: MoveLoc[3](loc0: u64)
+	25: MoveLoc[3](c: u64)
 	26: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/framework_reduced_06.opt.exp
@@ -7,56 +7,56 @@ struct S {
 	g: u64
 }
 
-bar(Arg0: &mut S): u64 * u64 /* def_idx: 0 */ {
+bar(_r: &mut S): u64 * u64 /* def_idx: 0 */ {
 B0:
 	0: LdU64(1)
-	1: MoveLoc[0](Arg0: &mut S)
+	1: MoveLoc[0](_r: &mut S)
 	2: Pop
 	3: LdU64(1)
 	4: Ret
 }
-f1(Arg0: &mut S, Arg1: u64, Arg2: address): &mut S * address * u64 /* def_idx: 1 */ {
+f1(a: &mut S, b: u64, c: address): &mut S * address * u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
-	1: MoveLoc[2](Arg2: address)
-	2: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](a: &mut S)
+	1: MoveLoc[2](c: address)
+	2: MoveLoc[1](b: u64)
 	3: Ret
 }
-f2(Arg0: address, Arg1: &mut S, Arg2: address, Arg3: u64, Arg4: &mut S) /* def_idx: 2 */ {
+f2(_r1: address, _r2: &mut S, _r3: address, _r4: u64, _r5: &mut S) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[1](Arg1: &mut S)
+	0: MoveLoc[1](_r2: &mut S)
 	1: Pop
-	2: MoveLoc[4](Arg4: &mut S)
+	2: MoveLoc[4](_r5: &mut S)
 	3: Pop
 	4: Ret
 }
-f3(Arg0: u64, Arg1: &u64) /* def_idx: 3 */ {
+f3(_r1: u64, _r2: &u64) /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[1](Arg1: &u64)
+	0: MoveLoc[1](_r2: &u64)
 	1: Pop
 	2: Ret
 }
-foo(Arg0: address, Arg1: &mut S, Arg2: &mut S): u64 /* def_idx: 4 */ {
-L3:	loc0: u64
+foo(a: address, ref1: &mut S, ref2: &mut S): u64 /* def_idx: 4 */ {
+L3:	$t8: u64
 B0:
-	0: MoveLoc[1](Arg1: &mut S)
+	0: MoveLoc[1](ref1: &mut S)
 	1: LdU64(1)
-	2: MoveLoc[0](Arg0: address)
+	2: MoveLoc[0](a: address)
 	3: Call f1(&mut S, u64, address): &mut S * address * u64
-	4: StLoc[3](loc0: u64)
-	5: StLoc[0](Arg0: address)
-	6: StLoc[1](Arg1: &mut S)
-	7: CopyLoc[0](Arg0: address)
-	8: CopyLoc[1](Arg1: &mut S)
-	9: MoveLoc[0](Arg0: address)
-	10: CopyLoc[3](loc0: u64)
-	11: MoveLoc[2](Arg2: &mut S)
+	4: StLoc[3]($t8: u64)
+	5: StLoc[0](a: address)
+	6: StLoc[1](ref1: &mut S)
+	7: CopyLoc[0](a: address)
+	8: CopyLoc[1](ref1: &mut S)
+	9: MoveLoc[0](a: address)
+	10: CopyLoc[3]($t8: u64)
+	11: MoveLoc[2](ref2: &mut S)
 	12: Call f2(address, &mut S, address, u64, &mut S)
-	13: CopyLoc[3](loc0: u64)
-	14: MoveLoc[1](Arg1: &mut S)
+	13: CopyLoc[3]($t8: u64)
+	14: MoveLoc[1](ref1: &mut S)
 	15: ImmBorrowField[0](S.g: u64)
 	16: Call f3(u64, &u64)
-	17: MoveLoc[3](loc0: u64)
+	17: MoveLoc[3]($t8: u64)
 	18: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.exp
@@ -4,15 +4,15 @@
 module 42.Test {
 
 
-foo(Arg0: u64): u64 /* def_idx: 0 */ {
+foo(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call identity<u64>(u64): u64
 	2: Ret
 }
-identity<Ty0>(Arg0: Ty0): Ty0 /* def_idx: 1 */ {
+identity<T>(x: T): T /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
+	0: MoveLoc[0](x: T)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/generic_call.opt.exp
@@ -4,15 +4,15 @@
 module 42.Test {
 
 
-foo(Arg0: u64): u64 /* def_idx: 0 */ {
+foo(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call identity<u64>(u64): u64
 	2: Ret
 }
-identity<Ty0>(Arg0: Ty0): Ty0 /* def_idx: 1 */ {
+identity<T>(x: T): T /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
+	0: MoveLoc[0](x: T)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.exp
@@ -14,43 +14,43 @@ struct R has store, key {
 	f: u64
 }
 
-check(Arg0: address): bool /* def_idx: 0 */ {
+check(a: address): bool /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: Exists[0](R)
 	2: Ret
 }
-publish(Arg0: &signer) /* def_idx: 1 */ {
+publish(s: &signer) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &signer)
+	0: MoveLoc[0](s: &signer)
 	1: LdU64(1)
 	2: Pack[0](R)
 	3: MoveTo[0](R)
 	4: Ret
 }
-read(Arg0: address): u64 /* def_idx: 2 */ {
+read(a: address): u64 /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: ImmBorrowGlobal[0](R)
 	2: ImmBorrowField[0](R.f: u64)
 	3: ReadRef
 	4: Ret
 }
-write(Arg0: address, Arg1: u64): u64 /* def_idx: 3 */ {
-L2:	loc0: u64
-L3:	loc1: &mut R
-L4:	loc2: &mut u64
+write(a: address, x: u64): u64 /* def_idx: 3 */ {
+L2:	$t4: u64
+L3:	r: &mut R
+L4:	$t5: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: MutBorrowGlobal[0](R)
 	2: LdU64(2)
-	3: StLoc[2](loc0: u64)
-	4: StLoc[3](loc1: &mut R)
-	5: MoveLoc[3](loc1: &mut R)
+	3: StLoc[2]($t4: u64)
+	4: StLoc[3](r: &mut R)
+	5: MoveLoc[3](r: &mut R)
 	6: MutBorrowField[0](R.f: u64)
-	7: StLoc[4](loc2: &mut u64)
-	8: MoveLoc[2](loc0: u64)
-	9: MoveLoc[4](loc2: &mut u64)
+	7: StLoc[4]($t5: &mut u64)
+	8: MoveLoc[2]($t4: u64)
+	9: MoveLoc[4]($t5: &mut u64)
 	10: WriteRef
 	11: LdU64(9)
 	12: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/globals.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/globals.opt.exp
@@ -14,36 +14,36 @@ struct R has store, key {
 	f: u64
 }
 
-check(Arg0: address): bool /* def_idx: 0 */ {
+check(a: address): bool /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: Exists[0](R)
 	2: Ret
 }
-publish(Arg0: &signer) /* def_idx: 1 */ {
+publish(s: &signer) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &signer)
+	0: MoveLoc[0](s: &signer)
 	1: LdU64(1)
 	2: Pack[0](R)
 	3: MoveTo[0](R)
 	4: Ret
 }
-read(Arg0: address): u64 /* def_idx: 2 */ {
+read(a: address): u64 /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: ImmBorrowGlobal[0](R)
 	2: ImmBorrowField[0](R.f: u64)
 	3: ReadRef
 	4: Ret
 }
-write(Arg0: address, Arg1: u64): u64 /* def_idx: 3 */ {
-L2:	loc0: &mut R
+write(a: address, x: u64): u64 /* def_idx: 3 */ {
+L2:	r: &mut R
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](a: address)
 	1: MutBorrowGlobal[0](R)
-	2: StLoc[2](loc0: &mut R)
+	2: StLoc[2](r: &mut R)
 	3: LdU64(2)
-	4: MoveLoc[2](loc0: &mut R)
+	4: MoveLoc[2](r: &mut R)
 	5: MutBorrowField[0](R.f: u64)
 	6: WriteRef
 	7: LdU64(9)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.exp
@@ -4,64 +4,64 @@
 module 42.if_else {
 
 
-if_else(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+if_else(cond: bool, x: u64): u64 /* def_idx: 0 */ {
+L2:	return: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(7)
 B1:
-	2: MoveLoc[1](Arg1: u64)
+	2: MoveLoc[1](x: u64)
 	3: LdU64(1)
 	4: Add
-	5: StLoc[2](loc0: u64)
+	5: StLoc[2](return: u64)
 	6: Branch(11)
 B2:
-	7: MoveLoc[1](Arg1: u64)
+	7: MoveLoc[1](x: u64)
 	8: LdU64(1)
 	9: Sub
-	10: StLoc[2](loc0: u64)
+	10: StLoc[2](return: u64)
 B3:
-	11: MoveLoc[2](loc0: u64)
+	11: MoveLoc[2](return: u64)
 	12: Ret
 }
-if_else_nested(Arg0: bool, Arg1: u64): u64 /* def_idx: 1 */ {
-L2:	loc0: u64
-L3:	loc1: u64
-L4:	loc2: u64
+if_else_nested(cond: bool, x: u64): u64 /* def_idx: 1 */ {
+L2:	$t4: u64
+L3:	$t9: u64
+L4:	return: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(7)
 B1:
-	2: CopyLoc[1](Arg1: u64)
+	2: CopyLoc[1](x: u64)
 	3: LdU64(1)
 	4: Add
-	5: StLoc[2](loc0: u64)
+	5: StLoc[2]($t4: u64)
 	6: Branch(11)
 B2:
-	7: CopyLoc[1](Arg1: u64)
+	7: CopyLoc[1](x: u64)
 	8: LdU64(1)
 	9: Sub
-	10: StLoc[2](loc0: u64)
+	10: StLoc[2]($t4: u64)
 B3:
 	11: LdU64(10)
-	12: StLoc[3](loc1: u64)
-	13: MoveLoc[2](loc0: u64)
-	14: MoveLoc[3](loc1: u64)
+	12: StLoc[3]($t9: u64)
+	13: MoveLoc[2]($t4: u64)
+	14: MoveLoc[3]($t9: u64)
 	15: Gt
 	16: BrFalse(22)
 B4:
-	17: MoveLoc[1](Arg1: u64)
+	17: MoveLoc[1](x: u64)
 	18: LdU64(2)
 	19: Mul
-	20: StLoc[4](loc2: u64)
+	20: StLoc[4](return: u64)
 	21: Branch(26)
 B5:
-	22: MoveLoc[1](Arg1: u64)
+	22: MoveLoc[1](x: u64)
 	23: LdU64(2)
 	24: Div
-	25: StLoc[4](loc2: u64)
+	25: StLoc[4](return: u64)
 B6:
-	26: MoveLoc[4](loc2: u64)
+	26: MoveLoc[4](return: u64)
 	27: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/if_else.opt.exp
@@ -4,61 +4,61 @@
 module 42.if_else {
 
 
-if_else(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+if_else(cond: bool, x: u64): u64 /* def_idx: 0 */ {
+L2:	$t3: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(8)
 B1:
-	2: MoveLoc[1](Arg1: u64)
+	2: MoveLoc[1](x: u64)
 	3: LdU64(1)
 	4: Add
-	5: StLoc[2](loc0: u64)
+	5: StLoc[2]($t3: u64)
 B2:
-	6: MoveLoc[2](loc0: u64)
+	6: MoveLoc[2]($t3: u64)
 	7: Ret
 B3:
-	8: MoveLoc[1](Arg1: u64)
+	8: MoveLoc[1](x: u64)
 	9: LdU64(1)
 	10: Sub
-	11: StLoc[2](loc0: u64)
+	11: StLoc[2]($t3: u64)
 	12: Branch(6)
 }
-if_else_nested(Arg0: bool, Arg1: u64): u64 /* def_idx: 1 */ {
-L2:	loc0: u64
-L3:	loc1: u64
+if_else_nested(cond: bool, x: u64): u64 /* def_idx: 1 */ {
+L2:	$t5: u64
+L3:	$t6: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(21)
 B1:
-	2: CopyLoc[1](Arg1: u64)
+	2: CopyLoc[1](x: u64)
 	3: LdU64(1)
 	4: Add
-	5: StLoc[2](loc0: u64)
+	5: StLoc[2]($t5: u64)
 B2:
-	6: MoveLoc[2](loc0: u64)
+	6: MoveLoc[2]($t5: u64)
 	7: LdU64(10)
 	8: Gt
 	9: BrFalse(16)
 B3:
-	10: MoveLoc[1](Arg1: u64)
+	10: MoveLoc[1](x: u64)
 	11: LdU64(2)
 	12: Mul
-	13: StLoc[3](loc1: u64)
+	13: StLoc[3]($t6: u64)
 B4:
-	14: MoveLoc[3](loc1: u64)
+	14: MoveLoc[3]($t6: u64)
 	15: Ret
 B5:
-	16: MoveLoc[1](Arg1: u64)
+	16: MoveLoc[1](x: u64)
 	17: LdU64(2)
 	18: Div
-	19: StLoc[3](loc1: u64)
+	19: StLoc[3]($t6: u64)
 	20: Branch(14)
 B6:
-	21: CopyLoc[1](Arg1: u64)
+	21: CopyLoc[1](x: u64)
 	22: LdU64(1)
 	23: Sub
-	24: StLoc[2](loc0: u64)
+	24: StLoc[2]($t5: u64)
 	25: Branch(6)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/index_then_field_select.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/index_then_field_select.exp
@@ -6,49 +6,49 @@ struct Coin has copy, drop {
 	_0: u256
 }
 
-inc_vec_new(Arg0: &mut vector<u256>, Arg1: u64) /* def_idx: 0 */ {
+inc_vec_new(x: &mut vector<u256>, index: u64) /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut vector<u256>)
+	0: CopyLoc[0](x: &mut vector<u256>)
 	1: FreezeRef
-	2: CopyLoc[1](Arg1: u64)
+	2: CopyLoc[1](index: u64)
 	3: VecImmBorrow(2)
 	4: ReadRef
 	5: LdU256(1)
 	6: Add
-	7: MoveLoc[0](Arg0: &mut vector<u256>)
-	8: MoveLoc[1](Arg1: u64)
+	7: MoveLoc[0](x: &mut vector<u256>)
+	8: MoveLoc[1](index: u64)
 	9: VecMutBorrow(2)
 	10: WriteRef
 	11: Ret
 }
-test0(Arg0: &mut vector<Coin>, Arg1: u64) /* def_idx: 1 */ {
-L2:	loc0: &mut u256
+test0(x: &mut vector<Coin>, index: u64) /* def_idx: 1 */ {
+L2:	_p: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: &mut vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(4)
 	3: MutBorrowField[0](Coin._0: u256)
-	4: StLoc[2](loc0: &mut u256)
-	5: MoveLoc[2](loc0: &mut u256)
+	4: StLoc[2](_p: &mut u256)
+	5: MoveLoc[2](_p: &mut u256)
 	6: Pop
 	7: Ret
 }
-test1(Arg0: vector<Coin>, Arg1: u64) /* def_idx: 2 */ {
-L2:	loc0: &mut u256
+test1(x: vector<Coin>, index: u64) /* def_idx: 2 */ {
+L2:	_p: &mut u256
 B0:
-	0: MutBorrowLoc[0](Arg0: vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MutBorrowLoc[0](x: vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(4)
 	3: MutBorrowField[0](Coin._0: u256)
-	4: StLoc[2](loc0: &mut u256)
-	5: MoveLoc[2](loc0: &mut u256)
+	4: StLoc[2](_p: &mut u256)
+	5: MoveLoc[2](_p: &mut u256)
 	6: Pop
 	7: Ret
 }
-test3(Arg0: &vector<Coin>, Arg1: u64) /* def_idx: 3 */ {
+test3(x: &vector<Coin>, index: u64) /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: &vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: &vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecImmBorrow(4)
 	3: ReadRef
 	4: Pop

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/index_then_field_select.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/index_then_field_select.opt.exp
@@ -6,45 +6,45 @@ struct Coin has copy, drop {
 	_0: u256
 }
 
-inc_vec_new(Arg0: &mut vector<u256>, Arg1: u64) /* def_idx: 0 */ {
+inc_vec_new(x: &mut vector<u256>, index: u64) /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut vector<u256>)
+	0: CopyLoc[0](x: &mut vector<u256>)
 	1: FreezeRef
-	2: CopyLoc[1](Arg1: u64)
+	2: CopyLoc[1](index: u64)
 	3: VecImmBorrow(2)
 	4: ReadRef
 	5: LdU256(1)
 	6: Add
-	7: MoveLoc[0](Arg0: &mut vector<u256>)
-	8: MoveLoc[1](Arg1: u64)
+	7: MoveLoc[0](x: &mut vector<u256>)
+	8: MoveLoc[1](index: u64)
 	9: VecMutBorrow(2)
 	10: WriteRef
 	11: Ret
 }
-test0(Arg0: &mut vector<Coin>, Arg1: u64) /* def_idx: 1 */ {
-L2:	loc0: &mut u256
+test0(x: &mut vector<Coin>, index: u64) /* def_idx: 1 */ {
+L2:	_p: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: &mut vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(4)
 	3: MutBorrowField[0](Coin._0: u256)
 	4: Pop
 	5: Ret
 }
-test1(Arg0: vector<Coin>, Arg1: u64) /* def_idx: 2 */ {
-L2:	loc0: &mut u256
+test1(x: vector<Coin>, index: u64) /* def_idx: 2 */ {
+L2:	_p: &mut u256
 B0:
-	0: MutBorrowLoc[0](Arg0: vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MutBorrowLoc[0](x: vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(4)
 	3: MutBorrowField[0](Coin._0: u256)
 	4: Pop
 	5: Ret
 }
-test3(Arg0: &vector<Coin>, Arg1: u64) /* def_idx: 3 */ {
+test3(x: &vector<Coin>, index: u64) /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: &vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: &vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecImmBorrow(4)
 	3: ReadRef
 	4: Pop

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.exp
@@ -4,22 +4,22 @@
 module 42.loops {
 
 
-nested_loop(Arg0: u64): u64 /* def_idx: 0 */ {
+nested_loop(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(22)
 B1:
-	4: CopyLoc[0](Arg0: u64)
+	4: CopyLoc[0](x: u64)
 	5: LdU64(10)
 	6: Gt
 	7: BrFalse(14)
 B2:
-	8: MoveLoc[0](Arg0: u64)
+	8: MoveLoc[0](x: u64)
 	9: LdU64(1)
 	10: Sub
-	11: StLoc[0](Arg0: u64)
+	11: StLoc[0](x: u64)
 	12: Branch(16)
 B3:
 	13: Branch(15)
@@ -28,10 +28,10 @@ B4:
 B5:
 	15: Branch(4)
 B6:
-	16: MoveLoc[0](Arg0: u64)
+	16: MoveLoc[0](x: u64)
 	17: LdU64(1)
 	18: Sub
-	19: StLoc[0](Arg0: u64)
+	19: StLoc[0](x: u64)
 	20: Branch(0)
 B7:
 	21: Branch(23)
@@ -40,37 +40,37 @@ B8:
 B9:
 	23: Branch(0)
 B10:
-	24: MoveLoc[0](Arg0: u64)
+	24: MoveLoc[0](x: u64)
 	25: Ret
 }
-while_loop(Arg0: u64): u64 /* def_idx: 1 */ {
+while_loop(x: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(9)
 B1:
-	4: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[0](x: u64)
 	5: LdU64(1)
 	6: Sub
-	7: StLoc[0](Arg0: u64)
+	7: StLoc[0](x: u64)
 	8: Branch(10)
 B2:
 	9: Branch(11)
 B3:
 	10: Branch(0)
 B4:
-	11: MoveLoc[0](Arg0: u64)
+	11: MoveLoc[0](x: u64)
 	12: Ret
 }
-while_loop_with_break_and_continue(Arg0: u64): u64 /* def_idx: 2 */ {
+while_loop_with_break_and_continue(x: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(21)
 B1:
-	4: CopyLoc[0](Arg0: u64)
+	4: CopyLoc[0](x: u64)
 	5: LdU64(42)
 	6: Eq
 	7: BrFalse(10)
@@ -79,7 +79,7 @@ B2:
 B3:
 	9: Branch(10)
 B4:
-	10: CopyLoc[0](Arg0: u64)
+	10: CopyLoc[0](x: u64)
 	11: LdU64(21)
 	12: Eq
 	13: BrFalse(16)
@@ -88,17 +88,17 @@ B5:
 B6:
 	15: Branch(16)
 B7:
-	16: MoveLoc[0](Arg0: u64)
+	16: MoveLoc[0](x: u64)
 	17: LdU64(1)
 	18: Sub
-	19: StLoc[0](Arg0: u64)
+	19: StLoc[0](x: u64)
 	20: Branch(22)
 B8:
 	21: Branch(23)
 B9:
 	22: Branch(0)
 B10:
-	23: MoveLoc[0](Arg0: u64)
+	23: MoveLoc[0](x: u64)
 	24: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/loop.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/loop.opt.exp
@@ -4,80 +4,80 @@
 module 42.loops {
 
 
-nested_loop(Arg0: u64): u64 /* def_idx: 0 */ {
+nested_loop(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(18)
 B1:
-	4: CopyLoc[0](Arg0: u64)
+	4: CopyLoc[0](x: u64)
 	5: LdU64(10)
 	6: Gt
 	7: BrTrue(9)
 B2:
 	8: Branch(13)
 B3:
-	9: MoveLoc[0](Arg0: u64)
+	9: MoveLoc[0](x: u64)
 	10: LdU64(1)
 	11: Sub
-	12: StLoc[0](Arg0: u64)
+	12: StLoc[0](x: u64)
 B4:
-	13: MoveLoc[0](Arg0: u64)
+	13: MoveLoc[0](x: u64)
 	14: LdU64(1)
 	15: Sub
-	16: StLoc[0](Arg0: u64)
+	16: StLoc[0](x: u64)
 	17: Branch(0)
 B5:
-	18: MoveLoc[0](Arg0: u64)
+	18: MoveLoc[0](x: u64)
 	19: Ret
 }
-while_loop(Arg0: u64): u64 /* def_idx: 1 */ {
+while_loop(x: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrFalse(9)
 B1:
-	4: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[0](x: u64)
 	5: LdU64(1)
 	6: Sub
-	7: StLoc[0](Arg0: u64)
+	7: StLoc[0](x: u64)
 	8: Branch(0)
 B2:
-	9: MoveLoc[0](Arg0: u64)
+	9: MoveLoc[0](x: u64)
 	10: Ret
 }
-while_loop_with_break_and_continue(Arg0: u64): u64 /* def_idx: 2 */ {
+while_loop_with_break_and_continue(x: u64): u64 /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: LdU64(0)
 	2: Gt
 	3: BrTrue(5)
 B1:
 	4: Branch(10)
 B2:
-	5: CopyLoc[0](Arg0: u64)
+	5: CopyLoc[0](x: u64)
 	6: LdU64(42)
 	7: Eq
 	8: BrFalse(12)
 B3:
 	9: Branch(10)
 B4:
-	10: MoveLoc[0](Arg0: u64)
+	10: MoveLoc[0](x: u64)
 	11: Ret
 B5:
-	12: CopyLoc[0](Arg0: u64)
+	12: CopyLoc[0](x: u64)
 	13: LdU64(21)
 	14: Eq
 	15: BrFalse(17)
 B6:
 	16: Branch(0)
 B7:
-	17: MoveLoc[0](Arg0: u64)
+	17: MoveLoc[0](x: u64)
 	18: LdU64(1)
 	19: Sub
-	20: StLoc[0](Arg0: u64)
+	20: StLoc[0](x: u64)
 	21: Branch(0)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/multi_use.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/multi_use.exp
@@ -4,16 +4,16 @@
 module c0ffee.m {
 
 
-public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 0 */ {
+public consume(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u64) /* def_idx: 1 */ {
+public test(x: u64) /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[0](x: u64)
 	2: LdU64(1)
-	3: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[0](x: u64)
 	4: Call consume(u64, u64, u64, u64)
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/multi_use.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/multi_use.opt.exp
@@ -4,16 +4,16 @@
 module c0ffee.m {
 
 
-public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 0 */ {
+public consume(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u64) /* def_idx: 1 */ {
+public test(x: u64) /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[0](x: u64)
 	2: LdU64(1)
-	3: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[0](x: u64)
 	4: Call consume(u64, u64, u64, u64)
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.exp
@@ -4,170 +4,170 @@
 module 42.operators {
 
 
-arithm(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+arithm(x: u64, y: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u64)
+	2: CopyLoc[0](x: u64)
+	3: CopyLoc[1](y: u64)
 	4: Sub
 	5: Div
-	6: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[1](y: u64)
 	7: Mul
-	8: MoveLoc[0](Arg0: u64)
+	8: MoveLoc[0](x: u64)
 	9: Mod
 	10: Add
 	11: Ret
 }
-bits(Arg0: u64, Arg1: u8): u64 /* def_idx: 1 */ {
+bits(x: u64, y: u8): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u8)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u8)
 	2: Shl
-	3: CopyLoc[0](Arg0: u64)
+	3: CopyLoc[0](x: u64)
 	4: BitAnd
-	5: CopyLoc[0](Arg0: u64)
-	6: MoveLoc[1](Arg1: u8)
+	5: CopyLoc[0](x: u64)
+	6: MoveLoc[1](y: u8)
 	7: Shr
-	8: MoveLoc[0](Arg0: u64)
+	8: MoveLoc[0](x: u64)
 	9: Xor
 	10: BitOr
 	11: Ret
 }
-bools(Arg0: bool, Arg1: bool): bool /* def_idx: 2 */ {
-L2:	loc0: bool
-L3:	loc1: bool
-L4:	loc2: bool
-L5:	loc3: bool
+bools(x: bool, y: bool): bool /* def_idx: 2 */ {
+L2:	$t5: bool
+L3:	$t4: bool
+L4:	$t3: bool
+L5:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: bool)
+	0: CopyLoc[0](x: bool)
 	1: BrFalse(5)
 B1:
-	2: CopyLoc[1](Arg1: bool)
-	3: StLoc[2](loc0: bool)
+	2: CopyLoc[1](y: bool)
+	3: StLoc[2]($t5: bool)
 	4: Branch(7)
 B2:
 	5: LdFalse
-	6: StLoc[2](loc0: bool)
+	6: StLoc[2]($t5: bool)
 B3:
-	7: MoveLoc[2](loc0: bool)
+	7: MoveLoc[2]($t5: bool)
 	8: BrFalse(12)
 B4:
 	9: LdTrue
-	10: StLoc[3](loc1: bool)
+	10: StLoc[3]($t4: bool)
 	11: Branch(20)
 B5:
-	12: CopyLoc[0](Arg0: bool)
+	12: CopyLoc[0](x: bool)
 	13: BrFalse(18)
 B6:
-	14: CopyLoc[1](Arg1: bool)
+	14: CopyLoc[1](y: bool)
 	15: Not
-	16: StLoc[3](loc1: bool)
+	16: StLoc[3]($t4: bool)
 	17: Branch(20)
 B7:
 	18: LdFalse
-	19: StLoc[3](loc1: bool)
+	19: StLoc[3]($t4: bool)
 B8:
-	20: MoveLoc[3](loc1: bool)
+	20: MoveLoc[3]($t4: bool)
 	21: BrFalse(25)
 B9:
 	22: LdTrue
-	23: StLoc[4](loc2: bool)
+	23: StLoc[4]($t3: bool)
 	24: Branch(33)
 B10:
-	25: CopyLoc[0](Arg0: bool)
+	25: CopyLoc[0](x: bool)
 	26: Not
 	27: BrFalse(31)
 B11:
-	28: CopyLoc[1](Arg1: bool)
-	29: StLoc[4](loc2: bool)
+	28: CopyLoc[1](y: bool)
+	29: StLoc[4]($t3: bool)
 	30: Branch(33)
 B12:
 	31: LdFalse
-	32: StLoc[4](loc2: bool)
+	32: StLoc[4]($t3: bool)
 B13:
-	33: MoveLoc[4](loc2: bool)
+	33: MoveLoc[4]($t3: bool)
 	34: BrFalse(38)
 B14:
 	35: LdTrue
-	36: StLoc[5](loc3: bool)
+	36: StLoc[5](return: bool)
 	37: Branch(47)
 B15:
-	38: MoveLoc[0](Arg0: bool)
+	38: MoveLoc[0](x: bool)
 	39: Not
 	40: BrFalse(45)
 B16:
-	41: MoveLoc[1](Arg1: bool)
+	41: MoveLoc[1](y: bool)
 	42: Not
-	43: StLoc[5](loc3: bool)
+	43: StLoc[5](return: bool)
 	44: Branch(47)
 B17:
 	45: LdFalse
-	46: StLoc[5](loc3: bool)
+	46: StLoc[5](return: bool)
 B18:
-	47: MoveLoc[5](loc3: bool)
+	47: MoveLoc[5](return: bool)
 	48: Ret
 }
-equality<Ty0: drop>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 3 */ {
+equality<T: drop>(x: T, y: T): bool /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
-	1: MoveLoc[1](Arg1: Ty0)
+	0: MoveLoc[0](x: T)
+	1: MoveLoc[1](y: T)
 	2: Eq
 	3: Ret
 }
-inequality<Ty0: drop>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 4 */ {
+inequality<T: drop>(x: T, y: T): bool /* def_idx: 4 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
-	1: MoveLoc[1](Arg1: Ty0)
+	0: MoveLoc[0](x: T)
+	1: MoveLoc[1](y: T)
 	2: Neq
 	3: Ret
 }
-order(Arg0: u64, Arg1: u64): bool /* def_idx: 5 */ {
-L2:	loc0: bool
-L3:	loc1: bool
-L4:	loc2: bool
+order(x: u64, y: u64): bool /* def_idx: 5 */ {
+L2:	$t4: bool
+L3:	$t3: bool
+L4:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u64)
 	2: Lt
 	3: BrFalse(9)
 B1:
-	4: CopyLoc[0](Arg0: u64)
-	5: CopyLoc[1](Arg1: u64)
+	4: CopyLoc[0](x: u64)
+	5: CopyLoc[1](y: u64)
 	6: Le
-	7: StLoc[2](loc0: bool)
+	7: StLoc[2]($t4: bool)
 	8: Branch(11)
 B2:
 	9: LdFalse
-	10: StLoc[2](loc0: bool)
+	10: StLoc[2]($t4: bool)
 B3:
-	11: MoveLoc[2](loc0: bool)
+	11: MoveLoc[2]($t4: bool)
 	12: BrFalse(19)
 B4:
-	13: CopyLoc[0](Arg0: u64)
-	14: CopyLoc[1](Arg1: u64)
+	13: CopyLoc[0](x: u64)
+	14: CopyLoc[1](y: u64)
 	15: Gt
 	16: Not
-	17: StLoc[3](loc1: bool)
+	17: StLoc[3]($t3: bool)
 	18: Branch(21)
 B5:
 	19: LdFalse
-	20: StLoc[3](loc1: bool)
+	20: StLoc[3]($t3: bool)
 B6:
-	21: MoveLoc[3](loc1: bool)
+	21: MoveLoc[3]($t3: bool)
 	22: BrFalse(29)
 B7:
-	23: MoveLoc[0](Arg0: u64)
-	24: MoveLoc[1](Arg1: u64)
+	23: MoveLoc[0](x: u64)
+	24: MoveLoc[1](y: u64)
 	25: Ge
 	26: Not
-	27: StLoc[4](loc2: bool)
+	27: StLoc[4](return: bool)
 	28: Branch(31)
 B8:
 	29: LdFalse
-	30: StLoc[4](loc2: bool)
+	30: StLoc[4](return: bool)
 B9:
-	31: MoveLoc[4](loc2: bool)
+	31: MoveLoc[4](return: bool)
 	32: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/operators.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/operators.opt.exp
@@ -4,168 +4,168 @@
 module 42.operators {
 
 
-arithm(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+arithm(x: u64, y: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u64)
-	2: CopyLoc[0](Arg0: u64)
-	3: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u64)
+	2: CopyLoc[0](x: u64)
+	3: CopyLoc[1](y: u64)
 	4: Sub
 	5: Div
-	6: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[1](y: u64)
 	7: Mul
-	8: MoveLoc[0](Arg0: u64)
+	8: MoveLoc[0](x: u64)
 	9: Mod
 	10: Add
 	11: Ret
 }
-bits(Arg0: u64, Arg1: u8): u64 /* def_idx: 1 */ {
+bits(x: u64, y: u8): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u8)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u8)
 	2: Shl
-	3: CopyLoc[0](Arg0: u64)
+	3: CopyLoc[0](x: u64)
 	4: BitAnd
-	5: CopyLoc[0](Arg0: u64)
-	6: MoveLoc[1](Arg1: u8)
+	5: CopyLoc[0](x: u64)
+	6: MoveLoc[1](y: u8)
 	7: Shr
-	8: MoveLoc[0](Arg0: u64)
+	8: MoveLoc[0](x: u64)
 	9: Xor
 	10: BitOr
 	11: Ret
 }
-bools(Arg0: bool, Arg1: bool): bool /* def_idx: 2 */ {
-L2:	loc0: bool
-L3:	loc1: bool
-L4:	loc2: bool
-L5:	loc3: bool
+bools(x: bool, y: bool): bool /* def_idx: 2 */ {
+L2:	$t5: bool
+L3:	$t4: bool
+L4:	$t3: bool
+L5:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: bool)
+	0: CopyLoc[0](x: bool)
 	1: BrFalse(44)
 B1:
-	2: CopyLoc[1](Arg1: bool)
-	3: StLoc[2](loc0: bool)
+	2: CopyLoc[1](y: bool)
+	3: StLoc[2]($t5: bool)
 B2:
-	4: MoveLoc[2](loc0: bool)
+	4: MoveLoc[2]($t5: bool)
 	5: BrFalse(35)
 B3:
 	6: LdTrue
-	7: StLoc[3](loc1: bool)
+	7: StLoc[3]($t4: bool)
 B4:
-	8: MoveLoc[3](loc1: bool)
+	8: MoveLoc[3]($t4: bool)
 	9: BrFalse(27)
 B5:
 	10: LdTrue
-	11: StLoc[4](loc2: bool)
+	11: StLoc[4]($t3: bool)
 B6:
-	12: MoveLoc[4](loc2: bool)
+	12: MoveLoc[4]($t3: bool)
 	13: BrFalse(18)
 B7:
 	14: LdTrue
-	15: StLoc[5](loc3: bool)
+	15: StLoc[5](return: bool)
 B8:
-	16: MoveLoc[5](loc3: bool)
+	16: MoveLoc[5](return: bool)
 	17: Ret
 B9:
-	18: MoveLoc[0](Arg0: bool)
+	18: MoveLoc[0](x: bool)
 	19: BrTrue(24)
 B10:
-	20: MoveLoc[1](Arg1: bool)
+	20: MoveLoc[1](y: bool)
 	21: Not
-	22: StLoc[5](loc3: bool)
+	22: StLoc[5](return: bool)
 	23: Branch(16)
 B11:
 	24: LdFalse
-	25: StLoc[5](loc3: bool)
+	25: StLoc[5](return: bool)
 	26: Branch(16)
 B12:
-	27: CopyLoc[0](Arg0: bool)
+	27: CopyLoc[0](x: bool)
 	28: BrTrue(32)
 B13:
-	29: CopyLoc[1](Arg1: bool)
-	30: StLoc[4](loc2: bool)
+	29: CopyLoc[1](y: bool)
+	30: StLoc[4]($t3: bool)
 	31: Branch(12)
 B14:
 	32: LdFalse
-	33: StLoc[4](loc2: bool)
+	33: StLoc[4]($t3: bool)
 	34: Branch(12)
 B15:
-	35: CopyLoc[0](Arg0: bool)
+	35: CopyLoc[0](x: bool)
 	36: BrFalse(41)
 B16:
-	37: CopyLoc[1](Arg1: bool)
+	37: CopyLoc[1](y: bool)
 	38: Not
-	39: StLoc[3](loc1: bool)
+	39: StLoc[3]($t4: bool)
 	40: Branch(8)
 B17:
 	41: LdFalse
-	42: StLoc[3](loc1: bool)
+	42: StLoc[3]($t4: bool)
 	43: Branch(8)
 B18:
 	44: LdFalse
-	45: StLoc[2](loc0: bool)
+	45: StLoc[2]($t5: bool)
 	46: Branch(4)
 }
-equality<Ty0: drop>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 3 */ {
+equality<T: drop>(x: T, y: T): bool /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
-	1: MoveLoc[1](Arg1: Ty0)
+	0: MoveLoc[0](x: T)
+	1: MoveLoc[1](y: T)
 	2: Eq
 	3: Ret
 }
-inequality<Ty0: drop>(Arg0: Ty0, Arg1: Ty0): bool /* def_idx: 4 */ {
+inequality<T: drop>(x: T, y: T): bool /* def_idx: 4 */ {
 B0:
-	0: MoveLoc[0](Arg0: Ty0)
-	1: MoveLoc[1](Arg1: Ty0)
+	0: MoveLoc[0](x: T)
+	1: MoveLoc[1](y: T)
 	2: Neq
 	3: Ret
 }
-order(Arg0: u64, Arg1: u64): bool /* def_idx: 5 */ {
-L2:	loc0: bool
-L3:	loc1: bool
-L4:	loc2: bool
+order(x: u64, y: u64): bool /* def_idx: 5 */ {
+L2:	$t5: bool
+L3:	$t8: bool
+L4:	$t10: bool
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: CopyLoc[1](Arg1: u64)
+	0: CopyLoc[0](x: u64)
+	1: CopyLoc[1](y: u64)
 	2: Lt
 	3: BrFalse(30)
 B1:
-	4: CopyLoc[0](Arg0: u64)
-	5: CopyLoc[1](Arg1: u64)
+	4: CopyLoc[0](x: u64)
+	5: CopyLoc[1](y: u64)
 	6: Le
-	7: StLoc[2](loc0: bool)
+	7: StLoc[2]($t5: bool)
 B2:
-	8: MoveLoc[2](loc0: bool)
+	8: MoveLoc[2]($t5: bool)
 	9: BrFalse(27)
 B3:
-	10: CopyLoc[0](Arg0: u64)
-	11: CopyLoc[1](Arg1: u64)
+	10: CopyLoc[0](x: u64)
+	11: CopyLoc[1](y: u64)
 	12: Gt
 	13: Not
-	14: StLoc[3](loc1: bool)
+	14: StLoc[3]($t8: bool)
 B4:
-	15: MoveLoc[3](loc1: bool)
+	15: MoveLoc[3]($t8: bool)
 	16: BrFalse(24)
 B5:
-	17: MoveLoc[0](Arg0: u64)
-	18: MoveLoc[1](Arg1: u64)
+	17: MoveLoc[0](x: u64)
+	18: MoveLoc[1](y: u64)
 	19: Ge
 	20: Not
-	21: StLoc[4](loc2: bool)
+	21: StLoc[4]($t10: bool)
 B6:
-	22: MoveLoc[4](loc2: bool)
+	22: MoveLoc[4]($t10: bool)
 	23: Ret
 B7:
 	24: LdFalse
-	25: StLoc[4](loc2: bool)
+	25: StLoc[4]($t10: bool)
 	26: Branch(22)
 B8:
 	27: LdFalse
-	28: StLoc[3](loc1: bool)
+	28: StLoc[3]($t8: bool)
 	29: Branch(15)
 B9:
 	30: LdFalse
-	31: StLoc[2](loc0: bool)
+	31: StLoc[2]($t5: bool)
 	32: Branch(8)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_01.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_01.exp
@@ -4,13 +4,13 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-public test01(Arg0: u64) /* def_idx: 1 */ {
+public test01(a: u64) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](a: u64)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
@@ -19,27 +19,27 @@ B0:
 	6: Call consume(u64, u64, u64, u64, u64, u64)
 	7: Ret
 }
-public test02(Arg0: u64) /* def_idx: 2 */ {
+public test02(a: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](a: u64)
 	1: LdU64(1)
 	2: LdU64(2)
-	3: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[0](a: u64)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume(u64, u64, u64, u64, u64, u64)
 	7: Ret
 }
-public test03(Arg0: u64) /* def_idx: 3 */ {
+public test03(a: u64) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](a: u64)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume(u64, u64, u64, u64, u64, u64)
-	7: MoveLoc[0](Arg0: u64)
+	7: MoveLoc[0](a: u64)
 	8: LdU64(1)
 	9: LdU64(2)
 	10: LdU64(3)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_01.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_01.opt.exp
@@ -4,13 +4,13 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-public test01(Arg0: u64) /* def_idx: 1 */ {
+public test01(a: u64) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](a: u64)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
@@ -19,27 +19,27 @@ B0:
 	6: Call consume(u64, u64, u64, u64, u64, u64)
 	7: Ret
 }
-public test02(Arg0: u64) /* def_idx: 2 */ {
+public test02(a: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](a: u64)
 	1: LdU64(1)
 	2: LdU64(2)
-	3: MoveLoc[0](Arg0: u64)
+	3: MoveLoc[0](a: u64)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume(u64, u64, u64, u64, u64, u64)
 	7: Ret
 }
-public test03(Arg0: u64) /* def_idx: 3 */ {
+public test03(a: u64) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](a: u64)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume(u64, u64, u64, u64, u64, u64)
-	7: MoveLoc[0](Arg0: u64)
+	7: MoveLoc[0](a: u64)
 	8: LdU64(1)
 	9: LdU64(2)
 	10: LdU64(3)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_02.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_02.exp
@@ -6,31 +6,31 @@ struct S {
 	x: u64
 }
 
-consume1(Arg0: &S, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume1(_a: &S, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](_a: &S)
 	1: Pop
 	2: Ret
 }
-consume2(Arg0: &S, Arg1: u64, Arg2: u64, Arg3: &S, Arg4: u64, Arg5: u64) /* def_idx: 1 */ {
+consume2(_a: &S, _b: u64, _c: u64, _d: &S, _e: u64, _f: u64) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](_a: &S)
 	1: Pop
-	2: MoveLoc[3](Arg3: &S)
+	2: MoveLoc[3](_d: &S)
 	3: Pop
 	4: Ret
 }
-consume3(Arg0: &S, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: &u64, Arg5: u64) /* def_idx: 2 */ {
+consume3(_a: &S, _b: u64, _c: u64, _d: u64, _e: &u64, _f: u64) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](_a: &S)
 	1: Pop
-	2: MoveLoc[4](Arg4: &u64)
+	2: MoveLoc[4](_e: &u64)
 	3: Pop
 	4: Ret
 }
-public test01(Arg0: &S) /* def_idx: 3 */ {
+public test01(a: &S) /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
@@ -39,27 +39,27 @@ B0:
 	6: Call consume1(&S, u64, u64, u64, u64, u64)
 	7: Ret
 }
-public test02(Arg0: &S) /* def_idx: 4 */ {
+public test02(a: &S) /* def_idx: 4 */ {
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
-	3: MoveLoc[0](Arg0: &S)
+	3: MoveLoc[0](a: &S)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume2(&S, u64, u64, &S, u64, u64)
 	7: Ret
 }
-public test03(Arg0: &S) /* def_idx: 5 */ {
+public test03(a: &S) /* def_idx: 5 */ {
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume1(&S, u64, u64, u64, u64, u64)
-	7: MoveLoc[0](Arg0: &S)
+	7: MoveLoc[0](a: &S)
 	8: LdU64(1)
 	9: LdU64(2)
 	10: LdU64(3)
@@ -68,21 +68,21 @@ B0:
 	13: Call consume1(&S, u64, u64, u64, u64, u64)
 	14: Ret
 }
-public test04(Arg0: &S) /* def_idx: 6 */ {
+public test04(a: &S) /* def_idx: 6 */ {
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
-	4: CopyLoc[0](Arg0: &S)
+	4: CopyLoc[0](a: &S)
 	5: ImmBorrowField[0](S.x: u64)
 	6: LdU64(5)
 	7: Call consume3(&S, u64, u64, u64, &u64, u64)
-	8: CopyLoc[0](Arg0: &S)
+	8: CopyLoc[0](a: &S)
 	9: LdU64(1)
 	10: LdU64(2)
 	11: LdU64(3)
-	12: MoveLoc[0](Arg0: &S)
+	12: MoveLoc[0](a: &S)
 	13: ImmBorrowField[0](S.x: u64)
 	14: ReadRef
 	15: LdU64(5)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_02.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_02.opt.exp
@@ -6,31 +6,31 @@ struct S {
 	x: u64
 }
 
-consume1(Arg0: &S, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume1(_a: &S, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](_a: &S)
 	1: Pop
 	2: Ret
 }
-consume2(Arg0: &S, Arg1: u64, Arg2: u64, Arg3: &S, Arg4: u64, Arg5: u64) /* def_idx: 1 */ {
+consume2(_a: &S, _b: u64, _c: u64, _d: &S, _e: u64, _f: u64) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](_a: &S)
 	1: Pop
-	2: MoveLoc[3](Arg3: &S)
+	2: MoveLoc[3](_d: &S)
 	3: Pop
 	4: Ret
 }
-consume3(Arg0: &S, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: &u64, Arg5: u64) /* def_idx: 2 */ {
+consume3(_a: &S, _b: u64, _c: u64, _d: u64, _e: &u64, _f: u64) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](_a: &S)
 	1: Pop
-	2: MoveLoc[4](Arg4: &u64)
+	2: MoveLoc[4](_e: &u64)
 	3: Pop
 	4: Ret
 }
-public test01(Arg0: &S) /* def_idx: 3 */ {
+public test01(a: &S) /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
@@ -39,27 +39,27 @@ B0:
 	6: Call consume1(&S, u64, u64, u64, u64, u64)
 	7: Ret
 }
-public test02(Arg0: &S) /* def_idx: 4 */ {
+public test02(a: &S) /* def_idx: 4 */ {
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
-	3: MoveLoc[0](Arg0: &S)
+	3: MoveLoc[0](a: &S)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume2(&S, u64, u64, &S, u64, u64)
 	7: Ret
 }
-public test03(Arg0: &S) /* def_idx: 5 */ {
+public test03(a: &S) /* def_idx: 5 */ {
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
 	4: LdU64(4)
 	5: LdU64(5)
 	6: Call consume1(&S, u64, u64, u64, u64, u64)
-	7: MoveLoc[0](Arg0: &S)
+	7: MoveLoc[0](a: &S)
 	8: LdU64(1)
 	9: LdU64(2)
 	10: LdU64(3)
@@ -68,21 +68,21 @@ B0:
 	13: Call consume1(&S, u64, u64, u64, u64, u64)
 	14: Ret
 }
-public test04(Arg0: &S) /* def_idx: 6 */ {
+public test04(a: &S) /* def_idx: 6 */ {
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](a: &S)
 	1: LdU64(1)
 	2: LdU64(2)
 	3: LdU64(3)
-	4: CopyLoc[0](Arg0: &S)
+	4: CopyLoc[0](a: &S)
 	5: ImmBorrowField[0](S.x: u64)
 	6: LdU64(5)
 	7: Call consume3(&S, u64, u64, u64, &u64, u64)
-	8: CopyLoc[0](Arg0: &S)
+	8: CopyLoc[0](a: &S)
 	9: LdU64(1)
 	10: LdU64(2)
 	11: LdU64(3)
-	12: MoveLoc[0](Arg0: &S)
+	12: MoveLoc[0](a: &S)
 	13: ImmBorrowField[0](S.x: u64)
 	14: ReadRef
 	15: LdU64(5)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_04.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_04.exp
@@ -4,21 +4,21 @@
 module c0ffee.m {
 
 
-bar(Arg0: &mut u64) /* def_idx: 0 */ {
+bar(_x: &mut u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[0](_x: &mut u64)
 	1: Pop
 	2: Ret
 }
-baz(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 1 */ {
+baz(_x: u64, _y: u64, _z: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public foo(Arg0: u64) /* def_idx: 2 */ {
+public foo(x: u64) /* def_idx: 2 */ {
 B0:
-	0: MutBorrowLoc[0](Arg0: u64)
+	0: MutBorrowLoc[0](x: u64)
 	1: Call bar(&mut u64)
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: LdU64(1)
 	4: LdU64(2)
 	5: Call baz(u64, u64, u64)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_04.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_04.opt.exp
@@ -4,21 +4,21 @@
 module c0ffee.m {
 
 
-bar(Arg0: &mut u64) /* def_idx: 0 */ {
+bar(_x: &mut u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: &mut u64)
+	0: MoveLoc[0](_x: &mut u64)
 	1: Pop
 	2: Ret
 }
-baz(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 1 */ {
+baz(_x: u64, _y: u64, _z: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public foo(Arg0: u64) /* def_idx: 2 */ {
+public foo(x: u64) /* def_idx: 2 */ {
 B0:
-	0: MutBorrowLoc[0](Arg0: u64)
+	0: MutBorrowLoc[0](x: u64)
 	1: Call bar(&mut u64)
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: LdU64(1)
 	4: LdU64(2)
 	5: Call baz(u64, u64, u64)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_05.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_05.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume1(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume1(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -13,39 +13,39 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test1(Arg0: u64) /* def_idx: 2 */ {
+public test1(p: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: MoveLoc[0](p: u64)
 	2: LdU64(1)
 	3: Call consume1(u64, u64, u64)
 	4: Ret
 }
-public test2(Arg0: u64) /* def_idx: 3 */ {
+public test2(p: u64) /* def_idx: 3 */ {
 B0:
 	0: Call one(): u64
-	1: MoveLoc[0](Arg0: u64)
+	1: MoveLoc[0](p: u64)
 	2: LdU64(2)
 	3: Call consume1(u64, u64, u64)
 	4: Ret
 }
-public test3(Arg0: u64) /* def_idx: 4 */ {
-L1:	loc0: u64
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
+public test3(p: u64) /* def_idx: 4 */ {
+L1:	$t2: u64
+L2:	q: u64
+L3:	$t4: u64
+L4:	$t3: u64
 B0:
 	0: Call one(): u64
-	1: MoveLoc[0](Arg0: u64)
-	2: StLoc[1](loc0: u64)
-	3: StLoc[2](loc1: u64)
-	4: MoveLoc[2](loc1: u64)
+	1: MoveLoc[0](p: u64)
+	2: StLoc[1]($t2: u64)
+	3: StLoc[2](q: u64)
+	4: MoveLoc[2](q: u64)
 	5: LdU64(3)
-	6: StLoc[3](loc2: u64)
-	7: StLoc[4](loc3: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: MoveLoc[4](loc3: u64)
-	10: MoveLoc[3](loc2: u64)
+	6: StLoc[3]($t4: u64)
+	7: StLoc[4]($t3: u64)
+	8: MoveLoc[1]($t2: u64)
+	9: MoveLoc[4]($t3: u64)
+	10: MoveLoc[3]($t4: u64)
 	11: Call consume1(u64, u64, u64)
 	12: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_05.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/opt_load_05.opt.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume1(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume1(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -13,29 +13,29 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test1(Arg0: u64) /* def_idx: 2 */ {
+public test1(p: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: MoveLoc[0](p: u64)
 	2: LdU64(1)
 	3: Call consume1(u64, u64, u64)
 	4: Ret
 }
-public test2(Arg0: u64) /* def_idx: 3 */ {
+public test2(p: u64) /* def_idx: 3 */ {
 B0:
 	0: Call one(): u64
-	1: MoveLoc[0](Arg0: u64)
+	1: MoveLoc[0](p: u64)
 	2: LdU64(2)
 	3: Call consume1(u64, u64, u64)
 	4: Ret
 }
-public test3(Arg0: u64) /* def_idx: 4 */ {
-L1:	loc0: u64
+public test3(p: u64) /* def_idx: 4 */ {
+L1:	q: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[1](loc0: u64)
-	2: MoveLoc[0](Arg0: u64)
-	3: MoveLoc[1](loc0: u64)
+	1: StLoc[1](q: u64)
+	2: MoveLoc[0](p: u64)
+	3: MoveLoc[1](q: u64)
 	4: LdU64(3)
 	5: Call consume1(u64, u64, u64)
 	6: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.exp
@@ -8,99 +8,99 @@ struct S {
 	f3: u8
 }
 
-pack1(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 0 */ {
+pack1(x: u8, y: u8, z: u8): S /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[2](Arg2: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[2](z: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack2(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 1 */ {
-L3:	loc0: u8
-L4:	loc1: u8
+pack2(x: u8, y: u8, z: u8): S /* def_idx: 1 */ {
+L3:	$f3: u8
+L4:	$f1: u8
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: StLoc[3](loc0: u8)
-	3: StLoc[4](loc1: u8)
-	4: MoveLoc[4](loc1: u8)
-	5: MoveLoc[2](Arg2: u8)
-	6: MoveLoc[3](loc0: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: StLoc[3]($f3: u8)
+	3: StLoc[4]($f1: u8)
+	4: MoveLoc[4]($f1: u8)
+	5: MoveLoc[2](z: u8)
+	6: MoveLoc[3]($f3: u8)
 	7: Pack[0](S)
 	8: Ret
 }
-pack3(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 2 */ {
-L3:	loc0: u8
-L4:	loc1: u8
-L5:	loc2: u8
+pack3(x: u8, y: u8, z: u8): S /* def_idx: 2 */ {
+L3:	$t5: u8
+L4:	$f2: u8
+L5:	$t6: u8
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: StLoc[3](loc0: u8)
-	3: StLoc[4](loc1: u8)
-	4: MoveLoc[4](loc1: u8)
-	5: StLoc[5](loc2: u8)
-	6: MoveLoc[3](loc0: u8)
-	7: MoveLoc[5](loc2: u8)
-	8: MoveLoc[2](Arg2: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: StLoc[3]($t5: u8)
+	3: StLoc[4]($f2: u8)
+	4: MoveLoc[4]($f2: u8)
+	5: StLoc[5]($t6: u8)
+	6: MoveLoc[3]($t5: u8)
+	7: MoveLoc[5]($t6: u8)
+	8: MoveLoc[2](z: u8)
 	9: Pack[0](S)
 	10: Ret
 }
-pack4(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 3 */ {
-L3:	loc0: u8
-L4:	loc1: u8
-L5:	loc2: u8
-L6:	loc3: u8
+pack4(x: u8, y: u8, z: u8): S /* def_idx: 3 */ {
+L3:	$t6: u8
+L4:	$f3: u8
+L5:	$f2: u8
+L6:	$t7: u8
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[2](Arg2: u8)
-	3: StLoc[3](loc0: u8)
-	4: StLoc[4](loc1: u8)
-	5: StLoc[5](loc2: u8)
-	6: MoveLoc[5](loc2: u8)
-	7: StLoc[6](loc3: u8)
-	8: MoveLoc[3](loc0: u8)
-	9: MoveLoc[6](loc3: u8)
-	10: MoveLoc[4](loc1: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[2](z: u8)
+	3: StLoc[3]($t6: u8)
+	4: StLoc[4]($f3: u8)
+	5: StLoc[5]($f2: u8)
+	6: MoveLoc[5]($f2: u8)
+	7: StLoc[6]($t7: u8)
+	8: MoveLoc[3]($t6: u8)
+	9: MoveLoc[6]($t7: u8)
+	10: MoveLoc[4]($f3: u8)
 	11: Pack[0](S)
 	12: Ret
 }
-pack5(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 4 */ {
-L3:	loc0: u8
-L4:	loc1: u8
-L5:	loc2: u8
+pack5(x: u8, y: u8, z: u8): S /* def_idx: 4 */ {
+L3:	$t6: u8
+L4:	$t5: u8
+L5:	$f3: u8
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[2](Arg2: u8)
-	3: StLoc[3](loc0: u8)
-	4: StLoc[4](loc1: u8)
-	5: StLoc[5](loc2: u8)
-	6: MoveLoc[4](loc1: u8)
-	7: MoveLoc[3](loc0: u8)
-	8: MoveLoc[5](loc2: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[2](z: u8)
+	3: StLoc[3]($t6: u8)
+	4: StLoc[4]($t5: u8)
+	5: StLoc[5]($f3: u8)
+	6: MoveLoc[4]($t5: u8)
+	7: MoveLoc[3]($t6: u8)
+	8: MoveLoc[5]($f3: u8)
 	9: Pack[0](S)
 	10: Ret
 }
-pack6(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 5 */ {
-L3:	loc0: u8
-L4:	loc1: u8
-L5:	loc2: u8
-L6:	loc3: u8
+pack6(x: u8, y: u8, z: u8): S /* def_idx: 5 */ {
+L3:	$t6: u8
+L4:	$f2: u8
+L5:	$t7: u8
+L6:	$f3: u8
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[2](Arg2: u8)
-	3: StLoc[3](loc0: u8)
-	4: StLoc[4](loc1: u8)
-	5: MoveLoc[4](loc1: u8)
-	6: StLoc[5](loc2: u8)
-	7: StLoc[6](loc3: u8)
-	8: MoveLoc[3](loc0: u8)
-	9: MoveLoc[5](loc2: u8)
-	10: MoveLoc[6](loc3: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[2](z: u8)
+	3: StLoc[3]($t6: u8)
+	4: StLoc[4]($f2: u8)
+	5: MoveLoc[4]($f2: u8)
+	6: StLoc[5]($t7: u8)
+	7: StLoc[6]($f3: u8)
+	8: MoveLoc[3]($t6: u8)
+	9: MoveLoc[5]($t7: u8)
+	10: MoveLoc[6]($f3: u8)
 	11: Pack[0](S)
 	12: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_order.opt.exp
@@ -8,51 +8,51 @@ struct S {
 	f3: u8
 }
 
-pack1(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 0 */ {
+pack1(x: u8, y: u8, z: u8): S /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[2](Arg2: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[2](z: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack2(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 1 */ {
+pack2(x: u8, y: u8, z: u8): S /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u8)
-	1: MoveLoc[2](Arg2: u8)
-	2: MoveLoc[1](Arg1: u8)
+	0: MoveLoc[0](x: u8)
+	1: MoveLoc[2](z: u8)
+	2: MoveLoc[1](y: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack3(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 2 */ {
+pack3(x: u8, y: u8, z: u8): S /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[1](Arg1: u8)
-	1: MoveLoc[0](Arg0: u8)
-	2: MoveLoc[2](Arg2: u8)
+	0: MoveLoc[1](y: u8)
+	1: MoveLoc[0](x: u8)
+	2: MoveLoc[2](z: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack4(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 3 */ {
+pack4(x: u8, y: u8, z: u8): S /* def_idx: 3 */ {
 B0:
-	0: MoveLoc[2](Arg2: u8)
-	1: MoveLoc[0](Arg0: u8)
-	2: MoveLoc[1](Arg1: u8)
+	0: MoveLoc[2](z: u8)
+	1: MoveLoc[0](x: u8)
+	2: MoveLoc[1](y: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack5(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 4 */ {
+pack5(x: u8, y: u8, z: u8): S /* def_idx: 4 */ {
 B0:
-	0: MoveLoc[1](Arg1: u8)
-	1: MoveLoc[2](Arg2: u8)
-	2: MoveLoc[0](Arg0: u8)
+	0: MoveLoc[1](y: u8)
+	1: MoveLoc[2](z: u8)
+	2: MoveLoc[0](x: u8)
 	3: Pack[0](S)
 	4: Ret
 }
-pack6(Arg0: u8, Arg1: u8, Arg2: u8): S /* def_idx: 5 */ {
+pack6(x: u8, y: u8, z: u8): S /* def_idx: 5 */ {
 B0:
-	0: MoveLoc[2](Arg2: u8)
-	1: MoveLoc[1](Arg1: u8)
-	2: MoveLoc[0](Arg0: u8)
+	0: MoveLoc[2](z: u8)
+	1: MoveLoc[1](y: u8)
+	2: MoveLoc[0](x: u8)
 	3: Pack[0](S)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.exp
@@ -10,25 +10,25 @@ struct S {
 	g: T
 }
 
-pack(Arg0: u64, Arg1: u64): S /* def_idx: 0 */ {
+pack(x: u64, y: u64): S /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: u64)
+	1: MoveLoc[1](y: u64)
 	2: Pack[0](T)
 	3: Pack[1](S)
 	4: Ret
 }
-unpack(Arg0: S): u64 * u64 /* def_idx: 1 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+unpack(s: S): u64 * u64 /* def_idx: 1 */ {
+L1:	h: u64
+L2:	f: u64
 B0:
-	0: MoveLoc[0](Arg0: S)
+	0: MoveLoc[0](s: S)
 	1: Unpack[1](S)
 	2: Unpack[0](T)
-	3: StLoc[1](loc0: u64)
-	4: StLoc[2](loc1: u64)
-	5: MoveLoc[2](loc1: u64)
-	6: MoveLoc[1](loc0: u64)
+	3: StLoc[1](h: u64)
+	4: StLoc[2](f: u64)
+	5: MoveLoc[2](f: u64)
+	6: MoveLoc[1](h: u64)
 	7: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack.opt.exp
@@ -10,19 +10,19 @@ struct S {
 	g: T
 }
 
-pack(Arg0: u64, Arg1: u64): S /* def_idx: 0 */ {
+pack(x: u64, y: u64): S /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: u64)
+	1: MoveLoc[1](y: u64)
 	2: Pack[0](T)
 	3: Pack[1](S)
 	4: Ret
 }
-unpack(Arg0: S): u64 * u64 /* def_idx: 1 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+unpack(s: S): u64 * u64 /* def_idx: 1 */ {
+L1:	h: u64
+L2:	f: u64
 B0:
-	0: MoveLoc[0](Arg0: S)
+	0: MoveLoc[0](s: S)
 	1: Unpack[1](S)
 	2: Unpack[0](T)
 	3: Ret

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.exp
@@ -12,67 +12,67 @@ struct S {
 	g: u64
 }
 
-unpack_mut_ref(Arg0: &mut S): u64 * u64 /* def_idx: 0 */ {
-L1:	loc0: &mut u64
-L2:	loc1: &mut u64
+unpack_mut_ref(s: &mut S): u64 * u64 /* def_idx: 0 */ {
+L1:	g: &mut u64
+L2:	f: &mut u64
 B0:
-	0: CopyLoc[0](Arg0: &mut S)
+	0: CopyLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: MoveLoc[0](Arg0: &mut S)
+	2: MoveLoc[0](s: &mut S)
 	3: MutBorrowField[1](S.g: u64)
-	4: StLoc[1](loc0: &mut u64)
-	5: StLoc[2](loc1: &mut u64)
-	6: MoveLoc[2](loc1: &mut u64)
+	4: StLoc[1](g: &mut u64)
+	5: StLoc[2](f: &mut u64)
+	6: MoveLoc[2](f: &mut u64)
 	7: ReadRef
-	8: MoveLoc[1](loc0: &mut u64)
+	8: MoveLoc[1](g: &mut u64)
 	9: ReadRef
 	10: Ret
 }
-unpack_ref(Arg0: &S): u64 * u64 /* def_idx: 1 */ {
-L1:	loc0: &u64
-L2:	loc1: &u64
+unpack_ref(s: &S): u64 * u64 /* def_idx: 1 */ {
+L1:	g: &u64
+L2:	f: &u64
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](s: &S)
 	1: ImmBorrowField[0](S.f: u64)
-	2: MoveLoc[0](Arg0: &S)
+	2: MoveLoc[0](s: &S)
 	3: ImmBorrowField[1](S.g: u64)
-	4: StLoc[1](loc0: &u64)
-	5: StLoc[2](loc1: &u64)
-	6: MoveLoc[2](loc1: &u64)
+	4: StLoc[1](g: &u64)
+	5: StLoc[2](f: &u64)
+	6: MoveLoc[2](f: &u64)
 	7: ReadRef
-	8: MoveLoc[1](loc0: &u64)
+	8: MoveLoc[1](g: &u64)
 	9: ReadRef
 	10: Ret
 }
-unpack_ref_G(Arg0: &G): u64 * u64 * u64 * u64 /* def_idx: 2 */ {
-L1:	loc0: &S
-L2:	loc1: &u64
-L3:	loc2: &u64
-L4:	loc3: &u64
-L5:	loc4: &u64
+unpack_ref_G(g: &G): u64 * u64 * u64 * u64 /* def_idx: 2 */ {
+L1:	s: &S
+L2:	g: &u64
+L3:	f: &u64
+L4:	x2: &u64
+L5:	x1: &u64
 B0:
-	0: CopyLoc[0](Arg0: &G)
+	0: CopyLoc[0](g: &G)
 	1: ImmBorrowField[2](G.x1: u64)
-	2: CopyLoc[0](Arg0: &G)
+	2: CopyLoc[0](g: &G)
 	3: ImmBorrowField[3](G.x2: u64)
-	4: MoveLoc[0](Arg0: &G)
+	4: MoveLoc[0](g: &G)
 	5: ImmBorrowField[4](G.s: S)
-	6: StLoc[1](loc0: &S)
-	7: CopyLoc[1](loc0: &S)
+	6: StLoc[1](s: &S)
+	7: CopyLoc[1](s: &S)
 	8: ImmBorrowField[0](S.f: u64)
-	9: MoveLoc[1](loc0: &S)
+	9: MoveLoc[1](s: &S)
 	10: ImmBorrowField[1](S.g: u64)
-	11: StLoc[2](loc1: &u64)
-	12: StLoc[3](loc2: &u64)
-	13: StLoc[4](loc3: &u64)
-	14: StLoc[5](loc4: &u64)
-	15: MoveLoc[5](loc4: &u64)
+	11: StLoc[2](g: &u64)
+	12: StLoc[3](f: &u64)
+	13: StLoc[4](x2: &u64)
+	14: StLoc[5](x1: &u64)
+	15: MoveLoc[5](x1: &u64)
 	16: ReadRef
-	17: MoveLoc[4](loc3: &u64)
+	17: MoveLoc[4](x2: &u64)
 	18: ReadRef
-	19: MoveLoc[3](loc2: &u64)
+	19: MoveLoc[3](f: &u64)
 	20: ReadRef
-	21: MoveLoc[2](loc1: &u64)
+	21: MoveLoc[2](g: &u64)
 	22: ReadRef
 	23: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/pack_unpack_ref.opt.exp
@@ -12,58 +12,58 @@ struct S {
 	g: u64
 }
 
-unpack_mut_ref(Arg0: &mut S): u64 * u64 /* def_idx: 0 */ {
-L1:	loc0: &mut u64
+unpack_mut_ref(s: &mut S): u64 * u64 /* def_idx: 0 */ {
+L1:	g: &mut u64
 B0:
-	0: CopyLoc[0](Arg0: &mut S)
+	0: CopyLoc[0](s: &mut S)
 	1: MutBorrowField[0](S.f: u64)
-	2: MoveLoc[0](Arg0: &mut S)
+	2: MoveLoc[0](s: &mut S)
 	3: MutBorrowField[1](S.g: u64)
-	4: StLoc[1](loc0: &mut u64)
+	4: StLoc[1](g: &mut u64)
 	5: ReadRef
-	6: MoveLoc[1](loc0: &mut u64)
+	6: MoveLoc[1](g: &mut u64)
 	7: ReadRef
 	8: Ret
 }
-unpack_ref(Arg0: &S): u64 * u64 /* def_idx: 1 */ {
-L1:	loc0: &u64
+unpack_ref(s: &S): u64 * u64 /* def_idx: 1 */ {
+L1:	g: &u64
 B0:
-	0: CopyLoc[0](Arg0: &S)
+	0: CopyLoc[0](s: &S)
 	1: ImmBorrowField[0](S.f: u64)
-	2: MoveLoc[0](Arg0: &S)
+	2: MoveLoc[0](s: &S)
 	3: ImmBorrowField[1](S.g: u64)
-	4: StLoc[1](loc0: &u64)
+	4: StLoc[1](g: &u64)
 	5: ReadRef
-	6: MoveLoc[1](loc0: &u64)
+	6: MoveLoc[1](g: &u64)
 	7: ReadRef
 	8: Ret
 }
-unpack_ref_G(Arg0: &G): u64 * u64 * u64 * u64 /* def_idx: 2 */ {
-L1:	loc0: &u64
-L2:	loc1: &S
-L3:	loc2: &u64
-L4:	loc3: &u64
+unpack_ref_G(g: &G): u64 * u64 * u64 * u64 /* def_idx: 2 */ {
+L1:	x2: &u64
+L2:	s: &S
+L3:	f: &u64
+L4:	g: &u64
 B0:
-	0: CopyLoc[0](Arg0: &G)
+	0: CopyLoc[0](g: &G)
 	1: ImmBorrowField[2](G.x1: u64)
-	2: CopyLoc[0](Arg0: &G)
+	2: CopyLoc[0](g: &G)
 	3: ImmBorrowField[3](G.x2: u64)
-	4: StLoc[1](loc0: &u64)
-	5: MoveLoc[0](Arg0: &G)
+	4: StLoc[1](x2: &u64)
+	5: MoveLoc[0](g: &G)
 	6: ImmBorrowField[4](G.s: S)
-	7: StLoc[2](loc1: &S)
-	8: CopyLoc[2](loc1: &S)
+	7: StLoc[2](s: &S)
+	8: CopyLoc[2](s: &S)
 	9: ImmBorrowField[0](S.f: u64)
-	10: StLoc[3](loc2: &u64)
-	11: MoveLoc[2](loc1: &S)
+	10: StLoc[3](f: &u64)
+	11: MoveLoc[2](s: &S)
 	12: ImmBorrowField[1](S.g: u64)
-	13: StLoc[4](loc3: &u64)
+	13: StLoc[4](g: &u64)
 	14: ReadRef
-	15: MoveLoc[1](loc0: &u64)
+	15: MoveLoc[1](x2: &u64)
 	16: ReadRef
-	17: MoveLoc[3](loc2: &u64)
+	17: MoveLoc[3](f: &u64)
 	18: ReadRef
-	19: MoveLoc[4](loc3: &u64)
+	19: MoveLoc[4](g: &u64)
 	20: ReadRef
 	21: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
@@ -41,12 +41,12 @@ enum Inner {
 	y: u64
  }
 }
-enum Option<Ty0> has drop {
+enum Option<A> has drop {
  None{
 
  },
  Some{
-	value: Ty0
+	value: A
  }
 }
 enum Outer {
@@ -62,499 +62,499 @@ enum Outer {
  }
 }
 
-public inner_value(Arg0: Inner): u64 /* def_idx: 0 */ {
-L1:	loc0: &Inner
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
+public inner_value(self: Inner): u64 /* def_idx: 0 */ {
+L1:	$t2: &Inner
+L2:	return: u64
+L3:	y: u64
+L4:	x: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: Inner)
-	1: StLoc[1](loc0: &Inner)
-	2: CopyLoc[1](loc0: &Inner)
+	0: ImmBorrowLoc[0](self: Inner)
+	1: StLoc[1]($t2: &Inner)
+	2: CopyLoc[1]($t2: &Inner)
 	3: TestVariant[0](Inner/Inner1)
 	4: BrFalse(11)
 B1:
-	5: MoveLoc[1](loc0: &Inner)
+	5: MoveLoc[1]($t2: &Inner)
 	6: Pop
-	7: MoveLoc[0](Arg0: Inner)
+	7: MoveLoc[0](self: Inner)
 	8: UnpackVariant[0](Inner/Inner1)
-	9: StLoc[2](loc1: u64)
+	9: StLoc[2](return: u64)
 	10: Branch(25)
 B2:
-	11: MoveLoc[1](loc0: &Inner)
+	11: MoveLoc[1]($t2: &Inner)
 	12: TestVariant[1](Inner/Inner2)
 	13: BrFalse(23)
 B3:
-	14: MoveLoc[0](Arg0: Inner)
+	14: MoveLoc[0](self: Inner)
 	15: UnpackVariant[1](Inner/Inner2)
-	16: StLoc[3](loc2: u64)
-	17: StLoc[4](loc3: u64)
-	18: MoveLoc[4](loc3: u64)
-	19: MoveLoc[3](loc2: u64)
+	16: StLoc[3](y: u64)
+	17: StLoc[4](x: u64)
+	18: MoveLoc[4](x: u64)
+	19: MoveLoc[3](y: u64)
 	20: Add
-	21: StLoc[2](loc1: u64)
+	21: StLoc[2](return: u64)
 	22: Branch(25)
 B4:
 	23: LdU64(14566554180833181697)
 	24: Abort
 B5:
-	25: MoveLoc[2](loc1: u64)
+	25: MoveLoc[2](return: u64)
 	26: Ret
 }
-public is_inner1(Arg0: &Inner): bool /* def_idx: 1 */ {
-L1:	loc0: bool
-L2:	loc1: &Inner
+public is_inner1(self: &Inner): bool /* def_idx: 1 */ {
+L1:	return: bool
+L2:	$t3: &Inner
 B0:
-	0: CopyLoc[0](Arg0: &Inner)
+	0: CopyLoc[0](self: &Inner)
 	1: TestVariant[0](Inner/Inner1)
 	2: BrFalse(8)
 B1:
-	3: MoveLoc[0](Arg0: &Inner)
+	3: MoveLoc[0](self: &Inner)
 	4: Pop
 	5: LdTrue
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 	7: Branch(17)
 B2:
-	8: MoveLoc[0](Arg0: &Inner)
-	9: StLoc[2](loc1: &Inner)
-	10: MoveLoc[2](loc1: &Inner)
+	8: MoveLoc[0](self: &Inner)
+	9: StLoc[2]($t3: &Inner)
+	10: MoveLoc[2]($t3: &Inner)
 	11: Pop
 	12: LdFalse
-	13: StLoc[1](loc0: bool)
+	13: StLoc[1](return: bool)
 	14: Branch(17)
 B3:
 	15: LdU64(14566554180833181697)
 	16: Abort
 B4:
-	17: MoveLoc[1](loc0: bool)
+	17: MoveLoc[1](return: bool)
 	18: Ret
 }
-public is_some<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
-L1:	loc0: bool
+public is_some<A>(x: &Option<A>): bool /* def_idx: 2 */ {
+L1:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: &Option<Ty0>)
-	1: TestVariantGeneric[0](Option/None<Ty0>)
+	0: CopyLoc[0](x: &Option<A>)
+	1: TestVariantGeneric[0](Option/None<A>)
 	2: BrFalse(8)
 B1:
-	3: MoveLoc[0](Arg0: &Option<Ty0>)
+	3: MoveLoc[0](x: &Option<A>)
 	4: Pop
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 	7: Branch(16)
 B2:
-	8: MoveLoc[0](Arg0: &Option<Ty0>)
-	9: TestVariantGeneric[1](Option/Some<Ty0>)
+	8: MoveLoc[0](x: &Option<A>)
+	9: TestVariantGeneric[1](Option/Some<A>)
 	10: BrFalse(14)
 B3:
 	11: LdTrue
-	12: StLoc[1](loc0: bool)
+	12: StLoc[1](return: bool)
 	13: Branch(16)
 B4:
 	14: LdU64(14566554180833181697)
 	15: Abort
 B5:
-	16: MoveLoc[1](loc0: bool)
+	16: MoveLoc[1](return: bool)
 	17: Ret
 }
-public is_some_dropped<Ty0: drop>(Arg0: Option<Ty0>): bool /* def_idx: 3 */ {
-L1:	loc0: bool
+public is_some_dropped<A: drop>(x: Option<A>): bool /* def_idx: 3 */ {
+L1:	return: bool
 B0:
-	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
-	1: TestVariantGeneric[0](Option/None<Ty0>)
+	0: ImmBorrowLoc[0](x: Option<A>)
+	1: TestVariantGeneric[0](Option/None<A>)
 	2: BrFalse(8)
 B1:
-	3: MoveLoc[0](Arg0: Option<Ty0>)
-	4: UnpackVariantGeneric[0](Option/None<Ty0>)
+	3: MoveLoc[0](x: Option<A>)
+	4: UnpackVariantGeneric[0](Option/None<A>)
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 	7: Branch(15)
 B2:
-	8: MoveLoc[0](Arg0: Option<Ty0>)
+	8: MoveLoc[0](x: Option<A>)
 	9: LdTrue
-	10: StLoc[1](loc0: bool)
+	10: StLoc[1](return: bool)
 	11: Pop
 	12: Branch(15)
 B3:
 	13: LdU64(14566554180833181697)
 	14: Abort
 B4:
-	15: MoveLoc[1](loc0: bool)
+	15: MoveLoc[1](return: bool)
 	16: Ret
 }
-public is_some_specialized(Arg0: &Option<Option<u64>>): bool /* def_idx: 4 */ {
-L1:	loc0: bool
+public is_some_specialized(x: &Option<Option<u64>>): bool /* def_idx: 4 */ {
+L1:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	0: CopyLoc[0](x: &Option<Option<u64>>)
 	1: TestVariantGeneric[2](Option/None<Option<u64>>)
 	2: BrFalse(8)
 B1:
-	3: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	3: MoveLoc[0](x: &Option<Option<u64>>)
 	4: Pop
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 	7: Branch(38)
 B2:
-	8: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	8: CopyLoc[0](x: &Option<Option<u64>>)
 	9: TestVariantGeneric[3](Option/Some<Option<u64>>)
 	10: BrTrue(12)
 B3:
 	11: Branch(22)
 B4:
-	12: CopyLoc[0](Arg0: &Option<Option<u64>>)
-	13: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
+	12: CopyLoc[0](x: &Option<Option<u64>>)
+	13: ImmBorrowVariantFieldGeneric[0](Some.value: A)
 	14: TestVariantGeneric[4](Option/None<u64>)
 	15: BrTrue(17)
 B5:
 	16: Branch(22)
 B6:
-	17: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	17: MoveLoc[0](x: &Option<Option<u64>>)
 	18: Pop
 	19: LdFalse
-	20: StLoc[1](loc0: bool)
+	20: StLoc[1](return: bool)
 	21: Branch(38)
 B7:
-	22: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	22: CopyLoc[0](x: &Option<Option<u64>>)
 	23: TestVariantGeneric[3](Option/Some<Option<u64>>)
 	24: BrTrue(28)
 B8:
-	25: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	25: MoveLoc[0](x: &Option<Option<u64>>)
 	26: Pop
 	27: Branch(36)
 B9:
-	28: MoveLoc[0](Arg0: &Option<Option<u64>>)
-	29: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
+	28: MoveLoc[0](x: &Option<Option<u64>>)
+	29: ImmBorrowVariantFieldGeneric[0](Some.value: A)
 	30: TestVariantGeneric[5](Option/Some<u64>)
 	31: BrTrue(33)
 B10:
 	32: Branch(36)
 B11:
 	33: LdTrue
-	34: StLoc[1](loc0: bool)
+	34: StLoc[1](return: bool)
 	35: Branch(38)
 B12:
 	36: LdU64(14566554180833181697)
 	37: Abort
 B13:
-	38: MoveLoc[1](loc0: bool)
+	38: MoveLoc[1](return: bool)
 	39: Ret
 }
-public outer_value(Arg0: Outer): u64 /* def_idx: 5 */ {
-L1:	loc0: &Outer
-L2:	loc1: u64
-L3:	loc2: Box
+public outer_value(o: Outer): u64 /* def_idx: 5 */ {
+L1:	$t2: &Outer
+L2:	return: u64
+L3:	b: Box
 B0:
-	0: ImmBorrowLoc[0](Arg0: Outer)
-	1: StLoc[1](loc0: &Outer)
-	2: CopyLoc[1](loc0: &Outer)
+	0: ImmBorrowLoc[0](o: Outer)
+	1: StLoc[1]($t2: &Outer)
+	2: CopyLoc[1]($t2: &Outer)
 	3: TestVariant[4](Outer/None)
 	4: BrFalse(12)
 B1:
-	5: MoveLoc[1](loc0: &Outer)
+	5: MoveLoc[1]($t2: &Outer)
 	6: Pop
-	7: MoveLoc[0](Arg0: Outer)
+	7: MoveLoc[0](o: Outer)
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
-	10: StLoc[2](loc1: u64)
+	10: StLoc[2](return: u64)
 	11: Branch(37)
 B2:
-	12: CopyLoc[1](loc0: &Outer)
+	12: CopyLoc[1]($t2: &Outer)
 	13: TestVariant[5](Outer/One)
 	14: BrFalse(22)
 B3:
-	15: MoveLoc[1](loc0: &Outer)
+	15: MoveLoc[1]($t2: &Outer)
 	16: Pop
-	17: MoveLoc[0](Arg0: Outer)
+	17: MoveLoc[0](o: Outer)
 	18: UnpackVariant[5](Outer/One)
 	19: Call inner_value(Inner): u64
-	20: StLoc[2](loc1: u64)
+	20: StLoc[2](return: u64)
 	21: Branch(37)
 B4:
-	22: MoveLoc[1](loc0: &Outer)
+	22: MoveLoc[1]($t2: &Outer)
 	23: TestVariant[6](Outer/Two)
 	24: BrFalse(35)
 B5:
-	25: MoveLoc[0](Arg0: Outer)
+	25: MoveLoc[0](o: Outer)
 	26: UnpackVariant[6](Outer/Two)
-	27: StLoc[3](loc2: Box)
+	27: StLoc[3](b: Box)
 	28: Call inner_value(Inner): u64
-	29: ImmBorrowLoc[3](loc2: Box)
+	29: ImmBorrowLoc[3](b: Box)
 	30: ImmBorrowField[0](Box.x: u64)
 	31: ReadRef
 	32: Add
-	33: StLoc[2](loc1: u64)
+	33: StLoc[2](return: u64)
 	34: Branch(37)
 B6:
 	35: LdU64(14566554180833181697)
 	36: Abort
 B7:
-	37: MoveLoc[2](loc1: u64)
+	37: MoveLoc[2](return: u64)
 	38: Ret
 }
-public outer_value_nested(Arg0: Outer): u64 /* def_idx: 6 */ {
-L1:	loc0: &Outer
-L2:	loc1: u64
-L3:	loc2: Box
+public outer_value_nested(o: Outer): u64 /* def_idx: 6 */ {
+L1:	$t2: &Outer
+L2:	return: u64
+L3:	b: Box
 B0:
-	0: ImmBorrowLoc[0](Arg0: Outer)
-	1: StLoc[1](loc0: &Outer)
-	2: CopyLoc[1](loc0: &Outer)
+	0: ImmBorrowLoc[0](o: Outer)
+	1: StLoc[1]($t2: &Outer)
+	2: CopyLoc[1]($t2: &Outer)
 	3: TestVariant[4](Outer/None)
 	4: BrFalse(12)
 B1:
-	5: MoveLoc[1](loc0: &Outer)
+	5: MoveLoc[1]($t2: &Outer)
 	6: Pop
-	7: MoveLoc[0](Arg0: Outer)
+	7: MoveLoc[0](o: Outer)
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
-	10: StLoc[2](loc1: u64)
+	10: StLoc[2](return: u64)
 	11: Branch(53)
 B2:
-	12: CopyLoc[1](loc0: &Outer)
+	12: CopyLoc[1]($t2: &Outer)
 	13: TestVariant[5](Outer/One)
 	14: BrTrue(16)
 B3:
 	15: Branch(28)
 B4:
-	16: CopyLoc[1](loc0: &Outer)
+	16: CopyLoc[1]($t2: &Outer)
 	17: ImmBorrowVariantField[1](One.i: Inner)
 	18: TestVariant[0](Inner/Inner1)
 	19: BrTrue(21)
 B5:
 	20: Branch(28)
 B6:
-	21: MoveLoc[1](loc0: &Outer)
+	21: MoveLoc[1]($t2: &Outer)
 	22: Pop
-	23: MoveLoc[0](Arg0: Outer)
+	23: MoveLoc[0](o: Outer)
 	24: UnpackVariant[5](Outer/One)
 	25: UnpackVariant[0](Inner/Inner1)
-	26: StLoc[2](loc1: u64)
+	26: StLoc[2](return: u64)
 	27: Branch(53)
 B7:
-	28: CopyLoc[1](loc0: &Outer)
+	28: CopyLoc[1]($t2: &Outer)
 	29: TestVariant[5](Outer/One)
 	30: BrFalse(38)
 B8:
-	31: MoveLoc[1](loc0: &Outer)
+	31: MoveLoc[1]($t2: &Outer)
 	32: Pop
-	33: MoveLoc[0](Arg0: Outer)
+	33: MoveLoc[0](o: Outer)
 	34: UnpackVariant[5](Outer/One)
 	35: Call inner_value(Inner): u64
-	36: StLoc[2](loc1: u64)
+	36: StLoc[2](return: u64)
 	37: Branch(53)
 B9:
-	38: MoveLoc[1](loc0: &Outer)
+	38: MoveLoc[1]($t2: &Outer)
 	39: TestVariant[6](Outer/Two)
 	40: BrFalse(51)
 B10:
-	41: MoveLoc[0](Arg0: Outer)
+	41: MoveLoc[0](o: Outer)
 	42: UnpackVariant[6](Outer/Two)
-	43: StLoc[3](loc2: Box)
+	43: StLoc[3](b: Box)
 	44: Call inner_value(Inner): u64
-	45: ImmBorrowLoc[3](loc2: Box)
+	45: ImmBorrowLoc[3](b: Box)
 	46: ImmBorrowField[0](Box.x: u64)
 	47: ReadRef
 	48: Add
-	49: StLoc[2](loc1: u64)
+	49: StLoc[2](return: u64)
 	50: Branch(53)
 B11:
 	51: LdU64(14566554180833181697)
 	52: Abort
 B12:
-	53: MoveLoc[2](loc1: u64)
+	53: MoveLoc[2](return: u64)
 	54: Ret
 }
-public outer_value_with_cond(Arg0: Outer): u64 /* def_idx: 7 */ {
-L1:	loc0: &Outer
-L2:	loc1: u64
-L3:	loc2: Box
+public outer_value_with_cond(o: Outer): u64 /* def_idx: 7 */ {
+L1:	$t2: &Outer
+L2:	return: u64
+L3:	b: Box
 B0:
-	0: ImmBorrowLoc[0](Arg0: Outer)
-	1: StLoc[1](loc0: &Outer)
-	2: CopyLoc[1](loc0: &Outer)
+	0: ImmBorrowLoc[0](o: Outer)
+	1: StLoc[1]($t2: &Outer)
+	2: CopyLoc[1]($t2: &Outer)
 	3: TestVariant[4](Outer/None)
 	4: BrFalse(12)
 B1:
-	5: MoveLoc[1](loc0: &Outer)
+	5: MoveLoc[1]($t2: &Outer)
 	6: Pop
-	7: MoveLoc[0](Arg0: Outer)
+	7: MoveLoc[0](o: Outer)
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
-	10: StLoc[2](loc1: u64)
+	10: StLoc[2](return: u64)
 	11: Branch(55)
 B2:
-	12: CopyLoc[1](loc0: &Outer)
+	12: CopyLoc[1]($t2: &Outer)
 	13: TestVariant[5](Outer/One)
 	14: BrTrue(16)
 B3:
 	15: Branch(30)
 B4:
-	16: CopyLoc[1](loc0: &Outer)
+	16: CopyLoc[1]($t2: &Outer)
 	17: ImmBorrowVariantField[1](One.i: Inner)
 	18: Call is_inner1(&Inner): bool
 	19: BrTrue(21)
 B5:
 	20: Branch(30)
 B6:
-	21: MoveLoc[1](loc0: &Outer)
+	21: MoveLoc[1]($t2: &Outer)
 	22: Pop
-	23: MoveLoc[0](Arg0: Outer)
+	23: MoveLoc[0](o: Outer)
 	24: UnpackVariant[5](Outer/One)
 	25: Call inner_value(Inner): u64
 	26: LdU64(2)
 	27: Mod
-	28: StLoc[2](loc1: u64)
+	28: StLoc[2](return: u64)
 	29: Branch(55)
 B7:
-	30: CopyLoc[1](loc0: &Outer)
+	30: CopyLoc[1]($t2: &Outer)
 	31: TestVariant[5](Outer/One)
 	32: BrFalse(40)
 B8:
-	33: MoveLoc[1](loc0: &Outer)
+	33: MoveLoc[1]($t2: &Outer)
 	34: Pop
-	35: MoveLoc[0](Arg0: Outer)
+	35: MoveLoc[0](o: Outer)
 	36: UnpackVariant[5](Outer/One)
 	37: Call inner_value(Inner): u64
-	38: StLoc[2](loc1: u64)
+	38: StLoc[2](return: u64)
 	39: Branch(55)
 B9:
-	40: MoveLoc[1](loc0: &Outer)
+	40: MoveLoc[1]($t2: &Outer)
 	41: TestVariant[6](Outer/Two)
 	42: BrFalse(53)
 B10:
-	43: MoveLoc[0](Arg0: Outer)
+	43: MoveLoc[0](o: Outer)
 	44: UnpackVariant[6](Outer/Two)
-	45: StLoc[3](loc2: Box)
+	45: StLoc[3](b: Box)
 	46: Call inner_value(Inner): u64
-	47: ImmBorrowLoc[3](loc2: Box)
+	47: ImmBorrowLoc[3](b: Box)
 	48: ImmBorrowField[0](Box.x: u64)
 	49: ReadRef
 	50: Add
-	51: StLoc[2](loc1: u64)
+	51: StLoc[2](return: u64)
 	52: Branch(55)
 B11:
 	53: LdU64(14566554180833181697)
 	54: Abort
 B12:
-	55: MoveLoc[2](loc1: u64)
+	55: MoveLoc[2](return: u64)
 	56: Ret
 }
-public outer_value_with_cond_ref(Arg0: &Outer): bool /* def_idx: 8 */ {
-L1:	loc0: bool
+public outer_value_with_cond_ref(o: &Outer): bool /* def_idx: 8 */ {
+L1:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: &Outer)
+	0: CopyLoc[0](o: &Outer)
 	1: TestVariant[4](Outer/None)
 	2: BrFalse(8)
 B1:
-	3: MoveLoc[0](Arg0: &Outer)
+	3: MoveLoc[0](o: &Outer)
 	4: Pop
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 	7: Branch(42)
 B2:
-	8: CopyLoc[0](Arg0: &Outer)
+	8: CopyLoc[0](o: &Outer)
 	9: TestVariant[5](Outer/One)
 	10: BrTrue(12)
 B3:
 	11: Branch(22)
 B4:
-	12: CopyLoc[0](Arg0: &Outer)
+	12: CopyLoc[0](o: &Outer)
 	13: ImmBorrowVariantField[1](One.i: Inner)
 	14: Call is_inner1(&Inner): bool
 	15: BrTrue(17)
 B5:
 	16: Branch(22)
 B6:
-	17: MoveLoc[0](Arg0: &Outer)
+	17: MoveLoc[0](o: &Outer)
 	18: Pop
 	19: LdTrue
-	20: StLoc[1](loc0: bool)
+	20: StLoc[1](return: bool)
 	21: Branch(42)
 B7:
-	22: CopyLoc[0](Arg0: &Outer)
+	22: CopyLoc[0](o: &Outer)
 	23: TestVariant[5](Outer/One)
 	24: BrFalse(30)
 B8:
-	25: MoveLoc[0](Arg0: &Outer)
+	25: MoveLoc[0](o: &Outer)
 	26: ImmBorrowVariantField[1](One.i: Inner)
 	27: Call is_inner1(&Inner): bool
-	28: StLoc[1](loc0: bool)
+	28: StLoc[1](return: bool)
 	29: Branch(42)
 B9:
-	30: CopyLoc[0](Arg0: &Outer)
+	30: CopyLoc[0](o: &Outer)
 	31: TestVariant[6](Outer/Two)
 	32: BrFalse(38)
 B10:
-	33: MoveLoc[0](Arg0: &Outer)
+	33: MoveLoc[0](o: &Outer)
 	34: ImmBorrowVariantField[2](Two.i: Inner)
 	35: Call is_inner1(&Inner): bool
-	36: StLoc[1](loc0: bool)
+	36: StLoc[1](return: bool)
 	37: Branch(42)
 B11:
-	38: MoveLoc[0](Arg0: &Outer)
+	38: MoveLoc[0](o: &Outer)
 	39: Pop
 	40: LdU64(14566554180833181697)
 	41: Abort
 B12:
-	42: MoveLoc[1](loc0: bool)
+	42: MoveLoc[1](return: bool)
 	43: Ret
 }
-select_common_fields(Arg0: CommonFields): u64 /* def_idx: 9 */ {
-L1:	loc0: &CommonFields
-L2:	loc1: bool
-L3:	loc2: u64
-L4:	loc3: u64
+select_common_fields(s: CommonFields): u64 /* def_idx: 9 */ {
+L1:	$t6: &CommonFields
+L2:	$t7: bool
+L3:	$t2: u64
+L4:	$t5: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: CommonFields)
+	0: ImmBorrowLoc[0](s: CommonFields)
 	1: ImmBorrowVariantField[3](Foo.x|Bar.x: u64)
 	2: ReadRef
-	3: ImmBorrowLoc[0](Arg0: CommonFields)
-	4: StLoc[1](loc0: &CommonFields)
-	5: CopyLoc[1](loc0: &CommonFields)
+	3: ImmBorrowLoc[0](s: CommonFields)
+	4: StLoc[1]($t6: &CommonFields)
+	5: CopyLoc[1]($t6: &CommonFields)
 	6: TestVariant[7](CommonFields/Foo)
-	7: StLoc[2](loc1: bool)
-	8: StLoc[3](loc2: u64)
-	9: MoveLoc[2](loc1: bool)
+	7: StLoc[2]($t7: bool)
+	8: StLoc[3]($t2: u64)
+	9: MoveLoc[2]($t7: bool)
 	10: BrFalse(18)
 B1:
-	11: MoveLoc[1](loc0: &CommonFields)
+	11: MoveLoc[1]($t6: &CommonFields)
 	12: Pop
-	13: MoveLoc[0](Arg0: CommonFields)
+	13: MoveLoc[0](s: CommonFields)
 	14: UnpackVariant[7](CommonFields/Foo)
-	15: StLoc[4](loc3: u64)
+	15: StLoc[4]($t5: u64)
 	16: Pop
 	17: Branch(28)
 B2:
-	18: MoveLoc[1](loc0: &CommonFields)
+	18: MoveLoc[1]($t6: &CommonFields)
 	19: TestVariant[8](CommonFields/Bar)
 	20: BrFalse(26)
 B3:
-	21: MoveLoc[0](Arg0: CommonFields)
+	21: MoveLoc[0](s: CommonFields)
 	22: UnpackVariant[8](CommonFields/Bar)
-	23: StLoc[4](loc3: u64)
+	23: StLoc[4]($t5: u64)
 	24: Pop
 	25: Branch(28)
 B4:
 	26: LdU64(14566554180833181697)
 	27: Abort
 B5:
-	28: MoveLoc[3](loc2: u64)
-	29: MoveLoc[4](loc3: u64)
+	28: MoveLoc[3]($t2: u64)
+	29: MoveLoc[4]($t5: u64)
 	30: Add
 	31: Ret
 }
-select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
-L1:	loc0: &CommonFieldsAtDifferentOffset
-L2:	loc1: &u64
+select_common_fields_different_offset(s: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
+L1:	$t2: &CommonFieldsAtDifferentOffset
+L2:	$t3: &u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: CommonFieldsAtDifferentOffset)
-	1: StLoc[1](loc0: &CommonFieldsAtDifferentOffset)
-	2: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	0: ImmBorrowLoc[0](s: CommonFieldsAtDifferentOffset)
+	1: StLoc[1]($t2: &CommonFieldsAtDifferentOffset)
+	2: CopyLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	3: TestVariant[9](CommonFieldsAtDifferentOffset/Bar)
 	4: BrFalse(6)
 B1:
 	5: Branch(11)
 B2:
-	6: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	6: CopyLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	7: TestVariant[10](CommonFieldsAtDifferentOffset/Balt)
 	8: BrFalse(10)
 B3:
@@ -562,16 +562,16 @@ B3:
 B4:
 	10: Branch(15)
 B5:
-	11: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	11: MoveLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	12: ImmBorrowVariantField[4](Bar.z|Balt.z: u64)
-	13: StLoc[2](loc1: &u64)
+	13: StLoc[2]($t3: &u64)
 	14: Branch(18)
 B6:
-	15: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	15: MoveLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	16: ImmBorrowVariantField[5](Baz.z: u64)
-	17: StLoc[2](loc1: &u64)
+	17: StLoc[2]($t3: &u64)
 B7:
-	18: MoveLoc[2](loc1: &u64)
+	18: MoveLoc[2]($t3: &u64)
 	19: ReadRef
 	20: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
@@ -41,12 +41,12 @@ enum Inner {
 	y: u64
  }
 }
-enum Option<Ty0> has drop {
+enum Option<A> has drop {
  None{
 
  },
  Some{
-	value: Ty0
+	value: A
  }
 }
 enum Outer {
@@ -62,486 +62,486 @@ enum Outer {
  }
 }
 
-public inner_value(Arg0: Inner): u64 /* def_idx: 0 */ {
-L1:	loc0: &Inner
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
+public inner_value(self: Inner): u64 /* def_idx: 0 */ {
+L1:	$t2: &Inner
+L2:	x: u64
+L3:	y: u64
+L4:	x: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: Inner)
-	1: StLoc[1](loc0: &Inner)
-	2: CopyLoc[1](loc0: &Inner)
+	0: ImmBorrowLoc[0](self: Inner)
+	1: StLoc[1]($t2: &Inner)
+	2: CopyLoc[1]($t2: &Inner)
 	3: TestVariant[0](Inner/Inner1)
 	4: BrFalse(12)
 B1:
-	5: MoveLoc[1](loc0: &Inner)
+	5: MoveLoc[1]($t2: &Inner)
 	6: Pop
-	7: MoveLoc[0](Arg0: Inner)
+	7: MoveLoc[0](self: Inner)
 	8: UnpackVariant[0](Inner/Inner1)
-	9: StLoc[2](loc1: u64)
+	9: StLoc[2](x: u64)
 B2:
-	10: MoveLoc[2](loc1: u64)
+	10: MoveLoc[2](x: u64)
 	11: Ret
 B3:
-	12: MoveLoc[1](loc0: &Inner)
+	12: MoveLoc[1]($t2: &Inner)
 	13: TestVariant[1](Inner/Inner2)
 	14: BrFalse(20)
 B4:
-	15: MoveLoc[0](Arg0: Inner)
+	15: MoveLoc[0](self: Inner)
 	16: UnpackVariant[1](Inner/Inner2)
 	17: Add
-	18: StLoc[2](loc1: u64)
+	18: StLoc[2](x: u64)
 	19: Branch(10)
 B5:
 	20: LdU64(14566554180833181697)
 	21: Abort
 }
-public is_inner1(Arg0: &Inner): bool /* def_idx: 1 */ {
-L1:	loc0: bool
+public is_inner1(self: &Inner): bool /* def_idx: 1 */ {
+L1:	$t2: bool
 B0:
-	0: CopyLoc[0](Arg0: &Inner)
+	0: CopyLoc[0](self: &Inner)
 	1: TestVariant[0](Inner/Inner1)
 	2: BrFalse(9)
 B1:
-	3: MoveLoc[0](Arg0: &Inner)
+	3: MoveLoc[0](self: &Inner)
 	4: Pop
 	5: LdTrue
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1]($t2: bool)
 B2:
-	7: MoveLoc[1](loc0: bool)
+	7: MoveLoc[1]($t2: bool)
 	8: Ret
 B3:
-	9: MoveLoc[0](Arg0: &Inner)
+	9: MoveLoc[0](self: &Inner)
 	10: Pop
 	11: LdFalse
-	12: StLoc[1](loc0: bool)
+	12: StLoc[1]($t2: bool)
 	13: Branch(7)
 }
-public is_some<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
-L1:	loc0: bool
+public is_some<A>(x: &Option<A>): bool /* def_idx: 2 */ {
+L1:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: &Option<Ty0>)
-	1: TestVariantGeneric[0](Option/None<Ty0>)
+	0: CopyLoc[0](x: &Option<A>)
+	1: TestVariantGeneric[0](Option/None<A>)
 	2: BrFalse(9)
 B1:
-	3: MoveLoc[0](Arg0: &Option<Ty0>)
+	3: MoveLoc[0](x: &Option<A>)
 	4: Pop
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 B2:
-	7: MoveLoc[1](loc0: bool)
+	7: MoveLoc[1](return: bool)
 	8: Ret
 B3:
-	9: MoveLoc[0](Arg0: &Option<Ty0>)
-	10: TestVariantGeneric[1](Option/Some<Ty0>)
+	9: MoveLoc[0](x: &Option<A>)
+	10: TestVariantGeneric[1](Option/Some<A>)
 	11: BrFalse(15)
 B4:
 	12: LdTrue
-	13: StLoc[1](loc0: bool)
+	13: StLoc[1](return: bool)
 	14: Branch(7)
 B5:
 	15: LdU64(14566554180833181697)
 	16: Abort
 }
-public is_some_dropped<Ty0: drop>(Arg0: Option<Ty0>): bool /* def_idx: 3 */ {
-L1:	loc0: bool
+public is_some_dropped<A: drop>(x: Option<A>): bool /* def_idx: 3 */ {
+L1:	$t3: bool
 B0:
-	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
-	1: TestVariantGeneric[0](Option/None<Ty0>)
+	0: ImmBorrowLoc[0](x: Option<A>)
+	1: TestVariantGeneric[0](Option/None<A>)
 	2: BrFalse(9)
 B1:
-	3: MoveLoc[0](Arg0: Option<Ty0>)
-	4: UnpackVariantGeneric[0](Option/None<Ty0>)
+	3: MoveLoc[0](x: Option<A>)
+	4: UnpackVariantGeneric[0](Option/None<A>)
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1]($t3: bool)
 B2:
-	7: MoveLoc[1](loc0: bool)
+	7: MoveLoc[1]($t3: bool)
 	8: Ret
 B3:
 	9: LdTrue
-	10: StLoc[1](loc0: bool)
+	10: StLoc[1]($t3: bool)
 	11: Branch(7)
 }
-public is_some_specialized(Arg0: &Option<Option<u64>>): bool /* def_idx: 4 */ {
-L1:	loc0: bool
+public is_some_specialized(x: &Option<Option<u64>>): bool /* def_idx: 4 */ {
+L1:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	0: CopyLoc[0](x: &Option<Option<u64>>)
 	1: TestVariantGeneric[2](Option/None<Option<u64>>)
 	2: BrFalse(9)
 B1:
-	3: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	3: MoveLoc[0](x: &Option<Option<u64>>)
 	4: Pop
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 B2:
-	7: MoveLoc[1](loc0: bool)
+	7: MoveLoc[1](return: bool)
 	8: Ret
 B3:
-	9: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	9: CopyLoc[0](x: &Option<Option<u64>>)
 	10: TestVariantGeneric[3](Option/Some<Option<u64>>)
 	11: BrTrue(28)
 B4:
 	12: Branch(13)
 B5:
-	13: CopyLoc[0](Arg0: &Option<Option<u64>>)
+	13: CopyLoc[0](x: &Option<Option<u64>>)
 	14: TestVariantGeneric[3](Option/Some<Option<u64>>)
 	15: BrTrue(20)
 B6:
-	16: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	16: MoveLoc[0](x: &Option<Option<u64>>)
 	17: Pop
 B7:
 	18: LdU64(14566554180833181697)
 	19: Abort
 B8:
-	20: MoveLoc[0](Arg0: &Option<Option<u64>>)
-	21: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
+	20: MoveLoc[0](x: &Option<Option<u64>>)
+	21: ImmBorrowVariantFieldGeneric[0](Some.value: A)
 	22: TestVariantGeneric[4](Option/Some<u64>)
 	23: BrTrue(25)
 B9:
 	24: Branch(18)
 B10:
 	25: LdTrue
-	26: StLoc[1](loc0: bool)
+	26: StLoc[1](return: bool)
 	27: Branch(7)
 B11:
-	28: CopyLoc[0](Arg0: &Option<Option<u64>>)
-	29: ImmBorrowVariantFieldGeneric[0](Some.value: Ty0)
+	28: CopyLoc[0](x: &Option<Option<u64>>)
+	29: ImmBorrowVariantFieldGeneric[0](Some.value: A)
 	30: TestVariantGeneric[5](Option/None<u64>)
 	31: BrTrue(33)
 B12:
 	32: Branch(13)
 B13:
-	33: MoveLoc[0](Arg0: &Option<Option<u64>>)
+	33: MoveLoc[0](x: &Option<Option<u64>>)
 	34: Pop
 	35: LdFalse
-	36: StLoc[1](loc0: bool)
+	36: StLoc[1](return: bool)
 	37: Branch(7)
 }
-public outer_value(Arg0: Outer): u64 /* def_idx: 5 */ {
-L1:	loc0: &Outer
-L2:	loc1: u64
-L3:	loc2: Box
+public outer_value(o: Outer): u64 /* def_idx: 5 */ {
+L1:	$t2: &Outer
+L2:	return: u64
+L3:	b: Box
 B0:
-	0: ImmBorrowLoc[0](Arg0: Outer)
-	1: StLoc[1](loc0: &Outer)
-	2: CopyLoc[1](loc0: &Outer)
+	0: ImmBorrowLoc[0](o: Outer)
+	1: StLoc[1]($t2: &Outer)
+	2: CopyLoc[1]($t2: &Outer)
 	3: TestVariant[4](Outer/None)
 	4: BrFalse(13)
 B1:
-	5: MoveLoc[1](loc0: &Outer)
+	5: MoveLoc[1]($t2: &Outer)
 	6: Pop
-	7: MoveLoc[0](Arg0: Outer)
+	7: MoveLoc[0](o: Outer)
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
-	10: StLoc[2](loc1: u64)
+	10: StLoc[2](return: u64)
 B2:
-	11: MoveLoc[2](loc1: u64)
+	11: MoveLoc[2](return: u64)
 	12: Ret
 B3:
-	13: CopyLoc[1](loc0: &Outer)
+	13: CopyLoc[1]($t2: &Outer)
 	14: TestVariant[5](Outer/One)
 	15: BrFalse(23)
 B4:
-	16: MoveLoc[1](loc0: &Outer)
+	16: MoveLoc[1]($t2: &Outer)
 	17: Pop
-	18: MoveLoc[0](Arg0: Outer)
+	18: MoveLoc[0](o: Outer)
 	19: UnpackVariant[5](Outer/One)
 	20: Call inner_value(Inner): u64
-	21: StLoc[2](loc1: u64)
+	21: StLoc[2](return: u64)
 	22: Branch(11)
 B5:
-	23: MoveLoc[1](loc0: &Outer)
+	23: MoveLoc[1]($t2: &Outer)
 	24: TestVariant[6](Outer/Two)
 	25: BrFalse(36)
 B6:
-	26: MoveLoc[0](Arg0: Outer)
+	26: MoveLoc[0](o: Outer)
 	27: UnpackVariant[6](Outer/Two)
-	28: StLoc[3](loc2: Box)
+	28: StLoc[3](b: Box)
 	29: Call inner_value(Inner): u64
-	30: ImmBorrowLoc[3](loc2: Box)
+	30: ImmBorrowLoc[3](b: Box)
 	31: ImmBorrowField[0](Box.x: u64)
 	32: ReadRef
 	33: Add
-	34: StLoc[2](loc1: u64)
+	34: StLoc[2](return: u64)
 	35: Branch(11)
 B7:
 	36: LdU64(14566554180833181697)
 	37: Abort
 }
-public outer_value_nested(Arg0: Outer): u64 /* def_idx: 6 */ {
-L1:	loc0: &Outer
-L2:	loc1: u64
-L3:	loc2: Box
+public outer_value_nested(o: Outer): u64 /* def_idx: 6 */ {
+L1:	$t2: &Outer
+L2:	return: u64
+L3:	b: Box
 B0:
-	0: ImmBorrowLoc[0](Arg0: Outer)
-	1: StLoc[1](loc0: &Outer)
-	2: CopyLoc[1](loc0: &Outer)
+	0: ImmBorrowLoc[0](o: Outer)
+	1: StLoc[1]($t2: &Outer)
+	2: CopyLoc[1]($t2: &Outer)
 	3: TestVariant[4](Outer/None)
 	4: BrFalse(13)
 B1:
-	5: MoveLoc[1](loc0: &Outer)
+	5: MoveLoc[1]($t2: &Outer)
 	6: Pop
-	7: MoveLoc[0](Arg0: Outer)
+	7: MoveLoc[0](o: Outer)
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
-	10: StLoc[2](loc1: u64)
+	10: StLoc[2](return: u64)
 B2:
-	11: MoveLoc[2](loc1: u64)
+	11: MoveLoc[2](return: u64)
 	12: Ret
 B3:
-	13: CopyLoc[1](loc0: &Outer)
+	13: CopyLoc[1]($t2: &Outer)
 	14: TestVariant[5](Outer/One)
 	15: BrTrue(42)
 B4:
 	16: Branch(17)
 B5:
-	17: CopyLoc[1](loc0: &Outer)
+	17: CopyLoc[1]($t2: &Outer)
 	18: TestVariant[5](Outer/One)
 	19: BrFalse(27)
 B6:
-	20: MoveLoc[1](loc0: &Outer)
+	20: MoveLoc[1]($t2: &Outer)
 	21: Pop
-	22: MoveLoc[0](Arg0: Outer)
+	22: MoveLoc[0](o: Outer)
 	23: UnpackVariant[5](Outer/One)
 	24: Call inner_value(Inner): u64
-	25: StLoc[2](loc1: u64)
+	25: StLoc[2](return: u64)
 	26: Branch(11)
 B7:
-	27: MoveLoc[1](loc0: &Outer)
+	27: MoveLoc[1]($t2: &Outer)
 	28: TestVariant[6](Outer/Two)
 	29: BrFalse(40)
 B8:
-	30: MoveLoc[0](Arg0: Outer)
+	30: MoveLoc[0](o: Outer)
 	31: UnpackVariant[6](Outer/Two)
-	32: StLoc[3](loc2: Box)
+	32: StLoc[3](b: Box)
 	33: Call inner_value(Inner): u64
-	34: ImmBorrowLoc[3](loc2: Box)
+	34: ImmBorrowLoc[3](b: Box)
 	35: ImmBorrowField[0](Box.x: u64)
 	36: ReadRef
 	37: Add
-	38: StLoc[2](loc1: u64)
+	38: StLoc[2](return: u64)
 	39: Branch(11)
 B9:
 	40: LdU64(14566554180833181697)
 	41: Abort
 B10:
-	42: CopyLoc[1](loc0: &Outer)
+	42: CopyLoc[1]($t2: &Outer)
 	43: ImmBorrowVariantField[1](One.i: Inner)
 	44: TestVariant[0](Inner/Inner1)
 	45: BrTrue(47)
 B11:
 	46: Branch(17)
 B12:
-	47: MoveLoc[1](loc0: &Outer)
+	47: MoveLoc[1]($t2: &Outer)
 	48: Pop
-	49: MoveLoc[0](Arg0: Outer)
+	49: MoveLoc[0](o: Outer)
 	50: UnpackVariant[5](Outer/One)
 	51: UnpackVariant[0](Inner/Inner1)
-	52: StLoc[2](loc1: u64)
+	52: StLoc[2](return: u64)
 	53: Branch(11)
 }
-public outer_value_with_cond(Arg0: Outer): u64 /* def_idx: 7 */ {
-L1:	loc0: &Outer
-L2:	loc1: u64
-L3:	loc2: Box
+public outer_value_with_cond(o: Outer): u64 /* def_idx: 7 */ {
+L1:	$t2: &Outer
+L2:	return: u64
+L3:	b: Box
 B0:
-	0: ImmBorrowLoc[0](Arg0: Outer)
-	1: StLoc[1](loc0: &Outer)
-	2: CopyLoc[1](loc0: &Outer)
+	0: ImmBorrowLoc[0](o: Outer)
+	1: StLoc[1]($t2: &Outer)
+	2: CopyLoc[1]($t2: &Outer)
 	3: TestVariant[4](Outer/None)
 	4: BrFalse(13)
 B1:
-	5: MoveLoc[1](loc0: &Outer)
+	5: MoveLoc[1]($t2: &Outer)
 	6: Pop
-	7: MoveLoc[0](Arg0: Outer)
+	7: MoveLoc[0](o: Outer)
 	8: UnpackVariant[4](Outer/None)
 	9: LdU64(0)
-	10: StLoc[2](loc1: u64)
+	10: StLoc[2](return: u64)
 B2:
-	11: MoveLoc[2](loc1: u64)
+	11: MoveLoc[2](return: u64)
 	12: Ret
 B3:
-	13: CopyLoc[1](loc0: &Outer)
+	13: CopyLoc[1]($t2: &Outer)
 	14: TestVariant[5](Outer/One)
 	15: BrTrue(42)
 B4:
 	16: Branch(17)
 B5:
-	17: CopyLoc[1](loc0: &Outer)
+	17: CopyLoc[1]($t2: &Outer)
 	18: TestVariant[5](Outer/One)
 	19: BrFalse(27)
 B6:
-	20: MoveLoc[1](loc0: &Outer)
+	20: MoveLoc[1]($t2: &Outer)
 	21: Pop
-	22: MoveLoc[0](Arg0: Outer)
+	22: MoveLoc[0](o: Outer)
 	23: UnpackVariant[5](Outer/One)
 	24: Call inner_value(Inner): u64
-	25: StLoc[2](loc1: u64)
+	25: StLoc[2](return: u64)
 	26: Branch(11)
 B7:
-	27: MoveLoc[1](loc0: &Outer)
+	27: MoveLoc[1]($t2: &Outer)
 	28: TestVariant[6](Outer/Two)
 	29: BrFalse(40)
 B8:
-	30: MoveLoc[0](Arg0: Outer)
+	30: MoveLoc[0](o: Outer)
 	31: UnpackVariant[6](Outer/Two)
-	32: StLoc[3](loc2: Box)
+	32: StLoc[3](b: Box)
 	33: Call inner_value(Inner): u64
-	34: ImmBorrowLoc[3](loc2: Box)
+	34: ImmBorrowLoc[3](b: Box)
 	35: ImmBorrowField[0](Box.x: u64)
 	36: ReadRef
 	37: Add
-	38: StLoc[2](loc1: u64)
+	38: StLoc[2](return: u64)
 	39: Branch(11)
 B9:
 	40: LdU64(14566554180833181697)
 	41: Abort
 B10:
-	42: CopyLoc[1](loc0: &Outer)
+	42: CopyLoc[1]($t2: &Outer)
 	43: ImmBorrowVariantField[1](One.i: Inner)
 	44: Call is_inner1(&Inner): bool
 	45: BrTrue(47)
 B11:
 	46: Branch(17)
 B12:
-	47: MoveLoc[1](loc0: &Outer)
+	47: MoveLoc[1]($t2: &Outer)
 	48: Pop
-	49: MoveLoc[0](Arg0: Outer)
+	49: MoveLoc[0](o: Outer)
 	50: UnpackVariant[5](Outer/One)
 	51: Call inner_value(Inner): u64
 	52: LdU64(2)
 	53: Mod
-	54: StLoc[2](loc1: u64)
+	54: StLoc[2](return: u64)
 	55: Branch(11)
 }
-public outer_value_with_cond_ref(Arg0: &Outer): bool /* def_idx: 8 */ {
-L1:	loc0: bool
+public outer_value_with_cond_ref(o: &Outer): bool /* def_idx: 8 */ {
+L1:	return: bool
 B0:
-	0: CopyLoc[0](Arg0: &Outer)
+	0: CopyLoc[0](o: &Outer)
 	1: TestVariant[4](Outer/None)
 	2: BrFalse(9)
 B1:
-	3: MoveLoc[0](Arg0: &Outer)
+	3: MoveLoc[0](o: &Outer)
 	4: Pop
 	5: LdFalse
-	6: StLoc[1](loc0: bool)
+	6: StLoc[1](return: bool)
 B2:
-	7: MoveLoc[1](loc0: bool)
+	7: MoveLoc[1](return: bool)
 	8: Ret
 B3:
-	9: CopyLoc[0](Arg0: &Outer)
+	9: CopyLoc[0](o: &Outer)
 	10: TestVariant[5](Outer/One)
 	11: BrTrue(33)
 B4:
 	12: Branch(13)
 B5:
-	13: CopyLoc[0](Arg0: &Outer)
+	13: CopyLoc[0](o: &Outer)
 	14: TestVariant[5](Outer/One)
 	15: BrFalse(21)
 B6:
-	16: MoveLoc[0](Arg0: &Outer)
+	16: MoveLoc[0](o: &Outer)
 	17: ImmBorrowVariantField[1](One.i: Inner)
 	18: Call is_inner1(&Inner): bool
-	19: StLoc[1](loc0: bool)
+	19: StLoc[1](return: bool)
 	20: Branch(7)
 B7:
-	21: CopyLoc[0](Arg0: &Outer)
+	21: CopyLoc[0](o: &Outer)
 	22: TestVariant[6](Outer/Two)
 	23: BrFalse(29)
 B8:
-	24: MoveLoc[0](Arg0: &Outer)
+	24: MoveLoc[0](o: &Outer)
 	25: ImmBorrowVariantField[2](Two.i: Inner)
 	26: Call is_inner1(&Inner): bool
-	27: StLoc[1](loc0: bool)
+	27: StLoc[1](return: bool)
 	28: Branch(7)
 B9:
-	29: MoveLoc[0](Arg0: &Outer)
+	29: MoveLoc[0](o: &Outer)
 	30: Pop
 	31: LdU64(14566554180833181697)
 	32: Abort
 B10:
-	33: CopyLoc[0](Arg0: &Outer)
+	33: CopyLoc[0](o: &Outer)
 	34: ImmBorrowVariantField[1](One.i: Inner)
 	35: Call is_inner1(&Inner): bool
 	36: BrTrue(38)
 B11:
 	37: Branch(13)
 B12:
-	38: MoveLoc[0](Arg0: &Outer)
+	38: MoveLoc[0](o: &Outer)
 	39: Pop
 	40: LdTrue
-	41: StLoc[1](loc0: bool)
+	41: StLoc[1](return: bool)
 	42: Branch(7)
 }
-select_common_fields(Arg0: CommonFields): u64 /* def_idx: 9 */ {
-L1:	loc0: &CommonFields
-L2:	loc1: u64
-L3:	loc2: u64
+select_common_fields(s: CommonFields): u64 /* def_idx: 9 */ {
+L1:	$t3: &CommonFields
+L2:	$t2: u64
+L3:	y: u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: CommonFields)
+	0: ImmBorrowLoc[0](s: CommonFields)
 	1: ImmBorrowVariantField[3](Foo.x|Bar.x: u64)
 	2: ReadRef
-	3: StLoc[2](loc1: u64)
-	4: ImmBorrowLoc[0](Arg0: CommonFields)
-	5: StLoc[1](loc0: &CommonFields)
-	6: CopyLoc[1](loc0: &CommonFields)
+	3: StLoc[2]($t2: u64)
+	4: ImmBorrowLoc[0](s: CommonFields)
+	5: StLoc[1]($t3: &CommonFields)
+	6: CopyLoc[1]($t3: &CommonFields)
 	7: TestVariant[7](CommonFields/Foo)
 	8: BrFalse(19)
 B1:
-	9: MoveLoc[1](loc0: &CommonFields)
+	9: MoveLoc[1]($t3: &CommonFields)
 	10: Pop
-	11: MoveLoc[0](Arg0: CommonFields)
+	11: MoveLoc[0](s: CommonFields)
 	12: UnpackVariant[7](CommonFields/Foo)
-	13: StLoc[3](loc2: u64)
+	13: StLoc[3](y: u64)
 	14: Pop
 B2:
-	15: MoveLoc[2](loc1: u64)
-	16: MoveLoc[3](loc2: u64)
+	15: MoveLoc[2]($t2: u64)
+	16: MoveLoc[3](y: u64)
 	17: Add
 	18: Ret
 B3:
-	19: MoveLoc[1](loc0: &CommonFields)
+	19: MoveLoc[1]($t3: &CommonFields)
 	20: TestVariant[8](CommonFields/Bar)
 	21: BrFalse(27)
 B4:
-	22: MoveLoc[0](Arg0: CommonFields)
+	22: MoveLoc[0](s: CommonFields)
 	23: UnpackVariant[8](CommonFields/Bar)
-	24: StLoc[3](loc2: u64)
+	24: StLoc[3](y: u64)
 	25: Pop
 	26: Branch(15)
 B5:
 	27: LdU64(14566554180833181697)
 	28: Abort
 }
-select_common_fields_different_offset(Arg0: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
-L1:	loc0: &CommonFieldsAtDifferentOffset
-L2:	loc1: &u64
+select_common_fields_different_offset(s: CommonFieldsAtDifferentOffset): u64 /* def_idx: 10 */ {
+L1:	$t2: &CommonFieldsAtDifferentOffset
+L2:	$t3: &u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: CommonFieldsAtDifferentOffset)
-	1: StLoc[1](loc0: &CommonFieldsAtDifferentOffset)
-	2: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	0: ImmBorrowLoc[0](s: CommonFieldsAtDifferentOffset)
+	1: StLoc[1]($t2: &CommonFieldsAtDifferentOffset)
+	2: CopyLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	3: TestVariant[9](CommonFieldsAtDifferentOffset/Bar)
 	4: BrFalse(12)
 B1:
 	5: Branch(6)
 B2:
-	6: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	6: MoveLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	7: ImmBorrowVariantField[4](Bar.z|Balt.z: u64)
-	8: StLoc[2](loc1: &u64)
+	8: StLoc[2]($t3: &u64)
 B3:
-	9: MoveLoc[2](loc1: &u64)
+	9: MoveLoc[2]($t3: &u64)
 	10: ReadRef
 	11: Ret
 B4:
-	12: CopyLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	12: CopyLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	13: TestVariant[10](CommonFieldsAtDifferentOffset/Balt)
 	14: BrFalse(16)
 B5:
 	15: Branch(6)
 B6:
-	16: MoveLoc[1](loc0: &CommonFieldsAtDifferentOffset)
+	16: MoveLoc[1]($t2: &CommonFieldsAtDifferentOffset)
 	17: ImmBorrowVariantField[5](Baz.z: u64)
-	18: StLoc[2](loc1: &u64)
+	18: StLoc[2]($t3: &u64)
 	19: Branch(9)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.exp
@@ -5,17 +5,17 @@ module 42.m {
 use 0000000000000000000000000000000000000000000000000000000000000001::vector;
 
 
-struct E<Ty0> has copy, drop, store {
-	key: Ty0
+struct E<Key> has copy, drop, store {
+	key: Key
 }
-struct Option<Ty0> has copy, drop, store {
-	vec: vector<Ty0>
+struct Option<Element> has copy, drop, store {
+	vec: vector<Element>
 }
 
-public destroy_none<Ty0>(Arg0: Option<Ty0>) /* def_idx: 0 */ {
+public destroy_none<Element>(t: Option<Element>) /* def_idx: 0 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
-	1: Call is_none<Ty0>(&Option<Ty0>): bool
+	0: ImmBorrowLoc[0](t: Option<Element>)
+	1: Call is_none<Element>(&Option<Element>): bool
 	2: BrFalse(4)
 B1:
 	3: Branch(6)
@@ -23,31 +23,31 @@ B2:
 	4: LdU64(262144)
 	5: Abort
 B3:
-	6: MoveLoc[0](Arg0: Option<Ty0>)
-	7: UnpackGeneric[0](Option<Ty0>)
+	6: MoveLoc[0](t: Option<Element>)
+	7: UnpackGeneric[0](Option<Element>)
 	8: VecUnpack(2, 0)
 	9: Ret
 }
-public foo<Ty0: drop + store>(Arg0: E<Ty0>, Arg1: &mut Ty0) /* def_idx: 1 */ {
-L2:	loc0: Ty0
+public foo<Key: drop + store>(data: E<Key>, v: &mut Key) /* def_idx: 1 */ {
+L2:	key: Key
 B0:
-	0: MoveLoc[0](Arg0: E<Ty0>)
-	1: UnpackGeneric[1](E<Ty0>)
-	2: PackGeneric[1](E<Ty0>)
-	3: UnpackGeneric[1](E<Ty0>)
+	0: MoveLoc[0](data: E<Key>)
+	1: UnpackGeneric[1](E<Key>)
+	2: PackGeneric[1](E<Key>)
+	3: UnpackGeneric[1](E<Key>)
 	4: LdU64(3)
 	5: Pop
-	6: StLoc[2](loc0: Ty0)
-	7: MoveLoc[2](loc0: Ty0)
-	8: MoveLoc[1](Arg1: &mut Ty0)
+	6: StLoc[2](key: Key)
+	7: MoveLoc[2](key: Key)
+	8: MoveLoc[1](v: &mut Key)
 	9: WriteRef
 	10: Ret
 }
-public is_none<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
+public is_none<Element>(t: &Option<Element>): bool /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &Option<Ty0>)
-	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Ty0>)
-	2: Call vector::is_empty<Ty0>(&vector<Ty0>): bool
+	0: MoveLoc[0](t: &Option<Element>)
+	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Element>)
+	2: Call vector::is_empty<Element>(&vector<Element>): bool
 	3: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.opt.exp
@@ -5,42 +5,42 @@ module 42.m {
 use 0000000000000000000000000000000000000000000000000000000000000001::vector;
 
 
-struct E<Ty0> has copy, drop, store {
-	key: Ty0
+struct E<Key> has copy, drop, store {
+	key: Key
 }
-struct Option<Ty0> has copy, drop, store {
-	vec: vector<Ty0>
+struct Option<Element> has copy, drop, store {
+	vec: vector<Element>
 }
 
-public destroy_none<Ty0>(Arg0: Option<Ty0>) /* def_idx: 0 */ {
+public destroy_none<Element>(t: Option<Element>) /* def_idx: 0 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
-	1: Call is_none<Ty0>(&Option<Ty0>): bool
+	0: ImmBorrowLoc[0](t: Option<Element>)
+	1: Call is_none<Element>(&Option<Element>): bool
 	2: BrFalse(7)
 B1:
-	3: MoveLoc[0](Arg0: Option<Ty0>)
-	4: UnpackGeneric[0](Option<Ty0>)
+	3: MoveLoc[0](t: Option<Element>)
+	4: UnpackGeneric[0](Option<Element>)
 	5: VecUnpack(2, 0)
 	6: Ret
 B2:
 	7: LdU64(262144)
 	8: Abort
 }
-public foo<Ty0: drop + store>(Arg0: E<Ty0>, Arg1: &mut Ty0) /* def_idx: 1 */ {
+public foo<Key: drop + store>(data: E<Key>, v: &mut Key) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: E<Ty0>)
-	1: UnpackGeneric[1](E<Ty0>)
-	2: PackGeneric[1](E<Ty0>)
-	3: UnpackGeneric[1](E<Ty0>)
-	4: MoveLoc[1](Arg1: &mut Ty0)
+	0: MoveLoc[0](data: E<Key>)
+	1: UnpackGeneric[1](E<Key>)
+	2: PackGeneric[1](E<Key>)
+	3: UnpackGeneric[1](E<Key>)
+	4: MoveLoc[1](v: &mut Key)
 	5: WriteRef
 	6: Ret
 }
-public is_none<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
+public is_none<Element>(t: &Option<Element>): bool /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &Option<Ty0>)
-	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Ty0>)
-	2: Call vector::is_empty<Ty0>(&vector<Ty0>): bool
+	0: MoveLoc[0](t: &Option<Element>)
+	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Element>)
+	2: Call vector::is_empty<Element>(&vector<Element>): bool
 	3: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.exp
@@ -5,17 +5,17 @@ module 42.m {
 use 0000000000000000000000000000000000000000000000000000000000000001::vector;
 
 
-struct E<Ty0> has copy, drop, store {
-	key: Ty0
+struct E<Key> has copy, drop, store {
+	key: Key
 }
-struct Option<Ty0> has copy, drop, store {
-	vec: vector<Ty0>
+struct Option<Element> has copy, drop, store {
+	vec: vector<Element>
 }
 
-public destroy_none<Ty0>(Arg0: Option<Ty0>) /* def_idx: 0 */ {
+public destroy_none<Element>(t: Option<Element>) /* def_idx: 0 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
-	1: Call is_none<Ty0>(&Option<Ty0>): bool
+	0: ImmBorrowLoc[0](t: Option<Element>)
+	1: Call is_none<Element>(&Option<Element>): bool
 	2: BrFalse(4)
 B1:
 	3: Branch(6)
@@ -23,31 +23,31 @@ B2:
 	4: LdU64(262144)
 	5: Abort
 B3:
-	6: MoveLoc[0](Arg0: Option<Ty0>)
-	7: UnpackGeneric[0](Option<Ty0>)
+	6: MoveLoc[0](t: Option<Element>)
+	7: UnpackGeneric[0](Option<Element>)
 	8: VecUnpack(2, 0)
 	9: Ret
 }
-public foo<Ty0: drop + store>(Arg0: E<Ty0>, Arg1: &mut Ty0) /* def_idx: 1 */ {
-L2:	loc0: Ty0
+public foo<Key: drop + store>(data: E<Key>, v: &mut Key) /* def_idx: 1 */ {
+L2:	key: Key
 B0:
-	0: MoveLoc[0](Arg0: E<Ty0>)
-	1: UnpackGeneric[1](E<Ty0>)
-	2: PackGeneric[1](E<Ty0>)
-	3: UnpackGeneric[1](E<Ty0>)
+	0: MoveLoc[0](data: E<Key>)
+	1: UnpackGeneric[1](E<Key>)
+	2: PackGeneric[1](E<Key>)
+	3: UnpackGeneric[1](E<Key>)
 	4: LdU64(3)
 	5: Pop
-	6: StLoc[2](loc0: Ty0)
-	7: MoveLoc[2](loc0: Ty0)
-	8: MoveLoc[1](Arg1: &mut Ty0)
+	6: StLoc[2](key: Key)
+	7: MoveLoc[2](key: Key)
+	8: MoveLoc[1](v: &mut Key)
 	9: WriteRef
 	10: Ret
 }
-public is_none<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
+public is_none<Element>(t: &Option<Element>): bool /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &Option<Ty0>)
-	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Ty0>)
-	2: Call vector::is_empty<Ty0>(&vector<Ty0>): bool
+	0: MoveLoc[0](t: &Option<Element>)
+	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Element>)
+	2: Call vector::is_empty<Element>(&vector<Element>): bool
 	3: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.opt.exp
@@ -5,42 +5,42 @@ module 42.m {
 use 0000000000000000000000000000000000000000000000000000000000000001::vector;
 
 
-struct E<Ty0> has copy, drop, store {
-	key: Ty0
+struct E<Key> has copy, drop, store {
+	key: Key
 }
-struct Option<Ty0> has copy, drop, store {
-	vec: vector<Ty0>
+struct Option<Element> has copy, drop, store {
+	vec: vector<Element>
 }
 
-public destroy_none<Ty0>(Arg0: Option<Ty0>) /* def_idx: 0 */ {
+public destroy_none<Element>(t: Option<Element>) /* def_idx: 0 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: Option<Ty0>)
-	1: Call is_none<Ty0>(&Option<Ty0>): bool
+	0: ImmBorrowLoc[0](t: Option<Element>)
+	1: Call is_none<Element>(&Option<Element>): bool
 	2: BrFalse(7)
 B1:
-	3: MoveLoc[0](Arg0: Option<Ty0>)
-	4: UnpackGeneric[0](Option<Ty0>)
+	3: MoveLoc[0](t: Option<Element>)
+	4: UnpackGeneric[0](Option<Element>)
 	5: VecUnpack(2, 0)
 	6: Ret
 B2:
 	7: LdU64(262144)
 	8: Abort
 }
-public foo<Ty0: drop + store>(Arg0: E<Ty0>, Arg1: &mut Ty0) /* def_idx: 1 */ {
+public foo<Key: drop + store>(data: E<Key>, v: &mut Key) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: E<Ty0>)
-	1: UnpackGeneric[1](E<Ty0>)
-	2: PackGeneric[1](E<Ty0>)
-	3: UnpackGeneric[1](E<Ty0>)
-	4: MoveLoc[1](Arg1: &mut Ty0)
+	0: MoveLoc[0](data: E<Key>)
+	1: UnpackGeneric[1](E<Key>)
+	2: PackGeneric[1](E<Key>)
+	3: UnpackGeneric[1](E<Key>)
+	4: MoveLoc[1](v: &mut Key)
 	5: WriteRef
 	6: Ret
 }
-public is_none<Ty0>(Arg0: &Option<Ty0>): bool /* def_idx: 2 */ {
+public is_none<Element>(t: &Option<Element>): bool /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &Option<Ty0>)
-	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Ty0>)
-	2: Call vector::is_empty<Ty0>(&vector<Ty0>): bool
+	0: MoveLoc[0](t: &Option<Element>)
+	1: ImmBorrowFieldGeneric[0](Option.vec: vector<Element>)
+	2: Call vector::is_empty<Element>(&vector<Element>): bool
 	3: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.exp
@@ -7,45 +7,45 @@ use 0000000000000000000000000000000000000000000000000000000000000001::vector as 
 
 
 
-public remove<Ty0>(Arg0: &mut vector<Ty0>, Arg1: u64): Ty0 /* def_idx: 0 */ {
-L2:	loc0: u64
-L3:	loc1: u64
+public remove<Element>(v: &mut vector<Element>, i: u64): Element /* def_idx: 0 */ {
+L2:	$t6: u64
+L3:	len: u64
 B0:
-	0: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	0: CopyLoc[0](v: &mut vector<Element>)
 	1: FreezeRef
 	2: VecLen(1)
-	3: CopyLoc[1](Arg1: u64)
-	4: StLoc[2](loc0: u64)
-	5: StLoc[3](loc1: u64)
-	6: MoveLoc[2](loc0: u64)
-	7: CopyLoc[3](loc1: u64)
+	3: CopyLoc[1](i: u64)
+	4: StLoc[2]($t6: u64)
+	5: StLoc[3](len: u64)
+	6: MoveLoc[2]($t6: u64)
+	7: CopyLoc[3](len: u64)
 	8: Ge
 	9: BrFalse(15)
 B1:
-	10: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	10: MoveLoc[0](v: &mut vector<Element>)
 	11: Pop
 	12: LdU64(1)
 	13: Abort
 B2:
 	14: Branch(15)
 B3:
-	15: MoveLoc[3](loc1: u64)
+	15: MoveLoc[3](len: u64)
 	16: LdU64(1)
 	17: Sub
-	18: StLoc[3](loc1: u64)
+	18: StLoc[3](len: u64)
 B4:
-	19: CopyLoc[1](Arg1: u64)
-	20: CopyLoc[3](loc1: u64)
+	19: CopyLoc[1](i: u64)
+	20: CopyLoc[3](len: u64)
 	21: Lt
 	22: BrFalse(32)
 B5:
-	23: CopyLoc[0](Arg0: &mut vector<Ty0>)
-	24: CopyLoc[1](Arg1: u64)
-	25: MoveLoc[1](Arg1: u64)
+	23: CopyLoc[0](v: &mut vector<Element>)
+	24: CopyLoc[1](i: u64)
+	25: MoveLoc[1](i: u64)
 	26: LdU64(1)
 	27: Add
-	28: StLoc[1](Arg1: u64)
-	29: CopyLoc[1](Arg1: u64)
+	28: StLoc[1](i: u64)
+	29: CopyLoc[1](i: u64)
 	30: VecSwap(1)
 	31: Branch(33)
 B6:
@@ -53,7 +53,7 @@ B6:
 B7:
 	33: Branch(19)
 B8:
-	34: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	34: MoveLoc[0](v: &mut vector<Element>)
 	35: VecPopBack(1)
 	36: Ret
 }
@@ -63,30 +63,30 @@ B0:
 	1: Ret
 }
 test_fold() /* def_idx: 2 */ {
-L0:	loc0: vector<u64>
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	v: vector<u64>
+L1:	accu: u64
+L2:	elem: u64
 B0:
 	0: LdU64(0)
 	1: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
-	2: StLoc[0](loc0: vector<u64>)
-	3: MutBorrowLoc[0](loc0: vector<u64>)
+	2: StLoc[0](v: vector<u64>)
+	3: MutBorrowLoc[0](v: vector<u64>)
 	4: Call 1vector::reverse<u64>(&mut vector<u64>)
-	5: StLoc[1](loc1: u64)
+	5: StLoc[1](accu: u64)
 B1:
-	6: ImmBorrowLoc[0](loc0: vector<u64>)
+	6: ImmBorrowLoc[0](v: vector<u64>)
 	7: Call 1vector::is_empty<u64>(&vector<u64>): bool
 	8: Not
 	9: BrFalse(20)
 B2:
-	10: MutBorrowLoc[0](loc0: vector<u64>)
+	10: MutBorrowLoc[0](v: vector<u64>)
 	11: VecPopBack(5)
-	12: MoveLoc[1](loc1: u64)
+	12: MoveLoc[1](accu: u64)
 	13: Pop
-	14: StLoc[2](loc2: u64)
-	15: MoveLoc[2](loc2: u64)
+	14: StLoc[2](elem: u64)
+	15: MoveLoc[2](elem: u64)
 	16: LdU64(0)
-	17: StLoc[1](loc1: u64)
+	17: StLoc[1](accu: u64)
 	18: Pop
 	19: Branch(21)
 B3:
@@ -94,7 +94,7 @@ B3:
 B4:
 	21: Branch(6)
 B5:
-	22: MoveLoc[1](loc1: u64)
+	22: MoveLoc[1](accu: u64)
 	23: LdU64(0)
 	24: Eq
 	25: BrFalse(27)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/vector.opt.exp
@@ -7,44 +7,44 @@ use 0000000000000000000000000000000000000000000000000000000000000001::vector as 
 
 
 
-public remove<Ty0>(Arg0: &mut vector<Ty0>, Arg1: u64): Ty0 /* def_idx: 0 */ {
-L2:	loc0: u64
+public remove<Element>(v: &mut vector<Element>, i: u64): Element /* def_idx: 0 */ {
+L2:	len: u64
 B0:
-	0: CopyLoc[0](Arg0: &mut vector<Ty0>)
+	0: CopyLoc[0](v: &mut vector<Element>)
 	1: FreezeRef
 	2: VecLen(1)
-	3: StLoc[2](loc0: u64)
-	4: CopyLoc[1](Arg1: u64)
-	5: CopyLoc[2](loc0: u64)
+	3: StLoc[2](len: u64)
+	4: CopyLoc[1](i: u64)
+	5: CopyLoc[2](len: u64)
 	6: Ge
 	7: BrFalse(12)
 B1:
-	8: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	8: MoveLoc[0](v: &mut vector<Element>)
 	9: Pop
 	10: LdU64(1)
 	11: Abort
 B2:
-	12: MoveLoc[2](loc0: u64)
+	12: MoveLoc[2](len: u64)
 	13: LdU64(1)
 	14: Sub
-	15: StLoc[2](loc0: u64)
+	15: StLoc[2](len: u64)
 B3:
-	16: CopyLoc[1](Arg1: u64)
-	17: CopyLoc[2](loc0: u64)
+	16: CopyLoc[1](i: u64)
+	17: CopyLoc[2](len: u64)
 	18: Lt
 	19: BrFalse(29)
 B4:
-	20: CopyLoc[0](Arg0: &mut vector<Ty0>)
-	21: CopyLoc[1](Arg1: u64)
-	22: MoveLoc[1](Arg1: u64)
+	20: CopyLoc[0](v: &mut vector<Element>)
+	21: CopyLoc[1](i: u64)
+	22: MoveLoc[1](i: u64)
 	23: LdU64(1)
 	24: Add
-	25: StLoc[1](Arg1: u64)
-	26: CopyLoc[1](Arg1: u64)
+	25: StLoc[1](i: u64)
+	26: CopyLoc[1](i: u64)
 	27: VecSwap(1)
 	28: Branch(16)
 B5:
-	29: MoveLoc[0](Arg0: &mut vector<Ty0>)
+	29: MoveLoc[0](v: &mut vector<Element>)
 	30: VecPopBack(1)
 	31: Ret
 }
@@ -54,28 +54,28 @@ B0:
 	1: Ret
 }
 test_fold() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: vector<u64>
+L0:	accu: u64
+L1:	v: vector<u64>
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](accu: u64)
 	2: LdConst[1](Vector(U64): [1, 1, 0, 0, 0, 0, 0, 0, 0])
-	3: StLoc[1](loc1: vector<u64>)
-	4: MutBorrowLoc[1](loc1: vector<u64>)
+	3: StLoc[1](v: vector<u64>)
+	4: MutBorrowLoc[1](v: vector<u64>)
 	5: Call 1vector::reverse<u64>(&mut vector<u64>)
 B1:
-	6: ImmBorrowLoc[1](loc1: vector<u64>)
+	6: ImmBorrowLoc[1](v: vector<u64>)
 	7: Call 1vector::is_empty<u64>(&vector<u64>): bool
 	8: BrTrue(15)
 B2:
-	9: MutBorrowLoc[1](loc1: vector<u64>)
+	9: MutBorrowLoc[1](v: vector<u64>)
 	10: VecPopBack(2)
 	11: Pop
 	12: LdU64(0)
-	13: StLoc[0](loc0: u64)
+	13: StLoc[0](accu: u64)
 	14: Branch(6)
 B3:
-	15: MoveLoc[0](loc0: u64)
+	15: MoveLoc[0](accu: u64)
 	16: LdU64(0)
 	17: Eq
 	18: BrFalse(20)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.exp
@@ -14,9 +14,9 @@ B0:
 	0: Nop
 	1: Ret
 }
-public foo(Arg0: &S): u8 /* def_idx: 1 */ {
+public foo(v: &S): u8 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](v: &S)
 	1: ImmBorrowField[0](S.data: vector<E>)
 	2: LdU64(0)
 	3: VecImmBorrow(3)

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/with_spec.opt.exp
@@ -14,9 +14,9 @@ B0:
 	0: Nop
 	1: Ret
 }
-public foo(Arg0: &S): u8 /* def_idx: 1 */ {
+public foo(v: &S): u8 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: &S)
+	0: MoveLoc[0](v: &S)
 	1: ImmBorrowField[0](S.data: vector<E>)
 	2: LdU64(0)
 	3: VecImmBorrow(3)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.off.exp
@@ -10,22 +10,22 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
+L0:	b: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: CopyLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
+	2: CopyLoc[0](b: u64)
 	3: Call take1(u64)
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](b: u64)
 	5: Call take2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.on.exp
@@ -57,22 +57,22 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
+L0:	b: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: CopyLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
+	2: CopyLoc[0](b: u64)
 	3: Call take1(u64)
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](b: u64)
 	5: Call take2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.off.exp
@@ -10,25 +10,25 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	b: u64
+L1:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: CopyLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
+	2: CopyLoc[0](b: u64)
 	3: Call take1(u64)
-	4: StLoc[1](loc1: u64)
-	5: MoveLoc[0](loc0: u64)
-	6: MoveLoc[1](loc1: u64)
+	4: StLoc[1](a: u64)
+	5: MoveLoc[0](b: u64)
+	6: MoveLoc[1](a: u64)
 	7: Call take2(u64, u64)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.on.exp
@@ -57,25 +57,25 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	b: u64
+L1:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: StLoc[1](loc1: u64)
-	3: CopyLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
+	2: StLoc[1](a: u64)
+	3: CopyLoc[0](b: u64)
 	4: Call take1(u64)
-	5: MoveLoc[0](loc0: u64)
-	6: MoveLoc[1](loc1: u64)
+	5: MoveLoc[0](b: u64)
+	6: MoveLoc[1](a: u64)
 	7: Call take2(u64, u64)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.off.exp
@@ -10,22 +10,22 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
+L0:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
 	1: Call take1(u64)
-	2: StLoc[0](loc0: u64)
-	3: CopyLoc[0](loc0: u64)
-	4: MoveLoc[0](loc0: u64)
+	2: StLoc[0](a: u64)
+	3: CopyLoc[0](a: u64)
+	4: MoveLoc[0](a: u64)
 	5: Call take2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.on.exp
@@ -57,22 +57,22 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
+L0:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
 	1: Call take1(u64)
-	2: StLoc[0](loc0: u64)
-	3: CopyLoc[0](loc0: u64)
-	4: MoveLoc[0](loc0: u64)
+	2: StLoc[0](a: u64)
+	3: CopyLoc[0](a: u64)
+	4: MoveLoc[0](a: u64)
 	5: Call take2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.off.exp
@@ -10,23 +10,23 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	b: u64
+L1:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
 	2: Call take1(u64)
-	3: CopyLoc[0](loc0: u64)
-	4: MoveLoc[0](loc0: u64)
+	3: CopyLoc[0](b: u64)
+	4: MoveLoc[0](b: u64)
 	5: Call take2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.on.exp
@@ -57,22 +57,22 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
+L0:	b: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
 	2: Call take1(u64)
-	3: CopyLoc[0](loc0: u64)
-	4: MoveLoc[0](loc0: u64)
+	3: CopyLoc[0](b: u64)
+	4: MoveLoc[0](b: u64)
 	5: Call take2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.off.exp
@@ -10,22 +10,22 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	b: u64
+L1:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
 	2: Call take1(u64)
-	3: MoveLoc[0](loc0: u64)
+	3: MoveLoc[0](b: u64)
 	4: Call take1(u64)
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.on.exp
@@ -54,21 +54,21 @@ B0:
 	1: LdU64(1)
 	2: Ret
 }
-take1(Arg0: u64) /* def_idx: 1 */ {
+take1(_x: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 2 */ {
+take2(_x: u64, _y: u64) /* def_idx: 2 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
+L0:	b: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
 	2: Call take1(u64)
-	3: MoveLoc[0](loc0: u64)
+	3: MoveLoc[0](b: u64)
 	4: Call take1(u64)
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.off.exp
@@ -9,17 +9,17 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+take2(_x: u64, _y: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
+public test(b: u64) /* def_idx: 2 */ {
+L1:	a: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[1](loc0: u64)
-	2: MoveLoc[0](Arg0: u64)
-	3: MoveLoc[1](loc0: u64)
+	1: StLoc[1](a: u64)
+	2: MoveLoc[0](b: u64)
+	3: MoveLoc[1](a: u64)
 	4: Call take2(u64, u64)
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.on.exp
@@ -43,17 +43,17 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-take2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+take2(_x: u64, _y: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: u64
+public test(b: u64) /* def_idx: 2 */ {
+L1:	a: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[1](loc0: u64)
-	2: MoveLoc[0](Arg0: u64)
-	3: MoveLoc[1](loc0: u64)
+	1: StLoc[1](a: u64)
+	2: MoveLoc[0](b: u64)
+	3: MoveLoc[1](a: u64)
 	4: Call take2(u64, u64)
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.off.exp
@@ -4,9 +4,9 @@
 module c0ffee.m {
 
 
-foo(Arg0: u64): u64 /* def_idx: 0 */ {
+foo(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: LdU64(1)
 	2: Add
 	3: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.on.exp
@@ -47,9 +47,9 @@ public fun m::test(): u64 {
 module c0ffee.m {
 
 
-foo(Arg0: u64): u64 /* def_idx: 0 */ {
+foo(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: LdU64(1)
 	2: Add
 	3: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.off.exp
@@ -12,25 +12,25 @@ B0:
 	3: LdU64(4)
 	4: Ret
 }
-take(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+take(_x: u64, _y: u64, _z: u64, _w: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
+L0:	d: u64
+L1:	c: u64
+L2:	b: u64
+L3:	a: u64
 B0:
 	0: Call foo(): u64 * u64 * u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: StLoc[1](loc1: u64)
-	3: StLoc[2](loc2: u64)
-	4: StLoc[3](loc3: u64)
-	5: MoveLoc[2](loc2: u64)
-	6: MoveLoc[1](loc1: u64)
-	7: MoveLoc[0](loc0: u64)
-	8: MoveLoc[3](loc3: u64)
+	1: StLoc[0](d: u64)
+	2: StLoc[1](c: u64)
+	3: StLoc[2](b: u64)
+	4: StLoc[3](a: u64)
+	5: MoveLoc[2](b: u64)
+	6: MoveLoc[1](c: u64)
+	7: MoveLoc[0](d: u64)
+	8: MoveLoc[3](a: u64)
 	9: Call take(u64, u64, u64, u64)
 	10: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.on.exp
@@ -64,25 +64,25 @@ B0:
 	3: LdU64(4)
 	4: Ret
 }
-take(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+take(_x: u64, _y: u64, _z: u64, _w: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
+L0:	d: u64
+L1:	c: u64
+L2:	b: u64
+L3:	a: u64
 B0:
 	0: Call foo(): u64 * u64 * u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: StLoc[1](loc1: u64)
-	3: StLoc[2](loc2: u64)
-	4: StLoc[3](loc3: u64)
-	5: MoveLoc[2](loc2: u64)
-	6: MoveLoc[1](loc1: u64)
-	7: MoveLoc[0](loc0: u64)
-	8: MoveLoc[3](loc3: u64)
+	1: StLoc[0](d: u64)
+	2: StLoc[1](c: u64)
+	3: StLoc[2](b: u64)
+	4: StLoc[3](a: u64)
+	5: MoveLoc[2](b: u64)
+	6: MoveLoc[1](c: u64)
+	7: MoveLoc[0](d: u64)
+	8: MoveLoc[3](a: u64)
 	9: Call take(u64, u64, u64, u64)
 	10: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_11.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_11.off.exp
@@ -4,9 +4,9 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: &u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: &u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[1](Arg1: &u64)
+	0: MoveLoc[1](_b: &u64)
 	1: Pop
 	2: Ret
 }
@@ -15,42 +15,42 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: vector<u64>) /* def_idx: 2 */ {
-L1:	loc0: &vector<u64>
-L2:	loc1: u64
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: &u64
+public test(v: vector<u64>) /* def_idx: 2 */ {
+L1:	$t3: &vector<u64>
+L2:	i: u64
+L3:	x: u64
+L4:	$t6: u64
+L5:	$t9: &u64
 B0:
 	0: Call one(): u64
-	1: ImmBorrowLoc[0](Arg0: vector<u64>)
-	2: StLoc[1](loc0: &vector<u64>)
+	1: ImmBorrowLoc[0](v: vector<u64>)
+	2: StLoc[1]($t3: &vector<u64>)
 	3: LdU64(0)
-	4: StLoc[2](loc1: u64)
-	5: StLoc[3](loc2: u64)
+	4: StLoc[2](i: u64)
+	5: StLoc[3](x: u64)
 B1:
-	6: CopyLoc[2](loc1: u64)
-	7: CopyLoc[1](loc0: &vector<u64>)
+	6: CopyLoc[2](i: u64)
+	7: CopyLoc[1]($t3: &vector<u64>)
 	8: VecLen(2)
 	9: Lt
 	10: BrFalse(25)
 B2:
-	11: CopyLoc[1](loc0: &vector<u64>)
-	12: CopyLoc[2](loc1: u64)
+	11: CopyLoc[1]($t3: &vector<u64>)
+	12: CopyLoc[2](i: u64)
 	13: VecImmBorrow(2)
-	14: CopyLoc[3](loc2: u64)
-	15: StLoc[4](loc3: u64)
-	16: StLoc[5](loc4: &u64)
-	17: MoveLoc[4](loc3: u64)
-	18: MoveLoc[5](loc4: &u64)
+	14: CopyLoc[3](x: u64)
+	15: StLoc[4]($t6: u64)
+	16: StLoc[5]($t9: &u64)
+	17: MoveLoc[4]($t6: u64)
+	18: MoveLoc[5]($t9: &u64)
 	19: Call consume(u64, &u64)
-	20: MoveLoc[2](loc1: u64)
+	20: MoveLoc[2](i: u64)
 	21: LdU64(1)
 	22: Add
-	23: StLoc[2](loc1: u64)
+	23: StLoc[2](i: u64)
 	24: Branch(6)
 B3:
-	25: MoveLoc[1](loc0: &vector<u64>)
+	25: MoveLoc[1]($t3: &vector<u64>)
 	26: Pop
 	27: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_11.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_11.on.exp
@@ -91,9 +91,9 @@ public fun m::test($t0: vector<u64>) {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: &u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: &u64) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[1](Arg1: &u64)
+	0: MoveLoc[1](_b: &u64)
 	1: Pop
 	2: Ret
 }
@@ -102,39 +102,39 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: vector<u64>) /* def_idx: 2 */ {
-L1:	loc0: u64
-L2:	loc1: &vector<u64>
-L3:	loc2: u64
-L4:	loc3: &u64
+public test(v: vector<u64>) /* def_idx: 2 */ {
+L1:	x: u64
+L2:	$t3: &vector<u64>
+L3:	i: u64
+L4:	$t9: &u64
 B0:
 	0: Call one(): u64
-	1: StLoc[1](loc0: u64)
-	2: ImmBorrowLoc[0](Arg0: vector<u64>)
-	3: StLoc[2](loc1: &vector<u64>)
+	1: StLoc[1](x: u64)
+	2: ImmBorrowLoc[0](v: vector<u64>)
+	3: StLoc[2]($t3: &vector<u64>)
 	4: LdU64(0)
-	5: StLoc[3](loc2: u64)
+	5: StLoc[3](i: u64)
 B1:
-	6: CopyLoc[3](loc2: u64)
-	7: CopyLoc[2](loc1: &vector<u64>)
+	6: CopyLoc[3](i: u64)
+	7: CopyLoc[2]($t3: &vector<u64>)
 	8: VecLen(2)
 	9: Lt
 	10: BrFalse(23)
 B2:
-	11: CopyLoc[2](loc1: &vector<u64>)
-	12: CopyLoc[3](loc2: u64)
+	11: CopyLoc[2]($t3: &vector<u64>)
+	12: CopyLoc[3](i: u64)
 	13: VecImmBorrow(2)
-	14: StLoc[4](loc3: &u64)
-	15: CopyLoc[1](loc0: u64)
-	16: MoveLoc[4](loc3: &u64)
+	14: StLoc[4]($t9: &u64)
+	15: CopyLoc[1](x: u64)
+	16: MoveLoc[4]($t9: &u64)
 	17: Call consume(u64, &u64)
-	18: MoveLoc[3](loc2: u64)
+	18: MoveLoc[3](i: u64)
 	19: LdU64(1)
 	20: Add
-	21: StLoc[3](loc2: u64)
+	21: StLoc[3](i: u64)
 	22: Branch(6)
 B3:
-	23: MoveLoc[2](loc1: &vector<u64>)
+	23: MoveLoc[2]($t3: &vector<u64>)
 	24: Pop
 	25: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.off.exp
@@ -4,34 +4,34 @@
 module c0ffee.m {
 
 
-bytes(Arg0: &u64): vector<u8> /* def_idx: 0 */ {
+bytes(_x: &u64): vector<u8> /* def_idx: 0 */ {
 B0:
 	0: LdConst[0](Vector(U8): [2, 1, 2])
-	1: MoveLoc[0](Arg0: &u64)
+	1: MoveLoc[0](_x: &u64)
 	2: Pop
 	3: Ret
 }
-cons_2(Arg0: u64, Arg1: &mut u64): u64 /* def_idx: 1 */ {
+cons_2(x: u64, _y: &mut u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[1](Arg1: &mut u64)
+	0: MoveLoc[1](_y: &mut u64)
 	1: Pop
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Ret
 }
-cons_2_another(Arg0: &u64, Arg1: u64) /* def_idx: 2 */ {
+cons_2_another(_x: &u64, _y: u64) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &u64)
+	0: MoveLoc[0](_x: &u64)
 	1: Pop
 	2: Ret
 }
-cons_7(Arg0: vector<u8>, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64): u64 /* def_idx: 3 */ {
+cons_7(_x: vector<u8>, _a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64): u64 /* def_idx: 3 */ {
 B0:
 	0: LdU64(0)
 	1: Ret
 }
-id(Arg0: u64): u64 /* def_idx: 4 */ {
+id(x: u64): u64 /* def_idx: 4 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Ret
 }
 one(): u64 /* def_idx: 5 */ {
@@ -39,70 +39,70 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-test(Arg0: u64): u64 /* def_idx: 6 */ {
-L1:	loc0: u64
-L2:	loc1: vector<u8>
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
-L6:	loc5: vector<u8>
-L7:	loc6: &u64
-L8:	loc7: u64
-L9:	loc8: u64
-L10:	loc9: u64
-L11:	loc10: u64
+test(new_address: u64): u64 /* def_idx: 6 */ {
+L1:	new_account: u64
+L2:	authentication_key: vector<u8>
+L3:	guid_creation_num: u64
+L4:	$t23: u64
+L5:	$t22: u64
+L6:	$t21: vector<u8>
+L7:	$t4: &u64
+L8:	$t8: u64
+L9:	$t6: u64
+L10:	$t29: u64
+L11:	$t27: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](new_address: u64)
 	1: Call id(u64): u64
-	2: StLoc[1](loc0: u64)
-	3: ImmBorrowLoc[0](Arg0: u64)
+	2: StLoc[1](new_account: u64)
+	3: ImmBorrowLoc[0](new_address: u64)
 	4: Call bytes(&u64): vector<u8>
-	5: StLoc[2](loc1: vector<u8>)
-	6: ImmBorrowLoc[2](loc1: vector<u8>)
+	5: StLoc[2](authentication_key: vector<u8>)
+	6: ImmBorrowLoc[2](authentication_key: vector<u8>)
 	7: VecLen(7)
 	8: LdU64(2)
 	9: Eq
 	10: BrFalse(51)
 B1:
 	11: LdU64(0)
-	12: StLoc[3](loc2: u64)
-	13: CopyLoc[0](Arg0: u64)
-	14: MutBorrowLoc[3](loc2: u64)
+	12: StLoc[3](guid_creation_num: u64)
+	13: CopyLoc[0](new_address: u64)
+	14: MutBorrowLoc[3](guid_creation_num: u64)
 	15: Call cons_2(u64, &mut u64): u64
 	16: Call id(u64): u64
-	17: MoveLoc[0](Arg0: u64)
-	18: MutBorrowLoc[3](loc2: u64)
+	17: MoveLoc[0](new_address: u64)
+	18: MutBorrowLoc[3](guid_creation_num: u64)
 	19: Call cons_2(u64, &mut u64): u64
 	20: Call id(u64): u64
-	21: ImmBorrowLoc[1](loc0: u64)
-	22: MoveLoc[2](loc1: vector<u8>)
+	21: ImmBorrowLoc[1](new_account: u64)
+	22: MoveLoc[2](authentication_key: vector<u8>)
 	23: LdU64(0)
-	24: MoveLoc[3](loc2: u64)
-	25: StLoc[4](loc3: u64)
-	26: StLoc[5](loc4: u64)
-	27: StLoc[6](loc5: vector<u8>)
-	28: StLoc[7](loc6: &u64)
+	24: MoveLoc[3](guid_creation_num: u64)
+	25: StLoc[4]($t23: u64)
+	26: StLoc[5]($t22: u64)
+	27: StLoc[6]($t21: vector<u8>)
+	28: StLoc[7]($t4: &u64)
 	29: Call one(): u64
 	30: Call id(u64): u64
 	31: Call one(): u64
 	32: Call id(u64): u64
-	33: StLoc[10](loc9: u64)
-	34: StLoc[11](loc10: u64)
-	35: StLoc[8](loc7: u64)
-	36: StLoc[9](loc8: u64)
-	37: MoveLoc[6](loc5: vector<u8>)
-	38: MoveLoc[5](loc4: u64)
-	39: MoveLoc[4](loc3: u64)
-	40: MoveLoc[9](loc8: u64)
-	41: MoveLoc[8](loc7: u64)
-	42: MoveLoc[11](loc10: u64)
-	43: MoveLoc[10](loc9: u64)
+	33: StLoc[10]($t29: u64)
+	34: StLoc[11]($t27: u64)
+	35: StLoc[8]($t8: u64)
+	36: StLoc[9]($t6: u64)
+	37: MoveLoc[6]($t21: vector<u8>)
+	38: MoveLoc[5]($t22: u64)
+	39: MoveLoc[4]($t23: u64)
+	40: MoveLoc[9]($t6: u64)
+	41: MoveLoc[8]($t8: u64)
+	42: MoveLoc[11]($t27: u64)
+	43: MoveLoc[10]($t29: u64)
 	44: Call cons_7(vector<u8>, u64, u64, u64, u64, u64, u64): u64
-	45: StLoc[9](loc8: u64)
-	46: MoveLoc[7](loc6: &u64)
-	47: MoveLoc[9](loc8: u64)
+	45: StLoc[9]($t6: u64)
+	46: MoveLoc[7]($t4: &u64)
+	47: MoveLoc[9]($t6: u64)
 	48: Call cons_2_another(&u64, u64)
-	49: MoveLoc[1](loc0: u64)
+	49: MoveLoc[1](new_account: u64)
 	50: Ret
 B2:
 	51: LdU64(42)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.on.exp
@@ -173,34 +173,34 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-bytes(Arg0: &u64): vector<u8> /* def_idx: 0 */ {
+bytes(_x: &u64): vector<u8> /* def_idx: 0 */ {
 B0:
 	0: LdConst[0](Vector(U8): [2, 1, 2])
-	1: MoveLoc[0](Arg0: &u64)
+	1: MoveLoc[0](_x: &u64)
 	2: Pop
 	3: Ret
 }
-cons_2(Arg0: u64, Arg1: &mut u64): u64 /* def_idx: 1 */ {
+cons_2(x: u64, _y: &mut u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[1](Arg1: &mut u64)
+	0: MoveLoc[1](_y: &mut u64)
 	1: Pop
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Ret
 }
-cons_2_another(Arg0: &u64, Arg1: u64) /* def_idx: 2 */ {
+cons_2_another(_x: &u64, _y: u64) /* def_idx: 2 */ {
 B0:
-	0: MoveLoc[0](Arg0: &u64)
+	0: MoveLoc[0](_x: &u64)
 	1: Pop
 	2: Ret
 }
-cons_7(Arg0: vector<u8>, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64): u64 /* def_idx: 3 */ {
+cons_7(_x: vector<u8>, _a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64): u64 /* def_idx: 3 */ {
 B0:
 	0: LdU64(0)
 	1: Ret
 }
-id(Arg0: u64): u64 /* def_idx: 4 */ {
+id(x: u64): u64 /* def_idx: 4 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Ret
 }
 one(): u64 /* def_idx: 5 */ {
@@ -208,50 +208,50 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-test(Arg0: u64): u64 /* def_idx: 6 */ {
-L1:	loc0: u64
-L2:	loc1: vector<u8>
-L3:	loc2: u64
-L4:	loc3: u64
-L5:	loc4: u64
+test(new_address: u64): u64 /* def_idx: 6 */ {
+L1:	new_account: u64
+L2:	authentication_key: vector<u8>
+L3:	guid_creation_num: u64
+L4:	$t6: u64
+L5:	$t8: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](new_address: u64)
 	1: Call id(u64): u64
-	2: StLoc[1](loc0: u64)
-	3: ImmBorrowLoc[0](Arg0: u64)
+	2: StLoc[1](new_account: u64)
+	3: ImmBorrowLoc[0](new_address: u64)
 	4: Call bytes(&u64): vector<u8>
-	5: StLoc[2](loc1: vector<u8>)
-	6: ImmBorrowLoc[2](loc1: vector<u8>)
+	5: StLoc[2](authentication_key: vector<u8>)
+	6: ImmBorrowLoc[2](authentication_key: vector<u8>)
 	7: VecLen(7)
 	8: LdU64(2)
 	9: Eq
 	10: BrFalse(37)
 B1:
 	11: LdU64(0)
-	12: StLoc[3](loc2: u64)
-	13: CopyLoc[0](Arg0: u64)
-	14: MutBorrowLoc[3](loc2: u64)
+	12: StLoc[3](guid_creation_num: u64)
+	13: CopyLoc[0](new_address: u64)
+	14: MutBorrowLoc[3](guid_creation_num: u64)
 	15: Call cons_2(u64, &mut u64): u64
 	16: Call id(u64): u64
-	17: StLoc[4](loc3: u64)
-	18: MoveLoc[0](Arg0: u64)
-	19: MutBorrowLoc[3](loc2: u64)
+	17: StLoc[4]($t6: u64)
+	18: MoveLoc[0](new_address: u64)
+	19: MutBorrowLoc[3](guid_creation_num: u64)
 	20: Call cons_2(u64, &mut u64): u64
 	21: Call id(u64): u64
-	22: StLoc[5](loc4: u64)
-	23: ImmBorrowLoc[1](loc0: u64)
-	24: MoveLoc[2](loc1: vector<u8>)
+	22: StLoc[5]($t8: u64)
+	23: ImmBorrowLoc[1](new_account: u64)
+	24: MoveLoc[2](authentication_key: vector<u8>)
 	25: LdU64(0)
-	26: MoveLoc[3](loc2: u64)
-	27: MoveLoc[4](loc3: u64)
-	28: MoveLoc[5](loc4: u64)
+	26: MoveLoc[3](guid_creation_num: u64)
+	27: MoveLoc[4]($t6: u64)
+	28: MoveLoc[5]($t8: u64)
 	29: Call one(): u64
 	30: Call id(u64): u64
 	31: Call one(): u64
 	32: Call id(u64): u64
 	33: Call cons_7(vector<u8>, u64, u64, u64, u64, u64, u64): u64
 	34: Call cons_2_another(&u64, u64)
-	35: MoveLoc[1](loc0: u64)
+	35: MoveLoc[1](new_account: u64)
 	36: Ret
 B2:
 	37: LdU64(42)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64) /* def_idx: 0 */ {
+public consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64, _g: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -14,13 +14,13 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
-L6:	loc6: u64
+L0:	g: u64
+L1:	f: u64
+L2:	e: u64
+L3:	d: u64
+L4:	c: u64
+L5:	b: u64
+L6:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.on.exp
@@ -70,7 +70,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64) /* def_idx: 0 */ {
+public consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64, _g: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -80,13 +80,13 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
-L6:	loc6: u64
+L0:	g: u64
+L1:	f: u64
+L2:	e: u64
+L3:	d: u64
+L4:	c: u64
+L5:	b: u64
+L6:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_02.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -18,11 +18,11 @@ B0:
 	5: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
+L0:	e: u64
+L1:	d: u64
+L2:	c: u64
+L3:	b: u64
+L4:	a: u64
 B0:
 	0: Call foo(): u64 * u64 * u64 * u64 * u64
 	1: Call consume(u64, u64, u64, u64, u64)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_02.on.exp
@@ -62,7 +62,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -76,11 +76,11 @@ B0:
 	5: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
+L0:	e: u64
+L1:	d: u64
+L2:	c: u64
+L3:	b: u64
+L4:	a: u64
 B0:
 	0: Call foo(): u64 * u64 * u64 * u64 * u64
 	1: Call consume(u64, u64, u64, u64, u64)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -18,12 +18,12 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.on.exp
@@ -70,11 +70,11 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -84,12 +84,12 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_04.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_04.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -21,12 +21,12 @@ B0:
 	4: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call four(): u64 * u64 * u64 * u64
 	1: Call two(): u64 * u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_04.on.exp
@@ -84,11 +84,11 @@ fun m::two(): (u64, u64) {
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -101,12 +101,12 @@ B0:
 	4: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call four(): u64 * u64 * u64 * u64
 	1: Call two(): u64 * u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -14,10 +14,10 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
+L0:	d: u64
+L1:	c: u64
+L2:	b: u64
+L3:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.on.exp
@@ -51,7 +51,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -61,10 +61,10 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
+L0:	d: u64
+L1:	c: u64
+L2:	b: u64
+L3:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.off.exp
@@ -4,36 +4,36 @@
 module c0ffee.m {
 
 
-foo(Arg0: u64): u64 * u64 /* def_idx: 0 */ {
+foo(x: u64): u64 * u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: MoveLoc[0](x: u64)
 	2: LdU64(1)
 	3: Sub
 	4: Ret
 }
-public test1(Arg0: u64) /* def_idx: 1 */ {
-L1:	loc0: u64
+public test1(x: u64) /* def_idx: 1 */ {
+L1:	y: u64
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call foo(u64): u64 * u64
-	2: StLoc[0](Arg0: u64)
+	2: StLoc[0](x: u64)
 	3: LdU64(0)
 	4: Eq
 	5: BrFalse(0)
 B1:
 	6: Ret
 }
-public test2(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: bool
+public test2(x: u64) /* def_idx: 2 */ {
+L1:	$t2: bool
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call foo(u64): u64 * u64
 	2: LdU64(0)
 	3: Eq
-	4: StLoc[1](loc0: bool)
-	5: StLoc[0](Arg0: u64)
-	6: MoveLoc[1](loc0: bool)
+	4: StLoc[1]($t2: bool)
+	5: StLoc[0](x: u64)
+	6: MoveLoc[1]($t2: bool)
 	7: BrFalse(0)
 B1:
 	8: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
@@ -76,35 +76,35 @@ public fun m::test2($t0: u64) {
 module c0ffee.m {
 
 
-foo(Arg0: u64): u64 * u64 /* def_idx: 0 */ {
+foo(x: u64): u64 * u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: MoveLoc[0](x: u64)
 	2: LdU64(1)
 	3: Sub
 	4: Ret
 }
-public test1(Arg0: u64) /* def_idx: 1 */ {
+public test1(x: u64) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call foo(u64): u64 * u64
-	2: StLoc[0](Arg0: u64)
+	2: StLoc[0](x: u64)
 	3: LdU64(0)
 	4: Eq
 	5: BrFalse(0)
 B1:
 	6: Ret
 }
-public test2(Arg0: u64) /* def_idx: 2 */ {
-L1:	loc0: bool
+public test2(x: u64) /* def_idx: 2 */ {
+L1:	$t2: bool
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Call foo(u64): u64 * u64
 	2: LdU64(0)
 	3: Eq
-	4: StLoc[1](loc0: bool)
-	5: StLoc[0](Arg0: u64)
-	6: MoveLoc[1](loc0: bool)
+	4: StLoc[1]($t2: bool)
+	5: StLoc[0](x: u64)
+	6: MoveLoc[1]($t2: bool)
 	7: BrFalse(0)
 B1:
 	8: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.off.exp
@@ -4,23 +4,23 @@
 module c0ffee.m {
 
 
-inc(Arg0: u64): u64 /* def_idx: 0 */ {
+inc(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: LdU64(1)
 	2: Add
 	3: Ret
 }
 public test() /* def_idx: 1 */ {
-L0:	loc0: u64
+L0:	x: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](x: u64)
 B1:
-	2: MoveLoc[0](loc0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Call inc(u64): u64
-	4: StLoc[0](loc0: u64)
-	5: CopyLoc[0](loc0: u64)
+	4: StLoc[0](x: u64)
+	5: CopyLoc[0](x: u64)
 	6: LdU64(10)
 	7: Gt
 	8: BrTrue(10)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.on.exp
@@ -57,23 +57,23 @@ public fun m::test() {
 module c0ffee.m {
 
 
-inc(Arg0: u64): u64 /* def_idx: 0 */ {
+inc(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: LdU64(1)
 	2: Add
 	3: Ret
 }
 public test() /* def_idx: 1 */ {
-L0:	loc0: u64
+L0:	x: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](x: u64)
 B1:
-	2: MoveLoc[0](loc0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Call inc(u64): u64
-	4: StLoc[0](loc0: u64)
-	5: CopyLoc[0](loc0: u64)
+	4: StLoc[0](x: u64)
+	5: CopyLoc[0](x: u64)
 	6: LdU64(10)
 	7: Gt
 	8: BrTrue(10)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64) /* def_idx: 0 */ {
+public consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64, _g: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -14,13 +14,13 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
-L6:	loc6: u64
+L0:	g: u64
+L1:	f: u64
+L2:	e: u64
+L3:	d: u64
+L4:	c: u64
+L5:	b: u64
+L6:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
@@ -29,20 +29,20 @@ B0:
 	4: Call one(): u64
 	5: Call one(): u64
 	6: Call one(): u64
-	7: StLoc[0](loc0: u64)
-	8: StLoc[1](loc1: u64)
-	9: StLoc[2](loc2: u64)
-	10: StLoc[3](loc3: u64)
-	11: StLoc[4](loc4: u64)
-	12: StLoc[5](loc5: u64)
-	13: StLoc[6](loc6: u64)
-	14: MoveLoc[5](loc5: u64)
-	15: MoveLoc[4](loc4: u64)
-	16: MoveLoc[3](loc3: u64)
-	17: MoveLoc[2](loc2: u64)
-	18: MoveLoc[1](loc1: u64)
-	19: MoveLoc[0](loc0: u64)
-	20: MoveLoc[6](loc6: u64)
+	7: StLoc[0](g: u64)
+	8: StLoc[1](f: u64)
+	9: StLoc[2](e: u64)
+	10: StLoc[3](d: u64)
+	11: StLoc[4](c: u64)
+	12: StLoc[5](b: u64)
+	13: StLoc[6](a: u64)
+	14: MoveLoc[5](b: u64)
+	15: MoveLoc[4](c: u64)
+	16: MoveLoc[3](d: u64)
+	17: MoveLoc[2](e: u64)
+	18: MoveLoc[1](f: u64)
+	19: MoveLoc[0](g: u64)
+	20: MoveLoc[6](a: u64)
 	21: Call consume(u64, u64, u64, u64, u64, u64, u64)
 	22: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.on.exp
@@ -71,7 +71,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-public consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64, Arg6: u64) /* def_idx: 0 */ {
+public consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64, _g: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -81,23 +81,23 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
-L6:	loc6: u64
+L0:	a: u64
+L1:	g: u64
+L2:	f: u64
+L3:	e: u64
+L4:	d: u64
+L5:	c: u64
+L6:	b: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](a: u64)
 	2: Call one(): u64
 	3: Call one(): u64
 	4: Call one(): u64
 	5: Call one(): u64
 	6: Call one(): u64
 	7: Call one(): u64
-	8: MoveLoc[0](loc0: u64)
+	8: MoveLoc[0](a: u64)
 	9: Call consume(u64, u64, u64, u64, u64, u64, u64)
 	10: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -14,19 +14,19 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	b: u64
+L1:	a: u64
+L2:	$t3: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
-	2: StLoc[0](loc0: u64)
-	3: StLoc[1](loc1: u64)
-	4: CopyLoc[1](loc1: u64)
-	5: StLoc[2](loc2: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: MoveLoc[2](loc2: u64)
-	8: MoveLoc[1](loc1: u64)
+	2: StLoc[0](b: u64)
+	3: StLoc[1](a: u64)
+	4: CopyLoc[1](a: u64)
+	5: StLoc[2]($t3: u64)
+	6: MoveLoc[0](b: u64)
+	7: MoveLoc[2]($t3: u64)
+	8: MoveLoc[1](a: u64)
 	9: Call consume(u64, u64, u64)
 	10: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.on.exp
@@ -44,7 +44,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -54,13 +54,13 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
+L0:	a: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](a: u64)
 	2: Call one(): u64
-	3: CopyLoc[0](loc0: u64)
-	4: MoveLoc[0](loc0: u64)
+	3: CopyLoc[0](a: u64)
+	4: MoveLoc[0](a: u64)
 	5: Call consume(u64, u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -15,18 +15,18 @@ B0:
 	2: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	b: u64
+L1:	a: u64
+L2:	$t3: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: StLoc[1](loc1: u64)
-	3: CopyLoc[1](loc1: u64)
-	4: StLoc[2](loc2: u64)
-	5: MoveLoc[0](loc0: u64)
-	6: MoveLoc[2](loc2: u64)
-	7: MoveLoc[1](loc1: u64)
+	1: StLoc[0](b: u64)
+	2: StLoc[1](a: u64)
+	3: CopyLoc[1](a: u64)
+	4: StLoc[2]($t3: u64)
+	5: MoveLoc[0](b: u64)
+	6: MoveLoc[2]($t3: u64)
+	7: MoveLoc[1](a: u64)
 	8: Call consume(u64, u64, u64)
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.on.exp
@@ -45,7 +45,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -56,18 +56,18 @@ B0:
 	2: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	b: u64
+L1:	a: u64
+L2:	$t3: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: StLoc[1](loc1: u64)
-	3: CopyLoc[1](loc1: u64)
-	4: StLoc[2](loc2: u64)
-	5: MoveLoc[0](loc0: u64)
-	6: MoveLoc[2](loc2: u64)
-	7: MoveLoc[1](loc1: u64)
+	1: StLoc[0](b: u64)
+	2: StLoc[1](a: u64)
+	3: CopyLoc[1](a: u64)
+	4: StLoc[2]($t3: u64)
+	5: MoveLoc[0](b: u64)
+	6: MoveLoc[2]($t3: u64)
+	7: MoveLoc[1](a: u64)
 	8: Call consume(u64, u64, u64)
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -14,16 +14,16 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	b: u64
+L1:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
-	2: StLoc[0](loc0: u64)
-	3: StLoc[1](loc1: u64)
-	4: CopyLoc[1](loc1: u64)
-	5: MoveLoc[0](loc0: u64)
-	6: MoveLoc[1](loc1: u64)
+	2: StLoc[0](b: u64)
+	3: StLoc[1](a: u64)
+	4: CopyLoc[1](a: u64)
+	5: MoveLoc[0](b: u64)
+	6: MoveLoc[1](a: u64)
 	7: Call consume(u64, u64, u64)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.on.exp
@@ -45,7 +45,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -55,16 +55,16 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	a: u64
+L1:	b: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](a: u64)
 	2: Call one(): u64
-	3: StLoc[1](loc1: u64)
-	4: CopyLoc[0](loc0: u64)
-	5: MoveLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
+	3: StLoc[1](b: u64)
+	4: CopyLoc[0](a: u64)
+	5: MoveLoc[1](b: u64)
+	6: MoveLoc[0](a: u64)
 	7: Call consume(u64, u64, u64)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -14,31 +14,31 @@ B0:
 	1: Ret
 }
 test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	$t1: u64
+L1:	a: u64
+L2:	$t6: u64
+L3:	$t5: u64
+L4:	$t4: u64
+L5:	$t3: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
-	2: StLoc[0](loc0: u64)
+	2: StLoc[0]($t1: u64)
 	3: Call one(): u64
 	4: Call one(): u64
 	5: Call one(): u64
 	6: Call one(): u64
-	7: StLoc[2](loc2: u64)
-	8: StLoc[3](loc3: u64)
-	9: StLoc[4](loc4: u64)
-	10: StLoc[5](loc5: u64)
-	11: StLoc[1](loc1: u64)
-	12: MoveLoc[0](loc0: u64)
-	13: MoveLoc[1](loc1: u64)
-	14: MoveLoc[5](loc5: u64)
-	15: MoveLoc[4](loc4: u64)
-	16: MoveLoc[3](loc3: u64)
-	17: MoveLoc[2](loc2: u64)
+	7: StLoc[2]($t6: u64)
+	8: StLoc[3]($t5: u64)
+	9: StLoc[4]($t4: u64)
+	10: StLoc[5]($t3: u64)
+	11: StLoc[1](a: u64)
+	12: MoveLoc[0]($t1: u64)
+	13: MoveLoc[1](a: u64)
+	14: MoveLoc[5]($t3: u64)
+	15: MoveLoc[4]($t4: u64)
+	16: MoveLoc[3]($t5: u64)
+	17: MoveLoc[2]($t6: u64)
 	18: Call consume(u64, u64, u64, u64, u64, u64)
 	19: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.on.exp
@@ -53,7 +53,7 @@ fun m::test() {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -63,12 +63,12 @@ B0:
 	1: Ret
 }
 test() /* def_idx: 2 */ {
-L0:	loc0: u64
+L0:	a: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](a: u64)
 	2: Call one(): u64
-	3: MoveLoc[0](loc0: u64)
+	3: MoveLoc[0](a: u64)
 	4: Call one(): u64
 	5: Call one(): u64
 	6: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -24,16 +24,16 @@ B0:
 	1: Ret
 }
 test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	$t6: u64
+L1:	a: u64
+L2:	$t11: u64
+L3:	$t10: u64
+L4:	$t9: u64
+L5:	$t8: u64
 B0:
 	0: Call multi(): u64 * u64 * u64 * u64 * u64 * u64
 	1: Call one(): u64
-	2: StLoc[0](loc0: u64)
+	2: StLoc[0]($t6: u64)
 	3: Pop
 	4: Pop
 	5: Pop
@@ -43,17 +43,17 @@ B0:
 	9: Call one(): u64
 	10: Call one(): u64
 	11: Call one(): u64
-	12: StLoc[2](loc2: u64)
-	13: StLoc[3](loc3: u64)
-	14: StLoc[4](loc4: u64)
-	15: StLoc[5](loc5: u64)
-	16: StLoc[1](loc1: u64)
-	17: MoveLoc[0](loc0: u64)
-	18: MoveLoc[1](loc1: u64)
-	19: MoveLoc[5](loc5: u64)
-	20: MoveLoc[4](loc4: u64)
-	21: MoveLoc[3](loc3: u64)
-	22: MoveLoc[2](loc2: u64)
+	12: StLoc[2]($t11: u64)
+	13: StLoc[3]($t10: u64)
+	14: StLoc[4]($t9: u64)
+	15: StLoc[5]($t8: u64)
+	16: StLoc[1](a: u64)
+	17: MoveLoc[0]($t6: u64)
+	18: MoveLoc[1](a: u64)
+	19: MoveLoc[5]($t8: u64)
+	20: MoveLoc[4]($t9: u64)
+	21: MoveLoc[3]($t10: u64)
+	22: MoveLoc[2]($t11: u64)
 	23: Call consume(u64, u64, u64, u64, u64, u64)
 	24: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.on.exp
@@ -83,7 +83,7 @@ fun m::test() {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64, Arg5: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64, _f: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -103,7 +103,7 @@ B0:
 	1: Ret
 }
 test() /* def_idx: 3 */ {
-L0:	loc0: u64
+L0:	a: u64
 B0:
 	0: Call multi(): u64 * u64 * u64 * u64 * u64 * u64
 	1: Pop
@@ -111,9 +111,9 @@ B0:
 	3: Pop
 	4: Pop
 	5: Pop
-	6: StLoc[0](loc0: u64)
+	6: StLoc[0](a: u64)
 	7: Call one(): u64
-	8: MoveLoc[0](loc0: u64)
+	8: MoveLoc[0](a: u64)
 	9: Call one(): u64
 	10: Call one(): u64
 	11: Call one(): u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -18,12 +18,12 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
@@ -31,11 +31,11 @@ B0:
 	3: Call one(): u64
 	4: Call one(): u64
 	5: Call one(): u64
-	6: StLoc[0](loc0: u64)
-	7: StLoc[1](loc1: u64)
+	6: StLoc[0](f: u64)
+	7: StLoc[1](e: u64)
 	8: Call consume_4(u64, u64, u64, u64)
-	9: MoveLoc[1](loc1: u64)
-	10: MoveLoc[0](loc0: u64)
+	9: MoveLoc[1](e: u64)
+	10: MoveLoc[0](f: u64)
 	11: Call consume_2(u64, u64)
 	12: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.on.exp
@@ -70,11 +70,11 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -84,12 +84,12 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
@@ -97,11 +97,11 @@ B0:
 	3: Call one(): u64
 	4: Call one(): u64
 	5: Call one(): u64
-	6: StLoc[0](loc0: u64)
-	7: StLoc[1](loc1: u64)
+	6: StLoc[0](f: u64)
+	7: StLoc[1](e: u64)
 	8: Call consume_4(u64, u64, u64, u64)
-	9: MoveLoc[1](loc1: u64)
-	10: MoveLoc[0](loc0: u64)
+	9: MoveLoc[1](e: u64)
+	10: MoveLoc[0](f: u64)
 	11: Call consume_2(u64, u64)
 	12: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_08.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_08.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -21,20 +21,20 @@ B0:
 	4: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call four(): u64 * u64 * u64 * u64
 	1: Call two(): u64 * u64
-	2: StLoc[0](loc0: u64)
-	3: StLoc[1](loc1: u64)
+	2: StLoc[0](f: u64)
+	3: StLoc[1](e: u64)
 	4: Call consume_4(u64, u64, u64, u64)
-	5: MoveLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
+	5: MoveLoc[1](e: u64)
+	6: MoveLoc[0](f: u64)
 	7: Call consume_2(u64, u64)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_08.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_08.on.exp
@@ -84,11 +84,11 @@ fun m::two(): (u64, u64) {
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_4(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64) /* def_idx: 1 */ {
+consume_4(_a: u64, _b: u64, _c: u64, _d: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -101,20 +101,20 @@ B0:
 	4: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call four(): u64 * u64 * u64 * u64
 	1: Call two(): u64 * u64
-	2: StLoc[0](loc0: u64)
-	3: StLoc[1](loc1: u64)
+	2: StLoc[0](f: u64)
+	3: StLoc[1](e: u64)
 	4: Call consume_4(u64, u64, u64, u64)
-	5: MoveLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
+	5: MoveLoc[1](e: u64)
+	6: MoveLoc[0](f: u64)
 	7: Call consume_2(u64, u64)
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_5(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 1 */ {
+consume_5(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -18,12 +18,12 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	f: u64
+L1:	e: u64
+L2:	d: u64
+L3:	c: u64
+L4:	b: u64
+L5:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
@@ -31,17 +31,17 @@ B0:
 	3: Call one(): u64
 	4: Call one(): u64
 	5: Call one(): u64
-	6: StLoc[0](loc0: u64)
-	7: StLoc[1](loc1: u64)
-	8: StLoc[2](loc2: u64)
-	9: StLoc[3](loc3: u64)
-	10: StLoc[4](loc4: u64)
-	11: MoveLoc[3](loc3: u64)
-	12: MoveLoc[2](loc2: u64)
-	13: MoveLoc[1](loc1: u64)
-	14: MoveLoc[0](loc0: u64)
+	6: StLoc[0](f: u64)
+	7: StLoc[1](e: u64)
+	8: StLoc[2](d: u64)
+	9: StLoc[3](c: u64)
+	10: StLoc[4](b: u64)
+	11: MoveLoc[3](c: u64)
+	12: MoveLoc[2](d: u64)
+	13: MoveLoc[1](e: u64)
+	14: MoveLoc[0](f: u64)
 	15: Call consume_5(u64, u64, u64, u64, u64)
-	16: MoveLoc[4](loc4: u64)
+	16: MoveLoc[4](b: u64)
 	17: Call consume_1(u64)
 	18: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.on.exp
@@ -71,11 +71,11 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_5(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 1 */ {
+consume_5(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -85,22 +85,22 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	b: u64
+L1:	f: u64
+L2:	e: u64
+L3:	d: u64
+L4:	c: u64
+L5:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
-	2: StLoc[0](loc0: u64)
+	2: StLoc[0](b: u64)
 	3: Call one(): u64
 	4: Call one(): u64
 	5: Call one(): u64
 	6: Call one(): u64
 	7: Call consume_5(u64, u64, u64, u64, u64)
-	8: MoveLoc[0](loc0: u64)
+	8: MoveLoc[0](b: u64)
 	9: Call consume_1(u64)
 	10: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -18,18 +18,18 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	c: u64
+L1:	b: u64
+L2:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
 	2: Call one(): u64
-	3: StLoc[0](loc0: u64)
-	4: StLoc[1](loc1: u64)
+	3: StLoc[0](c: u64)
+	4: StLoc[1](b: u64)
 	5: Call consume_1(u64)
-	6: MoveLoc[1](loc1: u64)
-	7: MoveLoc[0](loc0: u64)
+	6: MoveLoc[1](b: u64)
+	7: MoveLoc[0](c: u64)
 	8: Call consume_2(u64, u64)
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.on.exp
@@ -53,11 +53,11 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -67,15 +67,15 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	a: u64
+L1:	c: u64
+L2:	b: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](a: u64)
 	2: Call one(): u64
 	3: Call one(): u64
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](a: u64)
 	5: Call consume_1(u64)
 	6: Call consume_2(u64, u64)
 	7: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_11.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_11.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -15,15 +15,15 @@ B0:
 	2: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	d: u64
+L1:	c: u64
+L2:	b: u64
 B0:
 	0: Call one_one(): u64 * u64
 	1: Call one_one(): u64 * u64
-	2: StLoc[0](loc0: u64)
+	2: StLoc[0](d: u64)
 	3: Call consume_2(u64, u64)
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](d: u64)
 	5: Call consume_2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_11.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_11.on.exp
@@ -50,7 +50,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 0 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -61,15 +61,15 @@ B0:
 	2: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	d: u64
+L1:	c: u64
+L2:	b: u64
 B0:
 	0: Call one_one(): u64 * u64
 	1: Call one_one(): u64 * u64
-	2: StLoc[0](loc0: u64)
+	2: StLoc[0](d: u64)
 	3: Call consume_2(u64, u64)
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](d: u64)
 	5: Call consume_2(u64, u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_12.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_12.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_3(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 1 */ {
+consume_3(_a: u64, _b: u64, _c: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -19,20 +19,20 @@ B0:
 	2: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
+L0:	d: u64
+L1:	c: u64
+L2:	b: u64
+L3:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
 	1: Call one_one(): u64 * u64
-	2: StLoc[0](loc0: u64)
-	3: StLoc[1](loc1: u64)
-	4: StLoc[2](loc2: u64)
-	5: MoveLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
+	2: StLoc[0](d: u64)
+	3: StLoc[1](c: u64)
+	4: StLoc[2](b: u64)
+	5: MoveLoc[1](c: u64)
+	6: MoveLoc[0](d: u64)
 	7: Call consume_3(u64, u64, u64)
-	8: MoveLoc[2](loc2: u64)
+	8: MoveLoc[2](b: u64)
 	9: Call consume_1(u64)
 	10: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_12.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_12.on.exp
@@ -58,11 +58,11 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_3(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 1 */ {
+consume_3(_a: u64, _b: u64, _c: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -73,16 +73,16 @@ B0:
 	2: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
+L0:	b: u64
+L1:	d: u64
+L2:	c: u64
+L3:	a: u64
 B0:
 	0: Call one_one(): u64 * u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](b: u64)
 	2: Call one_one(): u64 * u64
 	3: Call consume_3(u64, u64, u64)
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](b: u64)
 	5: Call consume_1(u64)
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -18,16 +18,16 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	c: u64
+L1:	b: u64
+L2:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
 	2: Call one(): u64
-	3: StLoc[0](loc0: u64)
+	3: StLoc[0](c: u64)
 	4: Call consume_2(u64, u64)
-	5: MoveLoc[0](loc0: u64)
+	5: MoveLoc[0](c: u64)
 	6: Call consume_1(u64)
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.on.exp
@@ -53,11 +53,11 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -67,16 +67,16 @@ B0:
 	1: Ret
 }
 public test() /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	c: u64
+L1:	b: u64
+L2:	a: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
 	2: Call one(): u64
-	3: StLoc[0](loc0: u64)
+	3: StLoc[0](c: u64)
 	4: Call consume_2(u64, u64)
-	5: MoveLoc[0](loc0: u64)
+	5: MoveLoc[0](c: u64)
 	6: Call consume_1(u64)
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -17,18 +17,18 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: u64) /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+public test(a: u64) /* def_idx: 3 */ {
+L1:	c: u64
+L2:	b: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
-	2: StLoc[1](loc0: u64)
-	3: StLoc[2](loc1: u64)
-	4: MoveLoc[0](Arg0: u64)
-	5: MoveLoc[2](loc1: u64)
+	2: StLoc[1](c: u64)
+	3: StLoc[2](b: u64)
+	4: MoveLoc[0](a: u64)
+	5: MoveLoc[2](b: u64)
 	6: Call consume_2(u64, u64)
-	7: MoveLoc[1](loc0: u64)
+	7: MoveLoc[1](c: u64)
 	8: Call consume_1(u64)
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.on.exp
@@ -50,11 +50,11 @@ public fun m::test($t0: u64) {
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -63,14 +63,14 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: u64) /* def_idx: 3 */ {
-L1:	loc0: u64
+public test(a: u64) /* def_idx: 3 */ {
+L1:	b: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](b: u64)
 	2: Call one(): u64
-	3: MoveLoc[0](Arg0: u64)
-	4: MoveLoc[1](loc0: u64)
+	3: MoveLoc[0](a: u64)
+	4: MoveLoc[1](b: u64)
 	5: Call consume_2(u64, u64)
 	6: Call consume_1(u64)
 	7: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.off.exp
@@ -4,11 +4,11 @@
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -17,13 +17,13 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: u64) /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+public test(a: u64) /* def_idx: 3 */ {
+L1:	c: u64
+L2:	b: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](a: u64)
 	3: Call consume_1(u64)
 	4: Call consume_2(u64, u64)
 	5: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.on.exp
@@ -49,11 +49,11 @@ public fun m::test($t0: u64) {
 module c0ffee.m {
 
 
-consume_1(Arg0: u64) /* def_idx: 0 */ {
+consume_1(_a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+consume_2(_a: u64, _b: u64) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
@@ -62,13 +62,13 @@ B0:
 	0: LdU64(1)
 	1: Ret
 }
-public test(Arg0: u64) /* def_idx: 3 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+public test(a: u64) /* def_idx: 3 */ {
+L1:	c: u64
+L2:	b: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](a: u64)
 	3: Call consume_1(u64)
 	4: Call consume_2(u64, u64)
 	5: Ret

--- a/third_party/move/move-compiler-v2/tests/flush-writes/tuples_in_order_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/tuples_in_order_use_01.off.exp
@@ -4,7 +4,7 @@
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -18,11 +18,11 @@ B0:
 	5: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
+L0:	e: u64
+L1:	d: u64
+L2:	c: u64
+L3:	b: u64
+L4:	a: u64
 B0:
 	0: Call foo(): u64 * u64 * u64 * u64 * u64
 	1: Call consume(u64, u64, u64, u64, u64)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/tuples_in_order_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/tuples_in_order_use_01.on.exp
@@ -62,7 +62,7 @@ public fun m::test() {
 module c0ffee.m {
 
 
-consume(Arg0: u64, Arg1: u64, Arg2: u64, Arg3: u64, Arg4: u64) /* def_idx: 0 */ {
+consume(_a: u64, _b: u64, _c: u64, _d: u64, _e: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
@@ -76,11 +76,11 @@ B0:
 	5: Ret
 }
 public test() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
-L3:	loc3: u64
-L4:	loc4: u64
+L0:	e: u64
+L1:	d: u64
+L2:	c: u64
+L3:	b: u64
+L4:	a: u64
 B0:
 	0: Call foo(): u64 * u64 * u64 * u64 * u64
 	1: Call consume(u64, u64, u64, u64, u64)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
@@ -10,43 +10,43 @@ B0:
 	1: Ret
 }
 public test1(): u64 * u64 /* def_idx: 1 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	z: u64
+L1:	y: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
 	2: Call one(): u64
-	3: StLoc[0](loc0: u64)
-	4: StLoc[1](loc1: u64)
+	3: StLoc[0](z: u64)
+	4: StLoc[1](y: u64)
 	5: Pop
-	6: MoveLoc[1](loc1: u64)
-	7: MoveLoc[0](loc0: u64)
+	6: MoveLoc[1](y: u64)
+	7: MoveLoc[0](z: u64)
 	8: Ret
 }
 public test2(): u64 * u64 /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	z: u64
+L1:	x: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
 	2: Call one(): u64
-	3: StLoc[0](loc0: u64)
+	3: StLoc[0](z: u64)
 	4: Pop
-	5: MoveLoc[0](loc0: u64)
+	5: MoveLoc[0](z: u64)
 	6: Ret
 }
 public test3(): u64 * u64 /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	z: u64
+L1:	x: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
 	2: Call one(): u64
-	3: StLoc[0](loc0: u64)
+	3: StLoc[0](z: u64)
 	4: Pop
-	5: StLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: MoveLoc[1](loc1: u64)
+	5: StLoc[1](x: u64)
+	6: MoveLoc[0](z: u64)
+	7: MoveLoc[1](x: u64)
 	8: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
@@ -85,8 +85,8 @@ B0:
 	1: Ret
 }
 public test1(): u64 * u64 /* def_idx: 1 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	z: u64
+L1:	y: u64
 B0:
 	0: Call one(): u64
 	1: Pop
@@ -95,8 +95,8 @@ B0:
 	4: Ret
 }
 public test2(): u64 * u64 /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	z: u64
+L1:	x: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
@@ -105,15 +105,15 @@ B0:
 	4: Ret
 }
 public test3(): u64 * u64 /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	x: u64
+L1:	z: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](x: u64)
 	2: Call one(): u64
 	3: Pop
 	4: Call one(): u64
-	5: MoveLoc[0](loc0: u64)
+	5: MoveLoc[0](x: u64)
 	6: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
@@ -14,28 +14,28 @@ B0:
 	1: Ret
 }
 public test(): u64 * u64 /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: bool
-L3:	loc3: u64
+L0:	z: u64
+L1:	y: u64
+L2:	$t5: bool
+L3:	x: u64
 B0:
 	0: Call one(): u64
 	1: Call one(): u64
 	2: Call one(): u64
-	3: StLoc[0](loc0: u64)
+	3: StLoc[0](z: u64)
 	4: LdU64(0)
 	5: Eq
-	6: StLoc[2](loc2: bool)
-	7: StLoc[3](loc3: u64)
-	8: MoveLoc[2](loc2: bool)
+	6: StLoc[2]($t5: bool)
+	7: StLoc[3](x: u64)
+	8: MoveLoc[2]($t5: bool)
 	9: BrTrue(11)
 B1:
 	10: Branch(12)
 B2:
 	11: Call bar()
 B3:
-	12: MoveLoc[3](loc3: u64)
-	13: MoveLoc[0](loc0: u64)
+	12: MoveLoc[3](x: u64)
+	13: MoveLoc[0](z: u64)
 	14: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
@@ -75,14 +75,14 @@ B0:
 	1: Ret
 }
 public test(): u64 * u64 /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	x: u64
+L1:	z: u64
 B0:
 	0: Call one(): u64
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](x: u64)
 	2: Call one(): u64
 	3: Call one(): u64
-	4: StLoc[1](loc1: u64)
+	4: StLoc[1](z: u64)
 	5: LdU64(0)
 	6: Eq
 	7: BrTrue(9)
@@ -91,8 +91,8 @@ B1:
 B2:
 	9: Call bar()
 B3:
-	10: MoveLoc[0](loc0: u64)
-	11: MoveLoc[1](loc1: u64)
+	10: MoveLoc[0](x: u64)
+	11: MoveLoc[1](z: u64)
 	12: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.off.exp
@@ -16,13 +16,13 @@ B0:
 	3: Ret
 }
 public test1() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	z: u64
+L1:	y: u64
+L2:	x: u64
 B0:
 	0: Call foo(): u64 * u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: StLoc[1](loc1: u64)
+	1: StLoc[0](z: u64)
+	2: StLoc[1](y: u64)
 	3: LdU64(0)
 	4: Eq
 	5: BrTrue(7)
@@ -31,7 +31,7 @@ B1:
 B2:
 	7: Call bar()
 B3:
-	8: MoveLoc[1](loc1: u64)
+	8: MoveLoc[1](y: u64)
 	9: LdU64(0)
 	10: Eq
 	11: BrTrue(13)
@@ -40,7 +40,7 @@ B4:
 B5:
 	13: Call bar()
 B6:
-	14: MoveLoc[0](loc0: u64)
+	14: MoveLoc[0](z: u64)
 	15: LdU64(0)
 	16: Eq
 	17: BrTrue(19)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
@@ -116,12 +116,12 @@ B0:
 	3: Ret
 }
 public test1() /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	z: u64
+L1:	y: u64
 B0:
 	0: Call foo(): u64 * u64 * u64
-	1: StLoc[0](loc0: u64)
-	2: StLoc[1](loc1: u64)
+	1: StLoc[0](z: u64)
+	2: StLoc[1](y: u64)
 	3: LdU64(0)
 	4: Eq
 	5: BrTrue(7)
@@ -130,7 +130,7 @@ B1:
 B2:
 	7: Call bar()
 B3:
-	8: MoveLoc[1](loc1: u64)
+	8: MoveLoc[1](y: u64)
 	9: LdU64(0)
 	10: Eq
 	11: BrTrue(13)
@@ -139,7 +139,7 @@ B4:
 B5:
 	13: Call bar()
 B6:
-	14: MoveLoc[0](loc0: u64)
+	14: MoveLoc[0](z: u64)
 	15: LdU64(0)
 	16: Eq
 	17: BrTrue(19)

--- a/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.off.exp
@@ -4,14 +4,14 @@
 module c0ffee.m {
 
 
-public test(Arg0: u64) /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+public test(x: u64) /* def_idx: 0 */ {
+L1:	$t2: u64
+L2:	y: &mut u64
 B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: StLoc[2](loc1: &mut u64)
+	0: MutBorrowLoc[0](x: u64)
+	1: StLoc[2](y: &mut u64)
 	2: LdU64(42)
-	3: MoveLoc[2](loc1: &mut u64)
+	3: MoveLoc[2](y: &mut u64)
 	4: WriteRef
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.on.exp
@@ -21,14 +21,14 @@ public fun m::test($t0: u64) {
 module c0ffee.m {
 
 
-public test(Arg0: u64) /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+public test(x: u64) /* def_idx: 0 */ {
+L1:	$t2: u64
+L2:	y: &mut u64
 B0:
-	0: MutBorrowLoc[0](Arg0: u64)
-	1: StLoc[2](loc1: &mut u64)
+	0: MutBorrowLoc[0](x: u64)
+	1: StLoc[2](y: &mut u64)
 	2: LdU64(42)
-	3: MoveLoc[2](loc1: &mut u64)
+	3: MoveLoc[2](y: &mut u64)
 	4: WriteRef
 	5: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
@@ -725,25 +725,25 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
 module cafe.vectors {
 
 
-entry public guess_flips_break2(Arg0: vector<u8>): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: &vector<u8>
+entry public guess_flips_break2(flips: vector<u8>): u64 /* def_idx: 0 */ {
+L1:	i: u64
+L2:	flipsref5: &vector<u8>
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
-	2: ImmBorrowLoc[0](Arg0: vector<u8>)
-	3: StLoc[2](loc1: &vector<u8>)
+	1: StLoc[1](i: u64)
+	2: ImmBorrowLoc[0](flips: vector<u8>)
+	3: StLoc[2](flipsref5: &vector<u8>)
 B1:
-	4: CopyLoc[1](loc0: u64)
-	5: CopyLoc[2](loc1: &vector<u8>)
+	4: CopyLoc[1](i: u64)
+	5: CopyLoc[2](flipsref5: &vector<u8>)
 	6: VecLen(2)
 	7: Lt
 	8: BrTrue(10)
 B2:
 	9: Branch(18)
 B3:
-	10: CopyLoc[2](loc1: &vector<u8>)
-	11: CopyLoc[1](loc0: u64)
+	10: CopyLoc[2](flipsref5: &vector<u8>)
+	11: CopyLoc[1](i: u64)
 	12: VecImmBorrow(2)
 	13: ReadRef
 	14: LdU8(0)
@@ -752,16 +752,16 @@ B3:
 B4:
 	17: Branch(18)
 B5:
-	18: MoveLoc[2](loc1: &vector<u8>)
+	18: MoveLoc[2](flipsref5: &vector<u8>)
 	19: VecLen(2)
 	20: Ret
 B6:
-	21: MoveLoc[1](loc0: u64)
+	21: MoveLoc[1](i: u64)
 	22: LdU64(1)
 	23: Add
-	24: StLoc[1](loc0: u64)
-	25: CopyLoc[2](loc1: &vector<u8>)
-	26: CopyLoc[1](loc0: u64)
+	24: StLoc[1](i: u64)
+	25: CopyLoc[2](flipsref5: &vector<u8>)
+	26: CopyLoc[1](i: u64)
 	27: VecImmBorrow(2)
 	28: ReadRef
 	29: LdU8(5)

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
@@ -1296,36 +1296,36 @@ module 42.m {
 
 
 foo(): u64 /* def_idx: 0 */ {
-L0:	loc0: vector<u64>
-L1:	loc1: &mut vector<u64>
-L2:	loc2: &mut vector<u64>
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	v: vector<u64>
+L1:	r: &mut vector<u64>
+L2:	v: &mut vector<u64>
+L3:	i: u64
+L4:	len: u64
+L5:	$t9: u64
 B0:
 	0: LdConst[0](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	1: StLoc[0](loc0: vector<u64>)
-	2: MutBorrowLoc[0](loc0: vector<u64>)
-	3: StLoc[1](loc1: &mut vector<u64>)
-	4: CopyLoc[1](loc1: &mut vector<u64>)
-	5: StLoc[2](loc2: &mut vector<u64>)
+	1: StLoc[0](v: vector<u64>)
+	2: MutBorrowLoc[0](v: vector<u64>)
+	3: StLoc[1](r: &mut vector<u64>)
+	4: CopyLoc[1](r: &mut vector<u64>)
+	5: StLoc[2](v: &mut vector<u64>)
 	6: LdU64(0)
-	7: StLoc[3](loc3: u64)
-	8: CopyLoc[2](loc2: &mut vector<u64>)
+	7: StLoc[3](i: u64)
+	8: CopyLoc[2](v: &mut vector<u64>)
 	9: FreezeRef
 	10: VecLen(1)
-	11: StLoc[4](loc4: u64)
+	11: StLoc[4](len: u64)
 B1:
-	12: CopyLoc[3](loc3: u64)
-	13: CopyLoc[4](loc4: u64)
+	12: CopyLoc[3](i: u64)
+	13: CopyLoc[4](len: u64)
 	14: Lt
 	15: BrTrue(17)
 B2:
 	16: Branch(26)
 B3:
-	17: CopyLoc[2](loc2: &mut vector<u64>)
+	17: CopyLoc[2](v: &mut vector<u64>)
 	18: FreezeRef
-	19: CopyLoc[3](loc3: u64)
+	19: CopyLoc[3](i: u64)
 	20: VecImmBorrow(1)
 	21: ReadRef
 	22: LdU64(1)
@@ -1334,21 +1334,21 @@ B3:
 B4:
 	25: Branch(26)
 B5:
-	26: CopyLoc[3](loc3: u64)
-	27: StLoc[5](loc5: u64)
-	28: MoveLoc[3](loc3: u64)
+	26: CopyLoc[3](i: u64)
+	27: StLoc[5]($t9: u64)
+	28: MoveLoc[3](i: u64)
 	29: LdU64(1)
 	30: Add
-	31: StLoc[3](loc3: u64)
+	31: StLoc[3](i: u64)
 B6:
-	32: CopyLoc[3](loc3: u64)
-	33: CopyLoc[4](loc4: u64)
+	32: CopyLoc[3](i: u64)
+	33: CopyLoc[4](len: u64)
 	34: Lt
 	35: BrFalse(58)
 B7:
-	36: CopyLoc[2](loc2: &mut vector<u64>)
+	36: CopyLoc[2](v: &mut vector<u64>)
 	37: FreezeRef
-	38: CopyLoc[3](loc3: u64)
+	38: CopyLoc[3](i: u64)
 	39: VecImmBorrow(1)
 	40: ReadRef
 	41: LdU64(1)
@@ -1357,34 +1357,34 @@ B7:
 B8:
 	44: Branch(53)
 B9:
-	45: CopyLoc[2](loc2: &mut vector<u64>)
-	46: CopyLoc[5](loc5: u64)
-	47: CopyLoc[3](loc3: u64)
+	45: CopyLoc[2](v: &mut vector<u64>)
+	46: CopyLoc[5]($t9: u64)
+	47: CopyLoc[3](i: u64)
 	48: VecSwap(1)
-	49: MoveLoc[5](loc5: u64)
+	49: MoveLoc[5]($t9: u64)
 	50: LdU64(1)
 	51: Add
-	52: StLoc[5](loc5: u64)
+	52: StLoc[5]($t9: u64)
 B10:
-	53: MoveLoc[3](loc3: u64)
+	53: MoveLoc[3](i: u64)
 	54: LdU64(1)
 	55: Add
-	56: StLoc[3](loc3: u64)
+	56: StLoc[3](i: u64)
 	57: Branch(32)
 B11:
-	58: MoveLoc[2](loc2: &mut vector<u64>)
+	58: MoveLoc[2](v: &mut vector<u64>)
 	59: Pop
-	60: MoveLoc[1](loc1: &mut vector<u64>)
+	60: MoveLoc[1](r: &mut vector<u64>)
 	61: FreezeRef
 	62: LdU64(0)
 	63: VecImmBorrow(1)
 	64: ReadRef
 	65: Ret
 B12:
-	66: MoveLoc[3](loc3: u64)
+	66: MoveLoc[3](i: u64)
 	67: LdU64(1)
 	68: Add
-	69: StLoc[3](loc3: u64)
+	69: StLoc[3](i: u64)
 	70: Branch(12)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline_typed.exp
@@ -1296,36 +1296,36 @@ module 42.m {
 
 
 foo(): u64 /* def_idx: 0 */ {
-L0:	loc0: vector<u64>
-L1:	loc1: &mut vector<u64>
-L2:	loc2: &mut vector<u64>
-L3:	loc3: u64
-L4:	loc4: u64
-L5:	loc5: u64
+L0:	v: vector<u64>
+L1:	r: &mut vector<u64>
+L2:	v: &mut vector<u64>
+L3:	i: u64
+L4:	len: u64
+L5:	$t9: u64
 B0:
 	0: LdConst[0](Vector(U64): [3, 1, 0, 0, 0, 0, 0, 0, 0, 2, 0, 0, 0, 0, 0, 0, 0, 3, 0, 0, 0, 0, 0, 0, 0])
-	1: StLoc[0](loc0: vector<u64>)
-	2: MutBorrowLoc[0](loc0: vector<u64>)
-	3: StLoc[1](loc1: &mut vector<u64>)
-	4: CopyLoc[1](loc1: &mut vector<u64>)
-	5: StLoc[2](loc2: &mut vector<u64>)
+	1: StLoc[0](v: vector<u64>)
+	2: MutBorrowLoc[0](v: vector<u64>)
+	3: StLoc[1](r: &mut vector<u64>)
+	4: CopyLoc[1](r: &mut vector<u64>)
+	5: StLoc[2](v: &mut vector<u64>)
 	6: LdU64(0)
-	7: StLoc[3](loc3: u64)
-	8: CopyLoc[2](loc2: &mut vector<u64>)
+	7: StLoc[3](i: u64)
+	8: CopyLoc[2](v: &mut vector<u64>)
 	9: FreezeRef
 	10: VecLen(1)
-	11: StLoc[4](loc4: u64)
+	11: StLoc[4](len: u64)
 B1:
-	12: CopyLoc[3](loc3: u64)
-	13: CopyLoc[4](loc4: u64)
+	12: CopyLoc[3](i: u64)
+	13: CopyLoc[4](len: u64)
 	14: Lt
 	15: BrTrue(17)
 B2:
 	16: Branch(26)
 B3:
-	17: CopyLoc[2](loc2: &mut vector<u64>)
+	17: CopyLoc[2](v: &mut vector<u64>)
 	18: FreezeRef
-	19: CopyLoc[3](loc3: u64)
+	19: CopyLoc[3](i: u64)
 	20: VecImmBorrow(1)
 	21: ReadRef
 	22: LdU64(1)
@@ -1334,21 +1334,21 @@ B3:
 B4:
 	25: Branch(26)
 B5:
-	26: CopyLoc[3](loc3: u64)
-	27: StLoc[5](loc5: u64)
-	28: MoveLoc[3](loc3: u64)
+	26: CopyLoc[3](i: u64)
+	27: StLoc[5]($t9: u64)
+	28: MoveLoc[3](i: u64)
 	29: LdU64(1)
 	30: Add
-	31: StLoc[3](loc3: u64)
+	31: StLoc[3](i: u64)
 B6:
-	32: CopyLoc[3](loc3: u64)
-	33: CopyLoc[4](loc4: u64)
+	32: CopyLoc[3](i: u64)
+	33: CopyLoc[4](len: u64)
 	34: Lt
 	35: BrFalse(58)
 B7:
-	36: CopyLoc[2](loc2: &mut vector<u64>)
+	36: CopyLoc[2](v: &mut vector<u64>)
 	37: FreezeRef
-	38: CopyLoc[3](loc3: u64)
+	38: CopyLoc[3](i: u64)
 	39: VecImmBorrow(1)
 	40: ReadRef
 	41: LdU64(1)
@@ -1357,34 +1357,34 @@ B7:
 B8:
 	44: Branch(53)
 B9:
-	45: CopyLoc[2](loc2: &mut vector<u64>)
-	46: CopyLoc[5](loc5: u64)
-	47: CopyLoc[3](loc3: u64)
+	45: CopyLoc[2](v: &mut vector<u64>)
+	46: CopyLoc[5]($t9: u64)
+	47: CopyLoc[3](i: u64)
 	48: VecSwap(1)
-	49: MoveLoc[5](loc5: u64)
+	49: MoveLoc[5]($t9: u64)
 	50: LdU64(1)
 	51: Add
-	52: StLoc[5](loc5: u64)
+	52: StLoc[5]($t9: u64)
 B10:
-	53: MoveLoc[3](loc3: u64)
+	53: MoveLoc[3](i: u64)
 	54: LdU64(1)
 	55: Add
-	56: StLoc[3](loc3: u64)
+	56: StLoc[3](i: u64)
 	57: Branch(32)
 B11:
-	58: MoveLoc[2](loc2: &mut vector<u64>)
+	58: MoveLoc[2](v: &mut vector<u64>)
 	59: Pop
-	60: MoveLoc[1](loc1: &mut vector<u64>)
+	60: MoveLoc[1](r: &mut vector<u64>)
 	61: FreezeRef
 	62: LdU64(0)
 	63: VecImmBorrow(1)
 	64: ReadRef
 	65: Ret
 B12:
-	66: MoveLoc[3](loc3: u64)
+	66: MoveLoc[3](i: u64)
 	67: LdU64(1)
 	68: Add
-	69: StLoc[3](loc3: u64)
+	69: StLoc[3](i: u64)
 	70: Branch(12)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/op-equal/eval_order.exp
+++ b/third_party/move/move-compiler-v2/tests/op-equal/eval_order.exp
@@ -439,93 +439,93 @@ public fun m::test3(): u64 {
 module c0ffee.m {
 
 
-mod1(Arg0: &mut u64) /* def_idx: 0 */ {
+mod1(r: &mut u64) /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut u64)
+	0: CopyLoc[0](r: &mut u64)
 	1: ReadRef
 	2: LdU64(2)
 	3: Add
-	4: MoveLoc[0](Arg0: &mut u64)
+	4: MoveLoc[0](r: &mut u64)
 	5: WriteRef
 	6: Ret
 }
-mod2(Arg0: &mut u64): u64 /* def_idx: 1 */ {
-L1:	loc0: &mut u64
+mod2(r: &mut u64): u64 /* def_idx: 1 */ {
+L1:	$t1: &mut u64
 B0:
-	0: CopyLoc[0](Arg0: &mut u64)
-	1: StLoc[1](loc0: &mut u64)
-	2: CopyLoc[1](loc0: &mut u64)
+	0: CopyLoc[0](r: &mut u64)
+	1: StLoc[1]($t1: &mut u64)
+	2: CopyLoc[1]($t1: &mut u64)
 	3: ReadRef
 	4: LdU64(2)
 	5: Add
-	6: MoveLoc[1](loc0: &mut u64)
+	6: MoveLoc[1]($t1: &mut u64)
 	7: WriteRef
-	8: MoveLoc[0](Arg0: &mut u64)
+	8: MoveLoc[0](r: &mut u64)
 	9: ReadRef
 	10: Ret
 }
 public test0(): u64 /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	v: u64
+L1:	$t5: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)
 	2: Add
-	3: StLoc[0](loc0: u64)
-	4: CopyLoc[0](loc0: u64)
-	5: StLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: MoveLoc[1](loc1: u64)
+	3: StLoc[0](v: u64)
+	4: CopyLoc[0](v: u64)
+	5: StLoc[1]($t5: u64)
+	6: MoveLoc[0](v: u64)
+	7: MoveLoc[1]($t5: u64)
 	8: Add
-	9: StLoc[0](loc0: u64)
-	10: CopyLoc[0](loc0: u64)
-	11: StLoc[1](loc1: u64)
-	12: MoveLoc[0](loc0: u64)
-	13: MoveLoc[1](loc1: u64)
+	9: StLoc[0](v: u64)
+	10: CopyLoc[0](v: u64)
+	11: StLoc[1]($t5: u64)
+	12: MoveLoc[0](v: u64)
+	13: MoveLoc[1]($t5: u64)
 	14: Add
 	15: Ret
 }
 public test1(): u64 /* def_idx: 3 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	v: u64
+L1:	$t4: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)
 	2: Add
-	3: StLoc[0](loc0: u64)
-	4: CopyLoc[0](loc0: u64)
-	5: StLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: MoveLoc[1](loc1: u64)
+	3: StLoc[0](v: u64)
+	4: CopyLoc[0](v: u64)
+	5: StLoc[1]($t4: u64)
+	6: MoveLoc[0](v: u64)
+	7: MoveLoc[1]($t4: u64)
 	8: Add
 	9: Ret
 }
 public test2(): u64 /* def_idx: 4 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	v: u64
+L1:	$t: u64
 B0:
 	0: LdU64(1)
-	1: StLoc[0](loc0: u64)
-	2: MutBorrowLoc[0](loc0: u64)
+	1: StLoc[0](v: u64)
+	2: MutBorrowLoc[0](v: u64)
 	3: Call mod1(&mut u64)
-	4: CopyLoc[0](loc0: u64)
-	5: StLoc[1](loc1: u64)
-	6: MoveLoc[0](loc0: u64)
-	7: MoveLoc[1](loc1: u64)
+	4: CopyLoc[0](v: u64)
+	5: StLoc[1]($t: u64)
+	6: MoveLoc[0](v: u64)
+	7: MoveLoc[1]($t: u64)
 	8: Add
 	9: Ret
 }
 public test3(): u64 /* def_idx: 5 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	v: u64
+L1:	$t: u64
 B0:
 	0: LdU64(1)
-	1: StLoc[0](loc0: u64)
-	2: MutBorrowLoc[0](loc0: u64)
+	1: StLoc[0](v: u64)
+	2: MutBorrowLoc[0](v: u64)
 	3: Call mod2(&mut u64): u64
-	4: StLoc[1](loc1: u64)
-	5: MoveLoc[0](loc0: u64)
-	6: MoveLoc[1](loc1: u64)
+	4: StLoc[1]($t: u64)
+	5: MoveLoc[0](v: u64)
+	6: MoveLoc[1]($t: u64)
 	7: Add
 	8: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/op-equal/valid0.exp
+++ b/third_party/move/move-compiler-v2/tests/op-equal/valid0.exp
@@ -944,234 +944,234 @@ module 42.test {
 struct Coin has drop, key {
 	_0: u256
 }
-struct Wrapper<Ty0> has drop, key {
-	_0: Ty0
+struct Wrapper<T> has drop, key {
+	_0: T
 }
 
-add1_new(Arg0: u256): u256 /* def_idx: 0 */ {
+add1_new(x: u256): u256 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u256)
+	0: MoveLoc[0](x: u256)
 	1: LdU256(1)
 	2: Add
 	3: Ret
 }
-add1_old(Arg0: u256): u256 /* def_idx: 1 */ {
+add1_old(x: u256): u256 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u256)
+	0: MoveLoc[0](x: u256)
 	1: LdU256(1)
 	2: Add
 	3: Ret
 }
-coin_inc_new_1(Arg0: &mut Coin) /* def_idx: 2 */ {
-L1:	loc0: &mut u256
+coin_inc_new_1(self: &mut Coin) /* def_idx: 2 */ {
+L1:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut Coin)
+	0: MoveLoc[0](self: &mut Coin)
 	1: MutBorrowField[0](Coin._0: u256)
-	2: StLoc[1](loc0: &mut u256)
-	3: CopyLoc[1](loc0: &mut u256)
+	2: StLoc[1]($t1: &mut u256)
+	3: CopyLoc[1]($t1: &mut u256)
 	4: ReadRef
 	5: LdU256(1)
 	6: Add
-	7: MoveLoc[1](loc0: &mut u256)
+	7: MoveLoc[1]($t1: &mut u256)
 	8: WriteRef
 	9: Ret
 }
-coin_inc_new_2(Arg0: &mut Coin) /* def_idx: 3 */ {
-L1:	loc0: &mut u256
+coin_inc_new_2(self: &mut Coin) /* def_idx: 3 */ {
+L1:	p: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut Coin)
+	0: MoveLoc[0](self: &mut Coin)
 	1: MutBorrowField[0](Coin._0: u256)
-	2: StLoc[1](loc0: &mut u256)
-	3: CopyLoc[1](loc0: &mut u256)
+	2: StLoc[1](p: &mut u256)
+	3: CopyLoc[1](p: &mut u256)
 	4: ReadRef
 	5: LdU256(1)
 	6: Add
-	7: MoveLoc[1](loc0: &mut u256)
+	7: MoveLoc[1](p: &mut u256)
 	8: WriteRef
 	9: Ret
 }
-coin_inc_old_1(Arg0: &mut Coin) /* def_idx: 4 */ {
+coin_inc_old_1(self: &mut Coin) /* def_idx: 4 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut Coin)
+	0: CopyLoc[0](self: &mut Coin)
 	1: ImmBorrowField[0](Coin._0: u256)
 	2: ReadRef
 	3: LdU256(1)
 	4: Add
-	5: MoveLoc[0](Arg0: &mut Coin)
+	5: MoveLoc[0](self: &mut Coin)
 	6: MutBorrowField[0](Coin._0: u256)
 	7: WriteRef
 	8: Ret
 }
-coin_inc_old_2(Arg0: &mut Coin) /* def_idx: 5 */ {
-L1:	loc0: &mut u256
+coin_inc_old_2(self: &mut Coin) /* def_idx: 5 */ {
+L1:	p: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut Coin)
+	0: MoveLoc[0](self: &mut Coin)
 	1: MutBorrowField[0](Coin._0: u256)
-	2: StLoc[1](loc0: &mut u256)
-	3: CopyLoc[1](loc0: &mut u256)
+	2: StLoc[1](p: &mut u256)
+	3: CopyLoc[1](p: &mut u256)
 	4: ReadRef
 	5: LdU256(1)
 	6: Add
-	7: MoveLoc[1](loc0: &mut u256)
+	7: MoveLoc[1](p: &mut u256)
 	8: WriteRef
 	9: Ret
 }
-inc_coin_at(Arg0: address) /* def_idx: 6 */ {
-L1:	loc0: &mut u256
+inc_coin_at(addr: address) /* def_idx: 6 */ {
+L1:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](addr: address)
 	1: MutBorrowGlobal[0](Coin)
 	2: MutBorrowField[0](Coin._0: u256)
-	3: StLoc[1](loc0: &mut u256)
-	4: CopyLoc[1](loc0: &mut u256)
+	3: StLoc[1]($t1: &mut u256)
+	4: CopyLoc[1]($t1: &mut u256)
 	5: ReadRef
 	6: LdU256(1)
 	7: Add
-	8: MoveLoc[1](loc0: &mut u256)
+	8: MoveLoc[1]($t1: &mut u256)
 	9: WriteRef
 	10: Ret
 }
-inc_new(Arg0: &mut u256) /* def_idx: 7 */ {
+inc_new(x: &mut u256) /* def_idx: 7 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut u256)
+	0: CopyLoc[0](x: &mut u256)
 	1: ReadRef
 	2: LdU256(1)
 	3: Add
-	4: MoveLoc[0](Arg0: &mut u256)
+	4: MoveLoc[0](x: &mut u256)
 	5: WriteRef
 	6: Ret
 }
-inc_old(Arg0: &mut u256) /* def_idx: 8 */ {
+inc_old(x: &mut u256) /* def_idx: 8 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut u256)
+	0: CopyLoc[0](x: &mut u256)
 	1: ReadRef
 	2: LdU256(1)
 	3: Add
-	4: MoveLoc[0](Arg0: &mut u256)
+	4: MoveLoc[0](x: &mut u256)
 	5: WriteRef
 	6: Ret
 }
-inc_vec_coin_new(Arg0: vector<Coin>, Arg1: u64) /* def_idx: 9 */ {
-L2:	loc0: &mut u256
+inc_vec_coin_new(x: vector<Coin>, index: u64) /* def_idx: 9 */ {
+L2:	$t1: &mut u256
 B0:
-	0: MutBorrowLoc[0](Arg0: vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MutBorrowLoc[0](x: vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(6)
 	3: MutBorrowField[0](Coin._0: u256)
-	4: StLoc[2](loc0: &mut u256)
-	5: CopyLoc[2](loc0: &mut u256)
+	4: StLoc[2]($t1: &mut u256)
+	5: CopyLoc[2]($t1: &mut u256)
 	6: ReadRef
 	7: LdU256(1)
 	8: Add
-	9: MoveLoc[2](loc0: &mut u256)
+	9: MoveLoc[2]($t1: &mut u256)
 	10: WriteRef
 	11: Ret
 }
-inc_vec_coin_old(Arg0: vector<Coin>, Arg1: u64) /* def_idx: 10 */ {
+inc_vec_coin_old(x: vector<Coin>, index: u64) /* def_idx: 10 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<Coin>)
-	1: CopyLoc[1](Arg1: u64)
+	0: ImmBorrowLoc[0](x: vector<Coin>)
+	1: CopyLoc[1](index: u64)
 	2: VecImmBorrow(6)
 	3: ImmBorrowField[0](Coin._0: u256)
 	4: ReadRef
 	5: LdU256(1)
 	6: Add
-	7: MutBorrowLoc[0](Arg0: vector<Coin>)
-	8: MoveLoc[1](Arg1: u64)
+	7: MutBorrowLoc[0](x: vector<Coin>)
+	8: MoveLoc[1](index: u64)
 	9: VecMutBorrow(6)
 	10: MutBorrowField[0](Coin._0: u256)
 	11: WriteRef
 	12: Ret
 }
-inc_vec_new(Arg0: &mut vector<u256>, Arg1: u64) /* def_idx: 11 */ {
-L2:	loc0: &mut u256
+inc_vec_new(x: &mut vector<u256>, index: u64) /* def_idx: 11 */ {
+L2:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut vector<u256>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: &mut vector<u256>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(0)
-	3: StLoc[2](loc0: &mut u256)
-	4: CopyLoc[2](loc0: &mut u256)
+	3: StLoc[2]($t1: &mut u256)
+	4: CopyLoc[2]($t1: &mut u256)
 	5: ReadRef
 	6: LdU256(1)
 	7: Add
-	8: MoveLoc[2](loc0: &mut u256)
+	8: MoveLoc[2]($t1: &mut u256)
 	9: WriteRef
 	10: Ret
 }
-inc_vec_old(Arg0: vector<u256>, Arg1: u64) /* def_idx: 12 */ {
+inc_vec_old(x: vector<u256>, index: u64) /* def_idx: 12 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<u256>)
-	1: CopyLoc[1](Arg1: u64)
+	0: ImmBorrowLoc[0](x: vector<u256>)
+	1: CopyLoc[1](index: u64)
 	2: VecImmBorrow(0)
 	3: ReadRef
 	4: LdU256(1)
 	5: Add
-	6: MutBorrowLoc[0](Arg0: vector<u256>)
-	7: MoveLoc[1](Arg1: u64)
+	6: MutBorrowLoc[0](x: vector<u256>)
+	7: MoveLoc[1](index: u64)
 	8: VecMutBorrow(0)
 	9: WriteRef
 	10: Ret
 }
-inc_vec_wrapped_coin_new(Arg0: vector<Wrapper<Coin>>, Arg1: u64) /* def_idx: 13 */ {
-L2:	loc0: &mut u256
+inc_vec_wrapped_coin_new(x: vector<Wrapper<Coin>>, index: u64) /* def_idx: 13 */ {
+L2:	$t1: &mut u256
 B0:
-	0: MutBorrowLoc[0](Arg0: vector<Wrapper<Coin>>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MutBorrowLoc[0](x: vector<Wrapper<Coin>>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(10)
-	3: MutBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	3: MutBorrowFieldGeneric[0](Wrapper._0: T)
 	4: MutBorrowField[0](Coin._0: u256)
-	5: StLoc[2](loc0: &mut u256)
-	6: CopyLoc[2](loc0: &mut u256)
+	5: StLoc[2]($t1: &mut u256)
+	6: CopyLoc[2]($t1: &mut u256)
 	7: ReadRef
 	8: LdU256(1)
 	9: Add
-	10: MoveLoc[2](loc0: &mut u256)
+	10: MoveLoc[2]($t1: &mut u256)
 	11: WriteRef
 	12: Ret
 }
-inc_vec_wrapped_coin_old(Arg0: vector<Wrapper<Coin>>, Arg1: u64) /* def_idx: 14 */ {
+inc_vec_wrapped_coin_old(x: vector<Wrapper<Coin>>, index: u64) /* def_idx: 14 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: vector<Wrapper<Coin>>)
-	1: CopyLoc[1](Arg1: u64)
+	0: ImmBorrowLoc[0](x: vector<Wrapper<Coin>>)
+	1: CopyLoc[1](index: u64)
 	2: VecImmBorrow(10)
-	3: ImmBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	3: ImmBorrowFieldGeneric[0](Wrapper._0: T)
 	4: ImmBorrowField[0](Coin._0: u256)
 	5: ReadRef
 	6: LdU256(1)
 	7: Add
-	8: MutBorrowLoc[0](Arg0: vector<Wrapper<Coin>>)
-	9: MoveLoc[1](Arg1: u64)
+	8: MutBorrowLoc[0](x: vector<Wrapper<Coin>>)
+	9: MoveLoc[1](index: u64)
 	10: VecMutBorrow(10)
-	11: MutBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	11: MutBorrowFieldGeneric[0](Wrapper._0: T)
 	12: MutBorrowField[0](Coin._0: u256)
 	13: WriteRef
 	14: Ret
 }
-inc_wrapped_coin_new(Arg0: &mut Wrapper<Coin>) /* def_idx: 15 */ {
-L1:	loc0: &mut u256
+inc_wrapped_coin_new(x: &mut Wrapper<Coin>) /* def_idx: 15 */ {
+L1:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut Wrapper<Coin>)
-	1: MutBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	0: MoveLoc[0](x: &mut Wrapper<Coin>)
+	1: MutBorrowFieldGeneric[0](Wrapper._0: T)
 	2: MutBorrowField[0](Coin._0: u256)
-	3: StLoc[1](loc0: &mut u256)
-	4: CopyLoc[1](loc0: &mut u256)
+	3: StLoc[1]($t1: &mut u256)
+	4: CopyLoc[1]($t1: &mut u256)
 	5: ReadRef
 	6: LdU256(1)
 	7: Add
-	8: MoveLoc[1](loc0: &mut u256)
+	8: MoveLoc[1]($t1: &mut u256)
 	9: WriteRef
 	10: Ret
 }
-inc_wrapped_coin_old(Arg0: &mut Wrapper<Coin>) /* def_idx: 16 */ {
+inc_wrapped_coin_old(x: &mut Wrapper<Coin>) /* def_idx: 16 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut Wrapper<Coin>)
-	1: ImmBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	0: CopyLoc[0](x: &mut Wrapper<Coin>)
+	1: ImmBorrowFieldGeneric[0](Wrapper._0: T)
 	2: ImmBorrowField[0](Coin._0: u256)
 	3: ReadRef
 	4: LdU256(1)
 	5: Add
-	6: MoveLoc[0](Arg0: &mut Wrapper<Coin>)
-	7: MutBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	6: MoveLoc[0](x: &mut Wrapper<Coin>)
+	7: MutBorrowFieldGeneric[0](Wrapper._0: T)
 	8: MutBorrowField[0](Coin._0: u256)
 	9: WriteRef
 	10: Ret

--- a/third_party/move/move-compiler-v2/tests/op-equal/valid1.exp
+++ b/third_party/move/move-compiler-v2/tests/op-equal/valid1.exp
@@ -531,140 +531,140 @@ module 42.test {
 struct Coin has drop, key {
 	_0: u256
 }
-struct Wrapper<Ty0> has drop, key {
-	_0: Ty0
+struct Wrapper<T> has drop, key {
+	_0: T
 }
 
-bitand_vec_coin_new(Arg0: vector<Coin>, Arg1: u64) /* def_idx: 0 */ {
-L2:	loc0: &mut u256
+bitand_vec_coin_new(x: vector<Coin>, index: u64) /* def_idx: 0 */ {
+L2:	$t1: &mut u256
 B0:
-	0: MutBorrowLoc[0](Arg0: vector<Coin>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MutBorrowLoc[0](x: vector<Coin>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(2)
 	3: MutBorrowField[0](Coin._0: u256)
-	4: StLoc[2](loc0: &mut u256)
-	5: CopyLoc[2](loc0: &mut u256)
+	4: StLoc[2]($t1: &mut u256)
+	5: CopyLoc[2]($t1: &mut u256)
 	6: ReadRef
 	7: LdU256(42)
 	8: BitAnd
-	9: MoveLoc[2](loc0: &mut u256)
+	9: MoveLoc[2]($t1: &mut u256)
 	10: WriteRef
 	11: Ret
 }
-bitor_vec_new(Arg0: &mut vector<u256>, Arg1: u64) /* def_idx: 1 */ {
-L2:	loc0: &mut u256
+bitor_vec_new(x: &mut vector<u256>, index: u64) /* def_idx: 1 */ {
+L2:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut vector<u256>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: &mut vector<u256>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(5)
-	3: StLoc[2](loc0: &mut u256)
-	4: CopyLoc[2](loc0: &mut u256)
+	3: StLoc[2]($t1: &mut u256)
+	4: CopyLoc[2]($t1: &mut u256)
 	5: ReadRef
 	6: LdU256(42)
 	7: BitOr
-	8: MoveLoc[2](loc0: &mut u256)
+	8: MoveLoc[2]($t1: &mut u256)
 	9: WriteRef
 	10: Ret
 }
-coin_double(Arg0: &mut Coin) /* def_idx: 2 */ {
-L1:	loc0: &mut u256
+coin_double(self: &mut Coin) /* def_idx: 2 */ {
+L1:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut Coin)
+	0: MoveLoc[0](self: &mut Coin)
 	1: MutBorrowField[0](Coin._0: u256)
-	2: StLoc[1](loc0: &mut u256)
-	3: CopyLoc[1](loc0: &mut u256)
+	2: StLoc[1]($t1: &mut u256)
+	3: CopyLoc[1]($t1: &mut u256)
 	4: ReadRef
 	5: LdU256(2)
 	6: Mul
-	7: MoveLoc[1](loc0: &mut u256)
+	7: MoveLoc[1]($t1: &mut u256)
 	8: WriteRef
 	9: Ret
 }
-coin_mod_2(Arg0: &mut Coin) /* def_idx: 3 */ {
-L1:	loc0: &mut u256
+coin_mod_2(self: &mut Coin) /* def_idx: 3 */ {
+L1:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut Coin)
+	0: MoveLoc[0](self: &mut Coin)
 	1: MutBorrowField[0](Coin._0: u256)
-	2: StLoc[1](loc0: &mut u256)
-	3: CopyLoc[1](loc0: &mut u256)
+	2: StLoc[1]($t1: &mut u256)
+	3: CopyLoc[1]($t1: &mut u256)
 	4: ReadRef
 	5: LdU256(2)
 	6: Mod
-	7: MoveLoc[1](loc0: &mut u256)
+	7: MoveLoc[1]($t1: &mut u256)
 	8: WriteRef
 	9: Ret
 }
-half_wrapped_coin_new(Arg0: &mut Wrapper<Coin>) /* def_idx: 4 */ {
-L1:	loc0: &mut u256
+half_wrapped_coin_new(x: &mut Wrapper<Coin>) /* def_idx: 4 */ {
+L1:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: &mut Wrapper<Coin>)
-	1: MutBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	0: MoveLoc[0](x: &mut Wrapper<Coin>)
+	1: MutBorrowFieldGeneric[0](Wrapper._0: T)
 	2: MutBorrowField[0](Coin._0: u256)
-	3: StLoc[1](loc0: &mut u256)
-	4: CopyLoc[1](loc0: &mut u256)
+	3: StLoc[1]($t1: &mut u256)
+	4: CopyLoc[1]($t1: &mut u256)
 	5: ReadRef
 	6: LdU256(2)
 	7: Div
-	8: MoveLoc[1](loc0: &mut u256)
+	8: MoveLoc[1]($t1: &mut u256)
 	9: WriteRef
 	10: Ret
 }
-shl_vec_wrapped_coin_old(Arg0: vector<Wrapper<Coin>>, Arg1: u64) /* def_idx: 5 */ {
-L2:	loc0: &mut u256
+shl_vec_wrapped_coin_old(x: vector<Wrapper<Coin>>, index: u64) /* def_idx: 5 */ {
+L2:	$t1: &mut u256
 B0:
-	0: MutBorrowLoc[0](Arg0: vector<Wrapper<Coin>>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MutBorrowLoc[0](x: vector<Wrapper<Coin>>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(9)
-	3: MutBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	3: MutBorrowFieldGeneric[0](Wrapper._0: T)
 	4: MutBorrowField[0](Coin._0: u256)
-	5: StLoc[2](loc0: &mut u256)
-	6: CopyLoc[2](loc0: &mut u256)
+	5: StLoc[2]($t1: &mut u256)
+	6: CopyLoc[2]($t1: &mut u256)
 	7: ReadRef
 	8: LdU8(1)
 	9: Shl
-	10: MoveLoc[2](loc0: &mut u256)
+	10: MoveLoc[2]($t1: &mut u256)
 	11: WriteRef
 	12: Ret
 }
-shr_coin_at(Arg0: address) /* def_idx: 6 */ {
-L1:	loc0: &mut u256
+shr_coin_at(addr: address) /* def_idx: 6 */ {
+L1:	$t1: &mut u256
 B0:
-	0: MoveLoc[0](Arg0: address)
+	0: MoveLoc[0](addr: address)
 	1: MutBorrowGlobal[0](Coin)
 	2: MutBorrowField[0](Coin._0: u256)
-	3: StLoc[1](loc0: &mut u256)
-	4: CopyLoc[1](loc0: &mut u256)
+	3: StLoc[1]($t1: &mut u256)
+	4: CopyLoc[1]($t1: &mut u256)
 	5: ReadRef
 	6: LdU8(1)
 	7: Shr
-	8: MoveLoc[1](loc0: &mut u256)
+	8: MoveLoc[1]($t1: &mut u256)
 	9: WriteRef
 	10: Ret
 }
-sub1(Arg0: &mut u256) /* def_idx: 7 */ {
+sub1(x: &mut u256) /* def_idx: 7 */ {
 B0:
-	0: CopyLoc[0](Arg0: &mut u256)
+	0: CopyLoc[0](x: &mut u256)
 	1: ReadRef
 	2: LdU256(1)
 	3: Sub
-	4: MoveLoc[0](Arg0: &mut u256)
+	4: MoveLoc[0](x: &mut u256)
 	5: WriteRef
 	6: Ret
 }
-xor_vec_wrapped_coin_new(Arg0: vector<Wrapper<Coin>>, Arg1: u64) /* def_idx: 8 */ {
-L2:	loc0: &mut u256
+xor_vec_wrapped_coin_new(x: vector<Wrapper<Coin>>, index: u64) /* def_idx: 8 */ {
+L2:	$t1: &mut u256
 B0:
-	0: MutBorrowLoc[0](Arg0: vector<Wrapper<Coin>>)
-	1: MoveLoc[1](Arg1: u64)
+	0: MutBorrowLoc[0](x: vector<Wrapper<Coin>>)
+	1: MoveLoc[1](index: u64)
 	2: VecMutBorrow(9)
-	3: MutBorrowFieldGeneric[0](Wrapper._0: Ty0)
+	3: MutBorrowFieldGeneric[0](Wrapper._0: T)
 	4: MutBorrowField[0](Coin._0: u256)
-	5: StLoc[2](loc0: &mut u256)
-	6: CopyLoc[2](loc0: &mut u256)
+	5: StLoc[2]($t1: &mut u256)
+	6: CopyLoc[2]($t1: &mut u256)
 	7: ReadRef
 	8: LdU256(1)
 	9: Xor
-	10: MoveLoc[2](loc0: &mut u256)
+	10: MoveLoc[2]($t1: &mut u256)
 	11: WriteRef
 	12: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/op-equal/valid2.exp
+++ b/third_party/move/move-compiler-v2/tests/op-equal/valid2.exp
@@ -170,42 +170,42 @@ struct S has drop {
 	x: u64
 }
 
-foo(Arg0: &mut S): u64 /* def_idx: 0 */ {
-L1:	loc0: &mut u64
+foo(self: &mut S): u64 /* def_idx: 0 */ {
+L1:	$t1: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: &mut S)
+	0: MoveLoc[0](self: &mut S)
 	1: MutBorrowField[0](S.x: u64)
-	2: StLoc[1](loc0: &mut u64)
-	3: CopyLoc[1](loc0: &mut u64)
+	2: StLoc[1]($t1: &mut u64)
+	3: CopyLoc[1]($t1: &mut u64)
 	4: ReadRef
 	5: LdU64(1)
 	6: Add
-	7: MoveLoc[1](loc0: &mut u64)
+	7: MoveLoc[1]($t1: &mut u64)
 	8: WriteRef
 	9: LdU64(1)
 	10: Ret
 }
 public test(): u64 /* def_idx: 1 */ {
-L0:	loc0: S
-L1:	loc1: u64
-L2:	loc2: &mut u64
+L0:	s: S
+L1:	$t2: u64
+L2:	$t1: &mut u64
 B0:
 	0: LdU64(0)
 	1: Pack[0](S)
-	2: StLoc[0](loc0: S)
-	3: MutBorrowLoc[0](loc0: S)
+	2: StLoc[0](s: S)
+	3: MutBorrowLoc[0](s: S)
 	4: Call foo(&mut S): u64
-	5: StLoc[1](loc1: u64)
-	6: MutBorrowLoc[0](loc0: S)
+	5: StLoc[1]($t2: u64)
+	6: MutBorrowLoc[0](s: S)
 	7: MutBorrowField[0](S.x: u64)
-	8: StLoc[2](loc2: &mut u64)
-	9: CopyLoc[2](loc2: &mut u64)
+	8: StLoc[2]($t1: &mut u64)
+	9: CopyLoc[2]($t1: &mut u64)
 	10: ReadRef
-	11: MoveLoc[1](loc1: u64)
+	11: MoveLoc[1]($t2: u64)
 	12: Add
-	13: MoveLoc[2](loc2: &mut u64)
+	13: MoveLoc[2]($t1: &mut u64)
 	14: WriteRef
-	15: ImmBorrowLoc[0](loc0: S)
+	15: ImmBorrowLoc[0](s: S)
 	16: ImmBorrowField[0](S.x: u64)
 	17: ReadRef
 	18: Ret

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_both_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/assign_both_branch.exp
@@ -57,20 +57,20 @@ fun m::test($t0: bool): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
+test(cond: bool): u64 /* def_idx: 0 */ {
+L1:	$t3: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](cond: bool)
 	1: BrFalse(6)
 B1:
 	2: LdU64(1)
-	3: StLoc[1](loc0: u64)
+	3: StLoc[1]($t3: u64)
 B2:
-	4: MoveLoc[1](loc0: u64)
+	4: MoveLoc[1]($t3: u64)
 	5: Ret
 B3:
 	6: LdU64(2)
-	7: StLoc[1](loc0: u64)
+	7: StLoc[1]($t3: u64)
 	8: Branch(4)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.exp
+++ b/third_party/move/move-compiler-v2/tests/uninit-use-checker/no_error.exp
@@ -64,10 +64,10 @@ fun m::foo($t0: u64, $t1: u64): u64 {
 module c0.m {
 
 
-foo(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+foo(p: u64, q: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](p: u64)
+	1: MoveLoc[1](q: u64)
 	2: Add
 	3: LdU64(1)
 	4: Add

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_or_return_always.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/abort_or_return_always.exp
@@ -60,9 +60,9 @@ fun m::test($t0: bool): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool): u64 /* def_idx: 0 */ {
+test(p: bool): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](p: bool)
 	1: BrFalse(4)
 B1:
 	2: LdU64(0)

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/break_unreachable.exp
@@ -144,16 +144,16 @@ module c0ffee.m {
 
 
 test() /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](i: u64)
 B1:
-	2: MoveLoc[0](loc0: u64)
+	2: MoveLoc[0](i: u64)
 	3: LdU64(1)
 	4: Add
-	5: StLoc[0](loc0: u64)
-	6: CopyLoc[0](loc0: u64)
+	5: StLoc[0](i: u64)
+	6: CopyLoc[0](i: u64)
 	7: LdU64(10)
 	8: Eq
 	9: BrTrue(11)

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
@@ -128,14 +128,14 @@ fun m::test($t0: bool, $t1: bool) {
 module c0ffee.m {
 
 
-test(Arg0: bool, Arg1: bool) /* def_idx: 0 */ {
+test(p: bool, q: bool) /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](p: bool)
 	1: BrTrue(3)
 B1:
 	2: Branch(8)
 B2:
-	3: MoveLoc[1](Arg1: bool)
+	3: MoveLoc[1](q: bool)
 	4: BrFalse(6)
 B3:
 	5: Branch(7)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.exp
@@ -175,17 +175,17 @@ public fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-add(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+add(a: u64, b: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](a: u64)
+	1: MoveLoc[1](b: u64)
 	2: Add
 	3: Ret
 }
-public test(Arg0: u64): u64 /* def_idx: 1 */ {
+public test(p: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: MoveLoc[0](p: u64)
 	2: LdU64(1)
 	3: Add
 	4: Call add(u64, u64): u64

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/args_with_side_effects.opt.exp
@@ -175,17 +175,17 @@ public fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-add(Arg0: u64, Arg1: u64): u64 /* def_idx: 0 */ {
+add(a: u64, b: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](a: u64)
+	1: MoveLoc[1](b: u64)
 	2: Add
 	3: Ret
 }
-public test(Arg0: u64): u64 /* def_idx: 1 */ {
+public test(p: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: MoveLoc[0](p: u64)
 	2: LdU64(1)
 	3: Add
 	4: Call add(u64, u64): u64

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.exp
@@ -137,14 +137,14 @@ module c0ffee.m {
 
 
 test() /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: &u64
+L0:	x: u64
+L1:	$t2: &u64
 B0:
 	0: LdU64(5)
-	1: StLoc[0](loc0: u64)
-	2: ImmBorrowLoc[0](loc0: u64)
+	1: StLoc[0](x: u64)
+	2: ImmBorrowLoc[0](x: u64)
 	3: Pop
-	4: ImmBorrowLoc[0](loc0: u64)
+	4: ImmBorrowLoc[0](x: u64)
 	5: ReadRef
 	6: LdU64(5)
 	7: Eq

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/borrowed_var.opt.exp
@@ -148,17 +148,17 @@ module c0ffee.m {
 
 
 test() /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: &u64
-L2:	loc2: u64
+L0:	$t1: u64
+L1:	$t2: &u64
+L2:	$t4: u64
 B0:
 	0: LdU64(5)
-	1: StLoc[0](loc0: u64)
-	2: ImmBorrowLoc[0](loc0: u64)
+	1: StLoc[0]($t1: u64)
+	2: ImmBorrowLoc[0]($t1: u64)
 	3: Pop
 	4: LdU64(5)
-	5: StLoc[2](loc2: u64)
-	6: ImmBorrowLoc[2](loc2: u64)
+	5: StLoc[2]($t4: u64)
+	6: ImmBorrowLoc[2]($t4: u64)
 	7: ReadRef
 	8: LdU64(5)
 	9: Eq

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.exp
@@ -138,17 +138,17 @@ fun m::foo($t0: bool, $t1: u64): u64 {
 module c0ffee.m {
 
 
-foo(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
+foo(b: bool, p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](b: bool)
 	1: BrTrue(3)
 B1:
 	2: Branch(5)
 B2:
 	3: LdU64(0)
-	4: StLoc[1](Arg1: u64)
+	4: StLoc[1](p: u64)
 B3:
-	5: MoveLoc[1](Arg1: u64)
+	5: MoveLoc[1](p: u64)
 	6: LdU64(1)
 	7: Add
 	8: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_1.opt.exp
@@ -138,17 +138,17 @@ fun m::foo($t0: bool, $t1: u64): u64 {
 module c0ffee.m {
 
 
-foo(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
+foo(b: bool, p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](b: bool)
 	1: BrTrue(3)
 B1:
 	2: Branch(5)
 B2:
 	3: LdU64(0)
-	4: StLoc[1](Arg1: u64)
+	4: StLoc[1](p: u64)
 B3:
-	5: MoveLoc[1](Arg1: u64)
+	5: MoveLoc[1](p: u64)
 	6: LdU64(1)
 	7: Add
 	8: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.exp
@@ -105,20 +105,20 @@ fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool, Arg1: u64, Arg2: u64): u64 /* def_idx: 0 */ {
-L3:	loc0: u64
+test(b: bool, p: u64, q: u64): u64 /* def_idx: 0 */ {
+L3:	a: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](b: bool)
 	1: BrFalse(6)
 B1:
-	2: MoveLoc[1](Arg1: u64)
-	3: StLoc[3](loc0: u64)
+	2: MoveLoc[1](p: u64)
+	3: StLoc[3](a: u64)
 B2:
-	4: MoveLoc[3](loc0: u64)
+	4: MoveLoc[3](a: u64)
 	5: Ret
 B3:
-	6: MoveLoc[2](Arg2: u64)
-	7: StLoc[3](loc0: u64)
+	6: MoveLoc[2](q: u64)
+	7: StLoc[3](a: u64)
 	8: Branch(4)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_2.opt.exp
@@ -105,20 +105,20 @@ fun m::test($t0: bool, $t1: u64, $t2: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool, Arg1: u64, Arg2: u64): u64 /* def_idx: 0 */ {
-L3:	loc0: u64
+test(b: bool, p: u64, q: u64): u64 /* def_idx: 0 */ {
+L3:	a: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](b: bool)
 	1: BrFalse(6)
 B1:
-	2: MoveLoc[1](Arg1: u64)
-	3: StLoc[3](loc0: u64)
+	2: MoveLoc[1](p: u64)
+	3: StLoc[3](a: u64)
 B2:
-	4: MoveLoc[3](loc0: u64)
+	4: MoveLoc[3](a: u64)
 	5: Ret
 B3:
-	6: MoveLoc[2](Arg2: u64)
-	7: StLoc[3](loc0: u64)
+	6: MoveLoc[2](q: u64)
+	7: StLoc[3](a: u64)
 	8: Branch(4)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.exp
@@ -104,20 +104,20 @@ fun m::test($t0: bool, $t1: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+test(b: bool, p: u64): u64 /* def_idx: 0 */ {
+L2:	a: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](b: bool)
 	1: BrFalse(6)
 B1:
-	2: MoveLoc[1](Arg1: u64)
-	3: StLoc[2](loc0: u64)
+	2: MoveLoc[1](p: u64)
+	3: StLoc[2](a: u64)
 B2:
-	4: MoveLoc[2](loc0: u64)
+	4: MoveLoc[2](a: u64)
 	5: Ret
 B3:
-	6: MoveLoc[1](Arg1: u64)
-	7: StLoc[2](loc0: u64)
+	6: MoveLoc[1](p: u64)
+	7: StLoc[2](a: u64)
 	8: Branch(4)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_3.opt.exp
@@ -104,20 +104,20 @@ fun m::test($t0: bool, $t1: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool, Arg1: u64): u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+test(b: bool, p: u64): u64 /* def_idx: 0 */ {
+L2:	a: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](b: bool)
 	1: BrFalse(6)
 B1:
-	2: MoveLoc[1](Arg1: u64)
-	3: StLoc[2](loc0: u64)
+	2: MoveLoc[1](p: u64)
+	3: StLoc[2](a: u64)
 B2:
-	4: MoveLoc[2](loc0: u64)
+	4: MoveLoc[2](a: u64)
 	5: Ret
 B3:
-	6: MoveLoc[1](Arg1: u64)
-	7: StLoc[2](loc0: u64)
+	6: MoveLoc[1](p: u64)
+	7: StLoc[2](a: u64)
 	8: Branch(4)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.exp
@@ -228,12 +228,12 @@ script {
 
 
 main() /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	$t5: u64
 B0:
 	0: LdU64(5)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0]($t5: u64)
 B1:
-	2: CopyLoc[0](loc0: u64)
+	2: CopyLoc[0]($t5: u64)
 	3: LdU64(5)
 	4: Eq
 	5: BrFalse(7)
@@ -244,7 +244,7 @@ B3:
 	8: Abort
 B4:
 	9: LdU64(0)
-	10: StLoc[0](loc0: u64)
+	10: StLoc[0]($t5: u64)
 	11: Branch(2)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/branch_assigns_then_moves_then_assigns.opt.exp
@@ -228,12 +228,12 @@ script {
 
 
 main() /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	$t5: u64
 B0:
 	0: LdU64(5)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0]($t5: u64)
 B1:
-	2: CopyLoc[0](loc0: u64)
+	2: CopyLoc[0]($t5: u64)
 	3: LdU64(5)
 	4: Eq
 	5: BrFalse(7)
@@ -244,7 +244,7 @@ B3:
 	8: Abort
 B4:
 	9: LdU64(0)
-	10: StLoc[0](loc0: u64)
+	10: StLoc[0]($t5: u64)
 	11: Branch(2)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.exp
@@ -220,20 +220,20 @@ module 32.m {
 
 
 main() /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	x: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](x: u64)
 	2: Branch(4)
 B1:
 	3: Branch(8)
 B2:
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](x: u64)
 	5: LdU64(1)
 	6: Add
-	7: StLoc[0](loc0: u64)
+	7: StLoc[0](x: u64)
 B3:
-	8: MoveLoc[0](loc0: u64)
+	8: MoveLoc[0](x: u64)
 	9: LdU64(1)
 	10: Eq
 	11: BrFalse(13)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/bug_12068.opt.exp
@@ -220,20 +220,20 @@ module 32.m {
 
 
 main() /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	x: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](x: u64)
 	2: Branch(4)
 B1:
 	3: Branch(8)
 B2:
-	4: MoveLoc[0](loc0: u64)
+	4: MoveLoc[0](x: u64)
 	5: LdU64(1)
 	6: Add
-	7: StLoc[0](loc0: u64)
+	7: StLoc[0](x: u64)
 B3:
-	8: MoveLoc[0](loc0: u64)
+	8: MoveLoc[0](x: u64)
 	9: LdU64(1)
 	10: Eq
 	11: BrFalse(13)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
@@ -164,14 +164,14 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-id(Arg0: u64): u64 /* def_idx: 0 */ {
+id(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Ret
 }
-test(Arg0: u64): u64 /* def_idx: 1 */ {
+test(p: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Call id(u64): u64
 	2: Call id(u64): u64
 	3: Call id(u64): u64

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.opt.exp
@@ -164,14 +164,14 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-id(Arg0: u64): u64 /* def_idx: 0 */ {
+id(x: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Ret
 }
-test(Arg0: u64): u64 /* def_idx: 1 */ {
+test(p: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Call id(u64): u64
 	2: Call id(u64): u64
 	3: Call id(u64): u64

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.exp
@@ -155,21 +155,21 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-update(Arg0: &mut u64) /* def_idx: 0 */ {
+update(p: &mut u64) /* def_idx: 0 */ {
 B0:
 	0: LdU64(0)
-	1: MoveLoc[0](Arg0: &mut u64)
+	1: MoveLoc[0](p: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-test(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
+test(p: u64): u64 /* def_idx: 1 */ {
+L1:	a: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[1](loc0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: MutBorrowLoc[1](a: u64)
 	3: Call update(&mut u64)
-	4: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[0](p: u64)
 	5: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_2.opt.exp
@@ -155,21 +155,21 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-update(Arg0: &mut u64) /* def_idx: 0 */ {
+update(p: &mut u64) /* def_idx: 0 */ {
 B0:
 	0: LdU64(0)
-	1: MoveLoc[0](Arg0: &mut u64)
+	1: MoveLoc[0](p: &mut u64)
 	2: WriteRef
 	3: Ret
 }
-test(Arg0: u64): u64 /* def_idx: 1 */ {
-L1:	loc0: u64
+test(p: u64): u64 /* def_idx: 1 */ {
+L1:	a: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: MutBorrowLoc[1](loc0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: MutBorrowLoc[1](a: u64)
 	3: Call update(&mut u64)
-	4: MoveLoc[0](Arg0: u64)
+	4: MoveLoc[0](p: u64)
 	5: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
@@ -104,10 +104,10 @@ public fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-public test(Arg0: u64): u64 /* def_idx: 0 */ {
+public test(a: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](a: u64)
+	1: MoveLoc[0](a: u64)
 	2: Add
 	3: Pop
 	4: LdU64(2)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
@@ -93,10 +93,10 @@ public fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-public test(Arg0: u64): u64 /* def_idx: 0 */ {
+public test(a: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](a: u64)
+	1: MoveLoc[0](a: u64)
 	2: Add
 	3: Pop
 	4: LdU64(2)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
@@ -195,21 +195,21 @@ fun m::test($t0: u64, $t1: bool) {
 module c0ffee.m {
 
 
-consume(Arg0: u64) /* def_idx: 0 */ {
+consume(a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-test(Arg0: u64, Arg1: bool) /* def_idx: 1 */ {
+test(a: u64, p: bool) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[1](Arg1: bool)
+	0: MoveLoc[1](p: bool)
 	1: BrFalse(5)
 B1:
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](a: u64)
 	3: Call consume(u64)
 B2:
 	4: Ret
 B3:
-	5: MoveLoc[0](Arg0: u64)
+	5: MoveLoc[0](a: u64)
 	6: LdU64(1)
 	7: Add
 	8: Pop

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
@@ -195,21 +195,21 @@ fun m::test($t0: u64, $t1: bool) {
 module c0ffee.m {
 
 
-consume(Arg0: u64) /* def_idx: 0 */ {
+consume(a: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-test(Arg0: u64, Arg1: bool) /* def_idx: 1 */ {
+test(a: u64, p: bool) /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[1](Arg1: bool)
+	0: MoveLoc[1](p: bool)
 	1: BrFalse(5)
 B1:
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](a: u64)
 	3: Call consume(u64)
 B2:
 	4: Ret
 B3:
-	5: MoveLoc[0](Arg0: u64)
+	5: MoveLoc[0](a: u64)
 	6: LdU64(1)
 	7: Add
 	8: Pop

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.exp
@@ -150,25 +150,25 @@ fun m::test($t0: bool): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: bool): u64 /* def_idx: 0 */ {
+L1:	x: u64
+L2:	y: u64
 B0:
 	0: LdU64(2)
-	1: StLoc[1](loc0: u64)
-	2: MoveLoc[0](Arg0: bool)
+	1: StLoc[1](x: u64)
+	2: MoveLoc[0](p: bool)
 	3: BrFalse(8)
 B1:
 	4: LdU64(3)
-	5: StLoc[2](loc1: u64)
+	5: StLoc[2](y: u64)
 B2:
-	6: MoveLoc[2](loc1: u64)
+	6: MoveLoc[2](y: u64)
 	7: Ret
 B3:
-	8: MoveLoc[1](loc0: u64)
+	8: MoveLoc[1](x: u64)
 	9: LdU64(1)
 	10: Add
-	11: StLoc[2](loc1: u64)
+	11: StLoc[2](y: u64)
 	12: Branch(6)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/conditional.opt.exp
@@ -90,20 +90,20 @@ fun m::test($t0: bool): u64 {
 module c0ffee.m {
 
 
-test(Arg0: bool): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
+test(p: bool): u64 /* def_idx: 0 */ {
+L1:	return: u64
 B0:
-	0: MoveLoc[0](Arg0: bool)
+	0: MoveLoc[0](p: bool)
 	1: BrFalse(6)
 B1:
 	2: LdU64(3)
-	3: StLoc[1](loc0: u64)
+	3: StLoc[1](return: u64)
 B2:
-	4: MoveLoc[1](loc0: u64)
+	4: MoveLoc[1](return: u64)
 	5: Ret
 B3:
 	6: LdU64(3)
-	7: StLoc[1](loc0: u64)
+	7: StLoc[1](return: u64)
 	8: Branch(4)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.exp
@@ -303,43 +303,43 @@ struct W has copy, drop {
 	x: u64
 }
 
-consume(Arg0: u64) /* def_idx: 0 */ {
+consume(_x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test1(Arg0: u64) /* def_idx: 2 */ {
+public test1(x: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: MoveLoc[0](x: u64)
 	2: Call consume(u64)
 	3: Call consume(u64)
 	4: Ret
 }
-public test2(Arg0: u64) /* def_idx: 3 */ {
+public test2(x: u64) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: Call consume(u64)
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Call consume(u64)
 	4: Ret
 }
-public test3(Arg0: W) /* def_idx: 4 */ {
+public test3(x: W) /* def_idx: 4 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
-	1: MoveLoc[0](Arg0: W)
+	0: CopyLoc[0](x: W)
+	1: MoveLoc[0](x: W)
 	2: Call consume_(W)
 	3: Call consume_(W)
 	4: Ret
 }
-public test4(Arg0: W) /* def_idx: 5 */ {
+public test4(x: W) /* def_idx: 5 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](x: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](x: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_1.opt.exp
@@ -303,43 +303,43 @@ struct W has copy, drop {
 	x: u64
 }
 
-consume(Arg0: u64) /* def_idx: 0 */ {
+consume(_x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test1(Arg0: u64) /* def_idx: 2 */ {
+public test1(x: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
+	1: MoveLoc[0](x: u64)
 	2: Call consume(u64)
 	3: Call consume(u64)
 	4: Ret
 }
-public test2(Arg0: u64) /* def_idx: 3 */ {
+public test2(x: u64) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: Call consume(u64)
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Call consume(u64)
 	4: Ret
 }
-public test3(Arg0: W) /* def_idx: 4 */ {
+public test3(x: W) /* def_idx: 4 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
-	1: MoveLoc[0](Arg0: W)
+	0: CopyLoc[0](x: W)
+	1: MoveLoc[0](x: W)
 	2: Call consume_(W)
 	3: Call consume_(W)
 	4: Ret
 }
-public test4(Arg0: W) /* def_idx: 5 */ {
+public test4(x: W) /* def_idx: 5 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](x: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](x: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.exp
@@ -185,27 +185,27 @@ struct W has copy, drop {
 	x: u64
 }
 
-consume(Arg0: u64) /* def_idx: 0 */ {
+consume(_x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test1(Arg0: u64) /* def_idx: 2 */ {
+public test1(x: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: Call consume(u64)
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Call consume(u64)
 	4: Ret
 }
-public test2(Arg0: W) /* def_idx: 3 */ {
+public test2(x: W) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](x: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](x: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_2.opt.exp
@@ -185,27 +185,27 @@ struct W has copy, drop {
 	x: u64
 }
 
-consume(Arg0: u64) /* def_idx: 0 */ {
+consume(_x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test1(Arg0: u64) /* def_idx: 2 */ {
+public test1(x: u64) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u64)
+	0: CopyLoc[0](x: u64)
 	1: Call consume(u64)
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](x: u64)
 	3: Call consume(u64)
 	4: Ret
 }
-public test2(Arg0: W) /* def_idx: 3 */ {
+public test2(x: W) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](x: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](x: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.exp
@@ -189,27 +189,27 @@ struct W has copy, drop {
 	a: u32
 }
 
-consume(Arg0: u32) /* def_idx: 0 */ {
+consume(_a: u32) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_a: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u32) /* def_idx: 2 */ {
+public test(a: u32) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u32)
+	0: CopyLoc[0](a: u32)
 	1: Call consume(u32)
-	2: MoveLoc[0](Arg0: u32)
+	2: MoveLoc[0](a: u32)
 	3: Call consume(u32)
 	4: Ret
 }
-public test_(Arg0: W) /* def_idx: 3 */ {
+public test_(a: W) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](a: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](a: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_3.opt.exp
@@ -189,27 +189,27 @@ struct W has copy, drop {
 	a: u32
 }
 
-consume(Arg0: u32) /* def_idx: 0 */ {
+consume(_a: u32) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_a: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u32) /* def_idx: 2 */ {
+public test(a: u32) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u32)
+	0: CopyLoc[0](a: u32)
 	1: Call consume(u32)
-	2: MoveLoc[0](Arg0: u32)
+	2: MoveLoc[0](a: u32)
 	3: Call consume(u32)
 	4: Ret
 }
-public test_(Arg0: W) /* def_idx: 3 */ {
+public test_(a: W) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](a: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](a: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.exp
@@ -211,27 +211,27 @@ struct W has copy, drop {
 	m: u32
 }
 
-consume(Arg0: u32) /* def_idx: 0 */ {
+consume(_x: u32) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u32) /* def_idx: 2 */ {
+public test(a: u32) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u32)
+	0: CopyLoc[0](a: u32)
 	1: Call consume(u32)
-	2: MoveLoc[0](Arg0: u32)
+	2: MoveLoc[0](a: u32)
 	3: Call consume(u32)
 	4: Ret
 }
-public test_struct(Arg0: W) /* def_idx: 3 */ {
+public test_struct(a: W) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](a: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](a: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_4.opt.exp
@@ -211,27 +211,27 @@ struct W has copy, drop {
 	m: u32
 }
 
-consume(Arg0: u32) /* def_idx: 0 */ {
+consume(_x: u32) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: u32) /* def_idx: 2 */ {
+public test(a: u32) /* def_idx: 2 */ {
 B0:
-	0: CopyLoc[0](Arg0: u32)
+	0: CopyLoc[0](a: u32)
 	1: Call consume(u32)
-	2: MoveLoc[0](Arg0: u32)
+	2: MoveLoc[0](a: u32)
 	3: Call consume(u32)
 	4: Ret
 }
-public test_struct(Arg0: W) /* def_idx: 3 */ {
+public test_struct(a: W) /* def_idx: 3 */ {
 B0:
-	0: CopyLoc[0](Arg0: W)
+	0: CopyLoc[0](a: W)
 	1: Call consume_(W)
-	2: MoveLoc[0](Arg0: W)
+	2: MoveLoc[0](a: W)
 	3: Call consume_(W)
 	4: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.exp
@@ -357,65 +357,65 @@ struct W has copy, drop {
 	x: u32
 }
 
-consume(Arg0: u32) /* def_idx: 0 */ {
+consume(_x: u32) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: bool, Arg1: u32) /* def_idx: 2 */ {
-L2:	loc0: u32
+public test(p: bool, a: u32) /* def_idx: 2 */ {
+L2:	b: u32
 B0:
-	0: CopyLoc[1](Arg1: u32)
-	1: StLoc[2](loc0: u32)
-	2: CopyLoc[0](Arg0: bool)
+	0: CopyLoc[1](a: u32)
+	1: StLoc[2](b: u32)
+	2: CopyLoc[0](p: bool)
 	3: BrFalse(14)
 B1:
-	4: CopyLoc[2](loc0: u32)
+	4: CopyLoc[2](b: u32)
 	5: Call consume(u32)
 B2:
-	6: MoveLoc[0](Arg0: bool)
+	6: MoveLoc[0](p: bool)
 	7: BrTrue(11)
 B3:
-	8: MoveLoc[1](Arg1: u32)
+	8: MoveLoc[1](a: u32)
 	9: Call consume(u32)
 B4:
 	10: Ret
 B5:
-	11: MoveLoc[2](loc0: u32)
+	11: MoveLoc[2](b: u32)
 	12: Call consume(u32)
 	13: Branch(10)
 B6:
-	14: CopyLoc[1](Arg1: u32)
+	14: CopyLoc[1](a: u32)
 	15: Call consume(u32)
 	16: Branch(6)
 }
-public test_struct(Arg0: bool, Arg1: W) /* def_idx: 3 */ {
-L2:	loc0: W
+public test_struct(p: bool, a: W) /* def_idx: 3 */ {
+L2:	b: W
 B0:
-	0: CopyLoc[1](Arg1: W)
-	1: StLoc[2](loc0: W)
-	2: CopyLoc[0](Arg0: bool)
+	0: CopyLoc[1](a: W)
+	1: StLoc[2](b: W)
+	2: CopyLoc[0](p: bool)
 	3: BrFalse(14)
 B1:
-	4: CopyLoc[2](loc0: W)
+	4: CopyLoc[2](b: W)
 	5: Call consume_(W)
 B2:
-	6: MoveLoc[0](Arg0: bool)
+	6: MoveLoc[0](p: bool)
 	7: BrTrue(11)
 B3:
-	8: MoveLoc[1](Arg1: W)
+	8: MoveLoc[1](a: W)
 	9: Call consume_(W)
 B4:
 	10: Ret
 B5:
-	11: MoveLoc[2](loc0: W)
+	11: MoveLoc[2](b: W)
 	12: Call consume_(W)
 	13: Branch(10)
 B6:
-	14: CopyLoc[1](Arg1: W)
+	14: CopyLoc[1](a: W)
 	15: Call consume_(W)
 	16: Branch(6)
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/consume_5.opt.exp
@@ -357,65 +357,65 @@ struct W has copy, drop {
 	x: u32
 }
 
-consume(Arg0: u32) /* def_idx: 0 */ {
+consume(_x: u32) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-consume_(Arg0: W) /* def_idx: 1 */ {
+consume_(_x: W) /* def_idx: 1 */ {
 B0:
 	0: Ret
 }
-public test(Arg0: bool, Arg1: u32) /* def_idx: 2 */ {
-L2:	loc0: u32
+public test(p: bool, a: u32) /* def_idx: 2 */ {
+L2:	b: u32
 B0:
-	0: CopyLoc[1](Arg1: u32)
-	1: StLoc[2](loc0: u32)
-	2: CopyLoc[0](Arg0: bool)
+	0: CopyLoc[1](a: u32)
+	1: StLoc[2](b: u32)
+	2: CopyLoc[0](p: bool)
 	3: BrFalse(14)
 B1:
-	4: CopyLoc[2](loc0: u32)
+	4: CopyLoc[2](b: u32)
 	5: Call consume(u32)
 B2:
-	6: MoveLoc[0](Arg0: bool)
+	6: MoveLoc[0](p: bool)
 	7: BrTrue(11)
 B3:
-	8: MoveLoc[1](Arg1: u32)
+	8: MoveLoc[1](a: u32)
 	9: Call consume(u32)
 B4:
 	10: Ret
 B5:
-	11: MoveLoc[2](loc0: u32)
+	11: MoveLoc[2](b: u32)
 	12: Call consume(u32)
 	13: Branch(10)
 B6:
-	14: CopyLoc[1](Arg1: u32)
+	14: CopyLoc[1](a: u32)
 	15: Call consume(u32)
 	16: Branch(6)
 }
-public test_struct(Arg0: bool, Arg1: W) /* def_idx: 3 */ {
-L2:	loc0: W
+public test_struct(p: bool, a: W) /* def_idx: 3 */ {
+L2:	b: W
 B0:
-	0: CopyLoc[1](Arg1: W)
-	1: StLoc[2](loc0: W)
-	2: CopyLoc[0](Arg0: bool)
+	0: CopyLoc[1](a: W)
+	1: StLoc[2](b: W)
+	2: CopyLoc[0](p: bool)
 	3: BrFalse(14)
 B1:
-	4: CopyLoc[2](loc0: W)
+	4: CopyLoc[2](b: W)
 	5: Call consume_(W)
 B2:
-	6: MoveLoc[0](Arg0: bool)
+	6: MoveLoc[0](p: bool)
 	7: BrTrue(11)
 B3:
-	8: MoveLoc[1](Arg1: W)
+	8: MoveLoc[1](a: W)
 	9: Call consume_(W)
 B4:
 	10: Ret
 B5:
-	11: MoveLoc[2](loc0: W)
+	11: MoveLoc[2](b: W)
 	12: Call consume_(W)
 	13: Branch(10)
 B6:
-	14: CopyLoc[1](Arg1: W)
+	14: CopyLoc[1](a: W)
 	15: Call consume_(W)
 	16: Branch(6)
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.exp
@@ -68,7 +68,7 @@ public fun m::test($t0: u64) {
 module c0ffee.m {
 
 
-public test(Arg0: u64) /* def_idx: 0 */ {
+public test(x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.opt.exp
@@ -68,7 +68,7 @@ public fun m::test($t0: u64) {
 module c0ffee.m {
 
 
-public test(Arg0: u64) /* def_idx: 0 */ {
+public test(x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.exp
@@ -82,9 +82,9 @@ fun m::cyclic($t0: u64): u64 {
 module c0ffee.m {
 
 
-cyclic(Arg0: u64): u64 /* def_idx: 0 */ {
+cyclic(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignments.opt.exp
@@ -82,9 +82,9 @@ fun m::cyclic($t0: u64): u64 {
 module c0ffee.m {
 
 
-cyclic(Arg0: u64): u64 /* def_idx: 0 */ {
+cyclic(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.exp
@@ -315,39 +315,39 @@ public fun m::test2($t0: u64, $t1: u64) {
 module c0ffee.m {
 
 
-public test1(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
-L3:	loc0: u64
+public test1(x: u64, a: u64, b: u64) /* def_idx: 0 */ {
+L3:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[3](loc0: u64)
+	1: StLoc[3](i: u64)
 B1:
-	2: CopyLoc[3](loc0: u64)
-	3: CopyLoc[0](Arg0: u64)
+	2: CopyLoc[3](i: u64)
+	3: CopyLoc[0](x: u64)
 	4: Lt
 	5: BrFalse(11)
 B2:
-	6: MoveLoc[3](loc0: u64)
+	6: MoveLoc[3](i: u64)
 	7: LdU64(1)
 	8: Add
-	9: StLoc[3](loc0: u64)
+	9: StLoc[3](i: u64)
 	10: Branch(2)
 B3:
 	11: Ret
 }
-public test2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+public test2(x: u64, a: u64) /* def_idx: 1 */ {
 B0:
 	0: LdU64(0)
-	1: StLoc[1](Arg1: u64)
+	1: StLoc[1](a: u64)
 B1:
-	2: CopyLoc[1](Arg1: u64)
-	3: CopyLoc[0](Arg0: u64)
+	2: CopyLoc[1](a: u64)
+	3: CopyLoc[0](x: u64)
 	4: Lt
 	5: BrFalse(11)
 B2:
-	6: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[1](a: u64)
 	7: LdU64(1)
 	8: Add
-	9: StLoc[1](Arg1: u64)
+	9: StLoc[1](a: u64)
 	10: Branch(2)
 B3:
 	11: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_dead_store.opt.exp
@@ -315,39 +315,39 @@ public fun m::test2($t0: u64, $t1: u64) {
 module c0ffee.m {
 
 
-public test1(Arg0: u64, Arg1: u64, Arg2: u64) /* def_idx: 0 */ {
-L3:	loc0: u64
+public test1(x: u64, a: u64, b: u64) /* def_idx: 0 */ {
+L3:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[3](loc0: u64)
+	1: StLoc[3](i: u64)
 B1:
-	2: CopyLoc[3](loc0: u64)
-	3: CopyLoc[0](Arg0: u64)
+	2: CopyLoc[3](i: u64)
+	3: CopyLoc[0](x: u64)
 	4: Lt
 	5: BrFalse(11)
 B2:
-	6: MoveLoc[3](loc0: u64)
+	6: MoveLoc[3](i: u64)
 	7: LdU64(1)
 	8: Add
-	9: StLoc[3](loc0: u64)
+	9: StLoc[3](i: u64)
 	10: Branch(2)
 B3:
 	11: Ret
 }
-public test2(Arg0: u64, Arg1: u64) /* def_idx: 1 */ {
+public test2(x: u64, a: u64) /* def_idx: 1 */ {
 B0:
 	0: LdU64(0)
-	1: StLoc[1](Arg1: u64)
+	1: StLoc[1](a: u64)
 B1:
-	2: CopyLoc[1](Arg1: u64)
-	3: CopyLoc[0](Arg0: u64)
+	2: CopyLoc[1](a: u64)
+	3: CopyLoc[0](x: u64)
 	4: Lt
 	5: BrFalse(11)
 B2:
-	6: MoveLoc[1](Arg1: u64)
+	6: MoveLoc[1](a: u64)
 	7: LdU64(1)
 	8: Add
-	9: StLoc[1](Arg1: u64)
+	9: StLoc[1](a: u64)
 	10: Branch(2)
 B3:
 	11: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.exp
@@ -74,9 +74,9 @@ fun m::dead($t0: u64): u64 {
 module c0ffee.m {
 
 
-dead(Arg0: u64): u64 /* def_idx: 0 */ {
+dead(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_1.opt.exp
@@ -74,9 +74,9 @@ fun m::dead($t0: u64): u64 {
 module c0ffee.m {
 
 
-dead(Arg0: u64): u64 /* def_idx: 0 */ {
+dead(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.exp
@@ -53,9 +53,9 @@ fun m::dead($t0: u64): u64 {
 module c0ffee.m {
 
 
-dead(Arg0: u64): u64 /* def_idx: 0 */ {
+dead(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_2.opt.exp
@@ -53,9 +53,9 @@ fun m::dead($t0: u64): u64 {
 module c0ffee.m {
 
 
-dead(Arg0: u64): u64 /* def_idx: 0 */ {
+dead(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
@@ -125,23 +125,23 @@ public fun m::test($t0: bool): u32 {
 module c0ffee.m {
 
 
-public test(Arg0: bool): u32 /* def_idx: 0 */ {
-L1:	loc0: u32
-L2:	loc1: u32
+public test(p: bool): u32 /* def_idx: 0 */ {
+L1:	x: u32
+L2:	return: u32
 B0:
 	0: LdU32(1)
-	1: StLoc[1](loc0: u32)
-	2: MoveLoc[0](Arg0: bool)
+	1: StLoc[1](x: u32)
+	2: MoveLoc[0](p: bool)
 	3: BrFalse(8)
 B1:
-	4: MoveLoc[1](loc0: u32)
-	5: StLoc[2](loc1: u32)
+	4: MoveLoc[1](x: u32)
+	5: StLoc[2](return: u32)
 B2:
-	6: MoveLoc[2](loc1: u32)
+	6: MoveLoc[2](return: u32)
 	7: Ret
 B3:
 	8: LdU32(9)
-	9: StLoc[2](loc1: u32)
+	9: StLoc[2](return: u32)
 	10: Branch(6)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
@@ -114,23 +114,23 @@ public fun m::test($t0: bool): u32 {
 module c0ffee.m {
 
 
-public test(Arg0: bool): u32 /* def_idx: 0 */ {
-L1:	loc0: u32
-L2:	loc1: u32
+public test(p: bool): u32 /* def_idx: 0 */ {
+L1:	y: u32
+L2:	return: u32
 B0:
 	0: LdU32(1)
-	1: StLoc[1](loc0: u32)
-	2: MoveLoc[0](Arg0: bool)
+	1: StLoc[1](y: u32)
+	2: MoveLoc[0](p: bool)
 	3: BrFalse(8)
 B1:
-	4: MoveLoc[1](loc0: u32)
-	5: StLoc[2](loc1: u32)
+	4: MoveLoc[1](y: u32)
+	5: StLoc[2](return: u32)
 B2:
-	6: MoveLoc[2](loc1: u32)
+	6: MoveLoc[2](return: u32)
 	7: Ret
 B3:
 	8: LdU32(9)
-	9: StLoc[2](loc1: u32)
+	9: StLoc[2](return: u32)
 	10: Branch(6)
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
@@ -275,17 +275,17 @@ B0:
 	0: LdU64(3)
 	1: Ret
 }
-public test2(Arg0: u64): u64 /* def_idx: 1 */ {
+public test2(y: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](y: u64)
 	1: Ret
 }
-public test3(Arg0: u64): u64 /* def_idx: 2 */ {
+public test3(y: u64): u64 /* def_idx: 2 */ {
 B0:
 	0: LdU64(8)
 	1: Ret
 }
-public test4(Arg0: u64): u64 /* def_idx: 3 */ {
+public test4(y: u64): u64 /* def_idx: 3 */ {
 B0:
 	0: LdU64(1)
 	1: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.opt.exp
@@ -241,17 +241,17 @@ B0:
 	0: LdU64(3)
 	1: Ret
 }
-public test2(Arg0: u64): u64 /* def_idx: 1 */ {
+public test2(y: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](y: u64)
 	1: Ret
 }
-public test3(Arg0: u64): u64 /* def_idx: 2 */ {
+public test3(y: u64): u64 /* def_idx: 2 */ {
 B0:
 	0: LdU64(8)
 	1: Ret
 }
-public test4(Arg0: u64): u64 /* def_idx: 3 */ {
+public test4(y: u64): u64 /* def_idx: 3 */ {
 B0:
 	0: LdU64(1)
 	1: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.exp
@@ -87,9 +87,9 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
+test(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
+	0: ImmBorrowLoc[0](p: u64)
 	1: ReadRef
 	2: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_1.opt.exp
@@ -87,9 +87,9 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
+test(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
+	0: ImmBorrowLoc[0](p: u64)
 	1: ReadRef
 	2: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
@@ -120,12 +120,12 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: &u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: &u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
+	0: ImmBorrowLoc[0](p: u64)
 	1: Pop
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](p: u64)
 	3: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
@@ -120,12 +120,12 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: &u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: &u64
 B0:
-	0: ImmBorrowLoc[0](Arg0: u64)
+	0: ImmBorrowLoc[0](p: u64)
 	1: Pop
-	2: MoveLoc[0](Arg0: u64)
+	2: MoveLoc[0](p: u64)
 	3: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
@@ -135,16 +135,16 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	u: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)
-	2: StLoc[0](loc0: u64)
-	3: CopyLoc[0](loc0: u64)
+	2: StLoc[0](u: u64)
+	3: CopyLoc[0](u: u64)
 	4: Add
 	5: Pop
-	6: CopyLoc[0](loc0: u64)
-	7: MoveLoc[0](loc0: u64)
+	6: CopyLoc[0](u: u64)
+	7: MoveLoc[0](u: u64)
 	8: Add
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.exp
@@ -144,15 +144,15 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	u: u64
+L1:	t: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: StLoc[1](loc1: u64)
+	3: StLoc[1](t: u64)
 	4: LdU64(2)
-	5: MoveLoc[1](loc1: u64)
+	5: MoveLoc[1](t: u64)
 	6: Add
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_2.opt.exp
@@ -121,14 +121,14 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	t: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(1)
 	2: Add
-	3: StLoc[0](loc0: u64)
+	3: StLoc[0](t: u64)
 	4: LdU64(2)
-	5: MoveLoc[0](loc0: u64)
+	5: MoveLoc[0](t: u64)
 	6: Add
 	7: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
@@ -133,7 +133,7 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	u: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(1)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.exp
@@ -197,29 +197,29 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: u64
+L2:	count: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](a: u64)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](count: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
+	4: CopyLoc[2](count: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
-	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[1](loc0: u64)
-	10: MoveLoc[2](loc1: u64)
+	8: CopyLoc[0](p: u64)
+	9: StLoc[1](a: u64)
+	10: MoveLoc[2](count: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[2](loc1: u64)
+	13: StLoc[2](count: u64)
 	14: Branch(4)
 B3:
-	15: MoveLoc[1](loc0: u64)
+	15: MoveLoc[1](a: u64)
 	16: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_1.opt.exp
@@ -197,29 +197,29 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: u64
+L2:	count: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](a: u64)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](count: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
+	4: CopyLoc[2](count: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
-	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[1](loc0: u64)
-	10: MoveLoc[2](loc1: u64)
+	8: CopyLoc[0](p: u64)
+	9: StLoc[1](a: u64)
+	10: MoveLoc[2](count: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[2](loc1: u64)
+	13: StLoc[2](count: u64)
 	14: Branch(4)
 B3:
-	15: MoveLoc[1](loc0: u64)
+	15: MoveLoc[1](a: u64)
 	16: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.exp
@@ -197,29 +197,29 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: u64
+L2:	count: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](count: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
+	4: CopyLoc[2](count: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
-	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[1](loc0: u64)
-	10: MoveLoc[2](loc1: u64)
+	8: CopyLoc[0](p: u64)
+	9: StLoc[1](a: u64)
+	10: MoveLoc[2](count: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[2](loc1: u64)
+	13: StLoc[2](count: u64)
 	14: Branch(4)
 B3:
-	15: MoveLoc[1](loc0: u64)
+	15: MoveLoc[1](a: u64)
 	16: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/loop_2.opt.exp
@@ -197,29 +197,29 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: u64
+L2:	count: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
 	2: LdU64(0)
-	3: StLoc[2](loc1: u64)
+	3: StLoc[2](count: u64)
 B1:
-	4: CopyLoc[2](loc1: u64)
+	4: CopyLoc[2](count: u64)
 	5: LdU64(10)
 	6: Lt
 	7: BrFalse(15)
 B2:
-	8: CopyLoc[0](Arg0: u64)
-	9: StLoc[1](loc0: u64)
-	10: MoveLoc[2](loc1: u64)
+	8: CopyLoc[0](p: u64)
+	9: StLoc[1](a: u64)
+	10: MoveLoc[2](count: u64)
 	11: LdU64(1)
 	12: Add
-	13: StLoc[2](loc1: u64)
+	13: StLoc[2](count: u64)
 	14: Branch(4)
 B3:
-	15: MoveLoc[1](loc0: u64)
+	15: MoveLoc[1](a: u64)
 	16: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.exp
@@ -95,15 +95,15 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	$t4: u64
+L2:	b: &mut u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MutBorrowLoc[0](Arg0: u64)
-	2: StLoc[2](loc1: &mut u64)
+	0: CopyLoc[0](p: u64)
+	1: MutBorrowLoc[0](p: u64)
+	2: StLoc[2](b: &mut u64)
 	3: LdU64(1)
-	4: MoveLoc[2](loc1: &mut u64)
+	4: MoveLoc[2](b: &mut u64)
 	5: WriteRef
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_1.opt.exp
@@ -95,15 +95,15 @@ fun m::test($t0: u64): u64 {
 module c0ffee.m {
 
 
-test(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: &mut u64
+test(p: u64): u64 /* def_idx: 0 */ {
+L1:	$t4: u64
+L2:	b: &mut u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: MutBorrowLoc[0](Arg0: u64)
-	2: StLoc[2](loc1: &mut u64)
+	0: CopyLoc[0](p: u64)
+	1: MutBorrowLoc[0](p: u64)
+	2: StLoc[2](b: &mut u64)
 	3: LdU64(1)
-	4: MoveLoc[2](loc1: &mut u64)
+	4: MoveLoc[2](b: &mut u64)
 	5: WriteRef
 	6: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.exp
@@ -146,23 +146,23 @@ struct S has copy, drop {
 	b: u64
 }
 
-test(Arg0: S): u64 /* def_idx: 0 */ {
-L1:	loc0: S
-L2:	loc1: S
-L3:	loc2: u64
-L4:	loc3: &mut u64
+test(s: S): u64 /* def_idx: 0 */ {
+L1:	p: S
+L2:	q: S
+L3:	$t6: u64
+L4:	ref: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: S)
-	1: StLoc[1](loc0: S)
-	2: CopyLoc[1](loc0: S)
-	3: StLoc[2](loc1: S)
-	4: MutBorrowLoc[1](loc0: S)
+	0: MoveLoc[0](s: S)
+	1: StLoc[1](p: S)
+	2: CopyLoc[1](p: S)
+	3: StLoc[2](q: S)
+	4: MutBorrowLoc[1](p: S)
 	5: MutBorrowField[0](S.a: u64)
-	6: StLoc[4](loc3: &mut u64)
+	6: StLoc[4](ref: &mut u64)
 	7: LdU64(0)
-	8: MoveLoc[4](loc3: &mut u64)
+	8: MoveLoc[4](ref: &mut u64)
 	9: WriteRef
-	10: ImmBorrowLoc[2](loc1: S)
+	10: ImmBorrowLoc[2](q: S)
 	11: ImmBorrowField[0](S.a: u64)
 	12: ReadRef
 	13: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/mut_refs_2.opt.exp
@@ -146,23 +146,23 @@ struct S has copy, drop {
 	b: u64
 }
 
-test(Arg0: S): u64 /* def_idx: 0 */ {
-L1:	loc0: S
-L2:	loc1: S
-L3:	loc2: u64
-L4:	loc3: &mut u64
+test(s: S): u64 /* def_idx: 0 */ {
+L1:	p: S
+L2:	q: S
+L3:	$t6: u64
+L4:	ref: &mut u64
 B0:
-	0: MoveLoc[0](Arg0: S)
-	1: StLoc[1](loc0: S)
-	2: CopyLoc[1](loc0: S)
-	3: StLoc[2](loc1: S)
-	4: MutBorrowLoc[1](loc0: S)
+	0: MoveLoc[0](s: S)
+	1: StLoc[1](p: S)
+	2: CopyLoc[1](p: S)
+	3: StLoc[2](q: S)
+	4: MutBorrowLoc[1](p: S)
 	5: MutBorrowField[0](S.a: u64)
-	6: StLoc[4](loc3: &mut u64)
+	6: StLoc[4](ref: &mut u64)
 	7: LdU64(0)
-	8: MoveLoc[4](loc3: &mut u64)
+	8: MoveLoc[4](ref: &mut u64)
 	9: WriteRef
-	10: ImmBorrowLoc[2](loc1: S)
+	10: ImmBorrowLoc[2](q: S)
 	11: ImmBorrowField[0](S.a: u64)
 	12: ReadRef
 	13: Ret

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/overlapping_vars.exp
@@ -114,9 +114,9 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: u64
-L2:	loc2: u64
+L0:	z: u64
+L1:	y: u64
+L2:	x: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -110,7 +110,7 @@ module c0ffee.m {
 
 
 test(): u64 /* def_idx: 0 */ {
-L0:	loc0: u64
+L0:	b: u64
 B0:
 	0: LdU64(9)
 	1: LdU64(2)

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
@@ -448,56 +448,56 @@ public fun m::test4($t0: u64): u64 {
 module c0ffee.m {
 
 
-public test1(Arg0: u64) /* def_idx: 0 */ {
+public test1(x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-public test2(Arg0: u64): u64 /* def_idx: 1 */ {
+public test2(x: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Ret
 }
 public test3(): u64 /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	i: u64
+L1:	x: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](i: u64)
 	2: LdU64(1)
-	3: StLoc[1](loc1: u64)
+	3: StLoc[1](x: u64)
 B1:
-	4: CopyLoc[0](loc0: u64)
+	4: CopyLoc[0](i: u64)
 	5: LdU64(42)
 	6: Lt
 	7: BrFalse(13)
 B2:
-	8: MoveLoc[0](loc0: u64)
+	8: MoveLoc[0](i: u64)
 	9: LdU64(1)
 	10: Add
-	11: StLoc[0](loc0: u64)
+	11: StLoc[0](i: u64)
 	12: Branch(4)
 B3:
-	13: MoveLoc[1](loc1: u64)
+	13: MoveLoc[1](x: u64)
 	14: Ret
 }
-public test4(Arg0: u64): u64 /* def_idx: 3 */ {
-L1:	loc0: u64
+public test4(x: u64): u64 /* def_idx: 3 */ {
+L1:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](i: u64)
 B1:
-	2: CopyLoc[1](loc0: u64)
+	2: CopyLoc[1](i: u64)
 	3: LdU64(42)
 	4: Lt
 	5: BrFalse(11)
 B2:
-	6: MoveLoc[1](loc0: u64)
+	6: MoveLoc[1](i: u64)
 	7: LdU64(1)
 	8: Add
-	9: StLoc[1](loc0: u64)
+	9: StLoc[1](i: u64)
 	10: Branch(2)
 B3:
-	11: MoveLoc[0](Arg0: u64)
+	11: MoveLoc[0](x: u64)
 	12: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
@@ -448,56 +448,56 @@ public fun m::test4($t0: u64): u64 {
 module c0ffee.m {
 
 
-public test1(Arg0: u64) /* def_idx: 0 */ {
+public test1(x: u64) /* def_idx: 0 */ {
 B0:
 	0: Ret
 }
-public test2(Arg0: u64): u64 /* def_idx: 1 */ {
+public test2(x: u64): u64 /* def_idx: 1 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](x: u64)
 	1: Ret
 }
 public test3(): u64 /* def_idx: 2 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	i: u64
+L1:	x: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[0](loc0: u64)
+	1: StLoc[0](i: u64)
 	2: LdU64(1)
-	3: StLoc[1](loc1: u64)
+	3: StLoc[1](x: u64)
 B1:
-	4: CopyLoc[0](loc0: u64)
+	4: CopyLoc[0](i: u64)
 	5: LdU64(42)
 	6: Lt
 	7: BrFalse(13)
 B2:
-	8: MoveLoc[0](loc0: u64)
+	8: MoveLoc[0](i: u64)
 	9: LdU64(1)
 	10: Add
-	11: StLoc[0](loc0: u64)
+	11: StLoc[0](i: u64)
 	12: Branch(4)
 B3:
-	13: MoveLoc[1](loc1: u64)
+	13: MoveLoc[1](x: u64)
 	14: Ret
 }
-public test4(Arg0: u64): u64 /* def_idx: 3 */ {
-L1:	loc0: u64
+public test4(x: u64): u64 /* def_idx: 3 */ {
+L1:	i: u64
 B0:
 	0: LdU64(0)
-	1: StLoc[1](loc0: u64)
+	1: StLoc[1](i: u64)
 B1:
-	2: CopyLoc[1](loc0: u64)
+	2: CopyLoc[1](i: u64)
 	3: LdU64(42)
 	4: Lt
 	5: BrFalse(11)
 B2:
-	6: MoveLoc[1](loc0: u64)
+	6: MoveLoc[1](i: u64)
 	7: LdU64(1)
 	8: Add
-	9: StLoc[1](loc0: u64)
+	9: StLoc[1](i: u64)
 	10: Branch(2)
 B3:
-	11: MoveLoc[0](Arg0: u64)
+	11: MoveLoc[0](x: u64)
 	12: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
@@ -145,20 +145,20 @@ fun m::test($t0: u64): bool {
 module c0ffee.m {
 
 
-test(Arg0: u64): bool /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): bool /* def_idx: 0 */ {
+L1:	a: u64
+L2:	b: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[1](loc0: u64)
-	3: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: CopyLoc[1](a: u64)
+	3: MoveLoc[0](p: u64)
 	4: LdU64(1)
 	5: Add
 	6: Pop
-	7: StLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: MoveLoc[2](loc1: u64)
+	7: StLoc[2](b: u64)
+	8: MoveLoc[1](a: u64)
+	9: MoveLoc[2](b: u64)
 	10: Eq
 	11: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
@@ -145,20 +145,20 @@ fun m::test($t0: u64): bool {
 module c0ffee.m {
 
 
-test(Arg0: u64): bool /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): bool /* def_idx: 0 */ {
+L1:	a: u64
+L2:	b: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[1](loc0: u64)
-	3: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: CopyLoc[1](a: u64)
+	3: MoveLoc[0](p: u64)
 	4: LdU64(1)
 	5: Add
 	6: Pop
-	7: StLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: MoveLoc[2](loc1: u64)
+	7: StLoc[2](b: u64)
+	8: MoveLoc[1](a: u64)
+	9: MoveLoc[2](b: u64)
 	10: Eq
 	11: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
@@ -145,20 +145,20 @@ fun m::test($t0: u64): bool {
 module c0ffee.m {
 
 
-test(Arg0: u64): bool /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): bool /* def_idx: 0 */ {
+L1:	a: u64
+L2:	c: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[1](loc0: u64)
-	3: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: CopyLoc[1](a: u64)
+	3: MoveLoc[0](p: u64)
 	4: LdU64(1)
 	5: Add
 	6: Pop
-	7: StLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: MoveLoc[2](loc1: u64)
+	7: StLoc[2](c: u64)
+	8: MoveLoc[1](a: u64)
+	9: MoveLoc[2](c: u64)
 	10: Eq
 	11: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
@@ -145,20 +145,20 @@ fun m::test($t0: u64): bool {
 module c0ffee.m {
 
 
-test(Arg0: u64): bool /* def_idx: 0 */ {
-L1:	loc0: u64
-L2:	loc1: u64
+test(p: u64): bool /* def_idx: 0 */ {
+L1:	a: u64
+L2:	c: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[1](loc0: u64)
-	3: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: CopyLoc[1](a: u64)
+	3: MoveLoc[0](p: u64)
 	4: LdU64(1)
 	5: Add
 	6: Pop
-	7: StLoc[2](loc1: u64)
-	8: MoveLoc[1](loc0: u64)
-	9: MoveLoc[2](loc1: u64)
+	7: StLoc[2](c: u64)
+	8: MoveLoc[1](a: u64)
+	9: MoveLoc[2](c: u64)
 	10: Eq
 	11: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.exp
@@ -113,9 +113,9 @@ struct Foo has copy {
 	e: u64
 }
 
-sequential(Arg0: Foo): Foo /* def_idx: 0 */ {
+sequential(p: Foo): Foo /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: Foo)
+	0: MoveLoc[0](p: Foo)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/sequential_assign_struct.opt.exp
@@ -113,9 +113,9 @@ struct Foo has copy {
 	e: u64
 }
 
-sequential(Arg0: Foo): Foo /* def_idx: 0 */ {
+sequential(p: Foo): Foo /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: Foo)
+	0: MoveLoc[0](p: Foo)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.exp
@@ -107,9 +107,9 @@ fun m::sequential($t0: u64): u64 {
 module c0ffee.m {
 
 
-sequential(Arg0: u64): u64 /* def_idx: 0 */ {
+sequential(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/simple_sequential_assign.opt.exp
@@ -107,9 +107,9 @@ fun m::sequential($t0: u64): u64 {
 module c0ffee.m {
 
 
-sequential(Arg0: u64): u64 /* def_idx: 0 */ {
+sequential(p: u64): u64 /* def_idx: 0 */ {
 B0:
-	0: MoveLoc[0](Arg0: u64)
+	0: MoveLoc[0](p: u64)
 	1: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
@@ -134,17 +134,17 @@ fun m::copy_kill($t0: u64): u64 {
 module c0ffee.m {
 
 
-copy_kill(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
+copy_kill(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[1](loc0: u64)
-	3: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: CopyLoc[1](a: u64)
+	3: MoveLoc[0](p: u64)
 	4: LdU64(1)
 	5: Add
 	6: Pop
-	7: MoveLoc[1](loc0: u64)
+	7: MoveLoc[1](a: u64)
 	8: Add
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
@@ -134,17 +134,17 @@ fun m::copy_kill($t0: u64): u64 {
 module c0ffee.m {
 
 
-copy_kill(Arg0: u64): u64 /* def_idx: 0 */ {
-L1:	loc0: u64
+copy_kill(p: u64): u64 /* def_idx: 0 */ {
+L1:	a: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[1](loc0: u64)
-	2: CopyLoc[1](loc0: u64)
-	3: MoveLoc[0](Arg0: u64)
+	0: CopyLoc[0](p: u64)
+	1: StLoc[1](a: u64)
+	2: CopyLoc[1](a: u64)
+	3: MoveLoc[0](p: u64)
 	4: LdU64(1)
 	5: Add
 	6: Pop
-	7: MoveLoc[1](loc0: u64)
+	7: MoveLoc[1](a: u64)
 	8: Add
 	9: Ret
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.exp
@@ -89,15 +89,15 @@ public fun m::test($t0: u64, $t1: u64): (u64, u64) {
 module c0ffee.m {
 
 
-public test(Arg0: u64, Arg1: u64): u64 * u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+public test(x: u64, y: u64): u64 * u64 /* def_idx: 0 */ {
+L2:	t: u64
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
-	2: StLoc[0](Arg0: u64)
-	3: StLoc[1](Arg1: u64)
-	4: MoveLoc[0](Arg0: u64)
-	5: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: u64)
+	1: MoveLoc[1](y: u64)
+	2: StLoc[0](x: u64)
+	3: StLoc[1](y: u64)
+	4: MoveLoc[0](x: u64)
+	5: MoveLoc[1](y: u64)
 	6: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap.opt.exp
@@ -89,15 +89,15 @@ public fun m::test($t0: u64, $t1: u64): (u64, u64) {
 module c0ffee.m {
 
 
-public test(Arg0: u64, Arg1: u64): u64 * u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+public test(x: u64, y: u64): u64 * u64 /* def_idx: 0 */ {
+L2:	t: u64
 B0:
-	0: MoveLoc[0](Arg0: u64)
-	1: MoveLoc[1](Arg1: u64)
-	2: StLoc[0](Arg0: u64)
-	3: StLoc[1](Arg1: u64)
-	4: MoveLoc[0](Arg0: u64)
-	5: MoveLoc[1](Arg1: u64)
+	0: MoveLoc[0](x: u64)
+	1: MoveLoc[1](y: u64)
+	2: StLoc[0](x: u64)
+	3: StLoc[1](y: u64)
+	4: MoveLoc[0](x: u64)
+	5: MoveLoc[1](y: u64)
 	6: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.exp
@@ -216,29 +216,29 @@ public fun m::test($t0: u64, $t1: u64): (u64, u64) {
 module c0ffee.m {
 
 
-public test(Arg0: u64, Arg1: u64): u64 * u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+public test(x: u64, y: u64): u64 * u64 /* def_idx: 0 */ {
+L2:	i: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[2](loc0: u64)
+	0: CopyLoc[0](x: u64)
+	1: StLoc[2](i: u64)
 B1:
-	2: CopyLoc[2](loc0: u64)
+	2: CopyLoc[2](i: u64)
 	3: LdU64(0)
 	4: Gt
 	5: BrFalse(15)
 B2:
-	6: MoveLoc[0](Arg0: u64)
-	7: MoveLoc[1](Arg1: u64)
-	8: StLoc[0](Arg0: u64)
-	9: StLoc[1](Arg1: u64)
-	10: MoveLoc[2](loc0: u64)
+	6: MoveLoc[0](x: u64)
+	7: MoveLoc[1](y: u64)
+	8: StLoc[0](x: u64)
+	9: StLoc[1](y: u64)
+	10: MoveLoc[2](i: u64)
 	11: LdU64(1)
 	12: Sub
-	13: StLoc[2](loc0: u64)
+	13: StLoc[2](i: u64)
 	14: Branch(2)
 B3:
-	15: MoveLoc[0](Arg0: u64)
-	16: MoveLoc[1](Arg1: u64)
+	15: MoveLoc[0](x: u64)
+	16: MoveLoc[1](y: u64)
 	17: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/swap_in_a_loop.opt.exp
@@ -216,29 +216,29 @@ public fun m::test($t0: u64, $t1: u64): (u64, u64) {
 module c0ffee.m {
 
 
-public test(Arg0: u64, Arg1: u64): u64 * u64 /* def_idx: 0 */ {
-L2:	loc0: u64
+public test(x: u64, y: u64): u64 * u64 /* def_idx: 0 */ {
+L2:	i: u64
 B0:
-	0: CopyLoc[0](Arg0: u64)
-	1: StLoc[2](loc0: u64)
+	0: CopyLoc[0](x: u64)
+	1: StLoc[2](i: u64)
 B1:
-	2: CopyLoc[2](loc0: u64)
+	2: CopyLoc[2](i: u64)
 	3: LdU64(0)
 	4: Gt
 	5: BrFalse(15)
 B2:
-	6: MoveLoc[0](Arg0: u64)
-	7: MoveLoc[1](Arg1: u64)
-	8: StLoc[0](Arg0: u64)
-	9: StLoc[1](Arg1: u64)
-	10: MoveLoc[2](loc0: u64)
+	6: MoveLoc[0](x: u64)
+	7: MoveLoc[1](y: u64)
+	8: StLoc[0](x: u64)
+	9: StLoc[1](y: u64)
+	10: MoveLoc[2](i: u64)
 	11: LdU64(1)
 	12: Sub
-	13: StLoc[2](loc0: u64)
+	13: StLoc[2](i: u64)
 	14: Branch(2)
 B3:
-	15: MoveLoc[0](Arg0: u64)
-	16: MoveLoc[1](Arg1: u64)
+	15: MoveLoc[0](x: u64)
+	16: MoveLoc[1](y: u64)
 	17: Ret
 }
 }

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
@@ -105,8 +105,8 @@ module c0ffee.m {
 
 
 public test() /* def_idx: 0 */ {
-L0:	loc0: u64
-L1:	loc1: u64
+L0:	y: u64
+L1:	x: u64
 B0:
 	0: LdU64(1)
 	1: LdU64(2)

--- a/third_party/move/tools/move-cli/src/base/coverage.rs
+++ b/third_party/move/tools/move-cli/src/base/coverage.rs
@@ -60,9 +60,9 @@ pub struct Coverage {
 impl Coverage {
     pub fn execute(self, path: Option<PathBuf>, config: BuildConfig) -> anyhow::Result<()> {
         let path = reroot_path(path)?;
-        let coverage_map = CoverageMap::from_binary_file(path.join(".coverage_map.mvcov"))?;
+        let coverage_map = CoverageMap::from_binary_file(&path.join(".coverage_map.mvcov"))?;
         let package = config.compile_package(&path, &mut Vec::new())?;
-        let modules: Vec<_> = package
+        let root_modules: Vec<_> = package
             .root_modules()
             .filter_map(|unit| match &unit.unit {
                 CompiledUnit::Module(NamedCompiledModule { module, .. }) => Some(module.clone()),
@@ -73,14 +73,24 @@ impl Coverage {
             CoverageSummaryOptions::Source { module_name } => {
                 let unit = package.get_module_by_name_from_root(&module_name)?;
                 let source_path = &unit.source_path;
-                let (module, source_map) = match &unit.unit {
-                    CompiledUnit::Module(NamedCompiledModule {
-                        module, source_map, ..
-                    }) => (module, source_map),
+                let source_map = match &unit.unit {
+                    CompiledUnit::Module(NamedCompiledModule { source_map, .. }) => source_map,
                     _ => panic!("Should all be modules"),
                 };
-                let source_coverage_builder =
-                    SourceCoverageBuilder::new(module, &coverage_map, source_map);
+                let root_modules_with_source_maps: Vec<_> = package
+                    .root_modules()
+                    .map(|unit| match &unit.unit {
+                        CompiledUnit::Module(NamedCompiledModule {
+                            module, source_map, ..
+                        }) => (module, source_map),
+                        _ => unreachable!("Should all be modules"),
+                    })
+                    .collect();
+                let source_coverage_builder = SourceCoverageBuilder::new(
+                    &coverage_map,
+                    source_map,
+                    root_modules_with_source_maps,
+                );
                 let source_coverage = source_coverage_builder.compute_source_coverage(source_path);
                 source_coverage
                     .output_source_coverage(&mut std::io::stdout(), self.color, self.tag)
@@ -94,14 +104,14 @@ impl Coverage {
                 let coverage_map = coverage_map.to_unified_exec_map();
                 if output_csv {
                     format_csv_summary(
-                        modules.as_slice(),
+                        root_modules.as_slice(),
                         &coverage_map,
                         summarize_inst_cov,
                         &mut std::io::stdout(),
                     )
                 } else {
                     format_human_summary(
-                        modules.as_slice(),
+                        root_modules.as_slice(),
                         &coverage_map,
                         summarize_inst_cov,
                         &mut std::io::stdout(),

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -348,8 +348,8 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
             let buf_writer = &mut *LOGGING_FILE_WRITER.lock().unwrap();
             buf_writer.flush().unwrap();
         }
-        let coverage_map = CoverageMap::from_trace_file(trace_path.clone());
-        output_map_to_file(coverage_map_path, &coverage_map).unwrap();
+        let coverage_map = CoverageMap::from_trace_file(&trace_path)?;
+        output_map_to_file(&coverage_map_path, &coverage_map)?;
     }
     cleanup_trace();
     Ok(UnitTestResult::Success)

--- a/third_party/move/tools/move-cli/src/test/mod.rs
+++ b/third_party/move/tools/move-cli/src/test/mod.rs
@@ -106,7 +106,7 @@ fn collect_coverage(
     }
 
     // collect filtered trace
-    let coverage_map = CoverageMap::from_trace_file(trace_file)
+    let coverage_map = CoverageMap::from_trace_file(&trace_file)?
         .to_unified_exec_map()
         .into_coverage_map_with_modules(filter);
 

--- a/third_party/move/tools/move-coverage/src/bin/coverage-summaries.rs
+++ b/third_party/move/tools/move-coverage/src/bin/coverage-summaries.rs
@@ -4,6 +4,7 @@
 
 #![forbid(unsafe_code)]
 
+use anyhow::{bail, Context};
 use clap::Parser;
 use move_binary_format::file_format::CompiledModule;
 use move_coverage::{
@@ -24,57 +25,92 @@ use std::{
     version
 )]
 struct Args {
-    /// The path to the coverage map or trace file
-    #[clap(long = "input-trace-path", short = 't')]
+    /// The path to the coverage map file
+    #[clap(long = "input-trace-path")]
     pub input_trace_path: String,
-    /// Whether the passed-in file is a raw trace file or a serialized coverage map
-    #[clap(long = "is-raw-trace", short = 'r')]
+    /// Whether the passed-in file is a raw trace file (true) or a serialized coverage map (false)
+    #[clap(long = "is-raw-trace")]
     pub is_raw_trace_file: bool,
     /// The path to the module binary
-    #[clap(long = "module-path", short = 'b')]
+    #[clap(long = "module-path")]
     pub module_binary_path: Option<String>,
+    /// The path to a directory containing binaries to be processed (e.g., `./build/*/bytecode_modules`)
+    #[clap(long = "modules-dir")]
+    pub modules_dir: Option<String>,
     /// Optional path for summaries. Printed to stdout if not present.
-    #[clap(long = "summary-path", short = 'o')]
+    #[clap(long = "summary-path")]
     pub summary_path: Option<String>,
     /// Whether function coverage summaries should be displayed
-    #[clap(long = "summarize-functions", short = 'f')]
+    #[clap(long = "summarize-functions")]
     pub summarize_functions: bool,
-    /// The path to the standard library binary directory for Move
-    #[clap(long = "stdlib-path", short = 's')]
+    /// The path to the standard library binary directory for Move (e.g., `.../build/MoveStdlib/bytecode_modules`)
+    #[clap(long = "stdlib-path")]
     pub stdlib_path: Option<String>,
     /// Whether path coverage should be derived (default is instruction coverage)
-    #[clap(long = "derive-path-coverage", short = 'p')]
+    #[clap(long = "derive-path-coverage")]
     pub derive_path_coverage: bool,
     /// Output CSV data of coverage
-    #[clap(long = "csv", short = 'c')]
+    #[clap(long = "csv")]
     pub csv_output: bool,
 }
 
-fn get_modules(args: &Args) -> Vec<CompiledModule> {
-    let mut modules = Vec::new();
-    if let Some(stdlib_path) = &args.stdlib_path {
-        let stdlib_modules = fs::read_dir(stdlib_path).unwrap().map(|file| {
-            let bytes = fs::read(file.unwrap().path()).unwrap();
-            CompiledModule::deserialize(&bytes).expect("Module blob can't be deserialized")
-        });
-        modules.extend(stdlib_modules);
+fn maybe_add_modules(
+    modules: &mut Vec<CompiledModule>,
+    modules_dir: &Option<String>,
+) -> anyhow::Result<()> {
+    if let Some(modules_path) = modules_dir {
+        let new_modules_files = fs::read_dir(modules_path)
+            .with_context(|| format!("Reading module directory {}", modules_path))?;
+        let new_modules: Result<Vec<CompiledModule>, _> = new_modules_files
+            .map(|dirent_or_error| {
+                dirent_or_error
+                    .with_context(|| format!("Iterating over module directory {}", modules_path))
+                    .and_then(|file| {
+                        fs::read(file.path())
+                            .map_err(anyhow::Error::from)
+                            .and_then(|bytes| {
+                                CompiledModule::deserialize(&bytes).with_context(|| {
+                                    format!("Reading file {}", file.path().to_string_lossy())
+                                })
+                            })
+                    })
+            })
+            .collect();
+        let mut new_modules = new_modules?;
+        modules.append(&mut new_modules);
     }
+    Ok(())
+}
+
+fn get_modules(args: &Args) -> anyhow::Result<Vec<CompiledModule>> {
+    let mut modules = Vec::new();
+    maybe_add_modules(&mut modules, &args.stdlib_path)?;
+    maybe_add_modules(&mut modules, &args.modules_dir)?;
 
     if let Some(module_binary_path) = &args.module_binary_path {
-        let bytecode_bytes = fs::read(module_binary_path).expect("Unable to read bytecode file");
-        let compiled_module = CompiledModule::deserialize(&bytecode_bytes)
-            .expect("Module blob can't be deserialized");
+        let bytecode_bytes = fs::read(module_binary_path).with_context(|| {
+            format!(
+                "Failed to get_modules for module path {}",
+                module_binary_path
+            )
+        })?;
+        let compiled_module = CompiledModule::deserialize(&bytecode_bytes).with_context(|| {
+            format!(
+                "Failed to get_modules for module path {}",
+                module_binary_path
+            )
+        })?;
         modules.push(compiled_module);
     }
 
     if modules.is_empty() {
-        panic!("No modules provided for coverage checking")
+        bail!("No modules provided for coverage checking")
     }
 
-    modules
+    Ok(modules)
 }
 
-fn main() {
+fn main() -> anyhow::Result<()> {
     let args = Args::parse();
     let input_trace_path = Path::new(&args.input_trace_path);
 
@@ -86,12 +122,19 @@ fn main() {
         None => Box::new(io::stdout()),
     };
 
-    let modules = get_modules(&args);
+    let modules = get_modules(&args)?;
     if args.derive_path_coverage {
         let trace_map = if args.is_raw_trace_file {
-            TraceMap::from_trace_file(input_trace_path)
+            TraceMap::from_trace_file(&input_trace_path).with_context(|| {
+                format!("Reading trace file {}", input_trace_path.to_string_lossy())
+            })?
         } else {
-            TraceMap::from_binary_file(input_trace_path)
+            TraceMap::from_binary_file(&input_trace_path).with_context(|| {
+                format!(
+                    "Reading binary coverage file {}",
+                    input_trace_path.to_string_lossy()
+                )
+            })?
         };
         if !args.csv_output {
             format_human_summary(
@@ -111,9 +154,16 @@ fn main() {
         }
     } else {
         let coverage_map = if args.is_raw_trace_file {
-            CoverageMap::from_trace_file(input_trace_path)
+            CoverageMap::from_trace_file(&input_trace_path).with_context(|| {
+                format!("Reading trace file {}", input_trace_path.to_string_lossy(),)
+            })?
         } else {
-            CoverageMap::from_binary_file(input_trace_path).unwrap()
+            CoverageMap::from_binary_file(&input_trace_path).with_context(|| {
+                format!(
+                    "Reading binary coverage file {}",
+                    input_trace_path.to_string_lossy(),
+                )
+            })?
         };
         let unified_exec_map = coverage_map.to_unified_exec_map();
         if !args.csv_output {
@@ -133,6 +183,7 @@ fn main() {
             )
         }
     }
+    Ok(())
 }
 
 #[test]

--- a/third_party/move/tools/move-coverage/src/coverage_map.rs
+++ b/third_party/move/tools/move-coverage/src/coverage_map.rs
@@ -4,7 +4,7 @@
 
 #![forbid(unsafe_code)]
 
-use anyhow::{format_err, Result};
+use anyhow::{format_err, Context, Result};
 use move_binary_format::file_format::{CodeOffset, CompiledModule};
 use move_core_types::{
     account_address::AccountAddress,
@@ -18,6 +18,7 @@ use std::{
     path::Path,
 };
 
+/// Map from code offset in a function to the number of times it was executed.
 pub type FunctionCoverage = BTreeMap<u64, u64>;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -61,12 +62,12 @@ impl CoverageMap {
     /// Takes in a file containing a raw VM trace, and returns an updated coverage map.
     pub fn update_coverage_from_trace_file<P: AsRef<Path> + std::fmt::Debug>(
         mut self,
-        filename: P,
-    ) -> Self {
-        let file = File::open(&filename)
-            .unwrap_or_else(|_| panic!("Unable to open coverage trace file '{:?}'", filename));
+        filename: &P,
+    ) -> Result<Self> {
+        let file = File::open(filename)
+            .map_err(|e| format_err!("Unable to open coverage trace file {:?}: {}", filename, e))?;
         for line in BufReader::new(file).lines() {
-            let line = line.unwrap();
+            let line = line?;
             let mut splits = line.split(',');
             // Use a dummy key so that the data structure of the coverage map does not need to be changed
             let exec_id = "dummy_exec_id";
@@ -87,26 +88,29 @@ impl CoverageMap {
                 assert_eq!(context_segs.pop().unwrap(), "Script",);
             }
         }
-        self
+        Ok(self)
     }
 
     /// Takes in a file containing a raw VM trace, and returns a coverage map.
-    pub fn from_trace_file<P: AsRef<Path> + std::fmt::Debug>(filename: P) -> Self {
+    pub fn from_trace_file<P: AsRef<Path> + std::fmt::Debug>(filename: &P) -> Result<Self> {
         let empty_module_map = CoverageMap {
             exec_maps: BTreeMap::new(),
         };
-        empty_module_map.update_coverage_from_trace_file(filename)
+        empty_module_map
+            .update_coverage_from_trace_file(filename)
+            .with_context(|| format!("Updating coverage from trace file {:?}", filename))
     }
 
     /// Takes in a file containing a serialized coverage map and returns a coverage map.
-    pub fn from_binary_file<P: AsRef<Path> + std::fmt::Debug>(filename: P) -> Result<Self> {
+    pub fn from_binary_file<P: AsRef<Path> + std::fmt::Debug>(filename: &P) -> Result<Self> {
         let mut bytes = Vec::new();
-        File::open(&filename)
+        File::open(filename)
             .map_err(|e| format_err!("{}: Coverage map file '{:?}' doesn't exist", e, filename))?
             .read_to_end(&mut bytes)
             .ok()
             .ok_or_else(|| format_err!("Unable to read coverage map"))?;
-        bcs::from_bytes(&bytes).map_err(|_| format_err!("Error deserializing coverage map"))
+        bcs::from_bytes(&bytes)
+            .with_context(|| format!("Deserializing coverage map from binary file {:?}", filename))
     }
 
     // add entries in a cascading manner
@@ -267,10 +271,13 @@ impl ExecCoverageMapWithModules {
 
 impl TraceMap {
     /// Takes in a file containing a raw VM trace, and returns an updated coverage map.
-    pub fn update_from_trace_file<P: AsRef<Path>>(mut self, filename: P) -> Self {
-        let file = File::open(filename).unwrap();
+    pub fn update_from_trace_file<P: AsRef<Path> + std::fmt::Debug>(
+        mut self,
+        filename: &P,
+    ) -> Result<Self> {
+        let file = File::open(filename)?;
         for line in BufReader::new(file).lines() {
-            let line = line.unwrap();
+            let line = line?;
             let mut splits = line.split(',');
             // Use a dummy key so that the data structure of the coverage map does not need to be changed
             let exec_id = "dummy_exec_id";
@@ -291,11 +298,11 @@ impl TraceMap {
                 assert_eq!(context_segs.pop().unwrap(), "Script",);
             }
         }
-        self
+        Ok(self)
     }
 
     // Takes in a file containing a raw VM trace, and returns a parsed trace.
-    pub fn from_trace_file<P: AsRef<Path>>(filename: P) -> Self {
+    pub fn from_trace_file<P: AsRef<Path> + std::fmt::Debug>(filename: &P) -> Result<Self> {
         let trace_map = TraceMap {
             exec_maps: BTreeMap::new(),
         };
@@ -303,16 +310,14 @@ impl TraceMap {
     }
 
     // Takes in a file containing a serialized trace and deserialize it.
-    pub fn from_binary_file<P: AsRef<Path>>(filename: P) -> Self {
+    pub fn from_binary_file<P: AsRef<Path> + std::fmt::Debug>(filename: &P) -> Result<Self> {
         let mut bytes = Vec::new();
         File::open(filename)
             .ok()
             .and_then(|mut file| file.read_to_end(&mut bytes).ok())
-            .ok_or_else(|| format_err!("Error while reading in coverage map binary"))
-            .unwrap();
+            .ok_or_else(|| format_err!("Error while reading in coverage map binary"))?;
         bcs::from_bytes(&bytes)
-            .map_err(|_| format_err!("Error deserializing into coverage map"))
-            .unwrap()
+            .with_context(|| format!("Deserializing {:?} into coverage map", filename))
     }
 
     // add entries in a cascading manner
@@ -334,7 +339,10 @@ impl TraceMap {
     }
 }
 
-pub fn output_map_to_file<M: Serialize, P: AsRef<Path>>(file_name: P, data: &M) -> Result<()> {
+pub fn output_map_to_file<M: Serialize, P: AsRef<Path> + std::fmt::Debug>(
+    file_name: &P,
+    data: &M,
+) -> Result<()> {
     let bytes = bcs::to_bytes(data)?;
     let mut file = File::create(file_name)?;
     file.write_all(&bytes)?;

--- a/third_party/move/tools/move-coverage/src/source_coverage.rs
+++ b/third_party/move/tools/move-coverage/src/source_coverage.rs
@@ -6,7 +6,7 @@
 
 use crate::coverage_map::CoverageMap;
 use clap::ValueEnum;
-use codespan::{Files, Span};
+use codespan::{FileId, Files, Span};
 use colored::{self, Colorize};
 use move_binary_format::{
     access::ModuleAccess,
@@ -15,11 +15,11 @@ use move_binary_format::{
 };
 use move_bytecode_source_map::source_map::SourceMap;
 use move_command_line_common::files::FileHash;
-use move_core_types::identifier::Identifier;
 use move_ir_types::location::Loc;
 use serde::Serialize;
 use std::{
-    collections::BTreeMap,
+    cmp::{Ordering, PartialOrd},
+    collections::{BTreeMap, BTreeSet},
     fmt::{Display, Formatter},
     fs,
     io::{self, Write},
@@ -28,6 +28,8 @@ use std::{
 };
 
 /// Source-level coverage information for a function.
+/// Deprecated, use `FunctionSourceCoverageV2` instead.
+/// Kept around for legacy usages.
 #[derive(Clone, Debug, Serialize)]
 pub struct FunctionSourceCoverage {
     /// Is this a native function?
@@ -38,20 +40,82 @@ pub struct FunctionSourceCoverage {
     pub uncovered_locations: Vec<Loc>,
 }
 
+/// Source-level positive coverage information for a function.
+#[derive(Clone, Debug, Serialize)]
+pub struct FunctionSourceCoverageV2 {
+    /// Is this a native function?
+    /// If so, the remaining fields are empty.
+    pub fn_is_native: bool,
+
+    /// List of source locations in the function that were covered.
+    pub covered_locations: Vec<Loc>,
+
+    /// List of all (executable) source locations in the function.
+    pub all_locations: Vec<Loc>,
+}
+
+impl FunctionSourceCoverageV2 {
+    /// Coverage information for a native function.
+    fn for_native() -> Self {
+        Self {
+            fn_is_native: true,
+            covered_locations: vec![],
+            all_locations: vec![],
+        }
+    }
+}
+
 /// Builder for the source code coverage.
 #[derive(Debug, Serialize)]
 pub struct SourceCoverageBuilder<'a> {
-    /// Mapping from function name to the source-level uncovered locations for that function.
-    pub uncovered_locations: BTreeMap<Identifier, FunctionSourceCoverage>,
+    /// Source-level uncovered locations.
+    pub uncovered_locations: Vec<Loc>,
 
     source_map: &'a SourceMap,
 }
 
-#[derive(Debug, Serialize, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Serialize, Eq, PartialEq)]
 pub enum AbstractSegment {
     Bounded { start: u32, end: u32 },
     BoundedRight { end: u32 },
     BoundedLeft { start: u32 },
+}
+
+impl AbstractSegment {
+    fn get_start(&self) -> u32 {
+        use AbstractSegment::*;
+        match self {
+            Bounded { start, .. } => *start,
+            BoundedRight { .. } => 0u32,
+            BoundedLeft { start, .. } => *start,
+        }
+    }
+
+    fn get_number(&self) -> u8 {
+        use AbstractSegment::*;
+        match self {
+            Bounded { .. } => 0,
+            BoundedRight { .. } => 1,
+            BoundedLeft { .. } => 2,
+        }
+    }
+}
+
+impl PartialOrd for AbstractSegment {
+    fn partial_cmp(&self, other: &AbstractSegment) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for AbstractSegment {
+    fn cmp(&self, other: &AbstractSegment) -> Ordering {
+        use Ordering::*;
+        match self.get_start().cmp(&other.get_start()) {
+            Less => Less,
+            Greater => Greater,
+            Equal => self.get_number().cmp(&other.get_number()),
+        }
+    }
 }
 
 /// Option to control use of color escape codes in coverage output
@@ -179,75 +243,156 @@ pub struct SourceCoverage {
 
 impl<'a> SourceCoverageBuilder<'a> {
     pub fn new(
-        module: &CompiledModule,
         coverage_map: &CoverageMap,
         source_map: &'a SourceMap,
+        root_modules: Vec<(&CompiledModule, &'a SourceMap)>,
     ) -> Self {
-        let module_name = module.self_id();
+        let module_loc = source_map.definition_location;
         let unified_exec_map = coverage_map.to_unified_exec_map();
-        let module_map = unified_exec_map
-            .module_maps
-            .get(&(*module_name.address(), module_name.name().to_owned()));
 
-        let uncovered_locations: BTreeMap<Identifier, FunctionSourceCoverage> = module
-            .function_defs()
+        let mut fun_coverage: Vec<FunctionSourceCoverageV2> = Vec::new();
+        for (module, source_map) in root_modules.iter() {
+            let module_name = module.self_id();
+            let module_map = unified_exec_map
+                .module_maps
+                .get(&(*module_name.address(), module_name.name().to_owned()));
+            if let Some(module_map) = module_map {
+                for (function_def_idx, function_def) in module.function_defs().iter().enumerate() {
+                    let fn_handle = module.function_handle_at(function_def.function);
+                    let fn_name = module.identifier_at(fn_handle.name).to_owned();
+                    let function_def_idx = FunctionDefinitionIndex(function_def_idx as u16);
+                    let function_covered_locations: FunctionSourceCoverageV2 =
+                        match &function_def.code {
+                            None => FunctionSourceCoverageV2::for_native(),
+                            Some(code_unit) => match module_map.function_maps.get(&fn_name) {
+                                None => {
+                                    let all_locations = minimize_locations(
+                                        (0..code_unit.code.len())
+                                            .filter_map(|code_offset| {
+                                                if let Ok(loc) = source_map.get_code_location(
+                                                    function_def_idx,
+                                                    code_offset as CodeOffset,
+                                                ) {
+                                                    Some(loc)
+                                                } else {
+                                                    None
+                                                }
+                                            })
+                                            .collect(),
+                                    );
+                                    FunctionSourceCoverageV2 {
+                                        fn_is_native: false,
+                                        covered_locations: vec![],
+                                        all_locations,
+                                    }
+                                },
+                                Some(function_coverage) => {
+                                    let (fun_cov, fun_uncov): (Vec<_>, Vec<_>) =
+                                        (0..code_unit.code.len())
+                                            .filter_map(|code_offset| {
+                                                if let Ok(loc) = source_map.get_code_location(
+                                                    function_def_idx,
+                                                    code_offset as CodeOffset,
+                                                ) {
+                                                    if function_coverage
+                                                        .get(&(code_offset as u64))
+                                                        .unwrap_or(&0)
+                                                        != &0
+                                                    {
+                                                        // Non-zero execution count, so covered.
+                                                        Some((loc, true))
+                                                    } else {
+                                                        Some((loc, false))
+                                                    }
+                                                } else {
+                                                    None
+                                                }
+                                            })
+                                            .partition(|(_, covered)| *covered);
+
+                                    let covered_locations: Vec<_> = minimize_locations(
+                                        fun_cov.iter().map(|(loc, _)| *loc).collect(),
+                                    );
+                                    let uncovered_locations: Vec<_> = minimize_locations(
+                                        fun_uncov.iter().map(|(loc, _)| *loc).collect(),
+                                    );
+                                    // If any uncovered locations are the same as covered locations,
+                                    // remove them from uncovered locations.
+                                    let uncovered_locations =
+                                        BTreeSet::from_iter(uncovered_locations.into_iter())
+                                            .difference(&BTreeSet::from_iter(
+                                                covered_locations.iter().cloned(),
+                                            ))
+                                            .cloned()
+                                            .collect();
+                                    // Covered locations may be an over-approximation, so uncovered
+                                    // locations are subtracted from covered locations.
+                                    let covered_locations = subtract_locations(
+                                        covered_locations.into_iter().collect(),
+                                        &uncovered_locations,
+                                    );
+                                    let all_locations: Vec<_> = minimize_locations(
+                                        fun_cov
+                                            .iter()
+                                            .chain(fun_uncov.iter())
+                                            .map(|(loc, _)| *loc)
+                                            .collect(),
+                                    );
+
+                                    FunctionSourceCoverageV2 {
+                                        fn_is_native: false,
+                                        covered_locations,
+                                        all_locations,
+                                    }
+                                },
+                            },
+                        };
+                    fun_coverage.push(function_covered_locations);
+                }
+            }
+        }
+
+        // Filter locations for this module and build 2 sets: covered and all locations.
+        // Note that compiler v1 sets module_loc to the location of symbol in definition, so if
+        // there are multiple modules in one file we may leave others in the picture.
+        let module_file_hash = module_loc.file_hash();
+
+        let (covered, all): (BTreeSet<Loc>, BTreeSet<Loc>) = fun_coverage
             .iter()
-            .enumerate()
-            .flat_map(|(function_def_idx, function_def)| {
-                let fn_handle = module.function_handle_at(function_def.function);
-                let fn_name = module.identifier_at(fn_handle.name).to_owned();
-                let function_def_idx = FunctionDefinitionIndex(function_def_idx as u16);
-
-                // If the function summary doesn't exist then that function hasn't been called yet.
-                let coverage = match &function_def.code {
-                    None => Some(FunctionSourceCoverage {
-                        fn_is_native: true,
-                        uncovered_locations: Vec::new(),
-                    }),
-                    Some(code_unit) => {
-                        module_map.map(|fn_map| match fn_map.function_maps.get(&fn_name) {
-                            None => {
-                                let function_map = source_map
-                                    .get_function_source_map(function_def_idx)
-                                    .unwrap();
-                                let mut uncovered_locations =
-                                    vec![function_map.definition_location];
-                                uncovered_locations.extend(function_map.code_map.values());
-
-                                FunctionSourceCoverage {
-                                    fn_is_native: false,
-                                    uncovered_locations,
-                                }
-                            },
-                            Some(function_coverage) => {
-                                let uncovered_locations: Vec<_> = (0..code_unit.code.len())
-                                    .flat_map(|code_offset| {
-                                        if !function_coverage.contains_key(&(code_offset as u64)) {
-                                            Some(
-                                                source_map
-                                                    .get_code_location(
-                                                        function_def_idx,
-                                                        code_offset as CodeOffset,
-                                                    )
-                                                    .unwrap(),
-                                            )
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .collect();
-                                FunctionSourceCoverage {
-                                    fn_is_native: false,
-                                    uncovered_locations,
-                                }
-                            },
-                        })
-                    },
-                };
-                coverage.map(|x| (fn_name, x))
+            .map(
+                |FunctionSourceCoverageV2 {
+                     covered_locations,
+                     all_locations,
+                     ..
+                 }| {
+                    let cov: BTreeSet<_> = covered_locations
+                        .iter()
+                        .filter(|loc| loc.file_hash() == module_file_hash)
+                        .cloned()
+                        .collect();
+                    let all: BTreeSet<_> = all_locations
+                        .iter()
+                        .filter(|loc| loc.file_hash() == module_file_hash)
+                        .cloned()
+                        .collect();
+                    (cov, all)
+                },
+            )
+            .reduce(|(c1, a1), (c2, a2)| {
+                (
+                    c1.union(&c2).cloned().collect(),
+                    a1.union(&a2).cloned().collect(),
+                )
             })
-            .collect();
+            .unwrap_or_else(|| (BTreeSet::new(), BTreeSet::new()));
 
+        let covered = minimize_locations(covered.into_iter().collect())
+            .into_iter()
+            .collect();
+        let all = minimize_locations(all.into_iter().collect())
+            .into_iter()
+            .collect::<BTreeSet<_>>();
+        let uncovered_locations = subtract_locations(all, &covered);
         Self {
             uncovered_locations,
             source_map,
@@ -261,47 +406,16 @@ impl<'a> SourceCoverageBuilder<'a> {
             "File contents {} out of sync with source map",
             file_path.display()
         );
-        let file_hash = self.source_map.definition_location.file_hash();
         let mut files = Files::new();
         let file_id = files.add(file_path.as_os_str().to_os_string(), file_contents.clone());
 
-        let mut uncovered_segments = BTreeMap::new();
+        let uncovered_spans: Vec<_> = self
+            .uncovered_locations
+            .iter()
+            .map(|loc| Span::new(loc.start(), loc.end()))
+            .collect();
 
-        for (_key, fn_cov) in self.uncovered_locations.iter() {
-            for span in merge_spans(file_hash, fn_cov.clone()).into_iter() {
-                let start_loc = files.location(file_id, span.start()).unwrap();
-                let end_loc = files.location(file_id, span.end()).unwrap();
-                let start_line = start_loc.line.0;
-                let end_line = end_loc.line.0;
-                let segments = uncovered_segments
-                    .entry(start_line)
-                    .or_insert_with(Vec::new);
-                if start_line == end_line {
-                    let segment = AbstractSegment::Bounded {
-                        start: start_loc.column.0,
-                        end: end_loc.column.0,
-                    };
-                    // TODO: There is some issue with the source map where we have multiple spans
-                    // from different functions. This can be seen in the source map for `Roles.move`
-                    if !segments.contains(&segment) {
-                        segments.push(segment);
-                    }
-                } else {
-                    segments.push(AbstractSegment::BoundedLeft {
-                        start: start_loc.column.0,
-                    });
-                    for i in start_line + 1..end_line {
-                        let segment = uncovered_segments.entry(i).or_insert_with(Vec::new);
-                        segment.push(AbstractSegment::BoundedLeft { start: 0 });
-                    }
-                    let last_segment = uncovered_segments.entry(end_line).or_insert_with(Vec::new);
-                    last_segment.push(AbstractSegment::BoundedRight {
-                        end: end_loc.column.0,
-                    });
-                }
-            }
-        }
-        uncovered_segments.values_mut().for_each(|v| v.sort());
+        let uncovered_segments = spans_to_segments(&mut files, file_id, uncovered_spans);
 
         let mut annotated_lines = Vec::new();
         for (line_number, mut line) in file_contents.lines().map(|x| x.to_owned()).enumerate() {
@@ -398,6 +512,47 @@ impl SourceCoverage {
     }
 }
 
+/// Converts a (sorted) list of non-overlapping `Loc` into a map from line number to
+/// set of `AbstractSegment` for each line of the file `file_id` in fileset `files`.
+fn spans_to_segments(
+    files: &mut Files<String>,
+    file_id: FileId,
+    spans: Vec<Span>,
+) -> BTreeMap<u32, Vec<AbstractSegment>> {
+    let mut segments = BTreeMap::new();
+
+    for span in spans.into_iter() {
+        let start_loc = files.location(file_id, span.start()).unwrap();
+        let end_loc = files.location(file_id, span.end()).unwrap();
+        let start_line = start_loc.line.0;
+        let end_line = end_loc.line.0;
+        let line_segments = segments.entry(start_line).or_insert_with(Vec::new);
+        if start_line == end_line {
+            let segment = AbstractSegment::Bounded {
+                start: start_loc.column.0,
+                end: end_loc.column.0,
+            };
+            if !line_segments.contains(&segment) {
+                line_segments.push(segment);
+            }
+        } else {
+            line_segments.push(AbstractSegment::BoundedLeft {
+                start: start_loc.column.0,
+            });
+            for i in start_line + 1..end_line {
+                let line_segments = segments.entry(i).or_insert_with(Vec::new);
+                line_segments.push(AbstractSegment::BoundedLeft { start: 0 });
+            }
+            let last_line_segments = segments.entry(end_line).or_insert_with(Vec::new);
+            last_line_segments.push(AbstractSegment::BoundedRight {
+                end: end_loc.column.0,
+            });
+        }
+    }
+    segments.values_mut().for_each(|v| v.sort());
+    segments
+}
+
 /// Merge overlapping spans.
 pub fn merge_spans(file_hash: FileHash, cov: FunctionSourceCoverage) -> Vec<Span> {
     if cov.uncovered_locations.is_empty() {
@@ -431,10 +586,86 @@ pub fn merge_spans(file_hash: FileHash, cov: FunctionSourceCoverage) -> Vec<Span
     unioned
 }
 
+/// Given a list of locations, merge overlapping and abutting locations.
+fn minimize_locations(mut locs: Vec<Loc>) -> Vec<Loc> {
+    locs.sort();
+    let mut result = vec![];
+    let mut locs_iter = locs.into_iter();
+    if let Some(mut current_loc) = locs_iter.next() {
+        for next_loc in locs_iter {
+            if !current_loc.try_merge(&next_loc) {
+                result.push(current_loc);
+                current_loc = next_loc;
+            }
+        }
+        result.push(current_loc);
+    }
+    result
+}
+
+/// Given two (sorted) sets of locations, subtract the second set from the first set.
+fn subtract_locations(locs1: BTreeSet<Loc>, locs2: &BTreeSet<Loc>) -> Vec<Loc> {
+    let mut result = vec![];
+    let mut locs1_iter = locs1.into_iter();
+    let mut locs2_iter = locs2.iter();
+    if let Some(mut current_loc1) = locs1_iter.next() {
+        if let Some(mut current_loc2) = locs2_iter.next() {
+            loop {
+                if current_loc1.overlaps(current_loc2) {
+                    let mut diff = current_loc1.subtract(current_loc2);
+                    if let Some(new_loc1) = diff.pop() {
+                        result.append(&mut diff);
+                        current_loc1 = new_loc1;
+                        // continue
+                    } else {
+                        // diff was empty, get a new loc1
+                        if let Some(new_loc1) = locs1_iter.next() {
+                            current_loc1 = new_loc1;
+                            // retry loc2
+                            // continue
+                        } else {
+                            // no more loc1, return
+                            return result;
+                        }
+                    }
+                } else {
+                    // no overlap
+                    if current_loc1 <= *current_loc2 {
+                        // loc1 is done.  save it and get a new one.
+                        result.push(current_loc1);
+                        if let Some(new_loc1) = locs1_iter.next() {
+                            current_loc1 = new_loc1;
+                            // continue
+                        } else {
+                            // No more loc1, return
+                            return result;
+                        }
+                    } else {
+                        // loc1 might have more overlaps, try another loc2
+                        if let Some(new_loc2) = locs2_iter.next() {
+                            current_loc2 = new_loc2;
+                            // continue
+                        } else {
+                            // loc2 is finished but loc1 is not,
+                            // finish adding all loc1
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+        result.push(current_loc1);
+        for loc1 in locs1_iter {
+            result.push(loc1);
+        }
+    }
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::FunctionSourceCoverage;
-    use crate::source_coverage::merge_spans;
+    use crate::source_coverage::{merge_spans, minimize_locations, subtract_locations};
     use codespan::Span;
     use move_command_line_common::files::FileHash;
     use move_ir_types::location::Loc;
@@ -462,7 +693,7 @@ mod tests {
             Loc::new(test_hash, 21, 25),
             // Should stay the same:
             Loc::new(test_hash, 26, 29),
-            // Shouldn't intefere with other hashes.
+            // Shouldn't interfere with other hashes.
             Loc::new(other_hash, 2, 20),
         ];
         let expected_spans = vec![
@@ -500,5 +731,85 @@ mod tests {
             uncovered_locations,
         };
         assert!(merge_spans(test_hash, cov).is_empty());
+    }
+
+    #[test]
+    fn test_minimize_locations_works() {
+        let test_hash = FileHash([0; 32]);
+        let other_hash = FileHash([1; 32]);
+
+        let original_locations = vec![
+            // Should be merged:
+            Loc::new(test_hash, 50, 51),
+            Loc::new(test_hash, 51, 52),
+            // Should be merged:
+            Loc::new(test_hash, 3, 5),
+            Loc::new(test_hash, 2, 10),
+            Loc::new(test_hash, 5, 11),
+            // Should stay the same:
+            Loc::new(test_hash, 15, 16),
+            // Should be merged:
+            Loc::new(test_hash, 20, 25),
+            Loc::new(test_hash, 24, 25),
+            Loc::new(test_hash, 21, 25),
+            // Should stay the same:
+            Loc::new(test_hash, 27, 29),
+            // Should be merged:
+            Loc::new(test_hash, 101, 102),
+            Loc::new(test_hash, 103, 105),
+            Loc::new(test_hash, 106, 111),
+            Loc::new(test_hash, 110, 120),
+            // Shouldn't interfere with other hashes.
+            Loc::new(other_hash, 2, 20),
+        ];
+        let minimized_locations = vec![
+            Loc::new(test_hash, 2, 11),
+            Loc::new(test_hash, 15, 16),
+            Loc::new(test_hash, 20, 25),
+            Loc::new(test_hash, 27, 29),
+            Loc::new(test_hash, 50, 52),
+            Loc::new(test_hash, 101, 120),
+            Loc::new(other_hash, 2, 20),
+        ];
+
+        assert_eq!(minimized_locations, minimize_locations(original_locations));
+    }
+
+    #[test]
+    fn test_subtract_locations_works() {
+        let test_hash = FileHash([0; 32]);
+        let other_hash = FileHash([1; 32]);
+
+        let locs1 = vec![
+            Loc::new(test_hash, 5, 10),
+            Loc::new(test_hash, 15, 20),
+            Loc::new(test_hash, 25, 30),
+            Loc::new(test_hash, 35, 40),
+            Loc::new(test_hash, 45, 50),
+        ];
+
+        let locs2 = vec![
+            Loc::new(test_hash, 8, 12),
+            Loc::new(test_hash, 12, 16),
+            Loc::new(test_hash, 27, 28),
+            Loc::new(test_hash, 41, 42),
+            Loc::new(test_hash, 42, 44),
+            Loc::new(test_hash, 51, 54),
+            Loc::new(other_hash, 10, 12),
+        ];
+
+        let expected = vec![
+            Loc::new(test_hash, 5, 7),
+            Loc::new(test_hash, 17, 20),
+            Loc::new(test_hash, 25, 26),
+            Loc::new(test_hash, 29, 30),
+            Loc::new(test_hash, 35, 40),
+            Loc::new(test_hash, 45, 50),
+        ];
+
+        assert_eq!(
+            expected,
+            subtract_locations(locs1.into_iter().collect(), &locs2.into_iter().collect())
+        );
     }
 }


### PR DESCRIPTION
## Description

Fixes #15117, #15698, #15032.

Starting point for this PR was https://github.com/aptos-labs/aptos-core/pull/15250, but there are several modifications.

Main changes:
- When we compute source coverage for a module `m`, we look at how various modules within the  package containing `m` contribute to the coverage of `m` (due to inline functions, e.g.,).
- Names from source map are used in the disassembly listing (which causes the large change set in the expected files in tests).

## How Has This Been Tested?
- Manually tested each of the scenarios in #15117, #15698, #15032, and verified that we do not crash.
- Manually tested some handcrafted Move projects for sanity checks.
- Existing tests: baselines have been updated and checked that they only change variable names in disassembly listings.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Other: Move Coverage Tool
