### PR TITLE
[2/n] Make loader V2 default

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -361,7 +361,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             },
             FeatureFlag::CollectionOwner => AptosFeatureFlag::COLLECTION_OWNER,
             FeatureFlag::NativeMemoryOperations => AptosFeatureFlag::NATIVE_MEMORY_OPERATIONS,
-            FeatureFlag::EnableLoaderV2 => AptosFeatureFlag::ENABLE_LOADER_V2,
+            FeatureFlag::EnableLoaderV2 => AptosFeatureFlag::_ENABLE_LOADER_V2,
             FeatureFlag::DisallowInitModuleToPublishModules => {
                 AptosFeatureFlag::_DISALLOW_INIT_MODULE_TO_PUBLISH_MODULES
             },
@@ -520,7 +520,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             },
             AptosFeatureFlag::COLLECTION_OWNER => FeatureFlag::CollectionOwner,
             AptosFeatureFlag::NATIVE_MEMORY_OPERATIONS => FeatureFlag::NativeMemoryOperations,
-            AptosFeatureFlag::ENABLE_LOADER_V2 => FeatureFlag::EnableLoaderV2,
+            AptosFeatureFlag::_ENABLE_LOADER_V2 => FeatureFlag::EnableLoaderV2,
             AptosFeatureFlag::_DISALLOW_INIT_MODULE_TO_PUBLISH_MODULES => {
                 FeatureFlag::DisallowInitModuleToPublishModules
             },

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -100,7 +100,7 @@ pub enum FeatureFlag {
     /// AIP-105 (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-105.md)
     NATIVE_MEMORY_OPERATIONS = 80,
     /// The feature was used to gate the rollout of new loader used by Move VM. It was enabled on
-    /// mainnet and cannot be disabled.
+    /// mainnet and can no longer be disabled.
     _ENABLE_LOADER_V2 = 81,
     /// Prior to this feature flag, it was possible to attempt 'init_module' to publish modules
     /// that results in a new package created but without any code. With this feature, it is no

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -99,7 +99,9 @@ pub enum FeatureFlag {
     /// covers mem::swap and vector::move_range
     /// AIP-105 (https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-105.md)
     NATIVE_MEMORY_OPERATIONS = 80,
-    ENABLE_LOADER_V2 = 81,
+    /// The feature was used to gate the rollout of new loader used by Move VM. It was enabled on
+    /// mainnet and cannot be disabled.
+    _ENABLE_LOADER_V2 = 81,
     /// Prior to this feature flag, it was possible to attempt 'init_module' to publish modules
     /// that results in a new package created but without any code. With this feature, it is no
     /// longer possible and an explicit error is returned if publishing is attempted. The feature
@@ -205,7 +207,6 @@ impl FeatureFlag {
             FeatureFlag::TRANSACTION_SIMULATION_ENHANCEMENT,
             FeatureFlag::NATIVE_MEMORY_OPERATIONS,
             FeatureFlag::COLLECTION_OWNER,
-            FeatureFlag::ENABLE_LOADER_V2,
             FeatureFlag::PERMISSIONED_SIGNER,
             FeatureFlag::ENABLE_CALL_TREE_AND_INSTRUCTION_VM_CACHE,
             FeatureFlag::ACCOUNT_ABSTRACTION,
@@ -366,7 +367,7 @@ impl Features {
     }
 
     pub fn is_loader_v2_enabled(&self) -> bool {
-        self.is_enabled(FeatureFlag::ENABLE_LOADER_V2)
+        true
     }
 
     pub fn is_call_tree_and_instruction_vm_cache_enabled(&self) -> bool {


### PR DESCRIPTION
## Description

Make V2 loader default. This breaks some historical transactions, as described here: https://docs.google.com/spreadsheets/d/16IVAe72g3Rcf3LqMKaj80a0Isa8ma3SaJFMVzOtVOfI/edit?usp=sharing. Note that since this doc was created there can be a few more differences.

TODO: cannot add txns to skip to the replay easily, will update this soon.

Note: the actual loader V1 removal comes in the next PR.

## How Has This Been Tested?

Replay run: (TBA)

## Key Areas to Review

## Type of Change

- [x] Refactoring


## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine


## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
