### PR TITLE
[aptos-workspace-server] add ability to listen for a stop command + bump aptos CLI version to 6.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "6.1.0"
+version = "6.1.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [6.1.1]
+- Added a new feature to `aptos workspace run`: The workspace server now listens for a "stop" command from
+stdin, which triggers a graceful shutdown when received.
+
 ## [6.1.0]
 - Remove FFI support from Aptos CLI.
 - Various compiler bug fixes.

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "6.1.0"
+version = "6.1.1"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
This adds to `aptos-workspace-server` the ability to listen for a `stop` command from `stdin` so to allow external programs to conveniently trigger a graceful shutdown. This is especially needed on Windows, where it is not possible to send a SIGINT to just a child process.

This also bumps the CLI version to 6.1.1.