### PR TITLE
[backpressure] proposals can add a per-block gas limit

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1063,6 +1063,7 @@ where
 
         let shared_commit_state = ExplicitSyncWrapper::new(BlockGasLimitProcessor::new(
             self.config.onchain.block_gas_limit_type.clone(),
+            self.config.onchain.block_gas_limit_override(),
             num_txns,
         ));
         let shared_maybe_error = AtomicBool::new(false);
@@ -1309,6 +1310,7 @@ where
         let mut ret = Vec::with_capacity(num_txns);
         let mut block_limit_processor = BlockGasLimitProcessor::<T>::new(
             self.config.onchain.block_gas_limit_type.clone(),
+            self.config.onchain.block_gas_limit_override(),
             num_txns,
         );
 

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -13,6 +13,7 @@ use std::time::Instant;
 
 pub struct BlockGasLimitProcessor<T: Transaction> {
     block_gas_limit_type: BlockGasLimitType,
+    block_gas_limit_override: Option<u64>,
     accumulated_effective_block_gas: u64,
     accumulated_approx_output_size: u64,
     accumulated_fee_statement: FeeStatement,
@@ -22,9 +23,14 @@ pub struct BlockGasLimitProcessor<T: Transaction> {
 }
 
 impl<T: Transaction> BlockGasLimitProcessor<T> {
-    pub fn new(block_gas_limit_type: BlockGasLimitType, init_size: usize) -> Self {
+    pub fn new(
+        block_gas_limit_type: BlockGasLimitType,
+        block_gas_limit_override: Option<u64>,
+        init_size: usize,
+    ) -> Self {
         Self {
             block_gas_limit_type,
+            block_gas_limit_override,
             accumulated_effective_block_gas: 0,
             accumulated_approx_output_size: 0,
             accumulated_fee_statement: FeeStatement::zero(),
@@ -85,8 +91,16 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         }
     }
 
+    fn block_gas_limit(&self) -> Option<u64> {
+        if self.block_gas_limit_override.is_some() {
+            self.block_gas_limit_override
+        } else {
+            self.block_gas_limit_type.block_gas_limit()
+        }
+    }
+
     fn should_end_block(&mut self, mode: &str) -> bool {
-        if let Some(per_block_gas_limit) = self.block_gas_limit_type.block_gas_limit() {
+        if let Some(per_block_gas_limit) = self.block_gas_limit() {
             // When the accumulated block gas of the committed txns exceeds
             // PER_BLOCK_GAS_LIMIT, early halt BlockSTM.
             let accumulated_block_gas = self.get_effective_accumulated_block_gas();
@@ -177,8 +191,8 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         info!(
             effective_block_gas = accumulated_effective_block_gas,
             block_gas_limit = self.block_gas_limit_type.block_gas_limit().unwrap_or(0),
+            block_gas_limit_override = self.block_gas_limit_override.unwrap_or(0),
             block_gas_limit_exceeded = self
-                .block_gas_limit_type
                 .block_gas_limit()
                 .map_or(false, |limit| accumulated_effective_block_gas >= limit),
             approx_output_size = accumulated_approx_output_size,
@@ -222,7 +236,6 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
     pub(crate) fn get_block_end_info(&self) -> BlockEndInfo {
         BlockEndInfo::V0 {
             block_gas_limit_reached: self
-                .block_gas_limit_type
                 .block_gas_limit()
                 .map(|per_block_gas_limit| {
                     self.get_effective_accumulated_block_gas() >= per_block_gas_limit
@@ -268,7 +281,7 @@ mod test {
 
     #[test]
     fn test_output_limit_not_used() {
-        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(DEFAULT_COMPLEX_LIMIT, 10);
+        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(DEFAULT_COMPLEX_LIMIT, None, 10);
         // Assert passing none here doesn't panic.
         processor.accumulate_fee_statement(FeeStatement::zero(), None, None);
         assert!(!processor.should_end_block_parallel());
@@ -292,7 +305,7 @@ mod test {
             use_granular_resource_group_conflicts: false,
         };
 
-        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, 10);
+        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, None, 10);
 
         processor.accumulate_fee_statement(execution_fee(10), None, None);
         assert!(!processor.should_end_block_parallel());
@@ -316,7 +329,7 @@ mod test {
             use_granular_resource_group_conflicts: false,
         };
 
-        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, 10);
+        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, None, 10);
 
         processor.accumulate_fee_statement(FeeStatement::zero(), None, Some(10));
         assert_eq!(processor.accumulated_approx_output_size, 10);
@@ -354,7 +367,7 @@ mod test {
             use_granular_resource_group_conflicts: false,
         };
 
-        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, 10);
+        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, None, 10);
 
         processor.accumulate_fee_statement(
             execution_fee(10),
@@ -416,7 +429,7 @@ mod test {
             use_granular_resource_group_conflicts: true,
         };
 
-        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, 10);
+        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, None, 10);
 
         assert!(!processor.should_end_block_parallel());
         processor.accumulate_fee_statement(

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -133,7 +133,7 @@ pub struct ExecutionBackpressureLookbackConfig {
 /// Execution backpressure which handles txn/s variance,
 /// and adjusts block sizes to "recalibrate it" to wanted range.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ExecutionBackpressureTxnLimitLookbackConfig {
+pub struct ExecutionBackpressureTxnLimitConfig {
     pub lookback_config: ExecutionBackpressureLookbackConfig,
     /// A minimal number of transactions per block, even if calibration suggests otherwise
     /// To make sure backpressure doesn't become too aggressive.
@@ -143,7 +143,7 @@ pub struct ExecutionBackpressureTxnLimitLookbackConfig {
 /// Execution backpressure which handles gas/s variance,
 /// and adjusts gas limit to "recalibrate it" to wanted range.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ExecutionBackpressureGasLimitLookbackConfig {
+pub struct ExecutionBackpressureGasLimitConfig {
     pub lookback_config: ExecutionBackpressureLookbackConfig,
     pub block_execution_overhead_ms: u64,
     pub min_calibrated_block_gas_limit: u64,
@@ -151,8 +151,8 @@ pub struct ExecutionBackpressureGasLimitLookbackConfig {
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ExecutionBackpressureConfig {
-    pub txn_limit_lookback: ExecutionBackpressureTxnLimitLookbackConfig,
-    pub gas_limit_lookback: ExecutionBackpressureGasLimitLookbackConfig,
+    pub txn_limit: Option<ExecutionBackpressureTxnLimitConfig>,
+    pub gas_limit: Option<ExecutionBackpressureGasLimitConfig>,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -218,23 +218,27 @@ impl Default for ConsensusConfig {
             vote_back_pressure_limit: 7,
             min_max_txns_in_block_after_filtering_from_backpressure: MIN_BLOCK_TXNS_AFTER_FILTERING,
             execution_backpressure: Some(ExecutionBackpressureConfig {
-                txn_limit_lookback: ExecutionBackpressureLookbackConfig {
-                    num_blocks_to_look_at: 12,
-                    min_block_time_ms_to_activate: 100,
-                    min_blocks_to_activate: 4,
-                    metric: ExecutionBackpressureMetric::Percentile(0.5),
-                    target_block_time_ms: 200,
-                },
-                min_calibrated_txns_per_block: 8,
-                gas_limit_lookback: ExecutionBackpressureLookbackConfig {
-                    num_blocks_to_look_at: 20,
-                    min_block_time_ms_to_activate: 10,
-                    min_blocks_to_activate: 4,
-                    metric: ExecutionBackpressureMetric::Mean,
-                    target_block_time_ms: 200,
-                },
-                block_execution_overhead_ms: 10,
-                min_calibrated_block_gas_limit: 2000,
+                txn_limit: Some(ExecutionBackpressureTxnLimitConfig {
+                    lookback_config: ExecutionBackpressureLookbackConfig {
+                        num_blocks_to_look_at: 12,
+                        min_block_time_ms_to_activate: 100,
+                        min_blocks_to_activate: 4,
+                        metric: ExecutionBackpressureMetric::Percentile(0.5),
+                        target_block_time_ms: 200,
+                    },
+                    min_calibrated_txns_per_block: 8,
+                }),
+                gas_limit: Some(ExecutionBackpressureGasLimitConfig {
+                    lookback_config: ExecutionBackpressureLookbackConfig {
+                        num_blocks_to_look_at: 20,
+                        min_block_time_ms_to_activate: 10,
+                        min_blocks_to_activate: 4,
+                        metric: ExecutionBackpressureMetric::Mean,
+                        target_block_time_ms: 200,
+                    },
+                    block_execution_overhead_ms: 10,
+                    min_calibrated_block_gas_limit: 2000,
+                }),
             }),
             pipeline_backpressure: vec![
                 PipelineBackpressureValues {

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -103,10 +103,14 @@ pub enum QcAggregatorType {
     NoDelay,
 }
 
-/// Execution backpressure which handles gas/s variance,
-/// and adjusts block sizes to "recalibrate it" to wanted range.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ExecutionBackpressureConfig {
+pub enum ExecutionBackpressureMetric {
+    Mean,
+    Percentile(f64),
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ExecutionBackpressureLookbackConfig {
     /// Look at execution time for this many last blocks
     pub num_blocks_to_look_at: usize,
 
@@ -119,17 +123,25 @@ pub struct ExecutionBackpressureConfig {
     /// at least `min_blocks_to_activate` are above `min_block_time_ms_to_activate`
     pub min_blocks_to_activate: usize,
 
-    /// Out of blocks in the window, take this percentile (from 0-1 range), to use for calibration.
-    /// i.e. 0.5 means take a median of last `num_blocks_to_look_at` blocks.
-    pub percentile: f64,
+    /// Out of blocks in the window, the metric to use for calibration.
+    /// i.e. Percentile(0.5) means take a median of last `num_blocks_to_look_at` blocks.
+    pub metric: ExecutionBackpressureMetric,
     /// Recalibrating max block size, to target blocks taking this long.
     pub target_block_time_ms: usize,
+}
+
+/// Execution backpressure which handles gas/s variance,
+/// and adjusts block sizes to "recalibrate it" to wanted range.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ExecutionBackpressureConfig {
+    pub txn_limit_lookback: ExecutionBackpressureLookbackConfig,
     /// A minimal number of transactions per block, even if calibration suggests otherwise
     /// To make sure backpressure doesn't become too aggressive.
     pub min_calibrated_txns_per_block: u64,
-    // We compute re-calibrated block size, and use that for `max_txns_in_block`.
-    // But after execution pool and cost of overpacking being minimal - we should
-    // change so that backpressure sets `max_txns_to_execute` instead
+
+    pub gas_limit_lookback: ExecutionBackpressureLookbackConfig,
+    pub block_execution_overhead_ms: u64,
+    pub min_calibrated_block_gas_limit: u64,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
@@ -195,13 +207,23 @@ impl Default for ConsensusConfig {
             vote_back_pressure_limit: 7,
             min_max_txns_in_block_after_filtering_from_backpressure: MIN_BLOCK_TXNS_AFTER_FILTERING,
             execution_backpressure: Some(ExecutionBackpressureConfig {
-                num_blocks_to_look_at: 12,
-                min_blocks_to_activate: 4,
-                percentile: 0.5,
-                target_block_time_ms: 200,
-                min_block_time_ms_to_activate: 100,
-                // allow at least two spreading group from reordering in a single block, to utilize paralellism
+                txn_limit_lookback: ExecutionBackpressureLookbackConfig {
+                    num_blocks_to_look_at: 12,
+                    min_block_time_ms_to_activate: 100,
+                    min_blocks_to_activate: 4,
+                    metric: ExecutionBackpressureMetric::Percentile(0.5),
+                    target_block_time_ms: 200,
+                },
                 min_calibrated_txns_per_block: 8,
+                gas_limit_lookback: ExecutionBackpressureLookbackConfig {
+                    num_blocks_to_look_at: 20,
+                    min_block_time_ms_to_activate: 10,
+                    min_blocks_to_activate: 4,
+                    metric: ExecutionBackpressureMetric::Mean,
+                    target_block_time_ms: 200,
+                },
+                block_execution_overhead_ms: 10,
+                min_calibrated_block_gas_limit: 2000,
             }),
             pipeline_backpressure: vec![
                 PipelineBackpressureValues {

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -130,18 +130,29 @@ pub struct ExecutionBackpressureLookbackConfig {
     pub target_block_time_ms: usize,
 }
 
-/// Execution backpressure which handles gas/s variance,
+/// Execution backpressure which handles txn/s variance,
 /// and adjusts block sizes to "recalibrate it" to wanted range.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
-pub struct ExecutionBackpressureConfig {
-    pub txn_limit_lookback: ExecutionBackpressureLookbackConfig,
+pub struct ExecutionBackpressureTxnLimitLookbackConfig {
+    pub lookback_config: ExecutionBackpressureLookbackConfig,
     /// A minimal number of transactions per block, even if calibration suggests otherwise
     /// To make sure backpressure doesn't become too aggressive.
     pub min_calibrated_txns_per_block: u64,
+}
 
-    pub gas_limit_lookback: ExecutionBackpressureLookbackConfig,
+/// Execution backpressure which handles gas/s variance,
+/// and adjusts gas limit to "recalibrate it" to wanted range.
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ExecutionBackpressureGasLimitLookbackConfig {
+    pub lookback_config: ExecutionBackpressureLookbackConfig,
     pub block_execution_overhead_ms: u64,
     pub min_calibrated_block_gas_limit: u64,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
+pub struct ExecutionBackpressureConfig {
+    pub txn_limit_lookback: ExecutionBackpressureTxnLimitLookbackConfig,
+    pub gas_limit_lookback: ExecutionBackpressureGasLimitLookbackConfig,
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -98,6 +98,7 @@ pub struct QuorumStoreConfig {
     pub allow_batches_without_pos_in_proposal: bool,
     pub enable_opt_quorum_store: bool,
     pub opt_qs_minimum_batch_age_usecs: u64,
+    pub enable_payload_v2: bool,
 }
 
 impl Default for QuorumStoreConfig {
@@ -138,6 +139,7 @@ impl Default for QuorumStoreConfig {
             allow_batches_without_pos_in_proposal: true,
             enable_opt_quorum_store: false,
             opt_qs_minimum_batch_age_usecs: Duration::from_millis(20).as_micros() as u64,
+            enable_payload_v2: false,
         }
     }
 }

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -113,7 +113,8 @@ impl Block {
                 Payload::InQuorumStore(pos) => pos.proofs.len(),
                 Payload::DirectMempool(_txns) => 0,
                 Payload::InQuorumStoreWithLimit(pos) => pos.proof_with_data.proofs.len(),
-                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+                | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                     inline_batches.len() + proof_with_data.proofs.len()
                 },
                 Payload::OptQuorumStore(opt_quorum_store_payload) => {

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -185,7 +185,6 @@ impl ProofWithDataWithTxnLimit {
 
     pub fn extend(&mut self, other: ProofWithDataWithTxnLimit) {
         self.proof_with_data.extend(other.proof_with_data);
-        // InQuorumStoreWithLimit TODO: what is the right logic here ???
         if self.max_txns_to_execute.is_none() {
             self.max_txns_to_execute = other.max_txns_to_execute;
         }
@@ -375,7 +374,6 @@ impl Payload {
                 b3.extend(b2);
                 let mut p3 = p1;
                 p3.extend(p2);
-                // TODO: What's the right logic here?
                 let m3 = sum_options(m1, m2);
                 Payload::QuorumStoreInlineHybrid(b3, p3, m3)
             },
@@ -392,19 +390,16 @@ impl Payload {
                 Payload::QuorumStoreInlineHybridV2(b3, p3, l3)
             },
             (Payload::QuorumStoreInlineHybrid(b1, p1, m1), Payload::InQuorumStore(p2)) => {
-                // TODO: How to update m1?
                 let mut p3 = p1;
                 p3.extend(p2);
                 Payload::QuorumStoreInlineHybrid(b1, p3, m1)
             },
             (Payload::QuorumStoreInlineHybridV2(b1, p1, l1), Payload::InQuorumStore(p2)) => {
-                // TODO: How to update m1?
                 let mut p3 = p1;
                 p3.extend(p2);
                 Payload::QuorumStoreInlineHybridV2(b1, p3, l1)
             },
             (Payload::QuorumStoreInlineHybrid(b1, p1, m1), Payload::InQuorumStoreWithLimit(p2)) => {
-                // TODO: What's the right logic here?
                 let m3 = sum_options(m1, p2.max_txns_to_execute);
                 let mut p3 = p1;
                 p3.extend(p2.proof_with_data);
@@ -414,7 +409,6 @@ impl Payload {
                 Payload::QuorumStoreInlineHybridV2(b1, p1, l1),
                 Payload::InQuorumStoreWithLimit(p2),
             ) => {
-                // TODO: What's the right logic here?
                 let m3 = sum_options(l1.max_txns_to_execute(), p2.max_txns_to_execute);
                 let g3 = l1.block_gas_limit();
                 let l3 = PayloadExecutionLimit::TxnAndGasLimits(TxnAndGasLimits {
@@ -436,7 +430,6 @@ impl Payload {
                 Payload::QuorumStoreInlineHybridV2(b2, p3, l2)
             },
             (Payload::InQuorumStoreWithLimit(p1), Payload::QuorumStoreInlineHybrid(b2, p2, m2)) => {
-                // TODO: What's the right logic here?
                 let m3 = sum_options(p1.max_txns_to_execute, m2);
                 let mut p3 = p1.proof_with_data;
                 p3.extend(p2);
@@ -446,7 +439,6 @@ impl Payload {
                 Payload::InQuorumStoreWithLimit(p1),
                 Payload::QuorumStoreInlineHybridV2(b2, p2, l2),
             ) => {
-                // TODO: What's the right logic here?
                 let m3 = sum_options(p1.max_txns_to_execute, l2.max_txns_to_execute());
                 let g3 = l2.block_gas_limit();
                 let l3 = PayloadExecutionLimit::TxnAndGasLimits(TxnAndGasLimits {

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    payload::{OptBatches, OptQuorumStorePayload, PayloadExecutionLimit},
+    payload::{OptBatches, OptQuorumStorePayload, PayloadExecutionLimit, TxnAndGasLimits},
     proof_of_store::{BatchInfo, ProofCache, ProofOfStore},
 };
 use anyhow::ensure;
@@ -192,11 +192,11 @@ impl ProofWithDataWithTxnLimit {
     }
 }
 
-fn sum_max_txns_to_execute(m1: Option<u64>, m2: Option<u64>) -> Option<u64> {
-    match (m1, m2) {
-        (None, _) => m2,
-        (_, None) => m1,
-        (Some(m1), Some(m2)) => Some(m1 + m2),
+fn sum_options(o1: Option<u64>, o2: Option<u64>) -> Option<u64> {
+    match (o1, o2) {
+        (None, _) => o2,
+        (_, None) => o1,
+        (Some(o1), Some(o2)) => Some(o1 + o2),
     }
 }
 
@@ -212,10 +212,19 @@ pub enum Payload {
         Option<u64>,
     ),
     OptQuorumStore(OptQuorumStorePayload),
+    QuorumStoreInlineHybridV2(
+        Vec<(BatchInfo, Vec<SignedTransaction>)>,
+        ProofWithData,
+        PayloadExecutionLimit,
+    ),
 }
 
 impl Payload {
-    pub fn transform_to_quorum_store_v2(self, max_txns_to_execute: Option<u64>) -> Self {
+    pub fn transform_to_quorum_store_v2(
+        self,
+        max_txns_to_execute: Option<u64>,
+        block_gas_limit_override: Option<u64>,
+    ) -> Self {
         match self {
             Payload::InQuorumStore(proof_with_status) => Payload::InQuorumStoreWithLimit(
                 ProofWithDataWithTxnLimit::new(proof_with_status, max_txns_to_execute),
@@ -234,10 +243,23 @@ impl Payload {
                 panic!("Payload is in direct mempool format");
             },
             Payload::OptQuorumStore(mut opt_qs_payload) => {
-                opt_qs_payload.set_execution_limit(PayloadExecutionLimit::max_txns_to_execute(
-                    max_txns_to_execute,
+                opt_qs_payload.set_execution_limit(PayloadExecutionLimit::TxnAndGasLimits(
+                    TxnAndGasLimits {
+                        transaction_limit: max_txns_to_execute,
+                        gas_limit: block_gas_limit_override,
+                    },
                 ));
                 Payload::OptQuorumStore(opt_qs_payload)
+            },
+            Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
+                Payload::QuorumStoreInlineHybridV2(
+                    inline_batches,
+                    proof_with_data,
+                    PayloadExecutionLimit::TxnAndGasLimits(TxnAndGasLimits {
+                        transaction_limit: max_txns_to_execute,
+                        gas_limit: block_gas_limit_override,
+                    }),
+                )
             },
         }
     }
@@ -263,7 +285,8 @@ impl Payload {
                 // where we prepare the block from the payload
                 proof_with_status.proof_with_data.len()
             },
-            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+            | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 proof_with_data.len()
                     + inline_batches
                         .iter()
@@ -299,6 +322,16 @@ impl Payload {
                 let max_txns_to_execute = opt_qs_payload.max_txns_to_execute().unwrap_or(u64::MAX);
                 num_txns.min(max_txns_to_execute)
             },
+            Payload::QuorumStoreInlineHybridV2(
+                inline_batches,
+                proof_with_data,
+                execution_limit,
+            ) => ((proof_with_data.len()
+                + inline_batches
+                    .iter()
+                    .map(|(_, txns)| txns.len())
+                    .sum::<usize>()) as u64)
+                .min(execution_limit.max_txns_to_execute().unwrap_or(u64::MAX)),
         }
     }
 
@@ -309,7 +342,8 @@ impl Payload {
             Payload::InQuorumStoreWithLimit(proof_with_status) => {
                 proof_with_status.proof_with_data.proofs.is_empty()
             },
-            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+            | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 proof_with_data.proofs.is_empty() && inline_batches.is_empty()
             },
             Payload::OptQuorumStore(opt_qs_payload) => opt_qs_payload.is_empty(),
@@ -342,8 +376,20 @@ impl Payload {
                 let mut p3 = p1;
                 p3.extend(p2);
                 // TODO: What's the right logic here?
-                let m3 = sum_max_txns_to_execute(m1, m2);
+                let m3 = sum_options(m1, m2);
                 Payload::QuorumStoreInlineHybrid(b3, p3, m3)
+            },
+            (
+                Payload::QuorumStoreInlineHybridV2(b1, p1, l1),
+                Payload::QuorumStoreInlineHybridV2(b2, p2, l2),
+            ) => {
+                let mut b3 = b1;
+                b3.extend(b2);
+                let mut p3 = p1;
+                p3.extend(p2);
+                let mut l3 = l1.clone();
+                l3.extend(l2);
+                Payload::QuorumStoreInlineHybridV2(b3, p3, l3)
             },
             (Payload::QuorumStoreInlineHybrid(b1, p1, m1), Payload::InQuorumStore(p2)) => {
                 // TODO: How to update m1?
@@ -351,32 +397,81 @@ impl Payload {
                 p3.extend(p2);
                 Payload::QuorumStoreInlineHybrid(b1, p3, m1)
             },
+            (Payload::QuorumStoreInlineHybridV2(b1, p1, l1), Payload::InQuorumStore(p2)) => {
+                // TODO: How to update m1?
+                let mut p3 = p1;
+                p3.extend(p2);
+                Payload::QuorumStoreInlineHybridV2(b1, p3, l1)
+            },
             (Payload::QuorumStoreInlineHybrid(b1, p1, m1), Payload::InQuorumStoreWithLimit(p2)) => {
                 // TODO: What's the right logic here?
-                let m3 = sum_max_txns_to_execute(m1, p2.max_txns_to_execute);
+                let m3 = sum_options(m1, p2.max_txns_to_execute);
                 let mut p3 = p1;
                 p3.extend(p2.proof_with_data);
                 Payload::QuorumStoreInlineHybrid(b1, p3, m3)
+            },
+            (
+                Payload::QuorumStoreInlineHybridV2(b1, p1, l1),
+                Payload::InQuorumStoreWithLimit(p2),
+            ) => {
+                // TODO: What's the right logic here?
+                let m3 = sum_options(l1.max_txns_to_execute(), p2.max_txns_to_execute);
+                let g3 = l1.block_gas_limit();
+                let l3 = PayloadExecutionLimit::TxnAndGasLimits(TxnAndGasLimits {
+                    transaction_limit: m3,
+                    gas_limit: g3,
+                });
+                let mut p3 = p1;
+                p3.extend(p2.proof_with_data);
+                Payload::QuorumStoreInlineHybridV2(b1, p3, l3)
             },
             (Payload::InQuorumStore(p1), Payload::QuorumStoreInlineHybrid(b2, p2, m2)) => {
                 let mut p3 = p1;
                 p3.extend(p2);
                 Payload::QuorumStoreInlineHybrid(b2, p3, m2)
             },
+            (Payload::InQuorumStore(p1), Payload::QuorumStoreInlineHybridV2(b2, p2, l2)) => {
+                let mut p3 = p1;
+                p3.extend(p2);
+                Payload::QuorumStoreInlineHybridV2(b2, p3, l2)
+            },
             (Payload::InQuorumStoreWithLimit(p1), Payload::QuorumStoreInlineHybrid(b2, p2, m2)) => {
                 // TODO: What's the right logic here?
-                let m3 = sum_max_txns_to_execute(p1.max_txns_to_execute, m2);
+                let m3 = sum_options(p1.max_txns_to_execute, m2);
                 let mut p3 = p1.proof_with_data;
                 p3.extend(p2);
                 Payload::QuorumStoreInlineHybrid(b2, p3, m3)
             },
             (
-                Payload::QuorumStoreInlineHybrid(_inline_batches, _proofs, _limit),
+                Payload::InQuorumStoreWithLimit(p1),
+                Payload::QuorumStoreInlineHybridV2(b2, p2, l2),
+            ) => {
+                // TODO: What's the right logic here?
+                let m3 = sum_options(p1.max_txns_to_execute, l2.max_txns_to_execute());
+                let g3 = l2.block_gas_limit();
+                let l3 = PayloadExecutionLimit::TxnAndGasLimits(TxnAndGasLimits {
+                    transaction_limit: m3,
+                    gas_limit: g3,
+                });
+                let mut p3 = p1.proof_with_data;
+                p3.extend(p2);
+                Payload::QuorumStoreInlineHybridV2(b2, p3, l3)
+            },
+            (
+                Payload::QuorumStoreInlineHybrid(_inline_batches, _proofs, _),
                 Payload::OptQuorumStore(_opt_qs),
             )
             | (
                 Payload::OptQuorumStore(_opt_qs),
-                Payload::QuorumStoreInlineHybrid(_inline_batches, _proofs, _limit),
+                Payload::QuorumStoreInlineHybrid(_inline_batches, _proofs, _),
+            )
+            | (
+                Payload::QuorumStoreInlineHybridV2(_inline_batches, _proofs, _),
+                Payload::OptQuorumStore(_opt_qs),
+            )
+            | (
+                Payload::OptQuorumStore(_opt_qs),
+                Payload::QuorumStoreInlineHybridV2(_inline_batches, _proofs, _),
             ) => {
                 unimplemented!(
                     "Cannot extend OptQuorumStore with QuorumStoreInlineHybrid or viceversa"
@@ -410,7 +505,8 @@ impl Payload {
             Payload::InQuorumStoreWithLimit(proof_with_status) => {
                 proof_with_status.proof_with_data.num_bytes()
             },
-            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+            | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 proof_with_data.num_bytes()
                     + inline_batches
                         .iter()
@@ -490,7 +586,8 @@ impl Payload {
                 verifier,
                 proof_cache,
             ),
-            (true, Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)) => {
+            (true, Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _))
+            | (true, Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _)) => {
                 Self::verify_with_cache(&proof_with_data.proofs, verifier, proof_cache)?;
                 Self::verify_inline_batches(
                     inline_batches.iter().map(|(info, txns)| (info, txns)),
@@ -536,7 +633,8 @@ impl Payload {
                     "Payload epoch doesn't match given epoch"
                 );
             },
-            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+            | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 ensure!(
                     proof_with_data.proofs.iter().all(|p| p.epoch() == epoch),
                     "Payload proof epoch doesn't match given epoch"
@@ -570,7 +668,8 @@ impl fmt::Display for Payload {
                     proof_with_status.proof_with_data.proofs.len()
                 )
             },
-            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+            | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 write!(
                     f,
                     "Inline txns: {}, InMemory proofs: {}",
@@ -683,7 +782,8 @@ impl From<&Vec<&Payload>> for PayloadFilter {
                             exclude_batches.insert(proof.info().clone());
                         }
                     },
-                    Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+                    Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+                    | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                         for proof in &proof_with_data.proofs {
                             exclude_batches.insert(proof.info().clone());
                         }

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -518,6 +518,5 @@ pub struct ExecutionSummary {
     pub to_retry: u64,
     pub execution_time: Duration,
     pub root_hash: HashValue,
-    // TODO: when is it None?
     pub gas_used: Option<u64>,
 }

--- a/consensus/consensus-types/src/pipelined_block.rs
+++ b/consensus/consensus-types/src/pipelined_block.rs
@@ -68,7 +68,7 @@ impl From<Error> for TaskError {
 pub type TaskResult<T> = Result<T, TaskError>;
 pub type TaskFuture<T> = Shared<BoxFuture<'static, TaskResult<T>>>;
 
-pub type PrepareResult = Arc<Vec<SignatureVerifiedTransaction>>;
+pub type PrepareResult = (Arc<Vec<SignatureVerifiedTransaction>>, Option<u64>);
 pub type ExecuteResult = Duration;
 pub type LedgerUpdateResult = (StateComputeResult, Duration, Option<u64>);
 pub type PostLedgerUpdateResult = ();
@@ -227,6 +227,12 @@ impl PipelinedBlock {
             to_retry,
             execution_time,
             root_hash: self.state_compute_result.root_hash(),
+            gas_used: self
+                .state_compute_result
+                .execution_output
+                .block_end_info
+                .as_ref()
+                .map(|info| info.block_effective_gas_units()),
         };
 
         // We might be retrying execution, so it might have already been set.
@@ -512,4 +518,6 @@ pub struct ExecutionSummary {
     pub to_retry: u64,
     pub execution_time: Duration,
     pub root_hash: HashValue,
+    // TODO: when is it None?
+    pub gas_used: Option<u64>,
 }

--- a/consensus/src/block_preparer.rs
+++ b/consensus/src/block_preparer.rs
@@ -41,7 +41,7 @@ impl BlockPreparer {
         &self,
         block: &Block,
         block_qc_fut: Shared<impl Future<Output = Option<Arc<QuorumCert>>>>,
-    ) -> ExecutorResult<Vec<SignedTransaction>> {
+    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
         fail_point!("consensus::prepare_block", |_| {
             use aptos_executor_types::ExecutorError;
             use std::{thread, time::Duration};
@@ -50,7 +50,7 @@ impl BlockPreparer {
         });
         let start_time = Instant::now();
 
-        let (txns, max_txns_from_block_to_execute) = tokio::select! {
+        let (txns, max_txns_from_block_to_execute, block_gas_limit) = tokio::select! {
                 // Poll the block qc future until a QC is received. Ignore None outcomes.
                 Some(qc) = block_qc_fut => {
                     let block_voters = Some(qc.ledger_info().get_voters_bitvec().clone());
@@ -84,6 +84,6 @@ impl BlockPreparer {
         .await
         .expect("Failed to spawn blocking task for transaction generation");
         counters::BLOCK_PREPARER_LATENCY.observe_duration(start_time.elapsed());
-        result
+        result.map(|result| (result, block_gas_limit))
     }
 }

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -1101,6 +1101,7 @@ mod test {
                 vec![],
                 proofs_of_store.clone(),
                 None,
+                None,
                 vec![],
             );
 

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -1103,6 +1103,7 @@ mod test {
                 None,
                 None,
                 vec![],
+                true,
             );
 
             // Insert the block payload into the store

--- a/consensus/src/consensus_observer/publisher/consensus_publisher.rs
+++ b/consensus/src/consensus_observer/publisher/consensus_publisher.rs
@@ -543,6 +543,7 @@ mod test {
             vec![],
             vec![],
             Some(10),
+            Some(10_000),
             vec![],
         );
         let block_payload_message = ConsensusObserverMessage::new_block_payload_message(

--- a/consensus/src/consensus_observer/publisher/consensus_publisher.rs
+++ b/consensus/src/consensus_observer/publisher/consensus_publisher.rs
@@ -545,6 +545,7 @@ mod test {
             Some(10),
             Some(10_000),
             vec![],
+            true,
         );
         let block_payload_message = ConsensusObserverMessage::new_block_payload_message(
             BlockInfo::empty(),

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -35,6 +35,13 @@ pub const TXN_COMMIT_FAILED_EXPIRED_LABEL: &str = "failed_expired";
 /// Transaction commit was unsuccessful, but will be retried
 pub const TXN_COMMIT_RETRY_LABEL: &str = "retry";
 
+fn gas_buckets() -> Vec<f64> {
+    exponential_buckets(
+        /*start=*/ 1.0, /*factor=*/ 1.5, /*count=*/ 30,
+    )
+    .unwrap()
+}
+
 //////////////////////
 // HEALTH COUNTERS
 //////////////////////
@@ -388,6 +395,16 @@ pub static PROPOSER_ESTIMATED_CALIBRATED_BLOCK_TXNS: Lazy<Histogram> = Lazy::new
         "aptos_proposer_estimated_calibrated_block_txns",
         "Histogram for max number of transactions calibrated block should have, based on the proposer",
         NUM_CONSENSUS_TRANSACTIONS_BUCKETS.to_vec()
+    )
+    .unwrap()
+});
+
+/// Histogram for max gas calibrated block should have, based on the proposer
+pub static PROPOSER_ESTIMATED_CALIBRATED_BLOCK_GAS: Lazy<Histogram> = Lazy::new(|| {
+    register_histogram!(
+        "aptos_proposer_estimated_calibrated_block_gas",
+        "Histogram for max gas calibrated block should have, based on the proposer",
+        gas_buckets()
     )
     .unwrap()
 });

--- a/consensus/src/dag/tests/helpers.rs
+++ b/consensus/src/dag/tests/helpers.rs
@@ -35,8 +35,8 @@ impl TPayloadManager for MockPayloadManager {
         &self,
         _block: &Block,
         _block_signers: Option<BitVec>,
-    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
-        Ok((Vec::new(), None))
+    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)> {
+        Ok((Vec::new(), None, None))
     }
 }
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -914,6 +914,10 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             onchain_consensus_config.max_failed_authors_to_store(),
             self.config
                 .min_max_txns_in_block_after_filtering_from_backpressure,
+            onchain_execution_config
+                .block_executor_onchain_config()
+                .block_gas_limit_type
+                .block_gas_limit(),
             pipeline_backpressure_config,
             chain_health_backoff_config,
             self.quorum_store_enabled,

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -186,6 +186,15 @@ impl PipelineBackpressureConfig {
         }
     }
 
+    /// TODO: disable txn limit backoff and use only gas limit based backoff once execution pool is deployed.
+    ///
+    /// Until then, we need to compute wanted block size to create.
+    /// Unfortunately, there is multiple layers where transactions are filtered.
+    /// After deduping/reordering logic is applied, max_txns_to_execute limits the transactions
+    /// passed to executor (`summary.payload_len` here), and then some are discarded for various
+    /// reasons, which we approximate are cheaply ignored.
+    /// For the rest, only `summary.to_commit` fraction of `summary.to_commit + summary.to_retry`
+    /// was executed. And so assuming same discard rate, we scale `summary.payload_len` with it.
     fn get_execution_block_size_backoff(
         &self,
         block_execution_times: &[ExecutionSummary],
@@ -242,6 +251,10 @@ impl PipelineBackpressureConfig {
         })
     }
 
+    /// TODO: once execution pool is deployed, enable gas limit based backoff in execution (via onchain config).
+    ///
+    /// Until it is enabled in execution, the printed log is useful for auditing and calibrating
+    /// the computed backoff.
     fn get_execution_gas_limit_backoff(
         &self,
         block_execution_times: &[ExecutionSummary],

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -25,6 +25,8 @@ use aptos_types::{on_chain_config::ValidatorTxnConfig, validator_signer::Validat
 use futures::{future::BoxFuture, FutureExt};
 use std::{sync::Arc, time::Duration};
 
+const MAX_BLOCK_GAS_LIMIT: u64 = 30_000;
+
 fn empty_callback() -> BoxFuture<'static, ()> {
     async move {}.boxed()
 }
@@ -52,6 +54,7 @@ async fn test_proposal_generation_empty_tree() {
         PayloadTxnsSize::new(1, 10),
         10,
         1,
+        Some(MAX_BLOCK_GAS_LIMIT),
         PipelineBackpressureConfig::new_no_backoff(),
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
@@ -98,6 +101,7 @@ async fn test_proposal_generation_parent() {
         PayloadTxnsSize::new(1, 500),
         10,
         1,
+        Some(MAX_BLOCK_GAS_LIMIT),
         PipelineBackpressureConfig::new_no_backoff(),
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
@@ -174,6 +178,7 @@ async fn test_old_proposal_generation() {
         PayloadTxnsSize::new(1, 500),
         10,
         1,
+        Some(MAX_BLOCK_GAS_LIMIT),
         PipelineBackpressureConfig::new_no_backoff(),
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
@@ -215,6 +220,7 @@ async fn test_correct_failed_authors() {
         PayloadTxnsSize::new(1, 500),
         10,
         1,
+        Some(MAX_BLOCK_GAS_LIMIT),
         PipelineBackpressureConfig::new_no_backoff(),
         ChainHealthBackoffConfig::new_no_backoff(),
         false,

--- a/consensus/src/payload_manager/co_payload_manager.rs
+++ b/consensus/src/payload_manager/co_payload_manager.rs
@@ -29,7 +29,7 @@ async fn get_transactions_for_observer(
     block: &Block,
     block_payloads: &Arc<Mutex<BTreeMap<(u64, Round), BlockPayloadStatus>>>,
     consensus_publisher: &Option<Arc<ConsensusPublisher>>,
-) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
+) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)> {
     // The data should already be available (as consensus observer will only ever
     // forward a block to the executor once the data has been received and verified).
     let block_payload = match block_payloads.lock().entry((block.epoch(), block.round())) {
@@ -70,6 +70,7 @@ async fn get_transactions_for_observer(
     Ok((
         transaction_payload.transactions(),
         transaction_payload.transaction_limit(),
+        transaction_payload.gas_limit(),
     ))
 }
 
@@ -104,8 +105,7 @@ impl TPayloadManager for ConsensusObserverPayloadManager {
         &self,
         block: &Block,
         _block_signers: Option<BitVec>,
-    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
-        return get_transactions_for_observer(block, &self.txns_pool, &self.consensus_publisher)
-            .await;
+    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)> {
+        get_transactions_for_observer(block, &self.txns_pool, &self.consensus_publisher).await
     }
 }

--- a/consensus/src/payload_manager/direct_mempool_payload_manager.rs
+++ b/consensus/src/payload_manager/direct_mempool_payload_manager.rs
@@ -34,13 +34,13 @@ impl TPayloadManager for DirectMempoolPayloadManager {
         &self,
         block: &Block,
         _block_signers: Option<BitVec>,
-    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
+    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)> {
         let Some(payload) = block.payload() else {
-            return Ok((Vec::new(), None));
+            return Ok((Vec::new(), None, None));
         };
 
         match payload {
-            Payload::DirectMempool(txns) => Ok((txns.clone(), None)),
+            Payload::DirectMempool(txns) => Ok((txns.clone(), None, None)),
             _ => unreachable!(
                 "DirectMempoolPayloadManager: Unacceptable payload type {}. Epoch: {}, Round: {}, Block: {}",
                 payload,

--- a/consensus/src/payload_manager/mod.rs
+++ b/consensus/src/payload_manager/mod.rs
@@ -40,5 +40,5 @@ pub trait TPayloadManager: Send + Sync {
         &self,
         block: &Block,
         block_voters: Option<BitVec>,
-    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)>;
+    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)>;
 }

--- a/consensus/src/payload_manager/quorum_store_payload_manager.rs
+++ b/consensus/src/payload_manager/quorum_store_payload_manager.rs
@@ -63,6 +63,7 @@ pub struct QuorumStorePayloadManager {
     maybe_consensus_publisher: Option<Arc<ConsensusPublisher>>,
     ordered_authors: Vec<PeerId>,
     address_to_validator_index: HashMap<PeerId, usize>,
+    enable_payload_v2: bool,
 }
 
 impl QuorumStorePayloadManager {
@@ -72,6 +73,7 @@ impl QuorumStorePayloadManager {
         maybe_consensus_publisher: Option<Arc<ConsensusPublisher>>,
         ordered_authors: Vec<PeerId>,
         address_to_validator_index: HashMap<PeerId, usize>,
+        enable_payload_v2: bool,
     ) -> Self {
         Self {
             batch_reader,
@@ -79,6 +81,7 @@ impl QuorumStorePayloadManager {
             maybe_consensus_publisher,
             ordered_authors,
             address_to_validator_index,
+            enable_payload_v2,
         }
     }
 
@@ -154,6 +157,7 @@ impl QuorumStorePayloadManager {
             *max_txns_to_execute,
             *block_gas_limit_override,
             inline_batches,
+            self.enable_payload_v2,
         ))
     }
 }

--- a/consensus/src/payload_manager/quorum_store_payload_manager.rs
+++ b/consensus/src/payload_manager/quorum_store_payload_manager.rs
@@ -118,6 +118,46 @@ impl QuorumStorePayloadManager {
     }
 }
 
+impl QuorumStorePayloadManager {
+    async fn get_transactions_quorum_store_inline_hybrid(
+        &self,
+        block: &Block,
+        inline_batches: &[(BatchInfo, Vec<SignedTransaction>)],
+        proof_with_data: &ProofWithData,
+        max_txns_to_execute: &Option<u64>,
+        block_gas_limit_override: &Option<u64>,
+    ) -> ExecutorResult<BlockTransactionPayload> {
+        let all_transactions = {
+            let mut all_txns = process_qs_payload(
+                proof_with_data,
+                self.batch_reader.clone(),
+                block,
+                &self.ordered_authors,
+            )
+            .await?;
+            all_txns.append(
+                &mut inline_batches
+                    .iter()
+                    // TODO: Can clone be avoided here?
+                    .flat_map(|(_batch_info, txns)| txns.clone())
+                    .collect(),
+            );
+            all_txns
+        };
+        let inline_batches = inline_batches
+            .iter()
+            .map(|(batch_info, _)| batch_info.clone())
+            .collect();
+        Ok(BlockTransactionPayload::new_quorum_store_inline_hybrid(
+            all_transactions,
+            proof_with_data.proofs.clone(),
+            *max_txns_to_execute,
+            *block_gas_limit_override,
+            inline_batches,
+        ))
+    }
+}
+
 #[async_trait]
 impl TPayloadManager for QuorumStorePayloadManager {
     fn notify_commit(&self, block_timestamp: u64, payloads: Vec<Payload>) {
@@ -141,7 +181,8 @@ impl TPayloadManager for QuorumStorePayloadManager {
                     .iter()
                     .map(|proof| proof.info().clone())
                     .collect::<Vec<_>>(),
-                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+                | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                     inline_batches
                         .iter()
                         .map(|(batch_info, _)| batch_info.clone())
@@ -218,7 +259,8 @@ impl TPayloadManager for QuorumStorePayloadManager {
                     self.batch_reader.clone(),
                 );
             },
-            Payload::QuorumStoreInlineHybrid(_, proof_with_data, _) => {
+            Payload::QuorumStoreInlineHybrid(_, proof_with_data, _)
+            | Payload::QuorumStoreInlineHybridV2(_, proof_with_data, _) => {
                 request_txns_and_update_status(proof_with_data, self.batch_reader.clone());
             },
             Payload::DirectMempool(_) => {
@@ -254,7 +296,8 @@ impl TPayloadManager for QuorumStorePayloadManager {
             },
             Payload::InQuorumStore(_) => Ok(()),
             Payload::InQuorumStoreWithLimit(_) => Ok(()),
-            Payload::QuorumStoreInlineHybrid(inline_batches, proofs, _) => {
+            Payload::QuorumStoreInlineHybrid(inline_batches, proofs, _)
+            | Payload::QuorumStoreInlineHybridV2(inline_batches, proofs, _) => {
                 fn update_availability_metrics<'a>(
                     batch_reader: &Arc<dyn BatchReader>,
                     is_proof_label: &str,
@@ -326,9 +369,9 @@ impl TPayloadManager for QuorumStorePayloadManager {
         &self,
         block: &Block,
         block_signers: Option<BitVec>,
-    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>)> {
+    ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)> {
         let Some(payload) = block.payload() else {
-            return Ok((Vec::new(), None));
+            return Ok((Vec::new(), None, None));
         };
 
         let transaction_payload = match payload {
@@ -364,33 +407,28 @@ impl TPayloadManager for QuorumStorePayloadManager {
                 proof_with_data,
                 max_txns_to_execute,
             ) => {
-                let all_transactions = {
-                    let mut all_txns = process_qs_payload(
-                        proof_with_data,
-                        self.batch_reader.clone(),
-                        block,
-                        &self.ordered_authors,
-                    )
-                    .await?;
-                    all_txns.append(
-                        &mut inline_batches
-                            .iter()
-                            // TODO: Can clone be avoided here?
-                            .flat_map(|(_batch_info, txns)| txns.clone())
-                            .collect(),
-                    );
-                    all_txns
-                };
-                let inline_batches = inline_batches
-                    .iter()
-                    .map(|(batch_info, _)| batch_info.clone())
-                    .collect();
-                BlockTransactionPayload::new_quorum_store_inline_hybrid(
-                    all_transactions,
-                    proof_with_data.proofs.clone(),
-                    *max_txns_to_execute,
+                self.get_transactions_quorum_store_inline_hybrid(
+                    block,
                     inline_batches,
+                    proof_with_data,
+                    max_txns_to_execute,
+                    &None,
                 )
+                .await?
+            },
+            Payload::QuorumStoreInlineHybridV2(
+                inline_batches,
+                proof_with_data,
+                execution_limits,
+            ) => {
+                self.get_transactions_quorum_store_inline_hybrid(
+                    block,
+                    inline_batches,
+                    proof_with_data,
+                    &execution_limits.max_txns_to_execute(),
+                    &execution_limits.block_gas_limit(),
+                )
+                .await?
             },
             Payload::OptQuorumStore(opt_qs_payload) => {
                 let opt_batch_txns = process_optqs_payload(
@@ -442,6 +480,7 @@ impl TPayloadManager for QuorumStorePayloadManager {
         Ok((
             transaction_payload.transactions(),
             transaction_payload.transaction_limit(),
+            transaction_payload.gas_limit(),
         ))
     }
 }

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -34,6 +34,7 @@ pub struct ProofManager {
     back_pressure_total_proof_limit: u64,
     remaining_total_proof_num: u64,
     allow_batches_without_pos_in_proposal: bool,
+    enable_payload_v2: bool,
 }
 
 impl ProofManager {
@@ -43,6 +44,7 @@ impl ProofManager {
         back_pressure_total_proof_limit: u64,
         batch_store: Arc<BatchStore>,
         allow_batches_without_pos_in_proposal: bool,
+        enable_payload_v2: bool,
         batch_expiry_gap_when_init_usecs: u64,
     ) -> Self {
         Self {
@@ -56,6 +58,7 @@ impl ProofManager {
             back_pressure_total_proof_limit,
             remaining_total_proof_num: 0,
             allow_batches_without_pos_in_proposal,
+            enable_payload_v2,
         }
     }
 
@@ -199,7 +202,19 @@ impl ProofManager {
                 proof_block.len(),
                 inline_block.len()
             );
-            Payload::QuorumStoreInlineHybrid(inline_block, ProofWithData::new(proof_block), None)
+            if self.enable_payload_v2 {
+                Payload::QuorumStoreInlineHybridV2(
+                    inline_block,
+                    ProofWithData::new(proof_block),
+                    PayloadExecutionLimit::None,
+                )
+            } else {
+                Payload::QuorumStoreInlineHybrid(
+                    inline_block,
+                    ProofWithData::new(proof_block),
+                    None,
+                )
+            }
         };
 
         let res = GetPayloadResponse::GetPayloadResponse(response);

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -448,6 +448,7 @@ impl InnerBuilder {
                 consensus_publisher,
                 self.verifier.get_ordered_account_addresses(),
                 self.verifier.address_to_validator_index().clone(),
+                self.config.enable_payload_v2,
             )),
             Some(self.quorum_store_msg_tx.clone()),
         )

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -365,6 +365,7 @@ impl InnerBuilder {
                 * self.num_validators,
             self.batch_store.clone().unwrap(),
             self.config.allow_batches_without_pos_in_proposal,
+            self.config.enable_payload_v2,
             self.config.batch_expiry_gap_when_init_usecs,
         );
         spawn_named!(

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -178,6 +178,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         PayloadTxnsSize::new(1, 1024),
         10,
         1,
+        Some(30_000),
         PipelineBackpressureConfig::new_no_backoff(),
         ChainHealthBackoffConfig::new_no_backoff(),
         false,

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -312,6 +312,7 @@ impl NodeSetup {
             PayloadTxnsSize::new(5, 500),
             10,
             1,
+            Some(30_000),
             PipelineBackpressureConfig::new_no_backoff(),
             ChainHealthBackoffConfig::new_no_backoff(),
             false,

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -75,7 +75,7 @@ impl MockExecutionClient {
                 .lock()
                 .remove(&block.id())
                 .ok_or_else(|| format_err!("Cannot find block"))?;
-            let (mut payload_txns, _max_txns_from_block_to_execute) = self
+            let (mut payload_txns, _max_txns_from_block_to_execute, _block_gas_limit) = self
                 .payload_manager
                 .get_transactions(block.block(), None)
                 .await?;

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -101,7 +101,8 @@ pub fn extract_txns_from_block<'a>(
                     .map(|proof| *proof.digest()),
                 all_batches,
             ),
-            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _) => {
+            Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
+            | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 let mut all_txns = extract_txns_from_quorum_store(
                     proof_with_data.proofs.iter().map(|proof| *proof.digest()),
                     all_batches,

--- a/testsuite/forge-cli/src/suites/dag.rs
+++ b/testsuite/forge-cli/src/suites/dag.rs
@@ -115,6 +115,10 @@ fn dag_realistic_env_max_load_test(
                     config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
                     config_v4.transaction_shuffler_type = TransactionShufflerType::default_for_genesis();
                 }
+                OnChainExecutionConfig::V5(config_v5) => {
+                    config_v5.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                    config_v5.transaction_shuffler_type = TransactionShufflerType::default_for_genesis();
+                }
             }
             helm_values["chain"]["on_chain_execution_config"] =
                 serde_yaml::to_value(on_chain_execution_config).expect("must serialize");
@@ -215,6 +219,9 @@ fn dag_reconfig_enable_test() -> ForgeConfig {
                     }
                     OnChainExecutionConfig::V4(config_v4) => {
                         config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                    }
+                    OnChainExecutionConfig::V5(config_v5) => {
+                        config_v5.block_gas_limit_type = BlockGasLimitType::NoLimit;
                     }
             }
             helm_values["chain"]["on_chain_execution_config"] =

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -441,6 +441,10 @@ pub(crate) fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                         config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
                         config_v4.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
                     }
+                    OnChainExecutionConfig::V5(config_v5) => {
+                        config_v5.block_gas_limit_type = BlockGasLimitType::NoLimit;
+                        config_v5.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
+                    }
                 }
                 helm_values["chain"]["on_chain_execution_config"] =
                     serde_yaml::to_value(on_chain_execution_config).expect("must serialize");

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -794,6 +794,16 @@ Payload:
       OptQuorumStore:
         NEWTYPE:
           TYPENAME: OptQuorumStorePayload
+    5:
+      QuorumStoreInlineHybridV2:
+        TUPLE:
+          - SEQ:
+              TUPLE:
+                - TYPENAME: BatchInfo
+                - SEQ:
+                    TYPENAME: SignedTransaction
+          - TYPENAME: ProofWithData
+          - TYPENAME: PayloadExecutionLimit
 PayloadExecutionLimit:
   ENUM:
     0:
@@ -801,6 +811,10 @@ PayloadExecutionLimit:
     1:
       MaxTransactionsToExecute:
         NEWTYPE: U64
+    2:
+      TxnAndGasLimits:
+        NEWTYPE:
+          TYPENAME: TxnAndGasLimits
 Pepper:
   NEWTYPESTRUCT:
     TUPLEARRAY:
@@ -1171,6 +1185,12 @@ TwoChainTimeoutCertificate:
         TYPENAME: TwoChainTimeout
     - signatures_with_rounds:
         TYPENAME: AggregateSignatureWithRounds
+TxnAndGasLimits:
+  STRUCT:
+    - transaction_limit:
+        OPTION: U64
+    - gas_limit:
+        OPTION: U64
 TypeTag:
   ENUM:
     0:

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -63,12 +63,24 @@ impl BlockExecutorLocalConfig {
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct BlockExecutorConfigFromOnchain {
     pub block_gas_limit_type: BlockGasLimitType,
+    enable_per_block_gas_limit: bool,
+    per_block_gas_limit: Option<u64>,
 }
 
 impl BlockExecutorConfigFromOnchain {
+    pub fn new(block_gas_limit_type: BlockGasLimitType, enable_per_block_gas_limit: bool) -> Self {
+        Self {
+            block_gas_limit_type,
+            enable_per_block_gas_limit,
+            per_block_gas_limit: None,
+        }
+    }
+
     pub fn new_no_block_limit() -> Self {
         Self {
             block_gas_limit_type: BlockGasLimitType::NoLimit,
+            enable_per_block_gas_limit: false,
+            per_block_gas_limit: None,
         }
     }
 
@@ -76,6 +88,8 @@ impl BlockExecutorConfigFromOnchain {
         Self {
             block_gas_limit_type: maybe_block_gas_limit
                 .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
+            enable_per_block_gas_limit: false,
+            per_block_gas_limit: None,
         }
     }
 
@@ -94,6 +108,24 @@ impl BlockExecutorConfigFromOnchain {
                     add_block_limit_outcome_onchain: false,
                     use_granular_resource_group_conflicts: false,
                 },
+            enable_per_block_gas_limit: false,
+            per_block_gas_limit: None,
+        }
+    }
+
+    pub fn with_block_gas_limit_override(self, block_gas_limit_override: Option<u64>) -> Self {
+        Self {
+            block_gas_limit_type: self.block_gas_limit_type,
+            enable_per_block_gas_limit: self.enable_per_block_gas_limit,
+            per_block_gas_limit: block_gas_limit_override,
+        }
+    }
+
+    pub fn block_gas_limit_override(&self) -> Option<u64> {
+        if self.enable_per_block_gas_limit {
+            self.per_block_gas_limit
+        } else {
+            None
         }
     }
 }

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -18,6 +18,7 @@ pub enum OnChainExecutionConfig {
     Missing,
     // Reminder: Add V4 and future versions here, after Missing (order matters for enums).
     V4(ExecutionConfigV4),
+    V5(ExecutionConfigV5),
 }
 
 /// The public interface that exposes all values with safe fallback.
@@ -30,6 +31,7 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V2(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V3(config) => config.transaction_shuffler_type.clone(),
             OnChainExecutionConfig::V4(config) => config.transaction_shuffler_type.clone(),
+            OnChainExecutionConfig::V5(config) => config.transaction_shuffler_type.clone(),
         }
     }
 
@@ -45,13 +47,26 @@ impl OnChainExecutionConfig {
                 .block_gas_limit
                 .map_or(BlockGasLimitType::NoLimit, BlockGasLimitType::Limit),
             OnChainExecutionConfig::V4(config) => config.block_gas_limit_type.clone(),
+            OnChainExecutionConfig::V5(config) => config.block_gas_limit_type.clone(),
+        }
+    }
+
+    pub fn enable_per_block_gas_limit(&self) -> bool {
+        match &self {
+            OnChainExecutionConfig::Missing
+            | OnChainExecutionConfig::V1(_)
+            | OnChainExecutionConfig::V2(_)
+            | OnChainExecutionConfig::V3(_)
+            | OnChainExecutionConfig::V4(_) => false,
+            OnChainExecutionConfig::V5(config) => config.enable_per_block_gas_limit,
         }
     }
 
     pub fn block_executor_onchain_config(&self) -> BlockExecutorConfigFromOnchain {
-        BlockExecutorConfigFromOnchain {
-            block_gas_limit_type: self.block_gas_limit_type(),
-        }
+        BlockExecutorConfigFromOnchain::new(
+            self.block_gas_limit_type(),
+            self.enable_per_block_gas_limit(),
+        )
     }
 
     /// The type of the transaction deduper being used.
@@ -63,15 +78,17 @@ impl OnChainExecutionConfig {
             OnChainExecutionConfig::V2(_config) => TransactionDeduperType::NoDedup,
             OnChainExecutionConfig::V3(config) => config.transaction_deduper_type.clone(),
             OnChainExecutionConfig::V4(config) => config.transaction_deduper_type.clone(),
+            OnChainExecutionConfig::V5(config) => config.transaction_deduper_type.clone(),
         }
     }
 
     /// The default values to use for new networks, e.g., devnet, forge.
     /// Features that are ready for deployment can be enabled here.
     pub fn default_for_genesis() -> Self {
-        OnChainExecutionConfig::V4(ExecutionConfigV4 {
+        OnChainExecutionConfig::V5(ExecutionConfigV5 {
             transaction_shuffler_type: TransactionShufflerType::default_for_genesis(),
             block_gas_limit_type: BlockGasLimitType::default_for_genesis(),
+            enable_per_block_gas_limit: true,
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         })
     }
@@ -139,6 +156,14 @@ pub struct ExecutionConfigV3 {
 pub struct ExecutionConfigV4 {
     pub transaction_shuffler_type: TransactionShufflerType,
     pub block_gas_limit_type: BlockGasLimitType,
+    pub transaction_deduper_type: TransactionDeduperType,
+}
+
+#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+pub struct ExecutionConfigV5 {
+    pub transaction_shuffler_type: TransactionShufflerType,
+    pub block_gas_limit_type: BlockGasLimitType,
+    pub enable_per_block_gas_limit: bool,
     pub transaction_deduper_type: TransactionDeduperType,
 }
 

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -88,7 +88,7 @@ impl OnChainExecutionConfig {
         OnChainExecutionConfig::V5(ExecutionConfigV5 {
             transaction_shuffler_type: TransactionShufflerType::default_for_genesis(),
             block_gas_limit_type: BlockGasLimitType::default_for_genesis(),
-            enable_per_block_gas_limit: true,
+            enable_per_block_gas_limit: false,
             transaction_deduper_type: TransactionDeduperType::TxnHashAndAuthenticatorV1,
         })
     }

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -48,4 +48,13 @@ impl BlockEndInfo {
             } => *block_gas_limit_reached || *block_output_limit_reached,
         }
     }
+
+    pub fn block_effective_gas_units(&self) -> u64 {
+        match self {
+            Self::V0 {
+                block_effective_block_gas_units,
+                ..
+            } => *block_effective_block_gas_units,
+        }
+    }
 }


### PR DESCRIPTION
## Description
* Proposers will immediately start computing per-block gas limit and adding to their proposals.
  * The limit uses a mean, with a parameter for per-block overheads.
* Execution actually applying these per-block gas limits is gated by an on-chain execution config. (Default off.)

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
