### PR TITLE
AccountAbstraction that works per domain

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -139,6 +139,7 @@ pub enum FeatureFlag {
     AccountAbstraction,
     VMBinaryFormatV8,
     BulletproofsBatchNatives,
+    DomainAccountAbstraction,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -369,6 +370,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::PermissionedSigner => AptosFeatureFlag::PERMISSIONED_SIGNER,
             FeatureFlag::AccountAbstraction => AptosFeatureFlag::ACCOUNT_ABSTRACTION,
             FeatureFlag::BulletproofsBatchNatives => AptosFeatureFlag::BULLETPROOFS_BATCH_NATIVES,
+            FeatureFlag::DomainAccountAbstraction => AptosFeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION,
         }
     }
 }
@@ -526,6 +528,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::PERMISSIONED_SIGNER => FeatureFlag::PermissionedSigner,
             AptosFeatureFlag::ACCOUNT_ABSTRACTION => FeatureFlag::AccountAbstraction,
             AptosFeatureFlag::BULLETPROOFS_BATCH_NATIVES => FeatureFlag::BulletproofsBatchNatives,
+            AptosFeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION => FeatureFlag::DomainAccountAbstraction,
         }
     }
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1930,7 +1930,15 @@ impl AptosVM {
                     function_info,
                     auth_data,
                 }) => {
-                    if self.features().is_account_abstraction_enabled() {
+                    let enabled = match auth_data {
+                        AbstractionAuthData::V1 { .. } => {
+                            self.features().is_account_abstraction_enabled()
+                        },
+                        AbstractionAuthData::DomainV1 { .. } => {
+                            self.features().is_domain_account_abstraction_enabled()
+                        },
+                    };
+                    if enabled {
                         dispatchable_authenticate(
                             session,
                             gas_meter,
@@ -1962,7 +1970,15 @@ impl AptosVM {
                     function_info,
                     auth_data,
                 } => {
-                    if self.features().is_account_abstraction_enabled() {
+                    let enabled = match auth_data {
+                        AbstractionAuthData::V1 { .. } => {
+                            self.features().is_account_abstraction_enabled()
+                        },
+                        AbstractionAuthData::DomainV1 { .. } => {
+                            self.features().is_domain_account_abstraction_enabled()
+                        },
+                    };
+                    if enabled {
                         dispatchable_authenticate(
                             session,
                             gas_meter,

--- a/aptos-move/framework/aptos-framework/doc/account_abstraction.md
+++ b/aptos-move/framework/aptos-framework/doc/account_abstraction.md
@@ -8,15 +8,22 @@
 -  [Struct `UpdateDispatchableAuthenticator`](#0x1_account_abstraction_UpdateDispatchableAuthenticator)
 -  [Struct `RemoveDispatchableAuthenticator`](#0x1_account_abstraction_RemoveDispatchableAuthenticator)
 -  [Enum Resource `DispatchableAuthenticator`](#0x1_account_abstraction_DispatchableAuthenticator)
+-  [Enum `DomainRegisterValue`](#0x1_account_abstraction_DomainRegisterValue)
+-  [Enum Resource `DomainDispatchableAuthenticator`](#0x1_account_abstraction_DomainDispatchableAuthenticator)
 -  [Constants](#@Constants_0)
+-  [Function `using_dispatchable_authenticator`](#0x1_account_abstraction_using_dispatchable_authenticator)
+-  [Function `dispatchable_authenticator`](#0x1_account_abstraction_dispatchable_authenticator)
+-  [Function `derive_domain_account_address_view`](#0x1_account_abstraction_derive_domain_account_address_view)
+-  [Function `derive_domain_account_address`](#0x1_account_abstraction_derive_domain_account_address)
 -  [Function `add_authentication_function`](#0x1_account_abstraction_add_authentication_function)
 -  [Function `remove_authentication_function`](#0x1_account_abstraction_remove_authentication_function)
 -  [Function `remove_authenticator`](#0x1_account_abstraction_remove_authenticator)
+-  [Function `register_domain_with_authentication_function`](#0x1_account_abstraction_register_domain_with_authentication_function)
+-  [Function `initialize`](#0x1_account_abstraction_initialize)
 -  [Function `resource_addr`](#0x1_account_abstraction_resource_addr)
 -  [Function `update_dispatchable_authenticator_impl`](#0x1_account_abstraction_update_dispatchable_authenticator_impl)
--  [Function `using_dispatchable_authenticator`](#0x1_account_abstraction_using_dispatchable_authenticator)
--  [Function `dispatchable_authenticator`](#0x1_account_abstraction_dispatchable_authenticator)
 -  [Function `dispatchable_authenticator_internal`](#0x1_account_abstraction_dispatchable_authenticator_internal)
+-  [Function `dispatchable_domain_authenticator_internal`](#0x1_account_abstraction_dispatchable_domain_authenticator_internal)
 -  [Function `authenticate`](#0x1_account_abstraction_authenticate)
 -  [Function `dispatchable_authenticate`](#0x1_account_abstraction_dispatchable_authenticate)
 -  [Function `add_dispatchable_authentication_function`](#0x1_account_abstraction_add_dispatchable_authentication_function)
@@ -27,16 +34,22 @@
 
 
 <pre><code><b>use</b> <a href="auth_data.md#0x1_auth_data">0x1::auth_data</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
+<b>use</b> <a href="big_ordered_map.md#0x1_big_ordered_map">0x1::big_ordered_map</a>;
 <b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs">0x1::from_bcs</a>;
 <b>use</b> <a href="function_info.md#0x1_function_info">0x1::function_info</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">0x1::hash</a>;
 <b>use</b> <a href="object.md#0x1_object">0x1::object</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="ordered_map.md#0x1_ordered_map">0x1::ordered_map</a>;
 <b>use</b> <a href="permissioned_signer.md#0x1_permissioned_signer">0x1::permissioned_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">0x1::signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<b>use</b> <a href="system_addresses.md#0x1_system_addresses">0x1::system_addresses</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
 </code></pre>
 
 
@@ -151,6 +164,79 @@ enum <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthent
 
 </details>
 
+<a id="0x1_account_abstraction_DomainRegisterValue"></a>
+
+## Enum `DomainRegisterValue`
+
+
+
+<pre><code>enum <a href="account_abstraction.md#0x1_account_abstraction_DomainRegisterValue">DomainRegisterValue</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>Empty</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="0x1_account_abstraction_DomainDispatchableAuthenticator"></a>
+
+## Enum Resource `DomainDispatchableAuthenticator`
+
+The dispatchable domain-scoped authenticator, that defines how to authenticate
+
+
+<pre><code>enum <a href="account_abstraction.md#0x1_account_abstraction_DomainDispatchableAuthenticator">DomainDispatchableAuthenticator</a> <b>has</b> key
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>auth_functions: <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>, <a href="account_abstraction.md#0x1_account_abstraction_DomainRegisterValue">account_abstraction::DomainRegisterValue</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
 <a id="@Constants_0"></a>
 
 ## Constants
@@ -170,6 +256,17 @@ enum <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthent
 
 
 <pre><code><b>const</b> <a href="account_abstraction.md#0x1_account_abstraction_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x1_account_abstraction_DOMAIN_ABSTRACTION_DERIVED_SCHEME"></a>
+
+domain_aa_account_address uses this for domain separation within its native implementation
+source is defined in Scheme enum in types/src/transaction/authenticator.rs
+
+
+<pre><code><b>const</b> <a href="account_abstraction.md#0x1_account_abstraction_DOMAIN_ABSTRACTION_DERIVED_SCHEME">DOMAIN_ABSTRACTION_DERIVED_SCHEME</a>: u8 = 5;
 </code></pre>
 
 
@@ -201,6 +298,15 @@ enum <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthent
 
 
 
+<a id="0x1_account_abstraction_EDOMAIN_AA_NOT_INITIALIZED"></a>
+
+
+
+<pre><code><b>const</b> <a href="account_abstraction.md#0x1_account_abstraction_EDOMAIN_AA_NOT_INITIALIZED">EDOMAIN_AA_NOT_INITIALIZED</a>: u64 = 6;
+</code></pre>
+
+
+
 <a id="0x1_account_abstraction_EFUNCTION_INFO_EXISTENCE"></a>
 
 
@@ -218,6 +324,132 @@ enum <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthent
 </code></pre>
 
 
+
+<a id="0x1_account_abstraction_using_dispatchable_authenticator"></a>
+
+## Function `using_dispatchable_authenticator`
+
+Return <code><b>true</b></code> if the account is an abstracted account that can be authenticated with dispatchable move authenticator.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">using_dispatchable_authenticator</a>(addr: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">using_dispatchable_authenticator</a>(addr: <b>address</b>): bool {
+    <b>exists</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(<a href="account_abstraction.md#0x1_account_abstraction_resource_addr">resource_addr</a>(addr))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_account_abstraction_dispatchable_authenticator"></a>
+
+## Function `dispatchable_authenticator`
+
+Return the current dispatchable authenticator move function info. <code>None</code> means this authentication scheme is disabled.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator">dispatchable_authenticator</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator">dispatchable_authenticator</a>(addr: <b>address</b>): Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;FunctionInfo&gt;&gt; <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a> {
+    <b>let</b> resource_addr = <a href="account_abstraction.md#0x1_account_abstraction_resource_addr">resource_addr</a>(addr);
+    <b>if</b> (<b>exists</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(resource_addr)) {
+        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(
+            <a href="ordered_map.md#0x1_ordered_map_keys">ordered_map::keys</a>(&<b>borrow_global</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(resource_addr).auth_functions)
+        )
+    } <b>else</b> { <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>() }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_account_abstraction_derive_domain_account_address_view"></a>
+
+## Function `derive_domain_account_address_view`
+
+Return the account address corresponding to the given <code>account_identity</code>,
+for the domain account abstraction defined by the given function.
+
+
+<pre><code>#[view]
+<b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_derive_domain_account_address_view">derive_domain_account_address_view</a>(module_address: <b>address</b>, module_name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, function_name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, account_identity: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_derive_domain_account_address_view">derive_domain_account_address_view</a>(
+    module_address: <b>address</b>,
+    module_name: String,
+    function_name: String,
+    account_identity: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+): <b>address</b> {
+    <a href="account_abstraction.md#0x1_account_abstraction_derive_domain_account_address">derive_domain_account_address</a>(
+        <a href="function_info.md#0x1_function_info_new_function_info_from_address">function_info::new_function_info_from_address</a>(module_address, module_name, function_name),
+        &account_identity,
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_account_abstraction_derive_domain_account_address"></a>
+
+## Function `derive_domain_account_address`
+
+Return the account address corresponding to the given <code>account_identity</code>,
+for the domain account abstraction defined by the given function.
+TODO: probably worth creating some module with all these derived functions,
+and do computation/caching in rust to avoid recomputation, as we do for objects.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_derive_domain_account_address">derive_domain_account_address</a>(domain_func_info: <a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>, account_identity: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_derive_domain_account_address">derive_domain_account_address</a>(domain_func_info: FunctionInfo, account_identity: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <b>address</b> {
+    // using <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">bcs</a> serialized structs here - this allows for no need for separators.
+    // Alternative would've been <b>to</b> create unique <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">string</a>, we would need <b>to</b> convert domain_func_info into <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">string</a>,
+    // then authentication_key <b>to</b> hex, and then we need separators <b>as</b> well - like ::
+    let bytes = <a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&domain_func_info);
+    bytes.append(<a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(account_identity));
+    bytes.push_back(<a href="account_abstraction.md#0x1_account_abstraction_DOMAIN_ABSTRACTION_DERIVED_SCHEME">DOMAIN_ABSTRACTION_DERIVED_SCHEME</a>);
+    <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs_to_address">from_bcs::to_address</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash_sha3_256">hash::sha3_256</a>(bytes))
+}
+</code></pre>
+
+
+
+</details>
 
 <a id="0x1_account_abstraction_add_authentication_function"></a>
 
@@ -260,6 +492,7 @@ Note: it is a private entry function that can only be called directly from trans
 ## Function `remove_authentication_function`
 
 Remove dispatchable authentication function that enables account abstraction via this function.
+dispatchable function needs to verify that signing_data.authenticator() is a valid signature of signing_data.digest().
 Note: it is a private entry function that can only be called directly from transaction.
 
 
@@ -321,6 +554,77 @@ Note: it is a private entry function that can only be called directly from trans
             <a href="account.md#0x1_account">account</a>: addr,
         });
     };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_account_abstraction_register_domain_with_authentication_function"></a>
+
+## Function `register_domain_with_authentication_function`
+
+Add dispatchable domain-scoped authentication function, that enables account abstraction via this function.
+This means all accounts within the domain can use it to authenticate, without needing an initialization (unlike non-domain AA).
+dispatchable function needs to verify two things:
+- that signing_data.domain_authenticator() is a valid signature of signing_data.digest() (just like regular AA)
+- that signing_data.domain_account_identity() is correct identity representing the authenticator
+(missing this step would allow impersonation)
+
+Note: This is  public entry function, as it requires framework signer, and that can
+only be obtained as a part of the governance script.
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_register_domain_with_authentication_function">register_domain_with_authentication_function</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, module_address: <b>address</b>, module_name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>, function_name: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> entry <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_register_domain_with_authentication_function">register_domain_with_authentication_function</a>(
+    aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    module_address: <b>address</b>,
+    module_name: String,
+    function_name: String,
+) <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DomainDispatchableAuthenticator">DomainDispatchableAuthenticator</a> {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+
+    <b>borrow_global_mut</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DomainDispatchableAuthenticator">DomainDispatchableAuthenticator</a>&gt;(@aptos_framework).auth_functions.add(
+        <a href="function_info.md#0x1_function_info_new_function_info_from_address">function_info::new_function_info_from_address</a>(module_address, module_name, function_name),
+        DomainRegisterValue::Empty,
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_account_abstraction_initialize"></a>
+
+## Function `initialize`
+
+
+
+<pre><code>entry <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>entry <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_initialize">initialize</a>(aptos_framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) {
+    <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
+    <b>move_to</b>(
+        aptos_framework,
+        DomainDispatchableAuthenticator::V1 { auth_functions: <a href="big_ordered_map.md#0x1_big_ordered_map_new_with_config">big_ordered_map::new_with_config</a>(0, 0, <b>false</b>) }
+    );
 }
 </code></pre>
 
@@ -421,63 +725,6 @@ Note: it is a private entry function that can only be called directly from trans
 
 </details>
 
-<a id="0x1_account_abstraction_using_dispatchable_authenticator"></a>
-
-## Function `using_dispatchable_authenticator`
-
-Return <code><b>true</b></code> if the account is an abstracted account that can be authenticated with dispatchable move authenticator.
-
-
-<pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">using_dispatchable_authenticator</a>(addr: <b>address</b>): bool
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">using_dispatchable_authenticator</a>(addr: <b>address</b>): bool {
-    <b>exists</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(<a href="account_abstraction.md#0x1_account_abstraction_resource_addr">resource_addr</a>(addr))
-}
-</code></pre>
-
-
-
-</details>
-
-<a id="0x1_account_abstraction_dispatchable_authenticator"></a>
-
-## Function `dispatchable_authenticator`
-
-Return the current dispatchable authenticator move function info. <code>None</code> means this authentication scheme is disabled.
-
-
-<pre><code>#[view]
-<b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator">dispatchable_authenticator</a>(addr: <b>address</b>): <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>&gt;&gt;
-</code></pre>
-
-
-
-<details>
-<summary>Implementation</summary>
-
-
-<pre><code><b>public</b> <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator">dispatchable_authenticator</a>(addr: <b>address</b>): Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;FunctionInfo&gt;&gt; <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a> {
-    <b>let</b> resource_addr = <a href="account_abstraction.md#0x1_account_abstraction_resource_addr">resource_addr</a>(addr);
-    <b>if</b> (<b>exists</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(resource_addr)) {
-        <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(
-            <a href="ordered_map.md#0x1_ordered_map_keys">ordered_map::keys</a>(&<b>borrow_global</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(resource_addr).auth_functions)
-        )
-    } <b>else</b> { <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>() }
-}
-</code></pre>
-
-
-
-</details>
-
 <a id="0x1_account_abstraction_dispatchable_authenticator_internal"></a>
 
 ## Function `dispatchable_authenticator_internal`
@@ -496,6 +743,31 @@ Return the current dispatchable authenticator move function info. <code>None</co
 <pre><code>inline <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator_internal">dispatchable_authenticator_internal</a>(addr: <b>address</b>): &OrderedMap&lt;FunctionInfo, bool&gt; {
     <b>assert</b>!(<a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">using_dispatchable_authenticator</a>(addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EDISPATCHABLE_AUTHENTICATOR_IS_NOT_USED">EDISPATCHABLE_AUTHENTICATOR_IS_NOT_USED</a>));
     &<b>borrow_global</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>&gt;(<a href="account_abstraction.md#0x1_account_abstraction_resource_addr">resource_addr</a>(addr)).auth_functions
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_account_abstraction_dispatchable_domain_authenticator_internal"></a>
+
+## Function `dispatchable_domain_authenticator_internal`
+
+
+
+<pre><code><b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_domain_authenticator_internal">dispatchable_domain_authenticator_internal</a>(): &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="function_info.md#0x1_function_info_FunctionInfo">function_info::FunctionInfo</a>, <a href="account_abstraction.md#0x1_account_abstraction_DomainRegisterValue">account_abstraction::DomainRegisterValue</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_domain_authenticator_internal">dispatchable_domain_authenticator_internal</a>(): &BigOrderedMap&lt;FunctionInfo, <a href="account_abstraction.md#0x1_account_abstraction_DomainRegisterValue">DomainRegisterValue</a>&gt; {
+    <b>assert</b>!(<b>exists</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DomainDispatchableAuthenticator">DomainDispatchableAuthenticator</a>&gt;(@aptos_framework), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EDOMAIN_AA_NOT_INITIALIZED">EDOMAIN_AA_NOT_INITIALIZED</a>));
+    &<b>borrow_global</b>&lt;<a href="account_abstraction.md#0x1_account_abstraction_DomainDispatchableAuthenticator">DomainDispatchableAuthenticator</a>&gt;(@aptos_framework).auth_functions
 }
 </code></pre>
 
@@ -522,10 +794,19 @@ Return the current dispatchable authenticator move function info. <code>None</co
     <a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     func_info: FunctionInfo,
     signing_data: AbstractionAuthData,
-): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a> {
+): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a>, <a href="account_abstraction.md#0x1_account_abstraction_DomainDispatchableAuthenticator">DomainDispatchableAuthenticator</a> {
     <b>let</b> master_signer_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
-    <b>let</b> func_infos = <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator_internal">dispatchable_authenticator_internal</a>(master_signer_addr);
-    <b>assert</b>!(<a href="ordered_map.md#0x1_ordered_map_contains">ordered_map::contains</a>(func_infos, &func_info), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EFUNCTION_INFO_EXISTENCE">EFUNCTION_INFO_EXISTENCE</a>));
+
+    <b>if</b> (signing_data.is_domain()) {
+        <b>assert</b>!(master_signer_addr == <a href="account_abstraction.md#0x1_account_abstraction_derive_domain_account_address">derive_domain_account_address</a>(func_info, signing_data.domain_account_identity()), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account_abstraction.md#0x1_account_abstraction_EINCONSISTENT_SIGNER_ADDRESS">EINCONSISTENT_SIGNER_ADDRESS</a>));
+
+        <b>let</b> func_infos = <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_domain_authenticator_internal">dispatchable_domain_authenticator_internal</a>();
+        <b>assert</b>!(func_infos.contains(&func_info), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EFUNCTION_INFO_EXISTENCE">EFUNCTION_INFO_EXISTENCE</a>));
+    } <b>else</b> {
+        <b>let</b> func_infos = <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator_internal">dispatchable_authenticator_internal</a>(master_signer_addr);
+        <b>assert</b>!(<a href="ordered_map.md#0x1_ordered_map_contains">ordered_map::contains</a>(func_infos, &func_info), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EFUNCTION_INFO_EXISTENCE">EFUNCTION_INFO_EXISTENCE</a>));
+    };
+
     <a href="function_info.md#0x1_function_info_load_module_from_function">function_info::load_module_from_function</a>(&func_info);
     <b>let</b> returned_signer = <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticate">dispatchable_authenticate</a>(<a href="account.md#0x1_account">account</a>, signing_data, &func_info);
     // Returned <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> MUST represent the same <a href="account.md#0x1_account">account</a> <b>address</b>. Otherwise, it may <b>break</b> the <b>invariant</b> of Aptos blockchain!

--- a/aptos-move/framework/aptos-framework/doc/auth_data.md
+++ b/aptos-move/framework/aptos-framework/doc/auth_data.md
@@ -5,14 +5,59 @@
 
 
 
+-  [Enum `DomainAccount`](#0x1_auth_data_DomainAccount)
 -  [Enum `AbstractionAuthData`](#0x1_auth_data_AbstractionAuthData)
+-  [Constants](#@Constants_0)
 -  [Function `digest`](#0x1_auth_data_digest)
 -  [Function `authenticator`](#0x1_auth_data_authenticator)
+-  [Function `is_domain`](#0x1_auth_data_is_domain)
+-  [Function `domain_authenticator`](#0x1_auth_data_domain_authenticator)
+-  [Function `domain_account_identity`](#0x1_auth_data_domain_account_identity)
 
 
-<pre><code></code></pre>
+<pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+</code></pre>
 
 
+
+<a id="0x1_auth_data_DomainAccount"></a>
+
+## Enum `DomainAccount`
+
+
+
+<pre><code>enum <a href="auth_data.md#0x1_auth_data_DomainAccount">DomainAccount</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>account_identity: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
 
 <a id="0x1_auth_data_AbstractionAuthData"></a>
 
@@ -57,7 +102,64 @@
 
 </details>
 
+<details>
+<summary>DomainV1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>digest: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>authenticator: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="account.md#0x1_account">account</a>: <a href="auth_data.md#0x1_auth_data_DomainAccount">auth_data::DomainAccount</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
 </details>
+
+</details>
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_auth_data_ENOT_DOMAIN_AUTH_DATA"></a>
+
+
+
+<pre><code><b>const</b> <a href="auth_data.md#0x1_auth_data_ENOT_DOMAIN_AUTH_DATA">ENOT_DOMAIN_AUTH_DATA</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x1_auth_data_ENOT_REGULAR_AUTH_DATA"></a>
+
+
+
+<pre><code><b>const</b> <a href="auth_data.md#0x1_auth_data_ENOT_REGULAR_AUTH_DATA">ENOT_REGULAR_AUTH_DATA</a>: u64 = 1;
+</code></pre>
+
+
 
 <a id="0x1_auth_data_digest"></a>
 
@@ -65,7 +167,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_digest">digest</a>(signing_data: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_digest">digest</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -74,8 +176,8 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_digest">digest</a>(signing_data: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    &signing_data.digest
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_digest">digest</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    &self.digest
 }
 </code></pre>
 
@@ -89,7 +191,7 @@
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_authenticator">authenticator</a>(signing_data: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_authenticator">authenticator</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -98,8 +200,83 @@
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_authenticator">authenticator</a>(signing_data: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
-    &signing_data.authenticator
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_authenticator">authenticator</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>assert</b>!(self is V1, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="auth_data.md#0x1_auth_data_ENOT_REGULAR_AUTH_DATA">ENOT_REGULAR_AUTH_DATA</a>));
+    &self.authenticator
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_auth_data_is_domain"></a>
+
+## Function `is_domain`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_is_domain">is_domain</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_is_domain">is_domain</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">AbstractionAuthData</a>): bool {
+    self is DomainV1
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_auth_data_domain_authenticator"></a>
+
+## Function `domain_authenticator`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_domain_authenticator">domain_authenticator</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_domain_authenticator">domain_authenticator</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>assert</b>!(self is DomainV1, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="auth_data.md#0x1_auth_data_ENOT_REGULAR_AUTH_DATA">ENOT_REGULAR_AUTH_DATA</a>));
+    &self.authenticator
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_auth_data_domain_account_identity"></a>
+
+## Function `domain_account_identity`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_domain_account_identity">domain_account_identity</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="auth_data.md#0x1_auth_data_domain_account_identity">domain_account_identity</a>(self: &<a href="auth_data.md#0x1_auth_data_AbstractionAuthData">AbstractionAuthData</a>): &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
+    <b>assert</b>!(self is DomainV1, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="auth_data.md#0x1_auth_data_ENOT_DOMAIN_AUTH_DATA">ENOT_DOMAIN_AUTH_DATA</a>));
+    &self.<a href="account.md#0x1_account">account</a>.account_identity
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/common_domain_aa_auths.md
+++ b/aptos-move/framework/aptos-framework/doc/common_domain_aa_auths.md
@@ -1,0 +1,73 @@
+
+<a id="0x1_common_domain_aa_auths"></a>
+
+# Module `0x1::common_domain_aa_auths`
+
+
+
+-  [Constants](#@Constants_0)
+-  [Function `authenticate_ed25519_hex`](#0x1_common_domain_aa_auths_authenticate_ed25519_hex)
+
+
+<pre><code><b>use</b> <a href="auth_data.md#0x1_auth_data">0x1::auth_data</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519">0x1::ed25519</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/string_utils.md#0x1_string_utils">0x1::string_utils</a>;
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_common_domain_aa_auths_EINVALID_SIGNATURE"></a>
+
+
+
+<pre><code><b>const</b> <a href="common_domain_aa_auths.md#0x1_common_domain_aa_auths_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_common_domain_aa_auths_authenticate_ed25519_hex"></a>
+
+## Function `authenticate_ed25519_hex`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="common_domain_aa_auths.md#0x1_common_domain_aa_auths_authenticate_ed25519_hex">authenticate_ed25519_hex</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: <a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="common_domain_aa_auths.md#0x1_common_domain_aa_auths_authenticate_ed25519_hex">authenticate_ed25519_hex</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: AbstractionAuthData): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+    <b>let</b> hex_digest = <a href="../../aptos-stdlib/doc/string_utils.md#0x1_string_utils_to_string">string_utils::to_string</a>(aa_auth_data.digest());
+
+    <b>let</b> public_key = new_unvalidated_public_key_from_bytes(*aa_auth_data.domain_account_identity());
+    <b>let</b> signature = new_signature_from_bytes(*aa_auth_data.domain_authenticator());
+    <b>assert</b>!(
+        <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_signature_verify_strict">ed25519::signature_verify_strict</a>(
+            &signature,
+            &public_key,
+            *hex_digest.bytes(),
+        ),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="common_domain_aa_auths.md#0x1_common_domain_aa_auths_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>)
+    );
+
+    <a href="account.md#0x1_account">account</a>
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/domain_account_abstraction_ed25519_hex.md
+++ b/aptos-move/framework/aptos-framework/doc/domain_account_abstraction_ed25519_hex.md
@@ -1,0 +1,80 @@
+
+<a id="0x1_domain_account_abstraction_ed25519_hex"></a>
+
+# Module `0x1::domain_account_abstraction_ed25519_hex`
+
+Domain account abstraction using ed25519 hex for signing.
+
+Authentication takes digest, converts to hex (prefixed with 0x, with lowercase letters),
+and then expects that to be signed.
+authenticator is expected to be signature: vector<u8>
+account_identity is raw public_key.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `authenticate`](#0x1_domain_account_abstraction_ed25519_hex_authenticate)
+
+
+<pre><code><b>use</b> <a href="auth_data.md#0x1_auth_data">0x1::auth_data</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519">0x1::ed25519</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<b>use</b> <a href="../../aptos-stdlib/doc/string_utils.md#0x1_string_utils">0x1::string_utils</a>;
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_domain_account_abstraction_ed25519_hex_EINVALID_SIGNATURE"></a>
+
+
+
+<pre><code><b>const</b> <a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_domain_account_abstraction_ed25519_hex_authenticate"></a>
+
+## Function `authenticate`
+
+Authorization function for domain account abstraction.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_authenticate">authenticate</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: <a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_authenticate">authenticate</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: AbstractionAuthData): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+    <b>let</b> hex_digest = <a href="../../aptos-stdlib/doc/string_utils.md#0x1_string_utils_to_string">string_utils::to_string</a>(aa_auth_data.digest());
+
+    <b>let</b> public_key = new_unvalidated_public_key_from_bytes(*aa_auth_data.domain_account_identity());
+    <b>let</b> signature = new_signature_from_bytes(*aa_auth_data.domain_authenticator());
+    <b>assert</b>!(
+        <a href="../../aptos-stdlib/doc/ed25519.md#0x1_ed25519_signature_verify_strict">ed25519::signature_verify_strict</a>(
+            &signature,
+            &public_key,
+            *hex_digest.bytes(),
+        ),
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>)
+    );
+
+    <a href="account.md#0x1_account">account</a>
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -11,6 +11,7 @@
 -  [Function `grant_gas_permission`](#0x1_transaction_validation_grant_gas_permission)
 -  [Function `revoke_gas_permission`](#0x1_transaction_validation_revoke_gas_permission)
 -  [Function `initialize`](#0x1_transaction_validation_initialize)
+-  [Function `allow_missing_txn_authentication_key`](#0x1_transaction_validation_allow_missing_txn_authentication_key)
 -  [Function `prologue_common`](#0x1_transaction_validation_prologue_common)
 -  [Function `script_prologue`](#0x1_transaction_validation_script_prologue)
 -  [Function `script_prologue_extended`](#0x1_transaction_validation_script_prologue_extended)
@@ -388,6 +389,33 @@ Only called during genesis to initialize system resources for this module.
 
 </details>
 
+<a id="0x1_transaction_validation_allow_missing_txn_authentication_key"></a>
+
+## Function `allow_missing_txn_authentication_key`
+
+
+
+<pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(transaction_sender: <b>address</b>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(transaction_sender: <b>address</b>): bool {
+    // aa verifies authentication itself
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>() &&
+    (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_domain_account_abstraction_enabled">features::is_domain_account_abstraction_enabled</a>()
+        || <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">account_abstraction::using_dispatchable_authenticator</a>(transaction_sender))
+}
+</code></pre>
+
+
+
+</details>
+
 <a id="0x1_transaction_validation_prologue_common"></a>
 
 ## Function `prologue_common`
@@ -439,10 +467,7 @@ Only called during genesis to initialize system resources for this module.
                 );
             } <b>else</b> {
                 <b>assert</b>!(
-                    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>(
-                    ) && <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">account_abstraction::using_dispatchable_authenticator</a>(
-                        transaction_sender
-                    ),
+                    <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(transaction_sender),
                     <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
                 )
             };
@@ -472,10 +497,17 @@ Only called during genesis to initialize system resources for this module.
 
         <b>if</b> (!<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_transaction_simulation_enhancement_enabled">features::transaction_simulation_enhancement_enabled</a>() ||
                 !<a href="transaction_validation.md#0x1_transaction_validation_skip_auth_key_check">skip_auth_key_check</a>(is_simulation, &txn_authentication_key)) {
-            <b>assert</b>!(
-                txn_authentication_key == <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&transaction_sender)),
-                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
-            );
+            <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&txn_authentication_key)) {
+                <b>assert</b>!(
+                    txn_authentication_key == <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs_to_bytes">bcs::to_bytes</a>(&transaction_sender)),
+                    <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
+                );
+            } <b>else</b> {
+                <b>assert</b>!(
+                    <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(transaction_sender),
+                    <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
+                );
+            }
         }
     };
 
@@ -767,10 +799,7 @@ Only called during genesis to initialize system resources for this module.
                 );
             } <b>else</b> {
                 <b>assert</b>!(
-                    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>(
-                    ) && <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">account_abstraction::using_dispatchable_authenticator</a>(
-                        secondary_address
-                    ),
+                    <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(secondary_address),
                     <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
                 )
             };
@@ -1159,6 +1188,7 @@ new set of functions
 
 <pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_unified_prologue">unified_prologue</a>(
     sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    // None means no need <b>to</b> check, i.e. either AA (<b>where</b> it is already checked) or simulation
     txn_sender_public_key: Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
     txn_sequence_number: u64,
     secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
@@ -1207,7 +1237,9 @@ If there is no fee_payer, fee_payer = sender
 <pre><code><b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_unified_prologue_fee_payer">unified_prologue_fee_payer</a>(
     sender: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
     fee_payer: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>,
+    // None means no need <b>to</b> check, i.e. either AA (<b>where</b> it is already checked) or simulation
     txn_sender_public_key: Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
+    // None means no need <b>to</b> check, i.e. either AA (<b>where</b> it is already checked) or simulation
     fee_payer_public_key_hash: Option&lt;<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;,
     txn_sequence_number: u64,
     secondary_signer_addresses: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<b>address</b>&gt;,
@@ -1240,9 +1272,7 @@ If there is no fee_payer, fee_payer = sender
             );
         } <b>else</b> {
             <b>assert</b>!(
-                <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>() && <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">account_abstraction::using_dispatchable_authenticator</a>(
-                    fee_payer_address
-                ),
+                <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(fee_payer_address),
                 <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>)
             )
         };

--- a/aptos-move/framework/aptos-framework/sources/account/auth_data.move
+++ b/aptos-move/framework/aptos-framework/sources/account/auth_data.move
@@ -1,6 +1,18 @@
 module aptos_framework::auth_data {
+    use std::error;
+
+    const ENOT_REGULAR_AUTH_DATA: u64 = 1;
+    const ENOT_DOMAIN_AUTH_DATA: u64 = 2;
+
+    enum DomainAccount has copy, drop {
+        V1 {
+            account_identity: vector<u8>,
+        }
+    }
+
     enum AbstractionAuthData has copy, drop {
         V1 { digest: vector<u8>, authenticator: vector<u8> },
+        DomainV1 { digest: vector<u8>, authenticator: vector<u8>, account: DomainAccount }
     }
 
     #[test_only]
@@ -8,11 +20,29 @@ module aptos_framework::auth_data {
         AbstractionAuthData::V1 { digest, authenticator }
     }
 
-    public fun digest(signing_data: &AbstractionAuthData): &vector<u8> {
-        &signing_data.digest
+    public fun digest(self: &AbstractionAuthData): &vector<u8> {
+        &self.digest
     }
 
-    public fun authenticator(signing_data: &AbstractionAuthData): &vector<u8> {
-        &signing_data.authenticator
+    // separate authenticator and domain_authenticator - to not allow accidental mixing
+    // in user authentication code
+
+    public fun authenticator(self: &AbstractionAuthData): &vector<u8> {
+        assert!(self is V1, error::invalid_argument(ENOT_REGULAR_AUTH_DATA));
+        &self.authenticator
+    }
+
+    public fun is_domain(self: &AbstractionAuthData): bool {
+        self is DomainV1
+    }
+
+    public fun domain_authenticator(self: &AbstractionAuthData): &vector<u8> {
+        assert!(self is DomainV1, error::invalid_argument(ENOT_REGULAR_AUTH_DATA));
+        &self.authenticator
+    }
+
+    public fun domain_account_identity(self: &AbstractionAuthData): &vector<u8> {
+        assert!(self is DomainV1, error::invalid_argument(ENOT_DOMAIN_AUTH_DATA));
+        &self.account.account_identity
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -99,6 +99,14 @@ module aptos_framework::transaction_validation {
         });
     }
 
+    // TODO: can be removed after features have been rolled out.
+    inline fun allow_missing_txn_authentication_key(transaction_sender: address): bool {
+        // aa verifies authentication itself
+        features::is_account_abstraction_enabled() &&
+        (features::is_domain_account_abstraction_enabled()
+            || account_abstraction::using_dispatchable_authenticator(transaction_sender))
+    }
+
     fun prologue_common(
         sender: &signer,
         gas_payer: &signer,
@@ -135,10 +143,7 @@ module aptos_framework::transaction_validation {
                     );
                 } else {
                     assert!(
-                        features::is_account_abstraction_enabled(
-                        ) && account_abstraction::using_dispatchable_authenticator(
-                            transaction_sender
-                        ),
+                        allow_missing_txn_authentication_key(transaction_sender),
                         error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
                     )
                 };
@@ -168,10 +173,17 @@ module aptos_framework::transaction_validation {
 
             if (!features::transaction_simulation_enhancement_enabled() ||
                     !skip_auth_key_check(is_simulation, &txn_authentication_key)) {
-                assert!(
-                    txn_authentication_key == option::some(bcs::to_bytes(&transaction_sender)),
-                    error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
-                );
+                if (option::is_some(&txn_authentication_key)) {
+                    assert!(
+                        txn_authentication_key == option::some(bcs::to_bytes(&transaction_sender)),
+                        error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
+                    );
+                } else {
+                    assert!(
+                        allow_missing_txn_authentication_key(transaction_sender),
+                        error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
+                    );
+                }
             }
         };
 
@@ -369,10 +381,7 @@ module aptos_framework::transaction_validation {
                     );
                 } else {
                     assert!(
-                        features::is_account_abstraction_enabled(
-                        ) && account_abstraction::using_dispatchable_authenticator(
-                            secondary_address
-                        ),
+                        allow_missing_txn_authentication_key(secondary_address),
                         error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
                     )
                 };
@@ -593,6 +602,7 @@ module aptos_framework::transaction_validation {
 
     fun unified_prologue(
         sender: signer,
+        // None means no need to check, i.e. either AA (where it is already checked) or simulation
         txn_sender_public_key: Option<vector<u8>>,
         txn_sequence_number: u64,
         secondary_signer_addresses: vector<address>,
@@ -621,7 +631,9 @@ module aptos_framework::transaction_validation {
     fun unified_prologue_fee_payer(
         sender: signer,
         fee_payer: signer,
+        // None means no need to check, i.e. either AA (where it is already checked) or simulation
         txn_sender_public_key: Option<vector<u8>>,
+        // None means no need to check, i.e. either AA (where it is already checked) or simulation
         fee_payer_public_key_hash: Option<vector<u8>>,
         txn_sequence_number: u64,
         secondary_signer_addresses: vector<address>,
@@ -654,9 +666,7 @@ module aptos_framework::transaction_validation {
                 );
             } else {
                 assert!(
-                    features::is_account_abstraction_enabled() && account_abstraction::using_dispatchable_authenticator(
-                        fee_payer_address
-                    ),
+                    allow_missing_txn_authentication_key(fee_payer_address),
                     error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY)
                 )
             };

--- a/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
+++ b/aptos-move/framework/cached-packages/src/aptos_framework_sdk_builder.rs
@@ -179,7 +179,25 @@ pub enum EntryFunctionCall {
         _function_name: Vec<u8>,
     },
 
+    AccountAbstractionInitialize {},
+
+    /// Add dispatchable domain-scoped authentication function, that enables account abstraction via this function.
+    /// This means all accounts within the domain can use it to authenticate, without needing an initialization (unlike non-domain AA).
+    /// dispatchable function needs to verify two things:
+    /// - that signing_data.domain_authenticator() is a valid signature of signing_data.digest() (just like regular AA)
+    /// - that signing_data.domain_account_identity() is correct identity representing the authenticator
+    ///   (missing this step would allow impersonation)
+    ///
+    /// Note: This is  public entry function, as it requires framework signer, and that can
+    /// only be obtained as a part of the governance script.
+    AccountAbstractionRegisterDomainWithAuthenticationFunction {
+        module_address: AccountAddress,
+        module_name: Vec<u8>,
+        function_name: Vec<u8>,
+    },
+
     /// Remove dispatchable authentication function that enables account abstraction via this function.
+    /// dispatchable function needs to verify that signing_data.authenticator() is a valid signature of signing_data.digest().
     /// Note: it is a private entry function that can only be called directly from transaction.
     AccountAbstractionRemoveAuthenticationFunction {
         module_address: AccountAddress,
@@ -1278,6 +1296,16 @@ impl EntryFunctionCall {
                 _module_name,
                 _function_name,
             ),
+            AccountAbstractionInitialize {} => account_abstraction_initialize(),
+            AccountAbstractionRegisterDomainWithAuthenticationFunction {
+                module_address,
+                module_name,
+                function_name,
+            } => account_abstraction_register_domain_with_authentication_function(
+                module_address,
+                module_name,
+                function_name,
+            ),
             AccountAbstractionRemoveAuthenticationFunction {
                 module_address,
                 module_name,
@@ -2229,7 +2257,55 @@ pub fn account_abstraction_add_dispatchable_authentication_function(
     ))
 }
 
+pub fn account_abstraction_initialize() -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("account_abstraction").to_owned(),
+        ),
+        ident_str!("initialize").to_owned(),
+        vec![],
+        vec![],
+    ))
+}
+
+/// Add dispatchable domain-scoped authentication function, that enables account abstraction via this function.
+/// This means all accounts within the domain can use it to authenticate, without needing an initialization (unlike non-domain AA).
+/// dispatchable function needs to verify two things:
+/// - that signing_data.domain_authenticator() is a valid signature of signing_data.digest() (just like regular AA)
+/// - that signing_data.domain_account_identity() is correct identity representing the authenticator
+///   (missing this step would allow impersonation)
+///
+/// Note: This is  public entry function, as it requires framework signer, and that can
+/// only be obtained as a part of the governance script.
+pub fn account_abstraction_register_domain_with_authentication_function(
+    module_address: AccountAddress,
+    module_name: Vec<u8>,
+    function_name: Vec<u8>,
+) -> TransactionPayload {
+    TransactionPayload::EntryFunction(EntryFunction::new(
+        ModuleId::new(
+            AccountAddress::new([
+                0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                0, 0, 0, 1,
+            ]),
+            ident_str!("account_abstraction").to_owned(),
+        ),
+        ident_str!("register_domain_with_authentication_function").to_owned(),
+        vec![],
+        vec![
+            bcs::to_bytes(&module_address).unwrap(),
+            bcs::to_bytes(&module_name).unwrap(),
+            bcs::to_bytes(&function_name).unwrap(),
+        ],
+    ))
+}
+
 /// Remove dispatchable authentication function that enables account abstraction via this function.
+/// dispatchable function needs to verify that signing_data.authenticator() is a valid signature of signing_data.digest().
 /// Note: it is a private entry function that can only be called directly from transaction.
 pub fn account_abstraction_remove_authentication_function(
     module_address: AccountAddress,
@@ -5437,6 +5513,32 @@ mod decoder {
         }
     }
 
+    pub fn account_abstraction_initialize(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(_script) = payload {
+            Some(EntryFunctionCall::AccountAbstractionInitialize {})
+        } else {
+            None
+        }
+    }
+
+    pub fn account_abstraction_register_domain_with_authentication_function(
+        payload: &TransactionPayload,
+    ) -> Option<EntryFunctionCall> {
+        if let TransactionPayload::EntryFunction(script) = payload {
+            Some(
+                EntryFunctionCall::AccountAbstractionRegisterDomainWithAuthenticationFunction {
+                    module_address: bcs::from_bytes(script.args().get(0)?).ok()?,
+                    module_name: bcs::from_bytes(script.args().get(1)?).ok()?,
+                    function_name: bcs::from_bytes(script.args().get(2)?).ok()?,
+                },
+            )
+        } else {
+            None
+        }
+    }
+
     pub fn account_abstraction_remove_authentication_function(
         payload: &TransactionPayload,
     ) -> Option<EntryFunctionCall> {
@@ -7264,6 +7366,14 @@ static SCRIPT_FUNCTION_DECODER_MAP: once_cell::sync::Lazy<EntryFunctionDecoderMa
         map.insert(
             "account_abstraction_add_dispatchable_authentication_function".to_string(),
             Box::new(decoder::account_abstraction_add_dispatchable_authentication_function),
+        );
+        map.insert(
+            "account_abstraction_initialize".to_string(),
+            Box::new(decoder::account_abstraction_initialize),
+        );
+        map.insert(
+            "account_abstraction_register_domain_with_authentication_function".to_string(),
+            Box::new(decoder::account_abstraction_register_domain_with_authentication_function),
         );
         map.insert(
             "account_abstraction_remove_authentication_function".to_string(),

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -141,6 +141,7 @@ return true.
 -  [Function `is_account_abstraction_enabled`](#0x1_features_is_account_abstraction_enabled)
 -  [Function `get_bulletproofs_batch_feature`](#0x1_features_get_bulletproofs_batch_feature)
 -  [Function `bulletproofs_batch_enabled`](#0x1_features_bulletproofs_batch_enabled)
+-  [Function `is_domain_account_abstraction_enabled`](#0x1_features_is_domain_account_abstraction_enabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -505,6 +506,18 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_DISPATCHABLE_FUNGIBLE_ASSET">DISPATCHABLE_FUNGIBLE_ASSET</a>: u64 = 63;
+</code></pre>
+
+
+
+<a id="0x1_features_DOMAIN_ACCOUNT_ABSTRACTION"></a>
+
+Whether the account abstraction is enabled.
+
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_DOMAIN_ACCOUNT_ABSTRACTION">DOMAIN_ACCOUNT_ABSTRACTION</a>: u64 = 88;
 </code></pre>
 
 
@@ -3501,6 +3514,30 @@ Deprecated feature
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_bulletproofs_batch_enabled">bulletproofs_batch_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_BULLETPROOFS_BATCH_NATIVES">BULLETPROOFS_BATCH_NATIVES</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_is_domain_account_abstraction_enabled"></a>
+
+## Function `is_domain_account_abstraction_enabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_domain_account_abstraction_enabled">is_domain_account_abstraction_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_domain_account_abstraction_enabled">is_domain_account_abstraction_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_DOMAIN_ACCOUNT_ABSTRACTION">DOMAIN_ACCOUNT_ABSTRACTION</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -644,6 +644,15 @@ module std::features {
         is_enabled(BULLETPROOFS_BATCH_NATIVES)
     }
 
+    /// Whether the account abstraction is enabled.
+    ///
+    /// Lifetime: transient
+    const DOMAIN_ACCOUNT_ABSTRACTION: u64 = 88;
+
+    public fun is_domain_account_abstraction_enabled(): bool acquires Features {
+        is_enabled(DOMAIN_ACCOUNT_ABSTRACTION)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -85,6 +85,7 @@ const RANDOMNESS_API_V0_CONFIG_MODULE_NAME: &str = "randomness_api_v0_config";
 const RANDOMNESS_CONFIG_SEQNUM_MODULE_NAME: &str = "randomness_config_seqnum";
 const RANDOMNESS_CONFIG_MODULE_NAME: &str = "randomness_config";
 const RANDOMNESS_MODULE_NAME: &str = "randomness";
+const ACCOUNT_ABSTRACTION_MODULE_NAME: &str = "account_abstraction";
 const RECONFIGURATION_STATE_MODULE_NAME: &str = "reconfiguration_state";
 
 const NUM_SECONDS_PER_YEAR: u64 = 365 * 24 * 60 * 60;
@@ -296,6 +297,7 @@ pub fn encode_genesis_change_set(
     initialize_randomness_config(&mut session, &module_storage, randomness_config);
     initialize_randomness_resources(&mut session, &module_storage);
     initialize_on_chain_governance(&mut session, &module_storage, genesis_config);
+    initialize_account_abstraction(&mut session, &module_storage);
     create_and_initialize_validators(&mut session, &module_storage, validators);
     if genesis_config.is_test {
         allow_core_resources_to_set_version(&mut session, &module_storage);
@@ -580,6 +582,20 @@ fn initialize_randomness_resources(
         session,
         module_storage,
         RANDOMNESS_MODULE_NAME,
+        "initialize",
+        vec![],
+        serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]),
+    );
+}
+
+fn initialize_account_abstraction(
+    session: &mut SessionExt,
+    module_storage: &impl AptosModuleStorage,
+) {
+    exec_function(
+        session,
+        module_storage,
+        ACCOUNT_ABSTRACTION_MODULE_NAME,
         "initialize",
         vec![],
         serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]),

--- a/execution/executor/tests/internal_indexer_test.rs
+++ b/execution/executor/tests/internal_indexer_test.rs
@@ -377,6 +377,10 @@ fn test_db_indexer_data() {
             false,
             "0x1::randomness_config_seqnum::RandomnessConfigSeqNum",
         ),
+        (
+            false,
+            "0x1::account_abstraction::DomainDispatchableAuthenticator",
+        ),
         (false, "0x1::coin::CoinInfo<0x1::aptos_coin::AptosCoin>"),
         (
             false,

--- a/testsuite/generate-format/src/api.rs
+++ b/testsuite/generate-format/src/api.rs
@@ -117,6 +117,8 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::authenticator::AnySignature>(&samples)?;
     tracer.trace_type::<transaction::webauthn::AssertionSignature>(&samples)?;
     tracer.trace_type::<aptos_types::keyless::EphemeralCertificate>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::AbstractionAuthData>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::DomainAccount>(&samples)?;
 
     // events
     tracer.trace_type::<WithdrawEvent>(&samples)?;

--- a/testsuite/generate-format/src/aptos.rs
+++ b/testsuite/generate-format/src/aptos.rs
@@ -104,6 +104,8 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<PersistedStateValueMetadata>(&samples)?;
 
     tracer.trace_type::<transaction::authenticator::AccountAuthenticator>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::AbstractionAuthData>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::DomainAccount>(&samples)?;
     tracer.trace_type::<transaction::authenticator::TransactionAuthenticator>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AnyPublicKey>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AnySignature>(&samples)?;

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -100,6 +100,8 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<transaction::WriteSetPayload>(&samples)?;
     tracer.trace_type::<transaction::BlockEpiloguePayload>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AccountAuthenticator>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::AbstractionAuthData>(&samples)?;
+    tracer.trace_type::<transaction::authenticator::DomainAccount>(&samples)?;
     tracer.trace_type::<transaction::authenticator::TransactionAuthenticator>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AnyPublicKey>(&samples)?;
     tracer.trace_type::<transaction::authenticator::AnySignature>(&samples)?;

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -20,6 +20,13 @@ AbstractionAuthData:
         STRUCT:
           - signing_message_digest: BYTES
           - authenticator: BYTES
+    1:
+      DomainV1:
+        STRUCT:
+          - signing_message_digest: BYTES
+          - authenticator: BYTES
+          - account:
+              TYPENAME: DomainAccount
 AccessPath:
   STRUCT:
     - address:
@@ -243,6 +250,12 @@ DKGTranscriptMetadata:
 DepositEvent:
   STRUCT:
     - amount: U64
+DomainAccount:
+  ENUM:
+    0:
+      V1:
+        STRUCT:
+          - account_identity: BYTES
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -8,6 +8,13 @@ AbstractionAuthData:
         STRUCT:
           - signing_message_digest: BYTES
           - authenticator: BYTES
+    1:
+      DomainV1:
+        STRUCT:
+          - signing_message_digest: BYTES
+          - authenticator: BYTES
+          - account:
+              TYPENAME: DomainAccount
 AccessPath:
   STRUCT:
     - address:
@@ -223,6 +230,12 @@ DKGTranscriptMetadata:
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64
+DomainAccount:
+  ENUM:
+    0:
+      V1:
+        STRUCT:
+          - account_identity: BYTES
 Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -8,6 +8,13 @@ AbstractionAuthData:
         STRUCT:
           - signing_message_digest: BYTES
           - authenticator: BYTES
+    1:
+      DomainV1:
+        STRUCT:
+          - signing_message_digest: BYTES
+          - authenticator: BYTES
+          - account:
+              TYPENAME: DomainAccount
 AccessPath:
   STRUCT:
     - address:
@@ -501,6 +508,12 @@ DKGTranscriptMetadata:
 DeprecatedPayload:
   STRUCT:
     - dummy_value: U64
+DomainAccount:
+  ENUM:
+    0:
+      V1:
+        STRUCT:
+          - account_identity: BYTES
 Ed25519PublicKey:
   NEWTYPESTRUCT: BYTES
 Ed25519Signature:

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -121,6 +121,7 @@ pub enum FeatureFlag {
     /// Enables bytecode version v8
     VM_BINARY_FORMAT_V8 = 86,
     BULLETPROOFS_BATCH_NATIVES = 87,
+    DOMAIN_ACCOUNT_ABSTRACTION = 88,
 }
 
 impl FeatureFlag {
@@ -207,6 +208,7 @@ impl FeatureFlag {
             FeatureFlag::ENABLE_CALL_TREE_AND_INSTRUCTION_VM_CACHE,
             FeatureFlag::ACCOUNT_ABSTRACTION,
             FeatureFlag::BULLETPROOFS_BATCH_NATIVES,
+            FeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION,
         ]
     }
 }
@@ -284,6 +286,10 @@ impl Features {
 
     pub fn is_account_abstraction_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::ACCOUNT_ABSTRACTION)
+    }
+
+    pub fn is_domain_account_abstraction_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION)
     }
 
     pub fn is_module_event_enabled(&self) -> bool {


### PR DESCRIPTION
Current AA requires registration for each account, and user has to have private key for an address to be able to do so.

This change allows for AA to be per domain - for example for Solana we need "ed25519_hex", and domain-separated addresses to automatically accept it.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
