### PR TITLE
Improve script composer

### DIFF
--- a/aptos-move/script-composer/src/tests/mod.rs
+++ b/aptos-move/script-composer/src/tests/mod.rs
@@ -621,6 +621,32 @@ fn test_module() {
         .unwrap();
     run_txn(builder, &mut h);
 
+    // Adding two calls to the same functions
+    let mut builder = TransactionComposer::single_signer();
+    load_module(&mut builder, &h, "0x1::batched_execution");
+    builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "create_generic_droppable_value".to_string(),
+            vec!["0x1::batched_execution::Foo".to_string()],
+            vec![CallArgument::new_bytes(
+                MoveValue::U8(10).simple_serialize().unwrap(),
+            )],
+        )
+        .unwrap();
+
+    builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "create_generic_droppable_value".to_string(),
+            vec!["0x1::batched_execution::Foo".to_string()],
+            vec![CallArgument::new_bytes(
+                MoveValue::U8(10).simple_serialize().unwrap(),
+            )],
+        )
+        .unwrap();
+    run_txn(builder, &mut h);
+
     // Create a generic value and consume it
     let mut builder = TransactionComposer::single_signer();
     load_module(&mut builder, &h, "0x1::batched_execution");


### PR DESCRIPTION
## Description
Improve script composer logic:
1. Fixed deduplication problem with importing multiple generic calls.
2. Cache the module loaded results into a thread local, hopefully this would allow for a faster re-loading process.
3. Rename the wasm bindgen to camel case to align with TS apis.

## How Has This Been Tested?
Added test case for the bug fix. Caching logic would be captured by the native CI.

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
