### PR TITLE
[Fullnode Sync] Fix the fullnode sync job ulimit check.

### DIFF
--- a/.github/actions/fullnode-sync/fullnode_sync.py
+++ b/.github/actions/fullnode-sync/fullnode_sync.py
@@ -250,6 +250,9 @@ def setup_fullnode_config(bootstrapping_mode, continuous_syncing_mode, data_dir_
   data_streaming_service_config = {"max_concurrent_requests": 10, "max_concurrent_state_requests": 12}
   fullnode_config['state_sync'] = {"state_sync_driver": state_sync_driver_config, "data_streaming_service":data_streaming_service_config}
 
+  # Avoid having to set ulimit configurations
+  fullnode_config['storage'] = {"ensure_rlimit_nofile": 0}
+
   # Write the config file back to disk
   with open(FULLNODE_CONFIG_NAME, "w") as file:
     yaml.dump(fullnode_config, file)


### PR DESCRIPTION
## Description
This PR adds a storage config to the fullnode sync jobs to avoid checking for ulimits. This check was recently introduced by https://github.com/aptos-labs/aptos-core/pull/15875, but it's not a hard requirement for our tests. Right now the tests are failing with:

```
Identified node type (PublicFullnode) and chain ID (Some(mainnet)) from node config!
thread 'main' panicked at aptos-node/src/utils.rs:121:17:
Failed raising RLIMIT_NOFILE soft limit to 100000. Error: Operation not permitted (os error 1)
```

## Testing Plan
Existing test infratructure.
