### PR TITLE
Make permissioned signer abort on address_of

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -1424,7 +1424,7 @@ many contexts:
 
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="account.md#0x1_account_rotate_authentication_key_internal">rotate_authentication_key_internal</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_auth_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(<a href="account.md#0x1_account_exists_at">exists_at</a>(addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&new_auth_key) == 32,
@@ -1524,7 +1524,7 @@ to rotate his address to Alice's address in the first place.
     cap_rotate_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     cap_update_table: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a>, <a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a> {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(<a href="account.md#0x1_account_exists_at">exists_at</a>(addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
     <a href="account.md#0x1_account_check_rotation_permission">check_rotation_permission</a>(<a href="account.md#0x1_account">account</a>);
     <b>let</b> account_resource = <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(addr);
@@ -1606,7 +1606,7 @@ to rotate his address to Alice's address in the first place.
     <b>assert</b>!(<a href="account.md#0x1_account_exists_at">exists_at</a>(rotation_cap_offerer_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EOFFERER_ADDRESS_DOES_NOT_EXIST">EOFFERER_ADDRESS_DOES_NOT_EXIST</a>));
 
     // Check that there <b>exists</b> a rotation <a href="../../aptos-stdlib/doc/capability.md#0x1_capability">capability</a> offer at the offerer's <a href="account.md#0x1_account">account</a> resource for the delegate.
-    <b>let</b> delegate_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegate_signer);
+    <b>let</b> delegate_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(delegate_signer);
     <b>let</b> offerer_account_resource = <b>borrow_global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(rotation_cap_offerer_address);
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_contains">option::contains</a>(&offerer_account_resource.rotation_capability_offer.for, &delegate_address),
@@ -1683,7 +1683,7 @@ offer, calling this function will replace the previous <code>recipient_address</
     recipient_address: <b>address</b>,
 ) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
     <a href="account.md#0x1_account_check_rotation_permission">check_rotation_permission</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(<a href="account.md#0x1_account_exists_at">exists_at</a>(recipient_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
 
     // proof that this <a href="account.md#0x1_account">account</a> intends <b>to</b> delegate its rotation <a href="../../aptos-stdlib/doc/capability.md#0x1_capability">capability</a> <b>to</b> another <a href="account.md#0x1_account">account</a>
@@ -1764,7 +1764,7 @@ authority of the new authentication key.
 
 
 <pre><code>entry <b>fun</b> <a href="account.md#0x1_account_set_originating_address">set_originating_address</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a>, <a href="account.md#0x1_account_OriginatingAddress">OriginatingAddress</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(<b>exists</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
     <b>let</b> auth_key_as_address =
         <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(<b>borrow_global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(account_addr).authentication_key);
@@ -1862,7 +1862,7 @@ Revoke the rotation capability offer given to <code>to_be_revoked_recipient_addr
 <pre><code><b>public</b> entry <b>fun</b> <a href="account.md#0x1_account_revoke_rotation_capability">revoke_rotation_capability</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, to_be_revoked_address: <b>address</b>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
     <b>assert</b>!(<a href="account.md#0x1_account_exists_at">exists_at</a>(to_be_revoked_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
     <a href="account.md#0x1_account_check_rotation_permission">check_rotation_permission</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>let</b> account_resource = <b>borrow_global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(addr);
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_contains">option::contains</a>(&account_resource.rotation_capability_offer.for, &to_be_revoked_address),
@@ -1894,7 +1894,7 @@ Revoke any rotation capability offer in the specified account.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="account.md#0x1_account_revoke_any_rotation_capability">revoke_any_rotation_capability</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
     <a href="account.md#0x1_account_check_rotation_permission">check_rotation_permission</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> account_resource = <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>));
+    <b>let</b> account_resource = <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>));
     <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> account_resource.rotation_capability_offer.for);
 }
 </code></pre>
@@ -1935,7 +1935,7 @@ to the account owner's signer capability).
     recipient_address: <b>address</b>
 ) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
     <a href="account.md#0x1_account_check_offering_permission">check_offering_permission</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> source_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> source_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(<a href="account.md#0x1_account_exists_at">exists_at</a>(recipient_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
 
     // Proof that this <a href="account.md#0x1_account">account</a> intends <b>to</b> delegate its <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <a href="../../aptos-stdlib/doc/capability.md#0x1_capability">capability</a> <b>to</b> another <a href="account.md#0x1_account">account</a>.
@@ -2035,7 +2035,7 @@ has a signer capability offer from <code><a href="account.md#0x1_account">accoun
 <pre><code><b>public</b> entry <b>fun</b> <a href="account.md#0x1_account_revoke_signer_capability">revoke_signer_capability</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, to_be_revoked_address: <b>address</b>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
     <b>assert</b>!(<a href="account.md#0x1_account_exists_at">exists_at</a>(to_be_revoked_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_EACCOUNT_DOES_NOT_EXIST">EACCOUNT_DOES_NOT_EXIST</a>));
     <a href="account.md#0x1_account_check_offering_permission">check_offering_permission</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>let</b> account_resource = <b>borrow_global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(addr);
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_contains">option::contains</a>(&account_resource.signer_capability_offer.for, &to_be_revoked_address),
@@ -2067,7 +2067,7 @@ Revoke any signer capability offer in the specified account.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="account.md#0x1_account_revoke_any_signer_capability">revoke_any_signer_capability</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
     <a href="account.md#0x1_account_check_offering_permission">check_offering_permission</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> account_resource = <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>));
+    <b>let</b> account_resource = <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>));
     <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_extract">option::extract</a>(&<b>mut</b> account_resource.signer_capability_offer.for);
 }
 </code></pre>
@@ -2099,7 +2099,7 @@ at the offerer's address.
 
     // Check <b>if</b> there's an existing <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <a href="../../aptos-stdlib/doc/capability.md#0x1_capability">capability</a> offer from the offerer.
     <b>let</b> account_resource = <b>borrow_global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(offerer_address);
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(
         <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_contains">option::contains</a>(&account_resource.signer_capability_offer.for, &addr),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account.md#0x1_account_ENO_SUCH_SIGNER_CAPABILITY">ENO_SUCH_SIGNER_CAPABILITY</a>)
@@ -2297,7 +2297,7 @@ than <code>(1/2)^(256)</code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x1_account_create_resource_account">create_resource_account</a>(source: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="account.md#0x1_account_SignerCapability">SignerCapability</a>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
-    <b>let</b> resource_addr = <a href="account.md#0x1_account_create_resource_address">create_resource_address</a>(&<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(source), seed);
+    <b>let</b> resource_addr = <a href="account.md#0x1_account_create_resource_address">create_resource_address</a>(&<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(source), seed);
     <b>let</b> resource = <b>if</b> (<a href="account.md#0x1_account_exists_at">exists_at</a>(resource_addr)) {
         <b>let</b> <a href="account.md#0x1_account">account</a> = <b>borrow_global</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(resource_addr);
         <b>assert</b>!(
@@ -2386,7 +2386,7 @@ GUID management methods.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="account.md#0x1_account_create_guid">create_guid</a>(account_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="guid.md#0x1_guid_GUID">guid::GUID</a> <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a> {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(account_signer);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(account_signer);
     <b>let</b> <a href="account.md#0x1_account">account</a> = <b>borrow_global_mut</b>&lt;<a href="account.md#0x1_account_Account">Account</a>&gt;(addr);
     <b>let</b> <a href="guid.md#0x1_guid">guid</a> = <a href="guid.md#0x1_guid_create">guid::create</a>(addr, &<b>mut</b> <a href="account.md#0x1_account">account</a>.guid_creation_num);
     <b>assert</b>!(

--- a/aptos-move/framework/aptos-framework/doc/account_abstraction.md
+++ b/aptos-move/framework/aptos-framework/doc/account_abstraction.md
@@ -313,7 +313,7 @@ Note: it is a private entry function that can only be called directly from trans
     <a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
 ) <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a> {
     <b>assert</b>!(!is_permissioned_signer(<a href="account.md#0x1_account">account</a>), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="account_abstraction.md#0x1_account_abstraction_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>));
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>let</b> resource_addr = <a href="account_abstraction.md#0x1_account_abstraction_resource_addr">resource_addr</a>(addr);
     <b>if</b> (<b>exists</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(resource_addr)) {
         <b>move_from</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(resource_addr);
@@ -372,7 +372,7 @@ Note: it is a private entry function that can only be called directly from trans
     auth_function: FunctionInfo,
     is_add: bool,
 ) <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a> {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>let</b> resource_addr = <a href="account_abstraction.md#0x1_account_abstraction_resource_addr">resource_addr</a>(addr);
     <b>let</b> dispatcher_auth_function_info = <a href="function_info.md#0x1_function_info_new_function_info_from_address">function_info::new_function_info_from_address</a>(
         @aptos_framework,
@@ -523,7 +523,7 @@ Return the current dispatchable authenticator move function info. <code>None</co
     func_info: FunctionInfo,
     signing_data: AbstractionAuthData,
 ): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a> {
-    <b>let</b> master_signer_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
+    <b>let</b> master_signer_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&<a href="account.md#0x1_account">account</a>);
     <b>let</b> func_infos = <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator_internal">dispatchable_authenticator_internal</a>(master_signer_addr);
     <b>assert</b>!(<a href="ordered_map.md#0x1_ordered_map_contains">ordered_map::contains</a>(func_infos, &func_info), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EFUNCTION_INFO_EXISTENCE">EFUNCTION_INFO_EXISTENCE</a>));
     <a href="function_info.md#0x1_function_info_load_module_from_function">function_info::load_module_from_function</a>(&func_info);

--- a/aptos-move/framework/aptos-framework/doc/aptos_account.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_account.md
@@ -579,7 +579,7 @@ Set whether <code><a href="account.md#0x1_account">account</a></code> can receiv
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="aptos_account.md#0x1_aptos_account_set_allow_direct_coin_transfers">set_allow_direct_coin_transfers</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, allow: bool) <b>acquires</b> <a href="aptos_account.md#0x1_aptos_account_DirectTransferConfig">DirectTransferConfig</a> {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>if</b> (<b>exists</b>&lt;<a href="aptos_account.md#0x1_aptos_account_DirectTransferConfig">DirectTransferConfig</a>&gt;(addr)) {
         <b>let</b> direct_transfer_config = <b>borrow_global_mut</b>&lt;<a href="aptos_account.md#0x1_aptos_account_DirectTransferConfig">DirectTransferConfig</a>&gt;(addr);
         // Short-circuit <b>to</b> avoid emitting an <a href="event.md#0x1_event">event</a> <b>if</b> direct transfer config is not changing.
@@ -664,7 +664,7 @@ By default, this returns true if an account has not explicitly set whether the c
 
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="aptos_account.md#0x1_aptos_account_register_apt">register_apt</a>(account_signer: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_new_accounts_default_to_fa_apt_store_enabled">features::new_accounts_default_to_fa_apt_store_enabled</a>()) {
-        <a href="aptos_account.md#0x1_aptos_account_ensure_primary_fungible_store_exists">ensure_primary_fungible_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(account_signer));
+        <a href="aptos_account.md#0x1_aptos_account_ensure_primary_fungible_store_exists">ensure_primary_fungible_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(account_signer));
     } <b>else</b> {
         <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(account_signer);
     }
@@ -699,7 +699,7 @@ to transfer APT) - if we want to allow APT PFS without account itself
 <pre><code><b>public</b>(<b>friend</b>) entry <b>fun</b> <a href="aptos_account.md#0x1_aptos_account_fungible_transfer_only">fungible_transfer_only</a>(
     source: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <b>to</b>: <b>address</b>, amount: u64
 ) {
-    <b>let</b> sender_store = <a href="aptos_account.md#0x1_aptos_account_ensure_primary_fungible_store_exists">ensure_primary_fungible_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(source));
+    <b>let</b> sender_store = <a href="aptos_account.md#0x1_aptos_account_ensure_primary_fungible_store_exists">ensure_primary_fungible_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(source));
     <b>let</b> recipient_store = <a href="aptos_account.md#0x1_aptos_account_ensure_primary_fungible_store_exists">ensure_primary_fungible_store_exists</a>(<b>to</b>);
 
     // <b>use</b> <b>internal</b> APIs, <b>as</b> they skip:

--- a/aptos-move/framework/aptos-framework/doc/aptos_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_coin.md
@@ -244,7 +244,7 @@ Can only called during genesis to initialize the Aptos coin.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="aptos_coin.md#0x1_aptos_coin_has_mint_capability">has_mint_capability</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): bool {
-    <b>exists</b>&lt;<a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>))
+    <b>exists</b>&lt;<a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>))
 }
 </code></pre>
 
@@ -310,7 +310,7 @@ Expects account and APT store to be registered before calling.
         18446744073709551615,
         &mint_cap,
     );
-    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">AptosCoin</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(core_resources), coins);
+    <a href="coin.md#0x1_coin_deposit">coin::deposit</a>&lt;<a href="aptos_coin.md#0x1_aptos_coin_AptosCoin">AptosCoin</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(core_resources), coins);
 
     <b>move_to</b>(core_resources, <a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a> { mint_cap });
     <b>move_to</b>(core_resources, <a href="aptos_coin.md#0x1_aptos_coin_Delegations">Delegations</a> { inner: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>() });
@@ -343,7 +343,7 @@ Create new coins and deposit them into dst_addr's account.
     dst_addr: <b>address</b>,
     amount: u64,
 ) <b>acquires</b> <a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
 
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a>&gt;(account_addr),
@@ -410,7 +410,7 @@ Claim the delegated mint capability and destroy the delegated token.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="aptos_coin.md#0x1_aptos_coin_claim_mint_capability">claim_mint_capability</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="aptos_coin.md#0x1_aptos_coin_Delegations">Delegations</a>, <a href="aptos_coin.md#0x1_aptos_coin_MintCapStore">MintCapStore</a> {
-    <b>let</b> maybe_index = <a href="aptos_coin.md#0x1_aptos_coin_find_delegation">find_delegation</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>));
+    <b>let</b> maybe_index = <a href="aptos_coin.md#0x1_aptos_coin_find_delegation">find_delegation</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>));
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&maybe_index), <a href="aptos_coin.md#0x1_aptos_coin_EDELEGATION_NOT_FOUND">EDELEGATION_NOT_FOUND</a>);
     <b>let</b> idx = *<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&maybe_index);
     <b>let</b> delegations = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="aptos_coin.md#0x1_aptos_coin_Delegations">Delegations</a>&gt;(@core_resources).inner;

--- a/aptos-move/framework/aptos-framework/doc/aptos_governance.md
+++ b/aptos-move/framework/aptos-framework/doc/aptos_governance.md
@@ -1405,7 +1405,7 @@ Return proposal_id when a proposal is successfully created.
     is_multi_step_proposal: bool,
 ): u64 <b>acquires</b> <a href="aptos_governance.md#0x1_aptos_governance_GovernanceConfig">GovernanceConfig</a>, <a href="aptos_governance.md#0x1_aptos_governance_GovernanceEvents">GovernanceEvents</a> {
     <a href="aptos_governance.md#0x1_aptos_governance_check_governance_permission">check_governance_permission</a>(proposer);
-    <b>let</b> proposer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(proposer);
+    <b>let</b> proposer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(proposer);
     <b>assert</b>!(
         <a href="stake.md#0x1_stake_get_delegated_voter">stake::get_delegated_voter</a>(stake_pool) == proposer_address,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="aptos_governance.md#0x1_aptos_governance_ENOT_DELEGATED_VOTER">ENOT_DELEGATED_VOTER</a>)
@@ -1638,7 +1638,7 @@ cannot vote on the proposal even after partial governance voting is enabled.
     should_pass: bool,
 ) <b>acquires</b> <a href="aptos_governance.md#0x1_aptos_governance_ApprovedExecutionHashes">ApprovedExecutionHashes</a>, <a href="aptos_governance.md#0x1_aptos_governance_VotingRecords">VotingRecords</a>, <a href="aptos_governance.md#0x1_aptos_governance_VotingRecordsV2">VotingRecordsV2</a>, <a href="aptos_governance.md#0x1_aptos_governance_GovernanceEvents">GovernanceEvents</a> {
     <a href="permissioned_signer.md#0x1_permissioned_signer_assert_master_signer">permissioned_signer::assert_master_signer</a>(voter);
-    <b>let</b> voter_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(voter);
+    <b>let</b> voter_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(voter);
     <b>assert</b>!(<a href="stake.md#0x1_stake_get_delegated_voter">stake::get_delegated_voter</a>(stake_pool) == voter_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="aptos_governance.md#0x1_aptos_governance_ENOT_DELEGATED_VOTER">ENOT_DELEGATED_VOTER</a>));
 
     <a href="aptos_governance.md#0x1_aptos_governance_assert_proposal_expiration">assert_proposal_expiration</a>(stake_pool, proposal_id);

--- a/aptos-move/framework/aptos-framework/doc/code.md
+++ b/aptos-move/framework/aptos-framework/doc/code.md
@@ -661,7 +661,7 @@ Initialize package metadata for Genesis.
 <pre><code><b>fun</b> <a href="code.md#0x1_code_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, package_owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata: <a href="code.md#0x1_code_PackageMetadata">PackageMetadata</a>)
 <b>acquires</b> <a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(package_owner);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(package_owner);
     <b>if</b> (!<b>exists</b>&lt;<a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a>&gt;(addr)) {
         <b>move_to</b>(package_owner, <a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a> { packages: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[metadata] })
     } <b>else</b> {
@@ -699,7 +699,7 @@ package.
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="code.md#0x1_code_EINCOMPATIBLE_POLICY_DISABLED">EINCOMPATIBLE_POLICY_DISABLED</a>),
     );
 
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>if</b> (!<b>exists</b>&lt;<a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a>&gt;(addr)) {
         <b>move_to</b>(owner, <a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a> { packages: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>() })
     };
@@ -778,7 +778,7 @@ package.
     <b>let</b> code_object_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(&code_object);
     <b>assert</b>!(<b>exists</b>&lt;<a href="code.md#0x1_code_PackageRegistry">PackageRegistry</a>&gt;(code_object_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="code.md#0x1_code_ECODE_OBJECT_DOES_NOT_EXIST">ECODE_OBJECT_DOES_NOT_EXIST</a>));
     <b>assert</b>!(
-        <a href="object.md#0x1_object_is_owner">object::is_owner</a>(code_object, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(publisher)),
+        <a href="object.md#0x1_object_is_owner">object::is_owner</a>(code_object, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(publisher)),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="code.md#0x1_code_ENOT_PACKAGE_OWNER">ENOT_PACKAGE_OWNER</a>)
     );
 

--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -2156,7 +2156,7 @@ or disallow upgradability of total supply.
         <a href="fungible_asset.md#0x1_fungible_asset_withdraw_permission_check_by_address">fungible_asset::withdraw_permission_check_by_address</a>(
             <a href="account.md#0x1_account">account</a>,
             <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address">primary_fungible_store::primary_store_address</a>(
-                <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>),
+                <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>),
                 <a href="coin.md#0x1_coin_ensure_paired_metadata">ensure_paired_metadata</a>&lt;CoinType&gt;()
             ),
             0
@@ -2188,7 +2188,7 @@ Voluntarily migrate to fungible store for <code>CoinType</code> if not yet.
 <pre><code><b>public</b> entry <b>fun</b> <a href="coin.md#0x1_coin_migrate_to_fungible_store">migrate_to_fungible_store</a>&lt;CoinType&gt;(
     <a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
 ) <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <a href="coin.md#0x1_coin_assert_signer_has_permission">assert_signer_has_permission</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>);
     <a href="coin.md#0x1_coin_maybe_convert_to_fungible_store">maybe_convert_to_fungible_store</a>&lt;CoinType&gt;(account_addr);
 }
@@ -2798,7 +2798,7 @@ Deposit the coin balance into the recipient's account and emit an event.
     <a href="coin.md#0x1_coin">coin</a>: <a href="coin.md#0x1_coin_Coin">Coin</a>&lt;CoinType&gt;
 ) <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a> {
     <b>let</b> metadata = <a href="coin.md#0x1_coin_ensure_paired_metadata">ensure_paired_metadata</a>&lt;CoinType&gt;();
-    <b>let</b> account_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <a href="fungible_asset.md#0x1_fungible_asset_refill_permission">fungible_asset::refill_permission</a>(
         <a href="account.md#0x1_account">account</a>,
         <a href="coin.md#0x1_coin">coin</a>.value,
@@ -3162,7 +3162,7 @@ Same as <code>initialize</code> but supply can be initialized to parallelizable 
     monitor_supply: bool,
     parallelizable: bool,
 ): (<a href="coin.md#0x1_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x1_coin_FreezeCapability">FreezeCapability</a>&lt;CoinType&gt;, <a href="coin.md#0x1_coin_MintCapability">MintCapability</a>&lt;CoinType&gt;) <b>acquires</b> <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <a href="coin.md#0x1_coin_assert_signer_has_permission">assert_signer_has_permission</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>);
 
     <b>assert</b>!(
@@ -3280,7 +3280,7 @@ Returns minted <code><a href="coin.md#0x1_coin_Coin">Coin</a></code>.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="coin.md#0x1_coin_register">register</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <a href="coin.md#0x1_coin_assert_signer_has_permission">assert_signer_has_permission</a>&lt;CoinType&gt;(<a href="account.md#0x1_account">account</a>);
     // Short-circuit and do nothing <b>if</b> <a href="account.md#0x1_account">account</a> is already registered for CoinType.
     <b>if</b> (<a href="coin.md#0x1_coin_is_account_registered">is_account_registered</a>&lt;CoinType&gt;(account_addr)) {
@@ -3377,7 +3377,7 @@ Withdraw specified <code>amount</code> of coin <code>CoinType</code> from the si
     <a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     amount: u64,
 ): <a href="coin.md#0x1_coin_Coin">Coin</a>&lt;CoinType&gt; <b>acquires</b> <a href="coin.md#0x1_coin_CoinStore">CoinStore</a>, <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_CoinInfo">CoinInfo</a>, <a href="coin.md#0x1_coin_PairedCoinType">PairedCoinType</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
 
     <b>let</b> (coin_amount_to_withdraw, fa_amount_to_withdraw) = <a href="coin.md#0x1_coin_calculate_amount_to_withdraw">calculate_amount_to_withdraw</a>&lt;CoinType&gt;(
         account_addr,

--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -2952,7 +2952,7 @@ Ownership over setting the operator/voter is granted to <code>owner</code> who h
 ) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, <a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>, <a href="delegation_pool.md#0x1_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>, <a href="delegation_pool.md#0x1_delegation_pool_NextCommissionPercentage">NextCommissionPercentage</a> {
     <a href="delegation_pool.md#0x1_delegation_pool_check_delegation_pool_management_permission">check_delegation_pool_management_permission</a>(owner);
     <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_delegation_pools_enabled">features::delegation_pools_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="delegation_pool.md#0x1_delegation_pool_EDELEGATION_POOLS_DISABLED">EDELEGATION_POOLS_DISABLED</a>));
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>assert</b>!(!<a href="delegation_pool.md#0x1_delegation_pool_owner_cap_exists">owner_cap_exists</a>(owner_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="delegation_pool.md#0x1_delegation_pool_EOWNER_CAP_ALREADY_EXISTS">EOWNER_CAP_ALREADY_EXISTS</a>));
     <b>assert</b>!(<a href="delegation_pool.md#0x1_delegation_pool_operator_commission_percentage">operator_commission_percentage</a> &lt;= <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>));
 
@@ -2963,7 +2963,7 @@ Ownership over setting the operator/voter is granted to <code>owner</code> who h
     <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&stake_pool_signer);
 
     // stake_pool_signer will be owner of the <a href="stake.md#0x1_stake">stake</a> pool and have its `<a href="stake.md#0x1_stake_OwnerCapability">stake::OwnerCapability</a>`
-    <b>let</b> pool_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&stake_pool_signer);
+    <b>let</b> pool_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&stake_pool_signer);
     <a href="stake.md#0x1_stake_initialize_stake_owner">stake::initialize_stake_owner</a>(&stake_pool_signer, 0, owner_address, owner_address);
 
     <b>let</b> inactive_shares = <a href="../../aptos-stdlib/doc/table.md#0x1_table_new">table::new</a>&lt;<a href="delegation_pool.md#0x1_delegation_pool_ObservedLockupCycle">ObservedLockupCycle</a>, <a href="../../aptos-stdlib/doc/pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>&gt;();
@@ -3066,7 +3066,7 @@ The existing voter will be replaced. The function is permissionless.
     <b>let</b> stake_pool_signer = <a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(<a href="delegation_pool.md#0x1_delegation_pool">delegation_pool</a>);
     // delegated_voter is managed by the <a href="stake.md#0x1_stake">stake</a> pool itself, which <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <a href="../../aptos-stdlib/doc/capability.md#0x1_capability">capability</a> is managed by <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>.
     // So <a href="voting.md#0x1_voting">voting</a> power of this <a href="stake.md#0x1_stake">stake</a> pool can only be used through this <b>module</b>.
-    <a href="stake.md#0x1_stake_set_delegated_voter">stake::set_delegated_voter</a>(&stake_pool_signer, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&stake_pool_signer));
+    <a href="stake.md#0x1_stake_set_delegated_voter">stake::set_delegated_voter</a>(&stake_pool_signer, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&stake_pool_signer));
 
     <b>move_to</b>(&stake_pool_signer, <a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a> {
         votes: <a href="../../aptos-stdlib/doc/smart_table.md#0x1_smart_table_new">smart_table::new</a>(),
@@ -3116,7 +3116,7 @@ Vote on a proposal with a voter's voting power. To successfully vote, the follow
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation.
     <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
 
-    <b>let</b> voter_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(voter);
+    <b>let</b> voter_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(voter);
     <b>let</b> remaining_voting_power = <a href="delegation_pool.md#0x1_delegation_pool_calculate_and_update_remaining_voting_power">calculate_and_update_remaining_voting_power</a>(
         pool_address,
         voter_address,
@@ -3198,7 +3198,7 @@ voting power in THIS delegation pool must be not less than the minimum required 
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
     <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
 
-    <b>let</b> voter_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(voter);
+    <b>let</b> voter_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(voter);
     <b>let</b> pool = <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
     <b>let</b> governance_records = <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>&gt;(pool_address);
     <b>let</b> total_voting_power = <a href="delegation_pool.md#0x1_delegation_pool_calculate_and_update_delegated_votes">calculate_and_update_delegated_votes</a>(pool, governance_records, voter_addr);
@@ -3966,7 +3966,7 @@ Allows an owner to change the operator of the underlying stake pool.
     new_operator: <b>address</b>
 ) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, <a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>, <a href="delegation_pool.md#0x1_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>, <a href="delegation_pool.md#0x1_delegation_pool_NextCommissionPercentage">NextCommissionPercentage</a> {
     <a href="delegation_pool.md#0x1_delegation_pool_check_delegation_pool_management_permission">check_delegation_pool_management_permission</a>(owner);
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner));
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
     // ensure the <b>old</b> operator is paid its uncommitted commission rewards
     <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
@@ -4007,7 +4007,7 @@ one for each pool.
     ));
     // The beneficiay <b>address</b> of an operator is stored under the operator's <b>address</b>.
     // So, the operator does not need <b>to</b> be validated <b>with</b> respect <b>to</b> a staking pool.
