### PR TITLE
[refactoring] Make Aptos VM stateless, associate with outer lifetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3625,6 +3625,7 @@ name = "aptos-resource-viewer"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "aptos-framework",
  "aptos-types",
  "aptos-vm",
  "aptos-vm-environment",
@@ -4614,6 +4615,8 @@ dependencies = [
  "aptos-table-natives",
  "aptos-types",
  "aptos-vm-types",
+ "ark-bn254",
+ "ark-groth16",
  "bcs 0.1.4",
  "move-binary-format",
  "move-bytecode-verifier",

--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -129,7 +129,7 @@ impl AptosDebugger {
         }
 
         let env = AptosEnvironment::new(&state_view);
-        let vm = AptosVM::new(&env, &state_view);
+        let vm = AptosVM::new(&env);
         let resolver = state_view.as_move_resolver();
         let code_storage = state_view.as_aptos_code_storage(&env);
 

--- a/aptos-move/aptos-release-builder/src/simulate.rs
+++ b/aptos-move/aptos-release-builder/src/simulate.rs
@@ -458,7 +458,7 @@ fn add_script_execution_hash(
  **************************************************************************************************/
 fn force_end_epoch(state_view: &SimulationStateView<impl StateView>) -> Result<()> {
     let env = AptosEnvironment::new_with_injected_create_signer_for_gov_sim(&state_view);
-    let vm = AptosVM::new(&env, &state_view);
+    let vm = AptosVM::new(&env);
     let resolver = state_view.as_move_resolver();
     let module_storage = state_view.as_aptos_code_storage(&env);
 
@@ -612,7 +612,7 @@ pub async fn simulate_multistep_proposal(
 
         // Create a new VM to ensure the loader is clean.
         let env = AptosEnvironment::new_with_injected_create_signer_for_gov_sim(&state_view);
-        let vm = AptosVM::new(&env, &state_view);
+        let vm = AptosVM::new(&env);
         let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
         let resolver = state_view.as_move_resolver();

--- a/aptos-move/aptos-resource-viewer/Cargo.toml
+++ b/aptos-move/aptos-resource-viewer/Cargo.toml
@@ -14,6 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
+aptos-framework = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 aptos-vm-environment = { workspace = true }

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -9,8 +9,8 @@
 pub mod module_view;
 
 use crate::module_view::ModuleView;
+use aptos_framework::get_resource_group_member_from_metadata;
 use aptos_types::state_store::StateView;
-use aptos_vm::data_cache::get_resource_group_member_from_metadata;
 use move_binary_format::CompiledModule;
 use move_core_types::{
     identifier::{IdentStr, Identifier},

--- a/aptos-move/aptos-vm-environment/Cargo.toml
+++ b/aptos-move/aptos-vm-environment/Cargo.toml
@@ -21,6 +21,8 @@ aptos-native-interface = { workspace = true }
 aptos-table-natives = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm-types = { workspace = true }
+ark-bn254 = { workspace = true }
+ark-groth16 = { workspace = true }
 bcs = { workspace = true }
 move-binary-format = { workspace = true }
 move-bytecode-verifier = { workspace = true }

--- a/aptos-move/aptos-vm/src/data_cache.rs
+++ b/aptos-move/aptos-vm/src/data_cache.rs
@@ -12,6 +12,7 @@ use aptos_aggregator::{
     resolver::{TAggregatorV1View, TDelayedFieldView},
     types::{DelayedFieldValue, DelayedFieldsSpeculativeError},
 };
+use aptos_framework::get_resource_group_member_from_metadata;
 use aptos_table_natives::{TableHandle, TableResolver};
 use aptos_types::{
     error::{PanicError, PanicOr},
@@ -50,18 +51,6 @@ use std::{
     collections::{BTreeMap, HashMap, HashSet},
     sync::Arc,
 };
-
-pub fn get_resource_group_member_from_metadata(
-    struct_tag: &StructTag,
-    metadata: &[Metadata],
-) -> Option<StructTag> {
-    let metadata = aptos_framework::get_metadata(metadata)?;
-    metadata
-        .struct_attributes
-        .get(struct_tag.name.as_ident_str().as_str())?
-        .iter()
-        .find_map(|attr| attr.get_resource_group_member())
-}
 
 /// Adapter to convert a `ExecutorView` into a `AptosMoveResolver`.
 ///

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -1,21 +1,21 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    data_cache::get_resource_group_member_from_metadata,
-    move_vm_ext::{
-        resource_state_key, write_op_converter::WriteOpConverter, AptosMoveResolver, SessionId,
-    },
+use crate::move_vm_ext::{
+    resource_state_key, write_op_converter::WriteOpConverter, AptosMoveResolver, SessionId,
 };
-use aptos_framework::natives::{
-    aggregator_natives::{AggregatorChangeSet, AggregatorChangeV1, NativeAggregatorContext},
-    code::{NativeCodeContext, PublishRequest},
-    cryptography::{algebra::AlgebraContext, ristretto255_point::NativeRistrettoPointContext},
-    event::NativeEventContext,
-    object::NativeObjectContext,
-    randomness::RandomnessContext,
-    state_storage::NativeStateStorageContext,
-    transaction_context::NativeTransactionContext,
+use aptos_framework::{
+    get_resource_group_member_from_metadata,
+    natives::{
+        aggregator_natives::{AggregatorChangeSet, AggregatorChangeV1, NativeAggregatorContext},
+        code::{NativeCodeContext, PublishRequest},
+        cryptography::{algebra::AlgebraContext, ristretto255_point::NativeRistrettoPointContext},
+        event::NativeEventContext,
+        object::NativeObjectContext,
+        randomness::RandomnessContext,
+        state_storage::NativeStateStorageContext,
+        transaction_context::NativeTransactionContext,
+    },
 };
 use aptos_table_natives::{NativeTableContext, TableChangeSet};
 use aptos_types::{

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -109,17 +109,17 @@ impl GenesisMoveVM {
     }
 }
 
-pub struct MoveVmExt {
+pub struct MoveVmExt<'env> {
     inner: MoveVM,
-    pub(crate) env: AptosEnvironment,
+    pub(crate) environment: &'env AptosEnvironment,
 }
 
-impl MoveVmExt {
-    pub fn new(env: &AptosEnvironment) -> Self {
-        let vm = MoveVM::new_with_runtime_environment(env.runtime_environment());
+impl<'env> MoveVmExt<'env> {
+    pub fn new(environment: &'env AptosEnvironment) -> Self {
+        let vm = MoveVM::new_with_runtime_environment(environment.runtime_environment());
         Self {
             inner: vm,
-            env: env.clone(),
+            environment,
         }
     }
 
@@ -132,15 +132,15 @@ impl MoveVmExt {
         SessionExt::new(
             session_id,
             &self.inner,
-            self.env.chain_id(),
-            self.env.features(),
+            self.environment.chain_id(),
+            self.environment.features(),
             maybe_user_transaction_context,
             resolver,
         )
     }
 }
 
-impl Deref for MoveVmExt {
+impl<'env> Deref for MoveVmExt<'env> {
     type Target = MoveVM;
 
     fn deref(&self) -> &Self::Target {

--- a/aptos-move/aptos-vm/src/testing.rs
+++ b/aptos-move/aptos-vm/src/testing.rs
@@ -68,7 +68,7 @@ pub mod testing_only {
     }
 }
 
-impl AptosVM {
+impl<'env> AptosVM<'env> {
     #[cfg(any(test, feature = "testing"))]
     pub fn test_failed_transaction_cleanup(
         &self,

--- a/aptos-move/aptos-vm/src/validator_txns/dkg.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/dkg.rs
@@ -48,7 +48,7 @@ enum ExecutionFailure {
     Unexpected(VMStatus),
 }
 
-impl AptosVM {
+impl<'env> AptosVM<'env> {
     pub(crate) fn process_dkg_result(
         &self,
         resolver: &impl AptosMoveResolver,

--- a/aptos-move/aptos-vm/src/validator_txns/jwk.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/jwk.rs
@@ -54,7 +54,7 @@ enum ExecutionFailure {
     Unexpected(VMStatus),
 }
 
-impl AptosVM {
+impl<'env> AptosVM<'env> {
     pub(crate) fn process_jwk_update(
         &self,
         resolver: &impl AptosMoveResolver,

--- a/aptos-move/aptos-vm/src/validator_txns/mod.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/mod.rs
@@ -12,7 +12,7 @@ use aptos_vm_types::{
 };
 use move_core_types::vm_status::VMStatus;
 
-impl AptosVM {
+impl<'env> AptosVM<'env> {
     pub(crate) fn process_validator_transaction(
         &self,
         resolver: &impl AptosMoveResolver,

--- a/aptos-move/block-executor/src/proptest_types/types.rs
+++ b/aptos-move/block-executor/src/proptest_types/types.rs
@@ -830,14 +830,6 @@ pub(crate) struct MockTask<K, E> {
     phantom_data: PhantomData<(K, E)>,
 }
 
-impl<K, E> MockTask<K, E> {
-    pub fn new() -> Self {
-        Self {
-            phantom_data: PhantomData,
-        }
-    }
-}
-
 impl<K, E> ExecutorTask for MockTask<K, E>
 where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
@@ -847,12 +839,8 @@ where
     type Output = MockOutput<K, E>;
     type Txn = MockTransaction<K, E>;
 
-    fn init(_environment: &AptosEnvironment, _state_view: &impl TStateView<Key = K>) -> Self {
-        Self::new()
-    }
-
     fn execute_transaction(
-        &self,
+        _environment: &AptosEnvironment,
         view: &(impl TExecutorView<K, u32, MoveTypeLayout, ValueType>
               + TResourceGroupView<GroupKey = K, ResourceTag = u32, Layout = MoveTypeLayout>
               + AptosCodeStorage

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -8,11 +8,8 @@ use aptos_aggregator::{
 };
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    error::PanicError,
-    fee_statement::FeeStatement,
-    state_store::{state_value::StateValueMetadata, TStateView},
-    transaction::BlockExecutableTransaction as Transaction,
-    write_set::WriteOp,
+    error::PanicError, fee_statement::FeeStatement, state_store::state_value::StateValueMetadata,
+    transaction::BlockExecutableTransaction as Transaction, write_set::WriteOp,
 };
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_types::{
@@ -67,15 +64,9 @@ pub trait ExecutorTask: Sync {
     /// Type of error when the executor failed to process a transaction and needs to abort.
     type Error: Debug + Clone + Send + Sync + Eq + 'static;
 
-    /// Create an instance of the transaction executor.
-    fn init(
-        environment: &AptosEnvironment,
-        state_view: &impl TStateView<Key = <Self::Txn as Transaction>::Key>,
-    ) -> Self;
-
     /// Execute a single transaction given the view of the current state.
     fn execute_transaction(
-        &self,
+        environment: &AptosEnvironment,
         view: &(impl TExecutorView<
             <Self::Txn as Transaction>::Key,
             <Self::Txn as Transaction>::Tag,

--- a/aptos-move/e2e-move-tests/src/tests/vm.rs
+++ b/aptos-move/e2e-move-tests/src/tests/vm.rs
@@ -30,7 +30,7 @@ fn failed_transaction_cleanup_charges_gas(status_code: StatusCode) {
 
     let state_view = h.executor.get_state_view();
     let env = AptosEnvironment::new(&state_view);
-    let vm = AptosVM::new(&env, state_view);
+    let vm = AptosVM::new(&env);
 
     let balance = 10_000;
     let output = vm

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -824,7 +824,7 @@ impl FakeExecutor {
 
         // TODO(Gas): revisit this.
         let env = AptosEnvironment::new(&self.data_store);
-        let vm = AptosVM::new(&env, self.get_state_view());
+        let vm = AptosVM::new(&env);
 
         let resolver = self.data_store.as_move_resolver();
         let code_storage = self.get_state_view().as_aptos_code_storage(&env);
@@ -897,7 +897,7 @@ impl FakeExecutor {
     /// Validates the given transaction by running it through the VM validator.
     pub fn validate_transaction(&self, txn: SignedTransaction) -> VMValidatorResult {
         let env = AptosEnvironment::new(&self.data_store);
-        let vm = AptosVM::new(&env, self.get_state_view());
+        let vm = AptosVM::new(&env);
         vm.validate_transaction(
             txn,
             &self.data_store,

--- a/aptos-move/framework/src/module_metadata.rs
+++ b/aptos-move/framework/src/module_metadata.rs
@@ -188,6 +188,18 @@ thread_local! {
     static V0_METADATA_CACHE: RefCell<LruCache<Vec<u8>, Option<Arc<RuntimeModuleMetadataV1>>>> = RefCell::new(LruCache::new(METADATA_CACHE_SIZE));
 }
 
+pub fn get_resource_group_member_from_metadata(
+    struct_tag: &StructTag,
+    metadata: &[Metadata],
+) -> Option<StructTag> {
+    let metadata = get_metadata(metadata)?;
+    metadata
+        .struct_attributes
+        .get(struct_tag.name.as_ident_str().as_str())?
+        .iter()
+        .find_map(|attr| attr.get_resource_group_member())
+}
+
 /// Extract metadata from the VM, upgrading V0 to V1 representation as needed
 pub fn get_metadata(md: &[Metadata]) -> Option<Arc<RuntimeModuleMetadataV1>> {
     if let Some(data) = md.iter().find(|md| md.key == APTOS_METADATA_KEY_V1) {

--- a/crates/aptos/src/common/local_simulation.rs
+++ b/crates/aptos/src/common/local_simulation.rs
@@ -23,7 +23,7 @@ pub fn run_transaction_using_debugger(
 ) -> CliTypedResult<(VMStatus, VMOutput)> {
     let state_view = debugger.state_view_at_version(version);
     let env = AptosEnvironment::new(&state_view);
-    let vm = AptosVM::new(&env, &state_view);
+    let vm = AptosVM::new(&env);
     let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
     let resolver = state_view.as_move_resolver();
@@ -43,7 +43,7 @@ pub fn benchmark_transaction_using_debugger(
 ) -> CliTypedResult<(VMStatus, VMOutput)> {
     let state_view = debugger.state_view_at_version(version);
     let env = AptosEnvironment::new(&state_view);
-    let vm = AptosVM::new(&env, &state_view);
+    let vm = AptosVM::new(&env);
     let log_context = AdapterLogSchema::new(state_view.id(), 0);
 
     let resolver = state_view.as_move_resolver();
@@ -58,7 +58,7 @@ pub fn benchmark_transaction_using_debugger(
         for _i in 0..n {
             // Create a new VM each time so to include code loading as part of the
             // total running time.
-            let vm = AptosVM::new(&env, &state_view);
+            let vm = AptosVM::new(&env);
             let code_storage = state_view.as_aptos_code_storage(&env);
             let log_context = AdapterLogSchema::new(state_view.id(), 0);
 

--- a/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
+++ b/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
@@ -42,7 +42,7 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
         // let features = Features::fetch_config(&state_view).unwrap_or_default();
 
         let env = AptosEnvironment::new(state_view);
-        let vm = AptosVM::new(&env, state_view);
+        let vm = AptosVM::new(&env);
 
         let transaction_outputs = NATIVE_EXECUTOR_POOL.install(|| {
             txn_provider

--- a/experimental/execution/ptx-executor/src/runner.rs
+++ b/experimental/execution/ptx-executor/src/runner.rs
@@ -234,11 +234,10 @@ impl<'scope, 'view: 'scope, BaseView: StateView + Sync> Worker<'view, BaseView> 
         let idx = format!("{}", self.worker_index);
         let _timer = PER_WORKER_TIMER.timer_with(&[&idx, "block_total"]);
         // Share a VM in the same thread.
-        // TODO(ptx): maybe warm up vm like done in AptosExecutorTask
         let env = AptosEnvironment::new(&self.base_view);
         let vm = {
             let _timer = PER_WORKER_TIMER.timer_with(&[&idx, "vm_init"]);
-            AptosVM::new(&env, &self.base_view)
+            AptosVM::new(&env)
         };
 
         loop {

--- a/vm-validator/src/mocks/mock_vm_validator.rs
+++ b/vm-validator/src/mocks/mock_vm_validator.rs
@@ -6,12 +6,9 @@ use crate::vm_validator::TransactionValidation;
 use anyhow::Result;
 use aptos_types::{
     account_address::AccountAddress,
-    state_store::StateView,
     transaction::{SignedTransaction, VMValidatorResult},
     vm_status::StatusCode,
 };
-use aptos_vm::VMValidator;
-use move_vm_runtime::ModuleStorage;
 
 pub const ACCOUNT_DNE_TEST_ADD: AccountAddress =
     AccountAddress::new([0_u8; AccountAddress::LENGTH]);
@@ -31,20 +28,7 @@ pub const INVALID_AUTH_KEY_TEST_ADD: AccountAddress =
 #[derive(Clone)]
 pub struct MockVMValidator;
 
-impl VMValidator for MockVMValidator {
-    fn validate_transaction(
-        &self,
-        _transaction: SignedTransaction,
-        _state_view: &impl StateView,
-        _module_storage: &impl ModuleStorage,
-    ) -> VMValidatorResult {
-        VMValidatorResult::new(None, 0)
-    }
-}
-
 impl TransactionValidation for MockVMValidator {
-    type ValidationInstance = MockVMValidator;
-
     fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
         let txn = match txn.check_signature() {
             Ok(txn) => txn,

--- a/vm-validator/src/vm_validator.rs
+++ b/vm-validator/src/vm_validator.rs
@@ -40,8 +40,6 @@ use std::sync::{Arc, Mutex};
 mod vm_validator_test;
 
 pub trait TransactionValidation: Send + Sync + Clone {
-    type ValidationInstance: aptos_vm::VMValidator;
-
     /// Validate a txn from client
     fn validate_transaction(&self, _txn: SignedTransaction) -> Result<VMValidatorResult>;
 
@@ -313,8 +311,6 @@ impl PooledVMValidator {
 }
 
 impl TransactionValidation for PooledVMValidator {
-    type ValidationInstance = AptosVM;
-
     fn validate_transaction(&self, txn: SignedTransaction) -> Result<VMValidatorResult> {
         let vm_validator = self.get_next_vm();
 
@@ -327,10 +323,7 @@ impl TransactionValidation for PooledVMValidator {
         let vm_validator_locked = vm_validator.lock().unwrap();
 
         use aptos_vm::VMValidator;
-        let vm = AptosVM::new(
-            &vm_validator_locked.state.environment,
-            &vm_validator_locked.state.state_view,
-        );
+        let vm = AptosVM::new(&vm_validator_locked.state.environment);
         Ok(vm.validate_transaction(
             txn,
             &vm_validator_locked.state.state_view,


### PR DESCRIPTION
## Description

This PR moves PVK (used by keyless) to environment, making `AptosVM` completely stateless. This means that `ExecutorTask` can also be stateless, and one can simply call `execute_transaction(&environment, ...)` passing the outer environment to create a thin VM wrapper around that captures the reference.

I think this should also improve startup times because right now each thread loads transitive closure of `0x1::keyless_account` iiuc.

TODO: 
1. Double-check PVK is not reset every block and is the same for around an epoch.
2. Add tests for PVK fetching.

Note 1:`MoveVM` can also be made stateless, but this can be part of other PR (TBD).
Note 2: This hurts performance if V1 loader is used (no global caching) but we are switching to V2 anyway.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
