### PR TITLE
build indexer grpc-v2 binaries

### DIFF
--- a/docker/builder/build-indexer.sh
+++ b/docker/builder/build-indexer.sh
@@ -17,6 +17,8 @@ cargo build --locked --profile=$PROFILE \
     -p aptos-indexer-grpc-data-service \
     -p aptos-nft-metadata-crawler \
     -p aptos-indexer-grpc-file-checker \
+    -p aptos-indexer-grpc-data-service-v2 \
+    -p aptos-indexer-grpc-manager \
     "$@"
 
 # After building, copy the binaries we need to `dist` since the `target` directory is used as docker cache mount and only available during the RUN step
@@ -26,6 +28,8 @@ BINS=(
     aptos-indexer-grpc-data-service
     aptos-nft-metadata-crawler
     aptos-indexer-grpc-file-checker
+    aptos-indexer-grpc-data-service-v2
+    aptos-indexer-grpc-manager
 )
 
 mkdir dist

--- a/docker/builder/indexer-grpc.Dockerfile
+++ b/docker/builder/indexer-grpc.Dockerfile
@@ -6,6 +6,8 @@ COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-cache-worker /
 COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-file-store /usr/local/bin/aptos-indexer-grpc-file-store
 COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-data-service /usr/local/bin/aptos-indexer-grpc-data-service
 COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-file-checker /usr/local/bin/aptos-indexer-grpc-file-checker
+COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-data-service-v2 /usr/local/bin/aptos-indexer-grpc-data-service-v2
+COPY --link --from=indexer-builder /aptos/dist/aptos-indexer-grpc-manager /usr/local/bin/aptos-indexer-grpc-manager
 
 # The health check port
 EXPOSE 8080


### PR DESCRIPTION
## Description
Added support for two new indexer binaries: `aptos-indexer-grpc-data-service-v2` and `aptos-indexer-grpc-manager` to the build and Docker configuration. These binaries are now included in both the build process and the final Docker image.

## How Has This Been Tested?
- Verified successful build of new binaries through Docker build process
- Confirmed proper binary placement in Docker image
- Validated Docker image functionality with new components

## Key Areas to Review
- Build script modifications to include new binaries
- Docker file updates for proper binary copying
- Binary naming consistency across build and Docker configurations

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation