### PR TITLE
[benchmark] Make gas metering conditional

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1989,6 +1989,7 @@ dependencies = [
  "move-binary-format",
  "move-core-types",
  "move-vm-types",
+ "once_cell",
 ]
 
 [[package]]
@@ -3599,6 +3600,7 @@ dependencies = [
  "aptos-block-executor",
  "aptos-crypto",
  "aptos-framework",
+ "aptos-gas-meter",
  "aptos-gas-schedule",
  "aptos-logger",
  "aptos-move-debugger",

--- a/aptos-move/aptos-gas-meter/Cargo.toml
+++ b/aptos-move/aptos-gas-meter/Cargo.toml
@@ -21,3 +21,8 @@ aptos-vm-types = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-types = { workspace = true }
+once_cell = { workspace = true }
+
+[features]
+default = []
+benchmark = []

--- a/aptos-move/aptos-gas-meter/Cargo.toml
+++ b/aptos-move/aptos-gas-meter/Cargo.toml
@@ -25,4 +25,4 @@ once_cell = { workspace = true }
 
 [features]
 default = []
-benchmark = []
+bench = []

--- a/aptos-move/aptos-gas-meter/src/lib.rs
+++ b/aptos-move/aptos-gas-meter/src/lib.rs
@@ -7,7 +7,11 @@
 mod algebra;
 mod meter;
 mod traits;
+#[cfg(feature = "benchmark")]
+mod unmetered;
 
 pub use algebra::StandardGasAlgebra;
 pub use meter::StandardGasMeter;
 pub use traits::{AptosGasMeter, GasAlgebra};
+#[cfg(feature = "benchmark")]
+pub use unmetered::{enable_gas_metering, is_gas_metering_enabled, AptosUnmeteredGasMeter};

--- a/aptos-move/aptos-gas-meter/src/lib.rs
+++ b/aptos-move/aptos-gas-meter/src/lib.rs
@@ -7,11 +7,11 @@
 mod algebra;
 mod meter;
 mod traits;
-#[cfg(feature = "benchmark")]
+#[cfg(feature = "bench")]
 mod unmetered;
 
 pub use algebra::StandardGasAlgebra;
 pub use meter::StandardGasMeter;
 pub use traits::{AptosGasMeter, GasAlgebra};
-#[cfg(feature = "benchmark")]
+#[cfg(feature = "bench")]
 pub use unmetered::{enable_gas_metering, is_gas_metering_enabled, AptosUnmeteredGasMeter};

--- a/aptos-move/aptos-gas-meter/src/unmetered.rs
+++ b/aptos-move/aptos-gas-meter/src/unmetered.rs
@@ -1,0 +1,492 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{AptosGasMeter, GasAlgebra};
+use aptos_gas_algebra::{Fee, FeePerGasUnit, Gas, GasExpression, GasScalingFactor, Octa};
+use aptos_gas_schedule::VMGasParameters;
+use aptos_types::{
+    contract_event::ContractEvent, state_store::state_key::StateKey, write_set::WriteOpSize,
+};
+use aptos_vm_types::{
+    change_set::ChangeSetInterface,
+    module_and_script_storage::module_storage::AptosModuleStorage,
+    resolver::ExecutorView,
+    storage::{io_pricing::IoPricing, space_pricing::DiskSpacePricing},
+};
+use move_binary_format::{
+    errors::{PartialVMResult, VMResult},
+    file_format::CodeOffset,
+};
+use move_core_types::{
+    account_address::AccountAddress,
+    gas_algebra::{InternalGas, InternalGasUnit, NumArgs, NumBytes, NumTypeNodes},
+    identifier::IdentStr,
+    language_storage::ModuleId,
+};
+use move_vm_types::{
+    gas::{GasMeter, SimpleInstruction},
+    views::{TypeView, ValueView},
+};
+use once_cell::sync::OnceCell;
+use std::fmt::Debug;
+
+/// Gas algebra used by unmetered gas meter.
+pub struct UnmeteredGasAlgebra;
+
+impl GasAlgebra for UnmeteredGasAlgebra {
+    fn feature_version(&self) -> u64 {
+        unreachable!("Not used when not metering gas")
+    }
+
+    fn vm_gas_params(&self) -> &VMGasParameters {
+        unreachable!("Not used when not metering gas")
+    }
+
+    fn io_pricing(&self) -> &IoPricing {
+        unreachable!("Not used when not metering gas")
+    }
+
+    fn disk_space_pricing(&self) -> &DiskSpacePricing {
+        unreachable!("Not used when not metering gas")
+    }
+
+    fn balance_internal(&self) -> InternalGas {
+        InternalGas::zero()
+    }
+
+    fn check_consistency(&self) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_execution(
+        &mut self,
+        _abstract_amount: impl GasExpression<VMGasParameters, Unit = InternalGasUnit> + Debug,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_io(
+        &mut self,
+        _abstract_amount: impl GasExpression<VMGasParameters, Unit = InternalGasUnit>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_storage_fee(
+        &mut self,
+        _abstract_amount: impl GasExpression<VMGasParameters, Unit = Octa>,
+        _gas_unit_price: FeePerGasUnit,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn count_dependency(&mut self, _size: NumBytes) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn execution_gas_used(&self) -> InternalGas {
+        InternalGas::zero()
+    }
+
+    fn io_gas_used(&self) -> InternalGas {
+        InternalGas::zero()
+    }
+
+    fn storage_fee_used_in_gas_units(&self) -> InternalGas {
+        InternalGas::zero()
+    }
+
+    fn storage_fee_used(&self) -> Fee {
+        Fee::zero()
+    }
+
+    fn inject_balance(&mut self, _extra_balance: impl Into<Gas>) -> PartialVMResult<()> {
+        Ok(())
+    }
+}
+
+/// Gas meter which does not charge gas. Unfortunately, using it is not fully representable of
+/// not charging gas because there is still some work done outside.
+pub struct AptosUnmeteredGasMeter {
+    algebra: UnmeteredGasAlgebra,
+    // For sponsored account creation hack, we check the disk space pricing to calculate the
+    // expected cost of account creation. For now, just use
+    disk_pricing: DiskSpacePricing,
+}
+
+impl AptosUnmeteredGasMeter {
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            algebra: UnmeteredGasAlgebra,
+            disk_pricing: DiskSpacePricing::V2,
+        }
+    }
+}
+
+impl GasMeter for AptosUnmeteredGasMeter {
+    fn balance_internal(&self) -> InternalGas {
+        InternalGas::zero()
+    }
+
+    fn charge_simple_instr(&mut self, _instr: SimpleInstruction) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_br_true(&mut self, _target_offset: Option<CodeOffset>) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_br_false(&mut self, _target_offset: Option<CodeOffset>) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_branch(&mut self, _target_offset: CodeOffset) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_pop(&mut self, _popped_val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_call(
+        &mut self,
+        _module_id: &ModuleId,
+        _func_name: &str,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+        _num_locals: NumArgs,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_call_generic(
+        &mut self,
+        _module_id: &ModuleId,
+        _func_name: &str,
+        _ty_args: impl ExactSizeIterator<Item = impl TypeView> + Clone,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+        _num_locals: NumArgs,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_ld_const(&mut self, _size: NumBytes) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_ld_const_after_deserialization(
+        &mut self,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_copy_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_move_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_store_loc(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_pack(
+        &mut self,
+        _is_generic: bool,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_pack_variant(
+        &mut self,
+        _is_generic: bool,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_unpack(
+        &mut self,
+        _is_generic: bool,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_unpack_variant(
+        &mut self,
+        _is_generic: bool,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_read_ref(&mut self, _val: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_write_ref(
+        &mut self,
+        _new_val: impl ValueView,
+        _old_val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_eq(&mut self, _lhs: impl ValueView, _rhs: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_neq(&mut self, _lhs: impl ValueView, _rhs: impl ValueView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_borrow_global(
+        &mut self,
+        _is_mut: bool,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _is_success: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_exists(
+        &mut self,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _exists: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_move_from(
+        &mut self,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _val: Option<impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_move_to(
+        &mut self,
+        _is_generic: bool,
+        _ty: impl TypeView,
+        _val: impl ValueView,
+        _is_success: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_pack<'a>(
+        &mut self,
+        _ty: impl TypeView + 'a,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_len(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_borrow(
+        &mut self,
+        _is_mut: bool,
+        _ty: impl TypeView,
+        _is_success: bool,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_push_back(
+        &mut self,
+        _ty: impl TypeView,
+        _val: impl ValueView,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_pop_back(
+        &mut self,
+        _ty: impl TypeView,
+        _val: Option<impl ValueView>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_unpack(
+        &mut self,
+        _ty: impl TypeView,
+        _expect_num_elements: NumArgs,
+        _elems: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_vec_swap(&mut self, _ty: impl TypeView) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_load_resource(
+        &mut self,
+        _addr: AccountAddress,
+        _ty: impl TypeView,
+        _val: Option<impl ValueView>,
+        _bytes_loaded: NumBytes,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_native_function(
+        &mut self,
+        _amount: InternalGas,
+        _ret_vals: Option<impl ExactSizeIterator<Item = impl ValueView> + Clone>,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_native_function_before_execution(
+        &mut self,
+        _ty_args: impl ExactSizeIterator<Item = impl TypeView> + Clone,
+        _args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_drop_frame(
+        &mut self,
+        _locals: impl Iterator<Item = impl ValueView> + Clone,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_create_ty(&mut self, _num_nodes: NumTypeNodes) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_dependency(
+        &mut self,
+        _is_new: bool,
+        _addr: &AccountAddress,
+        _name: &IdentStr,
+        _size: NumBytes,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+}
+
+impl AptosGasMeter for AptosUnmeteredGasMeter {
+    type Algebra = UnmeteredGasAlgebra;
+
+    fn algebra(&self) -> &Self::Algebra {
+        &self.algebra
+    }
+
+    fn algebra_mut(&mut self) -> &mut Self::Algebra {
+        &mut self.algebra
+    }
+
+    fn charge_storage_fee(
+        &mut self,
+        _amount: Fee,
+        _gas_unit_price: FeePerGasUnit,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn charge_intrinsic_gas_for_transaction(&mut self, _txn_size: NumBytes) -> VMResult<()> {
+        Ok(())
+    }
+
+    fn charge_keyless(&mut self) -> VMResult<()> {
+        Ok(())
+    }
+
+    fn charge_io_gas_for_transaction(&mut self, _txn_size: NumBytes) -> VMResult<()> {
+        Ok(())
+    }
+
+    fn charge_io_gas_for_event(&mut self, _event: &ContractEvent) -> VMResult<()> {
+        Ok(())
+    }
+
+    fn charge_io_gas_for_write(&mut self, _key: &StateKey, _op: &WriteOpSize) -> VMResult<()> {
+        Ok(())
+    }
+
+    fn process_storage_fee_for_all(
+        &mut self,
+        _change_set: &mut impl ChangeSetInterface,
+        _txn_size: NumBytes,
+        _gas_unit_price: FeePerGasUnit,
+        _executor_view: &dyn ExecutorView,
+        _module_storage: &impl AptosModuleStorage,
+    ) -> VMResult<Fee> {
+        Ok(Fee::zero())
+    }
+
+    fn feature_version(&self) -> u64 {
+        unreachable!("Not used when not metering gas")
+    }
+
+    fn vm_gas_params(&self) -> &VMGasParameters {
+        unreachable!("Not used when not metering gas")
+    }
+
+    fn io_pricing(&self) -> &IoPricing {
+        unreachable!("Not used when not metering gas")
+    }
+
+    fn disk_space_pricing(&self) -> &DiskSpacePricing {
+        &self.disk_pricing
+    }
+
+    fn balance(&self) -> Gas {
+        Gas::zero()
+    }
+
+    fn gas_unit_scaling_factor(&self) -> GasScalingFactor {
+        GasScalingFactor::one()
+    }
+
+    fn execution_gas_used(&self) -> Gas {
+        Gas::zero()
+    }
+
+    fn io_gas_used(&self) -> Gas {
+        Gas::zero()
+    }
+
+    fn storage_fee_used(&self) -> Fee {
+        Fee::zero()
+    }
+
+    fn inject_balance(&mut self, _extra_balance: impl Into<Gas>) -> VMResult<()> {
+        Ok(())
+    }
+}
+
+static METER_GAS: OnceCell<bool> = OnceCell::new();
+
+/// If benchmarking, conditionally enable unmetered or metered executions.
+pub fn enable_gas_metering(enable: bool) {
+    if cfg!(feature = "benchmark") {
+        METER_GAS.set(enable).ok();
+    }
+}
+
+/// Returns whether the gas needs to be metered. When benchmarking, it is possible to configure it
+/// to be turned off.
+pub fn is_gas_metering_enabled() -> bool {
+    if cfg!(feature = "benchmark") {
+        METER_GAS.get().cloned().unwrap_or(true)
+    } else {
+        true
+    }
+}

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -72,6 +72,7 @@ rand_core = { workspace = true }
 
 [features]
 default = []
+benchmark = ["aptos-gas-meter/benchmark"]
 fuzzing = ["move-core-types/fuzzing", "move-binary-format/fuzzing", "move-vm-types/fuzzing", "aptos-framework/fuzzing", "aptos-types/fuzzing"]
 failpoints = ["fail/failpoints", "move-vm-runtime/failpoints"]
 testing = ["move-unit-test", "aptos-framework/testing"]

--- a/aptos-move/aptos-vm/Cargo.toml
+++ b/aptos-move/aptos-vm/Cargo.toml
@@ -72,7 +72,7 @@ rand_core = { workspace = true }
 
 [features]
 default = []
-benchmark = ["aptos-gas-meter/benchmark"]
+bench = ["aptos-gas-meter/bench"]
 fuzzing = ["move-core-types/fuzzing", "move-binary-format/fuzzing", "move-vm-types/fuzzing", "aptos-framework/fuzzing", "aptos-types/fuzzing"]
 failpoints = ["fail/failpoints", "move-vm-runtime/failpoints"]
 testing = ["move-unit-test", "aptos-framework/testing"]

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2296,6 +2296,10 @@ impl AptosVM {
         if cfg!(feature = "benchmark") && !is_gas_metering_enabled() {
             let txn_metadata = TransactionMetadata::new(txn);
             let is_approved_gov_script = is_approved_gov_script(resolver, txn, &txn_metadata);
+            let vm_params = &self
+                .gas_params(log_context)
+                .expect("Gas parameters must exist when benchmarking")
+                .vm;
             self.execute_user_transaction_impl(
                 resolver,
                 code_storage,
@@ -2303,7 +2307,7 @@ impl AptosVM {
                 txn_metadata,
                 is_approved_gov_script,
                 log_context,
-                &mut AptosUnmeteredGasMeter::new(),
+                &mut AptosUnmeteredGasMeter::new(vm_params, txn.max_gas_amount()),
             )
         } else {
             match self.execute_user_transaction_with_custom_gas_meter(

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2293,7 +2293,7 @@ impl AptosVM {
         txn: &SignedTransaction,
         log_context: &AdapterLogSchema,
     ) -> (VMStatus, VMOutput) {
-        if cfg!(feature = "benchmark") && !is_gas_metering_enabled() {
+        if cfg!(feature = "bench") && !is_gas_metering_enabled() {
             let txn_metadata = TransactionMetadata::new(txn);
             let is_approved_gov_script = is_approved_gov_script(resolver, txn, &txn_metadata);
             let vm_params = &self

--- a/aptos-move/replay-benchmark/Cargo.toml
+++ b/aptos-move/replay-benchmark/Cargo.toml
@@ -16,14 +16,14 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-block-executor = { workspace = true }
 aptos-framework = { workspace = true }
-aptos-gas-meter = { workspace = true, features = ["benchmark"] }
+aptos-gas-meter = { workspace = true, features = ["bench"] }
 aptos-gas-schedule = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-move-debugger = { workspace = true }
 aptos-push-metrics = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-types = { workspace = true }
-aptos-vm = { workspace = true, features = ["benchmark"] }
+aptos-vm = { workspace = true, features = ["bench"] }
 aptos-vm-environment = { workspace = true }
 bcs = { workspace = true }
 claims = { workspace = true }

--- a/aptos-move/replay-benchmark/Cargo.toml
+++ b/aptos-move/replay-benchmark/Cargo.toml
@@ -16,13 +16,14 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-block-executor = { workspace = true }
 aptos-framework = { workspace = true }
+aptos-gas-meter = { workspace = true, features = ["benchmark"] }
 aptos-gas-schedule = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-move-debugger = { workspace = true }
 aptos-push-metrics = { workspace = true }
 aptos-rest-client = { workspace = true }
 aptos-types = { workspace = true }
-aptos-vm = { workspace = true }
+aptos-vm = { workspace = true, features = ["benchmark"] }
 aptos-vm-environment = { workspace = true }
 bcs = { workspace = true }
 claims = { workspace = true }

--- a/aptos-move/replay-benchmark/README.md
+++ b/aptos-move/replay-benchmark/README.md
@@ -74,6 +74,11 @@ It is possible to increase your quota by creating an API key in Aptos Build. In 
 follow instructions here: https://developers.aptoslabs.com/docs/api-access/api-keys. Then, when
 using the tool the key can be specified using `--api-key K` flag.
 
+Finally, users of the tool can pass `--assert-no-out-of-gas` flag to the initialization command.
+It ensures that the range of transactions that are benchmarked do not run out of gas. This is
+particularly useful when benchmarking transactions with gas metering disabled: if historical
+transaction ran out of gas, not metering it changes the execution behavior.
+
 #### Example
 
 ```shell
@@ -216,7 +221,8 @@ for the first few blocks. By specifying `--num-block-to-skip N`, the tool will i
 for the first `N` blocks (the blocks will still be executed as a "warm-up").
 
 Execution can also be configured. By using `--disable-paranoid-mode`, the Move VM will not use
-runtime type checks, possible making execution faster.
+runtime type checks, possibly making execution faster. By using `--disable-gas-metering` flag,
+execution will run with a no-op gas meter.
 
 #### Example
 

--- a/aptos-move/replay-benchmark/src/commands/benchmark.rs
+++ b/aptos-move/replay-benchmark/src/commands/benchmark.rs
@@ -8,6 +8,7 @@ use crate::{
     workload::TransactionBlock,
 };
 use anyhow::{anyhow, bail};
+use aptos_gas_meter::enable_gas_metering;
 use aptos_logger::Level;
 use aptos_vm_environment::prod_configs::set_paranoid_type_checks;
 use clap::Parser;
@@ -69,6 +70,13 @@ pub struct BenchmarkCommand {
         help = "If false, Move VM runs in paranoid mode, if true, paranoid mode is not used"
     )]
     disable_paranoid_mode: bool,
+
+    #[clap(
+        long,
+        default_value_t = false,
+        help = "If true, a no-op gas meter will be used for execution"
+    )]
+    disable_gas_metering: bool,
 }
 
 impl BenchmarkCommand {
@@ -118,6 +126,8 @@ impl BenchmarkCommand {
             .collect::<Vec<_>>();
 
         set_paranoid_type_checks(!self.disable_paranoid_mode);
+        enable_gas_metering(!self.disable_gas_metering);
+
         BenchmarkRunner::new(
             self.concurrency_levels,
             self.num_repeats,

--- a/aptos-move/replay-benchmark/src/commands/initialize.rs
+++ b/aptos-move/replay-benchmark/src/commands/initialize.rs
@@ -62,6 +62,13 @@ pub struct InitializeCommand {
         help = "List of space-separated paths to compiled / built packages with Move code"
     )]
     override_packages: Vec<String>,
+
+    #[clap(
+        long,
+        default_value_t = false,
+        help = "If true, checks if any transaction runs out of gas and if so, returns an error"
+    )]
+    assert_no_out_of_gas: bool,
 }
 
 impl InitializeCommand {
@@ -89,8 +96,13 @@ impl InitializeCommand {
         )?;
 
         let debugger = build_debugger(self.rest_api.rest_endpoint, self.rest_api.api_key)?;
-        let inputs =
-            InputOutputDiffGenerator::generate(debugger, override_config, txn_blocks).await?;
+        let inputs = InputOutputDiffGenerator::generate(
+            debugger,
+            override_config,
+            txn_blocks,
+            self.assert_no_out_of_gas,
+        )
+        .await?;
 
         let bytes = bcs::to_bytes(&inputs).map_err(|err| {
             anyhow!(

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -979,6 +979,10 @@ impl ExecutionStatus {
         matches!(self, ExecutionStatus::Success)
     }
 
+    pub fn is_out_of_gas(&self) -> bool {
+        matches!(self, ExecutionStatus::OutOfGas)
+    }
+
     pub fn aug_with_aux_data(self, aux_data: &TransactionAuxiliaryData) -> Self {
         if let Some(aux_error) = aux_data.get_detail_error_message() {
             if let ExecutionStatus::MiscellaneousError(status_code) = self {


### PR DESCRIPTION
## Description

- Added `UnmeteredGasAlgebra` and `AptosUnmeteredGasMeter`. We have `UnmeteredGasMeter` defined in Move repository, but that one has no access to algebra, so using this seems better.
- Added conditional flag to enable/disable gas metering. This is protected by a cargo feature (`"benchmark"`) + defaults to true, so there should be no overhead or danger for prod builds, and benchmarking should be representative enough.
- Finally, added an option to disable gas metering for replay benchmarking. This should help us understand performance better for historical workloads.

## How Has This Been Tested?

Manual

## Key Areas to Review

Checked unmetered meter is not used in prod.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
- [x] Developer Infrastructure

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
