### PR TITLE
[move-vm][closures] New reentrancy checker

### DIFF
--- a/aptos-move/e2e-benchmark/data/calibration_values.tsv
+++ b/aptos-move/e2e-benchmark/data/calibration_values.tsv
@@ -16,7 +16,7 @@ ResourceGroupsSenderWriteTag { string_length: 1024 }	10	0.922	1.031	21.9
 ResourceGroupsSenderMultiChange { string_length: 1024 }	10	0.968	1.071	38.9
 TokenV1MintAndTransferFT	10	0.972	1.059	646.3
 TokenV1MintAndTransferNFTSequential	10	0.934	1.027	968.7
-TokenV2AmbassadorMint { numbered: true }	10	0.915	1.042	675.1
+TokenV2AmbassadorMint { numbered: true }	10	0.915	1.042	735.1
 LiquidityPoolSwap { is_stable: true }	10	0.925	1.009	912.4
 LiquidityPoolSwap { is_stable: false }	10	0.965	1.037	837.8
 CoinInitAndMint	10	0.944	1.037	319.6

--- a/testsuite/single_node_performance_values.tsv
+++ b/testsuite/single_node_performance_values.tsv
@@ -11,7 +11,7 @@ publish-package	1	VM	59	0.873	1.014	1132.4
 mix_publish_transfer	1	VM	59	0.895	1.028	17569.3
 batch100-transfer	1	VM	59	0.850	1.057	626.5
 batch100-transfer	1	NativeVM	59	0.816	1.170	1442.7
