### PR TITLE
[exec-pool] OnChainConsensusConfig V4

### DIFF
--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -74,6 +74,7 @@ use aptos_types::{
     on_chain_config::{
         ConsensusAlgorithmConfig, ConsensusConfigV1, OnChainConsensusConfig,
         OnChainJWKConsensusConfig, OnChainRandomnessConfig, ValidatorTxnConfig,
+        DEFAULT_WINDOW_SIZE,
     },
     transaction::SignedTransaction,
     validator_signer::ValidatorSigner,
@@ -153,7 +154,7 @@ impl NodeSetup {
         let mut onchain_consensus_config = onchain_consensus_config.unwrap_or_default();
         // With order votes feature, the validators additionally send order votes.
         // next_proposal and next_vote functions could potentially break because of it.
-        if let OnChainConsensusConfig::V3 {
+        if let OnChainConsensusConfig::V4 {
             alg:
                 ConsensusAlgorithmConfig::JolteonV2 {
                     main: _,
@@ -161,6 +162,7 @@ impl NodeSetup {
                     order_vote_enabled,
                 },
             vtxn: _,
+            window_size: _,
         } = &mut onchain_consensus_config
         {
             *order_vote_enabled = false;
@@ -2557,9 +2559,10 @@ fn no_vote_on_proposal_ext_when_receiving_limit_exceeded() {
         runtime.handle().clone(),
         1,
         None,
-        Some(OnChainConsensusConfig::V3 {
+        Some(OnChainConsensusConfig::V4 {
             alg: alg_config,
             vtxn: vtxn_config,
+            window_size: DEFAULT_WINDOW_SIZE,
         }),
         Some(local_config),
         Some(randomness_config),

--- a/testsuite/forge-cli/src/suites/dag.rs
+++ b/testsuite/forge-cli/src/suites/dag.rs
@@ -12,7 +12,7 @@ use aptos_forge::{
 };
 use aptos_sdk::types::on_chain_config::{
     BlockGasLimitType, ConsensusAlgorithmConfig, DagConsensusConfigV1, OnChainConsensusConfig,
-    OnChainExecutionConfig, TransactionShufflerType, ValidatorTxnConfig,
+    OnChainExecutionConfig, TransactionShufflerType, ValidatorTxnConfig, DEFAULT_WINDOW_SIZE,
 };
 use aptos_testcases::{
     consensus_reliability_tests::ChangingWorkingQuorumTest,
@@ -93,9 +93,10 @@ fn dag_realistic_env_max_load_test(
             helm_values["chain"]["epoch_duration_secs"] =
                 (if long_running { 600 } else { 300 }).into();
 
-            let onchain_consensus_config = OnChainConsensusConfig::V3 {
+            let onchain_consensus_config = OnChainConsensusConfig::V4 {
                 alg: ConsensusAlgorithmConfig::DAG(DagConsensusConfigV1::default()),
                 vtxn: ValidatorTxnConfig::default_for_genesis(),
+                window_size: DEFAULT_WINDOW_SIZE
             };
 
             helm_values["chain"]["on_chain_consensus_config"] =
@@ -177,9 +178,10 @@ fn dag_changing_working_quorum_test() -> ForgeConfig {
             helm_values["genesis"]["validator"]["num_validators_with_larger_stake"] =
                 num_large_validators.into();
 
-            let onchain_consensus_config = OnChainConsensusConfig::V3 {
+            let onchain_consensus_config = OnChainConsensusConfig::V4 {
                 alg: ConsensusAlgorithmConfig::DAG(DagConsensusConfigV1::default()),
                 vtxn: ValidatorTxnConfig::default_for_genesis(),
+                window_size: DEFAULT_WINDOW_SIZE,
             };
 
             helm_values["chain"]["on_chain_consensus_config"] =

--- a/testsuite/smoke-test/src/aptos_cli/validator.rs
+++ b/testsuite/smoke-test/src/aptos_cli/validator.rs
@@ -202,6 +202,10 @@ async fn test_onchain_config_change() {
                     alg: ConsensusAlgorithmConfig::Jolteon { main, .. },
                     ..
                 } => main,
+                OnChainConsensusConfig::V4 {
+                    alg: ConsensusAlgorithmConfig::Jolteon { main, .. },
+                    ..
+                } => main,
                 _ => unimplemented!(),
             };
 

--- a/testsuite/smoke-test/src/consensus/dag/dag_fault_tolerance.rs
+++ b/testsuite/smoke-test/src/consensus/dag/dag_fault_tolerance.rs
@@ -14,6 +14,7 @@ use aptos_forge::{
 };
 use aptos_types::on_chain_config::{
     ConsensusAlgorithmConfig, DagConsensusConfigV1, OnChainConsensusConfig, ValidatorTxnConfig,
+    DEFAULT_WINDOW_SIZE,
 };
 use rand::{rngs::SmallRng, Rng, SeedableRng};
 use std::sync::{atomic::AtomicBool, Arc};
@@ -39,9 +40,10 @@ pub async fn create_dag_swarm(num_nodes: usize) -> LocalSwarm {
             }
         }))
         .with_init_genesis_config(Arc::new(move |genesis_config| {
-            let onchain_consensus_config = OnChainConsensusConfig::V3 {
+            let onchain_consensus_config = OnChainConsensusConfig::V4 {
                 alg: ConsensusAlgorithmConfig::DAG(DagConsensusConfigV1::default()),
                 vtxn: ValidatorTxnConfig::default_for_genesis(),
+                window_size: DEFAULT_WINDOW_SIZE,
             };
 
             genesis_config.consensus_config = onchain_consensus_config;

--- a/testsuite/smoke-test/src/consensus_observer.rs
+++ b/testsuite/smoke-test/src/consensus_observer.rs
@@ -13,7 +13,7 @@ use aptos_config::{
 };
 use aptos_forge::{LocalNode, NodeExt, Swarm};
 use aptos_types::on_chain_config::{
-    ConsensusAlgorithmConfig, OnChainConsensusConfig, ValidatorTxnConfig,
+    ConsensusAlgorithmConfig, OnChainConsensusConfig, ValidatorTxnConfig, DEFAULT_WINDOW_SIZE,
 };
 use std::sync::Arc;
 
@@ -117,9 +117,10 @@ async fn test_consensus_observer_fullnode_sync_disable_quorum_store() {
             enable_consensus_observer(true, config);
         }))
         .with_init_genesis_config(Arc::new(|genesis_config| {
-            genesis_config.consensus_config = OnChainConsensusConfig::V3 {
+            genesis_config.consensus_config = OnChainConsensusConfig::V4 {
                 alg: ConsensusAlgorithmConfig::default_with_quorum_store_disabled(),
                 vtxn: ValidatorTxnConfig::default_for_genesis(),
+                window_size: DEFAULT_WINDOW_SIZE,
             };
         }))
         .with_vfn_config(vfn_config)

--- a/testsuite/smoke-test/src/state_sync.rs
+++ b/testsuite/smoke-test/src/state_sync.rs
@@ -659,6 +659,7 @@ async fn test_validator_sync_and_participate(fast_sync: bool, epoch_changes: boo
                 OnChainConsensusConfig::V1(consensus_config) => consensus_config,
                 OnChainConsensusConfig::V2(consensus_config) => consensus_config,
                 OnChainConsensusConfig::V3 { alg, .. } => alg.unwrap_jolteon_config_v1().clone(),
+                OnChainConsensusConfig::V4 { alg, .. } => alg.unwrap_jolteon_config_v1().clone(),
             };
             let leader_reputation_type = match &consensus_config.proposer_election_type {
                 ProposerElectionType::LeaderReputation(leader_reputation_type) => {

--- a/testsuite/testcases/src/dag_onchain_enable_test.rs
+++ b/testsuite/testcases/src/dag_onchain_enable_test.rs
@@ -11,6 +11,7 @@ use aptos_types::{
     account_config::CORE_CODE_ADDRESS,
     on_chain_config::{
         ConsensusAlgorithmConfig, DagConsensusConfigV1, OnChainConsensusConfig, ValidatorTxnConfig,
+        DEFAULT_WINDOW_SIZE,
     },
 };
 use async_trait::async_trait;
@@ -73,13 +74,14 @@ impl NetworkLoadTest for DagOnChainEnableTest {
 
         assert!(matches!(
             current_consensus_config,
-            OnChainConsensusConfig::V3 { .. }
+            OnChainConsensusConfig::V4 { .. }
         ));
 
-        // Change to V2
-        let new_consensus_config = OnChainConsensusConfig::V3 {
+        // Change to V4
+        let new_consensus_config = OnChainConsensusConfig::V4 {
             alg: ConsensusAlgorithmConfig::DAG(DagConsensusConfigV1::default()),
             vtxn: ValidatorTxnConfig::default_disabled(),
+            window_size: DEFAULT_WINDOW_SIZE,
         };
 
         let update_consensus_config_script = format!(
@@ -124,13 +126,14 @@ impl NetworkLoadTest for DagOnChainEnableTest {
 
         assert!(matches!(
             current_consensus_config,
-            OnChainConsensusConfig::V3 { .. }
+            OnChainConsensusConfig::V4 { .. }
         ));
 
         // Change to DAG
-        let new_consensus_config = OnChainConsensusConfig::V3 {
+        let new_consensus_config = OnChainConsensusConfig::V4 {
             alg: ConsensusAlgorithmConfig::DAG(DagConsensusConfigV1::default()),
             vtxn: ValidatorTxnConfig::default_disabled(),
+            window_size: DEFAULT_WINDOW_SIZE,
         };
 
         let update_consensus_config_script = format!(
@@ -177,7 +180,7 @@ impl NetworkLoadTest for DagOnChainEnableTest {
 
         assert!(matches!(
             current_consensus_config,
-            OnChainConsensusConfig::V3 { .. }
+            OnChainConsensusConfig::V4 { .. }
         ));
 
         // Change back to initial

--- a/types/src/on_chain_config/consensus_config.rs
+++ b/types/src/on_chain_config/consensus_config.rs
@@ -8,6 +8,10 @@ use move_core_types::account_address::AccountAddress;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
+/// Default Window Size for Execution Pool.
+/// This describes the number of blocks in the Execution Pool Window
+pub const DEFAULT_WINDOW_SIZE: Option<u64> = None;
+
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
 pub enum ConsensusAlgorithmConfig {
     Jolteon {
@@ -192,14 +196,21 @@ pub enum OnChainConsensusConfig {
         alg: ConsensusAlgorithmConfig,
         vtxn: ValidatorTxnConfig,
     },
+    V4 {
+        alg: ConsensusAlgorithmConfig,
+        vtxn: ValidatorTxnConfig,
+        // Execution pool block window
+        window_size: Option<u64>,
+    },
 }
 
 /// The public interface that exposes all values with safe fallback.
 impl OnChainConsensusConfig {
     pub fn default_for_genesis() -> Self {
-        OnChainConsensusConfig::V3 {
+        OnChainConsensusConfig::V4 {
             alg: ConsensusAlgorithmConfig::default_for_genesis(),
             vtxn: ValidatorTxnConfig::default_for_genesis(),
+            window_size: DEFAULT_WINDOW_SIZE,
         }
     }
 
@@ -209,7 +220,9 @@ impl OnChainConsensusConfig {
             OnChainConsensusConfig::V1(config) | OnChainConsensusConfig::V2(config) => {
                 config.exclude_round
             },
-            OnChainConsensusConfig::V3 { alg, .. } => alg.leader_reputation_exclude_round(),
+            OnChainConsensusConfig::V3 { alg, .. } | OnChainConsensusConfig::V4 { alg, .. } => {
+                alg.leader_reputation_exclude_round()
+            },
         }
     }
 
@@ -225,7 +238,9 @@ impl OnChainConsensusConfig {
             OnChainConsensusConfig::V1(config) | OnChainConsensusConfig::V2(config) => {
                 config.max_failed_authors_to_store
             },
-            OnChainConsensusConfig::V3 { alg, .. } => alg.max_failed_authors_to_store(),
+            OnChainConsensusConfig::V3 { alg, .. } | OnChainConsensusConfig::V4 { alg, .. } => {
+                alg.max_failed_authors_to_store()
+            },
         }
     }
 
@@ -235,7 +250,9 @@ impl OnChainConsensusConfig {
             OnChainConsensusConfig::V1(config) | OnChainConsensusConfig::V2(config) => {
                 &config.proposer_election_type
             },
-            OnChainConsensusConfig::V3 { alg, .. } => alg.proposer_election_type(),
+            OnChainConsensusConfig::V3 { alg, .. } | OnChainConsensusConfig::V4 { alg, .. } => {
+                alg.proposer_election_type()
+            },
         }
     }
 
@@ -243,7 +260,9 @@ impl OnChainConsensusConfig {
         match &self {
             OnChainConsensusConfig::V1(_config) => false,
             OnChainConsensusConfig::V2(_) => true,
-            OnChainConsensusConfig::V3 { alg, .. } => alg.quorum_store_enabled(),
+            OnChainConsensusConfig::V3 { alg, .. } | OnChainConsensusConfig::V4 { alg, .. } => {
+                alg.quorum_store_enabled()
+            },
         }
     }
 
@@ -251,7 +270,9 @@ impl OnChainConsensusConfig {
         match &self {
             OnChainConsensusConfig::V1(_config) => false,
             OnChainConsensusConfig::V2(_) => false,
-            OnChainConsensusConfig::V3 { alg, .. } => alg.order_vote_enabled(),
+            OnChainConsensusConfig::V3 { alg, .. } | OnChainConsensusConfig::V4 { alg, .. } => {
+                alg.order_vote_enabled()
+            },
         }
     }
 
@@ -259,14 +280,20 @@ impl OnChainConsensusConfig {
         match self {
             OnChainConsensusConfig::V1(_) => false,
             OnChainConsensusConfig::V2(_) => false,
-            OnChainConsensusConfig::V3 { alg, .. } => alg.is_dag_enabled(),
+            OnChainConsensusConfig::V3 { alg, .. } | OnChainConsensusConfig::V4 { alg, .. } => {
+                alg.is_dag_enabled()
+            },
         }
     }
 
     pub fn unwrap_dag_config_v1(&self) -> &DagConsensusConfigV1 {
         match &self {
-            OnChainConsensusConfig::V3 { alg, .. } => alg.unwrap_dag_config_v1(),
-            _ => unreachable!("not a dag config"),
+            OnChainConsensusConfig::V1(_) | OnChainConsensusConfig::V2(_) => {
+                unreachable!("not a dag config")
+            },
+            OnChainConsensusConfig::V3 { alg, .. } | OnChainConsensusConfig::V4 { alg, .. } => {
+                alg.unwrap_dag_config_v1()
+            },
         }
     }
 
@@ -275,7 +302,9 @@ impl OnChainConsensusConfig {
             OnChainConsensusConfig::V1(_) | OnChainConsensusConfig::V2(_) => {
                 ValidatorTxnConfig::default_disabled()
             },
-            OnChainConsensusConfig::V3 { vtxn, .. } => vtxn.clone(),
+            OnChainConsensusConfig::V3 { vtxn, .. } | OnChainConsensusConfig::V4 { vtxn, .. } => {
+                vtxn.clone()
+            },
         }
     }
 
@@ -288,7 +317,7 @@ impl OnChainConsensusConfig {
             OnChainConsensusConfig::V1(_) | OnChainConsensusConfig::V2(_) => {
                 // vtxn not supported. No-op.
             },
-            OnChainConsensusConfig::V3 { vtxn, .. } => {
+            OnChainConsensusConfig::V3 { vtxn, .. } | OnChainConsensusConfig::V4 { vtxn, .. } => {
                 *vtxn = ValidatorTxnConfig::V0;
             },
         }
@@ -296,35 +325,60 @@ impl OnChainConsensusConfig {
 
     pub fn enable_validator_txns(&mut self) {
         let new_self = match std::mem::take(self) {
-            OnChainConsensusConfig::V1(config) => OnChainConsensusConfig::V3 {
+            OnChainConsensusConfig::V1(config) => OnChainConsensusConfig::V4 {
                 alg: ConsensusAlgorithmConfig::JolteonV2 {
                     main: config,
                     quorum_store_enabled: false,
                     order_vote_enabled: false,
                 },
                 vtxn: ValidatorTxnConfig::default_enabled(),
+                window_size: DEFAULT_WINDOW_SIZE,
             },
-            OnChainConsensusConfig::V2(config) => OnChainConsensusConfig::V3 {
+            OnChainConsensusConfig::V2(config) => OnChainConsensusConfig::V4 {
                 alg: ConsensusAlgorithmConfig::JolteonV2 {
                     main: config,
                     quorum_store_enabled: true,
                     order_vote_enabled: false,
                 },
                 vtxn: ValidatorTxnConfig::default_enabled(),
+                window_size: DEFAULT_WINDOW_SIZE,
             },
             OnChainConsensusConfig::V3 {
                 vtxn: ValidatorTxnConfig::V0,
                 alg,
-            } => OnChainConsensusConfig::V3 {
+            } => OnChainConsensusConfig::V4 {
                 alg,
                 vtxn: ValidatorTxnConfig::default_enabled(),
+                window_size: DEFAULT_WINDOW_SIZE,
+            },
+            OnChainConsensusConfig::V4 {
+                alg,
+                vtxn: ValidatorTxnConfig::V0,
+                window_size,
+            } => OnChainConsensusConfig::V4 {
+                alg,
+                vtxn: ValidatorTxnConfig::default_enabled(),
+                window_size,
             },
             item @ OnChainConsensusConfig::V3 {
                 vtxn: ValidatorTxnConfig::V1 { .. },
                 ..
             } => item,
+            item @ OnChainConsensusConfig::V4 {
+                vtxn: ValidatorTxnConfig::V1 { .. },
+                ..
+            } => item,
         };
         *self = new_self;
+    }
+
+    pub fn window_size(&self) -> Option<u64> {
+        match self {
+            OnChainConsensusConfig::V1(_)
+            | OnChainConsensusConfig::V2(_)
+            | OnChainConsensusConfig::V3 { .. } => None,
+            OnChainConsensusConfig::V4 { window_size, .. } => *window_size,
+        }
     }
 }
 
@@ -332,9 +386,10 @@ impl OnChainConsensusConfig {
 /// TODO: rename to "default_if_missing()" to be consistent with others?
 impl Default for OnChainConsensusConfig {
     fn default() -> Self {
-        OnChainConsensusConfig::V3 {
+        OnChainConsensusConfig::V4 {
             alg: ConsensusAlgorithmConfig::default_if_missing(),
             vtxn: ValidatorTxnConfig::default_if_missing(),
+            window_size: DEFAULT_WINDOW_SIZE,
         }
     }
 }

--- a/types/src/on_chain_config/mod.rs
+++ b/types/src/on_chain_config/mod.rs
@@ -46,7 +46,7 @@ pub use self::{
     consensus_config::{
         AnchorElectionMode, ConsensusAlgorithmConfig, ConsensusConfigV1, DagConsensusConfigV1,
         LeaderReputationType, OnChainConsensusConfig, ProposerAndVoterConfig, ProposerElectionType,
-        ValidatorTxnConfig,
+        ValidatorTxnConfig, DEFAULT_WINDOW_SIZE,
     },
     execution_config::{
         BlockGasLimitType, ExecutionConfigV1, ExecutionConfigV2, ExecutionConfigV4,


### PR DESCRIPTION
## Description

A new `OnChainConsensusConfig` variant that includes a `window_size` for execution pool.

Note: `window_size` is be `Option<u64>` in the OnChainConfig, but will be converted to `Option<usize>` once it's deserialized and handled in memory