-    <b>let</b> operator_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator);
+    <b>let</b> operator_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(operator);
     <b>let</b> old_beneficiary = <a href="delegation_pool.md#0x1_delegation_pool_beneficiary_for_operator">beneficiary_for_operator</a>(operator_addr);
     <b>if</b> (<b>exists</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>&gt;(operator_addr)) {
         <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>&gt;(operator_addr).beneficiary_for_operator = new_beneficiary;
@@ -4052,7 +4052,7 @@ Allows an owner to update the commission percentage for the operator of the unde
         <a href="delegation_pool.md#0x1_delegation_pool_ECOMMISSION_RATE_CHANGE_NOT_SUPPORTED">ECOMMISSION_RATE_CHANGE_NOT_SUPPORTED</a>
     ));
     <b>assert</b>!(new_commission_percentage &lt;= <a href="delegation_pool.md#0x1_delegation_pool_MAX_FEE">MAX_FEE</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>));
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(owner_address);
     <b>assert</b>!(
         <a href="delegation_pool.md#0x1_delegation_pool_operator_commission_percentage">operator_commission_percentage</a>(pool_address) + <a href="delegation_pool.md#0x1_delegation_pool_MAX_COMMISSION_INCREASE">MAX_COMMISSION_INCREASE</a> &gt;= new_commission_percentage,
@@ -4119,7 +4119,7 @@ Allows an owner to change the delegated voter of the underlying stake pool.
         !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_delegation_pool_partial_governance_voting_enabled">features::delegation_pool_partial_governance_voting_enabled</a>(),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="delegation_pool.md#0x1_delegation_pool_EDEPRECATED_FUNCTION">EDEPRECATED_FUNCTION</a>)
     );
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner));
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
     <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
     <a href="stake.md#0x1_stake_set_delegated_voter">stake::set_delegated_voter</a>(&<a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(<b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address)), new_voter);
@@ -4158,7 +4158,7 @@ this change won't take effects until the next lockup period.
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
     <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
 
-    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator);
+    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(delegator);
     <b>let</b> <a href="delegation_pool.md#0x1_delegation_pool">delegation_pool</a> = <b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address);
     <b>let</b> governance_records = <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>&gt;(pool_address);
     <b>let</b> delegator_vote_delegation = <a href="delegation_pool.md#0x1_delegation_pool_update_and_borrow_mut_delegator_vote_delegation">update_and_borrow_mut_delegator_vote_delegation</a>(
@@ -4236,7 +4236,7 @@ Enable delegators allowlisting as the pool owner.
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="delegation_pool.md#0x1_delegation_pool_EDELEGATORS_ALLOWLISTING_NOT_SUPPORTED">EDELEGATORS_ALLOWLISTING_NOT_SUPPORTED</a>)
     );
 
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner));
     <b>if</b> (<a href="delegation_pool.md#0x1_delegation_pool_allowlisting_enabled">allowlisting_enabled</a>(pool_address)) { <b>return</b> };
 
     <b>let</b> pool_signer = <a href="delegation_pool.md#0x1_delegation_pool_retrieve_stake_pool_owner">retrieve_stake_pool_owner</a>(<b>borrow_global</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address));
@@ -4270,7 +4270,7 @@ Disable delegators allowlisting as the pool owner. The existing allowlist will b
     owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
 ) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a> {
     <a href="delegation_pool.md#0x1_delegation_pool_check_delegation_pool_management_permission">check_delegation_pool_management_permission</a>(owner);
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner));
     <a href="delegation_pool.md#0x1_delegation_pool_assert_allowlisting_enabled">assert_allowlisting_enabled</a>(pool_address);
 
     <b>let</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a> { allowlist } = <b>move_from</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a>&gt;(pool_address);
@@ -4306,7 +4306,7 @@ Allowlist a delegator as the pool owner.
     delegator_address: <b>address</b>,
 ) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a> {
     <a href="delegation_pool.md#0x1_delegation_pool_check_delegation_pool_management_permission">check_delegation_pool_management_permission</a>(owner);
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner));
     <a href="delegation_pool.md#0x1_delegation_pool_assert_allowlisting_enabled">assert_allowlisting_enabled</a>(pool_address);
 
     <b>if</b> (<a href="delegation_pool.md#0x1_delegation_pool_delegator_allowlisted">delegator_allowlisted</a>(pool_address, delegator_address)) { <b>return</b> };
@@ -4342,7 +4342,7 @@ Remove a delegator from the allowlist as the pool owner, but do not unlock their
     delegator_address: <b>address</b>,
 ) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a> {
     <a href="delegation_pool.md#0x1_delegation_pool_check_delegation_pool_management_permission">check_delegation_pool_management_permission</a>(owner);
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner));
     <a href="delegation_pool.md#0x1_delegation_pool_assert_allowlisting_enabled">assert_allowlisting_enabled</a>(pool_address);
 
     <b>if</b> (!<a href="delegation_pool.md#0x1_delegation_pool_delegator_allowlisted">delegator_allowlisted</a>(pool_address, delegator_address)) { <b>return</b> };
@@ -4378,7 +4378,7 @@ Evict a delegator that is not allowlisted by unlocking their entire stake.
     delegator_address: <b>address</b>,
 ) <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolOwnership">DelegationPoolOwnership</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>, <a href="delegation_pool.md#0x1_delegation_pool_GovernanceRecords">GovernanceRecords</a>, <a href="delegation_pool.md#0x1_delegation_pool_BeneficiaryForOperator">BeneficiaryForOperator</a>, <a href="delegation_pool.md#0x1_delegation_pool_NextCommissionPercentage">NextCommissionPercentage</a>, <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a> {
     <a href="delegation_pool.md#0x1_delegation_pool_check_delegation_pool_management_permission">check_delegation_pool_management_permission</a>(owner);
-    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner));
+    <b>let</b> pool_address = <a href="delegation_pool.md#0x1_delegation_pool_get_owned_pool_address">get_owned_pool_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner));
     <a href="delegation_pool.md#0x1_delegation_pool_assert_allowlisting_enabled">assert_allowlisting_enabled</a>(pool_address);
     <b>assert</b>!(
         !<a href="delegation_pool.md#0x1_delegation_pool_delegator_allowlisted">delegator_allowlisted</a>(pool_address, delegator_address),
@@ -4426,7 +4426,7 @@ Add <code>amount</code> of coins to the delegation pool <code>pool_address</code
     // short-circuit <b>if</b> amount <b>to</b> add is 0 so no <a href="event.md#0x1_event">event</a> is emitted
     <b>if</b> (amount == 0) { <b>return</b> };
 
-    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator);
+    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(delegator);
     <a href="delegation_pool.md#0x1_delegation_pool_assert_delegator_allowlisted">assert_delegator_allowlisted</a>(pool_address, delegator_address);
 
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
@@ -4507,7 +4507,7 @@ at most how much active stake there is on the stake pool.
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
     <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
 
-    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator);
+    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(delegator);
     <a href="delegation_pool.md#0x1_delegation_pool_unlock_internal">unlock_internal</a>(delegator_address, pool_address, amount);
 }
 </code></pre>
@@ -4606,7 +4606,7 @@ Move <code>amount</code> of coins from pending_inactive to active.
     // short-circuit <b>if</b> amount <b>to</b> reactivate is 0 so no <a href="event.md#0x1_event">event</a> is emitted
     <b>if</b> (amount == 0) { <b>return</b> };
 
-    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator);
+    <b>let</b> delegator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(delegator);
     <a href="delegation_pool.md#0x1_delegation_pool_assert_delegator_allowlisted">assert_delegator_allowlisted</a>(pool_address, delegator_address);
 
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
@@ -4677,7 +4677,7 @@ Withdraw <code>amount</code> of owned inactive stake from the delegation pool at
     <b>assert</b>!(amount &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="delegation_pool.md#0x1_delegation_pool_EWITHDRAW_ZERO_STAKE">EWITHDRAW_ZERO_STAKE</a>));
     // synchronize delegation and <a href="stake.md#0x1_stake">stake</a> pools before <a href="../../aptos-stdlib/doc/any.md#0x1_any">any</a> user operation
     <a href="delegation_pool.md#0x1_delegation_pool_synchronize_delegation_pool">synchronize_delegation_pool</a>(pool_address);
-    <a href="delegation_pool.md#0x1_delegation_pool_withdraw_internal">withdraw_internal</a>(<b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address), <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(delegator), amount);
+    <a href="delegation_pool.md#0x1_delegation_pool_withdraw_internal">withdraw_internal</a>(<b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPool">DelegationPool</a>&gt;(pool_address), <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(delegator), amount);
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/function_info.md
+++ b/aptos-move/framework/aptos-framework/doc/function_info.md
@@ -130,7 +130,7 @@ Creates a new function info from names.
     function_name: String,
 ): <a href="function_info.md#0x1_function_info_FunctionInfo">FunctionInfo</a> {
     <a href="function_info.md#0x1_function_info_new_function_info_from_address">new_function_info_from_address</a>(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(module_signer),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(module_signer),
         module_name,
         function_name,
     )

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -3099,7 +3099,7 @@ Check the permission for withdraw operation.
     abort_on_dispatch: bool,
 ) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
     <a href="fungible_asset.md#0x1_fungible_asset_withdraw_sanity_check_impl">withdraw_sanity_check_impl</a>(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner),
         store,
         abort_on_dispatch,
     )
@@ -4222,7 +4222,7 @@ Decrease the supply of a fungible asset by burning.
     owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     store: Object&lt;T&gt;,
 ) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
-    <b>assert</b>!(<a href="object.md#0x1_object_owns">object::owns</a>(store, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>));
+    <b>assert</b>!(<a href="object.md#0x1_object_owns">object::owns</a>(store, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>));
     <b>assert</b>!(!<a href="fungible_asset.md#0x1_fungible_asset_is_frozen">is_frozen</a>(store), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ESTORE_IS_FROZEN">ESTORE_IS_FROZEN</a>));
     <b>assert</b>!(<a href="fungible_asset.md#0x1_fungible_asset_allow_upgrade_to_concurrent_fungible_balance">allow_upgrade_to_concurrent_fungible_balance</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="fungible_asset.md#0x1_fungible_asset_ECONCURRENT_BALANCE_NOT_ENABLED">ECONCURRENT_BALANCE_NOT_ENABLED</a>));
     <a href="fungible_asset.md#0x1_fungible_asset_ensure_store_upgraded_to_concurrent_internal">ensure_store_upgraded_to_concurrent_internal</a>(<a href="object.md#0x1_object_object_address">object::object_address</a>(&store));

--- a/aptos-move/framework/aptos-framework/doc/jwks.md
+++ b/aptos-move/framework/aptos-framework/doc/jwks.md
@@ -800,11 +800,11 @@ reusing <code><a href="jwks.md#0x1_jwks_PatchedJWKs">PatchedJWKs</a> { <a href="
 
 <pre><code><b>public</b> <b>fun</b> <a href="jwks.md#0x1_jwks_patch_federated_jwks">patch_federated_jwks</a>(jwk_owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, patches: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="jwks.md#0x1_jwks_Patch">Patch</a>&gt;) <b>acquires</b> <a href="jwks.md#0x1_jwks_FederatedJWKs">FederatedJWKs</a> {
     // Prevents accidental calls in <a href="jwks.md#0x1_jwks">0x1::jwks</a> that install federated JWKs at the Aptos framework <b>address</b>.
-    <b>assert</b>!(!<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(jwk_owner)),
+    <b>assert</b>!(!<a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">system_addresses::is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(jwk_owner)),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="jwks.md#0x1_jwks_EINSTALL_FEDERATED_JWKS_AT_APTOS_FRAMEWORK">EINSTALL_FEDERATED_JWKS_AT_APTOS_FRAMEWORK</a>)
     );
 
-    <b>let</b> jwk_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(jwk_owner);
+    <b>let</b> jwk_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(jwk_owner);
     <b>if</b> (!<b>exists</b>&lt;<a href="jwks.md#0x1_jwks_FederatedJWKs">FederatedJWKs</a>&gt;(jwk_addr)) {
         <b>move_to</b>(jwk_owner, <a href="jwks.md#0x1_jwks_FederatedJWKs">FederatedJWKs</a> { <a href="jwks.md#0x1_jwks">jwks</a>: <a href="jwks.md#0x1_jwks_AllProvidersJWKs">AllProvidersJWKs</a> { entries: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[] } });
     };

--- a/aptos-move/framework/aptos-framework/doc/keyless_account.md
+++ b/aptos-move/framework/aptos-framework/doc/keyless_account.md
@@ -428,7 +428,7 @@ WARNING: See <code>set_configuration_for_next_epoch</code> for caveats.
         <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_borrow">option::borrow</a>(&pk)) == 32, <a href="keyless_account.md#0x1_keyless_account_E_TRAINING_WHEELS_PK_WRONG_SIZE">E_TRAINING_WHEELS_PK_WRONG_SIZE</a>)
     };
 
-    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
+    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx));
     config.training_wheels_pubkey = pk;
 }
 </code></pre>
@@ -457,7 +457,7 @@ WARNING: See <code>set_configuration_for_next_epoch</code> for caveats.
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
     <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
-    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
+    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx));
     config.max_exp_horizon_secs = max_exp_horizon_secs;
 }
 </code></pre>
@@ -486,7 +486,7 @@ WARNING: See <code>set_configuration_for_next_epoch</code> for caveats.
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
     <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
-    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
+    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx));
     config.override_aud_vals = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
 }
 </code></pre>
@@ -515,7 +515,7 @@ WARNING: See <code>set_configuration_for_next_epoch</code> for caveats.
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
     <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
-    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx));
+    <b>let</b> config = <b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> config.override_aud_vals, aud);
 }
 </code></pre>
@@ -618,7 +618,7 @@ WARNING: If a malicious key is set, this *could* lead to stolen funds.
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
         <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
-        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
+        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx))
     };
 
     config.training_wheels_pubkey = pk;
@@ -654,7 +654,7 @@ reconfiguration. Only callable via governance proposal.
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
         <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
-        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
+        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx))
     };
 
     config.max_exp_horizon_secs = max_exp_horizon_secs;
@@ -693,7 +693,7 @@ is no longer possible.
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
         <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
-        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
+        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx))
     };
 
     config.override_aud_vals = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
@@ -731,7 +731,7 @@ WARNING: If a malicious override <code>aud</code> is set, this *could* lead to s
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
         <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
-        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
+        *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(fx))
     };
 
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> config.override_aud_vals, aud);

--- a/aptos-move/framework/aptos-framework/doc/managed_coin.md
+++ b/aptos-move/framework/aptos-framework/doc/managed_coin.md
@@ -111,7 +111,7 @@ Withdraw an <code>amount</code> of coin <code>CoinType</code> from <code><a href
     <a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     amount: u64,
 ) <b>acquires</b> <a href="managed_coin.md#0x1_managed_coin_Capabilities">Capabilities</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
 
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="managed_coin.md#0x1_managed_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(account_addr),
@@ -194,7 +194,7 @@ Create new coins <code>CoinType</code> and deposit them into dst_addr's account.
     dst_addr: <b>address</b>,
     amount: u64,
 ) <b>acquires</b> <a href="managed_coin.md#0x1_managed_coin_Capabilities">Capabilities</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
 
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="managed_coin.md#0x1_managed_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(account_addr),
@@ -284,7 +284,7 @@ Removes capabilities from the account to be stored or destroyed elsewhere
 <pre><code><b>public</b> <b>fun</b> <a href="managed_coin.md#0x1_managed_coin_remove_caps">remove_caps</a>&lt;CoinType&gt;(
     <a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
 ): (BurnCapability&lt;CoinType&gt;, FreezeCapability&lt;CoinType&gt;, MintCapability&lt;CoinType&gt;) <b>acquires</b> <a href="managed_coin.md#0x1_managed_coin_Capabilities">Capabilities</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="managed_coin.md#0x1_managed_coin_Capabilities">Capabilities</a>&lt;CoinType&gt;&gt;(account_addr),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="managed_coin.md#0x1_managed_coin_ENO_CAPABILITIES">ENO_CAPABILITIES</a>),

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -1134,7 +1134,7 @@ by knowing the user generated seed used to create them. Named objects cannot be 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_named_object">create_named_object</a>(creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a> {
-    <b>let</b> creator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);
+    <b>let</b> creator_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(creator);
     <b>let</b> obj_addr = <a href="object.md#0x1_object_create_object_address">create_object_address</a>(&creator_address, seed);
     <a href="object.md#0x1_object_create_object_internal">create_object_internal</a>(creator_address, obj_addr, <b>false</b>)
 }
@@ -1278,7 +1278,7 @@ doesn't have the same bottlenecks.
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_object_from_account">create_object_from_account</a>(creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a> {
     <b>let</b> <a href="guid.md#0x1_guid">guid</a> = <a href="account.md#0x1_account_create_guid">account::create_guid</a>(creator);
-    <a href="object.md#0x1_object_create_object_from_guid">create_object_from_guid</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator), <a href="guid.md#0x1_guid">guid</a>)
+    <a href="object.md#0x1_object_create_object_from_guid">create_object_from_guid</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(creator), <a href="guid.md#0x1_guid">guid</a>)
 }
 </code></pre>
 
@@ -1310,7 +1310,7 @@ doesn't have the same bottlenecks.
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_object_from_object">create_object_from_object</a>(creator: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="object.md#0x1_object_ConstructorRef">ConstructorRef</a> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
     <b>let</b> <a href="guid.md#0x1_guid">guid</a> = <a href="object.md#0x1_object_create_guid">create_guid</a>(creator);
-    <a href="object.md#0x1_object_create_object_from_guid">create_object_from_guid</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator), <a href="guid.md#0x1_guid">guid</a>)
+    <a href="object.md#0x1_object_create_object_from_guid">create_object_from_guid</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(creator), <a href="guid.md#0x1_guid">guid</a>)
 }
 </code></pre>
 
@@ -1607,7 +1607,7 @@ Create a guid for the object, typically used for events
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_create_guid">create_guid</a>(<a href="object.md#0x1_object">object</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="guid.md#0x1_guid_GUID">guid::GUID</a> <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="object.md#0x1_object">object</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="object.md#0x1_object">object</a>);
     <b>let</b> object_data = <b>borrow_global_mut</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(addr);
     <a href="guid.md#0x1_guid_create">guid::create</a>(addr, &<b>mut</b> object_data.guid_creation_num)
 }
@@ -2031,7 +2031,7 @@ hierarchy.
     <a href="object.md#0x1_object">object</a>: <b>address</b>,
     <b>to</b>: <b>address</b>,
 ) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>assert</b>!(
         <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_exists">permissioned_signer::check_permission_exists</a>(owner, <a href="object.md#0x1_object_TransferPermission">TransferPermission</a> { <a href="object.md#0x1_object">object</a> }),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_EOBJECT_NOT_TRANSFERRABLE">EOBJECT_NOT_TRANSFERRABLE</a>)
@@ -2231,7 +2231,7 @@ Allow origin owners to reclaim any objects they previous burnt.
     );
 
     <b>let</b> <a href="object.md#0x1_object_TombStone">TombStone</a> { original_owner: original_owner_addr } = <b>move_from</b>&lt;<a href="object.md#0x1_object_TombStone">TombStone</a>&gt;(object_addr);
-    <b>assert</b>!(original_owner_addr == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(original_owner), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_ENOT_OBJECT_OWNER">ENOT_OBJECT_OWNER</a>));
+    <b>assert</b>!(original_owner_addr == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(original_owner), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object.md#0x1_object_ENOT_OBJECT_OWNER">ENOT_OBJECT_OWNER</a>));
     <a href="object.md#0x1_object_transfer_raw_inner">transfer_raw_inner</a>(object_addr, original_owner_addr);
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/object_code_deployment.md
+++ b/aptos-move/framework/aptos-framework/doc/object_code_deployment.md
@@ -259,13 +259,13 @@ the code to be published via <code><a href="code.md#0x1_code">code</a></code>. T
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED">EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED</a>),
     );
 
-    <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(publisher);
+    <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(publisher);
     <b>let</b> object_seed = <a href="object_code_deployment.md#0x1_object_code_deployment_object_seed">object_seed</a>(publisher_address);
     <b>let</b> constructor_ref = &<a href="object.md#0x1_object_create_named_object">object::create_named_object</a>(publisher, object_seed);
     <b>let</b> code_signer = &<a href="object.md#0x1_object_generate_signer">object::generate_signer</a>(constructor_ref);
     <a href="code.md#0x1_code_publish_package_txn">code::publish_package_txn</a>(code_signer, metadata_serialized, <a href="code.md#0x1_code">code</a>);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_Publish">Publish</a> { object_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(code_signer), });
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_Publish">Publish</a> { object_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(code_signer), });
 
     <b>move_to</b>(code_signer, <a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a> {
         extend_ref: <a href="object.md#0x1_object_generate_extend_ref">object::generate_extend_ref</a>(constructor_ref),
@@ -331,7 +331,7 @@ Requires the publisher to be the owner of the <code>code_object</code>.
     code_object: Object&lt;PackageRegistry&gt;,
 ) <b>acquires</b> <a href="object_code_deployment.md#0x1_object_code_deployment_ManagingRefs">ManagingRefs</a> {
     <a href="code.md#0x1_code_check_code_publishing_permission">code::check_code_publishing_permission</a>(publisher);
-    <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(publisher);
+    <b>let</b> publisher_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(publisher);
     <b>assert</b>!(
         <a href="object.md#0x1_object_is_owner">object::is_owner</a>(code_object, publisher_address),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_ENOT_CODE_OBJECT_OWNER">ENOT_CODE_OBJECT_OWNER</a>),
@@ -344,7 +344,7 @@ Requires the publisher to be the owner of the <code>code_object</code>.
     <b>let</b> code_signer = &<a href="object.md#0x1_object_generate_signer_for_extending">object::generate_signer_for_extending</a>(extend_ref);
     <a href="code.md#0x1_code_publish_package_txn">code::publish_package_txn</a>(code_signer, metadata_serialized, <a href="code.md#0x1_code">code</a>);
 
-    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_Upgrade">Upgrade</a> { object_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(code_signer), });
+    <a href="event.md#0x1_event_emit">event::emit</a>(<a href="object_code_deployment.md#0x1_object_code_deployment_Upgrade">Upgrade</a> { object_address: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(code_signer), });
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/permissioned_delegation.md
+++ b/aptos-move/framework/aptos-framework/doc/permissioned_delegation.md
@@ -276,7 +276,7 @@
     expiration_time: u64,
 ): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="permissioned_delegation.md#0x1_permissioned_delegation_RegisteredDelegations">RegisteredDelegations</a> {
     <b>assert</b>!(!is_permissioned_signer(master), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_delegation.md#0x1_permissioned_delegation_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>));
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(master);
     <b>if</b> (!<b>exists</b>&lt;<a href="permissioned_delegation.md#0x1_permissioned_delegation_RegisteredDelegations">RegisteredDelegations</a>&gt;(addr)) {
         <b>move_to</b>(master, <a href="permissioned_delegation.md#0x1_permissioned_delegation_RegisteredDelegations">RegisteredDelegations</a> {
             delegations: <a href="big_ordered_map.md#0x1_big_ordered_map_new_with_config">big_ordered_map::new_with_config</a>(50, 20, <b>false</b>)
@@ -315,7 +315,7 @@
     key: <a href="permissioned_delegation.md#0x1_permissioned_delegation_DelegationKey">DelegationKey</a>,
 ) <b>acquires</b> <a href="permissioned_delegation.md#0x1_permissioned_delegation_RegisteredDelegations">RegisteredDelegations</a> {
     <b>assert</b>!(!is_permissioned_signer(master), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_delegation.md#0x1_permissioned_delegation_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>));
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(master);
     <b>let</b> delegations = &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="permissioned_delegation.md#0x1_permissioned_delegation_RegisteredDelegations">RegisteredDelegations</a>&gt;(addr).delegations;
     <b>assert</b>!(delegations.contains(&key), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="permissioned_delegation.md#0x1_permissioned_delegation_EDELEGATION_EXISTENCE">EDELEGATION_EXISTENCE</a>));
     <b>let</b> delegation = delegations.remove(&key);
@@ -351,7 +351,7 @@
     key: <a href="permissioned_delegation.md#0x1_permissioned_delegation_DelegationKey">DelegationKey</a>,
 ): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="permissioned_delegation.md#0x1_permissioned_delegation_RegisteredDelegations">RegisteredDelegations</a> {
     <b>assert</b>!(!is_permissioned_signer(master), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_delegation.md#0x1_permissioned_delegation_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>));
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(master);
     <b>let</b> handle = <a href="permissioned_delegation.md#0x1_permissioned_delegation_get_storable_permissioned_handle">get_storable_permissioned_handle</a>(addr, key, <b>false</b>);
     <a href="permissioned_signer.md#0x1_permissioned_signer_signer_from_storable_permissioned_handle">permissioned_signer::signer_from_storable_permissioned_handle</a>(handle)
 }
@@ -406,7 +406,7 @@ Authorization function for account abstraction.
     <a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     abstraction_auth_data: AbstractionAuthData
 ): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="permissioned_delegation.md#0x1_permissioned_delegation_RegisteredDelegations">RegisteredDelegations</a> {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&<a href="account.md#0x1_account">account</a>);
     <b>let</b> stream = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_new">bcs_stream::new</a>(*<a href="auth_data.md#0x1_auth_data_authenticator">auth_data::authenticator</a>(&abstraction_auth_data));
     <b>let</b> public_key = new_unvalidated_public_key_from_bytes(
         <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x))

--- a/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
@@ -354,6 +354,16 @@ Types of permission capacity stored on chain.
 ## Constants
 
 
+<a id="0x1_permissioned_signer_ENOT_MASTER_SIGNER"></a>
+
+Trying to grant permission using non-master signer.
+
+
+<pre><code><b>const</b> <a href="permissioned_signer.md#0x1_permissioned_signer_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>: u64 = 1;
+</code></pre>
+
+
+
 <a id="0x1_permissioned_signer_ECANNOT_AUTHORIZE"></a>
 
 Cannot authorize a permission.
@@ -370,16 +380,6 @@ signer doesn't have enough capacity to extract permission.
 
 
 <pre><code><b>const</b> <a href="permissioned_signer.md#0x1_permissioned_signer_ECANNOT_EXTRACT_PERMISSION">ECANNOT_EXTRACT_PERMISSION</a>: u64 = 4;
-</code></pre>
-
-
-
-<a id="0x1_permissioned_signer_ENOT_MASTER_SIGNER"></a>
-
-Trying to grant permission using non-master signer.
-
-
-<pre><code><b>const</b> <a href="permissioned_signer.md#0x1_permissioned_signer_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>: u64 = 1;
 </code></pre>
 
 
@@ -481,7 +481,7 @@ the current transaction.
 
     <a href="permissioned_signer.md#0x1_permissioned_signer_assert_master_signer">assert_master_signer</a>(master);
     <b>let</b> permissions_storage_addr = generate_auid_address();
-    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master);
+    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(master);
 
     <a href="permissioned_signer.md#0x1_permissioned_signer_initialize_permission_address">initialize_permission_address</a>(permissions_storage_addr);
 
@@ -651,7 +651,7 @@ the storable permission handle to derive signer from it anymore.
         <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_exists">check_permission_exists</a>(s, <a href="permissioned_signer.md#0x1_permissioned_signer_RevokePermissionHandlePermission">RevokePermissionHandlePermission</a> {}),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_signer.md#0x1_permissioned_signer_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>)
     );
-    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(s);
+    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(s);
 
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_GrantedPermissionHandles">GrantedPermissionHandles</a>&gt;(master_account_addr),
@@ -696,7 +696,7 @@ Revoke all storable permission handle of the signer immediately.
         <a href="permissioned_signer.md#0x1_permissioned_signer_check_permission_exists">check_permission_exists</a>(s, <a href="permissioned_signer.md#0x1_permissioned_signer_RevokePermissionHandlePermission">RevokePermissionHandlePermission</a> {}),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_signer.md#0x1_permissioned_signer_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>)
     );
-    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(s);
+    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(s);
     <b>if</b> (!<b>exists</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_GrantedPermissionHandles">GrantedPermissionHandles</a>&gt;(master_account_addr)) { <b>return</b> };
 
     <b>let</b> granted_permissions =
@@ -777,7 +777,7 @@ The caller should check if <code>expiration_time</code> is not too far in the fu
 
     <a href="permissioned_signer.md#0x1_permissioned_signer_assert_master_signer">assert_master_signer</a>(master);
     <b>let</b> permissions_storage_addr = generate_auid_address();
-    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master);
+    <b>let</b> master_account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(master);
 
     <b>assert</b>!(
         <a href="timestamp.md#0x1_timestamp_now_seconds">timestamp::now_seconds</a>() &lt; expiration_time,
@@ -1229,7 +1229,7 @@ Consumption using <code>check_permission_consume</code> will deduct the capacity
     <b>assert</b>!(
         <a href="permissioned_signer.md#0x1_permissioned_signer_is_permissioned_signer">is_permissioned_signer</a>(permissioned)
             && !<a href="permissioned_signer.md#0x1_permissioned_signer_is_permissioned_signer">is_permissioned_signer</a>(master)
-            && <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master) == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(permissioned),
+            && <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(master) == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(permissioned),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_signer.md#0x1_permissioned_signer_ECANNOT_AUTHORIZE">ECANNOT_AUTHORIZE</a>)
     );
     <a href="permissioned_signer.md#0x1_permissioned_signer_insert_or">insert_or</a>(
@@ -1272,7 +1272,7 @@ Unlimited permission can be consumed however many times.
     <b>assert</b>!(
         <a href="permissioned_signer.md#0x1_permissioned_signer_is_permissioned_signer">is_permissioned_signer</a>(permissioned)
             && !<a href="permissioned_signer.md#0x1_permissioned_signer_is_permissioned_signer">is_permissioned_signer</a>(master)
-            && <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(master) == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(permissioned),
+            && <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(master) == <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(permissioned),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="permissioned_signer.md#0x1_permissioned_signer_ECANNOT_AUTHORIZE">ECANNOT_AUTHORIZE</a>)
     );
     <a href="permissioned_signer.md#0x1_permissioned_signer_insert_or">insert_or</a>(
@@ -1603,7 +1603,7 @@ given signer is already a permissioned signer.
 
 The implementation of this function requires to extend the value representation for signers in the VM.
 invariants:
-signer::address_of(master) == signer::address_of(signer_from_permissioned_handle(create_permissioned_handle(master))),
+signer::address_of_unpermissioned(master) == signer::address_of_unpermissioned(signer_from_permissioned_handle(create_permissioned_handle(master))),
 
 
 <pre><code><b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_signer_from_permissioned_handle_impl">signer_from_permissioned_handle_impl</a>(master_account_addr: <b>address</b>, permissions_storage_addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>

--- a/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
+++ b/aptos-move/framework/aptos-framework/doc/primary_fungible_store.md
@@ -391,7 +391,7 @@ Use instead of the corresponding view functions for dispatchable hooks to avoid 
     <a href="fungible_asset.md#0x1_fungible_asset_grant_permission_by_address">fungible_asset::grant_permission_by_address</a>(
         master,
         permissioned,
-        <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(permissioned), metadata),
+        <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(permissioned), metadata),
         amount
     );
 }
@@ -424,7 +424,7 @@ Use instead of the corresponding view functions for dispatchable hooks to avoid 
     <a href="fungible_asset.md#0x1_fungible_asset_grant_permission_by_address">fungible_asset::grant_permission_by_address</a>(
         master,
         permissioned,
-        <a href="object.md#0x1_object_create_user_derived_object_address">object::create_user_derived_object_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(permissioned), @aptos_fungible_asset),
+        <a href="object.md#0x1_object_create_user_derived_object_address">object::create_user_derived_object_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(permissioned), @aptos_fungible_asset),
         amount
     );
 }
