### PR TITLE
[cli] Bump to 6.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "6.0.3"
+version = "6.1.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
-- Remove FFI support from Aptos CLI
+## [6.1.0]
+- Remove FFI support from Aptos CLI.
+- Various compiler bug fixes.
+- Fix for coverage tool crash in the presence of inline functions.
 
 ## [6.0.3] - 2025/01/27
 - Update the processors used by localnet to 1.26.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "6.0.3"
+version = "6.1.0"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
## Description

Bump the CLI to 6.1.0

I will run the release workflow after https://github.com/aptos-labs/aptos-core/pull/15888 gets merged to `main`.

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK
