### PR TITLE
[cli] Disable macOS ARM build

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -105,23 +105,23 @@ jobs:
           name: cli-builds-macos-x86-64
           path: aptos-cli-*.zip
 
-  build-macos-arm-binary:
-    name: "Build MacOS ARM binary"
-    runs-on: macos-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.source_git_ref_override }}
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-        with:
-          macos: true
-      - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}"
-      - name: Upload Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-builds-macos-arm
-          path: aptos-cli-*.zip
+#  build-macos-arm-binary:
+#    name: "Build MacOS ARM binary"
+#    runs-on: macos-latest
+#    steps:
+#      - uses: actions/checkout@v4
+#        with:
+#          ref: ${{ github.event.inputs.source_git_ref_override }}
+#      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+#        with:
+#          macos: true
+#      - name: Build CLI
+#        run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}"
+#      - name: Upload Binary
+#        uses: actions/upload-artifact@v4
+#        with:
+#          name: cli-builds-macos-arm
+#          path: aptos-cli-*.zip
 
   build-windows-binary:
     name: "Build Windows binary"
@@ -150,7 +150,7 @@ jobs:
       - build-windows-binary
       - build-linux-binary
       - build-linux-arm-binary
-      - build-macos-arm-binary
+#      - build-macos-arm-binary
       - build-macos-x86_64-binary
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Description
There seems to be some intermittent dependency conflict that only occurs on the ARM machines.  Need more to debug.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