@@ -540,7 +540,7 @@ Withdraw <code>amount</code> of fungible asset from the given account's primary 
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_withdraw">withdraw</a>&lt;T: key&gt;(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, metadata: Object&lt;T&gt;, amount: u64): FungibleAsset <b>acquires</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_DeriveRefPod">DeriveRefPod</a> {
-    <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), metadata);
+    <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner), metadata);
     // Check <b>if</b> the store <a href="object.md#0x1_object">object</a> <b>has</b> been burnt or not. If so, unburn it first.
     <a href="primary_fungible_store.md#0x1_primary_fungible_store_may_be_unburn">may_be_unburn</a>(owner, store);
     <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_withdraw">dispatchable_fungible_asset::withdraw</a>(owner, store, amount)
@@ -602,12 +602,12 @@ the same amount of fund in the future.
         owner,
         <a href="fungible_asset.md#0x1_fungible_asset_amount">fungible_asset::amount</a>(&fa),
         <a href="primary_fungible_store.md#0x1_primary_fungible_store_primary_store_address_inlined">primary_store_address_inlined</a>(
-            <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner),
+            <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner),
             <a href="fungible_asset.md#0x1_fungible_asset_metadata_from_asset">fungible_asset::metadata_from_asset</a>(&fa),
         )
     );
     <b>let</b> metadata = <a href="fungible_asset.md#0x1_fungible_asset_asset_metadata">fungible_asset::asset_metadata</a>(&fa);
-    <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner), metadata);
+    <b>let</b> store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner), metadata);
     <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_deposit">dispatchable_fungible_asset::deposit</a>(store, fa);
 }
 </code></pre>
@@ -638,7 +638,7 @@ Transfer <code>amount</code> of fungible asset from sender's primary store to re
     recipient: <b>address</b>,
     amount: u64,
 ) <b>acquires</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_DeriveRefPod">DeriveRefPod</a> {
-    <b>let</b> sender_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender), metadata);
+    <b>let</b> sender_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(sender), metadata);
     // Check <b>if</b> the sender store <a href="object.md#0x1_object">object</a> <b>has</b> been burnt or not. If so, unburn it first.
     <a href="primary_fungible_store.md#0x1_primary_fungible_store_may_be_unburn">may_be_unburn</a>(sender, sender_store);
     <b>let</b> recipient_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(recipient, metadata);
@@ -674,7 +674,7 @@ Use the minimum deposit assertion api to make sure receipient will receive a min
     amount: u64,
     expected: u64,
 ) <b>acquires</b> <a href="primary_fungible_store.md#0x1_primary_fungible_store_DeriveRefPod">DeriveRefPod</a> {
-    <b>let</b> sender_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender), metadata);
+    <b>let</b> sender_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(sender), metadata);
     // Check <b>if</b> the sender store <a href="object.md#0x1_object">object</a> <b>has</b> been burnt or not. If so, unburn it first.
     <a href="primary_fungible_store.md#0x1_primary_fungible_store_may_be_unburn">may_be_unburn</a>(sender, sender_store);
     <b>let</b> recipient_store = <a href="primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">ensure_primary_store_exists</a>(recipient, metadata);

--- a/aptos-move/framework/aptos-framework/doc/reconfiguration.md
+++ b/aptos-move/framework/aptos-framework/doc/reconfiguration.md
@@ -255,7 +255,7 @@ Publishes <code><a href="reconfiguration.md#0x1_reconfiguration_Configuration">C
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
     // <b>assert</b> it matches `new_epoch_event_key()`, otherwise the <a href="event.md#0x1_event">event</a> can't be recognized
-    <b>assert</b>!(<a href="account.md#0x1_account_get_guid_next_creation_num">account::get_guid_next_creation_num</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework)) == 2, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="reconfiguration.md#0x1_reconfiguration_EINVALID_GUID_FOR_EVENT">EINVALID_GUID_FOR_EVENT</a>));
+    <b>assert</b>!(<a href="account.md#0x1_account_get_guid_next_creation_num">account::get_guid_next_creation_num</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(aptos_framework)) == 2, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="reconfiguration.md#0x1_reconfiguration_EINVALID_GUID_FOR_EVENT">EINVALID_GUID_FOR_EVENT</a>));
     <b>move_to</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a>&gt;(
         aptos_framework,
         <a href="reconfiguration.md#0x1_reconfiguration_Configuration">Configuration</a> {
@@ -320,7 +320,7 @@ This function should only be used for offline WriteSet generation purpose and sh
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
     <b>assert</b>!(!<a href="reconfiguration.md#0x1_reconfiguration_reconfiguration_enabled">reconfiguration_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="reconfiguration.md#0x1_reconfiguration_ECONFIGURATION">ECONFIGURATION</a>));
-    <a href="reconfiguration.md#0x1_reconfiguration_DisableReconfiguration">DisableReconfiguration</a> {} = <b>move_from</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_DisableReconfiguration">DisableReconfiguration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
+    <a href="reconfiguration.md#0x1_reconfiguration_DisableReconfiguration">DisableReconfiguration</a> {} = <b>move_from</b>&lt;<a href="reconfiguration.md#0x1_reconfiguration_DisableReconfiguration">DisableReconfiguration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(aptos_framework));
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/resource_account.md
+++ b/aptos-move/framework/aptos-framework/doc/resource_account.md
@@ -232,7 +232,7 @@ used for resource accounts that need access to <code>Coin&lt;AptosCoin&gt;</code
 ) <b>acquires</b> <a href="resource_account.md#0x1_resource_account_Container">Container</a> {
     <b>let</b> (resource, resource_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(origin, seed);
     <a href="coin.md#0x1_coin_register">coin::register</a>&lt;AptosCoin&gt;(&resource);
-    <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;AptosCoin&gt;(origin, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&resource), fund_amount);
+    <a href="coin.md#0x1_coin_transfer">coin::transfer</a>&lt;AptosCoin&gt;(origin, <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&resource), fund_amount);
     <a href="resource_account.md#0x1_resource_account_rotate_account_authentication_key_and_store_capability">rotate_account_authentication_key_and_store_capability</a>(
         origin,
         resource,
@@ -305,13 +305,13 @@ this account and leaves the signer cap readily available for pickup.
     resource_signer_cap: <a href="account.md#0x1_account_SignerCapability">account::SignerCapability</a>,
     optional_auth_key: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ) <b>acquires</b> <a href="resource_account.md#0x1_resource_account_Container">Container</a> {
-    <b>let</b> origin_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(origin);
+    <b>let</b> origin_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(origin);
     <b>if</b> (!<b>exists</b>&lt;<a href="resource_account.md#0x1_resource_account_Container">Container</a>&gt;(origin_addr)) {
         <b>move_to</b>(origin, <a href="resource_account.md#0x1_resource_account_Container">Container</a> { store: <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_create">simple_map::create</a>() })
     };
 
     <b>let</b> container = <b>borrow_global_mut</b>&lt;<a href="resource_account.md#0x1_resource_account_Container">Container</a>&gt;(origin_addr);
-    <b>let</b> resource_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&resource);
+    <b>let</b> resource_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&resource);
     <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(&<b>mut</b> container.store, resource_addr, resource_signer_cap);
 
     <b>let</b> auth_key = <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_is_empty">vector::is_empty</a>(&optional_auth_key)) {
@@ -351,7 +351,7 @@ the SignerCapability.
 ): <a href="account.md#0x1_account_SignerCapability">account::SignerCapability</a> <b>acquires</b> <a href="resource_account.md#0x1_resource_account_Container">Container</a> {
     <b>assert</b>!(<b>exists</b>&lt;<a href="resource_account.md#0x1_resource_account_Container">Container</a>&gt;(source_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="resource_account.md#0x1_resource_account_ECONTAINER_NOT_PUBLISHED">ECONTAINER_NOT_PUBLISHED</a>));
 
-    <b>let</b> resource_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(resource);
+    <b>let</b> resource_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(resource);
     <b>let</b> (resource_signer_cap, empty_container) = {
         <b>let</b> container = <b>borrow_global_mut</b>&lt;<a href="resource_account.md#0x1_resource_account_Container">Container</a>&gt;(source_addr);
         <b>assert</b>!(

--- a/aptos-move/framework/aptos-framework/doc/stake.md
+++ b/aptos-move/framework/aptos-framework/doc/stake.md
@@ -2492,7 +2492,7 @@ to set later.
         <a href="stake.md#0x1_stake_add_stake">add_stake</a>(owner, initial_stake_amount);
     };
 
-    <b>let</b> account_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> account_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>if</b> (account_address != operator) {
         <a href="stake.md#0x1_stake_set_operator">set_operator</a>(owner, operator)
     };
@@ -2568,7 +2568,7 @@ Initialize the validator account and give ownership to the signing account.
 
 <pre><code><b>fun</b> <a href="stake.md#0x1_stake_initialize_owner">initialize_owner</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="stake.md#0x1_stake_AllowedValidators">AllowedValidators</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>assert</b>!(<a href="stake.md#0x1_stake_is_allowed">is_allowed</a>(owner_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="stake.md#0x1_stake_EINELIGIBLE_VALIDATOR">EINELIGIBLE_VALIDATOR</a>));
     <b>assert</b>!(!<a href="stake.md#0x1_stake_stake_pool_exists">stake_pool_exists</a>(owner_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="stake.md#0x1_stake_EALREADY_REGISTERED">EALREADY_REGISTERED</a>));
 
@@ -2623,7 +2623,7 @@ Extract and return owner capability from the signing account.
 
 <pre><code><b>public</b> <b>fun</b> <a href="stake.md#0x1_stake_extract_owner_cap">extract_owner_cap</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a> <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>move_from</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address)
 }
@@ -2652,7 +2652,7 @@ staking pool.
 
 <pre><code><b>public</b> <b>fun</b> <a href="stake.md#0x1_stake_deposit_owner_cap">deposit_owner_cap</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, owner_cap: <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>) {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>assert</b>!(!<b>exists</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="stake.md#0x1_stake_EOWNER_CAP_ALREADY_EXISTS">EOWNER_CAP_ALREADY_EXISTS</a>));
+    <b>assert</b>!(!<b>exists</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="stake.md#0x1_stake_EOWNER_CAP_ALREADY_EXISTS">EOWNER_CAP_ALREADY_EXISTS</a>));
     <b>move_to</b>(owner, owner_cap);
 }
 </code></pre>
@@ -2704,7 +2704,7 @@ Allows an owner to change the operator of the stake pool.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x1_stake_set_operator">set_operator</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>) <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>, <a href="stake.md#0x1_stake_StakePool">StakePool</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>let</b> ownership_cap = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
     <a href="stake.md#0x1_stake_set_operator_with_cap">set_operator_with_cap</a>(ownership_cap, new_operator);
@@ -2781,7 +2781,7 @@ Allows an owner to change the delegated voter of the stake pool.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x1_stake_set_delegated_voter">set_delegated_voter</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_voter: <b>address</b>) <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>, <a href="stake.md#0x1_stake_StakePool">StakePool</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>let</b> ownership_cap = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
     <a href="stake.md#0x1_stake_set_delegated_voter_with_cap">set_delegated_voter_with_cap</a>(ownership_cap, new_voter);
@@ -2838,7 +2838,7 @@ Add <code>amount</code> of coins from the <code><a href="account.md#0x1_account"
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x1_stake_add_stake">add_stake</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, amount: u64) <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>, <a href="stake.md#0x1_stake_StakePool">StakePool</a>, <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>let</b> ownership_cap = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
     <a href="stake.md#0x1_stake_add_stake_with_cap">add_stake_with_cap</a>(ownership_cap, <a href="coin.md#0x1_coin_withdraw">coin::withdraw</a>&lt;AptosCoin&gt;(owner, amount));
@@ -2941,7 +2941,7 @@ Move <code>amount</code> of coins from pending_inactive to active.
 <pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x1_stake_reactivate_stake">reactivate_stake</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, amount: u64) <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>, <a href="stake.md#0x1_stake_StakePool">StakePool</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
     <a href="stake.md#0x1_stake_assert_reconfig_not_in_progress">assert_reconfig_not_in_progress</a>();
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>let</b> ownership_cap = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
     <a href="stake.md#0x1_stake_reactivate_stake_with_cap">reactivate_stake_with_cap</a>(ownership_cap, amount);
@@ -3033,7 +3033,7 @@ Rotate the consensus key of the validator, it'll take effect in next epoch.
     <a href="stake.md#0x1_stake_assert_stake_pool_exists">assert_stake_pool_exists</a>(pool_address);
 
     <b>let</b> stake_pool = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
 
     <b>assert</b>!(<b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="stake.md#0x1_stake_EVALIDATOR_CONFIG">EVALIDATOR_CONFIG</a>));
     <b>let</b> validator_info = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address);
@@ -3097,7 +3097,7 @@ Update the network and full node addresses of the validator. This only takes eff
     <a href="stake.md#0x1_stake_assert_reconfig_not_in_progress">assert_reconfig_not_in_progress</a>();
     <a href="stake.md#0x1_stake_assert_stake_pool_exists">assert_stake_pool_exists</a>(pool_address);
     <b>let</b> stake_pool = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
     <b>assert</b>!(<b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="stake.md#0x1_stake_EVALIDATOR_CONFIG">EVALIDATOR_CONFIG</a>));
     <b>let</b> validator_info = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(pool_address);
     <b>let</b> old_network_addresses = validator_info.network_addresses;
@@ -3152,7 +3152,7 @@ Similar to increase_lockup_with_cap but will use ownership capability from the s
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x1_stake_increase_lockup">increase_lockup</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>, <a href="stake.md#0x1_stake_StakePool">StakePool</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>let</b> ownership_cap = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
     <a href="stake.md#0x1_stake_increase_lockup_with_cap">increase_lockup_with_cap</a>(ownership_cap);
@@ -3278,7 +3278,7 @@ This internal version can only be called by the Genesis module during Genesis.
     <a href="stake.md#0x1_stake_assert_reconfig_not_in_progress">assert_reconfig_not_in_progress</a>();
     <a href="stake.md#0x1_stake_assert_stake_pool_exists">assert_stake_pool_exists</a>(pool_address);
     <b>let</b> stake_pool = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
     <b>assert</b>!(
         <a href="stake.md#0x1_stake_get_validator_state">get_validator_state</a>(pool_address) == <a href="stake.md#0x1_stake_VALIDATOR_STATUS_INACTIVE">VALIDATOR_STATUS_INACTIVE</a>,
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="stake.md#0x1_stake_EALREADY_ACTIVE_VALIDATOR">EALREADY_ACTIVE_VALIDATOR</a>),
@@ -3342,7 +3342,7 @@ Similar to unlock_with_cap but will use ownership capability from the signing ac
 <pre><code><b>public</b> entry <b>fun</b> <a href="stake.md#0x1_stake_unlock">unlock</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, amount: u64) <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>, <a href="stake.md#0x1_stake_StakePool">StakePool</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
     <a href="stake.md#0x1_stake_assert_reconfig_not_in_progress">assert_reconfig_not_in_progress</a>();
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>let</b> ownership_cap = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
     <a href="stake.md#0x1_stake_unlock_with_cap">unlock_with_cap</a>(amount, ownership_cap);
@@ -3430,7 +3430,7 @@ Withdraw from <code><a href="account.md#0x1_account">account</a></code>'s inacti
     withdraw_amount: u64
 ) <b>acquires</b> <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>, <a href="stake.md#0x1_stake_StakePool">StakePool</a>, <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a> {
     <a href="stake.md#0x1_stake_check_stake_permission">check_stake_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <a href="stake.md#0x1_stake_assert_owner_cap_exists">assert_owner_cap_exists</a>(owner_address);
     <b>let</b> ownership_cap = <b>borrow_global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
     <b>let</b> coins = <a href="stake.md#0x1_stake_withdraw_with_cap">withdraw_with_cap</a>(ownership_cap, withdraw_amount);
@@ -3540,7 +3540,7 @@ Can only be called by the operator of the validator/staking pool.
     <a href="stake.md#0x1_stake_assert_stake_pool_exists">assert_stake_pool_exists</a>(pool_address);
     <b>let</b> stake_pool = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
     // Account <b>has</b> <b>to</b> be the operator.
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(operator) == stake_pool.operator_address, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="stake.md#0x1_stake_ENOT_OPERATOR">ENOT_OPERATOR</a>));
 
     <b>let</b> validator_set = <b>borrow_global_mut</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
     // If the validator is still pending_active, directly kick the validator out.
@@ -4505,7 +4505,7 @@ Returns validator's next epoch voting power, including pending_active, active, a
     aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     accounts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;
 ) <b>acquires</b> <a href="stake.md#0x1_stake_AllowedValidators">AllowedValidators</a> {
-    <b>let</b> aptos_framework_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework);
+    <b>let</b> aptos_framework_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(aptos_framework);
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>if</b> (!<b>exists</b>&lt;<a href="stake.md#0x1_stake_AllowedValidators">AllowedValidators</a>&gt;(aptos_framework_address)) {
         <b>move_to</b>(aptos_framework, <a href="stake.md#0x1_stake_AllowedValidators">AllowedValidators</a> { accounts });
@@ -4672,115 +4672,6 @@ Returns validator's next epoch voting power, including pending_active, active, a
 <b>global</b> <a href="stake.md#0x1_stake_ghost_active_num">ghost_active_num</a>: u64;
 <a id="0x1_stake_ghost_pending_inactive_num"></a>
 <b>global</b> <a href="stake.md#0x1_stake_ghost_pending_inactive_num">ghost_pending_inactive_num</a>: u64;
-</code></pre>
-
-
-
-
-<a id="0x1_stake_spec_rewards_amount"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_rewards_amount">spec_rewards_amount</a>(
-   stake_amount: u64,
-   num_successful_proposals: u64,
-   num_total_proposals: u64,
-   rewards_rate: u64,
-   rewards_rate_denominator: u64,
-): u64;
-</code></pre>
-
-
-
-
-<a id="0x1_stake_spec_contains"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, addr: <b>address</b>): bool {
-   <b>exists</b> i in 0..len(validators): validators[i].addr == addr
-}
-</code></pre>
-
-
-
-
-<a id="0x1_stake_spec_is_current_epoch_validator"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address: <b>address</b>): bool {
-   <b>let</b> validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
-   !<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_active, pool_address)
-       && (<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.active_validators, pool_address)
-       || <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_inactive, pool_address))
-}
-</code></pre>
-
-
-
-
-<a id="0x1_stake_ResourceRequirement"></a>
-
-
-<pre><code><b>schema</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a> {
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;StakingConfig&gt;(@aptos_framework);
-    <b>requires</b> <b>exists</b>&lt;StakingRewardsConfig&gt;(@aptos_framework) || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>();
-    <b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
-}
-</code></pre>
-
-
-
-
-<a id="0x1_stake_spec_get_reward_rate_1"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_get_reward_rate_1">spec_get_reward_rate_1</a>(config: StakingConfig): num {
-   <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>()) {
-       <b>let</b> epoch_rewards_rate = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>&gt;(@aptos_framework).rewards_rate;
-       <b>if</b> (epoch_rewards_rate.value == 0) {
-           0
-       } <b>else</b> {
-           <b>let</b> denominator_0 = aptos_std::fixed_point64::spec_divide_u128(<a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">staking_config::MAX_REWARDS_RATE</a>, epoch_rewards_rate);
-           <b>let</b> denominator = <b>if</b> (denominator_0 &gt; <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>) {
-               <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>
-           } <b>else</b> {
-               denominator_0
-           };
-           <b>let</b> nominator = aptos_std::fixed_point64::spec_multiply_u128(denominator, epoch_rewards_rate);
-           nominator
-       }
-   } <b>else</b> {
-           config.rewards_rate
-   }
-}
-</code></pre>
-
-
-
-
-<a id="0x1_stake_spec_get_reward_rate_2"></a>
-
-
-<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_get_reward_rate_2">spec_get_reward_rate_2</a>(config: StakingConfig): num {
-   <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>()) {
-       <b>let</b> epoch_rewards_rate = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>&gt;(@aptos_framework).rewards_rate;
-       <b>if</b> (epoch_rewards_rate.value == 0) {
-           1
-       } <b>else</b> {
-           <b>let</b> denominator_0 = aptos_std::fixed_point64::spec_divide_u128(<a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">staking_config::MAX_REWARDS_RATE</a>, epoch_rewards_rate);
-           <b>let</b> denominator = <b>if</b> (denominator_0 &gt; <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>) {
-               <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>
-           } <b>else</b> {
-               denominator_0
-           };
-           denominator
-       }
-   } <b>else</b> {
-           config.rewards_rate_denominator
-   }
-}
 </code></pre>
 
 
@@ -5599,6 +5490,300 @@ Returns validator's next epoch voting power, including pending_active, active, a
 <b>invariant</b> len(validator_set.pending_inactive) == 0 ||
     <a href="stake.md#0x1_stake_spec_validator_indices_are_valid_config">spec_validator_indices_are_valid_config</a>(validator_set.pending_inactive,
         len(validator_set.active_validators) + len(validator_set.pending_inactive));
