### PR TITLE
[Consensus Observer] Add boilerplate for block with window messages.

### DIFF
--- a/consensus/src/consensus_observer/common/metrics.rs
+++ b/consensus/src/consensus_observer/common/metrics.rs
@@ -17,6 +17,7 @@ pub const COMMITTED_BLOCKS_LABEL: &str = "committed_blocks";
 pub const CREATED_SUBSCRIPTION_LABEL: &str = "created_subscription";
 pub const ORDERED_BLOCK_ENTRIES_LABEL: &str = "ordered_block_entries";
 pub const ORDERED_BLOCK_LABEL: &str = "ordered_block";
+pub const ORDERED_BLOCK_WITH_WINDOW_LABEL: &str = "ordered_block_with_window";
 pub const PENDING_BLOCK_ENTRIES_LABEL: &str = "pending_block_entries";
 pub const PENDING_BLOCKS_LABEL: &str = "pending_blocks";
 pub const STORED_PAYLOADS_LABEL: &str = "stored_payloads";

--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -12,7 +12,7 @@ use crate::{
             observer_client::ConsensusObserverClient,
             observer_message::{
                 BlockPayload, CommitDecision, ConsensusObserverDirectSend,
-                ConsensusObserverMessage, OrderedBlock,
+                ConsensusObserverMessage, OrderedBlock, OrderedBlockWithWindow,
             },
         },
         observer::{
@@ -348,6 +348,11 @@ impl ConsensusObserver {
         self.active_observer_state.epoch_state()
     }
 
+    /// Returns the window size for the execution pool
+    fn get_execution_pool_window_size(&self) -> Option<u64> {
+        self.active_observer_state.execution_pool_window_size()
+    }
+
     /// Returns the highest committed block epoch and round
     fn get_highest_committed_epoch_round(&self) -> (u64, Round) {
         if let Some(epoch_round) = self
@@ -675,6 +680,14 @@ impl ConsensusObserver {
                 )
                 .await;
             },
+            ConsensusObserverDirectSend::OrderedBlockWithWindow(ordered_block_with_window) => {
+                self.process_ordered_block_with_window_message(
+                    peer_network_id,
+                    message_received_time,
+                    ordered_block_with_window,
+                )
+                .await;
+            },
         }
 
         // Update the metrics for the processed blocks
@@ -688,6 +701,19 @@ impl ConsensusObserver {
         message_received_time: Instant,
         ordered_block: OrderedBlock,
     ) {
+        // If execution pool is enabled, ignore the message
+        if self.get_execution_pool_window_size().is_some() {
+            // Log the failure and update the invalid message counter
+            warn!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Received ordered block message from peer: {:?}, but execution pool is enabled! Ignoring: {:?}",
+                    peer_network_id, ordered_block.proof_block_info()
+                ))
+            );
+            increment_invalid_message_counter(&peer_network_id, metrics::ORDERED_BLOCK_LABEL);
+            return;
+        }
+
         // Verify the ordered blocks before processing
         if let Err(error) = ordered_block.verify_ordered_blocks() {
             // Log the error and update the invalid message counter
@@ -825,6 +851,101 @@ impl ConsensusObserver {
                 ))
             );
         }
+    }
+
+    /// Processes the ordered block with window message
+    async fn process_ordered_block_with_window_message(
+        &mut self,
+        peer_network_id: PeerNetworkId,
+        _message_received_time: Instant,
+        ordered_block_with_window: OrderedBlockWithWindow,
+    ) {
+        // If execution pool is disabled, ignore the message
+        let execution_pool_window_size = match self.get_execution_pool_window_size() {
+            Some(window_size) => window_size,
+            None => {
+                // Log the failure and update the invalid message counter
+                warn!(
+                    LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                        "Received ordered block with window message from peer: {:?}, but execution pool is disabled! Ignoring: {:?}",
+                        peer_network_id,
+                        ordered_block_with_window.ordered_block().proof_block_info()
+                    ))
+                );
+                increment_invalid_message_counter(
+                    &peer_network_id,
+                    metrics::ORDERED_BLOCK_WITH_WINDOW_LABEL,
+                );
+                return;
+            },
+        };
+
+        // Verify the ordered blocks before processing
+        let ordered_block = ordered_block_with_window.ordered_block();
+        if let Err(error) = ordered_block.verify_ordered_blocks() {
+            // Log the error and update the invalid message counter
+            error!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Failed to verify ordered block with window! Ignoring: {:?}, from peer: {:?}. Error: {:?}",
+                    ordered_block.proof_block_info(),
+                    peer_network_id,
+                    error
+                ))
+            );
+            increment_invalid_message_counter(
+                &peer_network_id,
+                metrics::ORDERED_BLOCK_WITH_WINDOW_LABEL,
+            );
+            return;
+        };
+
+        // Verify the execution pool window contents
+        let execution_pool_window = ordered_block_with_window.execution_pool_window();
+        if let Err(error) = execution_pool_window.verify_window_contents(execution_pool_window_size)
+        {
+            // Log the error and update the invalid message counter
+            error!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Failed to verify execution pool window contents! Ignoring: {:?}, from peer: {:?}. Error: {:?}",
+                    ordered_block.proof_block_info(),
+                    peer_network_id,
+                    error
+                ))
+            );
+            increment_invalid_message_counter(
+                &peer_network_id,
+                metrics::ORDERED_BLOCK_WITH_WINDOW_LABEL,
+            );
+            return;
+        };
+
+        // Get the epoch and round of the first block
+        let first_block = ordered_block.first_block();
+        let first_block_epoch_round = (first_block.epoch(), first_block.round());
+
+        // Determine if the block is behind the last ordered block, or if it is already pending
+        let last_ordered_block = self.get_last_ordered_block();
+        let block_out_of_date =
+            first_block_epoch_round <= (last_ordered_block.epoch(), last_ordered_block.round());
+        let block_pending = self
+            .pending_block_store
+            .lock()
+            .existing_pending_block(ordered_block);
+
+        // If the block is out of date or already pending, ignore it
+        if block_out_of_date || block_pending {
+            // Update the metrics for the dropped ordered block with window
+            update_metrics_for_dropped_ordered_block_with_window_message(
+                peer_network_id,
+                ordered_block,
+            );
+            return;
+        }
+
+        // Update the metrics for the received ordered block with window
+        update_metrics_for_ordered_block_with_window_message(peer_network_id, ordered_block);
+
+        // TODO: process the ordered block with window message (instead of just dropping it!)
     }
 
     /// Processes the given state sync notification
@@ -1217,6 +1338,25 @@ fn update_metrics_for_dropped_ordered_block_message(
     );
 }
 
+/// Updates the metrics for the dropped ordered block with window message
+fn update_metrics_for_dropped_ordered_block_with_window_message(
+    peer_network_id: PeerNetworkId,
+    ordered_block: &OrderedBlock,
+) {
+    // Increment the dropped message counter
+    increment_dropped_message_counter(&peer_network_id, metrics::ORDERED_BLOCK_WITH_WINDOW_LABEL);
+
+    // Log the dropped ordered block with window message
+    debug!(
+        LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+            "Ignoring ordered block with window message from peer: {:?}! Block epoch and round: ({}, {})",
+            peer_network_id,
+            ordered_block.proof_block_info().epoch(),
+            ordered_block.proof_block_info().round()
+        ))
+    );
+}
+
 /// Updates the metrics for the received ordered block message
 fn update_metrics_for_ordered_block_message(
     peer_network_id: PeerNetworkId,
@@ -1234,6 +1374,27 @@ fn update_metrics_for_ordered_block_message(
     metrics::set_gauge_with_label(
         &metrics::OBSERVER_RECEIVED_MESSAGE_ROUNDS,
         metrics::ORDERED_BLOCK_LABEL,
+        ordered_block.proof_block_info().round(),
+    );
+}
+
+/// Updates the metrics for the received ordered block with window message
+fn update_metrics_for_ordered_block_with_window_message(
+    peer_network_id: PeerNetworkId,
+    ordered_block: &OrderedBlock,
+) {
+    // Log the received ordered block with window message
+    let log_message = format!(
+        "Received ordered block with window: {}, from peer: {}!",
+        ordered_block.proof_block_info(),
+        peer_network_id
+    );
+    log_received_message(log_message);
+
+    // Update the metrics for the received ordered block with window
+    metrics::set_gauge_with_label(
+        &metrics::OBSERVER_RECEIVED_MESSAGE_ROUNDS,
+        metrics::ORDERED_BLOCK_WITH_WINDOW_LABEL,
         ordered_block.proof_block_info().round(),
     );
 }


### PR DESCRIPTION
## Description
This PR adds basic boilerplate code to consensus observer. It offers the following commits:
1. Add the execution pool window size to the active state. This is read from the on-chain configs and will be populated in a separate PR.
2. Add a new consensus observer message (ordered block with window), and boilerplate to process the message.

In the next PR, I'll work on actually processing the ordered block with window message.

## Testing Plan
Existing test infrastructure. Nothing has really changed here.