### PR TITLE
Fix async for script composer

### DIFF
--- a/aptos-move/script-composer/src/tests/mod.rs
+++ b/aptos-move/script-composer/src/tests/mod.rs
@@ -731,4 +731,43 @@ fn test_module() {
         .unwrap();
 
     run_txn(builder, &mut h);
+
+    // Test functions with multiple generics.
+    let mut builder = TransactionComposer::single_signer();
+    load_module(&mut builder, &h, "0x1::batched_execution");
+    let return1 = builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "create_generic_non_droppable_value".to_string(),
+            vec!["0x1::batched_execution::Foo".to_string()],
+            vec![CallArgument::new_bytes(
+                MoveValue::U8(10).simple_serialize().unwrap(),
+            )],
+        )
+        .unwrap();
+
+    let return2 = builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "create_generic_non_droppable_value".to_string(),
+            vec!["0x1::batched_execution::Bar".to_string()],
+            vec![CallArgument::new_bytes(
+                MoveValue::U8(20).simple_serialize().unwrap(),
+            )],
+        )
+        .unwrap();
+
+    builder
+        .add_batched_call(
+            "0x1::batched_execution".to_string(),
+            "multiple_generics".to_string(),
+            vec![
+                "0x1::batched_execution::Foo".to_string(),
+                "0x1::batched_execution::Bar".to_string(),
+            ],
+            vec![return1[0].clone(), return2[0].clone()],
+        )
+        .unwrap();
+
+    run_txn(builder, &mut h);
 }

--- a/aptos-move/script-composer/src/tests/test_modules/sources/test.move
+++ b/aptos-move/script-composer/src/tests/test_modules/sources/test.move
@@ -77,4 +77,12 @@ module 0x1::batched_execution {
     public fun multiple_returns(): (DroppableValue, NonDroppableValue) {
         return (DroppableValue { val: 0 }, NonDroppableValue { val: 1} )
     }
+
+    public fun multiple_generics<T, F>(v: GenericNonDroppableValue<T>, v2: GenericNonDroppableValue<F>) {
+        let GenericNonDroppableValue { val } = v;
+        assert!(val == 10, 10);
+
+        let GenericNonDroppableValue { val } = v2;
+        assert!(val == 20, 20);
+    }
 }


### PR DESCRIPTION
## Description
Get rid of async dfs in the script composer logic to avoid rust aliasing issue in wasm.



## How Has This Been Tested?
Added new test for multiple generics.


## Key Areas to Review
NA

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