+</code></pre>
+
+
+
+
+<a id="0x1_stake_AddStakeWithCapAbortsIfAndEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="stake.md#0x1_stake_AddStakeWithCapAbortsIfAndEnsures">AddStakeWithCapAbortsIfAndEnsures</a> {
+    owner_cap: <a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>;
+    amount: u64;
+    <b>let</b> pool_address = owner_cap.pool_address;
+    <b>aborts_if</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
+    <b>let</b> config = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingConfig">staking_config::StakingConfig</a>&gt;(@aptos_framework);
+    <b>let</b> validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+    <b>let</b> voting_power_increase_limit = config.voting_power_increase_limit;
+    <b>let</b> <b>post</b> post_validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+    <b>let</b> update_voting_power_increase = amount != 0 && (<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.active_validators, pool_address)
+                                                       || <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_active, pool_address));
+    <b>aborts_if</b> update_voting_power_increase && validator_set.total_joining_power + amount &gt; MAX_U128;
+    <b>ensures</b> update_voting_power_increase ==&gt; post_validator_set.total_joining_power == validator_set.total_joining_power + amount;
+    <b>aborts_if</b> update_voting_power_increase && validator_set.total_voting_power &gt; 0
+            && validator_set.total_voting_power * voting_power_increase_limit &gt; MAX_U128;
+    <b>aborts_if</b> update_voting_power_increase && validator_set.total_voting_power &gt; 0
+            && validator_set.total_joining_power + amount &gt; validator_set.total_voting_power * voting_power_increase_limit / 100;
+    <b>let</b> stake_pool = <b>global</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
+    <b>let</b> <b>post</b> post_stake_pool = <b>global</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(pool_address);
+    <b>let</b> value_pending_active = stake_pool.pending_active.value;
+    <b>let</b> value_active = stake_pool.active.value;
+    <b>ensures</b> amount != 0 && <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address) ==&gt; post_stake_pool.pending_active.value == value_pending_active + amount;
+    <b>ensures</b> amount != 0 && !<a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address) ==&gt; post_stake_pool.active.value == value_active + amount;
+    <b>let</b> maximum_stake = config.maximum_stake;
+    <b>let</b> value_pending_inactive = stake_pool.pending_inactive.value;
+    <b>let</b> next_epoch_voting_power = value_pending_active + value_active + value_pending_inactive;
+    <b>let</b> voting_power = next_epoch_voting_power + amount;
+    <b>aborts_if</b> amount != 0 && voting_power &gt; <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>;
+    <b>aborts_if</b> amount != 0 && voting_power &gt; maximum_stake;
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_AddStakeAbortsIfAndEnsures"></a>
+
+
+<pre><code><b>schema</b> <a href="stake.md#0x1_stake_AddStakeAbortsIfAndEnsures">AddStakeAbortsIfAndEnsures</a> {
+    owner: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
+    amount: u64;
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>aborts_if</b> !<b>exists</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
+    <b>let</b> owner_cap = <b>global</b>&lt;<a href="stake.md#0x1_stake_OwnerCapability">OwnerCapability</a>&gt;(owner_address);
+    <b>include</b> <a href="stake.md#0x1_stake_AddStakeWithCapAbortsIfAndEnsures">AddStakeWithCapAbortsIfAndEnsures</a> { owner_cap };
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_is_allowed"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_is_allowed">spec_is_allowed</a>(<a href="account.md#0x1_account">account</a>: <b>address</b>): bool {
+   <b>if</b> (!<b>exists</b>&lt;<a href="stake.md#0x1_stake_AllowedValidators">AllowedValidators</a>&gt;(@aptos_framework)) {
+       <b>true</b>
+   } <b>else</b> {
+       <b>let</b> allowed = <b>global</b>&lt;<a href="stake.md#0x1_stake_AllowedValidators">AllowedValidators</a>&gt;(@aptos_framework);
+       contains(allowed.accounts, <a href="account.md#0x1_account">account</a>)
+   }
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_find_validator"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_find_validator">spec_find_validator</a>(v: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, addr: <b>address</b>): Option&lt;u64&gt;;
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_validators_are_initialized"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validators_are_initialized">spec_validators_are_initialized</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;): bool {
+   <b>forall</b> i in 0..len(validators):
+       <a href="stake.md#0x1_stake_spec_has_stake_pool">spec_has_stake_pool</a>(validators[i].addr) &&
+           <a href="stake.md#0x1_stake_spec_has_validator_config">spec_has_validator_config</a>(validators[i].addr)
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_validators_are_initialized_addrs"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validators_are_initialized_addrs">spec_validators_are_initialized_addrs</a>(addrs: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;): bool {
+   <b>forall</b> i in 0..len(addrs):
+       <a href="stake.md#0x1_stake_spec_has_stake_pool">spec_has_stake_pool</a>(addrs[i]) &&
+           <a href="stake.md#0x1_stake_spec_has_validator_config">spec_has_validator_config</a>(addrs[i])
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_validator_indices_are_valid"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_indices_are_valid">spec_validator_indices_are_valid</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;): bool {
+   <a href="stake.md#0x1_stake_spec_validator_indices_are_valid_addr">spec_validator_indices_are_valid_addr</a>(validators, <a href="stake.md#0x1_stake_spec_validator_index_upper_bound">spec_validator_index_upper_bound</a>()) &&
+       <a href="stake.md#0x1_stake_spec_validator_indices_are_valid_config">spec_validator_indices_are_valid_config</a>(validators, <a href="stake.md#0x1_stake_spec_validator_index_upper_bound">spec_validator_index_upper_bound</a>())
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_validator_indices_are_valid_addr"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_indices_are_valid_addr">spec_validator_indices_are_valid_addr</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, upper_bound: u64): bool {
+   <b>forall</b> i in 0..len(validators):
+       <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(validators[i].addr).validator_index &lt; upper_bound
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_validator_indices_are_valid_config"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_indices_are_valid_config">spec_validator_indices_are_valid_config</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, upper_bound: u64): bool {
+   <b>forall</b> i in 0..len(validators):
+       validators[i].config.validator_index &lt; upper_bound
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_validator_indices_active_pending_inactive"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_indices_active_pending_inactive">spec_validator_indices_active_pending_inactive</a>(validator_set: <a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>): bool {
+   len(validator_set.pending_inactive) + len(validator_set.active_validators) == <a href="stake.md#0x1_stake_spec_validator_index_upper_bound">spec_validator_index_upper_bound</a>()
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_validator_index_upper_bound"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_validator_index_upper_bound">spec_validator_index_upper_bound</a>(): u64 {
+   len(<b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework).validators)
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_has_stake_pool"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_has_stake_pool">spec_has_stake_pool</a>(a: <b>address</b>): bool {
+   <b>exists</b>&lt;<a href="stake.md#0x1_stake_StakePool">StakePool</a>&gt;(a)
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_has_validator_config"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_has_validator_config">spec_has_validator_config</a>(a: <b>address</b>): bool {
+   <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorConfig">ValidatorConfig</a>&gt;(a)
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_rewards_amount"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_rewards_amount">spec_rewards_amount</a>(
+   stake_amount: u64,
+   num_successful_proposals: u64,
+   num_total_proposals: u64,
+   rewards_rate: u64,
+   rewards_rate_denominator: u64,
+): u64;
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_contains"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validators: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="stake.md#0x1_stake_ValidatorInfo">ValidatorInfo</a>&gt;, addr: <b>address</b>): bool {
+   <b>exists</b> i in 0..len(validators): validators[i].addr == addr
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_is_current_epoch_validator"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_is_current_epoch_validator">spec_is_current_epoch_validator</a>(pool_address: <b>address</b>): bool {
+   <b>let</b> validator_set = <b>global</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+   !<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_active, pool_address)
+       && (<a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.active_validators, pool_address)
+       || <a href="stake.md#0x1_stake_spec_contains">spec_contains</a>(validator_set.pending_inactive, pool_address))
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_ResourceRequirement"></a>
+
+
+<pre><code><b>schema</b> <a href="stake.md#0x1_stake_ResourceRequirement">ResourceRequirement</a> {
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorPerformance">ValidatorPerformance</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;<a href="stake.md#0x1_stake_ValidatorSet">ValidatorSet</a>&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;StakingConfig&gt;(@aptos_framework);
+    <b>requires</b> <b>exists</b>&lt;StakingRewardsConfig&gt;(@aptos_framework) || !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>();
+    <b>requires</b> <b>exists</b>&lt;<a href="timestamp.md#0x1_timestamp_CurrentTimeMicroseconds">timestamp::CurrentTimeMicroseconds</a>&gt;(@aptos_framework);
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_get_reward_rate_1"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_get_reward_rate_1">spec_get_reward_rate_1</a>(config: StakingConfig): num {
+   <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>()) {
+       <b>let</b> epoch_rewards_rate = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>&gt;(@aptos_framework).rewards_rate;
+       <b>if</b> (epoch_rewards_rate.value == 0) {
+           0
+       } <b>else</b> {
+           <b>let</b> denominator_0 = aptos_std::fixed_point64::spec_divide_u128(<a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">staking_config::MAX_REWARDS_RATE</a>, epoch_rewards_rate);
+           <b>let</b> denominator = <b>if</b> (denominator_0 &gt; <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>) {
+               <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>
+           } <b>else</b> {
+               denominator_0
+           };
+           <b>let</b> nominator = aptos_std::fixed_point64::spec_multiply_u128(denominator, epoch_rewards_rate);
+           nominator
+       }
+   } <b>else</b> {
+           config.rewards_rate
+   }
+}
+</code></pre>
+
+
+
+
+<a id="0x1_stake_spec_get_reward_rate_2"></a>
+
+
+<pre><code><b>fun</b> <a href="stake.md#0x1_stake_spec_get_reward_rate_2">spec_get_reward_rate_2</a>(config: StakingConfig): num {
+   <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_periodical_reward_rate_decrease_enabled">features::spec_periodical_reward_rate_decrease_enabled</a>()) {
+       <b>let</b> epoch_rewards_rate = <b>global</b>&lt;<a href="staking_config.md#0x1_staking_config_StakingRewardsConfig">staking_config::StakingRewardsConfig</a>&gt;(@aptos_framework).rewards_rate;
+       <b>if</b> (epoch_rewards_rate.value == 0) {
+           1
+       } <b>else</b> {
+           <b>let</b> denominator_0 = aptos_std::fixed_point64::spec_divide_u128(<a href="staking_config.md#0x1_staking_config_MAX_REWARDS_RATE">staking_config::MAX_REWARDS_RATE</a>, epoch_rewards_rate);
+           <b>let</b> denominator = <b>if</b> (denominator_0 &gt; <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>) {
+               <a href="stake.md#0x1_stake_MAX_U64">MAX_U64</a>
+           } <b>else</b> {
+               denominator_0
+           };
+           denominator
+       }
+   } <b>else</b> {
+           config.rewards_rate_denominator
+   }
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/staking_contract.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_contract.md
@@ -1698,7 +1698,7 @@ Staker can call this function to create a simple staking contract with a specifi
     <b>assert</b>!(principal &gt;= min_stake_required, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_contract.md#0x1_staking_contract_EINSUFFICIENT_STAKE_AMOUNT">EINSUFFICIENT_STAKE_AMOUNT</a>));
 
     // Initialize <a href="staking_contract.md#0x1_staking_contract_Store">Store</a> resource <b>if</b> this is the first time the staker <b>has</b> delegated <b>to</b> anyone.
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <b>if</b> (!<b>exists</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address)) {
         <b>move_to</b>(staker, <a href="staking_contract.md#0x1_staking_contract_new_staking_contracts_holder">new_staking_contracts_holder</a>(staker));
     };
@@ -1720,7 +1720,7 @@ Staker can call this function to create a simple staking contract with a specifi
     <a href="stake.md#0x1_stake_add_stake_with_cap">stake::add_stake_with_cap</a>(&owner_cap, coins);
 
     // Create the contract record.
-    <b>let</b> pool_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&stake_pool_signer);
+    <b>let</b> pool_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&stake_pool_signer);
     <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_add">simple_map::add</a>(staking_contracts, operator, <a href="staking_contract.md#0x1_staking_contract_StakingContract">StakingContract</a> {
         principal,
         pool_address,
@@ -1766,7 +1766,7 @@ Add more stake to an existing staking contract.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_add_stake">add_stake</a>(staker: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator: <b>address</b>, amount: u64) <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a> {
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker_address, operator);
 
     <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
@@ -1810,7 +1810,7 @@ Convenient function to allow the staker to update the voter address in a staking
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_update_voter">update_voter</a>(staker: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator: <b>address</b>, new_voter: <b>address</b>) <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a> {
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker_address, operator);
 
     <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
@@ -1851,7 +1851,7 @@ Convenient function to allow the staker to reset their stake pool's lockup perio
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_reset_lockup">reset_lockup</a>(staker: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator: <b>address</b>) <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a> {
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker_address, operator);
 
     <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
@@ -1898,7 +1898,7 @@ TODO: fix the typo in function name. commision -> commission
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="staking_contract.md#0x1_staking_contract_EINVALID_COMMISSION_PERCENTAGE">EINVALID_COMMISSION_PERCENTAGE</a>),
     );
 
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <b>assert</b>!(<b>exists</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="staking_contract.md#0x1_staking_contract_ENO_STAKING_CONTRACT_FOUND_FOR_STAKER">ENO_STAKING_CONTRACT_FOUND_FOR_STAKER</a>));
 
     <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
@@ -1963,7 +1963,7 @@ Only staker, operator or beneficiary can call this.
     staker: <b>address</b>,
     operator: <b>address</b>
 ) <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a>, <a href="staking_contract.md#0x1_staking_contract_BeneficiaryForOperator">BeneficiaryForOperator</a> {
-    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> account_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(
         account_addr == staker || account_addr == operator || account_addr == <a href="staking_contract.md#0x1_staking_contract_beneficiary_for_operator">beneficiary_for_operator</a>(operator),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="staking_contract.md#0x1_staking_contract_ENOT_STAKER_OR_OPERATOR_OR_BENEFICIARY">ENOT_STAKER_OR_OPERATOR_OR_BENEFICIARY</a>)
@@ -2074,7 +2074,7 @@ This also triggers paying commission to the operator for accounting simplicity.
     // Short-circuit <b>if</b> amount is 0.
     <b>if</b> (amount == 0) <b>return</b>;
 
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker_address, operator);
 
     <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="staking_contract.md#0x1_staking_contract_Store">Store</a>&gt;(staker_address);
@@ -2140,7 +2140,7 @@ Unlock all accumulated rewards since the last recorded principals.
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_contract.md#0x1_staking_contract_unlock_rewards">unlock_rewards</a>(staker: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator: <b>address</b>) <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a>, <a href="staking_contract.md#0x1_staking_contract_BeneficiaryForOperator">BeneficiaryForOperator</a> {
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker_address, operator);
 
     // Calculate how much rewards belongs <b>to</b> the staker after commission is paid.
@@ -2175,7 +2175,7 @@ Allows staker to switch operator without going through the lenghthy process to u
     old_operator: <b>address</b>,
     new_operator: <b>address</b>,
 ) <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a>, <a href="staking_contract.md#0x1_staking_contract_BeneficiaryForOperator">BeneficiaryForOperator</a> {
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker_address, old_operator);
 
     <b>let</b> commission_percentage = <a href="staking_contract.md#0x1_staking_contract_commission_percentage">commission_percentage</a>(staker_address, old_operator);
@@ -2209,7 +2209,7 @@ Allows staker to switch operator without going through the lenghthy process to u
     new_operator: <b>address</b>,
     new_commission_percentage: u64,
 ) <b>acquires</b> <a href="staking_contract.md#0x1_staking_contract_Store">Store</a>, <a href="staking_contract.md#0x1_staking_contract_BeneficiaryForOperator">BeneficiaryForOperator</a> {
-    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker);
+    <b>let</b> staker_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker);
     <a href="staking_contract.md#0x1_staking_contract_assert_staking_contract_exists">assert_staking_contract_exists</a>(staker_address, old_operator);
 
     // Merging two existing staking contracts is too complex <b>as</b> we'd need <b>to</b> merge two separate <a href="stake.md#0x1_stake">stake</a> pools.
@@ -2281,7 +2281,7 @@ the beneficiary. An operator can set one beneficiary for staking contract pools,
     ));
     // The beneficiay <b>address</b> of an operator is stored under the operator's <b>address</b>.
     // So, the operator does not need <b>to</b> be validated <b>with</b> respect <b>to</b> a staking pool.
-    <b>let</b> operator_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(operator);
+    <b>let</b> operator_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(operator);
     <b>let</b> old_beneficiary = <a href="staking_contract.md#0x1_staking_contract_beneficiary_for_operator">beneficiary_for_operator</a>(operator_addr);
     <b>if</b> (<b>exists</b>&lt;<a href="staking_contract.md#0x1_staking_contract_BeneficiaryForOperator">BeneficiaryForOperator</a>&gt;(operator_addr)) {
         <b>borrow_global_mut</b>&lt;<a href="staking_contract.md#0x1_staking_contract_BeneficiaryForOperator">BeneficiaryForOperator</a>&gt;(operator_addr).beneficiary_for_operator = new_beneficiary;
@@ -2534,7 +2534,7 @@ Calculate accumulated rewards and commissions since last update.
 ): (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, SignerCapability, OwnerCapability) {
     // Generate a seed that will be used <b>to</b> create the resource <a href="account.md#0x1_account">account</a> that hosts the staking contract.
     <b>let</b> seed = <a href="staking_contract.md#0x1_staking_contract_create_resource_account_seed">create_resource_account_seed</a>(
-        <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(staker), operator, contract_creation_seed);
+        <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(staker), operator, contract_creation_seed);
 
     <b>let</b> (stake_pool_signer, stake_pool_signer_cap) = <a href="account.md#0x1_account_create_resource_account">account::create_resource_account</a>(staker, seed);
     <a href="stake.md#0x1_stake_initialize_stake_owner">stake::initialize_stake_owner</a>(&stake_pool_signer, 0, operator, voter);

--- a/aptos-move/framework/aptos-framework/doc/staking_proxy.md
+++ b/aptos-move/framework/aptos-framework/doc/staking_proxy.md
@@ -205,7 +205,7 @@ Grant permission to mutate staking on behalf of the master signer.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_proxy.md#0x1_staking_proxy_set_vesting_contract_operator">set_vesting_contract_operator</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, old_operator: <b>address</b>, new_operator: <b>address</b>) {
     <a href="staking_proxy.md#0x1_staking_proxy_check_stake_proxy_permission">check_stake_proxy_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>let</b> vesting_contracts = &<a href="vesting.md#0x1_vesting_vesting_contracts">vesting::vesting_contracts</a>(owner_address);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(vesting_contracts, |vesting_contract| {
         <b>let</b> vesting_contract = *vesting_contract;
@@ -238,7 +238,7 @@ Grant permission to mutate staking on behalf of the master signer.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_proxy.md#0x1_staking_proxy_set_staking_contract_operator">set_staking_contract_operator</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, old_operator: <b>address</b>, new_operator: <b>address</b>) {
     <a href="staking_proxy.md#0x1_staking_proxy_check_stake_proxy_permission">check_stake_proxy_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>if</b> (<a href="staking_contract.md#0x1_staking_contract_staking_contract_exists">staking_contract::staking_contract_exists</a>(owner_address, old_operator)) {
         <b>let</b> current_commission_percentage = <a href="staking_contract.md#0x1_staking_contract_commission_percentage">staking_contract::commission_percentage</a>(owner_address, old_operator);
         <a href="staking_contract.md#0x1_staking_contract_switch_operator">staking_contract::switch_operator</a>(owner, old_operator, new_operator, current_commission_percentage);
@@ -267,7 +267,7 @@ Grant permission to mutate staking on behalf of the master signer.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_proxy.md#0x1_staking_proxy_set_stake_pool_operator">set_stake_pool_operator</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_operator: <b>address</b>) {
     <a href="staking_proxy.md#0x1_staking_proxy_check_stake_proxy_permission">check_stake_proxy_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>if</b> (<a href="stake.md#0x1_stake_stake_pool_exists">stake::stake_pool_exists</a>(owner_address)) {
         <a href="stake.md#0x1_stake_set_operator">stake::set_operator</a>(owner, new_operator);
     };
@@ -295,7 +295,7 @@ Grant permission to mutate staking on behalf of the master signer.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_proxy.md#0x1_staking_proxy_set_vesting_contract_voter">set_vesting_contract_voter</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator: <b>address</b>, new_voter: <b>address</b>) {
     <a href="staking_proxy.md#0x1_staking_proxy_check_stake_proxy_permission">check_stake_proxy_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>let</b> vesting_contracts = &<a href="vesting.md#0x1_vesting_vesting_contracts">vesting::vesting_contracts</a>(owner_address);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(vesting_contracts, |vesting_contract| {
         <b>let</b> vesting_contract = *vesting_contract;
@@ -327,7 +327,7 @@ Grant permission to mutate staking on behalf of the master signer.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_proxy.md#0x1_staking_proxy_set_staking_contract_voter">set_staking_contract_voter</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, operator: <b>address</b>, new_voter: <b>address</b>) {
     <a href="staking_proxy.md#0x1_staking_proxy_check_stake_proxy_permission">check_stake_proxy_permission</a>(owner);
-    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner);
+    <b>let</b> owner_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner);
     <b>if</b> (<a href="staking_contract.md#0x1_staking_contract_staking_contract_exists">staking_contract::staking_contract_exists</a>(owner_address, operator)) {
         <a href="staking_contract.md#0x1_staking_contract_update_voter">staking_contract::update_voter</a>(owner, operator, new_voter);
     };
@@ -355,7 +355,7 @@ Grant permission to mutate staking on behalf of the master signer.
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="staking_proxy.md#0x1_staking_proxy_set_stake_pool_voter">set_stake_pool_voter</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, new_voter: <b>address</b>) {
     <a href="staking_proxy.md#0x1_staking_proxy_check_stake_proxy_permission">check_stake_proxy_permission</a>(owner);
-    <b>if</b> (<a href="stake.md#0x1_stake_stake_pool_exists">stake::stake_pool_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(owner))) {
+    <b>if</b> (<a href="stake.md#0x1_stake_stake_pool_exists">stake::stake_pool_exists</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(owner))) {
         <a href="stake.md#0x1_stake_set_delegated_voter">stake::set_delegated_voter</a>(owner, new_voter);
     };
 }

--- a/aptos-move/framework/aptos-framework/doc/system_addresses.md
+++ b/aptos-move/framework/aptos-framework/doc/system_addresses.md
@@ -97,7 +97,7 @@ The operation can only be performed by the VM
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="system_addresses.md#0x1_system_addresses_assert_core_resource">assert_core_resource</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_core_resource_address">assert_core_resource_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>))
+    <a href="system_addresses.md#0x1_system_addresses_assert_core_resource_address">assert_core_resource_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>))
 }
 </code></pre>
 
@@ -170,7 +170,7 @@ The operation can only be performed by the VM
 
 <pre><code><b>public</b> <b>fun</b> <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">assert_aptos_framework</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <b>assert</b>!(
-        <a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>)),
+        <a href="system_addresses.md#0x1_system_addresses_is_aptos_framework_address">is_aptos_framework_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>)),
         <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="system_addresses.md#0x1_system_addresses_ENOT_APTOS_FRAMEWORK_ADDRESS">ENOT_APTOS_FRAMEWORK_ADDRESS</a>),
     )
 }
@@ -196,7 +196,7 @@ The operation can only be performed by the VM
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="system_addresses.md#0x1_system_addresses_assert_framework_reserved_address">assert_framework_reserved_address</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
-    <a href="system_addresses.md#0x1_system_addresses_assert_framework_reserved">assert_framework_reserved</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>));
+    <a href="system_addresses.md#0x1_system_addresses_assert_framework_reserved">assert_framework_reserved</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>));
 }
 </code></pre>
 
@@ -332,7 +332,7 @@ Return true if <code>addr</code> is a reserved address for the VM to call system
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="system_addresses.md#0x1_system_addresses_is_vm">is_vm</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>): bool {
-    <a href="system_addresses.md#0x1_system_addresses_is_vm_address">is_vm_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>))
+    <a href="system_addresses.md#0x1_system_addresses_is_vm_address">is_vm_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>))
 }
 </code></pre>
 
@@ -497,6 +497,20 @@ Return true if <code>addr</code> is either the VM address or an Aptos Framework 
 </code></pre>
 
 
+Specifies that a function aborts if the account does not have the root address.
+
+
+<a id="0x1_system_addresses_AbortsIfNotCoreResource"></a>
+
+
+<pre><code><b>schema</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotCoreResource">AbortsIfNotCoreResource</a> {
+    addr: <b>address</b>;
+    // This enforces <a id="high-level-req-1" href="#high-level-req">high-level requirement 1</a>:
+    <b>aborts_if</b> addr != @core_resources <b>with</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_PERMISSION_DENIED">error::PERMISSION_DENIED</a>;
+}
+</code></pre>
+
+
 
 <a id="@Specification_1_assert_aptos_framework"></a>
 
@@ -543,20 +557,6 @@ Return true if <code>addr</code> is either the VM address or an Aptos Framework 
 
 
 <pre><code><b>aborts_if</b> !<a href="system_addresses.md#0x1_system_addresses_is_framework_reserved_address">is_framework_reserved_address</a>(addr);
-</code></pre>
-
-
-Specifies that a function aborts if the account does not have the aptos framework address.
-
-
-<a id="0x1_system_addresses_AbortsIfNotAptosFramework"></a>
-
-
-<pre><code><b>schema</b> <a href="system_addresses.md#0x1_system_addresses_AbortsIfNotAptosFramework">AbortsIfNotAptosFramework</a> {
-    <a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>;
-    // This enforces <a id="high-level-req-2" href="#high-level-req">high-level requirement 2</a>:
-    <b>aborts_if</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>) != @aptos_framework <b>with</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_PERMISSION_DENIED">error::PERMISSION_DENIED</a>;
-}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/transaction_fee.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_fee.md
@@ -410,7 +410,7 @@ Only called during genesis.
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
     <b>let</b> <a href="transaction_fee.md#0x1_transaction_fee_AptosCoinCapabilities">AptosCoinCapabilities</a> {
         burn_cap,
-    } = <b>move_from</b>&lt;<a href="transaction_fee.md#0x1_transaction_fee_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(aptos_framework));
+    } = <b>move_from</b>&lt;<a href="transaction_fee.md#0x1_transaction_fee_AptosCoinCapabilities">AptosCoinCapabilities</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(aptos_framework));
     <b>let</b> burn_ref = <a href="coin.md#0x1_coin_convert_and_take_paired_burn_ref">coin::convert_and_take_paired_burn_ref</a>(burn_cap);
     <b>move_to</b>(aptos_framework, <a href="transaction_fee.md#0x1_transaction_fee_AptosFABurnCapabilities">AptosFABurnCapabilities</a> { burn_ref });
 }

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -420,8 +420,8 @@ Only called during genesis to initialize system resources for this module.
     );
     <b>assert</b>!(<a href="chain_id.md#0x1_chain_id_get">chain_id::get</a>() == <a href="chain_id.md#0x1_chain_id">chain_id</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EBAD_CHAIN_ID">PROLOGUE_EBAD_CHAIN_ID</a>));
 
-    <b>let</b> transaction_sender = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender);
-    <b>let</b> gas_payer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(gas_payer);
+    <b>let</b> transaction_sender = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(sender);
+    <b>let</b> gas_payer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(gas_payer);
 
     <b>if</b> (
         transaction_sender == gas_payer_address
@@ -927,7 +927,7 @@ Called by the Adapter
     txn_max_gas_units: u64,
     gas_units_remaining: u64,
 ) {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&<a href="account.md#0x1_account">account</a>);
     <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer">epilogue_gas_payer</a>(
         <a href="account.md#0x1_account">account</a>,
         addr,
@@ -966,7 +966,7 @@ Called by the Adapter
     gas_units_remaining: u64,
     is_simulation: bool,
 ) {
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&<a href="account.md#0x1_account">account</a>);
     <a href="transaction_validation.md#0x1_transaction_validation_epilogue_gas_payer_extended">epilogue_gas_payer_extended</a>(
         <a href="account.md#0x1_account">account</a>,
         addr,
@@ -1084,7 +1084,7 @@ Called by the Adapter
     };
 
     // Increment sequence number
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&<a href="account.md#0x1_account">account</a>);
     <a href="account.md#0x1_account_increment_sequence_number">account::increment_sequence_number</a>(addr);
 }
 </code></pre>
@@ -1232,7 +1232,7 @@ If there is no fee_payer, fee_payer = sender
     <a href="transaction_validation.md#0x1_transaction_validation_multi_agent_common_prologue">multi_agent_common_prologue</a>(secondary_signer_addresses, secondary_signer_public_key_hashes, is_simulation);
     <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_transaction_simulation_enhancement_enabled">features::transaction_simulation_enhancement_enabled</a>() ||
         !<a href="transaction_validation.md#0x1_transaction_validation_skip_auth_key_check">skip_auth_key_check</a>(is_simulation, &fee_payer_public_key_hash)) {
-        <b>let</b> fee_payer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&fee_payer);
+        <b>let</b> fee_payer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&fee_payer);
         <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&fee_payer_public_key_hash)) {
             <b>assert</b>!(
                 fee_payer_public_key_hash == <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(fee_payer_address)),
@@ -1287,7 +1287,7 @@ If there is no fee_payer, fee_payer = sender
     );
     <b>let</b> transaction_fee_amount = txn_gas_price * gas_used;
 
-    <b>let</b> gas_payer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&gas_payer);
+    <b>let</b> gas_payer_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&gas_payer);
     // it's important <b>to</b> maintain the <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">error</a> <a href="code.md#0x1_code">code</a> consistent <b>with</b> vm
     // <b>to</b> do failed transaction cleanup.
     <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_transaction_simulation_enhancement_enabled">features::transaction_simulation_enhancement_enabled</a>() || !<a href="transaction_validation.md#0x1_transaction_validation_skip_gas_payment">skip_gas_payment</a>(
@@ -1326,7 +1326,7 @@ If there is no fee_payer, fee_payer = sender
     };
 
     // Increment sequence number
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&<a href="account.md#0x1_account">account</a>);
     <a href="account.md#0x1_account_increment_sequence_number">account::increment_sequence_number</a>(addr);
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -165,7 +165,7 @@ TODO: update all the tests that reference this function, then disable this funct
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="version.md#0x1_version_set_version">set_version</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64) <b>acquires</b> <a href="version.md#0x1_version_Version">Version</a> {
-    <b>assert</b>!(<b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="version.md#0x1_version_ENOT_AUTHORIZED">ENOT_AUTHORIZED</a>));
+    <b>assert</b>!(<b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="version.md#0x1_version_ENOT_AUTHORIZED">ENOT_AUTHORIZED</a>));
     <a href="chain_status.md#0x1_chain_status_assert_genesis">chain_status::assert_genesis</a>();
 
     <b>let</b> old_major = <b>borrow_global</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework).major;
@@ -203,7 +203,7 @@ Example usage:
 
 
 <pre><code><b>public</b> entry <b>fun</b> <a href="version.md#0x1_version_set_for_next_epoch">set_for_next_epoch</a>(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, major: u64) <b>acquires</b> <a href="version.md#0x1_version_Version">Version</a> {
-    <b>assert</b>!(<b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="version.md#0x1_version_ENOT_AUTHORIZED">ENOT_AUTHORIZED</a>));
+    <b>assert</b>!(<b>exists</b>&lt;<a href="version.md#0x1_version_SetVersionCapability">SetVersionCapability</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>)), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="version.md#0x1_version_ENOT_AUTHORIZED">ENOT_AUTHORIZED</a>));
     <b>let</b> old_major = <b>borrow_global</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework).major;
     <b>assert</b>!(old_major &lt; major, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="version.md#0x1_version_EINVALID_MAJOR_VERSION_NUMBER">EINVALID_MAJOR_VERSION_NUMBER</a>));
     <a href="config_buffer.md#0x1_config_buffer_upsert">config_buffer::upsert</a>(<a href="version.md#0x1_version_Version">Version</a> {major});

