### PR TITLE
[doc][trivial] Fix docgen for #[verify_only]

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
+++ b/aptos-move/framework/aptos-framework/doc/aggregator_v2.md
@@ -49,6 +49,20 @@ read, read_snapshot, read_derived_string
 -  [Function `derive_string_concat`](#0x1_aggregator_v2_derive_string_concat)
 -  [Function `copy_snapshot`](#0x1_aggregator_v2_copy_snapshot)
 -  [Function `string_concat`](#0x1_aggregator_v2_string_concat)
+-  [Function `verify_aggregator_try_add_sub`](#0x1_aggregator_v2_verify_aggregator_try_add_sub)
+-  [Function `verify_aggregator_add_sub`](#0x1_aggregator_v2_verify_aggregator_add_sub)
+-  [Function `verify_correct_read`](#0x1_aggregator_v2_verify_correct_read)
+-  [Function `verify_invalid_read`](#0x1_aggregator_v2_verify_invalid_read)
+-  [Function `verify_invalid_is_least`](#0x1_aggregator_v2_verify_invalid_is_least)
+-  [Function `verify_copy_not_yet_supported`](#0x1_aggregator_v2_verify_copy_not_yet_supported)
+-  [Function `verify_string_concat1`](#0x1_aggregator_v2_verify_string_concat1)
+-  [Function `verify_aggregator_generic`](#0x1_aggregator_v2_verify_aggregator_generic)
+-  [Function `verify_aggregator_generic_add`](#0x1_aggregator_v2_verify_aggregator_generic_add)
+-  [Function `verify_aggregator_generic_sub`](#0x1_aggregator_v2_verify_aggregator_generic_sub)
+-  [Function `verify_aggregator_invalid_type1`](#0x1_aggregator_v2_verify_aggregator_invalid_type1)
+-  [Function `verify_snapshot_invalid_type1`](#0x1_aggregator_v2_verify_snapshot_invalid_type1)
+-  [Function `verify_snapshot_invalid_type2`](#0x1_aggregator_v2_verify_snapshot_invalid_type2)
+-  [Function `verify_aggregator_valid_type`](#0x1_aggregator_v2_verify_aggregator_valid_type)
 -  [Specification](#@Specification_1)
     -  [Struct `Aggregator`](#@Specification_1_Aggregator)
     -  [Function `max_value`](#@Specification_1_max_value)
@@ -68,10 +82,23 @@ read, read_snapshot, read_derived_string
     -  [Function `derive_string_concat`](#@Specification_1_derive_string_concat)
     -  [Function `copy_snapshot`](#@Specification_1_copy_snapshot)
     -  [Function `string_concat`](#@Specification_1_string_concat)
+    -  [Function `verify_aggregator_try_add_sub`](#@Specification_1_verify_aggregator_try_add_sub)
+    -  [Function `verify_aggregator_add_sub`](#@Specification_1_verify_aggregator_add_sub)
+    -  [Function `verify_invalid_read`](#@Specification_1_verify_invalid_read)
+    -  [Function `verify_invalid_is_least`](#@Specification_1_verify_invalid_is_least)
+    -  [Function `verify_copy_not_yet_supported`](#@Specification_1_verify_copy_not_yet_supported)
+    -  [Function `verify_aggregator_generic`](#@Specification_1_verify_aggregator_generic)
+    -  [Function `verify_aggregator_generic_add`](#@Specification_1_verify_aggregator_generic_add)
+    -  [Function `verify_aggregator_generic_sub`](#@Specification_1_verify_aggregator_generic_sub)
+    -  [Function `verify_aggregator_invalid_type1`](#@Specification_1_verify_aggregator_invalid_type1)
+    -  [Function `verify_snapshot_invalid_type1`](#@Specification_1_verify_snapshot_invalid_type1)
+    -  [Function `verify_snapshot_invalid_type2`](#@Specification_1_verify_snapshot_invalid_type2)
+    -  [Function `verify_aggregator_valid_type`](#@Specification_1_verify_aggregator_valid_type)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
 </code></pre>
 
@@ -782,6 +809,430 @@ DEPRECATED, use derive_string_concat() instead. always raises EAGGREGATOR_FUNCTI
 
 </details>
 
+<a id="0x1_aggregator_v2_verify_aggregator_try_add_sub"></a>
+
+## Function `verify_aggregator_try_add_sub`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_try_add_sub">verify_aggregator_try_add_sub</a>(): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_try_add_sub">verify_aggregator_try_add_sub</a>(): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;u64&gt; {
+    <b>let</b> agg = <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>(10);
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(agg) == 10;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(agg) == 0;
+    };
+    <b>let</b> x = <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(&<b>mut</b> agg, 5);
+    <b>spec</b> {
+        <b>assert</b> x;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_is_at_least">is_at_least</a>(agg, 5);
+    };
+    <b>let</b> y = <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(&<b>mut</b> agg, 6);
+    <b>spec</b> {
+        <b>assert</b> !y;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(agg) == 5;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(agg) == 10;
+    };
+    <b>let</b> y = <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(&<b>mut</b> agg, 4);
+    <b>spec</b> {
+        <b>assert</b> y;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(agg) == 1;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(agg) == 10;
+    };
+    <b>let</b> x = <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(&<b>mut</b> agg, 11);
+    <b>spec</b> {
+        <b>assert</b> !x;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(agg) == 1;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(agg) == 10;
+    };
+    <b>let</b> x = <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(&<b>mut</b> agg, 9);
+    <b>spec</b> {
+        <b>assert</b> x;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(agg) == 10;
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(agg) == 10;
+    };
+    agg
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_aggregator_add_sub"></a>
+
+## Function `verify_aggregator_add_sub`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_add_sub">verify_aggregator_add_sub</a>(sub_value: u64, add_value: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_add_sub">verify_aggregator_add_sub</a>(sub_value: u64, add_value: u64) {
+    <b>let</b> agg = <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>(10);
+    <a href="aggregator_v2.md#0x1_aggregator_v2_add">add</a>(&<b>mut</b> agg, add_value);
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(agg) == add_value;
+    };
+    <a href="aggregator_v2.md#0x1_aggregator_v2_sub">sub</a>(&<b>mut</b> agg, sub_value);
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(agg) == add_value - sub_value;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_correct_read"></a>
+
+## Function `verify_correct_read`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_correct_read">verify_correct_read</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_correct_read">verify_correct_read</a>() {
+    <b>let</b> snapshot = <a href="aggregator_v2.md#0x1_aggregator_v2_create_snapshot">create_snapshot</a>(42);
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_read_snapshot">spec_read_snapshot</a>(snapshot) == 42;
+    };
+    <b>let</b> derived = <a href="aggregator_v2.md#0x1_aggregator_v2_create_derived_string">create_derived_string</a>(std::string::utf8(b"42"));
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_read_derived_string">spec_read_derived_string</a>(derived).bytes == b"42";
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_invalid_read"></a>
+
+## Function `verify_invalid_read`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_invalid_read">verify_invalid_read</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u8&gt;): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_invalid_read">verify_invalid_read</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;u8&gt;): u8 {
+    <a href="aggregator_v2.md#0x1_aggregator_v2_read">read</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_invalid_is_least"></a>
+
+## Function `verify_invalid_is_least`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_invalid_is_least">verify_invalid_is_least</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_invalid_is_least">verify_invalid_is_least</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;u8&gt;): bool {
+    <a href="aggregator_v2.md#0x1_aggregator_v2_is_at_least">is_at_least</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, 0)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_copy_not_yet_supported"></a>
+
+## Function `verify_copy_not_yet_supported`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_copy_not_yet_supported">verify_copy_not_yet_supported</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_copy_not_yet_supported">verify_copy_not_yet_supported</a>() {
+    <b>let</b> snapshot = <a href="aggregator_v2.md#0x1_aggregator_v2_create_snapshot">create_snapshot</a>(42);
+    <a href="aggregator_v2.md#0x1_aggregator_v2_copy_snapshot">copy_snapshot</a>(&snapshot);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_string_concat1"></a>
+
+## Function `verify_string_concat1`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_string_concat1">verify_string_concat1</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_string_concat1">verify_string_concat1</a>() {
+    <b>let</b> snapshot = <a href="aggregator_v2.md#0x1_aggregator_v2_create_snapshot">create_snapshot</a>(42);
+    <b>let</b> derived = <a href="aggregator_v2.md#0x1_aggregator_v2_derive_string_concat">derive_string_concat</a>(std::string::utf8(b"before"), &snapshot, std::string::utf8(b"after"));
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_read_derived_string">spec_read_derived_string</a>(derived).bytes ==
+            concat(b"before", concat(<a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_string_value">spec_get_string_value</a>(snapshot).bytes, b"after"));
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_aggregator_generic"></a>
+
+## Function `verify_aggregator_generic`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic">verify_aggregator_generic</a>&lt;IntElement1: <b>copy</b>, drop, IntElement2: <b>copy</b>, drop&gt;(): (<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement1&gt;, <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement2&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic">verify_aggregator_generic</a>&lt;IntElement1: <b>copy</b> + drop, IntElement2: <b>copy</b>+drop&gt;(): (<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement1&gt;,  <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement2&gt;){
+    <b>let</b> x = <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;IntElement1&gt;();
+    <b>let</b> y = <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;IntElement2&gt;();
+    (x, y)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_aggregator_generic_add"></a>
+
+## Function `verify_aggregator_generic_add`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic_add">verify_aggregator_generic_add</a>&lt;IntElement: <b>copy</b>, drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic_add">verify_aggregator_generic_add</a>&lt;IntElement: <b>copy</b> + drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;, value: IntElement) {
+    <a href="aggregator_v2.md#0x1_aggregator_v2_try_add">try_add</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value);
+    <a href="aggregator_v2.md#0x1_aggregator_v2_is_at_least_impl">is_at_least_impl</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value);
+    // cannot specify <b>aborts_if</b> condition for generic `add`
+    // because comparison is not supported by IntElement
+    <a href="aggregator_v2.md#0x1_aggregator_v2_add">add</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_aggregator_generic_sub"></a>
+
+## Function `verify_aggregator_generic_sub`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic_sub">verify_aggregator_generic_sub</a>&lt;IntElement: <b>copy</b>, drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic_sub">verify_aggregator_generic_sub</a>&lt;IntElement: <b>copy</b> + drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;, value: IntElement) {
+    <a href="aggregator_v2.md#0x1_aggregator_v2_try_sub">try_sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value);
+    // cannot specify <b>aborts_if</b> condition for generic `sub`
+    // because comparison is not supported by IntElement
+    <a href="aggregator_v2.md#0x1_aggregator_v2_sub">sub</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>, value);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_aggregator_invalid_type1"></a>
+
+## Function `verify_aggregator_invalid_type1`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_invalid_type1">verify_aggregator_invalid_type1</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_invalid_type1">verify_aggregator_invalid_type1</a>() {
+    <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;u8&gt;();
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_snapshot_invalid_type1"></a>
+
+## Function `verify_snapshot_invalid_type1`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_snapshot_invalid_type1">verify_snapshot_invalid_type1</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_snapshot_invalid_type1">verify_snapshot_invalid_type1</a>() {
+    <b>use</b> std::option;
+    <a href="aggregator_v2.md#0x1_aggregator_v2_create_snapshot">create_snapshot</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(42));
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_snapshot_invalid_type2"></a>
+
+## Function `verify_snapshot_invalid_type2`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_snapshot_invalid_type2">verify_snapshot_invalid_type2</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_snapshot_invalid_type2">verify_snapshot_invalid_type2</a>() {
+    <a href="aggregator_v2.md#0x1_aggregator_v2_create_snapshot">create_snapshot</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[42]);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_aggregator_v2_verify_aggregator_valid_type"></a>
+
+## Function `verify_aggregator_valid_type`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_valid_type">verify_aggregator_valid_type</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_valid_type">verify_aggregator_valid_type</a>() {
+    <b>let</b> _agg_1 = <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;u64&gt;();
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(_agg_1) == MAX_U64;
+    };
+    <b>let</b> _agg_2 = <a href="aggregator_v2.md#0x1_aggregator_v2_create_unbounded_aggregator">create_unbounded_aggregator</a>&lt;u128&gt;();
+    <b>spec</b> {
+        <b>assert</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(_agg_2) == MAX_U128;
+    };
+    <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;u64&gt;(5);
+    <a href="aggregator_v2.md#0x1_aggregator_v2_create_aggregator">create_aggregator</a>&lt;u128&gt;(5);
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
@@ -1164,6 +1615,215 @@ DEPRECATED, use derive_string_concat() instead. always raises EAGGREGATOR_FUNCTI
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>&lt;IntElement&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">Aggregator</a>&lt;IntElement&gt;): IntElement;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_aggregator_try_add_sub"></a>
+
+### Function `verify_aggregator_try_add_sub`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_try_add_sub">verify_aggregator_try_add_sub</a>(): <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u64&gt;
+</code></pre>
+
+
+
+
+<pre><code><b>ensures</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_max_value">spec_get_max_value</a>(result) == 10;
+<b>ensures</b> <a href="aggregator_v2.md#0x1_aggregator_v2_spec_get_value">spec_get_value</a>(result) == 10;
+<b>ensures</b> <a href="aggregator_v2.md#0x1_aggregator_v2_read">read</a>(result) == 10;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_aggregator_add_sub"></a>
+
+### Function `verify_aggregator_add_sub`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_add_sub">verify_aggregator_add_sub</a>(sub_value: u64, add_value: u64)
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> aborts_if_is_strict;
+<b>aborts_if</b> add_value &gt; 10;
+<b>aborts_if</b> sub_value &gt; add_value;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_invalid_read"></a>
+
+### Function `verify_invalid_read`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_invalid_read">verify_invalid_read</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u8&gt;): u8
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>true</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_invalid_is_least"></a>
+
+### Function `verify_invalid_is_least`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_invalid_is_least">verify_invalid_is_least</a>(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;u8&gt;): bool
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>true</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_copy_not_yet_supported"></a>
+
+### Function `verify_copy_not_yet_supported`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_copy_not_yet_supported">verify_copy_not_yet_supported</a>()
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>true</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_aggregator_generic"></a>
+
+### Function `verify_aggregator_generic`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic">verify_aggregator_generic</a>&lt;IntElement1: <b>copy</b>, drop, IntElement2: <b>copy</b>, drop&gt;(): (<a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement1&gt;, <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement2&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement1&gt;().bytes != b"u64" && <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement1&gt;().bytes != b"u128";
+<b>aborts_if</b> <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement2&gt;().bytes != b"u64" && <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement2&gt;().bytes != b"u128";
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_aggregator_generic_add"></a>
+
+### Function `verify_aggregator_generic_add`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic_add">verify_aggregator_generic_add</a>&lt;IntElement: <b>copy</b>, drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement&gt;().bytes != b"u64" && <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement&gt;().bytes != b"u128";
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_aggregator_generic_sub"></a>
+
+### Function `verify_aggregator_generic_sub`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_generic_sub">verify_aggregator_generic_sub</a>&lt;IntElement: <b>copy</b>, drop&gt;(<a href="aggregator.md#0x1_aggregator">aggregator</a>: &<b>mut</b> <a href="aggregator_v2.md#0x1_aggregator_v2_Aggregator">aggregator_v2::Aggregator</a>&lt;IntElement&gt;, value: IntElement)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement&gt;().bytes != b"u64" && <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;IntElement&gt;().bytes != b"u128";
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_aggregator_invalid_type1"></a>
+
+### Function `verify_aggregator_invalid_type1`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_invalid_type1">verify_aggregator_invalid_type1</a>()
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>true</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_snapshot_invalid_type1"></a>
+
+### Function `verify_snapshot_invalid_type1`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_snapshot_invalid_type1">verify_snapshot_invalid_type1</a>()
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>true</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_snapshot_invalid_type2"></a>
+
+### Function `verify_snapshot_invalid_type2`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_snapshot_invalid_type2">verify_snapshot_invalid_type2</a>()
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>true</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_aggregator_valid_type"></a>
+
+### Function `verify_aggregator_valid_type`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="aggregator_v2.md#0x1_aggregator_v2_verify_aggregator_valid_type">verify_aggregator_valid_type</a>()
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -65,6 +65,7 @@ on a proposal multiple times as long as the total voting power of these votes do
 -  [Function `get_signer`](#0x1_aptos_governance_get_signer)
 -  [Function `create_proposal_metadata`](#0x1_aptos_governance_create_proposal_metadata)
 -  [Function `assert_voting_initialization`](#0x1_aptos_governance_assert_voting_initialization)
+-  [Function `initialize_for_verification`](#0x1_aptos_governance_initialize_for_verification)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
@@ -100,6 +101,7 @@ on a proposal multiple times as long as the total voting power of these votes do
     -  [Function `get_signer`](#@Specification_1_get_signer)
     -  [Function `create_proposal_metadata`](#@Specification_1_create_proposal_metadata)
     -  [Function `assert_voting_initialization`](#@Specification_1_assert_voting_initialization)
+    -  [Function `initialize_for_verification`](#@Specification_1_initialize_for_verification)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
@@ -2155,6 +2157,36 @@ Return a signer for making changes to 0x1 as part of on-chain governance proposa
 
 </details>
 
+<a id="0x1_aptos_governance_initialize_for_verification"></a>
+
+## Function `initialize_for_verification`
+
+
+
+<pre><code>#[verify_only]
+<b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_for_verification">initialize_for_verification</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, min_voting_threshold: u128, required_proposer_stake: u64, voting_duration_secs: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_for_verification">initialize_for_verification</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    min_voting_threshold: u128,
+    required_proposer_stake: u64,
+    voting_duration_secs: u64,
+) {
+    <a href="aptos_governance.md#0x1_aptos_governance_initialize">initialize</a>(aptos_framework, min_voting_threshold, required_proposer_stake, voting_duration_secs);
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
@@ -3380,6 +3412,24 @@ pool_address must exist in StakePool.
 
 
 <pre><code><b>include</b> <a href="aptos_governance.md#0x1_aptos_governance_VotingInitializationAbortIfs">VotingInitializationAbortIfs</a>;
+</code></pre>
+
+
+
+<a id="@Specification_1_initialize_for_verification"></a>
+
+### Function `initialize_for_verification`
+
+
+<pre><code>#[verify_only]
+<b>public</b> <b>fun</b> <a href="aptos_governance.md#0x1_aptos_governance_initialize_for_verification">initialize_for_verification</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, min_voting_threshold: u128, required_proposer_stake: u64, voting_duration_secs: u64)
+</code></pre>
+
+
+verify_only
+
+
+<pre><code><b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/genesis.md
+++ b/aptos-move/framework/aptos-framework/doc/genesis.md
@@ -21,6 +21,7 @@
 -  [Function `create_initialize_validator`](#0x1_genesis_create_initialize_validator)
 -  [Function `initialize_validator`](#0x1_genesis_initialize_validator)
 -  [Function `set_genesis_end`](#0x1_genesis_set_genesis_end)
+-  [Function `initialize_for_verification`](#0x1_genesis_initialize_for_verification)
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
@@ -30,6 +31,7 @@
     -  [Function `create_initialize_validators`](#@Specification_1_create_initialize_validators)
     -  [Function `create_initialize_validator`](#@Specification_1_create_initialize_validator)
     -  [Function `set_genesis_end`](#@Specification_1_set_genesis_end)
+    -  [Function `initialize_for_verification`](#@Specification_1_initialize_for_verification)
 
 
 <pre><code><b>use</b> <a href="account.md#0x1_account">0x1::account</a>;
@@ -45,6 +47,7 @@
 <b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="execution_config.md#0x1_execution_config">0x1::execution_config</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/fixed_point32.md#0x1_fixed_point32">0x1::fixed_point32</a>;
 <b>use</b> <a href="gas_schedule.md#0x1_gas_schedule">0x1::gas_schedule</a>;
 <b>use</b> <a href="reconfiguration.md#0x1_reconfiguration">0x1::reconfiguration</a>;
@@ -824,6 +827,80 @@ The last step of genesis.
 
 </details>
 
+<a id="0x1_genesis_initialize_for_verification"></a>
+
+## Function `initialize_for_verification`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="genesis.md#0x1_genesis_initialize_for_verification">initialize_for_verification</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, min_voting_threshold: u128, required_proposer_stake: u64, voting_duration_secs: u64, accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_AccountMap">genesis::AccountMap</a>&gt;, employee_vesting_start: u64, employee_vesting_period_duration: u64, employees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_EmployeeAccountMap">genesis::EmployeeAccountMap</a>&gt;, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="genesis.md#0x1_genesis_initialize_for_verification">initialize_for_verification</a>(
+    <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8,
+    initial_version: u64,
+    <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    epoch_interval_microsecs: u64,
+    minimum_stake: u64,
+    maximum_stake: u64,
+    recurring_lockup_duration_secs: u64,
+    allow_validator_set_change: bool,
+    rewards_rate: u64,
+    rewards_rate_denominator: u64,
+    voting_power_increase_limit: u64,
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    min_voting_threshold: u128,
+    required_proposer_stake: u64,
+    voting_duration_secs: u64,
+    accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_AccountMap">AccountMap</a>&gt;,
+    employee_vesting_start: u64,
+    employee_vesting_period_duration: u64,
+    employees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_EmployeeAccountMap">EmployeeAccountMap</a>&gt;,
+    validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">ValidatorConfigurationWithCommission</a>&gt;
+) {
+    <a href="genesis.md#0x1_genesis_initialize">initialize</a>(
+        <a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>,
+        <a href="chain_id.md#0x1_chain_id">chain_id</a>,
+        initial_version,
+        <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>,
+        <a href="execution_config.md#0x1_execution_config">execution_config</a>,
+        epoch_interval_microsecs,
+        minimum_stake,
+        maximum_stake,
+        recurring_lockup_duration_secs,
+        allow_validator_set_change,
+        rewards_rate,
+        rewards_rate_denominator,
+        voting_power_increase_limit
+    );
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_change_feature_flags_for_verification">features::change_feature_flags_for_verification</a>(aptos_framework, <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[1, 2], <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[]);
+    <a href="genesis.md#0x1_genesis_initialize_aptos_coin">initialize_aptos_coin</a>(aptos_framework);
+    <a href="aptos_governance.md#0x1_aptos_governance_initialize_for_verification">aptos_governance::initialize_for_verification</a>(
+        aptos_framework,
+        min_voting_threshold,
+        required_proposer_stake,
+        voting_duration_secs
+    );
+    <a href="genesis.md#0x1_genesis_create_accounts">create_accounts</a>(aptos_framework, accounts);
+    <a href="genesis.md#0x1_genesis_create_employee_validators">create_employee_validators</a>(employee_vesting_start, employee_vesting_period_duration, employees);
+    <a href="genesis.md#0x1_genesis_create_initialize_validators_with_commission">create_initialize_validators_with_commission</a>(aptos_framework, <b>true</b>, validators);
+    <a href="genesis.md#0x1_genesis_set_genesis_end">set_genesis_end</a>(aptos_framework);
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
@@ -1076,6 +1153,24 @@ The last step of genesis.
     <b>let</b> staking_rewards_config = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>&gt;(@aptos_framework);
     <b>requires</b> staking_rewards_config.last_rewards_rate_period_start_in_secs &lt;= <a href="timestamp.md#0x1_timestamp_spec_now_seconds">timestamp::spec_now_seconds</a>();
 }
+</code></pre>
+
+
+
+<a id="@Specification_1_initialize_for_verification"></a>
+
+### Function `initialize_for_verification`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="genesis.md#0x1_genesis_initialize_for_verification">initialize_for_verification</a>(<a href="gas_schedule.md#0x1_gas_schedule">gas_schedule</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="chain_id.md#0x1_chain_id">chain_id</a>: u8, initial_version: u64, <a href="consensus_config.md#0x1_consensus_config">consensus_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, <a href="execution_config.md#0x1_execution_config">execution_config</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, epoch_interval_microsecs: u64, minimum_stake: u64, maximum_stake: u64, recurring_lockup_duration_secs: u64, allow_validator_set_change: bool, rewards_rate: u64, rewards_rate_denominator: u64, voting_power_increase_limit: u64, aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, min_voting_threshold: u128, required_proposer_stake: u64, voting_duration_secs: u64, accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_AccountMap">genesis::AccountMap</a>&gt;, employee_vesting_start: u64, employee_vesting_period_duration: u64, employees: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_EmployeeAccountMap">genesis::EmployeeAccountMap</a>&gt;, validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="genesis.md#0x1_genesis_ValidatorConfigurationWithCommission">genesis::ValidatorConfigurationWithCommission</a>&gt;)
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> verify_duration_estimate = 120;
+<b>include</b> <a href="genesis.md#0x1_genesis_InitalizeRequires">InitalizeRequires</a>;
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/randomness.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness.md
@@ -37,6 +37,7 @@ Security holds under the same proof-of-stake assumption that secures the Aptos n
 -  [Function `permutation`](#0x1_randomness_permutation)
 -  [Function `safe_add_mod`](#0x1_randomness_safe_add_mod)
 -  [Function `take_first`](#0x1_randomness_take_first)
+-  [Function `safe_add_mod_for_verification`](#0x1_randomness_safe_add_mod_for_verification)
 -  [Function `fetch_and_increment_txn_counter`](#0x1_randomness_fetch_and_increment_txn_counter)
 -  [Function `is_unbiasable`](#0x1_randomness_is_unbiasable)
 -  [Specification](#@Specification_1)
@@ -54,6 +55,7 @@ Security holds under the same proof-of-stake assumption that secures the Aptos n
     -  [Function `u64_range`](#@Specification_1_u64_range)
     -  [Function `u256_range`](#@Specification_1_u256_range)
     -  [Function `permutation`](#@Specification_1_permutation)
+    -  [Function `safe_add_mod_for_verification`](#@Specification_1_safe_add_mod_for_verification)
     -  [Function `fetch_and_increment_txn_counter`](#@Specification_1_fetch_and_increment_txn_counter)
     -  [Function `is_unbiasable`](#@Specification_1_is_unbiasable)
 
@@ -924,6 +926,36 @@ Compute <code>(a + b) % m</code>, assuming <code>m &gt;= 1, 0 &lt;= a &lt; m, 0&
 
 </details>
 
+<a id="0x1_randomness_safe_add_mod_for_verification"></a>
+
+## Function `safe_add_mod_for_verification`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="randomness.md#0x1_randomness_safe_add_mod_for_verification">safe_add_mod_for_verification</a>(a: u256, b: u256, m: u256): u256
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="randomness.md#0x1_randomness_safe_add_mod_for_verification">safe_add_mod_for_verification</a>(a: u256, b: u256, m: u256): u256 {
+    <b>let</b> neg_b = m - b;
+    <b>if</b> (a &lt; neg_b) {
+        a + b
+    } <b>else</b> {
+        a - neg_b
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_randomness_fetch_and_increment_txn_counter"></a>
 
 ## Function `fetch_and_increment_txn_counter`
@@ -1261,6 +1293,25 @@ function as its payload.
 
 
 <pre><code><b>pragma</b> aborts_if_is_partial;
+</code></pre>
+
+
+
+<a id="@Specification_1_safe_add_mod_for_verification"></a>
+
+### Function `safe_add_mod_for_verification`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="randomness.md#0x1_randomness_safe_add_mod_for_verification">safe_add_mod_for_verification</a>(a: u256, b: u256, m: u256): u256
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> m &lt; b;
+<b>aborts_if</b> a &lt; m - b && a + b &gt; <a href="randomness.md#0x1_randomness_MAX_U256">MAX_U256</a>;
+<b>ensures</b> result == <a href="randomness.md#0x1_randomness_spec_safe_add_mod">spec_safe_add_mod</a>(a, b, m);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/type_info.md
+++ b/aptos-move/framework/aptos-stdlib/doc/type_info.md
@@ -15,12 +15,15 @@
 -  [Function `type_name`](#0x1_type_info_type_name)
 -  [Function `chain_id_internal`](#0x1_type_info_chain_id_internal)
 -  [Function `size_of_val`](#0x1_type_info_size_of_val)
+-  [Function `verify_type_of`](#0x1_type_info_verify_type_of)
+-  [Function `verify_type_of_generic`](#0x1_type_info_verify_type_of_generic)
 -  [Specification](#@Specification_1)
     -  [Function `chain_id`](#@Specification_1_chain_id)
     -  [Function `type_of`](#@Specification_1_type_of)
     -  [Function `type_name`](#@Specification_1_type_name)
     -  [Function `chain_id_internal`](#@Specification_1_chain_id_internal)
     -  [Function `size_of_val`](#@Specification_1_size_of_val)
+    -  [Function `verify_type_of_generic`](#@Specification_1_verify_type_of_generic)
 
 
 <pre><code><b>use</b> <a href="../../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
@@ -288,18 +291,75 @@ analysis of vector size dynamism.
 
 </details>
 
+<a id="0x1_type_info_verify_type_of"></a>
+
+## Function `verify_type_of`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of">verify_type_of</a>()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of">verify_type_of</a>() {
+    <b>let</b> <a href="type_info.md#0x1_type_info">type_info</a> = <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>&gt;();
+    <b>let</b> account_address = <a href="type_info.md#0x1_type_info_account_address">account_address</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> module_name = <a href="type_info.md#0x1_type_info_module_name">module_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> struct_name = <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>spec</b> {
+        <b>assert</b> account_address == @aptos_std;
+        <b>assert</b> module_name == b"<a href="type_info.md#0x1_type_info">type_info</a>";
+        <b>assert</b> struct_name == b"<a href="type_info.md#0x1_type_info_TypeInfo">TypeInfo</a>";
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_type_info_verify_type_of_generic"></a>
+
+## Function `verify_type_of_generic`
+
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of_generic">verify_type_of_generic</a>&lt;T&gt;()
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of_generic">verify_type_of_generic</a>&lt;T&gt;() {
+    <b>let</b> <a href="type_info.md#0x1_type_info">type_info</a> = <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;();
+    <b>let</b> account_address = <a href="type_info.md#0x1_type_info_account_address">account_address</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> module_name = <a href="type_info.md#0x1_type_info_module_name">module_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>let</b> struct_name = <a href="type_info.md#0x1_type_info_struct_name">struct_name</a>(&<a href="type_info.md#0x1_type_info">type_info</a>);
+    <b>spec</b> {
+        <b>assert</b> account_address == <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;().account_address;
+        <b>assert</b> module_name == <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;().module_name;
+        <b>assert</b> struct_name == <a href="type_info.md#0x1_type_info_type_of">type_of</a>&lt;T&gt;().struct_name;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
-
-
-
-<a id="0x1_type_info_spec_is_struct"></a>
-
-
-<pre><code><b>native</b> <b>fun</b> <a href="type_info.md#0x1_type_info_spec_is_struct">spec_is_struct</a>&lt;T&gt;(): bool;
-</code></pre>
-
 
 
 <a id="@Specification_1_chain_id"></a>
@@ -391,6 +451,32 @@ analysis of vector size dynamism.
 
 
 <pre><code><b>ensures</b> result == <a href="type_info.md#0x1_type_info_spec_size_of_val">spec_size_of_val</a>&lt;T&gt;(val_ref);
+</code></pre>
+
+
+
+<a id="@Specification_1_verify_type_of_generic"></a>
+
+### Function `verify_type_of_generic`
+
+
+<pre><code>#[verify_only]
+<b>fun</b> <a href="type_info.md#0x1_type_info_verify_type_of_generic">verify_type_of_generic</a>&lt;T&gt;()
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> !<a href="type_info.md#0x1_type_info_spec_is_struct">spec_is_struct</a>&lt;T&gt;();
+</code></pre>
+
+
+
+
+<a id="0x1_type_info_spec_is_struct"></a>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="type_info.md#0x1_type_info_spec_is_struct">spec_is_struct</a>&lt;T&gt;(): bool;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/bit_vector.md
+++ b/aptos-move/framework/move-stdlib/doc/bit_vector.md
@@ -14,6 +14,7 @@
 -  [Function `is_index_set`](#0x1_bit_vector_is_index_set)
 -  [Function `length`](#0x1_bit_vector_length)
 -  [Function `longest_set_sequence_starting_at`](#0x1_bit_vector_longest_set_sequence_starting_at)
+-  [Function `shift_left_for_verification_only`](#0x1_bit_vector_shift_left_for_verification_only)
 -  [Specification](#@Specification_1)
     -  [Struct `BitVector`](#@Specification_1_BitVector)
     -  [Function `new`](#@Specification_1_new)
@@ -22,6 +23,7 @@
     -  [Function `shift_left`](#@Specification_1_shift_left)
     -  [Function `is_index_set`](#@Specification_1_is_index_set)
     -  [Function `longest_set_sequence_starting_at`](#@Specification_1_longest_set_sequence_starting_at)
+    -  [Function `shift_left_for_verification_only`](#@Specification_1_shift_left_for_verification_only)
 
 
 <pre><code></code></pre>
@@ -345,6 +347,78 @@ sequence, then <code>0</code> is returned.
 
 </details>
 
+<a id="0x1_bit_vector_shift_left_for_verification_only"></a>
+
+## Function `shift_left_for_verification_only`
+
+
+
+<pre><code>#[verify_only]
+<b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_shift_left_for_verification_only">shift_left_for_verification_only</a>(self: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>, amount: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_shift_left_for_verification_only">shift_left_for_verification_only</a>(self: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">BitVector</a>, amount: u64) {
+    <b>if</b> (amount &gt;= self.length) {
+        <b>let</b> len = <a href="vector.md#0x1_vector_length">vector::length</a>(&self.bit_field);
+        <b>let</b> i = 0;
+        <b>while</b> ({
+            <b>spec</b> {
+                <b>invariant</b> len == self.length;
+                <b>invariant</b> <b>forall</b> k in 0..i: !self.bit_field[k];
+                <b>invariant</b> <b>forall</b> k in i..self.length: self.bit_field[k] == <b>old</b>(self).bit_field[k];
+            };
+            i &lt; len
+        }) {
+            <b>let</b> elem = <a href="vector.md#0x1_vector_borrow_mut">vector::borrow_mut</a>(&<b>mut</b> self.bit_field, i);
+            *elem = <b>false</b>;
+            i = i + 1;
+        };
+    } <b>else</b> {
+        <b>let</b> i = amount;
+
+        <b>while</b> ({
+            <b>spec</b> {
+                <b>invariant</b> i &gt;= amount;
+                <b>invariant</b> self.length == <b>old</b>(self).length;
+                <b>invariant</b> <b>forall</b> j in amount..i: <b>old</b>(self).bit_field[j] == self.bit_field[j - amount];
+                <b>invariant</b> <b>forall</b> j in (i-amount)..self.length : <b>old</b>(self).bit_field[j] == self.bit_field[j];
+                <b>invariant</b> <b>forall</b> k in 0..i-amount: self.bit_field[k] == <b>old</b>(self).bit_field[k + amount];
+            };
+            i &lt; self.length
+        }) {
+            <b>if</b> (<a href="bit_vector.md#0x1_bit_vector_is_index_set">is_index_set</a>(self, i)) <a href="bit_vector.md#0x1_bit_vector_set">set</a>(self, i - amount)
+            <b>else</b> <a href="bit_vector.md#0x1_bit_vector_unset">unset</a>(self, i - amount);
+            i = i + 1;
+        };
+
+
+        i = self.length - amount;
+
+        <b>while</b> ({
+            <b>spec</b> {
+                <b>invariant</b> <b>forall</b> j in self.length - amount..i: !self.bit_field[j];
+                <b>invariant</b> <b>forall</b> k in 0..self.length - amount: self.bit_field[k] == <b>old</b>(self).bit_field[k + amount];
+                <b>invariant</b> i &gt;= self.length - amount;
+            };
+            i &lt; self.length
+        }) {
+            <a href="bit_vector.md#0x1_bit_vector_unset">unset</a>(self, i);
+            i = i + 1;
+        }
+    }
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="@Specification_1"></a>
 
 ## Specification
@@ -547,6 +621,28 @@ sequence, then <code>0</code> is returned.
 
 <pre><code><b>aborts_if</b> start_index &gt;= self.length;
 <b>ensures</b> <b>forall</b> i in start_index..result: <a href="bit_vector.md#0x1_bit_vector_is_index_set">is_index_set</a>(self, i);
+</code></pre>
+
+
+
+<a id="@Specification_1_shift_left_for_verification_only"></a>
+
+### Function `shift_left_for_verification_only`
+
+
+<pre><code>#[verify_only]
+<b>public</b> <b>fun</b> <a href="bit_vector.md#0x1_bit_vector_shift_left_for_verification_only">shift_left_for_verification_only</a>(self: &<b>mut</b> <a href="bit_vector.md#0x1_bit_vector_BitVector">bit_vector::BitVector</a>, amount: u64)
+</code></pre>
+
+
+
+
+<pre><code><b>aborts_if</b> <b>false</b>;
+<b>ensures</b> amount &gt;= self.length ==&gt; (<b>forall</b> k in 0..self.length: !self.bit_field[k]);
+<b>ensures</b> amount &lt; self.length ==&gt;
+    (<b>forall</b> i in self.length - amount..self.length: !self.bit_field[i]);
+<b>ensures</b> amount &lt; self.length ==&gt;
+    (<b>forall</b> i in 0..self.length - amount: self.bit_field[i] == <b>old</b>(self).bit_field[i + amount]);
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -148,6 +148,7 @@ return true.
 -  [Function `contains`](#0x1_features_contains)
 -  [Function `apply_diff`](#0x1_features_apply_diff)
 -  [Function `ensure_framework_signer`](#0x1_features_ensure_framework_signer)
+-  [Function `change_feature_flags_for_verification`](#0x1_features_change_feature_flags_for_verification)
 -  [Specification](#@Specification_1)
     -  [Resource `Features`](#@Specification_1_Features)
     -  [Resource `PendingFeatures`](#@Specification_1_PendingFeatures)
@@ -3730,6 +3731,35 @@ Helper to check whether a feature flag is enabled.
 <pre><code><b>fun</b> <a href="features.md#0x1_features_ensure_framework_signer">ensure_framework_signer</a>(account: &<a href="signer.md#0x1_signer">signer</a>) {
     <b>let</b> addr = <a href="signer.md#0x1_signer_address_of">signer::address_of</a>(account);
     <b>assert</b>!(addr == @std, <a href="error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="features.md#0x1_features_EFRAMEWORK_SIGNER_NEEDED">EFRAMEWORK_SIGNER_NEEDED</a>));
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_change_feature_flags_for_verification"></a>
+
+## Function `change_feature_flags_for_verification`
+
+
+
+<pre><code>#[verify_only]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags_for_verification">change_feature_flags_for_verification</a>(framework: &<a href="signer.md#0x1_signer">signer</a>, enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;, disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_change_feature_flags_for_verification">change_feature_flags_for_verification</a>(
+    framework: &<a href="signer.md#0x1_signer">signer</a>,
+    enable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;,
+    disable: <a href="vector.md#0x1_vector">vector</a>&lt;u64&gt;
+) <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_change_feature_flags_internal">change_feature_flags_internal</a>(framework, enable, disable)
 }
 </code></pre>
 

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -241,7 +241,7 @@ impl BuiltPackage {
                 additional_named_addresses: options.named_addresses.clone(),
                 architecture: None,
                 generate_abis: options.with_abis,
-                generate_docs: false,
+                generate_docs: options.with_docs,
                 generate_move_model: true,
                 full_model_generation: options.check_test_code,
                 install_dir: options.install_dir.clone(),

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -588,6 +588,10 @@ impl CompiledPackage {
         }
         let mut flags = if resolution_graph.build_options.test_mode {
             Flags::testing()
+        } else if resolution_graph.build_options.generate_docs {
+            // Just set for docgen so that #[verify_only] functions will not be
+            // compiled and included into either compiled modules or abis
+            Flags::verification()
         } else {
             Flags::empty()
         };
@@ -697,6 +701,7 @@ impl CompiledPackage {
                         language_version: Some(effective_language_version),
                         compiler_version: Some(version),
                         compile_test_code: flags.keep_testing_functions(),
+                        compile_verify_code: flags.is_verification(),
                         experiments: config.experiments.clone(),
                         external_checks,
                         ..Default::default()


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR fixes #15687 by adding functions with the attribute `#[verify_only]` as compilation targets when using the model generated by Compiler V2.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Framework document is updated

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Whether this change may lead to unexpected behavior in other paths.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