-vector-picture30k	1	VM	59	0.904	1.039	118.0
+vector-picture30k	1	VM	59	0.904	1.039	128.0
 vector-picture30k	100	VM	59	0.601	1.069	1834.8
 smart-table-picture30-k-with200-change	1	VM	59	0.897	1.046	17.2
 smart-table-picture30-k-with200-change	100	VM	59	0.877	1.141	237.6

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -1078,7 +1078,7 @@ impl<'env> ModuleContext<'env> {
                 if fun.is_inline() {
                     continue;
                 }
-                if let Some(callees) = fun.get_used_functions() {
+                if let Some(callees) = fun.get_called_functions() {
                     let mut usage = usage_map[&fun.get_id()].clone();
                     let count = usage.len();
                     // Extend usage by that of callees from the same module. Acquires is only

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -266,8 +266,8 @@ pub fn run_bytecode_gen(env: &GlobalEnv) -> FunctionTargetsHolder {
         let data = bytecode_generator::generate_bytecode(env, id);
         targets.insert_target_data(&id, FunctionVariant::Baseline, data);
         for callee in func_env
-            .get_called_functions()
-            .expect("called functions available")
+            .get_used_functions()
+            .expect("used functions available")
         {
             if !done.contains(callee) {
                 todo.insert(*callee);

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy.exp
@@ -1,0 +1,15 @@
+processed 5 tasks
+
+task 3 'run'. lines 45-45:
+return values: true
+
+task 4 'run'. lines 47-47:
+Error: Function execution failed with VMError: {
+    message: Resource `0x42::caller::R` cannot be accessed because of active reentrancy of defining module.,
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::caller,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("callee") }), FunctionDefinitionIndex(0), 2), (Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("caller") }), FunctionDefinitionIndex(1), 5)] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy.move
@@ -1,0 +1,47 @@
+//# publish
+module 0x42::callee {
+    public fun call_me<T>(x: &mut T, action: |&mut T|) {
+        action(x)
+    }
+}
+
+//# publish
+module 0x42::caller {
+    use 0x42::callee;
+    struct R has key, copy, drop {
+        count: u64
+    }
+
+    fun init(s: &signer) {
+        move_to(s, R{count: 0});
+    }
+
+    fun callback_ok(): bool acquires R {
+        let r = &mut R[@0x42];
+        // This callback is OK, because `R` is not acquired
+        callee::call_me(r, |x| do_something(x));
+        r.count += 1;
+        assert!(r.count == 2);
+        true
+    }
+
+    fun callback_fails(): bool acquires R {
+        let r = &mut R[@0x42];
+        // This callback will lead to reentrancy runtime error
+        callee::call_me(r, |_| R[@0x42].count += 1);
+        r.count += 1;
+        assert!(r.count == 2);
+        false
+    }
+
+    fun do_something(r: &mut R) {
+        r.count += 1
+    }
+}
+
+
+//# run 0x42::caller::init --signers 0x42
+
+//# run 0x42::caller::callback_ok
+
+//# run 0x42::caller::callback_fails --verbose

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_local.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_local.exp
@@ -1,0 +1,12 @@
+processed 3 tasks
+
+task 2 'run'. lines 20-20:
+Error: Function execution failed with VMError: {
+    message: Resource `0x42::tests::R` cannot be accessed because of active reentrancy of defining module.,
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::tests,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("tests") }), FunctionDefinitionIndex(1), 4)] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_local.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_local.move
@@ -1,0 +1,20 @@
+//# publish
+module 0x42::tests {
+    struct R(u64) has key;
+
+    public fun local_access_via_lambda_fails(): bool acquires R {
+        let add_one = || R[@0x42].0 += 1;
+        let r = &mut R[@0x42];
+        add_one();
+        r.0 += 1;
+        false
+    }
+
+    public fun init(s: &signer) {
+        move_to(s, R(0))
+    }
+}
+
+//# run 0x42::tests::init --signers 0x42
+
+//# run 0x42::tests::local_access_via_lambda_fails --verbose

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_nested.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_nested.exp
@@ -1,0 +1,37 @@
+processed 8 tasks
+
+task 4 'run'. lines 74-76:
+Error: Function execution failed with VMError: {
+    message: Resource `0x42::tests::R` cannot be accessed because of active reentrancy of defining module.,
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::tests,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("worker1") }), FunctionDefinitionIndex(2), 11), (Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("worker2") }), FunctionDefinitionIndex(2), 11), (Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("tests") }), FunctionDefinitionIndex(1), 1)] }),
+}
+
+task 5 'run'. lines 77-79:
+Error: Function execution failed with VMError: {
+    message: Resource `0x42::worker1::R` cannot be accessed because of active reentrancy of defining module.,
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::worker1,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("worker1") }), FunctionDefinitionIndex(2), 11), (Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("worker2") }), FunctionDefinitionIndex(2), 11), (Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("tests") }), FunctionDefinitionIndex(2), 2)] }),
+}
+
+task 6 'run'. lines 80-82:
+Error: Function execution failed with VMError: {
+    message: Resource `0x42::worker2::R` cannot be accessed because of active reentrancy of defining module.,
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::worker2,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("worker1") }), FunctionDefinitionIndex(2), 11), (Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("worker2") }), FunctionDefinitionIndex(2), 11), (Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("tests") }), FunctionDefinitionIndex(3), 2)] }),
+}
+
+task 7 'run'. lines 83-83:
+return values: true

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_nested.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_nested.move
@@ -1,0 +1,83 @@
+//# publish
+module 0x42::worker1 {
+    struct R(u64) has key;
+
+    public fun work(cont: ||) acquires R {
+        R[@0x42].0 += 1;
+        cont()
+    }
+
+    public fun set(x: u64) acquires R {
+        R[@0x42].0 = x
+    }
+
+    public fun init(s: &signer) {
+        move_to(s, R(0))
+    }
+}
+
+//# publish
+module 0x42::worker2 {
+    use 0x42::worker1;
+    struct R(u64) has key;
+
+    public fun work(cont: ||) acquires R {
+        R[@0x42].0 += 1;
+        worker1::work(cont)
+    }
+
+    public fun set(x: u64) acquires R {
+        R[@0x42].0 = x
+    }
+
+    public fun init(s: &signer) {
+        move_to(s, R(0))
+    }
+}
+
+//# publish
+module 0x42::tests {
+    use 0x42::worker1;
+    use 0x42::worker2;
+    struct R(u64) has key;
+
+    fun init(s: &signer) {
+        worker1::init(s);
+        worker2::init(s);
+        move_to(s, R(0));
+    }
+
+    fun direct_failure(): bool acquires R {
+        worker2::work(|| R[@042].0 += 1);
+        false
+    }
+
+    fun worker1_failure(): bool {
+        worker2::work(|| worker1::set(10));
+        false
+    }
+
+    fun worker2_failure(): bool {
+        worker2::work(|| worker2::set(10));
+        false
+    }
+
+    fun worker2_ok(): bool {
+        worker1::work(|| worker2::set(10));
+        true
+    }
+}
+
+//# run 0x42::tests::init --signers 0x42
+
+// task 4
+//# run 0x42::tests::direct_failure --verbose
+
+// task 5
+//# run 0x42::tests::worker1_failure --verbose
+
+// task 6
+//# run 0x42::tests::worker2_failure --verbose
+
+// task 7
+//# run 0x42::tests::worker2_ok

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -326,9 +326,8 @@ impl From<ModuleId> for (AccountAddress, Identifier) {
 
 static SCRIPT_MODULE_ID: Lazy<ModuleId> = Lazy::new(|| ModuleId {
     address: AccountAddress::from_str_strict(
-        // This value is sha256 of a source file in the Move compiler
-        // with ~5000 lines of code.
-        "0x37f3f7e2ef809b1739f0f9b78508ad47c5b861ba47a9ae1c2a9c93e81f8326f9",
+        // This is generated using sha256sum on 10k of bytes from /dev/urandom
+        "0x8bd18359a7ebb84407b6defa7bc5da9aca34a3d1ce764ddfb4d0adcc663430b4",
     )
     .expect("parsing of script address constant"),
     name: Identifier::new("__script__").expect("valid identifier for script"),

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -9,10 +9,12 @@ use crate::{
     parser::{parse_module_id, parse_struct_tag, parse_type_tag},
     safe_serialize,
 };
+use once_cell::sync::Lazy;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
 use std::{
+    borrow::ToOwned,
     fmt::{Display, Formatter},
     str::FromStr,
 };
@@ -320,6 +322,17 @@ impl From<ModuleId> for (AccountAddress, Identifier) {
     fn from(module_id: ModuleId) -> Self {
         (module_id.address, module_id.name)
     }
+}
+
+static SCRIPT_MODULE_ID: Lazy<ModuleId> = Lazy::new(|| ModuleId {
+    address: AccountAddress::ZERO,
+    name: Identifier::new("__script__").expect("valid identifier for script"),
+});
+
+/// Returns a pseudo module id which can be used for scripts and is distinct
+/// from regular module ids.
+pub fn pseudo_script_module_id() -> &'static ModuleId {
+    &SCRIPT_MODULE_ID
 }
 
 impl FromStr for ModuleId {

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -325,7 +325,12 @@ impl From<ModuleId> for (AccountAddress, Identifier) {
 }
 
 static SCRIPT_MODULE_ID: Lazy<ModuleId> = Lazy::new(|| ModuleId {
-    address: AccountAddress::ZERO,
+    address: AccountAddress::from_str_strict(
+        // This value is sha256 of a source file in the Move compiler
+        // with ~5000 lines of code.
+        "0x37f3f7e2ef809b1739f0f9b78508ad47c5b861ba47a9ae1c2a9c93e81f8326f9",
+    )
+    .expect("parsing of script address constant"),
     name: Identifier::new("__script__").expect("valid identifier for script"),
 });
 

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -31,6 +31,7 @@ mod debug;
 
 mod access_control;
 mod frame_type_cache;
+mod reentrancy_checker;
 mod runtime_type_checks;
 mod storage;
 

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -22,6 +22,7 @@ use move_core_types::{
     ability::{Ability, AbilitySet},
     function::ClosureMask,
     identifier::{IdentStr, Identifier},
+    language_storage,
     language_storage::{ModuleId, TypeTag},
     value::MoveTypeLayout,
     vm_status::StatusCode,
@@ -312,6 +313,14 @@ impl LoadedFunction {
         match &self.owner {
             LoadedFunctionOwner::Module(m) => Some(Module::self_id(m)),
             LoadedFunctionOwner::Script(_) => None,
+        }
+    }
+
+    /// Returns the module id or, if it is a script, the pseudo module id for scripts.
+    pub fn module_or_script_id(&self) -> &ModuleId {
+        match &self.owner {
+            LoadedFunctionOwner::Module(m) => Module::self_id(m),
+            LoadedFunctionOwner::Script(_) => language_storage::pseudo_script_module_id(),
         }
     }
 

--- a/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
+++ b/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
@@ -78,11 +78,12 @@ impl ReentrancyChecker {
                 },
             }
         } else if call_type == CallType::ClosureDynamicDispatch || caller_module.is_none() {
-            // If this is closure dispatch, or we have no caller module (i.e. top-level entry),
-            // count the intra-module call like an inter-module call -- as reentrance.
+            // If this is closure dispatch, or we have no caller module (i.e. top-level entry).
+            // Count the intra-module call like an inter-module call, as reentrance.
             // A static local call is governed by Move's `acquire` static semantics; however,
             // a dynamic dispatched local call has accesses not known at the caller side, so needs
-            // the runtime reentrancy check.
+            // the runtime reentrancy check. Note that this doesn't apply to NativeDynamicDispatch
+            // which already has a check in place preventing a dispatch into the same module.
             *self
                 .active_modules
                 .entry(callee_module.clone())

--- a/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
+++ b/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
@@ -1,0 +1,158 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements a reentrancy checker for dynamic dispatch. Two types of checks
+//! are implemented:
+//!
+//! (1) The resource lock mechanism for closure dispatch, as described in
+//!     [AIP-122](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-112.md).
+//!     In summary, for this mechanism access to any resource is disallowed on reentrancy.
+//! (2) The module lock mechanism for native dispatch as implemented for
+//!     [AIP-73](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-73.md).
+//!     For this mechanism reentrancy via any kind of function call is disallowed.
+//!     This entails (2), so every check failing for (1), also fails in (2). This
+//!     is by the property that resources can only be accessed inside the module
+//!     they are defined in.
+//!
+//! The checker by default operates in mode (1), but allows to enter code
+//! which operates in mode (2), which will override the more relaxed behavior of (1)
+//! until it is exited.
+
+use move_binary_format::errors::{PartialVMError, PartialVMResult};
+use move_core_types::{identifier::IdentStr, language_storage::ModuleId, vm_status::StatusCode};
+use move_vm_types::loaded_data::runtime_types::StructIdentifier;
+use std::collections::{btree_map::Entry, BTreeMap};
+
+/// The reentrancy checker's state
+#[derive(Default)]
+pub(crate) struct ReentrancyChecker {
+    /// A multiset (bag) of active modules. This is not a set because the same
+    /// module can be entered multiple times on closure dispatch.
+    active_modules: BTreeMap<ModuleId, usize>,
+    /// Whether we are in module lock mode. This happens if we enter a function via
+    /// `NativeDynamicDispatch`.
+    module_lock_count: usize,
+}
+
+/// Ways how functions are called
+#[derive(Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CallType {
+    /// Regular static function call
+    Regular,
+    /// Dynamic dispatch via the NativeDispatch feature.
+    NativeDynamicDispatch,
+    /// Dynamic dispatch via closure call.
+    ClosureDynamicDispatch,
+}
+
+impl ReentrancyChecker {
+    pub fn enter_function(
+        &mut self,
+        caller_module: Option<&ModuleId>,
+        callee_module: &ModuleId,
+        fun_name: &IdentStr,
+        call_type: CallType,
+    ) -> PartialVMResult<()> {
+        if call_type == CallType::NativeDynamicDispatch {
+            // If we enter a native dispatch function, also enter module locking mode
+            self.enter_module_lock()
+        }
+        if Some(callee_module) != caller_module {
+            // Cross module call.
+            // When module lock is active, and we have already called into this module, this
+            // reentry is disallowed
+            if self.module_lock_count > 0 && self.active_modules.contains_key(callee_module) {
+                return Err(
+                    PartialVMError::new(StatusCode::RUNTIME_DISPATCH_ERROR).with_message(format!(
+                        "Reentrancy disallowed: reentering `{}` via function `{}` \
+                     (module locking is active)",
+                        callee_module, fun_name
+                    )),
+                );
+            }
+            // Count the call.
+            *self
+                .active_modules
+                .entry(callee_module.clone())
+                .or_default() += 1;
+        } else if call_type == CallType::ClosureDynamicDispatch || caller_module.is_none() {
+            // If this is closure dispatch, or we have no caller module (i.e. top-level entry),
+            // count the call.
+            *self
+                .active_modules
+                .entry(callee_module.clone())
+                .or_default() += 1;
+        }
+        Ok(())
+    }
+
+    pub fn exit_function(
+        &mut self,
+        caller_module: &ModuleId,
+        callee_module: &ModuleId,
+        _fun_name: &IdentStr,
+        call_type: CallType,
+    ) -> PartialVMResult<()> {
+        if caller_module != callee_module || call_type == CallType::ClosureDynamicDispatch {
+            // If this is an exit from cross-module call, or exit from closure dispatch,
+            // decrement counter.
+            match self.active_modules.entry(callee_module.clone()) {
+                Entry::Occupied(mut e) => {
+                    let val = e.get_mut();
+                    if *val == 1 {
+                        e.remove_entry();
+                    } else {
+                        *val -= 1;
+                    }
+                },
+                Entry::Vacant(_) => {
+                    return Err(PartialVMError::new_invariant_violation(
+                        "Unbalanced reentrancy stack operation",
+                    ))
+                },
+            }
+        }
+        if call_type == CallType::NativeDynamicDispatch {
+            // If this is native dispatch, exit module lock.
+            self.exit_module_lock()?
+        }
+        Ok(())
+    }
+
+    pub fn enter_module_lock(&mut self) {
+        self.module_lock_count += 1
+    }
+
+    pub fn exit_module_lock(&mut self) -> PartialVMResult<()> {
+        if self.module_lock_count > 0 {
+            self.module_lock_count -= 1;
+            Ok(())
+        } else {
+            Err(PartialVMError::new_invariant_violation(
+                "Unbalanced module lock counter",
+            ))
+        }
+    }
+
+    pub fn check_resource_access(&self, struct_id: &StructIdentifier) -> PartialVMResult<()> {
+        if self
+            .active_modules
+            .get(&struct_id.module)
+            .copied()
+            .unwrap_or_default()
+            > 1
+        {
+            // If the count is greater one, we have reentered this module, and all
+            // resources it defines are locked.
+            Err(
+                PartialVMError::new(StatusCode::RUNTIME_DISPATCH_ERROR).with_message(format!(
+                    "Resource `{}` cannot be accessed because of active reentrancy of defining \
+                    module.",
+                    struct_id,
+                )),
+            )
+        } else {
+            Ok(())
+        }
+    }
+}


### PR DESCRIPTION
## Description

This implements a new reentrancy checker that supports both the rules of existing native dispatch (fungible assets et. al) as the ones for function value dispatch. The rules for the lattter are described in [AIP-112](https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-112.md#reentrancy-check), and are more liberal than for native dispatch: with funtion value dispatch, one can reenter a module, but resources defined in such a module are unaccessible. With native dispatch, reentrancy is already blocked when an attempt is made to enter a module the 2nd time.

The existing reentrancy check is pulled out from the interpreter into a new module `reentrancy_checker.rs` which handles both rule sets by processing when functions are entered/exited and whether by static call/dynamic dispatch.

There is no behavioral change, just a different implementation of a relative small logic (and now probably clearer than before), so no feature flag has been created for this.

This also fixes a few compiler bugs around lambdas and acquires check which were found during testing. Closes #15962

## How Has This Been Tested?

Existing tests for reentrancy are plenty and pass. The new logic is tested by a set of transactional tests.


## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)
