### PR TITLE
[benchmark] Make paranoid mode configurable

### DIFF
--- a/aptos-move/replay-benchmark/README.md
+++ b/aptos-move/replay-benchmark/README.md
@@ -211,9 +211,12 @@ of transactions. Typically, you want to have the concurrency level to match the 
 multiple concurrency levels are provided, the benchmark reports the measurements for each level.
 This way it is possible to see how concurrency affects the runtime. 
 
-Finally, in order to differentiate between cold and warm starts, there is an option to skip the
-measurement for the first few blocks. By specifying `--num-block-to-skip N`, the tool will ignore
-measurements for the first `N` blocks (the blocks will still be executed as a "warm-up").
+In order to differentiate between cold and warm starts, there is an option to skip the measurement
+for the first few blocks. By specifying `--num-block-to-skip N`, the tool will ignore measurements
+for the first `N` blocks (the blocks will still be executed as a "warm-up").
+
+Execution can also be configured. By using `--disable-paranoid-mode`, the Move VM will not use
+runtime type checks, possible making execution faster.
 
 #### Example
 

--- a/aptos-move/replay-benchmark/src/commands/benchmark.rs
+++ b/aptos-move/replay-benchmark/src/commands/benchmark.rs
@@ -9,6 +9,7 @@ use crate::{
 };
 use anyhow::{anyhow, bail};
 use aptos_logger::Level;
+use aptos_vm_environment::prod_configs::set_paranoid_type_checks;
 use clap::Parser;
 use std::path::PathBuf;
 use tokio::fs;
@@ -61,6 +62,13 @@ pub struct BenchmarkCommand {
                 the overall time to execute all blocks"
     )]
     measure_overall_time: bool,
+
+    #[clap(
+        long,
+        default_value_t = false,
+        help = "If false, Move VM runs in paranoid mode, if true, paranoid mode is not used"
+    )]
+    disable_paranoid_mode: bool,
 }
 
 impl BenchmarkCommand {
@@ -109,6 +117,7 @@ impl BenchmarkCommand {
             })
             .collect::<Vec<_>>();
 
+        set_paranoid_type_checks(!self.disable_paranoid_mode);
         BenchmarkRunner::new(
             self.concurrency_levels,
             self.num_repeats,


### PR DESCRIPTION
## Description

Adds a flag to disable paranoid mode for benchmarking. This way we can measure performance with and without on historical workloads.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
