### PR TITLE
[compiler-v2] Fix enum match not exhaustive

### DIFF
--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_coverage_err.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/matching_coverage_err.exp
@@ -301,7 +301,6 @@ error: match not exhaustive
    │                ^^^^^^
    │
    = missing `(_,Inner::Inner1{..})`
-   = missing `(Inner::Inner2{..},_)`
 
 error: unreachable pattern
    ┌─ tests/bytecode-generator/matching_coverage_err.move:78:14

--- a/third_party/move/move-compiler-v2/tests/checking/dotdot/dotdot_valid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/dotdot/dotdot_valid.exp
@@ -468,11 +468,3 @@ error: match not exhaustive
     │                ^
     │
     = missing `E1::C{..}`
-
-error: match not exhaustive
-    ┌─ tests/checking/dotdot/dotdot_valid.move:153:16
-    │
-153 │         match (x) {
-    │                ^
-    │
-    = missing `E1::C{..}`

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/dotdot/nested.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/dotdot/nested.exp
@@ -1,58 +1,13 @@
 processed 5 tasks
 
-task 0 'publish'. lines 1-51:
-Error: compilation errors:
- error: match not exhaustive
-   ┌─ TEMPFILE:22:16
-   │
-22 │         match (x) {
-   │                ^
-   │
-   = missing `E::V1{..}`
-   = missing `E::V2{..}`
-
-
-
 task 1 'run'. lines 53-53:
-Error: Function execution failed with VMError: {
-    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test doesn't exist,
-    major_status: LINKER_ERROR,
-    sub_status: None,
-    location: undefined,
-    indices: [],
-    offsets: [],
-    exec_state: None,
-}
+return values: 42
 
 task 2 'run'. lines 55-55:
-Error: Function execution failed with VMError: {
-    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test doesn't exist,
-    major_status: LINKER_ERROR,
-    sub_status: None,
-    location: undefined,
-    indices: [],
-    offsets: [],
-    exec_state: None,
-}
+return values: 42
 
 task 3 'run'. lines 57-57:
-Error: Function execution failed with VMError: {
-    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test doesn't exist,
-    major_status: LINKER_ERROR,
-    sub_status: None,
-    location: undefined,
-    indices: [],
-    offsets: [],
-    exec_state: None,
-}
+return values: 43
 
 task 4 'run'. lines 59-59:
-Error: Function execution failed with VMError: {
-    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test doesn't exist,
-    major_status: LINKER_ERROR,
-    sub_status: None,
-    location: undefined,
-    indices: [],
-    offsets: [],
-    exec_state: None,
-}
+return values: 43

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/bug-14296.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/bug-14296.exp
@@ -1,13 +1,1 @@
 processed 1 task
-
-task 0 'publish'. lines 1-24:
-Error: compilation errors:
- error: match not exhaustive
-   ┌─ TEMPFILE:16:16
-   │
-16 │         match (y) {
-   │                ^
-   │
-   = missing `E::V1{..}`
-
-

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/match_cover.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/match_cover.exp
@@ -1,0 +1,23 @@
+processed 4 tasks
+
+task 3 'publish'. lines 147-197:
+Error: compilation errors:
+ error: unreachable pattern
+    ┌─ TEMPFILE3:168:13
+    │
+168 │             E::V1 {..} => {}
+    │             ^^^^^^^^^^
+
+error: unreachable pattern
+    ┌─ TEMPFILE3:178:13
+    │
+178 │             E::V1 {b: G::G2{ a: H::H2 {b: _}}, a: F::F1} => {},
+    │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: unreachable pattern
+    ┌─ TEMPFILE3:187:13
+    │
+187 │             E::V1 {..} => {}
+    │             ^^^^^^^^^^
+
+

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/match_cover.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/match_cover.move
@@ -1,0 +1,197 @@
+//# publish
+module 0xc0ffee::m {
+    enum A has drop {
+        V1 { a: Q, b: R},
+    }
+
+    enum Q has drop {
+        Q1,
+        Q2,
+    }
+
+    enum R has drop {
+        R1,
+        R2,
+    }
+
+    public fun test1(a: A) {
+        match (a) {
+            A::V1 { a: Q::Q1, b: _ } => {},
+            A::V1 { a: _, b: R::R1 } => {},
+            A::V1 {a: Q::Q2, b: R::R2} => {},
+        }
+    }
+
+    public fun test2(a: A) {
+        match (a) {
+            A::V1 { a: Q::Q1, b: _ } => {},
+            A::V1 { a: _, b: R::R1 } => {},
+            A::V1 {..} => {},
+        }
+    }
+
+    public fun test3(a: A) {
+        match (a) {
+            A::V1 { a: Q::Q1, b: _ } => {},
+            A::V1 { a: _, b: R::R1 } => {},
+            _ => {},
+        }
+    }
+
+    public fun test4(a: A) {
+        match (a) {
+            A::V1 { a: Q::Q1, b: _ } => {},
+            A::V1 {..} => {},
+        }
+    }
+
+    public fun test5(a: A) {
+        match (a) {
+            A::V1 { a: Q::Q1, b: _ } => {},
+            A::V1 { a: Q::Q2, b: _ } => {},
+        }
+    }
+
+    public fun test6(a: A) {
+        match (a) {
+            A::V1 { a: Q::Q1, b: _ } => {},
+            A::V1 { a: Q::Q2, b: _ } if true => {},
+            _ => {},
+        }
+    }
+}
+
+
+//# publish
+module 0xc0ffee::n {
+    enum A has drop {
+        V1 { a: P, b: Q, c: R},
+    }
+
+    enum P has drop {
+        P1,
+        P2,
+    }
+
+    enum Q has drop {
+        Q1,
+        Q2,
+    }
+
+    enum R has drop {
+        R1,
+        R2,
+    }
+
+    public fun test(a: A) {
+        match (a) {
+            A::V1 { a: P::P1, b: _, c: _ } => {},
+            A::V1 { a: _, b: Q::Q1, c: _ } => {},
+            A::V1 { a: _, b: _, c: R::R1 } => {},
+            A::V1 { a: P::P2, b: Q::Q2, c: R::R2 } => {},
+        }
+    }
+}
+
+
+//# publish
+module 0xc0ffee::o {
+    enum E has drop {
+        V1 { a: F, b: G },
+        V2 { a: F, b: G, c: H }
+    }
+
+    enum F has drop {
+        F1,
+        F2 { a: G }
+    }
+
+    enum G has drop {
+        G1 { a: H, b: H },
+        G2 { a: H }
+    }
+
+    enum H has drop {
+        H1 { a: u64},
+        H2 { b: u64 }
+    }
+
+    public fun test1(e: E) {
+        match (e) {
+            E::V1 {b: _, ..} => {},
+            E::V2 {..} => {}
+        }
+    }
+
+    public fun test2(e: E) {
+        match (e) {
+            E::V1 {b: G::G1{ a: H::H1 { a: _}, b: _}, ..} => {},
+            E::V1 {b: G::G1{ a: _, b: H::H1 { .. }}, ..} => {},
+            E::V1 {b: _, a: F::F1} => {},
+            E::V1 {b: _, a: F::F2 {..} } => {},
+            E::V2 {..} => {}
+        }
+    }
+
+    public fun test3(e: E) {
+        match (e) {
+            E::V1 {b: G::G1{ .. }, a: _} => {},
+            E::V1 {b: _, a: F::F2 {..} } => {},
+            E::V1 {b: G::G2{ a: H::H2 {b: _}}, a: F::F1} => {},
+            E::V1 {b: _, a: F::F1} => {},
+            E::V2 {..} => {}
+        }
+    }
+}
+
+//# publish
+module 0xc0ffee::o_fail {
+    enum E has drop {
+        V1 { a: F, b: G },
+        V2 { a: F, b: G, c: H }
+    }
+
+    enum F has drop {
+        F1,
+        F2 { a: G }
+    }
+
+    enum G has drop {
+        G1 { a: H, b: H },
+        G2 { a: H }
+    }
+
+    enum H has drop {
+        H1 { a: u64},
+        H2 { b: u64 }
+    }
+
+    public fun test1(e: E) {
+        match (e) {
+            E::V1 {b: _, ..} => {},
+            E::V1 {..} => {}
+            E::V2 {..} => {}
+        }
+    }
+
+    public fun test2(e: E) {
+        match (e) {
+            E::V2 {..} => {}
+            E::V1 {b: G::G1{ .. }, a: _} => {},
+            E::V1 {b: _, a: F::F2 {..} } => {},
+            E::V1 {b: _, a: F::F1} => {},
+            E::V1 {b: G::G2{ a: H::H2 {b: _}}, a: F::F1} => {},
+        }
+    }
+
+    public fun test3(e: E) {
+        match (e) {
+            E::V1 {b: G::G1{ .. }, a: F::F1} => {},
+            E::V1 {b: G::G2{ .. }, a: F::F2 {..}} => {},
+            E::V1 {a: F::F2 {..}, ..} => {},
+            E::V1 {b: _, a: F::F1} => {},
+            E::V1 {..} => {}
+            E::V2 {..} => {}
+        }
+    }
+}


### PR DESCRIPTION
## Description

Fixes #14296.

Makes a couple of changes in the enum exhaustive match checker:
- When joining two shapes (see `try_join`), we have to unify `n` pairs of sub-shapes. Previously, we stopped if a single sub-shape pair was successful in unification. Now, we unify all `n` pairs of sub-shapes if possible.
- When specializing a list of shapes given a new shape (see `join_value_shape`), we stopped after doing this successfully on one of the shapes. Now, we go through the entire list of shapes and try specializing each one based on the new shape.

Currently on `main`, compiling:

```
module 0xc0ffee::n {
    enum A has drop {
        V1 { a: P, b: Q, c: R},
    }

    enum P has drop {
        P1,
        P2,
    }

    enum Q has drop {
        Q1,
        Q2,
    }

    enum R has drop {
        R1,
        R2,
    }

    public fun test(a: A) {
        match (a) {
            A::V1 { a: P::P1, b: _, c: _ } => {},
            A::V1 { a: _, b: Q::Q1, c: _ } => {},
            A::V1 { a: _, b: _, c: R::R1 } => {},
            A::V1 { a: P::P2, b: Q::Q2, c: R::R2 } => {},
        }
    }
}
```

incorrectly gives the error:

```
 error: match not exhaustive
   ┌─ TEMPFILE:19:16
   │
19 │         match (a) {
   │                ^
   │
   = missing `A::V1{a: _, b: _, c: R::R2}`
   = missing `A::V1{a: _, b: Q::Q2, c: _}`
   = missing `A::V1{a: P::P2, b: _, c: _}`
```

The above code successfully compiles with this PR.

## How Has This Been Tested?
- Existing tests pass, and the baseline files affected by the fix have been verified and updated.
- Added a new extensive test: `match_cover.move`.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
