### PR TITLE
Standardize Variable and Function Naming in mempool and network modules

### DIFF
--- a/mempool/src/shared_mempool/coordinator.rs
+++ b/mempool/src/shared_mempool/coordinator.rs
@@ -145,7 +145,7 @@ fn spawn_commit_notification_handler<NetworkClient, TransactionValidator>(
     let mempool = smp.mempool.clone();
     let mempool_validator = smp.validator.clone();
     let use_case_history = smp.use_case_history.clone();
-    let num_committed_txns_recieved_since_peers_updated = smp
+    let num_committed_txns_received_since_peers_updated = smp
         .network_interface
         .num_committed_txns_received_since_peers_updated
         .clone();
@@ -157,7 +157,7 @@ fn spawn_commit_notification_handler<NetworkClient, TransactionValidator>(
                 &mempool_validator,
                 &use_case_history,
                 commit_notification,
-                &num_committed_txns_recieved_since_peers_updated,
+                &num_committed_txns_received_since_peers_updated,
             );
         }
     });
@@ -232,7 +232,7 @@ fn handle_commit_notification<TransactionValidator>(
     mempool_validator: &Arc<RwLock<TransactionValidator>>,
     use_case_history: &Arc<Mutex<UseCaseHistory>>,
     msg: MempoolCommitNotification,
-    num_committed_txns_recieved_since_peers_updated: &Arc<AtomicU64>,
+    num_committed_txns_received_since_peers_updated: &Arc<AtomicU64>,
 ) where
     TransactionValidator: TransactionValidation,
 {
@@ -248,7 +248,7 @@ fn handle_commit_notification<TransactionValidator>(
         counters::COMMIT_STATE_SYNC_LABEL,
         msg.transactions.len(),
     );
-    num_committed_txns_recieved_since_peers_updated
+    num_committed_txns_received_since_peers_updated
         .fetch_add(msg.transactions.len() as u64, Ordering::Relaxed);
     process_committed_transactions(
         mempool,

--- a/network/builder/src/dummy.rs
+++ b/network/builder/src/dummy.rs
@@ -37,13 +37,13 @@ pub struct DummyMsg(pub Vec<u8>);
 
 pub fn dummy_network_config() -> NetworkApplicationConfig {
     let direct_send_protocols = vec![TEST_DIRECT_SEND_PROTOCOL];
-    let rpc_protocls = vec![TEST_RPC_PROTOCOL];
+    let rpc_protocols = vec![TEST_RPC_PROTOCOL];
 
     let network_client_config =
-        NetworkClientConfig::new(direct_send_protocols.clone(), rpc_protocls.clone());
+        NetworkClientConfig::new(direct_send_protocols.clone(), rpc_protocols.clone());
     let network_service_config = NetworkServiceConfig::new(
         direct_send_protocols,
-        rpc_protocls,
+        rpc_protocols,
         aptos_channel::Config::new(NETWORK_CHANNEL_SIZE),
     );
     NetworkApplicationConfig::new(network_client_config, network_service_config)


### PR DESCRIPTION
This PR updates variable and function names in `coordinator.rs` and `dummy.rs` to improve consistency and readability in the codebase. These changes align with standard naming conventions and reduce potential confusion.

### Changes:
- Updated `num_committed_txns_recieved_since_peers_updated` → `num_committed_txns_received_since_peers_updated` in `coordinator.rs`
- Standardized `rpc_protocls` → `rpc_protocols` in `dummy.rs`

### Tests
Since no functional changes were introduced, existing tests should sufficiently cover the modifications.
