### PR TITLE
[exec-pool] Add allow dead code for IncomingRpcRequest and ExecuteBlock

### DIFF
--- a/consensus/src/execution_pipeline.rs
+++ b/consensus/src/execution_pipeline.rs
@@ -401,6 +401,7 @@ struct ExecuteBlockCommand {
     result_tx: oneshot::Sender<ExecutorResult<PipelineExecutionResult>>,
     command_creation_time: Instant,
     lifetime_guard: CountedRequest<()>,
+    #[allow(dead_code)]
     shuffler: Arc<dyn TransactionShuffler>,
 }
 

--- a/consensus/src/network.rs
+++ b/consensus/src/network.rs
@@ -155,6 +155,7 @@ pub enum IncomingRpcRequest {
     DAGRequest(IncomingDAGRequest),
     CommitRequest(IncomingCommitRequest),
     RandGenRequest(IncomingRandGenRequest),
+    #[allow(dead_code)]
     BlockRetrieval(IncomingBlockRetrievalRequest),
 }
 


### PR DESCRIPTION
## Description

Temporarily adding `#[allow(dead_code)]` for fields and variants that are not being consumed yet. The code on `main` passes as-is on `scripts/rust-lint.sh`, this is just to remove some warnings.

For context, we’re deprecating the `BlockRetrievalRequest` struct in favor of an enum. And it needs to be phased over two releases. The `BlockRetrieval` variant here in the `IncomingRpcRequest` enum consumes this new `BlockRetrievalRequest` enum and isn’t being constructed yet (that’s why you’re seeing that message). The shuffler field is going to be used soon in https://github.com/aptos-labs/aptos-core/pull/14584/files.