### PR TITLE
[compiler-v2] Fix dependency ordering

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/fixed_point64.md
@@ -144,22 +144,22 @@ The multiplied value would be too large to be held in a <code>u128</code>
 
 
 
-<a id="0x1_fixed_point64_ENEGATIVE_RESULT"></a>
-
-Abort code on calculation result is negative.
-
-
-<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>: u64 = 65542;
-</code></pre>
-
-
-
 <a id="0x1_fixed_point64_ERATIO_OUT_OF_RANGE"></a>
 
 The computed ratio when converting to a <code><a href="fixed_point64.md#0x1_fixed_point64_FixedPoint64">FixedPoint64</a></code> would be unrepresentable
 
 
 <pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_ERATIO_OUT_OF_RANGE">ERATIO_OUT_OF_RANGE</a>: u64 = 131077;
+</code></pre>
+
+
+
+<a id="0x1_fixed_point64_ENEGATIVE_RESULT"></a>
+
+Abort code on calculation result is negative.
+
+
+<pre><code><b>const</b> <a href="fixed_point64.md#0x1_fixed_point64_ENEGATIVE_RESULT">ENEGATIVE_RESULT</a>: u64 = 65542;
 </code></pre>
 
 

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -94,6 +94,12 @@ fn test_veiled_coin() {
 }
 
 #[test]
+fn test_vector_pushback() {
+    let named_address = BTreeMap::new();
+    run_tests_for_pkg("vector_pushback", named_address);
+}
+
+#[test]
 fn test_common_account() {
     test_common("common_account");
 }

--- a/aptos-move/move-examples/vector_pushback/Move.toml
+++ b/aptos-move/move-examples/vector_pushback/Move.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vector_pushback"
+version = "1.0.0"
+authors = []
+
+[addresses]
+
+[dev-addresses]
+
+[dependencies.AptosFramework]
+local = "../../framework/aptos-framework/"
+
+[dev-dependencies]

--- a/aptos-move/move-examples/vector_pushback/README.md
+++ b/aptos-move/move-examples/vector_pushback/README.md
@@ -1,0 +1,2 @@
+This project exists to test the dependency ordering of modules in the presence of implicit dependencies.
+In this project, `0xdeadbeef::one` implicitly depends on `std::vector`.