--- a/aptos-move/framework/aptos-framework/doc/vesting.md
+++ b/aptos-move/framework/aptos-framework/doc/vesting.md
@@ -2288,7 +2288,7 @@ Create a vesting contract with a given configurations.
     <b>assert</b>!(grant_amount &gt; 0, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="vesting.md#0x1_vesting_EZERO_GRANT">EZERO_GRANT</a>));
 
     // If this is the first time this admin <a href="account.md#0x1_account">account</a> <b>has</b> created a <a href="vesting.md#0x1_vesting">vesting</a> contract, initialize the admin store.
-    <b>let</b> admin_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(admin);
+    <b>let</b> admin_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(admin);
     <b>if</b> (!<b>exists</b>&lt;<a href="vesting.md#0x1_vesting_AdminStore">AdminStore</a>&gt;(admin_address)) {
         <b>move_to</b>(admin, <a href="vesting.md#0x1_vesting_AdminStore">AdminStore</a> {
             vesting_contracts: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;<b>address</b>&gt;(),
@@ -2304,7 +2304,7 @@ Create a vesting contract with a given configurations.
         &contract_signer, operator, voter, grant, commission_percentage, contract_creation_seed);
 
     // Add the newly created <a href="vesting.md#0x1_vesting">vesting</a> contract's <b>address</b> <b>to</b> the admin store.
-    <b>let</b> contract_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&contract_signer);
+    <b>let</b> contract_address = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(&contract_signer);
     <b>let</b> admin_store = <b>borrow_global_mut</b>&lt;<a href="vesting.md#0x1_vesting_AdminStore">AdminStore</a>&gt;(admin_address);
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> admin_store.vesting_contracts, contract_address);
     <b>if</b> (std::features::module_event_migration_enabled()) {
@@ -3078,7 +3078,7 @@ account.
 ) <b>acquires</b> <a href="vesting.md#0x1_vesting_VestingAccountManagement">VestingAccountManagement</a>, <a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a> {
     <a href="vesting.md#0x1_vesting_check_vest_permission">check_vest_permission</a>(<a href="account.md#0x1_account">account</a>);
     <b>let</b> vesting_contract = <b>borrow_global_mut</b>&lt;<a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a>&gt;(contract_address);
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(
         addr == vesting_contract.admin ||
             addr == <a href="vesting.md#0x1_vesting_get_role_holder">get_role_holder</a>(contract_address, utf8(<a href="vesting.md#0x1_vesting_ROLE_BENEFICIARY_RESETTER">ROLE_BENEFICIARY_RESETTER</a>)),
@@ -3297,8 +3297,8 @@ This address should be deterministic for the same admin and vesting contract cre
     contract_creation_seed: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ): (<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, SignerCapability) <b>acquires</b> <a href="vesting.md#0x1_vesting_AdminStore">AdminStore</a> {
     <a href="vesting.md#0x1_vesting_check_vest_permission">check_vest_permission</a>(admin);
-    <b>let</b> admin_store = <b>borrow_global_mut</b>&lt;<a href="vesting.md#0x1_vesting_AdminStore">AdminStore</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(admin));
-    <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(admin));
+    <b>let</b> admin_store = <b>borrow_global_mut</b>&lt;<a href="vesting.md#0x1_vesting_AdminStore">AdminStore</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(admin));
+    <b>let</b> seed = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(admin));
     <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_append">vector::append</a>(&<b>mut</b> seed, <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&admin_store.nonce));
     admin_store.nonce = admin_store.nonce + 1;
 