--- a/aptos-move/move-examples/vector_pushback/sources/one.move
+++ b/aptos-move/move-examples/vector_pushback/sources/one.move
@@ -1,0 +1,13 @@
+module 0xdeadbeef::one {
+    public fun mod(v: vector<u64>): vector<u64> {
+        v.push_back(1);
+        v
+    }
+
+    #[test]
+    fun test() {
+        let v = vector[];
+        v = mod(v);
+        assert!(v[0] == 1);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/double_nesting.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/double_nesting.exp
@@ -1,14 +1,14 @@
 // -- Model dump before bytecode pipeline
-module 0x42::mathtest2 {
-    public inline fun fun2(a: u64,b: u64,c: u64): u64 {
-        Cast<u64>(Add<u128>(Add<u128>(Mul<u128>(7, Cast<u128>(a)), Mul<u128>(11, Cast<u128>(b))), Mul<u128>(13, Cast<u128>(c))))
-    }
-} // end 0x42::mathtest2
 module 0x42::mathtest {
     public inline fun fun1(a: u64,b: u64,c: u64): u64 {
         Cast<u64>(Add<u128>(Add<u128>(Mul<u128>(2, Cast<u128>(a)), Mul<u128>(3, Cast<u128>(b))), Mul<u128>(5, Cast<u128>(c))))
     }
 } // end 0x42::mathtest
+module 0x42::mathtest2 {
+    public inline fun fun2(a: u64,b: u64,c: u64): u64 {
+        Cast<u64>(Add<u128>(Add<u128>(Mul<u128>(7, Cast<u128>(a)), Mul<u128>(11, Cast<u128>(b))), Mul<u128>(13, Cast<u128>(c))))
+    }
+} // end 0x42::mathtest2
 module 0x42::test {
     use 0x42::mathtest; // resolved as: 0x42::mathtest
     use 0x42::mathtest2; // resolved as: 0x42::mathtest2
@@ -23,19 +23,19 @@ module 0x42::test {
 } // end 0x42::test
 
 // -- Sourcified model before bytecode pipeline
-module 0x42::mathtest2 {
-    public inline fun fun2(a: u64, b: u64, c: u64): u64 {
-        7u128 * (a as u128) + 11u128 * (b as u128) + 13u128 * (c as u128) as u64
-    }
-}
 module 0x42::mathtest {
     public inline fun fun1(a: u64, b: u64, c: u64): u64 {
         2u128 * (a as u128) + 3u128 * (b as u128) + 5u128 * (c as u128) as u64
     }
 }
+module 0x42::mathtest2 {
+    public inline fun fun2(a: u64, b: u64, c: u64): u64 {
+        7u128 * (a as u128) + 11u128 * (b as u128) + 13u128 * (c as u128) as u64
+    }
+}
 module 0x42::test {
-    use 0x42::mathtest2;
     use 0x42::mathtest;
+    use 0x42::mathtest2;
     fun test_nested_fun1() {
         if (true) () else abort 0;
     }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/multiple_nesting.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/multiple_nesting.exp
@@ -4,7 +4,7 @@ error: invalid 'module' declaration
    ┌─ tests/checking/inlining/multiple_nesting.move:4:9
    │
  4 │         mathtest2::mul_div2(c, a, b)
-   │         ^^^^^^^^^^^^^^^^^^^ '0x42::mathtest2' uses '0x42::mathtest'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^^^^^^^^^^^^^^^^ `0x42::mathtest2` uses `0x42::mathtest`. This `use` relationship creates a dependency cycle.
    ·
 11 │         mathtest::mul_div(b, a, c)
-   │         ----------------- '0x42::mathtest' uses '0x42::mathtest2'
+   │         ----------------- `0x42::mathtest` uses `0x42::mathtest2`

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/same_names.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/same_names.exp
@@ -1,12 +1,4 @@
 // -- Model dump before bytecode pipeline
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -15,6 +7,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -37,14 +37,6 @@ module 0x42::c {
 } // end 0x42::c
 
 // -- Sourcified model before bytecode pipeline
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        self.len
-    }
-}
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -53,9 +45,17 @@ module 0x42::a {
         self.len
     }
 }
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        self.len
+    }
+}
 module 0x42::c {
-    use 0x42::b;
     use 0x42::a;
+    use 0x42::b;
     inline fun foo(f: |(a::MyList, b::MyOtherList)|, x: a::MyList, y: b::MyOtherList) {
         f(x, y)
     }

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/same_names_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/same_names_typed.exp
@@ -1,12 +1,4 @@
 // -- Model dump before bytecode pipeline
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -15,6 +7,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -37,14 +37,6 @@ module 0x42::c {
 } // end 0x42::c
 
 // -- Sourcified model before bytecode pipeline
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        self.len
-    }
-}
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -53,9 +45,17 @@ module 0x42::a {
         self.len
     }
 }
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        self.len
+    }
+}
 module 0x42::c {
-    use 0x42::b;
     use 0x42::a;
+    use 0x42::b;
     inline fun foo(f: |(a::MyList, b::MyOtherList)|, x: a::MyList, y: b::MyOtherList) {
         f(x, y)
     }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
@@ -17,6 +17,16 @@ warning: unused type parameter
   │                        Unused type parameter `V`. Consider declaring it as phantom
 
 // -- Model dump before bytecode pipeline
+module 0x2::Map {
+    struct T<K,V> {
+    }
+    public native fun empty<K,V>(): T<K, V>;
+    public native fun remove<K,V>(m: &T<K, V>,k: &K): V;
+    public native fun contains_key<K,V>(m: &T<K, V>,k: &K): bool;
+    public native fun get<K,V>(m: &T<K, V>,k: &K): &V;
+    public native fun get_mut<K,V>(m: &mut T<K, V>,k: &K): &mut V;
+    public native fun insert<K,V>(m: &T<K, V>,k: K,v: V);
+} // end 0x2::Map
 module 0x2::Token {
     struct Coin<AssetType> {
         type: AssetType,
@@ -70,16 +80,6 @@ module 0x2::Token {
         pack Token::Coin<ATy>(Deref(Borrow(Immutable)(select Token::Coin.type<&mut Coin<ATy>>(coin))), amount)
     }
 } // end 0x2::Token
-module 0x2::Map {
-    struct T<K,V> {
-    }
-    public native fun empty<K,V>(): T<K, V>;
-    public native fun remove<K,V>(m: &T<K, V>,k: &K): V;
-    public native fun contains_key<K,V>(m: &T<K, V>,k: &K): bool;
-    public native fun get<K,V>(m: &T<K, V>,k: &K): &V;
-    public native fun get_mut<K,V>(m: &mut T<K, V>,k: &K): &mut V;
-    public native fun insert<K,V>(m: &T<K, V>,k: K,v: V);
-} // end 0x2::Map
 module 0x3::OneToOneMarket {
     use std::signer;
     use 0x2::Map; // resolved as: 0x2::Map
@@ -300,6 +300,16 @@ module 0x70dd::ToddNickels {
 } // end 0x70dd::ToddNickels
 
 // -- Sourcified model before bytecode pipeline
+module 0x2::Map {
+    struct T<K, V> has copy, drop, store {
+    }
+    public native fun empty<K, V>(): T<K, V>;
+    public native fun remove<K, V>(m: &T<K, V>, k: &K): V;
+    public native fun contains_key<K, V>(m: &T<K, V>, k: &K): bool;
+    public native fun get<K, V>(m: &T<K, V>, k: &K): &V;
+    public native fun get_mut<K, V>(m: &mut T<K, V>, k: &K): &mut V;
+    public native fun insert<K, V>(m: &T<K, V>, k: K, v: V);
+}
 module 0x2::Token {
     struct Coin<AssetType: copy + drop> has store {
         type: AssetType,
@@ -334,19 +344,9 @@ module 0x2::Token {
         Coin<ATy>{type: *&coin.type,value: amount}
     }
 }
-module 0x2::Map {
-    struct T<K, V> has copy, drop, store {
-    }
-    public native fun empty<K, V>(): T<K, V>;
-    public native fun remove<K, V>(m: &T<K, V>, k: &K): V;
-    public native fun contains_key<K, V>(m: &T<K, V>, k: &K): bool;
-    public native fun get<K, V>(m: &T<K, V>, k: &K): &V;
-    public native fun get_mut<K, V>(m: &mut T<K, V>, k: &K): &mut V;
-    public native fun insert<K, V>(m: &T<K, V>, k: K, v: V);
-}
 module 0x3::OneToOneMarket {
-    use 0x2::Token;
     use 0x2::Map;
+    use 0x2::Token;
     struct BorrowRecord<phantom InputAsset: copy + drop, phantom OutputAsset: copy + drop> has key {
         record: Map::T<address, u64>,
     }

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/direct_visibility.exp
@@ -1,9 +1,4 @@
 // -- Model dump before bytecode pipeline
-module 0x815::b {
-    friend fun f() {
-        Tuple()
-    }
-} // end 0x815::b
 module 0x815::a {
     friend fun f() {
         Tuple()
@@ -12,6 +7,11 @@ module 0x815::a {
         Tuple()
     }
 } // end 0x815::a
+module 0x815::b {
+    friend fun f() {
+        Tuple()
+    }
+} // end 0x815::b
 module 0x815::c {
     public fun f() {
         a::f();
@@ -22,16 +22,16 @@ module 0x815::c {
 } // end 0x815::c
 
 // -- Sourcified model before bytecode pipeline
-module 0x815::b {
-    friend 0x815::c;
-    friend fun f() {
-    }
-}
 module 0x815::a {
     friend 0x815::c;
     friend fun f() {
     }
     friend fun g() {
+    }
+}
+module 0x815::b {
+    friend 0x815::c;
+    friend fun f() {
     }
 }
 module 0x815::c {

--- a/third_party/move/move-compiler-v2/tests/lambda/inline-parity/same_names.lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda/inline-parity/same_names.lambda.exp
@@ -1,12 +1,4 @@
 // -- Model dump before env processor pipeline:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -15,6 +7,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -32,14 +32,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor unused checks:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -48,6 +40,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -65,14 +65,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor type parameter check:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -81,6 +73,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -98,14 +98,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor check recursive struct definition:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -114,6 +106,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -131,14 +131,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor check cyclic type instantiation:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -147,6 +139,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -164,14 +164,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor unused struct params check:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -180,6 +172,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -197,14 +197,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor access and use check before inlining:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -213,6 +205,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -230,14 +230,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor inlining:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -246,6 +238,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -263,14 +263,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor access and use check after inlining:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -279,6 +271,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -296,14 +296,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor acquires check:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -312,6 +304,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b
@@ -329,14 +329,6 @@ module 0x42::c {
 
 
 // -- Model dump after env processor simplifier:
-module 0x42::b {
-    struct MyOtherList {
-        len: u64,
-    }
-    public fun len(self: &MyOtherList): u64 {
-        select b::MyOtherList.len<&MyOtherList>(self)
-    }
-} // end 0x42::b
 module 0x42::a {
     struct MyList {
         len: u64,
@@ -345,6 +337,14 @@ module 0x42::a {
         select a::MyList.len<&MyList>(self)
     }
 } // end 0x42::a
+module 0x42::b {
+    struct MyOtherList {
+        len: u64,
+    }
+    public fun len(self: &MyOtherList): u64 {
+        select b::MyOtherList.len<&MyOtherList>(self)
+    }
+} // end 0x42::b
 module 0x42::c {
     use 0x42::a; // resolved as: 0x42::a
     use 0x42::b; // resolved as: 0x42::b

--- a/third_party/move/move-compiler-v2/tests/lambda/storable/doable_func.lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda/storable/doable_func.lambda.exp
@@ -1,24 +1,24 @@
 // -- Model dump before env processor pipeline:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -166,26 +166,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor unused checks:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -333,26 +333,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor type parameter check:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -500,26 +500,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor check recursive struct definition:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -667,26 +667,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor check cyclic type instantiation:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -834,26 +834,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor unused struct params check:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -1001,26 +1001,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor access and use check before inlining:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -1168,26 +1168,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor inlining:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -1335,26 +1335,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor access and use check after inlining:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -1502,26 +1502,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor acquires check:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -1669,26 +1669,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor simplifier:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -1815,26 +1815,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor lambda-lifting:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -1964,26 +1964,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor specification checker:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2
@@ -2113,26 +2113,26 @@ module 0x42::test {
 
 
 // -- Model dump after env processor specification rewriter:
-module 0x42::mod4 {
-    public fun alt_multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod4
-module 0x42::mod3 {
-    public fun multiply(x: u64,y: u64): u64 {
-        Mul<u64>(x, y)
-    }
-} // end 0x42::mod3
-module 0x42::mod2 {
-    friend fun double(x: u64): u64 {
-        Mul<u64>(x, 2)
-    }
-} // end 0x42::mod2
 module 0x42::mod1 {
     friend fun triple(x: u64): u64 {
         Mul<u64>(x, 3)
     }
 } // end 0x42::mod1
+module 0x42::mod2 {
+    friend fun double(x: u64): u64 {
+        Mul<u64>(x, 2)
+    }
+} // end 0x42::mod2
+module 0x42::mod3 {
+    public fun multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod3
+module 0x42::mod4 {
+    public fun alt_multiply(x: u64,y: u64): u64 {
+        Mul<u64>(x, y)
+    }
+} // end 0x42::mod4
 module 0x42::test {
     use 0x42::mod1; // resolved as: 0x42::mod1
     use 0x42::mod2; // resolved as: 0x42::mod2

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/friend_cycle_2.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/friend_cycle_2.exp
@@ -4,7 +4,7 @@ error: invalid 'module' declaration
   ┌─ tests/more-v1/dependencies/friend_cycle_2.move:8:5
   │
 4 │     friend 0x2::B;
-  │     -------------- '0x2::B' is a friend of '0x2::A'
+  │     -------------- `0x2::B` is a friend of `0x2::A`
   ·
 8 │     friend 0x2::A;
-  │     ^^^^^^^^^^^^^^ '0x2::A' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+  │     ^^^^^^^^^^^^^^ `0x2::A` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/friend_cycle_3.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/friend_cycle_3.exp
@@ -4,10 +4,10 @@ error: invalid 'module' declaration
    ┌─ tests/more-v1/dependencies/friend_cycle_3.move:8:5
    │
  4 │     friend 0x2::B;
-   │     -------------- '0x2::B' is a friend of '0x2::A'
+   │     -------------- `0x2::B` is a friend of `0x2::A`
    ·
  8 │     friend 0x2::C;
-   │     ^^^^^^^^^^^^^^ '0x2::C' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+   │     ^^^^^^^^^^^^^^ `0x2::C` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.
    ·
 12 │     friend 0x2::A;
-   │     -------------- '0x2::A' is a friend of '0x2::C'
+   │     -------------- `0x2::A` is a friend of `0x2::C`

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/intersecting_friend_cycles.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/intersecting_friend_cycles.exp
@@ -4,10 +4,10 @@ error: invalid 'module' declaration
    ┌─ tests/more-v1/dependencies/intersecting_friend_cycles.move:8:5
    │
  4 │     friend 0x2::B;
-   │     -------------- '0x2::B' is a friend of '0x2::A'
+   │     -------------- `0x2::B` is a friend of `0x2::A`
    ·
  8 │     friend 0x2::C;
-   │     ^^^^^^^^^^^^^^ '0x2::C' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+   │     ^^^^^^^^^^^^^^ `0x2::C` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.
    ·
 13 │     friend 0x2::A;
-   │     -------------- '0x2::A' is a friend of '0x2::C'
+   │     -------------- `0x2::A` is a friend of `0x2::C`

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/intersecting_use_cycles.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/intersecting_use_cycles.exp
@@ -4,10 +4,10 @@ error: invalid 'module' declaration
    ┌─ tests/more-v1/dependencies/intersecting_use_cycles.move:10:14
    │
  5 │     fun b(): 0x2::B::S { abort 0 }
-   │              --------- '0x2::B' uses '0x2::A'
+   │              --------- `0x2::B` uses `0x2::A`
    ·
 10 │     fun c(): 0x2::C::S { abort 0 }
-   │              ^^^^^^^^^ '0x2::C' uses '0x2::B'. This 'use' relationship creates a dependency cycle.
+   │              ^^^^^^^^^ `0x2::C` uses `0x2::B`. This `use` relationship creates a dependency cycle.
    ·
 17 │     fun A(): 0x2::A::S { abort 0 }
-   │              --------- '0x2::A' uses '0x2::C'
+   │              --------- `0x2::A` uses `0x2::C`

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/multiple_friend_cycles.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/multiple_friend_cycles.exp
@@ -4,7 +4,7 @@ error: invalid 'module' declaration
   ┌─ tests/more-v1/dependencies/multiple_friend_cycles.move:8:5
   │
 4 │     friend 0x2::B;
-  │     -------------- '0x2::B' is a friend of '0x2::A'
+  │     -------------- `0x2::B` is a friend of `0x2::A`
   ·
 8 │     friend 0x2::A;
-  │     ^^^^^^^^^^^^^^ '0x2::A' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+  │     ^^^^^^^^^^^^^^ `0x2::A` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/multiple_use_cycles.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/multiple_use_cycles.exp
@@ -4,7 +4,7 @@ error: invalid 'module' declaration
    ┌─ tests/more-v1/dependencies/multiple_use_cycles.move:25:14
    │
 25 │     fun f(): 0x2::F::S { abort 0 }
-   │              ^^^^^^^^^ '0x2::F' uses '0x2::D'. This 'use' relationship creates a dependency cycle.
+   │              ^^^^^^^^^ `0x2::F` uses `0x2::D`. This `use` relationship creates a dependency cycle.
    ·
 35 │     fun d(): 0x2::D::S { abort 0 }
-   │              --------- '0x2::D' uses '0x2::F'
+   │              --------- `0x2::D` uses `0x2::F`

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_cycle_2.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_cycle_2.exp
@@ -4,7 +4,7 @@ error: invalid 'module' declaration
    ┌─ tests/more-v1/dependencies/use_cycle_2.move:5:9
    │
  5 │         0x2::B::foo()
-   │         ^^^^^^^^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^^^^^^^^ `0x2::B` uses `0x2::A`. This `use` relationship creates a dependency cycle.
    ·
 11 │         0x2::A::foo()
-   │         ----------- '0x2::A' uses '0x2::B'
+   │         ----------- `0x2::A` uses `0x2::B`

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_cycle_3.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_cycle_3.exp
@@ -4,10 +4,10 @@ error: invalid 'module' declaration
     ┌─ tests/more-v1/dependencies/use_cycle_3.move:95:16
     │
  85 │     fun foo(): 0x4::A::S {
-    │                --------- '0x4::A' uses '0x4::C'
+    │                --------- `0x4::A` uses `0x4::C`
     ·
  95 │     fun foo(): 0x4::C::S {
-    │                ^^^^^^^^^ '0x4::C' uses '0x4::B'. This 'use' relationship creates a dependency cycle.
+    │                ^^^^^^^^^ `0x4::C` uses `0x4::B`. This `use` relationship creates a dependency cycle.
     ·
 106 │     fun foo(): 0x4::B::S {
-    │                --------- '0x4::B' uses '0x4::A'
+    │                --------- `0x4::B` uses `0x4::A`

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_friend_direct.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_friend_direct.exp
@@ -4,7 +4,7 @@ error: invalid 'module' declaration
   ┌─ tests/more-v1/dependencies/use_friend_direct.move:8:9
   │
 5 │     friend B;
-  │     --------- '0x2::B' is a friend of '0x2::A'
+  │     --------- `0x2::B` is a friend of `0x2::A`
   ·
 8 │         B::b()
-  │         ^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
+  │         ^^^^ `0x2::B` uses `0x2::A`. This `use` relationship creates a dependency cycle.

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_friend_transitive_by_friend.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_friend_transitive_by_friend.exp
@@ -4,10 +4,10 @@ error: invalid 'module' declaration
    ┌─ tests/more-v1/dependencies/use_friend_transitive_by_friend.move:14:5
    │
  6 │     friend B;
-   │     --------- '0x2::B' is a friend of '0x2::A'
+   │     --------- `0x2::B` is a friend of `0x2::A`
    ·
  9 │         C::c()
-   │         ---- '0x2::C' uses '0x2::A'
+   │         ---- `0x2::C` uses `0x2::A`
    ·
 14 │     friend 0x2::C;
-   │     ^^^^^^^^^^^^^^ '0x2::C' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+   │     ^^^^^^^^^^^^^^ `0x2::C` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.

--- a/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_friend_transitive_by_use.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/dependencies/use_friend_transitive_by_use.exp
@@ -4,10 +4,10 @@ error: invalid 'module' declaration
    ┌─ tests/more-v1/dependencies/use_friend_transitive_by_use.move:16:9
    │
  6 │     friend C;
-   │     --------- '0x2::C' is a friend of '0x2::A'
+   │     --------- `0x2::C` is a friend of `0x2::A`
    ·
  9 │         B::b()
-   │         ---- '0x2::B' uses '0x2::A'
+   │         ---- `0x2::B` uses `0x2::A`
    ·
 16 │         C::c()
-   │         ^^^^ '0x2::C' uses '0x2::B'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^ `0x2::C` uses `0x2::B`. This `use` relationship creates a dependency cycle.

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/double_nesting.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/double_nesting.exp
@@ -1,14 +1,14 @@
 // -- Model dump before bytecode pipeline
-module 0x42::mathtest2 {
-    public inline fun fun2(a: u64,b: u64,c: u64): u64 {
-        Cast<u64>(Add<u128>(Add<u128>(Mul<u128>(7, Cast<u128>(a)), Mul<u128>(11, Cast<u128>(b))), Mul<u128>(13, Cast<u128>(c))))
-    }
-} // end 0x42::mathtest2
 module 0x42::mathtest {
     public inline fun fun1(a: u64,b: u64,c: u64): u64 {
         Cast<u64>(Add<u128>(Add<u128>(Mul<u128>(2, Cast<u128>(a)), Mul<u128>(3, Cast<u128>(b))), Mul<u128>(5, Cast<u128>(c))))
     }
 } // end 0x42::mathtest
+module 0x42::mathtest2 {
+    public inline fun fun2(a: u64,b: u64,c: u64): u64 {
+        Cast<u64>(Add<u128>(Add<u128>(Mul<u128>(7, Cast<u128>(a)), Mul<u128>(11, Cast<u128>(b))), Mul<u128>(13, Cast<u128>(c))))
+    }
+} // end 0x42::mathtest2
 module 0x42::test {
     use 0x42::mathtest; // resolved as: 0x42::mathtest
     use 0x42::mathtest2; // resolved as: 0x42::mathtest2
@@ -23,19 +23,19 @@ module 0x42::test {
 } // end 0x42::test
 
 // -- Sourcified model before bytecode pipeline
-module 0x42::mathtest2 {
-    public inline fun fun2(a: u64, b: u64, c: u64): u64 {
-        7u128 * (a as u128) + 11u128 * (b as u128) + 13u128 * (c as u128) as u64
-    }
-}
 module 0x42::mathtest {
     public inline fun fun1(a: u64, b: u64, c: u64): u64 {
         2u128 * (a as u128) + 3u128 * (b as u128) + 5u128 * (c as u128) as u64
     }
 }
+module 0x42::mathtest2 {
+    public inline fun fun2(a: u64, b: u64, c: u64): u64 {
+        7u128 * (a as u128) + 11u128 * (b as u128) + 13u128 * (c as u128) as u64
+    }
+}
 module 0x42::test {
-    use 0x42::mathtest2;
     use 0x42::mathtest;
+    use 0x42::mathtest2;
     fun test_nested_fun1() {
         if (true) () else abort 0;
     }

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/package_visibility_cycle.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/package_visibility_cycle.exp
@@ -4,7 +4,7 @@ error: invalid 'module' declaration
   ┌─ tests/visibility-checker/package_visibility_cycle.move:3:9
   │
 3 │         0x42::B::foo()
-  │         ^^^^^^^^^^^^ '0x42::B' uses '0x42::A'. This 'use' relationship creates a dependency cycle.
+  │         ^^^^^^^^^^^^ `0x42::B` uses `0x42::A`. This `use` relationship creates a dependency cycle.
   ·
 9 │         0x42::A::foo()
-  │         ------------ '0x42::A' uses '0x42::B'
+  │         ------------ `0x42::A` uses `0x42::B`

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/visibility_complex.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/visibility_complex.exp
@@ -1,14 +1,14 @@
 // -- Model dump before bytecode pipeline
-module 0x42::B {
-    friend fun foo() {
-        Tuple()
-    }
-} // end 0x42::B
 module 0x42::A {
     friend fun foo() {
         Tuple()
     }
 } // end 0x42::A
+module 0x42::B {
+    friend fun foo() {
+        Tuple()
+    }
+} // end 0x42::B
 module 0x42::C {
     friend fun foo() {
         A::foo();
@@ -25,14 +25,14 @@ module 0x42::D {
 } // end 0x42::D
 
 // -- Sourcified model before bytecode pipeline
-module 0x42::B {
+module 0x42::A {
     friend 0x42::C;
-    friend 0x42::D;
     friend fun foo() {
     }
 }
-module 0x42::A {
+module 0x42::B {
     friend 0x42::C;
+    friend 0x42::D;
     friend fun foo() {
     }
 }

--- a/third_party/move/move-compiler/tests/move_check/dependencies/friend_cycle_2.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/friend_cycle_2.exp
@@ -2,8 +2,8 @@ error[E02004]: invalid 'module' declaration
   ┌─ tests/move_check/dependencies/friend_cycle_2.move:8:5
   │
 4 │     friend 0x2::B;
-  │     -------------- '0x2::B' is a friend of '0x2::A'
+  │     -------------- `0x2::B` is a friend of `0x2::A`
   ·
 8 │     friend 0x2::A;
-  │     ^^^^^^^^^^^^^^ '0x2::A' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+  │     ^^^^^^^^^^^^^^ `0x2::A` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/friend_cycle_3.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/friend_cycle_3.exp
@@ -2,11 +2,11 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/friend_cycle_3.move:8:5
    │
  4 │     friend 0x2::B;
-   │     -------------- '0x2::B' is a friend of '0x2::A'
+   │     -------------- `0x2::B` is a friend of `0x2::A`
    ·
  8 │     friend 0x2::C;
-   │     ^^^^^^^^^^^^^^ '0x2::C' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+   │     ^^^^^^^^^^^^^^ `0x2::C` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.
    ·
 12 │     friend 0x2::A;
-   │     -------------- '0x2::A' is a friend of '0x2::C'
+   │     -------------- `0x2::A` is a friend of `0x2::C`
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/intersecting_friend_cycles.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/intersecting_friend_cycles.exp
@@ -2,11 +2,11 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/intersecting_friend_cycles.move:8:5
    │
  4 │     friend 0x2::B;
-   │     -------------- '0x2::B' is a friend of '0x2::A'
+   │     -------------- `0x2::B` is a friend of `0x2::A`
    ·
  8 │     friend 0x2::C;
-   │     ^^^^^^^^^^^^^^ '0x2::C' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+   │     ^^^^^^^^^^^^^^ `0x2::C` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.
    ·
 13 │     friend 0x2::A;
-   │     -------------- '0x2::A' is a friend of '0x2::C'
+   │     -------------- `0x2::A` is a friend of `0x2::C`
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/intersecting_use_cycles.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/intersecting_use_cycles.exp
@@ -2,11 +2,11 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/intersecting_use_cycles.move:10:14
    │
  5 │     fun b(): 0x2::B::S { abort 0 }
-   │              --------- '0x2::B' uses '0x2::A'
+   │              --------- `0x2::B` uses `0x2::A`
    ·
 10 │     fun c(): 0x2::C::S { abort 0 }
-   │              ^^^^^^^^^ '0x2::C' uses '0x2::B'. This 'use' relationship creates a dependency cycle.
+   │              ^^^^^^^^^ `0x2::C` uses `0x2::B`. This `use` relationship creates a dependency cycle.
    ·
 17 │     fun A(): 0x2::A::S { abort 0 }
-   │              --------- '0x2::A' uses '0x2::C'
+   │              --------- `0x2::A` uses `0x2::C`
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/multiple_friend_cycles.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/multiple_friend_cycles.exp
@@ -2,8 +2,8 @@ error[E02004]: invalid 'module' declaration
   ┌─ tests/move_check/dependencies/multiple_friend_cycles.move:8:5
   │
 4 │     friend 0x2::B;
-  │     -------------- '0x2::B' is a friend of '0x2::A'
+  │     -------------- `0x2::B` is a friend of `0x2::A`
   ·
 8 │     friend 0x2::A;
-  │     ^^^^^^^^^^^^^^ '0x2::A' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+  │     ^^^^^^^^^^^^^^ `0x2::A` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/multiple_use_cycles.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/multiple_use_cycles.exp
@@ -2,8 +2,8 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/multiple_use_cycles.move:25:14
    │
 25 │     fun f(): 0x2::F::S { abort 0 }
-   │              ^^^^^^^^^ '0x2::F' uses '0x2::D'. This 'use' relationship creates a dependency cycle.
+   │              ^^^^^^^^^ `0x2::F` uses `0x2::D`. This `use` relationship creates a dependency cycle.
    ·
 35 │     fun d(): 0x2::D::S { abort 0 }
-   │              --------- '0x2::D' uses '0x2::F'
+   │              --------- `0x2::D` uses `0x2::F`
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/use_cycle_2.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/use_cycle_2.exp
@@ -2,8 +2,8 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/use_cycle_2.move:5:9
    │
  5 │         0x2::B::foo()
-   │         ^^^^^^^^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^^^^^^^^ `0x2::B` uses `0x2::A`. This `use` relationship creates a dependency cycle.
    ·
 11 │         0x2::A::foo()
-   │         ----------- '0x2::A' uses '0x2::B'
+   │         ----------- `0x2::A` uses `0x2::B`
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/use_cycle_3.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/use_cycle_3.exp
@@ -2,11 +2,11 @@ error[E02004]: invalid 'module' declaration
     ┌─ tests/move_check/dependencies/use_cycle_3.move:95:16
     │
  85 │     fun foo(): 0x4::A::S {
-    │                --------- '0x4::A' uses '0x4::C'
+    │                --------- `0x4::A` uses `0x4::C`
     ·
  95 │     fun foo(): 0x4::C::S {
-    │                ^^^^^^^^^ '0x4::C' uses '0x4::B'. This 'use' relationship creates a dependency cycle.
+    │                ^^^^^^^^^ `0x4::C` uses `0x4::B`. This `use` relationship creates a dependency cycle.
     ·
 106 │     fun foo(): 0x4::B::S {
-    │                --------- '0x4::B' uses '0x4::A'
+    │                --------- `0x4::B` uses `0x4::A`
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/use_friend_direct.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/use_friend_direct.exp
@@ -2,8 +2,8 @@ error[E02004]: invalid 'module' declaration
   ┌─ tests/move_check/dependencies/use_friend_direct.move:8:9
   │
 5 │     friend B;
-  │     --------- '0x2::B' is a friend of '0x2::A'
+  │     --------- `0x2::B` is a friend of `0x2::A`
   ·
 8 │         B::b()
-  │         ^^^^ '0x2::B' uses '0x2::A'. This 'use' relationship creates a dependency cycle.
+  │         ^^^^ `0x2::B` uses `0x2::A`. This `use` relationship creates a dependency cycle.
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_friend.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_friend.exp
@@ -2,11 +2,11 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/use_friend_transitive_by_friend.move:14:5
    │
  6 │     friend B;
-   │     --------- '0x2::B' is a friend of '0x2::A'
+   │     --------- `0x2::B` is a friend of `0x2::A`
    ·
  9 │         C::c()
-   │         ---- '0x2::C' uses '0x2::A'
+   │         ---- `0x2::C` uses `0x2::A`
    ·
 14 │     friend 0x2::C;
-   │     ^^^^^^^^^^^^^^ '0x2::C' is a friend of '0x2::B'. This 'friend' relationship creates a dependency cycle.
+   │     ^^^^^^^^^^^^^^ `0x2::C` is a friend of `0x2::B`. This `friend` relationship creates a dependency cycle.
 

--- a/third_party/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_use.exp
+++ b/third_party/move/move-compiler/tests/move_check/dependencies/use_friend_transitive_by_use.exp
@@ -2,11 +2,11 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/dependencies/use_friend_transitive_by_use.move:16:9
    │
  6 │     friend C;
-   │     --------- '0x2::C' is a friend of '0x2::A'
+   │     --------- `0x2::C` is a friend of `0x2::A`
    ·
  9 │         B::b()
-   │         ---- '0x2::B' uses '0x2::A'
+   │         ---- `0x2::B` uses `0x2::A`
    ·
 16 │         C::c()
-   │         ^^^^ '0x2::C' uses '0x2::B'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^ `0x2::C` uses `0x2::B`. This `use` relationship creates a dependency cycle.
 

--- a/third_party/move/move-compiler/tests/move_check/inlining/multiple_nesting.exp
+++ b/third_party/move/move-compiler/tests/move_check/inlining/multiple_nesting.exp
@@ -2,10 +2,10 @@ error[E02004]: invalid 'module' declaration
    ┌─ tests/move_check/inlining/multiple_nesting.move:4:9
    │
  4 │         mathtest2::mul_div2(c, a, b)
-   │         ^^^^^^^^^^^^^^^^^^^ '0x42::mathtest2' uses '0x42::mathtest'. This 'use' relationship creates a dependency cycle.
+   │         ^^^^^^^^^^^^^^^^^^^ `0x42::mathtest2` uses `0x42::mathtest`. This `use` relationship creates a dependency cycle.
    ·
 11 │         mathtest::mul_div(b, a, c)
-   │         ----------------- '0x42::mathtest' uses '0x42::mathtest2'
+   │         ----------------- `0x42::mathtest` uses `0x42::mathtest2`
 
 error[E14001]: recursion during function inlining not allowed
   ┌─ tests/move_check/inlining/multiple_nesting.move:4:20


### PR DESCRIPTION
## Description

This PR contains two fixes:
- all modules being compiled are explicitly ordered, instead of only ordering those modules that participate in a dependency relation (i.e., uses another module or is used by another module)
- if the `vector` module is included in the compilation (which for compiler v2, it always is), then the `vector` module and all its dependencies are ordered (and therefore "visited") before any other module: this allows other modules to be implicitly dependent on `vector`.

## How Has This Been Tested?
- Added a new test `vector_pushback` that currently fails on `main`
- Manual testing
- Existing tests: updated baselines after verifying the changes are reasonable.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