@@ -3337,7 +3337,7 @@ This address should be deterministic for the same admin and vesting contract cre
 
 <pre><code><b>fun</b> <a href="vesting.md#0x1_vesting_verify_admin">verify_admin</a>(admin: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, vesting_contract: &<a href="vesting.md#0x1_vesting_VestingContract">VestingContract</a>) {
     <a href="vesting.md#0x1_vesting_check_vest_permission">check_vest_permission</a>(admin);
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(admin) == vesting_contract.admin, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="vesting.md#0x1_vesting_ENOT_ADMIN">ENOT_ADMIN</a>));
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(admin) == vesting_contract.admin, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unauthenticated">error::unauthenticated</a>(<a href="vesting.md#0x1_vesting_ENOT_ADMIN">ENOT_ADMIN</a>));
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -891,7 +891,7 @@ Grant permission to vote on behalf of the master signer.
 
 <pre><code><b>public</b> <b>fun</b> <a href="voting.md#0x1_voting_register">register</a>&lt;ProposalType: store&gt;(<a href="account.md#0x1_account">account</a>: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
     <a href="voting.md#0x1_voting_check_vote_permission">check_vote_permission</a>(<a href="account.md#0x1_account">account</a>);
-    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(<a href="account.md#0x1_account">account</a>);
+    <b>let</b> addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of_unpermissioned">signer::address_of_unpermissioned</a>(<a href="account.md#0x1_account">account</a>);
     <b>assert</b>!(!<b>exists</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_already_exists">error::already_exists</a>(<a href="voting.md#0x1_voting_EVOTING_FORUM_ALREADY_REGISTERED">EVOTING_FORUM_ALREADY_REGISTERED</a>));
 
     <b>let</b> voting_forum = <a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt; {

--- a/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
+++ b/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
@@ -84,7 +84,7 @@ module aptos_framework::account_abstraction {
         account: &signer,
     ) acquires DispatchableAuthenticator {
         assert!(!is_permissioned_signer(account), error::permission_denied(ENOT_MASTER_SIGNER));
-        let addr = signer::address_of(account);
+        let addr = signer::address_of_unpermissioned(account);
         let resource_addr = resource_addr(addr);
         if (exists<DispatchableAuthenticator>(resource_addr)) {
             move_from<DispatchableAuthenticator>(resource_addr);
@@ -103,7 +103,7 @@ module aptos_framework::account_abstraction {
         auth_function: FunctionInfo,
         is_add: bool,
     ) acquires DispatchableAuthenticator {
-        let addr = signer::address_of(account);
+        let addr = signer::address_of_unpermissioned(account);
         let resource_addr = resource_addr(addr);
         let dispatcher_auth_function_info = function_info::new_function_info_from_address(
             @aptos_framework,
@@ -174,7 +174,9 @@ module aptos_framework::account_abstraction {
         func_info: FunctionInfo,
         signing_data: AbstractionAuthData,
     ): signer acquires DispatchableAuthenticator {
-        let master_signer_addr = signer::address_of(&account);
+        // We can call signer::address_of here as the account is passed in by VM directly so it will
+        // always be a master signer.
+        let master_signer_addr = signer::address_of_unpermissioned(&account);
         let func_infos = dispatchable_authenticator_internal(master_signer_addr);
         assert!(ordered_map::contains(func_infos, &func_info), error::not_found(EFUNCTION_INFO_EXISTENCE));
         function_info::load_module_from_function(&func_info);
@@ -198,7 +200,7 @@ module aptos_framework::account_abstraction {
     entry fun test_dispatchable_authenticator(
         bob: &signer,
     ) acquires DispatchableAuthenticator {
-        let bob_addr = signer::address_of(bob);
+        let bob_addr = signer::address_of_unpermissioned(bob);
         create_account_for_test(bob_addr);
         assert!(!using_dispatchable_authenticator(bob_addr), 0);
         add_authentication_function(

--- a/aptos-move/framework/aptos-framework/sources/account/permissioned_delegation.move
+++ b/aptos-move/framework/aptos-framework/sources/account/permissioned_delegation.move
@@ -56,7 +56,7 @@ module aptos_framework::permissioned_delegation {
         expiration_time: u64,
     ): signer acquires RegisteredDelegations {
         assert!(!is_permissioned_signer(master), error::permission_denied(ENOT_MASTER_SIGNER));
-        let addr = signer::address_of(master);
+        let addr = signer::address_of_unpermissioned(master);
         if (!exists<RegisteredDelegations>(addr)) {
             move_to(master, RegisteredDelegations {
                 delegations: big_ordered_map::new_with_config(50, 20, false)
@@ -75,7 +75,7 @@ module aptos_framework::permissioned_delegation {
         key: DelegationKey,
     ) acquires RegisteredDelegations {
         assert!(!is_permissioned_signer(master), error::permission_denied(ENOT_MASTER_SIGNER));
-        let addr = signer::address_of(master);
+        let addr = signer::address_of_unpermissioned(master);
         let delegations = &mut borrow_global_mut<RegisteredDelegations>(addr).delegations;
         assert!(delegations.contains(&key), error::not_found(EDELEGATION_EXISTENCE));
         let delegation = delegations.remove(&key);
@@ -91,7 +91,7 @@ module aptos_framework::permissioned_delegation {
         key: DelegationKey,
     ): signer acquires RegisteredDelegations {
         assert!(!is_permissioned_signer(master), error::permission_denied(ENOT_MASTER_SIGNER));
-        let addr = signer::address_of(master);
+        let addr = signer::address_of_unpermissioned(master);
         let handle = get_storable_permissioned_handle(addr, key, false);
         permissioned_signer::signer_from_storable_permissioned_handle(handle)
     }
@@ -106,7 +106,7 @@ module aptos_framework::permissioned_delegation {
         account: signer,
         abstraction_auth_data: AbstractionAuthData
     ): signer acquires RegisteredDelegations {
-        let addr = signer::address_of(&account);
+        let addr = signer::address_of_unpermissioned(&account);
         let stream = bcs_stream::new(*auth_data::authenticator(&abstraction_auth_data));
         let public_key = new_unvalidated_public_key_from_bytes(
             bcs_stream::deserialize_vector<u8>(&mut stream, |x| deserialize_u8(x))

--- a/aptos-move/framework/aptos-framework/sources/aptos_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/aptos_coin.move
@@ -56,7 +56,7 @@ module aptos_framework::aptos_coin {
     }
 
     public fun has_mint_capability(account: &signer): bool {
-        exists<MintCapStore>(signer::address_of(account))
+        exists<MintCapStore>(signer::address_of_unpermissioned(account))
     }
 
     /// Only called during genesis to destroy the aptos framework account's mint capability once all initial validators
@@ -82,7 +82,7 @@ module aptos_framework::aptos_coin {
             18446744073709551615,
             &mint_cap,
         );
-        coin::deposit<AptosCoin>(signer::address_of(core_resources), coins);
+        coin::deposit<AptosCoin>(signer::address_of_unpermissioned(core_resources), coins);
 
         move_to(core_resources, MintCapStore { mint_cap });
         move_to(core_resources, Delegations { inner: vector::empty() });
@@ -95,7 +95,7 @@ module aptos_framework::aptos_coin {
         dst_addr: address,
         amount: u64,
     ) acquires MintCapStore {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
 
         assert!(
             exists<MintCapStore>(account_addr),
@@ -122,7 +122,7 @@ module aptos_framework::aptos_coin {
     /// Only callable in tests and testnets where the core resources account exists.
     /// Claim the delegated mint capability and destroy the delegated token.
     public entry fun claim_mint_capability(account: &signer) acquires Delegations, MintCapStore {
-        let maybe_index = find_delegation(signer::address_of(account));
+        let maybe_index = find_delegation(signer::address_of_unpermissioned(account));
         assert!(option::is_some(&maybe_index), EDELEGATION_NOT_FOUND);
         let idx = *option::borrow(&maybe_index);
         let delegations = &mut borrow_global_mut<Delegations>(@core_resources).inner;

--- a/aptos-move/framework/aptos-framework/sources/chain_id.move
+++ b/aptos-move/framework/aptos-framework/sources/chain_id.move
@@ -28,7 +28,7 @@ module aptos_framework::chain_id {
 
     #[test_only]
     public fun initialize_for_test(aptos_framework: &signer, id: u8) {
-        if (!exists<ChainId>(signer::address_of(aptos_framework))) {
+        if (!exists<ChainId>(signer::address_of_unpermissioned(aptos_framework))) {
             initialize(aptos_framework, id);
         }
     }

--- a/aptos-move/framework/aptos-framework/sources/code.move
+++ b/aptos-move/framework/aptos-framework/sources/code.move
@@ -155,7 +155,7 @@ module aptos_framework::code {
     fun initialize(aptos_framework: &signer, package_owner: &signer, metadata: PackageMetadata)
     acquires PackageRegistry {
         system_addresses::assert_aptos_framework(aptos_framework);
-        let addr = signer::address_of(package_owner);
+        let addr = signer::address_of_unpermissioned(package_owner);
         if (!exists<PackageRegistry>(addr)) {
             move_to(package_owner, PackageRegistry { packages: vector[metadata] })
         } else {
@@ -173,7 +173,7 @@ module aptos_framework::code {
             error::invalid_argument(EINCOMPATIBLE_POLICY_DISABLED),
         );
 
-        let addr = signer::address_of(owner);
+        let addr = signer::address_of_unpermissioned(owner);
         if (!exists<PackageRegistry>(addr)) {
             move_to(owner, PackageRegistry { packages: vector::empty() })
         };
@@ -232,7 +232,7 @@ module aptos_framework::code {
         let code_object_addr = object::object_address(&code_object);
         assert!(exists<PackageRegistry>(code_object_addr), error::not_found(ECODE_OBJECT_DOES_NOT_EXIST));
         assert!(
-            object::is_owner(code_object, signer::address_of(publisher)),
+            object::is_owner(code_object, signer::address_of_unpermissioned(publisher)),
             error::permission_denied(ENOT_PACKAGE_OWNER)
         );
 

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -622,7 +622,7 @@ module aptos_framework::coin {
             fungible_asset::withdraw_permission_check_by_address(
                 account,
                 primary_fungible_store::primary_store_address(
-                    signer::address_of(account),
+                    signer::address_of_unpermissioned(account),
                     ensure_paired_metadata<CoinType>()
                 ),
                 0
@@ -634,7 +634,7 @@ module aptos_framework::coin {
     public entry fun migrate_to_fungible_store<CoinType>(
         account: &signer
     ) acquires CoinStore, CoinConversionMap, CoinInfo {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
         assert_signer_has_permission<CoinType>(account);
         maybe_convert_to_fungible_store<CoinType>(account_addr);
     }
@@ -891,7 +891,7 @@ module aptos_framework::coin {
         coin: Coin<CoinType>
     ) acquires CoinStore, CoinConversionMap, CoinInfo {
         let metadata = ensure_paired_metadata<CoinType>();
-        let account_address = signer::address_of(account);
+        let account_address = signer::address_of_unpermissioned(account);
         fungible_asset::refill_permission(
             account,
             coin.value,
@@ -1035,7 +1035,7 @@ module aptos_framework::coin {
         monitor_supply: bool,
         parallelizable: bool,
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) acquires CoinInfo, CoinConversionMap {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
         assert_signer_has_permission<CoinType>(account);
 
         assert!(
@@ -1093,7 +1093,7 @@ module aptos_framework::coin {
     }
 
     public fun register<CoinType>(account: &signer) acquires CoinInfo, CoinConversionMap {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
         assert_signer_has_permission<CoinType>(account);
         // Short-circuit and do nothing if account is already registered for CoinType.
         if (is_account_registered<CoinType>(account_addr)) {
@@ -1130,7 +1130,7 @@ module aptos_framework::coin {
         account: &signer,
         amount: u64,
     ): Coin<CoinType> acquires CoinStore, CoinConversionMap, CoinInfo, PairedCoinType {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
 
         let (coin_amount_to_withdraw, fa_amount_to_withdraw) = calculate_amount_to_withdraw<CoinType>(
             account_addr,
@@ -1271,7 +1271,7 @@ module aptos_framework::coin {
     #[test_only]
     fun create_coin_store<CoinType>(account: &signer) {
         assert!(is_coin_initialized<CoinType>(), error::invalid_argument(ECOIN_INFO_NOT_PUBLISHED));
-        if (!exists<CoinStore<CoinType>>(signer::address_of(account))) {
+        if (!exists<CoinStore<CoinType>>(signer::address_of_unpermissioned(account))) {
             let coin_store = CoinStore<CoinType> {
                 coin: Coin { value: 0 },
                 frozen: false,
@@ -1329,7 +1329,7 @@ module aptos_framework::coin {
 
         create_coin_store<FakeMoney>(destination);
         let coins_minted = mint<FakeMoney>(amount, &mint_cap);
-        deposit(signer::address_of(source), coins_minted);
+        deposit(signer::address_of_unpermissioned(source), coins_minted);
         move_to(source, FakeMoneyCapabilities {
             burn_cap,
             freeze_cap,
@@ -1342,9 +1342,9 @@ module aptos_framework::coin {
         source: signer,
         destination: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
-        let source_addr = signer::address_of(&source);
+        let source_addr = signer::address_of_unpermissioned(&source);
         account::create_account_for_test(source_addr);
-        let destination_addr = signer::address_of(&destination);
+        let destination_addr = signer::address_of_unpermissioned(&destination);
         account::create_account_for_test(destination_addr);
 
         let name = string::utf8(b"Fake money");
@@ -1394,9 +1394,9 @@ module aptos_framework::coin {
         source: signer,
         destination: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
-        let source_addr = signer::address_of(&source);
+        let source_addr = signer::address_of_unpermissioned(&source);
         account::create_account_for_test(source_addr);
-        let destination_addr = signer::address_of(&destination);
+        let destination_addr = signer::address_of_unpermissioned(&destination);
         account::create_account_for_test(destination_addr);
 
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, false);
@@ -1447,9 +1447,9 @@ module aptos_framework::coin {
         source: signer,
         destination: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
-        let source_addr = signer::address_of(&source);
+        let source_addr = signer::address_of_unpermissioned(&source);
         account::create_account_for_test(source_addr);
-        let destination_addr = signer::address_of(&destination);
+        let destination_addr = signer::address_of_unpermissioned(&destination);
         account::create_account_for_test(destination_addr);
 
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
@@ -1475,7 +1475,7 @@ module aptos_framework::coin {
     public entry fun test_burn_from_with_capability(
         source: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedFungibleAssetRefs {
-        let source_addr = signer::address_of(&source);
+        let source_addr = signer::address_of_unpermissioned(&source);
         account::create_account_for_test(source_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
 
@@ -1523,7 +1523,7 @@ module aptos_framework::coin {
     public fun test_destroy_non_zero(
         source: signer,
     ) acquires CoinInfo, CoinConversionMap  {
-        account::create_account_for_test(signer::address_of(&source));
+        account::create_account_for_test(signer::address_of_unpermissioned(&source));
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
         destroy_zero(coins_minted);
@@ -1539,7 +1539,7 @@ module aptos_framework::coin {
     public entry fun test_extract(
         source: signer,
     ) acquires CoinInfo, CoinStore, CoinConversionMap {
-        let source_addr = signer::address_of(&source);
+        let source_addr = signer::address_of_unpermissioned(&source);
         account::create_account_for_test(source_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&source, 1, true);
 
@@ -1577,7 +1577,7 @@ module aptos_framework::coin {
 
     #[test(account = @0x1)]
     public fun test_is_coin_store_frozen(account: signer) acquires CoinStore, CoinConversionMap, CoinInfo {
-        let account_addr = signer::address_of(&account);
+        let account_addr = signer::address_of_unpermissioned(&account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
         assert!(coin_store_exists<FakeMoney>(account_addr), 1);
@@ -1603,7 +1603,7 @@ module aptos_framework::coin {
     public entry fun burn_frozen(
         account: signer
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedFungibleAssetRefs {
-        let account_addr = signer::address_of(&account);
+        let account_addr = signer::address_of_unpermissioned(&account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
 
@@ -1626,7 +1626,7 @@ module aptos_framework::coin {
     #[test(account = @0x1)]
     #[expected_failure(abort_code = 0x50003, location = aptos_framework::fungible_asset)]
     public entry fun withdraw_frozen(account: signer) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
-        let account_addr = signer::address_of(&account);
+        let account_addr = signer::address_of_unpermissioned(&account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
         let coins_minted = mint<FakeMoney>(100, &mint_cap);
@@ -1647,7 +1647,7 @@ module aptos_framework::coin {
     #[test(account = @0x1)]
     #[expected_failure(abort_code = 0x5000A, location = Self)]
     public entry fun deposit_frozen(account: signer) acquires CoinInfo, CoinStore, CoinConversionMap {
-        let account_addr = signer::address_of(&account);
+        let account_addr = signer::address_of_unpermissioned(&account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
 
@@ -1666,7 +1666,7 @@ module aptos_framework::coin {
     public entry fun deposit_withdraw_unfrozen(
         account: signer
     ) acquires CoinInfo, CoinStore, CoinConversionMap, PairedCoinType {
-        let account_addr = signer::address_of(&account);
+        let account_addr = signer::address_of_unpermissioned(&account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(&account, 18, true);
 
@@ -1805,7 +1805,7 @@ module aptos_framework::coin {
     fun test_conversion_basic(
         account: &signer
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType, PairedFungibleAssetRefs {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
 
@@ -1867,8 +1867,8 @@ module aptos_framework::coin {
         account: &signer,
         aaron: &signer
     ) acquires CoinConversionMap, CoinInfo, CoinStore {
-        let account_addr = signer::address_of(account);
-        let aaron_addr = signer::address_of(aaron);
+        let account_addr = signer::address_of_unpermissioned(account);
+        let aaron_addr = signer::address_of_unpermissioned(aaron);
         account::create_account_for_test(account_addr);
         account::create_account_for_test(aaron_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
@@ -1894,7 +1894,7 @@ module aptos_framework::coin {
     fun test_deposit(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         let coin = mint<FakeMoney>(100, &mint_cap);
@@ -1921,7 +1921,7 @@ module aptos_framework::coin {
     fun test_withdraw(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
         account::create_account_for_test(account_addr);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         let coin = mint<FakeMoney>(200, &mint_cap);
@@ -1967,7 +1967,7 @@ module aptos_framework::coin {
     fun test_supply(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, PairedCoinType, PairedFungibleAssetRefs {
-        account::create_account_for_test(signer::address_of(account));
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         let coin = mint<FakeMoney>(100, &mint_cap);
         ensure_paired_metadata<FakeMoney>();
@@ -2006,9 +2006,9 @@ module aptos_framework::coin {
         aaron: &signer,
         bob: &signer
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedFungibleAssetRefs {
-        let account_addr = signer::address_of(account);
-        let aaron_addr = signer::address_of(aaron);
-        let bob_addr = signer::address_of(bob);
+        let account_addr = signer::address_of_unpermissioned(account);
+        let aaron_addr = signer::address_of_unpermissioned(aaron);
+        let bob_addr = signer::address_of_unpermissioned(bob);
         account::create_account_for_test(account_addr);
         account::create_account_for_test(aaron_addr);
         account::create_account_for_test(bob_addr);
@@ -2055,9 +2055,9 @@ module aptos_framework::coin {
         aaron: &signer,
         bob: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore {
-        let account_addr = signer::address_of(account);
-        let aaron_addr = signer::address_of(aaron);
-        let bob_addr = signer::address_of(bob);
+        let account_addr = signer::address_of_unpermissioned(account);
+        let aaron_addr = signer::address_of_unpermissioned(aaron);
+        let bob_addr = signer::address_of_unpermissioned(bob);
         account::create_account_for_test(account_addr);
         account::create_account_for_test(aaron_addr);
         account::create_account_for_test(bob_addr);
@@ -2101,8 +2101,8 @@ module aptos_framework::coin {
     fun test_migration_with_existing_primary_fungible_store(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
 
         let coin = mint<FakeMoney>(100, &mint_cap);
@@ -2133,8 +2133,8 @@ module aptos_framework::coin {
     fun test_withdraw_with_permissioned_signer_no_migration(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_fake_money(account, 1, true);
         create_coin_store<FakeMoney>(account);
         create_coin_conversion_map(account);
@@ -2164,8 +2164,8 @@ module aptos_framework::coin {
     fun test_withdraw_with_permissioned_signer(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_fake_money(account, 1, true);
         create_coin_store<FakeMoney>(account);
         create_coin_conversion_map(account);
@@ -2195,8 +2195,8 @@ module aptos_framework::coin {
     fun test_withdraw_with_permissioned_signer_no_capacity(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         ensure_paired_metadata<FakeMoney>();
 
@@ -2222,8 +2222,8 @@ module aptos_framework::coin {
     fun test_e2e_withdraw_with_permissioned_signer_and_migration(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         let metadata = ensure_paired_metadata<FakeMoney>();
 
@@ -2263,8 +2263,8 @@ module aptos_framework::coin {
     fun test_e2e_withdraw_with_permissioned_signer_no_permission_1(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         let metadata = ensure_paired_metadata<FakeMoney>();
 
@@ -2291,8 +2291,8 @@ module aptos_framework::coin {
     fun test_e2e_withdraw_with_permissioned_signer_no_permission_2(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         let metadata = ensure_paired_metadata<FakeMoney>();
 
@@ -2326,8 +2326,8 @@ module aptos_framework::coin {
     fun test_e2e_withdraw_with_permissioned_signer_no_permission_3(
         account: &signer,
     ) acquires CoinConversionMap, CoinInfo, CoinStore, PairedCoinType {
-        account::create_account_for_test(signer::address_of(account));
-        let account_addr = signer::address_of(account);
+        account::create_account_for_test(signer::address_of_unpermissioned(account));
+        let account_addr = signer::address_of_unpermissioned(account);
         let (burn_cap, freeze_cap, mint_cap) = initialize_and_register_fake_money(account, 1, true);
         let metadata = ensure_paired_metadata<FakeMoney>();
 

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -39,7 +39,7 @@ module aptos_framework::version {
     ///
     /// TODO: update all the tests that reference this function, then disable this function.
     public entry fun set_version(account: &signer, major: u64) acquires Version {
-        assert!(exists<SetVersionCapability>(signer::address_of(account)), error::permission_denied(ENOT_AUTHORIZED));
+        assert!(exists<SetVersionCapability>(signer::address_of_unpermissioned(account)), error::permission_denied(ENOT_AUTHORIZED));
         chain_status::assert_genesis();
 
         let old_major = borrow_global<Version>(@aptos_framework).major;
@@ -57,7 +57,7 @@ module aptos_framework::version {
     /// - `aptos_framework::version::set_for_next_epoch(&framework_signer, new_version);`
     /// - `aptos_framework::aptos_governance::reconfigure(&framework_signer);`
     public entry fun set_for_next_epoch(account: &signer, major: u64) acquires Version {
-        assert!(exists<SetVersionCapability>(signer::address_of(account)), error::permission_denied(ENOT_AUTHORIZED));
+        assert!(exists<SetVersionCapability>(signer::address_of_unpermissioned(account)), error::permission_denied(ENOT_AUTHORIZED));
         let old_major = borrow_global<Version>(@aptos_framework).major;
         assert!(old_major < major, error::invalid_argument(EINVALID_MAJOR_VERSION_NUMBER));
         config_buffer::upsert(Version {major});

--- a/aptos-move/framework/aptos-framework/sources/function_info.move
+++ b/aptos-move/framework/aptos-framework/sources/function_info.move
@@ -30,7 +30,7 @@ module aptos_framework::function_info {
         function_name: String,
     ): FunctionInfo {
         new_function_info_from_address(
-            signer::address_of(module_signer),
+            signer::address_of_unpermissioned(module_signer),
             module_name,
             function_name,
         )

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -903,7 +903,7 @@ module aptos_framework::fungible_asset {
         abort_on_dispatch: bool,
     ) acquires FungibleStore, DispatchFunctionStore {
         withdraw_sanity_check_impl(
-            signer::address_of(owner),
+            signer::address_of_unpermissioned(owner),
             store,
             abort_on_dispatch,
         )
@@ -1346,7 +1346,7 @@ module aptos_framework::fungible_asset {
         owner: &signer,
         store: Object<T>,
     ) acquires FungibleStore {
-        assert!(object::owns(store, signer::address_of(owner)), error::permission_denied(ENOT_STORE_OWNER));
+        assert!(object::owns(store, signer::address_of_unpermissioned(owner)), error::permission_denied(ENOT_STORE_OWNER));
         assert!(!is_frozen(store), error::invalid_argument(ESTORE_IS_FROZEN));
         assert!(allow_upgrade_to_concurrent_fungible_balance(), error::invalid_argument(ECONCURRENT_BALANCE_NOT_ENABLED));
         ensure_store_upgraded_to_concurrent_internal(object::object_address(&store));
@@ -1428,7 +1428,7 @@ module aptos_framework::fungible_asset {
 
     #[test_only]
     public fun create_test_token(creator: &signer): (ConstructorRef, Object<TestToken>) {
-        account::create_account_for_test(signer::address_of(creator));
+        account::create_account_for_test(signer::address_of_unpermissioned(creator));
         let creator_ref = object::create_named_object(creator, b"TEST");
         let object_signer = object::generate_signer(&creator_ref);
         move_to(&object_signer, TestToken {});
@@ -1466,7 +1466,7 @@ module aptos_framework::fungible_asset {
 
     #[test_only]
     public fun create_test_store<T: key>(owner: &signer, metadata: Object<T>): Object<FungibleStore> {
-        let owner_addr = signer::address_of(owner);
+        let owner_addr = signer::address_of_unpermissioned(owner);
         if (!account::exists_at(owner_addr)) {
             account::create_account_for_test(owner_addr);
         };
@@ -1782,7 +1782,7 @@ module aptos_framework::fungible_asset {
     #[test(creator = @0xcafe)]
     #[expected_failure(abort_code = 0x10012, location = Self)]
     fun test_add_fungibility_to_deletable_object(creator: &signer) {
-        account::create_account_for_test(signer::address_of(creator));
+        account::create_account_for_test(signer::address_of_unpermissioned(creator));
         let creator_ref = &object::create_object_from_account(creator);
         init_test_metadata(creator_ref);
     }

--- a/aptos-move/framework/aptos-framework/sources/jwks.move
+++ b/aptos-move/framework/aptos-framework/sources/jwks.move
@@ -179,11 +179,11 @@ module aptos_framework::jwks {
     /// reusing `PatchedJWKs { jwks: AllProviderJWKs }`, which is a JWK-consensus-specific struct.
     public fun patch_federated_jwks(jwk_owner: &signer, patches: vector<Patch>) acquires FederatedJWKs {
         // Prevents accidental calls in 0x1::jwks that install federated JWKs at the Aptos framework address.
-        assert!(!system_addresses::is_aptos_framework_address(signer::address_of(jwk_owner)),
+        assert!(!system_addresses::is_aptos_framework_address(signer::address_of_unpermissioned(jwk_owner)),
             error::invalid_argument(EINSTALL_FEDERATED_JWKS_AT_APTOS_FRAMEWORK)
         );
 
-        let jwk_addr = signer::address_of(jwk_owner);
+        let jwk_addr = signer::address_of_unpermissioned(jwk_owner);
         if (!exists<FederatedJWKs>(jwk_addr)) {
             move_to(jwk_owner, FederatedJWKs { jwks: AllProvidersJWKs { entries: vector[] } });
         };

--- a/aptos-move/framework/aptos-framework/sources/keyless_account.move
+++ b/aptos-move/framework/aptos-framework/sources/keyless_account.move
@@ -155,7 +155,7 @@ module aptos_framework::keyless_account {
             assert!(vector::length(option::borrow(&pk)) == 32, E_TRAINING_WHEELS_PK_WRONG_SIZE)
         };
 
-        let config = borrow_global_mut<Configuration>(signer::address_of(fx));
+        let config = borrow_global_mut<Configuration>(signer::address_of_unpermissioned(fx));
         config.training_wheels_pubkey = pk;
     }
 
@@ -164,7 +164,7 @@ module aptos_framework::keyless_account {
         system_addresses::assert_aptos_framework(fx);
         chain_status::assert_genesis();
 
-        let config = borrow_global_mut<Configuration>(signer::address_of(fx));
+        let config = borrow_global_mut<Configuration>(signer::address_of_unpermissioned(fx));
         config.max_exp_horizon_secs = max_exp_horizon_secs;
     }
 
@@ -173,7 +173,7 @@ module aptos_framework::keyless_account {
         system_addresses::assert_aptos_framework(fx);
         chain_status::assert_genesis();
 
-        let config = borrow_global_mut<Configuration>(signer::address_of(fx));
+        let config = borrow_global_mut<Configuration>(signer::address_of_unpermissioned(fx));
         config.override_aud_vals = vector[];
     }
 
@@ -182,7 +182,7 @@ module aptos_framework::keyless_account {
         system_addresses::assert_aptos_framework(fx);
         chain_status::assert_genesis();
 
-        let config = borrow_global_mut<Configuration>(signer::address_of(fx));
+        let config = borrow_global_mut<Configuration>(signer::address_of_unpermissioned(fx));
         vector::push_back(&mut config.override_aud_vals, aud);
     }
 
@@ -226,7 +226,7 @@ module aptos_framework::keyless_account {
         let config = if (config_buffer::does_exist<Configuration>()) {
             config_buffer::extract<Configuration>()
         } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
+            *borrow_global<Configuration>(signer::address_of_unpermissioned(fx))
         };
 
         config.training_wheels_pubkey = pk;
@@ -242,7 +242,7 @@ module aptos_framework::keyless_account {
         let config = if (config_buffer::does_exist<Configuration>()) {
             config_buffer::extract<Configuration>()
         } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
+            *borrow_global<Configuration>(signer::address_of_unpermissioned(fx))
         };
 
         config.max_exp_horizon_secs = max_exp_horizon_secs;
@@ -261,7 +261,7 @@ module aptos_framework::keyless_account {
         let config = if (config_buffer::does_exist<Configuration>()) {
             config_buffer::extract<Configuration>()
         } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
+            *borrow_global<Configuration>(signer::address_of_unpermissioned(fx))
         };
 
         config.override_aud_vals = vector[];
@@ -279,7 +279,7 @@ module aptos_framework::keyless_account {
         let config = if (config_buffer::does_exist<Configuration>()) {
             config_buffer::extract<Configuration>()
         } else {
-            *borrow_global<Configuration>(signer::address_of(fx))
+            *borrow_global<Configuration>(signer::address_of_unpermissioned(fx))
         };
 
         vector::push_back(&mut config.override_aud_vals, aud);

--- a/aptos-move/framework/aptos-framework/sources/managed_coin.move
+++ b/aptos-move/framework/aptos-framework/sources/managed_coin.move
@@ -38,7 +38,7 @@ module aptos_framework::managed_coin {
         account: &signer,
         amount: u64,
     ) acquires Capabilities {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
 
         assert!(
             exists<Capabilities<CoinType>>(account_addr),
@@ -81,7 +81,7 @@ module aptos_framework::managed_coin {
         dst_addr: address,
         amount: u64,
     ) acquires Capabilities {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
 
         assert!(
             exists<Capabilities<CoinType>>(account_addr),
@@ -111,7 +111,7 @@ module aptos_framework::managed_coin {
     public fun remove_caps<CoinType>(
         account: &signer
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) acquires Capabilities {
-        let account_addr = signer::address_of(account);
+        let account_addr = signer::address_of_unpermissioned(account);
         assert!(
             exists<Capabilities<CoinType>>(account_addr),
             error::not_found(ENO_CAPABILITIES),
@@ -145,11 +145,11 @@ module aptos_framework::managed_coin {
         destination: signer,
         mod_account: signer
     ) acquires Capabilities {
-        let source_addr = signer::address_of(&source);
-        let destination_addr = signer::address_of(&destination);
+        let source_addr = signer::address_of_unpermissioned(&source);
+        let destination_addr = signer::address_of_unpermissioned(&destination);
         aptos_framework::account::create_account_for_test(source_addr);
         aptos_framework::account::create_account_for_test(destination_addr);
-        aptos_framework::account::create_account_for_test(signer::address_of(&mod_account));
+        aptos_framework::account::create_account_for_test(signer::address_of_unpermissioned(&mod_account));
         aggregator_factory::initialize_aggregator_factory_for_test(&mod_account);
         aptos_framework::coin::create_coin_conversion_map(&framework);
 
@@ -179,7 +179,7 @@ module aptos_framework::managed_coin {
         assert!(coin::balance<FakeMoney>(source_addr) == 40, 3);
         assert!(coin::balance<FakeMoney>(destination_addr) == 20, 4);
 
-        coin::transfer<FakeMoney>(&source, signer::address_of(&mod_account), 40);
+        coin::transfer<FakeMoney>(&source, signer::address_of_unpermissioned(&mod_account), 40);
         burn<FakeMoney>(&mod_account, 40);
 
         assert!(coin::balance<FakeMoney>(source_addr) == 0, 1);
@@ -189,7 +189,7 @@ module aptos_framework::managed_coin {
 
         // Destroy mint capabilities
         destroy_caps<FakeMoney>(&mod_account);
-        assert!(!exists<Capabilities<FakeMoney>>(signer::address_of(&mod_account)), 3);
+        assert!(!exists<Capabilities<FakeMoney>>(signer::address_of_unpermissioned(&mod_account)), 3);
     }
 
     #[test(source = @0xa11ce, destination = @0xb0b, mod_account = @0x1)]
@@ -198,11 +198,11 @@ module aptos_framework::managed_coin {
         destination: signer,
         mod_account: signer
     ) acquires Capabilities {
-        let source_addr = signer::address_of(&source);
-        let destination_addr = signer::address_of(&destination);
+        let source_addr = signer::address_of_unpermissioned(&source);
+        let destination_addr = signer::address_of_unpermissioned(&destination);
         aptos_framework::account::create_account_for_test(source_addr);
         aptos_framework::account::create_account_for_test(destination_addr);
-        aptos_framework::account::create_account_for_test(signer::address_of(&mod_account));
+        aptos_framework::account::create_account_for_test(signer::address_of_unpermissioned(&mod_account));
         aggregator_factory::initialize_aggregator_factory_for_test(&mod_account);
 
         initialize<FakeMoney>(
@@ -216,7 +216,7 @@ module aptos_framework::managed_coin {
 
         // Remove capabilities
         let (burn_cap, freeze_cap, mint_cap) = remove_caps<FakeMoney>(&mod_account);
-        assert!(!exists<Capabilities<FakeMoney>>(signer::address_of(&mod_account)), 3);
+        assert!(!exists<Capabilities<FakeMoney>>(signer::address_of_unpermissioned(&mod_account)), 3);
         coin::destroy_mint_cap(mint_cap);
         coin::destroy_freeze_cap(freeze_cap);
         coin::destroy_burn_cap(burn_cap);
@@ -229,11 +229,11 @@ module aptos_framework::managed_coin {
         destination: signer,
         mod_account: signer,
     ) acquires Capabilities {
-        let source_addr = signer::address_of(&source);
+        let source_addr = signer::address_of_unpermissioned(&source);
 
         aptos_framework::account::create_account_for_test(source_addr);
-        aptos_framework::account::create_account_for_test(signer::address_of(&destination));
-        aptos_framework::account::create_account_for_test(signer::address_of(&mod_account));
+        aptos_framework::account::create_account_for_test(signer::address_of_unpermissioned(&destination));
+        aptos_framework::account::create_account_for_test(signer::address_of_unpermissioned(&mod_account));
         aggregator_factory::initialize_aggregator_factory_for_test(&mod_account);
 
         initialize<FakeMoney>(&mod_account, b"Fake money", b"FMD", 1, true);
@@ -251,11 +251,11 @@ module aptos_framework::managed_coin {
         destination: signer,
         mod_account: signer,
     ) acquires Capabilities {
-        let source_addr = signer::address_of(&source);
+        let source_addr = signer::address_of_unpermissioned(&source);
 
         aptos_framework::account::create_account_for_test(source_addr);
-        aptos_framework::account::create_account_for_test(signer::address_of(&destination));
-        aptos_framework::account::create_account_for_test(signer::address_of(&mod_account));
+        aptos_framework::account::create_account_for_test(signer::address_of_unpermissioned(&destination));
+        aptos_framework::account::create_account_for_test(signer::address_of_unpermissioned(&mod_account));
         aggregator_factory::initialize_aggregator_factory_for_test(&mod_account);
 
         initialize<FakeMoney>(&mod_account, b"Fake money", b"FMD", 1, true);

--- a/aptos-move/framework/aptos-framework/sources/object_code_deployment.move
+++ b/aptos-move/framework/aptos-framework/sources/object_code_deployment.move
@@ -92,13 +92,13 @@ module aptos_framework::object_code_deployment {
             error::unavailable(EOBJECT_CODE_DEPLOYMENT_NOT_SUPPORTED),
         );
 
-        let publisher_address = signer::address_of(publisher);
+        let publisher_address = signer::address_of_unpermissioned(publisher);
         let object_seed = object_seed(publisher_address);
         let constructor_ref = &object::create_named_object(publisher, object_seed);
         let code_signer = &object::generate_signer(constructor_ref);
         code::publish_package_txn(code_signer, metadata_serialized, code);
 
-        event::emit(Publish { object_address: signer::address_of(code_signer), });
+        event::emit(Publish { object_address: signer::address_of_unpermissioned(code_signer), });
 
         move_to(code_signer, ManagingRefs {
             extend_ref: object::generate_extend_ref(constructor_ref),
@@ -124,7 +124,7 @@ module aptos_framework::object_code_deployment {
         code_object: Object<PackageRegistry>,
     ) acquires ManagingRefs {
         code::check_code_publishing_permission(publisher);
-        let publisher_address = signer::address_of(publisher);
+        let publisher_address = signer::address_of_unpermissioned(publisher);
         assert!(
             object::is_owner(code_object, publisher_address),
             error::permission_denied(ENOT_CODE_OBJECT_OWNER),
@@ -137,7 +137,7 @@ module aptos_framework::object_code_deployment {
         let code_signer = &object::generate_signer_for_extending(extend_ref);
         code::publish_package_txn(code_signer, metadata_serialized, code);
 
-        event::emit(Upgrade { object_address: signer::address_of(code_signer), });
+        event::emit(Upgrade { object_address: signer::address_of_unpermissioned(code_signer), });
     }
 
     /// Make an existing upgradable package immutable. Once this is called, the package cannot be made upgradable again.

--- a/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
+++ b/aptos-move/framework/aptos-framework/sources/primary_fungible_store.move
@@ -136,7 +136,7 @@ module aptos_framework::primary_fungible_store {
         fungible_asset::grant_permission_by_address(
             master,
             permissioned,
-            primary_store_address_inlined(signer::address_of(permissioned), metadata),
+            primary_store_address_inlined(signer::address_of_unpermissioned(permissioned), metadata),
             amount
         );
     }
@@ -149,7 +149,7 @@ module aptos_framework::primary_fungible_store {
         fungible_asset::grant_permission_by_address(
             master,
             permissioned,
-            object::create_user_derived_object_address(signer::address_of(permissioned), @aptos_fungible_asset),
+            object::create_user_derived_object_address(signer::address_of_unpermissioned(permissioned), @aptos_fungible_asset),
             amount
         );
     }
@@ -185,7 +185,7 @@ module aptos_framework::primary_fungible_store {
 
     /// Withdraw `amount` of fungible asset from the given account's primary store.
     public fun withdraw<T: key>(owner: &signer, metadata: Object<T>, amount: u64): FungibleAsset acquires DeriveRefPod {
-        let store = ensure_primary_store_exists(signer::address_of(owner), metadata);
+        let store = ensure_primary_store_exists(signer::address_of_unpermissioned(owner), metadata);
         // Check if the store object has been burnt or not. If so, unburn it first.
         may_be_unburn(owner, store);
         dispatchable_fungible_asset::withdraw(owner, store, amount)
@@ -207,12 +207,12 @@ module aptos_framework::primary_fungible_store {
             owner,
             fungible_asset::amount(&fa),
             primary_store_address_inlined(
-                signer::address_of(owner),
+                signer::address_of_unpermissioned(owner),
                 fungible_asset::metadata_from_asset(&fa),
             )
         );
         let metadata = fungible_asset::asset_metadata(&fa);
-        let store = ensure_primary_store_exists(signer::address_of(owner), metadata);
+        let store = ensure_primary_store_exists(signer::address_of_unpermissioned(owner), metadata);
         dispatchable_fungible_asset::deposit(store, fa);
     }
 
@@ -223,7 +223,7 @@ module aptos_framework::primary_fungible_store {
         recipient: address,
         amount: u64,
     ) acquires DeriveRefPod {
-        let sender_store = ensure_primary_store_exists(signer::address_of(sender), metadata);
+        let sender_store = ensure_primary_store_exists(signer::address_of_unpermissioned(sender), metadata);
         // Check if the sender store object has been burnt or not. If so, unburn it first.
         may_be_unburn(sender, sender_store);
         let recipient_store = ensure_primary_store_exists(recipient, metadata);
@@ -239,7 +239,7 @@ module aptos_framework::primary_fungible_store {
         amount: u64,
         expected: u64,
     ) acquires DeriveRefPod {
-        let sender_store = ensure_primary_store_exists(signer::address_of(sender), metadata);
+        let sender_store = ensure_primary_store_exists(signer::address_of_unpermissioned(sender), metadata);
         // Check if the sender store object has been burnt or not. If so, unburn it first.
         may_be_unburn(sender, sender_store);
         let recipient_store = ensure_primary_store_exists(recipient, metadata);
@@ -338,8 +338,8 @@ module aptos_framework::primary_fungible_store {
     fun test_default_behavior(creator: &signer, aaron: &signer) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(creator);
         init_test_metadata_with_primary_store_enabled(&creator_ref);
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(!primary_store_exists(creator_address, metadata), 1);
         assert!(!primary_store_exists(aaron_address, metadata), 2);
         assert!(balance(creator_address, metadata) == 0, 3);
@@ -359,8 +359,8 @@ module aptos_framework::primary_fungible_store {
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(creator);
         let (mint_ref, transfer_ref, burn_ref) = init_test_metadata_with_primary_store_enabled(&creator_ref);
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(balance(creator_address, metadata) == 0, 1);
         assert!(balance(aaron_address, metadata) == 0, 2);
         mint(&mint_ref, creator_address, 100);
@@ -387,8 +387,8 @@ module aptos_framework::primary_fungible_store {
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(creator);
         let (mint_ref, _transfer_ref, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(balance(creator_address, metadata) == 0, 1);
         assert!(balance(aaron_address, metadata) == 0, 2);
         mint(&mint_ref, creator_address, 100);
@@ -406,8 +406,8 @@ module aptos_framework::primary_fungible_store {
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(user_1);
         let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
-        let user_1_address = signer::address_of(user_1);
-        let user_2_address = signer::address_of(user_2);
+        let user_1_address = signer::address_of_unpermissioned(user_1);
+        let user_2_address = signer::address_of_unpermissioned(user_2);
         mint(&mint_ref, user_1_address, 100);
         transfer(user_1, metadata, user_2_address, 80);
 
@@ -430,8 +430,8 @@ module aptos_framework::primary_fungible_store {
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(user_1);
         let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
-        let user_1_address = signer::address_of(user_1);
-        let user_2_address = signer::address_of(user_2);
+        let user_1_address = signer::address_of_unpermissioned(user_1);
+        let user_2_address = signer::address_of_unpermissioned(user_2);
         mint(&mint_ref, user_1_address, 100);
         transfer(user_1, metadata, user_2_address, 80);
 
@@ -451,8 +451,8 @@ module aptos_framework::primary_fungible_store {
     ) acquires DeriveRefPod {
         let (creator_ref, metadata) = create_test_token(creator);
         let (mint_ref, _transfer_ref, _burn_ref) = init_test_metadata_with_primary_store_enabled(&creator_ref);
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(balance(creator_address, metadata) == 0, 1);
         assert!(balance(aaron_address, metadata) == 0, 2);
         mint(&mint_ref, creator_address, 100);

--- a/aptos-move/framework/aptos-framework/sources/reconfiguration.move
+++ b/aptos-move/framework/aptos-framework/sources/reconfiguration.move
@@ -70,7 +70,7 @@ module aptos_framework::reconfiguration {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         // assert it matches `new_epoch_event_key()`, otherwise the event can't be recognized
-        assert!(account::get_guid_next_creation_num(signer::address_of(aptos_framework)) == 2, error::invalid_state(EINVALID_GUID_FOR_EVENT));
+        assert!(account::get_guid_next_creation_num(signer::address_of_unpermissioned(aptos_framework)) == 2, error::invalid_state(EINVALID_GUID_FOR_EVENT));
         move_to<Configuration>(
             aptos_framework,
             Configuration {
@@ -95,7 +95,7 @@ module aptos_framework::reconfiguration {
         system_addresses::assert_aptos_framework(aptos_framework);
 
         assert!(!reconfiguration_enabled(), error::invalid_state(ECONFIGURATION));
-        DisableReconfiguration {} = move_from<DisableReconfiguration>(signer::address_of(aptos_framework));
+        DisableReconfiguration {} = move_from<DisableReconfiguration>(signer::address_of_unpermissioned(aptos_framework));
     }
 
     fun reconfiguration_enabled(): bool {

--- a/aptos-move/framework/aptos-framework/sources/resource_account.move
+++ b/aptos-move/framework/aptos-framework/sources/resource_account.move
@@ -110,7 +110,7 @@ module aptos_framework::resource_account {
     ) acquires Container {
         let (resource, resource_signer_cap) = account::create_resource_account(origin, seed);
         coin::register<AptosCoin>(&resource);
-        coin::transfer<AptosCoin>(origin, signer::address_of(&resource), fund_amount);
+        coin::transfer<AptosCoin>(origin, signer::address_of_unpermissioned(&resource), fund_amount);
         rotate_account_authentication_key_and_store_capability(
             origin,
             resource,
@@ -143,13 +143,13 @@ module aptos_framework::resource_account {
         resource_signer_cap: account::SignerCapability,
         optional_auth_key: vector<u8>,
     ) acquires Container {
-        let origin_addr = signer::address_of(origin);
+        let origin_addr = signer::address_of_unpermissioned(origin);
         if (!exists<Container>(origin_addr)) {
             move_to(origin, Container { store: simple_map::create() })
         };
 
         let container = borrow_global_mut<Container>(origin_addr);
-        let resource_addr = signer::address_of(&resource);
+        let resource_addr = signer::address_of_unpermissioned(&resource);
         simple_map::add(&mut container.store, resource_addr, resource_signer_cap);
 
         let auth_key = if (vector::is_empty(&optional_auth_key)) {
@@ -169,7 +169,7 @@ module aptos_framework::resource_account {
     ): account::SignerCapability acquires Container {
         assert!(exists<Container>(source_addr), error::not_found(ECONTAINER_NOT_PUBLISHED));
 
-        let resource_addr = signer::address_of(resource);
+        let resource_addr = signer::address_of_unpermissioned(resource);
         let (resource_signer_cap, empty_container) = {
             let container = borrow_global_mut<Container>(source_addr);
             assert!(
@@ -192,7 +192,7 @@ module aptos_framework::resource_account {
 
     #[test(user = @0x1111)]
     public entry fun test_create_account_and_retrieve_cap(user: signer) acquires Container {
-        let user_addr = signer::address_of(&user);
+        let user_addr = signer::address_of_unpermissioned(&user);
         account::create_account(user_addr);
 
         let seed = x"01";
@@ -212,7 +212,7 @@ module aptos_framework::resource_account {
     public entry fun test_create_account_and_retrieve_cap_resource_address_does_not_exist(
         user: signer
     ) acquires Container {
-        let user_addr = signer::address_of(&user);
+        let user_addr = signer::address_of_unpermissioned(&user);
         account::create_account(user_addr);
 
         let seed = x"01";
@@ -230,7 +230,7 @@ module aptos_framework::resource_account {
 
     #[test(framework = @0x1, user = @0x1234)]
     public entry fun with_coin(framework: signer, user: signer) acquires Container {
-        let user_addr = signer::address_of(&user);
+        let user_addr = signer::address_of_unpermissioned(&user);
         let (burn, mint) = aptos_framework::aptos_coin::initialize_for_test(&framework);
         aptos_framework::aptos_account::create_account(copy user_addr);
 
@@ -250,7 +250,7 @@ module aptos_framework::resource_account {
     #[test(framework = @0x1, user = @0x2345)]
     #[expected_failure(abort_code = 0x60005, location = aptos_framework::coin)]
     public entry fun without_coin(framework: signer, user: signer) acquires Container {
-        let user_addr = signer::address_of(&user);
+        let user_addr = signer::address_of_unpermissioned(&user);
         let (burn, mint) = aptos_framework::aptos_coin::initialize_for_test(&framework);
         aptos_framework::aptos_account::create_account(user_addr);
 

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -567,7 +567,7 @@ module aptos_framework::stake {
             add_stake(owner, initial_stake_amount);
         };
 
-        let account_address = signer::address_of(owner);
+        let account_address = signer::address_of_unpermissioned(owner);
         if (account_address != operator) {
             set_operator(owner, operator)
         };
@@ -603,7 +603,7 @@ module aptos_framework::stake {
 
     fun initialize_owner(owner: &signer) acquires AllowedValidators {
         check_stake_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert!(is_allowed(owner_address), error::not_found(EINELIGIBLE_VALIDATOR));
         assert!(!stake_pool_exists(owner_address), error::already_exists(EALREADY_REGISTERED));
 
@@ -638,7 +638,7 @@ module aptos_framework::stake {
     /// Extract and return owner capability from the signing account.
     public fun extract_owner_cap(owner: &signer): OwnerCapability acquires OwnerCapability {
         check_stake_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         move_from<OwnerCapability>(owner_address)
     }
@@ -647,7 +647,7 @@ module aptos_framework::stake {
     /// staking pool.
     public fun deposit_owner_cap(owner: &signer, owner_cap: OwnerCapability) {
         check_stake_permission(owner);
-        assert!(!exists<OwnerCapability>(signer::address_of(owner)), error::not_found(EOWNER_CAP_ALREADY_EXISTS));
+        assert!(!exists<OwnerCapability>(signer::address_of_unpermissioned(owner)), error::not_found(EOWNER_CAP_ALREADY_EXISTS));
         move_to(owner, owner_cap);
     }
 
@@ -659,7 +659,7 @@ module aptos_framework::stake {
     /// Allows an owner to change the operator of the stake pool.
     public entry fun set_operator(owner: &signer, new_operator: address) acquires OwnerCapability, StakePool {
         check_stake_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
         set_operator_with_cap(ownership_cap, new_operator);
@@ -696,7 +696,7 @@ module aptos_framework::stake {
     /// Allows an owner to change the delegated voter of the stake pool.
     public entry fun set_delegated_voter(owner: &signer, new_voter: address) acquires OwnerCapability, StakePool {
         check_stake_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
         set_delegated_voter_with_cap(ownership_cap, new_voter);
@@ -713,7 +713,7 @@ module aptos_framework::stake {
     /// Add `amount` of coins from the `account` owning the StakePool.
     public entry fun add_stake(owner: &signer, amount: u64) acquires OwnerCapability, StakePool, ValidatorSet {
         check_stake_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
         add_stake_with_cap(ownership_cap, coin::withdraw<AptosCoin>(owner, amount));
@@ -776,7 +776,7 @@ module aptos_framework::stake {
     public entry fun reactivate_stake(owner: &signer, amount: u64) acquires OwnerCapability, StakePool {
         check_stake_permission(owner);
         assert_reconfig_not_in_progress();
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
         reactivate_stake_with_cap(ownership_cap, amount);
@@ -828,7 +828,7 @@ module aptos_framework::stake {
         assert_stake_pool_exists(pool_address);
 
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
+        assert!(signer::address_of_unpermissioned(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
 
         assert!(exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG));
         let validator_info = borrow_global_mut<ValidatorConfig>(pool_address);
@@ -872,7 +872,7 @@ module aptos_framework::stake {
         assert_reconfig_not_in_progress();
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
+        assert!(signer::address_of_unpermissioned(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
         assert!(exists<ValidatorConfig>(pool_address), error::not_found(EVALIDATOR_CONFIG));
         let validator_info = borrow_global_mut<ValidatorConfig>(pool_address);
         let old_network_addresses = validator_info.network_addresses;
@@ -907,7 +907,7 @@ module aptos_framework::stake {
     /// Similar to increase_lockup_with_cap but will use ownership capability from the signing account.
     public entry fun increase_lockup(owner: &signer) acquires OwnerCapability, StakePool {
         check_stake_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
         increase_lockup_with_cap(ownership_cap);
@@ -973,7 +973,7 @@ module aptos_framework::stake {
         assert_reconfig_not_in_progress();
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
+        assert!(signer::address_of_unpermissioned(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
         assert!(
             get_validator_state(pool_address) == VALIDATOR_STATUS_INACTIVE,
             error::invalid_state(EALREADY_ACTIVE_VALIDATOR),
@@ -1017,7 +1017,7 @@ module aptos_framework::stake {
     public entry fun unlock(owner: &signer, amount: u64) acquires OwnerCapability, StakePool {
         check_stake_permission(owner);
         assert_reconfig_not_in_progress();
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
         unlock_with_cap(amount, ownership_cap);
@@ -1065,7 +1065,7 @@ module aptos_framework::stake {
         withdraw_amount: u64
     ) acquires OwnerCapability, StakePool, ValidatorSet {
         check_stake_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         assert_owner_cap_exists(owner_address);
         let ownership_cap = borrow_global<OwnerCapability>(owner_address);
         let coins = withdraw_with_cap(ownership_cap, withdraw_amount);
@@ -1135,7 +1135,7 @@ module aptos_framework::stake {
         assert_stake_pool_exists(pool_address);
         let stake_pool = borrow_global_mut<StakePool>(pool_address);
         // Account has to be the operator.
-        assert!(signer::address_of(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
+        assert!(signer::address_of_unpermissioned(operator) == stake_pool.operator_address, error::unauthenticated(ENOT_OPERATOR));
 
         let validator_set = borrow_global_mut<ValidatorSet>(@aptos_framework);
         // If the validator is still pending_active, directly kick the validator out.
@@ -1748,7 +1748,7 @@ module aptos_framework::stake {
         aptos_framework: &signer,
         accounts: vector<address>
     ) acquires AllowedValidators {
-        let aptos_framework_address = signer::address_of(aptos_framework);
+        let aptos_framework_address = signer::address_of_unpermissioned(aptos_framework);
         system_addresses::assert_aptos_framework(aptos_framework);
         if (!exists<AllowedValidators>(aptos_framework_address)) {
             move_to(aptos_framework, AllowedValidators { accounts });
@@ -1871,7 +1871,7 @@ module aptos_framework::stake {
     #[test_only]
     public fun mint(account: &signer, amount: u64) acquires AptosCoinCapabilities {
         coin::register<AptosCoin>(account);
-        coin::deposit(signer::address_of(account), mint_coins(amount));
+        coin::deposit(signer::address_of_unpermissioned(account), mint_coins(amount));
     }
 
     #[test_only]
@@ -1890,8 +1890,8 @@ module aptos_framework::stake {
         should_join_validator_set: bool,
         should_end_epoch: bool,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
-        let validator_address = signer::address_of(validator);
-        if (!account::exists_at(signer::address_of(validator))) {
+        let validator_address = signer::address_of_unpermissioned(validator);
+        if (!account::exists_at(signer::address_of_unpermissioned(validator))) {
             account::create_account_for_test(validator_address);
         };
 
@@ -1955,7 +1955,7 @@ module aptos_framework::stake {
         pending_inactive: Coin<AptosCoin>,
         locked_until_secs: u64,
     ) acquires AllowedValidators, OwnerCapability, StakePool, ValidatorSet {
-        let account_address = signer::address_of(account);
+        let account_address = signer::address_of_unpermissioned(account);
         initialize_stake_owner(account, 0, account_address, account_address);
         let stake_pool = borrow_global_mut<StakePool>(account_address);
         coin::merge(&mut stake_pool.active, active);
@@ -2042,7 +2042,7 @@ module aptos_framework::stake {
 
         // Request to unlock 50 coins, which go to pending_inactive. Validator has 50 remaining in active.
         unlock(validator, 50);
-        assert_validator_state(signer::address_of(validator), 50, 0, 0, 50, 0);
+        assert_validator_state(signer::address_of_unpermissioned(validator), 50, 0, 0, 50, 0);
 
         // Add 9901 more. Total stake is 50 (active) + 50 (pending_inactive) + 9901 > 10000 so still exceeding max.
         mint_and_add_stake(validator, 9901);
@@ -2062,7 +2062,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100, true, true);
 
         // Leave validator set so validator is in pending_inactive state.
-        leave_validator_set(validator_1, signer::address_of(validator_1));
+        leave_validator_set(validator_1, signer::address_of_unpermissioned(validator_1));
 
         // Add 9901 more. Total stake is 50 (active) + 50 (pending_inactive) + 9901 > 10000 so still exceeding max.
         mint_and_add_stake(validator_1, 9901);
@@ -2078,7 +2078,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
         // Validator has a lockup now that they've joined the validator set.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
 
         // Validator adds more stake while already being active.
@@ -2137,7 +2137,7 @@ module aptos_framework::stake {
         // Validator sets lockup before even joining the set and lets half of lockup pass by.
         increase_lockup(validator);
         timestamp::fast_forward_seconds(LOCKUP_CYCLE_SECONDS / 2);
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS / 2, 1);
 
         // Join the validator set with an existing lockup
@@ -2183,12 +2183,12 @@ module aptos_framework::stake {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100, false, false);
 
         // Validator 1 needs to be in the set so validator 2's added stake counts against the limit.
-        join_validator_set(validator_1, signer::address_of(validator_1));
+        join_validator_set(validator_1, signer::address_of_unpermissioned(validator_1));
         end_epoch();
 
         // Validator 2 joins the validator set but their stake would lead to exceeding the voting power increase limit.
         // Therefore, this should fail.
-        join_validator_set(validator_2, signer::address_of(validator_2));
+        join_validator_set(validator_2, signer::address_of_unpermissioned(validator_2));
     }
 
     #[test(aptos_framework = @aptos_framework, validator_1 = @0x123, validator_2 = @0x234)]
@@ -2205,7 +2205,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100, false, false);
 
         // Add more stake while still pending_active.
-        let validator_2_address = signer::address_of(validator_2);
+        let validator_2_address = signer::address_of_unpermissioned(validator_2);
         join_validator_set(validator_2, validator_2_address);
         assert!(get_validator_state(validator_2_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
         mint_and_add_stake(validator_2, 100);
@@ -2243,7 +2243,7 @@ module aptos_framework::stake {
         // Validator joins but epoch hasn't ended, so the validator is still pending_active.
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, false);
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_validator_state(validator_address) == VALIDATOR_STATUS_PENDING_ACTIVE, 0);
 
         // Check that voting power increase is tracked.
@@ -2269,7 +2269,7 @@ module aptos_framework::stake {
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert_validator_state(validator_address, 100, 0, 0, 0, 0);
         end_epoch();
         assert_validator_state(validator_address, 110, 0, 0, 0, 0);
@@ -2305,7 +2305,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
         // Unlock half of the coins.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
         unlock(validator, 50);
         assert_validator_state(validator_address, 50, 0, 0, 50, 0);
@@ -2328,7 +2328,7 @@ module aptos_framework::stake {
         initialize_for_test(aptos_framework);
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
 
         // One more epoch passes to generate rewards.
@@ -2368,7 +2368,7 @@ module aptos_framework::stake {
 
         // Validator unlocks more stake than they have active. This should limit the unlock to 100.
         unlock(validator, 200);
-        assert_validator_state(signer::address_of(validator), 0, 0, 0, 100, 0);
+        assert_validator_state(signer::address_of_unpermissioned(validator), 0, 0, 0, 100, 0);
     }
 
     #[test(aptos_framework = @aptos_framework, validator = @0x123)]
@@ -2390,7 +2390,7 @@ module aptos_framework::stake {
 
         // Validator can only withdraw a max of 100 unlocked coins even if they request to withdraw more than 100.
         withdraw(validator, 200);
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         // Receive back all coins with an extra 1 for rewards.
         assert!(coin::balance<AptosCoin>(validator_address) == 1001, 2);
         assert_validator_state(validator_address, 0, 0, 0, 0, 0);
@@ -2407,7 +2407,7 @@ module aptos_framework::stake {
 
         // Validator unlocks stake, which gets moved into pending_inactive.
         unlock(validator, 50);
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert_validator_state(validator_address, 50, 0, 0, 50, 0);
 
         // Validator can reactivate pending_inactive stake.
@@ -2426,7 +2426,7 @@ module aptos_framework::stake {
 
         // Validator tries to reactivate more than available pending_inactive stake, which should limit to 50.
         unlock(validator, 50);
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert_validator_state(validator_address, 50, 0, 0, 50, 0);
         reactivate_stake(validator, 51);
         assert_validator_state(validator_address, 100, 0, 0, 0, 0);
@@ -2442,7 +2442,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
         // Unlock enough coins that the remaining is not enough to meet the min required.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 1);
         unlock(validator, 50);
         assert_validator_state(validator_address, 50, 0, 0, 50, 0);
@@ -2473,7 +2473,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100, true, true);
 
         // Leave the validator set while still having a lockup.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
         leave_validator_set(validator, validator_address);
         // Validator is in pending_inactive state but is technically still part of the validator set.
@@ -2517,7 +2517,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100, true, true);
 
         // Leave the validator set while still having a lockup.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         assert!(get_remaining_lockup_secs(validator_address) == LOCKUP_CYCLE_SECONDS, 0);
         leave_validator_set(validator, validator_address);
         end_epoch();
@@ -2549,7 +2549,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk_2, &pop_2, validator_2, 100, true, true);
 
         // Validator 1 leaves the validator set. Epoch has not ended so they're still pending_inactive.
-        leave_validator_set(validator_1, signer::address_of(validator_1));
+        leave_validator_set(validator_1, signer::address_of_unpermissioned(validator_1));
         // Validator 1 adds more stake. This should not succeed as it should not count as a voting power increase.
         mint_and_add_stake(validator_1, 51);
     }
@@ -2561,9 +2561,9 @@ module aptos_framework::stake {
         validator_2: &signer,
         validator_3: &signer
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
-        let validator_1_address = signer::address_of(validator_1);
-        let validator_2_address = signer::address_of(validator_2);
-        let validator_3_address = signer::address_of(validator_3);
+        let validator_1_address = signer::address_of_unpermissioned(validator_1);
+        let validator_2_address = signer::address_of_unpermissioned(validator_2);
+        let validator_3_address = signer::address_of_unpermissioned(validator_3);
 
         initialize_for_test_custom(aptos_framework, 100, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 100);
         let (_sk_1, pk_1, pop_1) = generate_identity();
@@ -2662,7 +2662,7 @@ module aptos_framework::stake {
 
         // Add stake when the validator is not yet activated.
         add_stake_with_cap(&owner_cap, mint_coins(100));
-        let pool_address = signer::address_of(validator);
+        let pool_address = signer::address_of_unpermissioned(validator);
         assert_validator_state(pool_address, 100, 0, 0, 0, 0);
 
         // Join the validator set with enough stake.
@@ -2738,7 +2738,7 @@ module aptos_framework::stake {
         initialize_test_validator(&pk, &pop, validator, 100, false, false);
 
         // Bypass the check to join. This is the same function called during Genesis.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         join_validator_set_internal(validator, validator_address);
         end_epoch();
 
@@ -2762,11 +2762,11 @@ module aptos_framework::stake {
         validator_4: &signer,
         validator_5: &signer,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
-        let v1_addr = signer::address_of(validator_1);
-        let v2_addr = signer::address_of(validator_2);
-        let v3_addr = signer::address_of(validator_3);
-        let v4_addr = signer::address_of(validator_4);
-        let v5_addr = signer::address_of(validator_5);
+        let v1_addr = signer::address_of_unpermissioned(validator_1);
+        let v2_addr = signer::address_of_unpermissioned(validator_2);
+        let v3_addr = signer::address_of_unpermissioned(validator_3);
+        let v4_addr = signer::address_of_unpermissioned(validator_4);
+        let v5_addr = signer::address_of_unpermissioned(validator_5);
 
         initialize_for_test(aptos_framework);
 
@@ -2835,11 +2835,11 @@ module aptos_framework::stake {
         validator_4: &signer,
         validator_5: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
-        let v1_addr = signer::address_of(validator_1);
-        let v2_addr = signer::address_of(validator_2);
-        let v3_addr = signer::address_of(validator_3);
-        let v4_addr = signer::address_of(validator_4);
-        let v5_addr = signer::address_of(validator_5);
+        let v1_addr = signer::address_of_unpermissioned(validator_1);
+        let v2_addr = signer::address_of_unpermissioned(validator_2);
+        let v3_addr = signer::address_of_unpermissioned(validator_3);
+        let v4_addr = signer::address_of_unpermissioned(validator_4);
+        let v5_addr = signer::address_of_unpermissioned(validator_5);
 
         initialize_for_test(aptos_framework);
 
@@ -2900,8 +2900,8 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         initialize_for_test(aptos_framework);
 
-        let validator_1_address = signer::address_of(validator_1);
-        let validator_2_address = signer::address_of(validator_2);
+        let validator_1_address = signer::address_of_unpermissioned(validator_1);
+        let validator_2_address = signer::address_of_unpermissioned(validator_2);
 
         // Both validators join the set.
         let (_sk_1, pk_1, pop_1) = generate_identity();
@@ -2950,8 +2950,8 @@ module aptos_framework::stake {
 
         let genesis_time_in_secs = timestamp::now_seconds();
 
-        let validator_1_address = signer::address_of(validator_1);
-        let validator_2_address = signer::address_of(validator_2);
+        let validator_1_address = signer::address_of_unpermissioned(validator_1);
+        let validator_2_address = signer::address_of_unpermissioned(validator_2);
 
         // Both validators join the set.
         let (_sk_1, pk_1, pop_1) = generate_identity();
@@ -3004,7 +3004,7 @@ module aptos_framework::stake {
     ) acquires AllowedValidators, OwnerCapability, StakePool, AptosCoinCapabilities, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         initialize_for_test(aptos_framework);
 
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         let (_sk, pk, pop) = generate_identity();
         initialize_test_validator(&pk, &pop, validator, 100, true, true);
 
@@ -3036,7 +3036,7 @@ module aptos_framework::stake {
         initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 100);
 
         // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         account::create_account_for_test(validator_address);
         initialize_stake_owner(validator, 0, validator_address, validator_address);
         mint_and_add_stake(validator, 100);
@@ -3054,13 +3054,13 @@ module aptos_framework::stake {
         initialize_for_test_custom(aptos_framework, 50, 10000, LOCKUP_CYCLE_SECONDS, true, 1, 100, 100);
 
         // Call initialize_stake_owner, which only initializes the stake pool but not validator config.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         account::create_account_for_test(validator_address);
         initialize_stake_owner(validator, 0, validator_address, validator_address);
         mint_and_add_stake(validator, 100);
 
         // Initialize validator config.
-        let validator_address = signer::address_of(validator);
+        let validator_address = signer::address_of_unpermissioned(validator);
         let (_sk_new, pk_new, pop_new) = generate_identity();
         let pk_new_bytes = bls12381::public_key_to_bytes(&pk_new);
         let pop_new_bytes = bls12381::proof_of_possession_to_bytes(&pop_new);
@@ -3133,7 +3133,7 @@ module aptos_framework::stake {
         assert!(vector::length(&borrow_global<ValidatorSet>(@aptos_framework).active_validators) == 2, 0);
 
         // Remove validator 1 from the active validator set. Only validator 2 remains.
-        let validator_to_remove = signer::address_of(validator_1);
+        let validator_to_remove = signer::address_of_unpermissioned(validator_1);
         remove_validators(aptos_framework, &vector[validator_to_remove]);
         assert!(vector::length(&borrow_global<ValidatorSet>(@aptos_framework).active_validators) == 1, 0);
         assert!(get_validator_state(validator_to_remove) == VALIDATOR_STATUS_PENDING_INACTIVE, 1);
@@ -3188,7 +3188,7 @@ module aptos_framework::stake {
         aptos_framework: &signer,
         validator: &signer,
     ) acquires AllowedValidators, OwnerCapability, StakePool, ValidatorSet {
-        let addr = signer::address_of(validator);
+        let addr = signer::address_of_unpermissioned(validator);
         let (burn, mint) = aptos_coin::initialize_for_test(aptos_framework);
         configure_allowed_validators(aptos_framework, vector[addr]);
 
@@ -3208,7 +3208,7 @@ module aptos_framework::stake {
         configure_allowed_validators(aptos_framework, vector[]);
         let (burn, mint) = aptos_coin::initialize_for_test(aptos_framework);
 
-        let addr = signer::address_of(validator);
+        let addr = signer::address_of_unpermissioned(validator);
         account::create_account_for_test(addr);
         coin::register<AptosCoin>(validator);
         initialize_stake_owner(validator, 0, addr, addr);

--- a/aptos-move/framework/aptos-framework/sources/staking_proxy.move
+++ b/aptos-move/framework/aptos-framework/sources/staking_proxy.move
@@ -40,7 +40,7 @@ module aptos_framework::staking_proxy {
 
     public entry fun set_vesting_contract_operator(owner: &signer, old_operator: address, new_operator: address) {
         check_stake_proxy_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         let vesting_contracts = &vesting::vesting_contracts(owner_address);
         vector::for_each_ref(vesting_contracts, |vesting_contract| {
             let vesting_contract = *vesting_contract;
@@ -53,7 +53,7 @@ module aptos_framework::staking_proxy {
 
     public entry fun set_staking_contract_operator(owner: &signer, old_operator: address, new_operator: address) {
         check_stake_proxy_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         if (staking_contract::staking_contract_exists(owner_address, old_operator)) {
             let current_commission_percentage = staking_contract::commission_percentage(owner_address, old_operator);
             staking_contract::switch_operator(owner, old_operator, new_operator, current_commission_percentage);
@@ -62,7 +62,7 @@ module aptos_framework::staking_proxy {
 
     public entry fun set_stake_pool_operator(owner: &signer, new_operator: address) {
         check_stake_proxy_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         if (stake::stake_pool_exists(owner_address)) {
             stake::set_operator(owner, new_operator);
         };
@@ -70,7 +70,7 @@ module aptos_framework::staking_proxy {
 
     public entry fun set_vesting_contract_voter(owner: &signer, operator: address, new_voter: address) {
         check_stake_proxy_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         let vesting_contracts = &vesting::vesting_contracts(owner_address);
         vector::for_each_ref(vesting_contracts, |vesting_contract| {
             let vesting_contract = *vesting_contract;
@@ -82,7 +82,7 @@ module aptos_framework::staking_proxy {
 
     public entry fun set_staking_contract_voter(owner: &signer, operator: address, new_voter: address) {
         check_stake_proxy_permission(owner);
-        let owner_address = signer::address_of(owner);
+        let owner_address = signer::address_of_unpermissioned(owner);
         if (staking_contract::staking_contract_exists(owner_address, operator)) {
             staking_contract::update_voter(owner, operator, new_voter);
         };
@@ -90,7 +90,7 @@ module aptos_framework::staking_proxy {
 
     public entry fun set_stake_pool_voter(owner: &signer, new_voter: address) {
         check_stake_proxy_permission(owner);
-        if (stake::stake_pool_exists(signer::address_of(owner))) {
+        if (stake::stake_pool_exists(signer::address_of_unpermissioned(owner))) {
             stake::set_delegated_voter(owner, new_voter);
         };
     }
@@ -112,10 +112,10 @@ module aptos_framework::staking_proxy {
         operator_2: &signer,
         new_operator: &signer,
     ) {
-        let owner_address = signer::address_of(owner);
-        let operator_1_address = signer::address_of(operator_1);
-        let operator_2_address = signer::address_of(operator_2);
-        let new_operator_address = signer::address_of(new_operator);
+        let owner_address = signer::address_of_unpermissioned(owner);
+        let operator_1_address = signer::address_of_unpermissioned(operator_1);
+        let operator_2_address = signer::address_of_unpermissioned(operator_2);
+        let new_operator_address = signer::address_of_unpermissioned(new_operator);
         vesting::setup(
             aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_operator_address]);
         staking_contract::setup_staking_contract(aptos_framework, owner, operator_1, INITIAL_BALANCE, 0);
@@ -157,10 +157,10 @@ module aptos_framework::staking_proxy {
         operator_2: &signer,
         new_operator: &signer,
     ) {
-        let owner_address = signer::address_of(owner);
-        let operator_1_address = signer::address_of(operator_1);
-        let operator_2_address = signer::address_of(operator_2);
-        let new_operator_address = signer::address_of(new_operator);
+        let owner_address = signer::address_of_unpermissioned(owner);
+        let operator_1_address = signer::address_of_unpermissioned(operator_1);
+        let operator_2_address = signer::address_of_unpermissioned(operator_2);
+        let new_operator_address = signer::address_of_unpermissioned(new_operator);
         vesting::setup(
             aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_operator_address]);
         staking_contract::setup_staking_contract(aptos_framework, owner, operator_2, INITIAL_BALANCE, 0);
@@ -189,10 +189,10 @@ module aptos_framework::staking_proxy {
         operator_2: &signer,
         new_voter: &signer,
     ) {
-        let owner_address = signer::address_of(owner);
-        let operator_1_address = signer::address_of(operator_1);
-        let operator_2_address = signer::address_of(operator_2);
-        let new_voter_address = signer::address_of(new_voter);
+        let owner_address = signer::address_of_unpermissioned(owner);
+        let operator_1_address = signer::address_of_unpermissioned(operator_1);
+        let operator_2_address = signer::address_of_unpermissioned(operator_2);
+        let new_voter_address = signer::address_of_unpermissioned(new_voter);
         vesting::setup(
             aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_voter_address]);
         staking_contract::setup_staking_contract(aptos_framework, owner, operator_1, INITIAL_BALANCE, 0);
@@ -234,10 +234,10 @@ module aptos_framework::staking_proxy {
         operator_2: &signer,
         new_voter: &signer,
     ) {
-        let owner_address = signer::address_of(owner);
-        let operator_1_address = signer::address_of(operator_1);
-        let operator_2_address = signer::address_of(operator_2);
-        let new_voter_address = signer::address_of(new_voter);
+        let owner_address = signer::address_of_unpermissioned(owner);
+        let operator_1_address = signer::address_of_unpermissioned(operator_1);
+        let operator_2_address = signer::address_of_unpermissioned(operator_2);
+        let new_voter_address = signer::address_of_unpermissioned(new_voter);
         vesting::setup(
             aptos_framework, &vector[owner_address, operator_1_address, operator_2_address, new_voter_address]);
         staking_contract::setup_staking_contract(aptos_framework, owner, operator_2, INITIAL_BALANCE, 0);

--- a/aptos-move/framework/aptos-framework/sources/system_addresses.move
+++ b/aptos-move/framework/aptos-framework/sources/system_addresses.move
@@ -12,7 +12,7 @@ module aptos_framework::system_addresses {
     const ENOT_FRAMEWORK_RESERVED_ADDRESS: u64 = 4;
 
     public fun assert_core_resource(account: &signer) {
-        assert_core_resource_address(signer::address_of(account))
+        assert_core_resource_address(signer::address_of_unpermissioned(account))
     }
 
     public fun assert_core_resource_address(addr: address) {
@@ -25,13 +25,13 @@ module aptos_framework::system_addresses {
 
     public fun assert_aptos_framework(account: &signer) {
         assert!(
-            is_aptos_framework_address(signer::address_of(account)),
+            is_aptos_framework_address(signer::address_of_unpermissioned(account)),
             error::permission_denied(ENOT_APTOS_FRAMEWORK_ADDRESS),
         )
     }
 
     public fun assert_framework_reserved_address(account: &signer) {
-        assert_framework_reserved(signer::address_of(account));
+        assert_framework_reserved(signer::address_of_unpermissioned(account));
     }
 
     public fun assert_framework_reserved(addr: address) {
@@ -67,7 +67,7 @@ module aptos_framework::system_addresses {
 
     /// Return true if `addr` is a reserved address for the VM to call system modules.
     public fun is_vm(account: &signer): bool {
-        is_vm_address(signer::address_of(account))
+        is_vm_address(signer::address_of_unpermissioned(account))
     }
 
     /// Return true if `addr` is a reserved address for the VM to call system modules.

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -121,7 +121,7 @@ module aptos_framework::transaction_fee {
         system_addresses::assert_aptos_framework(aptos_framework);
         let AptosCoinCapabilities {
             burn_cap,
-        } = move_from<AptosCoinCapabilities>(signer::address_of(aptos_framework));
+        } = move_from<AptosCoinCapabilities>(signer::address_of_unpermissioned(aptos_framework));
         let burn_ref = coin::convert_and_take_paired_burn_ref(burn_cap);
         move_to(aptos_framework, AptosFABurnCapabilities { burn_ref });
     }

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -116,8 +116,8 @@ module aptos_framework::transaction_validation {
         );
         assert!(chain_id::get() == chain_id, error::invalid_argument(PROLOGUE_EBAD_CHAIN_ID));
 
-        let transaction_sender = signer::address_of(sender);
-        let gas_payer_address = signer::address_of(gas_payer);
+        let transaction_sender = signer::address_of_unpermissioned(sender);
+        let gas_payer_address = signer::address_of_unpermissioned(gas_payer);
 
         if (
             transaction_sender == gas_payer_address
@@ -472,7 +472,7 @@ module aptos_framework::transaction_validation {
         txn_max_gas_units: u64,
         gas_units_remaining: u64,
     ) {
-        let addr = signer::address_of(&account);
+        let addr = signer::address_of_unpermissioned(&account);
         epilogue_gas_payer(
             account,
             addr,
@@ -494,7 +494,7 @@ module aptos_framework::transaction_validation {
         gas_units_remaining: u64,
         is_simulation: bool,
     ) {
-        let addr = signer::address_of(&account);
+        let addr = signer::address_of_unpermissioned(&account);
         epilogue_gas_payer_extended(
             account,
             addr,
@@ -575,7 +575,7 @@ module aptos_framework::transaction_validation {
         };
 
         // Increment sequence number
-        let addr = signer::address_of(&account);
+        let addr = signer::address_of_unpermissioned(&account);
         account::increment_sequence_number(addr);
     }
 
@@ -646,7 +646,7 @@ module aptos_framework::transaction_validation {
         multi_agent_common_prologue(secondary_signer_addresses, secondary_signer_public_key_hashes, is_simulation);
         if (!features::transaction_simulation_enhancement_enabled() ||
             !skip_auth_key_check(is_simulation, &fee_payer_public_key_hash)) {
-            let fee_payer_address = signer::address_of(&fee_payer);
+            let fee_payer_address = signer::address_of_unpermissioned(&fee_payer);
             if (option::is_some(&fee_payer_public_key_hash)) {
                 assert!(
                     fee_payer_public_key_hash == option::some(account::get_authentication_key(fee_payer_address)),
@@ -681,7 +681,7 @@ module aptos_framework::transaction_validation {
         );
         let transaction_fee_amount = txn_gas_price * gas_used;
 
-        let gas_payer_address = signer::address_of(&gas_payer);
+        let gas_payer_address = signer::address_of_unpermissioned(&gas_payer);
         // it's important to maintain the error code consistent with vm
         // to do failed transaction cleanup.
         if (!features::transaction_simulation_enhancement_enabled() || !skip_gas_payment(
@@ -720,7 +720,7 @@ module aptos_framework::transaction_validation {
         };
 
         // Increment sequence number
-        let addr = signer::address_of(&account);
+        let addr = signer::address_of_unpermissioned(&account);
         account::increment_sequence_number(addr);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -585,7 +585,7 @@ module aptos_framework::vesting {
         assert!(grant_amount > 0, error::invalid_argument(EZERO_GRANT));
 
         // If this is the first time this admin account has created a vesting contract, initialize the admin store.
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         if (!exists<AdminStore>(admin_address)) {
             move_to(admin, AdminStore {
                 vesting_contracts: vector::empty<address>(),
@@ -601,7 +601,7 @@ module aptos_framework::vesting {
             &contract_signer, operator, voter, grant, commission_percentage, contract_creation_seed);
 
         // Add the newly created vesting contract's address to the admin store.
-        let contract_address = signer::address_of(&contract_signer);
+        let contract_address = signer::address_of_unpermissioned(&contract_signer);
         let admin_store = borrow_global_mut<AdminStore>(admin_address);
         vector::push_back(&mut admin_store.vesting_contracts, contract_address);
         if (std::features::module_event_migration_enabled()) {
@@ -1075,7 +1075,7 @@ module aptos_framework::vesting {
     ) acquires VestingAccountManagement, VestingContract {
         check_vest_permission(account);
         let vesting_contract = borrow_global_mut<VestingContract>(contract_address);
-        let addr = signer::address_of(account);
+        let addr = signer::address_of_unpermissioned(account);
         assert!(
             addr == vesting_contract.admin ||
                 addr == get_role_holder(contract_address, utf8(ROLE_BENEFICIARY_RESETTER)),
@@ -1154,8 +1154,8 @@ module aptos_framework::vesting {
         contract_creation_seed: vector<u8>,
     ): (signer, SignerCapability) acquires AdminStore {
         check_vest_permission(admin);
-        let admin_store = borrow_global_mut<AdminStore>(signer::address_of(admin));
-        let seed = bcs::to_bytes(&signer::address_of(admin));
+        let admin_store = borrow_global_mut<AdminStore>(signer::address_of_unpermissioned(admin));
+        let seed = bcs::to_bytes(&signer::address_of_unpermissioned(admin));
         vector::append(&mut seed, bcs::to_bytes(&admin_store.nonce));
         admin_store.nonce = admin_store.nonce + 1;
 
@@ -1174,7 +1174,7 @@ module aptos_framework::vesting {
 
     fun verify_admin(admin: &signer, vesting_contract: &VestingContract) {
         check_vest_permission(admin);
-        assert!(signer::address_of(admin) == vesting_contract.admin, error::unauthenticated(ENOT_ADMIN));
+        assert!(signer::address_of_unpermissioned(admin) == vesting_contract.admin, error::unauthenticated(ENOT_ADMIN));
     }
 
     fun assert_vesting_contract_exists(contract_address: address) {
@@ -1300,7 +1300,7 @@ module aptos_framework::vesting {
             VESTING_PERIOD,
         );
 
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         let buy_ins = simple_map::create<address, Coin<AptosCoin>>();
         vector::enumerate_ref(shares, |i, share| {
             let shareholder = *vector::borrow(shareholders, i);
@@ -1328,10 +1328,10 @@ module aptos_framework::vesting {
         shareholder_2: &signer,
         withdrawal: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let withdrawal_address = signer::address_of(withdrawal);
-        let shareholder_1_address = signer::address_of(shareholder_1);
-        let shareholder_2_address = signer::address_of(shareholder_2);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let withdrawal_address = signer::address_of_unpermissioned(withdrawal);
+        let shareholder_1_address = signer::address_of_unpermissioned(shareholder_1);
+        let shareholder_2_address = signer::address_of_unpermissioned(shareholder_2);
         let shareholders = &vector[shareholder_1_address, shareholder_2_address];
         let shareholder_1_share = GRANT_AMOUNT / 4;
         let shareholder_2_share = GRANT_AMOUNT * 3 / 4;
@@ -1452,7 +1452,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         setup_vesting_contract(admin, &vector[@1], &vector[0], admin_address, 0);
     }
@@ -1463,7 +1463,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         setup_vesting_contract(admin, &vector[], &vector[], admin_address, 0);
     }
@@ -1474,7 +1474,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         setup_vesting_contract(admin, &vector[@1, @2], &vector[1], admin_address, 0);
     }
@@ -1485,7 +1485,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @5, 0);
     }
@@ -1496,7 +1496,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @11, 0);
     }
@@ -1507,7 +1507,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         create_account_for_test(@11);
         setup_vesting_contract(admin, &vector[@1, @2], &vector[1], @11, 0);
@@ -1544,8 +1544,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -1575,8 +1575,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -1605,9 +1605,9 @@ module aptos_framework::vesting {
         shareholder: &signer,
         operator: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let operator_address = signer::address_of(operator);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let operator_address = signer::address_of_unpermissioned(operator);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -1657,9 +1657,9 @@ module aptos_framework::vesting {
         shareholder: &signer,
         operator: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let operator_address = signer::address_of(operator);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let operator_address = signer::address_of_unpermissioned(operator);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -1713,8 +1713,8 @@ module aptos_framework::vesting {
         admin: &signer,
         operator: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let operator_address = signer::address_of(operator);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let operator_address = signer::address_of_unpermissioned(operator);
         setup(aptos_framework, &vector[admin_address, @11, operator_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 10);
@@ -1730,9 +1730,9 @@ module aptos_framework::vesting {
         shareholder: &signer,
         operator: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let operator_address = signer::address_of(operator);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let operator_address = signer::address_of_unpermissioned(operator);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -1804,11 +1804,11 @@ module aptos_framework::vesting {
         beneficiary: &signer,
         operator2: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let operator_address1 = signer::address_of(operator1);
-        let operator_address2 = signer::address_of(operator2);
-        let shareholder_address = signer::address_of(shareholder);
-        let beneficiary_address = signer::address_of(beneficiary);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let operator_address1 = signer::address_of_unpermissioned(operator1);
+        let operator_address2 = signer::address_of_unpermissioned(operator2);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
+        let beneficiary_address = signer::address_of_unpermissioned(beneficiary);
         setup(aptos_framework, &vector[admin_address, shareholder_address, operator_address1, beneficiary_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -1880,8 +1880,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -1897,8 +1897,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract_with_schedule(
             admin,
@@ -1948,8 +1948,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract_with_schedule(
             admin,
@@ -1989,8 +1989,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -2007,8 +2007,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -2025,8 +2025,8 @@ module aptos_framework::vesting {
         admin: &signer,
         shareholder: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
-        let shareholder_address = signer::address_of(shareholder);
+        let admin_address = signer::address_of_unpermissioned(admin);
+        let shareholder_address = signer::address_of_unpermissioned(shareholder);
         setup(aptos_framework, &vector[admin_address, shareholder_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[shareholder_address], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -2041,7 +2041,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address, 0);
@@ -2054,7 +2054,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@1, @2], &vector[GRANT_AMOUNT, GRANT_AMOUNT], admin_address, 0);
@@ -2067,7 +2067,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address, @11]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@1], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -2092,7 +2092,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -2108,7 +2108,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address, @11, @12]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -2137,7 +2137,7 @@ module aptos_framework::vesting {
         admin: &signer,
         resetter: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address, @11, @12]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
@@ -2145,7 +2145,7 @@ module aptos_framework::vesting {
         assert!(beneficiary(contract_address, @11) == @12, 0);
 
         // Reset the beneficiary with the resetter role.
-        let resetter_address = signer::address_of(resetter);
+        let resetter_address = signer::address_of_unpermissioned(resetter);
         set_beneficiary_resetter(admin, contract_address, resetter_address);
         assert!(simple_map::length(&borrow_global<VestingAccountManagement>(contract_address).roles) == 1, 0);
         reset_beneficiary(resetter, contract_address, @11);
@@ -2160,13 +2160,13 @@ module aptos_framework::vesting {
         resetter: &signer,
         random: &signer,
     ) acquires AdminStore, VestingAccountManagement, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address, @11]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);
 
         // Reset the beneficiary with a random account. This should failed.
-        set_beneficiary_resetter(admin, contract_address, signer::address_of(resetter));
+        set_beneficiary_resetter(admin, contract_address, signer::address_of_unpermissioned(resetter));
         reset_beneficiary(random, contract_address, @11);
     }
 
@@ -2175,7 +2175,7 @@ module aptos_framework::vesting {
         aptos_framework: &signer,
         admin: &signer,
     ) acquires AdminStore, VestingContract {
-        let admin_address = signer::address_of(admin);
+        let admin_address = signer::address_of_unpermissioned(admin);
         setup(aptos_framework, &vector[admin_address, @11, @12]);
         let contract_address = setup_vesting_contract(
             admin, &vector[@11], &vector[GRANT_AMOUNT], admin_address, 0);

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -208,7 +208,7 @@ module aptos_framework::voting {
 
     public fun register<ProposalType: store>(account: &signer) {
         check_vote_permission(account);
-        let addr = signer::address_of(account);
+        let addr = signer::address_of_unpermissioned(account);
         assert!(!exists<VotingForum<ProposalType>>(addr), error::already_exists(EVOTING_FORUM_ALREADY_REGISTERED));
 
         let voting_forum = VotingForum<ProposalType> {
@@ -793,7 +793,7 @@ module aptos_framework::voting {
     ): u64 acquires VotingForum {
         // Register voting forum and create a proposal.
         register<TestProposal>(governance);
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         let proposal = TestProposal {};
 
         // This works because our Move unit test extensions mock out the execution hash to be [1].
@@ -862,7 +862,7 @@ module aptos_framework::voting {
         is_multi_step: bool
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         register<TestProposal>(governance);
         let proposal = TestProposal {};
@@ -919,7 +919,7 @@ module aptos_framework::voting {
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), use_create_multi_step);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
@@ -982,7 +982,7 @@ module aptos_framework::voting {
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
@@ -1024,7 +1024,7 @@ module aptos_framework::voting {
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
@@ -1087,7 +1087,7 @@ module aptos_framework::voting {
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
         let proof = TestProposal {};
@@ -1127,7 +1127,7 @@ module aptos_framework::voting {
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), is_multi_step);
 
@@ -1163,7 +1163,7 @@ module aptos_framework::voting {
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(&aptos_framework);
-        let governance_address = signer::address_of(&governance);
+        let governance_address = signer::address_of_unpermissioned(&governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal(&governance, option::none<u128>());
         // Voting period is over. Voting should now fail.
@@ -1183,7 +1183,7 @@ module aptos_framework::voting {
         timestamp::set_time_has_started_for_testing(&aptos_framework);
 
         // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(&governance);
+        let governance_address = signer::address_of_unpermissioned(&governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(&governance, option::some(100), true);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);
@@ -1210,7 +1210,7 @@ module aptos_framework::voting {
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(governance, option::some(100), is_multi_step);
 
@@ -1249,7 +1249,7 @@ module aptos_framework::voting {
     ) acquires VotingForum {
         account::create_account_for_test(@aptos_framework);
         timestamp::set_time_has_started_for_testing(aptos_framework);
-        account::create_account_for_test(signer::address_of(governance));
+        account::create_account_for_test(signer::address_of_unpermissioned(governance));
         // This should fail.
         create_test_proposal_generic(governance, option::some(5), is_multi_step);
     }
@@ -1278,7 +1278,7 @@ module aptos_framework::voting {
         timestamp::set_time_has_started_for_testing(aptos_framework);
 
         // Register voting forum and create a proposal.
-        let governance_address = signer::address_of(governance);
+        let governance_address = signer::address_of_unpermissioned(governance);
         account::create_account_for_test(governance_address);
         let proposal_id = create_test_proposal_generic(governance, option::none<u128>(), true);
         assert!(get_proposal_state<TestProposal>(governance_address, proposal_id) == PROPOSAL_STATE_PENDING, 0);

--- a/aptos-move/framework/aptos-framework/tests/deflation_token.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token.move
@@ -16,7 +16,7 @@ module 0xcafe::deflation_token {
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
         let burn_ref = fungible_asset::generate_burn_ref(constructor_ref);
 
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
         move_to<BurnStore>(account, BurnStore { burn_ref });
 
         let withdraw = function_info::new_function_info(

--- a/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/deflation_token_tests.move
@@ -290,7 +290,7 @@ module 0xcafe::deflation_token_tests {
     fun test_register_on_non_metadata_object(
         creator: &signer,
     ) {
-        account::create_account_for_test(signer::address_of(creator));
+        account::create_account_for_test(signer::address_of_unpermissioned(creator));
         let creator_ref = object::create_named_object(creator, b"TEST");
          let withdraw = function_info::new_function_info(
             creator,
@@ -317,8 +317,8 @@ module 0xcafe::deflation_token_tests {
         let metadata = object::convert<TestToken, Metadata>(token_object);
 
         deflation_token::initialize(creator, &creator_ref);
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(primary_fungible_store::balance(creator_address, metadata) == 0, 1);
         assert!(primary_fungible_store::balance(aaron_address, metadata) == 0, 2);
         primary_fungible_store::mint(&mint_ref, creator_address, 100);

--- a/aptos-move/framework/aptos-framework/tests/native_dispatch_token.move
+++ b/aptos-move/framework/aptos-framework/tests/native_dispatch_token.move
@@ -10,7 +10,7 @@ module 0xcafe::native_dispatch_token {
     use std::string;
 
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
         let withdraw = function_info::new_function_info(
             account,
             string::utf8(b"native_dispatch_token"),

--- a/aptos-move/framework/aptos-framework/tests/nil_op_token.move
+++ b/aptos-move/framework/aptos-framework/tests/nil_op_token.move
@@ -10,7 +10,7 @@ module 0xcafe::nil_op_token {
     use std::string;
 
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
         let withdraw = function_info::new_function_info(
             account,
             string::utf8(b"nil_op_token"),

--- a/aptos-move/framework/aptos-framework/tests/permissioned_signer_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/permissioned_signer_tests.move
@@ -24,7 +24,7 @@ module aptos_framework::permissioned_signer_tests {
 
         assert!(permissioned_signer::is_permissioned_signer(&perm_signer), 1);
         assert!(!permissioned_signer::is_permissioned_signer(creator), 1);
-        assert!(signer::address_of(&perm_signer) == signer::address_of(creator), 1);
+        assert!(signer::address_of_unpermissioned(&perm_signer) == signer::address_of_unpermissioned(creator), 1);
 
         permissioned_signer::authorize_increase(creator, &perm_signer, 100, OnePermission {});
         assert!(
@@ -108,7 +108,7 @@ module aptos_framework::permissioned_signer_tests {
 
         assert!(permissioned_signer::is_permissioned_signer(&perm_signer), 1);
         assert!(!permissioned_signer::is_permissioned_signer(creator), 1);
-        assert!(signer::address_of(&perm_signer) == signer::address_of(creator), 1);
+        assert!(signer::address_of_unpermissioned(&perm_signer) == signer::address_of_unpermissioned(creator), 1);
 
         permissioned_signer::authorize_increase(creator, &perm_signer, 100, OnePermission {});
         assert!(

--- a/aptos-move/framework/aptos-framework/tests/permissioned_token.move
+++ b/aptos-move/framework/aptos-framework/tests/permissioned_token.move
@@ -18,7 +18,7 @@ module 0xcafe::permissioned_token {
     }
 
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef, allowed_sender: vector<address>) {
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
         move_to<AllowlistStore>(account, AllowlistStore { allowed_sender });
 
         let withdraw = function_info::new_function_info(
@@ -36,7 +36,7 @@ module 0xcafe::permissioned_token {
     }
 
     public fun add_to_allow_list(account: &signer, new_address: address) acquires AllowlistStore {
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
         let allowed_sender = borrow_global_mut<AllowlistStore>(@0xcafe);
         if(!vector::contains(&allowed_sender.allowed_sender, &new_address)) {
             vector::push_back(&mut allowed_sender.allowed_sender, new_address);

--- a/aptos-move/framework/aptos-framework/tests/reentrant_token.move
+++ b/aptos-move/framework/aptos-framework/tests/reentrant_token.move
@@ -10,7 +10,7 @@ module 0xcafe::reentrant_token {
     use std::string;
 
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
         let deposit = function_info::new_function_info(
             account,
             string::utf8(b"reentrant_token"),

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token.move
@@ -10,7 +10,7 @@ module 0xcafe::simple_token {
     use std::string;
 
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
 
         let withdraw = function_info::new_function_info(
             account,

--- a/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/simple_dispatchable_token_pfs_tests.move
@@ -21,8 +21,8 @@ module aptos_framework::simple_token_pfs_tests {
         let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(user_1, &creator_ref);
 
-        let user_1_address = signer::address_of(user_1);
-        let user_2_address = signer::address_of(user_2);
+        let user_1_address = signer::address_of_unpermissioned(user_1);
+        let user_2_address = signer::address_of_unpermissioned(user_2);
         mint(&mint_ref, user_1_address, 100);
         transfer(user_1, metadata, user_2_address, 80);
 
@@ -47,8 +47,8 @@ module aptos_framework::simple_token_pfs_tests {
         let (mint_ref, _, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(user_1, &creator_ref);
 
-        let user_1_address = signer::address_of(user_1);
-        let user_2_address = signer::address_of(user_2);
+        let user_1_address = signer::address_of_unpermissioned(user_1);
+        let user_2_address = signer::address_of_unpermissioned(user_2);
         mint(&mint_ref, user_1_address, 100);
         transfer(user_1, metadata, user_2_address, 80);
 
@@ -67,8 +67,8 @@ module aptos_framework::simple_token_pfs_tests {
         init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(creator, &creator_ref);
 
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(!primary_store_exists(creator_address, metadata), 1);
         assert!(!primary_store_exists(aaron_address, metadata), 2);
         assert!(balance(creator_address, metadata) == 0, 3);
@@ -90,8 +90,8 @@ module aptos_framework::simple_token_pfs_tests {
         let (mint_ref, transfer_ref, burn_ref) = init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(creator, &creator_ref);
 
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(balance(creator_address, metadata) == 0, 1);
         assert!(balance(aaron_address, metadata) == 0, 2);
         mint(&mint_ref, creator_address, 100);
@@ -120,8 +120,8 @@ module aptos_framework::simple_token_pfs_tests {
         let (mint_ref, _transfer_ref, _) = init_test_metadata_with_primary_store_enabled(&creator_ref);
         simple_token::initialize(creator, &creator_ref);
 
-        let creator_address = signer::address_of(creator);
-        let aaron_address = signer::address_of(aaron);
+        let creator_address = signer::address_of_unpermissioned(creator);
+        let aaron_address = signer::address_of_unpermissioned(aaron);
         assert!(balance(creator_address, metadata) == 0, 1);
         assert!(balance(aaron_address, metadata) == 0, 2);
         mint(&mint_ref, creator_address, 100);

--- a/aptos-move/framework/aptos-framework/tests/ten_x_token.move
+++ b/aptos-move/framework/aptos-framework/tests/ten_x_token.move
@@ -16,7 +16,7 @@ module 0xcafe::ten_x_token {
     }
 
     public fun initialize(account: &signer, constructor_ref: &ConstructorRef) {
-        assert!(signer::address_of(account) == @0xcafe, 1);
+        assert!(signer::address_of_unpermissioned(account) == @0xcafe, 1);
         let balance_ref = fungible_asset::generate_raw_balance_ref(constructor_ref);
         let supply_ref = fungible_asset::generate_raw_supply_ref(constructor_ref);
         move_to<BalanceStore>(account, BalanceStore { balance_ref, supply_ref });

--- a/aptos-move/framework/aptos-framework/tests/ten_x_token_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/ten_x_token_tests.move
@@ -41,7 +41,7 @@ module aptos_framework::ten_x_token_tests {
         let metadata = object::convert<TestToken, Metadata>(token_object);
 
         ten_x_token::initialize(creator, &creator_ref);
-        let creator_address = signer::address_of(creator);
+        let creator_address = signer::address_of_unpermissioned(creator);
 
         let fa = fungible_asset::mint(&mint, 100);
         primary_fungible_store::deposit(creator_address, fa);

--- a/aptos-move/framework/move-stdlib/doc/signer.md
+++ b/aptos-move/framework/move-stdlib/doc/signer.md
@@ -5,18 +5,25 @@
 
 
 
+-  [Constants](#@Constants_0)
 -  [Function `borrow_address`](#0x1_signer_borrow_address)
+-  [Function `borrow_address_unpermissioned`](#0x1_signer_borrow_address_unpermissioned)
 -  [Function `address_of`](#0x1_signer_address_of)
--  [Specification](#@Specification_0)
+-  [Function `address_of_unpermissioned`](#0x1_signer_address_of_unpermissioned)
+-  [Function `is_permissioned_signer`](#0x1_signer_is_permissioned_signer)
+-  [Specification](#@Specification_1)
 
 
 <pre><code></code></pre>
 
 
 
-<a id="0x1_signer_borrow_address"></a>
+<a id="@Constants_0"></a>
 
-## Function `borrow_address`
+## Constants
+
+
+<a id="0x1_signer_ENOT_MASTER_SIGNER"></a>
 
 signer is a builtin move type that represents an address that has been verfied by the VM.
 
@@ -37,8 +44,19 @@ account: address,
 ```
 ^ The discrepency is needed to maintain backwards compatibility of signer serialization
 semantics.
+Access address of a permissioned signer;
 
-<code>borrow_address</code> borrows this inner field
+
+<pre><code><b>const</b> <a href="signer.md#0x1_signer_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_signer_borrow_address"></a>
+
+## Function `borrow_address`
+
+<code>borrow_address</code> borrows this inner field, abort if <code>s</code> is a permissioned signer.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_borrow_address">borrow_address</a>(s: &<a href="signer.md#0x1_signer">signer</a>): &<b>address</b>
@@ -51,6 +69,29 @@ semantics.
 
 
 <pre><code><b>native</b> <b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_borrow_address">borrow_address</a>(s: &<a href="signer.md#0x1_signer">signer</a>): &<b>address</b>;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_signer_borrow_address_unpermissioned"></a>
+
+## Function `borrow_address_unpermissioned`
+
+<code>borrow_address_unpermissioned</code> borrows this inner field, without checking if <code>s</code> is a permissioned signer.
+
+
+<pre><code><b>fun</b> <a href="signer.md#0x1_signer_borrow_address_unpermissioned">borrow_address_unpermissioned</a>(s: &<a href="signer.md#0x1_signer">signer</a>): &<b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="signer.md#0x1_signer_borrow_address_unpermissioned">borrow_address_unpermissioned</a>(s: &<a href="signer.md#0x1_signer">signer</a>): &<b>address</b>;
 </code></pre>
 
 
@@ -81,7 +122,53 @@ semantics.
 
 </details>
 
-<a id="@Specification_0"></a>
+<a id="0x1_signer_address_of_unpermissioned"></a>
+
+## Function `address_of_unpermissioned`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_address_of_unpermissioned">address_of_unpermissioned</a>(s: &<a href="signer.md#0x1_signer">signer</a>): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="signer.md#0x1_signer_address_of_unpermissioned">address_of_unpermissioned</a>(s: &<a href="signer.md#0x1_signer">signer</a>): <b>address</b> {
+    *<a href="signer.md#0x1_signer_borrow_address_unpermissioned">borrow_address_unpermissioned</a>(s)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_signer_is_permissioned_signer"></a>
+
+## Function `is_permissioned_signer`
+
+
+
+<pre><code><b>fun</b> <a href="signer.md#0x1_signer_is_permissioned_signer">is_permissioned_signer</a>(s: &<a href="signer.md#0x1_signer">signer</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="signer.md#0x1_signer_is_permissioned_signer">is_permissioned_signer</a>(s: &<a href="signer.md#0x1_signer">signer</a>): bool;
+</code></pre>
+
+
+
+</details>
+
+<a id="@Specification_1"></a>
 
 ## Specification
 

--- a/aptos-move/framework/move-stdlib/sources/signer.move
+++ b/aptos-move/framework/move-stdlib/sources/signer.move
@@ -1,4 +1,6 @@
 module std::signer {
+    use std::error;
+
     /// signer is a builtin move type that represents an address that has been verfied by the VM.
     ///
     /// VM Runtime representation is equivalent to following:
@@ -18,14 +20,27 @@ module std::signer {
     /// ```
     /// ^ The discrepency is needed to maintain backwards compatibility of signer serialization
     /// semantics.
-    ///
-    /// `borrow_address` borrows this inner field
+
+    /// Access address of a permissioned signer;
+    const ENOT_MASTER_SIGNER: u64 = 1;
+
+    /// `borrow_address` borrows this inner field, abort if `s` is a permissioned signer.
     native public fun borrow_address(s: &signer): &address;
 
-    // Copies the address of the signer
+    /// `borrow_address_unpermissioned` borrows this inner field, without checking if `s` is a permissioned signer.
+    native fun borrow_address_unpermissioned(s: &signer): &address;
+
+    // Copies the address of the signer, abort if `s` is a permissioned signer.
     public fun address_of(s: &signer): address {
         *borrow_address(s)
     }
+
+    // Copies the address of the signer, without checking if `s` is a permissioned signer.
+    public fun address_of_unpermissioned(s: &signer): address {
+        *borrow_address_unpermissioned(s)
+    }
+
+    native fun is_permissioned_signer(s: &signer): bool;
 
     /// Return true only if `s` is a transaction signer. This is a spec function only available in spec.
     spec native fun is_txn_signer(s: signer): bool;

--- a/aptos-move/framework/move-stdlib/src/natives/signer.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/signer.rs
@@ -5,9 +5,12 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_gas_schedule::gas_params::natives::move_stdlib::*;
+use aptos_gas_schedule::gas_params::natives::{
+    aptos_framework::IS_PERMISSIONED_SIGNER_BASE, move_stdlib::*,
+};
 use aptos_native_interface::{
-    safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeResult,
+    safely_pop_arg, RawSafeNative, SafeNativeBuilder, SafeNativeContext, SafeNativeError,
+    SafeNativeResult,
 };
 use move_vm_runtime::native_functions::NativeFunction;
 use move_vm_types::{
@@ -36,6 +39,36 @@ fn native_borrow_address(
 
     context.charge(SIGNER_BORROW_ADDRESS_BASE)?;
 
+    if context
+        .get_feature_flags()
+        .is_enabled(aptos_types::on_chain_config::FeatureFlag::PERMISSIONED_SIGNER)
+        && signer_reference.is_permissioned()?
+    {
+        return Err(SafeNativeError::Abort { abort_code: 1 });
+    }
+
+    Ok(smallvec![signer_reference.borrow_signer()?])
+}
+
+/***************************************************************************************************
+ * native fun borrow_address_unpermissioned
+ *
+ *   gas cost: base_cost
+ *
+ **************************************************************************************************/
+#[inline]
+fn native_borrow_address_unpermissioned(
+    context: &mut SafeNativeContext,
+    _ty_args: Vec<Type>,
+    mut arguments: VecDeque<Value>,
+) -> SafeNativeResult<SmallVec<[Value; 1]>> {
+    debug_assert!(_ty_args.is_empty());
+    debug_assert!(arguments.len() == 1);
+
+    let signer_reference = safely_pop_arg!(arguments, SignerRef);
+
+    context.charge(SIGNER_BORROW_ADDRESS_BASE)?;
+
     Ok(smallvec![signer_reference.borrow_signer()?])
 }
 
@@ -45,6 +78,12 @@ fn native_borrow_address(
 pub fn make_all(
     builder: &SafeNativeBuilder,
 ) -> impl Iterator<Item = (String, NativeFunction)> + '_ {
-    let natives = [("borrow_address", native_borrow_address as RawSafeNative)];
+    let natives = [
+        ("borrow_address", native_borrow_address as RawSafeNative),
+        (
+            "borrow_address_unpermissioned",
+            native_borrow_address_unpermissioned,
+        ),
+    ];
     builder.make_named_natives(natives)
 }


### PR DESCRIPTION
## Description
Make permissioned signer abort on address_of to address security concern over legacy signer code.

## How Has This Been Tested?
Added new tests, existing framework tests shouldn't fail.

## Key Areas to Review
Whether the new natives added need to be gated.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
