### PR TITLE
[compiler-v2][trivial] Clarify unused assignment warning text

### DIFF
--- a/third_party/move/move-compiler-v2/src/pipeline/unused_assignment_checker.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/unused_assignment_checker.rs
@@ -40,13 +40,15 @@ impl UnusedAssignmentChecker {
             let live_after = &live_var_info.after;
             let dst_name = dst_name.display(target.func_env.symbol_pool()).to_string();
             if !dst_name.starts_with('_') && live_after.get(&dst).is_none() {
-                target
-                    .global_env()
-                    .diag(
-                        Severity::Warning,
-                        &loc,
-                        &format!("Unused assignment to `{}`. Consider removing or prefixing with an underscore: `_{}`", dst_name, dst_name)
-                    );
+                target.global_env().diag(
+                    Severity::Warning,
+                    &loc,
+                    &format!(
+                        "Unused assignment/binding to `{}`. Consider removing the assignment/binding, \
+                        or prefixing with an underscore (e.g., `_{}`), or binding to `_`",
+                        dst_name, dst_name
+                    ),
+                );
             }
         }
     }

--- a/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
@@ -56,7 +56,7 @@ fun m::g() {
 
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/ability-transform/destroy_after_call.move:8:9
   │
 8 │         r = f(r);

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/freeze_mut_ref.exp
@@ -366,37 +366,37 @@ fun freeze_mut_ref::t8($t0: bool, $t1: &mut 0x42::freeze_mut_ref::S, $t2: &0x42:
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/bytecode-generator/freeze_mut_ref.move:58:9
    │
 58 │         (x, y) = (&mut 0, &mut 0);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/bytecode-generator/freeze_mut_ref.move:58:9
    │
 58 │         (x, y) = (&mut 0, &mut 0);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/bytecode-generator/freeze_mut_ref.move:66:24
    │
 66 │         let g = &mut ({x = x + 1; s}).f;
    │                        ^^^^^^^^^
 
-warning: Unused assignment to `z`. Consider removing or prefixing with an underscore: `_z`
+warning: Unused assignment/binding to `z`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_z`), or binding to `_`
    ┌─ tests/bytecode-generator/freeze_mut_ref.move:69:20
    │
 69 │         *({*f = 0; z = y; g}) = 2;
    │                    ^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/bytecode-generator/freeze_mut_ref.move:74:19
    │
 74 │         if (cond) x = copy s else x = other;
    │                   ^^^^^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/bytecode-generator/freeze_mut_ref.move:74:35
    │
 74 │         if (cond) x = copy s else x = other;

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard7.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/wildcard7.exp
@@ -53,7 +53,7 @@ public fun m::test(): u8 {
 
 
 Diagnostics:
-warning: Unused assignment to `q`. Consider removing or prefixing with an underscore: `_q`
+warning: Unused assignment/binding to `q`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_q`), or binding to `_`
   ┌─ tests/bytecode-generator/wildcard7.move:6:13
   │
 6 │         let (_, q) = (x, z);

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/call_1.exp
@@ -35,7 +35,7 @@ fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/copy-propagation/call_1.move:7:17
   │
 7 │         let a = p;

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/immut_refs_2.exp
@@ -25,7 +25,7 @@ fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/copy-propagation/immut_refs_2.move:4:17
   │
 4 │         let a = &p;

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_1.exp
@@ -24,7 +24,7 @@ fun m::test($t0: u64): bool {
 
 
 Diagnostics:
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
   ┌─ tests/copy-propagation/seq_kills_1.move:7:9
   │
 7 │         b = p + 1; // kill b := a, which removes the whole copy chain

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/seq_kills_2.exp
@@ -24,7 +24,7 @@ fun m::test($t0: u64): bool {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/copy-propagation/seq_kills_2.move:7:9
   │
 7 │         a = p + 1; // kill b := a

--- a/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/copy-propagation/straight_line_kills.exp
@@ -22,7 +22,7 @@ fun m::copy_kill($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `p`. Consider removing or prefixing with an underscore: `_p`
+warning: Unused assignment/binding to `p`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_p`), or binding to `_`
   ┌─ tests/copy-propagation/straight_line_kills.move:5:9
   │
 5 │         p = p + 1;

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.exp
@@ -68,67 +68,67 @@ warning: Unused local variable `s`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `const_true`. Consider removing or prefixing with an underscore: `_const_true`
+warning: Unused assignment/binding to `const_true`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_const_true`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:3:26
   │
 3 │         let const_true = u(true);
   │                          ^^^^^^^
 
-warning: Unused assignment to `const_false`. Consider removing or prefixing with an underscore: `_const_false`
+warning: Unused assignment/binding to `const_false`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_const_false`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:4:27
   │
 4 │         let const_false = u(false);
   │                           ^^^^^^^^
 
-warning: Unused assignment to `hex_u8`. Consider removing or prefixing with an underscore: `_hex_u8`
+warning: Unused assignment/binding to `hex_u8`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u8`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:5:26
   │
 5 │         let hex_u8: u8 = u(0x1);
   │                          ^^^^^^
 
-warning: Unused assignment to `hex_u16`. Consider removing or prefixing with an underscore: `_hex_u16`
+warning: Unused assignment/binding to `hex_u16`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u16`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:6:28
   │
 6 │         let hex_u16: u16 = u(0x1BAE);
   │                            ^^^^^^^^^
 
-warning: Unused assignment to `hex_u32`. Consider removing or prefixing with an underscore: `_hex_u32`
+warning: Unused assignment/binding to `hex_u32`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u32`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:7:28
   │
 7 │         let hex_u32: u32 = u(0xDEAD80);
   │                            ^^^^^^^^^^^
 
-warning: Unused assignment to `hex_u64`. Consider removing or prefixing with an underscore: `_hex_u64`
+warning: Unused assignment/binding to `hex_u64`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u64`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:8:28
   │
 8 │         let hex_u64: u64 = u(0xCAFE);
   │                            ^^^^^^^^^
 
-warning: Unused assignment to `hex_u128`. Consider removing or prefixing with an underscore: `_hex_u128`
+warning: Unused assignment/binding to `hex_u128`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u128`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:9:30
   │
 9 │         let hex_u128: u128 = u(0xDEADBEEF);
   │                              ^^^^^^^^^^^^^
 
-warning: Unused assignment to `hex_u256`. Consider removing or prefixing with an underscore: `_hex_u256`
+warning: Unused assignment/binding to `hex_u256`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u256`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:10:30
    │
 10 │         let hex_u256: u256 = u(0x1123_456A_BCDE_F);
    │                              ^^^^^^^^^^^^^^^^^^^^^
 
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:11:17
    │
 11 │         let a = u(@0x42);
    │                 ^^^^^^^^
 
-warning: Unused assignment to `vec`. Consider removing or prefixing with an underscore: `_vec`
+warning: Unused assignment/binding to `vec`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_vec`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:12:19
    │
 12 │         let vec = u(vector[1, 2, 3]);
    │                   ^^^^^^^^^^^^^^^^^^
 
-warning: Unused assignment to `s`. Consider removing or prefixing with an underscore: `_s`
+warning: Unused assignment/binding to `s`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_s`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:13:17
    │
 13 │         let s = u(b"Hello!\n");

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/const.opt.exp
@@ -68,67 +68,67 @@ warning: Unused local variable `s`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `const_true`. Consider removing or prefixing with an underscore: `_const_true`
+warning: Unused assignment/binding to `const_true`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_const_true`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:3:26
   │
 3 │         let const_true = u(true);
   │                          ^^^^^^^
 
-warning: Unused assignment to `const_false`. Consider removing or prefixing with an underscore: `_const_false`
+warning: Unused assignment/binding to `const_false`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_const_false`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:4:27
   │
 4 │         let const_false = u(false);
   │                           ^^^^^^^^
 
-warning: Unused assignment to `hex_u8`. Consider removing or prefixing with an underscore: `_hex_u8`
+warning: Unused assignment/binding to `hex_u8`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u8`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:5:26
   │
 5 │         let hex_u8: u8 = u(0x1);
   │                          ^^^^^^
 
-warning: Unused assignment to `hex_u16`. Consider removing or prefixing with an underscore: `_hex_u16`
+warning: Unused assignment/binding to `hex_u16`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u16`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:6:28
   │
 6 │         let hex_u16: u16 = u(0x1BAE);
   │                            ^^^^^^^^^
 
-warning: Unused assignment to `hex_u32`. Consider removing or prefixing with an underscore: `_hex_u32`
+warning: Unused assignment/binding to `hex_u32`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u32`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:7:28
   │
 7 │         let hex_u32: u32 = u(0xDEAD80);
   │                            ^^^^^^^^^^^
 
-warning: Unused assignment to `hex_u64`. Consider removing or prefixing with an underscore: `_hex_u64`
+warning: Unused assignment/binding to `hex_u64`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u64`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:8:28
   │
 8 │         let hex_u64: u64 = u(0xCAFE);
   │                            ^^^^^^^^^
 
-warning: Unused assignment to `hex_u128`. Consider removing or prefixing with an underscore: `_hex_u128`
+warning: Unused assignment/binding to `hex_u128`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u128`), or binding to `_`
   ┌─ tests/file-format-generator/const.move:9:30
   │
 9 │         let hex_u128: u128 = u(0xDEADBEEF);
   │                              ^^^^^^^^^^^^^
 
-warning: Unused assignment to `hex_u256`. Consider removing or prefixing with an underscore: `_hex_u256`
+warning: Unused assignment/binding to `hex_u256`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_hex_u256`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:10:30
    │
 10 │         let hex_u256: u256 = u(0x1123_456A_BCDE_F);
    │                              ^^^^^^^^^^^^^^^^^^^^^
 
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:11:17
    │
 11 │         let a = u(@0x42);
    │                 ^^^^^^^^
 
-warning: Unused assignment to `vec`. Consider removing or prefixing with an underscore: `_vec`
+warning: Unused assignment/binding to `vec`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_vec`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:12:19
    │
 12 │         let vec = u(vector[1, 2, 3]);
    │                   ^^^^^^^^^^^^^^^^^^
 
-warning: Unused assignment to `s`. Consider removing or prefixing with an underscore: `_s`
+warning: Unused assignment/binding to `s`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_s`), or binding to `_`
    ┌─ tests/file-format-generator/const.move:13:17
    │
 13 │         let s = u(b"Hello!\n");

--- a/third_party/move/move-compiler-v2/tests/more-v1/liveness/trailing_semi_loops.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/liveness/trailing_semi_loops.exp
@@ -8,7 +8,7 @@ warning: Unused local variable `x`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/more-v1/liveness/trailing_semi_loops.move:76:17
    │
 76 │                 x = 2;

--- a/third_party/move/move-compiler-v2/tests/more-v1/locals/assign_partial_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/locals/assign_partial_resource.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/more-v1/locals/assign_partial_resource.move:6:21
   │
 6 │         if (cond) { r = R{}; };
   │                     ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/assign_partial_resource.move:13:29
    │
 13 │         if (cond) {} else { r = R{}; };
    │                             ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/assign_partial_resource.move:20:24
    │
 20 │         while (cond) { r = R{} };
    │                        ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/assign_partial_resource.move:27:16
    │
 27 │         loop { r = R{} }

--- a/third_party/move/move-compiler-v2/tests/more-v1/locals/assign_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/locals/assign_resource.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/more-v1/locals/assign_resource.move:5:17
   │
 5 │         let r = R{};
   │                 ^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/assign_resource.move:29:17
    │
 29 │         let r = R{};

--- a/third_party/move/move-compiler-v2/tests/more-v1/locals/unused_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/locals/unused_resource.exp
@@ -14,31 +14,31 @@ warning: Unused local variable `r`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/more-v1/locals/unused_resource.move:5:17
   │
 5 │         let r = R{};
   │                 ^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/unused_resource.move:15:21
    │
 15 │         if (cond) { r = R{}; };
    │                     ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/unused_resource.move:20:29
    │
 20 │         if (cond) {} else { r = R{}; };
    │                             ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/unused_resource.move:25:24
    │
 25 │         while (cond) { r = R{} };
    │                        ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/unused_resource.move:29:24
    │
 29 │         loop { let r = R{}; }

--- a/third_party/move/move-compiler-v2/tests/more-v1/locals/unused_resource_explicit_return.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/locals/unused_resource_explicit_return.exp
@@ -20,19 +20,19 @@ warning: Unused local variable `x`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/more-v1/locals/unused_resource_explicit_return.move:5:17
   │
 5 │         let r = R{};
   │                 ^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/more-v1/locals/unused_resource_explicit_return.move:28:17
    │
 28 │         let r = R{};
    │                 ^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/more-v1/locals/unused_resource_explicit_return.move:33:17
    │
 33 │         let x = &R{};

--- a/third_party/move/move-compiler-v2/tests/more-v1/translated_ir_tests/move/commands/invalid_fallthrough2.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/translated_ir_tests/move/commands/invalid_fallthrough2.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/more-v1/translated_ir_tests/move/commands/invalid_fallthrough2.move:5:3
   │
 5 │   x = 7

--- a/third_party/move/move-compiler-v2/tests/more-v1/translated_ir_tests/move/commands/invalid_fallthrough3.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/translated_ir_tests/move/commands/invalid_fallthrough3.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/more-v1/translated_ir_tests/move/commands/invalid_fallthrough3.move:5:3
   │
 5 │   x = 7;

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/reference-safety/write_ref_dest.move:16:9
    │
 16 │         (y, _) = (*&y, 1);

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.no-opt.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.no-opt.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/reference-safety/write_ref_dest.move:16:9
    │
 16 │         (y, _) = (*&y, 1);

--- a/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.old.exp
+++ b/third_party/move/move-compiler-v2/tests/reference-safety/write_ref_dest.old.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/reference-safety/write_ref_dest.move:16:9
    │
 16 │         (y, _) = (*&y, 1);

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/bind_with_type_annot.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/bind_with_type_annot.exp
@@ -49,19 +49,19 @@ module 0x8675309::M {
 
 
 Diagnostics:
-warning: Unused assignment to `f`. Consider removing or prefixing with an underscore: `_f`
+warning: Unused assignment/binding to `f`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_f`), or binding to `_`
   ┌─ tests/simplifier-elimination/bind_with_type_annot.move:7:20
   │
 7 │         let (x, b, R{f}): (u64, bool, R) = (0, false, R { f: 0 }); x; b; f;
   │                    ^^^^
 
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
   ┌─ tests/simplifier-elimination/bind_with_type_annot.move:7:13
   │
 7 │         let (x, b, R{f}): (u64, bool, R) = (0, false, R { f: 0 }); x; b; f;
   │             ^^^^^^^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/simplifier-elimination/bind_with_type_annot.move:7:13
   │
 7 │         let (x, b, R{f}): (u64, bool, R) = (0, false, R { f: 0 }); x; b; f;

--- a/third_party/move/move-compiler-v2/tests/simplifier/random.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/random.exp
@@ -222,7 +222,7 @@ module 0x8675::M {
 
 
 Diagnostics:
-warning: Unused assignment to `q`. Consider removing or prefixing with an underscore: `_q`
+warning: Unused assignment/binding to `q`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_q`), or binding to `_`
    ┌─ tests/simplifier/random.move:48:17
    │
 48 │         let q = v;

--- a/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
+++ b/third_party/move/move-compiler-v2/tests/unreachable-code-remover/conditional_loop_unreachable.exp
@@ -43,13 +43,13 @@ fun m::test($t0: bool, $t1: bool) {
 
 
 Diagnostics:
-warning: Unused assignment to `i`. Consider removing or prefixing with an underscore: `_i`
+warning: Unused assignment/binding to `i`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_i`), or binding to `_`
   ┌─ tests/unreachable-code-remover/conditional_loop_unreachable.move:7:17
   │
 7 │                 i = i + 1;
   │                 ^^^^^^^^^
 
-warning: Unused assignment to `i`. Consider removing or prefixing with an underscore: `_i`
+warning: Unused assignment/binding to `i`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_i`), or binding to `_`
    ┌─ tests/unreachable-code-remover/conditional_loop_unreachable.move:12:13
    │
 12 │             i = i + 1;

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/struct_assign_swap.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/struct_assign_swap.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/struct_assign_swap.move:16:13
    │
 16 │         let S { f: x, g: y } = S { f: y, g: x };
    │             ^^^^^^^^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/unused-assignment/struct_assign_swap.move:16:13
    │
 16 │         let S { f: x, g: y } = S { f: y, g: x };

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/typing/declare_duplicate_binding2.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/typing/declare_duplicate_binding2.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/unused-assignment/typing/declare_duplicate_binding2.move:7:9
   │
 7 │         x = 0;
   │         ^^^^^
 
-warning: Unused assignment to `f`. Consider removing or prefixing with an underscore: `_f`
+warning: Unused assignment/binding to `f`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_f`), or binding to `_`
   ┌─ tests/unused-assignment/typing/declare_duplicate_binding2.move:8:9
   │
 8 │         f = 0;
   │         ^^^^^
 
-warning: Unused assignment to `g`. Consider removing or prefixing with an underscore: `_g`
+warning: Unused assignment/binding to `g`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_g`), or binding to `_`
   ┌─ tests/unused-assignment/typing/declare_duplicate_binding2.move:9:9
   │
 9 │         g = 0;

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/unused_assign_to_param.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/unused_assign_to_param.exp
@@ -1,18 +1,18 @@
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/unused-assignment/unused_assign_to_param.move:3:9
   │
 3 │         x = 42;
   │         ^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/unused-assignment/unused_assign_to_param.move:8:13
   │
 8 │             x = 42;
   │             ^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/unused_assign_to_param.move:10:9
    │
 10 │         x = 42;

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/unused_call_assign_shadow.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/unused_call_assign_shadow.exp
@@ -32,25 +32,25 @@ warning: Unused local variable `x`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/unused-assignment/unused_call_assign_shadow.move:4:9
   │
 4 │         x = x + 1;
   │         ^^^^^^^^^
 
-warning: Unused assignment to `w`. Consider removing or prefixing with an underscore: `_w`
+warning: Unused assignment/binding to `w`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_w`), or binding to `_`
   ┌─ tests/unused-assignment/unused_call_assign_shadow.move:8:17
   │
 8 │         let w = bar(false);
   │                 ^^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/unused-assignment/unused_call_assign_shadow.move:14:13
    │
 14 │             y = y + 1;
    │             ^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/unused-assignment/unused_call_assign_shadow.move:16:13
    │
 16 │             y = y + 2;

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/unused_in_pattern.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/unused_in_pattern.exp
@@ -32,49 +32,49 @@ warning: Unused local variable `y`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:15:3
    │
 15 │         S { x, y } = s;
    │         ^^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:15:3
    │
 15 │         S { x, y } = s;
    │         ^^^^^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:20:7
    │
 20 │         let S { x, y } = s;
    │             ^^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:20:7
    │
 20 │         let S { x, y } = s;
    │             ^^^^^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:28:10
    │
 28 │         T { z: S { x, y } } = t;
    │                ^^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:28:10
    │
 28 │         T { z: S { x, y } } = t;
    │                ^^^^^^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:33:14
    │
 33 │         let T { z: S { x, y } } = t;
    │                    ^^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/unused-assignment/unused_in_pattern.move:33:14
    │
 33 │         let T { z: S { x, y } } = t;

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/v1-liveness/unused_assignment.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/v1-liveness/unused_assignment.exp
@@ -14,43 +14,43 @@ warning: Unused local variable `x`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/unused-assignment/v1-liveness/unused_assignment.move:7:17
   │
 7 │         let x = 0;
   │                 ^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/unused-assignment/v1-liveness/unused_assignment.move:8:9
   │
 8 │         x = 0;
   │         ^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/v1-liveness/unused_assignment.move:21:13
    │
 21 │             x = 0;
    │             ^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/v1-liveness/unused_assignment.move:26:17
    │
 26 │         let x = 0;
    │                 ^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/v1-liveness/unused_assignment.move:28:13
    │
 28 │             x = 1;
    │             ^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/v1-liveness/unused_assignment.move:30:13
    │
 30 │             x = 2;
    │             ^^^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/v1-liveness/unused_assignment.move:41:13
    │
 41 │             x = 1;

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/assign_partial_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/assign_partial_resource.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/unused-assignment/v1-locals/assign_partial_resource.move:6:21
   │
 6 │         if (cond) { r = R{}; };
   │                     ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/assign_partial_resource.move:13:29
    │
 13 │         if (cond) {} else { r = R{}; };
    │                             ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/assign_partial_resource.move:20:24
    │
 20 │         while (cond) { r = R{} };
    │                        ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/assign_partial_resource.move:27:16
    │
 27 │         loop { r = R{} }

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/assign_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/assign_resource.exp
@@ -1,12 +1,12 @@
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/unused-assignment/v1-locals/assign_resource.move:5:17
   │
 5 │         let r = R{};
   │                 ^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/assign_resource.move:29:17
    │
 29 │         let r = R{};

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/unused_copyable.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/unused_copyable.exp
@@ -20,7 +20,7 @@ warning: Unused local variable `s`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `s`. Consider removing or prefixing with an underscore: `_s`
+warning: Unused assignment/binding to `s`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_s`), or binding to `_`
   ┌─ tests/unused-assignment/v1-locals/unused_copyable.move:9:17
   │
 9 │         let s = S{};

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/unused_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/unused_resource.exp
@@ -14,31 +14,31 @@ warning: Unused local variable `r`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/unused-assignment/v1-locals/unused_resource.move:5:17
   │
 5 │         let r = R{};
   │                 ^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/unused_resource.move:15:21
    │
 15 │         if (cond) { r = R{}; };
    │                     ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/unused_resource.move:20:29
    │
 20 │         if (cond) {} else { r = R{}; };
    │                             ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/unused_resource.move:25:24
    │
 25 │         while (cond) { r = R{} };
    │                        ^^^^^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/unused_resource.move:29:24
    │
 29 │         loop { let r = R{}; }

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/unused_resource_explicit_return.exp
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/v1-locals/unused_resource_explicit_return.exp
@@ -20,19 +20,19 @@ warning: Unused local variable `x`. Consider removing or prefixing with an under
 
 
 Diagnostics:
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
   ┌─ tests/unused-assignment/v1-locals/unused_resource_explicit_return.move:5:17
   │
 5 │         let r = R{};
   │                 ^^^
 
-warning: Unused assignment to `r`. Consider removing or prefixing with an underscore: `_r`
+warning: Unused assignment/binding to `r`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_r`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/unused_resource_explicit_return.move:28:17
    │
 28 │         let r = R{};
    │                 ^^^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/unused-assignment/v1-locals/unused_resource_explicit_return.move:33:17
    │
 33 │         let x = &R{};

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.exp
@@ -35,7 +35,7 @@ fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/call_1.move:7:17
   │
 7 │         let a = p;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/call_1.opt.exp
@@ -35,7 +35,7 @@ fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/call_1.move:7:17
   │
 7 │         let a = p;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.exp
@@ -23,7 +23,7 @@ public fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/cant_coalesce_1.move:3:17
   │
 3 │         let x = a + a;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_coalesce_1.opt.exp
@@ -21,7 +21,7 @@ public fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/cant_coalesce_1.move:3:17
   │
 3 │         let x = a + a;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.exp
@@ -35,13 +35,13 @@ fun m::test($t0: u64, $t1: bool) {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
    ┌─ tests/variable-coalescing/cant_copy_propagate.move:11:13
    │
 11 │             a = 99;
    │             ^^^^^^
 
-warning: Unused assignment to `c`. Consider removing or prefixing with an underscore: `_c`
+warning: Unused assignment/binding to `c`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_c`), or binding to `_`
    ┌─ tests/variable-coalescing/cant_copy_propagate.move:13:13
    │
 13 │             c = c + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cant_copy_propagate.opt.exp
@@ -35,13 +35,13 @@ fun m::test($t0: u64, $t1: bool) {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
    ┌─ tests/variable-coalescing/cant_copy_propagate.move:11:13
    │
 11 │             a = 99;
    │             ^^^^^^
 
-warning: Unused assignment to `c`. Consider removing or prefixing with an underscore: `_c`
+warning: Unused assignment/binding to `c`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_c`), or binding to `_`
    ┌─ tests/variable-coalescing/cant_copy_propagate.move:13:13
    │
 13 │             c = c + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.exp
@@ -14,7 +14,7 @@ public fun m::test($t0: u64) {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/cyclic_assignment_without_use.move:6:9
   │
 6 │         a = c;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/cyclic_assignment_without_use.opt.exp
@@ -14,7 +14,7 @@ public fun m::test($t0: u64) {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/cyclic_assignment_without_use.move:6:9
   │
 6 │         a = c;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.exp
@@ -22,7 +22,7 @@ public fun m::test($t0: bool): u32 {
 
 
 Diagnostics:
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/variable-coalescing/dead_assignment_3.move:10:13
    │
 10 │             y = y;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_3.opt.exp
@@ -20,7 +20,7 @@ public fun m::test($t0: bool): u32 {
 
 
 Diagnostics:
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
    ┌─ tests/variable-coalescing/dead_assignment_3.move:10:13
    │
 10 │             y = y;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.exp
@@ -69,19 +69,19 @@ public fun m::test4($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/dead_assignment_4.move:3:17
   │
 3 │         let x = 1;
   │                 ^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/dead_assignment_4.move:9:17
   │
 9 │         let x = y;
   │                 ^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/variable-coalescing/dead_assignment_4.move:14:17
    │
 14 │         let x = y;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/dead_assignment_4.opt.exp
@@ -63,13 +63,13 @@ public fun m::test4($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/dead_assignment_4.move:9:17
   │
 9 │         let x = y;
   │                 ^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ tests/variable-coalescing/dead_assignment_4.move:14:17
    │
 14 │         let x = y;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.exp
@@ -25,7 +25,7 @@ fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/immut_refs_2.move:4:17
   │
 4 │         let a = &p;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/immut_refs_2.opt.exp
@@ -25,7 +25,7 @@ fun m::test($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/immut_refs_2.move:4:17
   │
 4 │         let a = &p;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.exp
@@ -22,7 +22,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `t`. Consider removing or prefixing with an underscore: `_t`
+warning: Unused assignment/binding to `t`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_t`), or binding to `_`
   ┌─ tests/variable-coalescing/intermingled_1.move:5:9
   │
 5 │         t = t + u;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_1.opt.exp
@@ -18,7 +18,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `t`. Consider removing or prefixing with an underscore: `_t`
+warning: Unused assignment/binding to `t`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_t`), or binding to `_`
   ┌─ tests/variable-coalescing/intermingled_1.move:5:9
   │
 5 │         t = t + u;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.exp
@@ -22,7 +22,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `t`. Consider removing or prefixing with an underscore: `_t`
+warning: Unused assignment/binding to `t`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_t`), or binding to `_`
   ┌─ tests/variable-coalescing/intermingled_3.move:5:9
   │
 5 │         t = t + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/intermingled_3.opt.exp
@@ -18,7 +18,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `t`. Consider removing or prefixing with an underscore: `_t`
+warning: Unused assignment/binding to `t`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_t`), or binding to `_`
   ┌─ tests/variable-coalescing/intermingled_3.move:5:9
   │
 5 │         t = t + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.exp
@@ -14,7 +14,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/multi_assigns.move:3:17
   │
 3 │         let x = 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/multi_assigns.opt.exp
@@ -14,7 +14,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/multi_assigns.move:3:17
   │
 3 │         let x = 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.exp
@@ -25,13 +25,13 @@ fun m::test() {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars1.move:4:9
   │
 4 │         x = x + 1;
   │         ^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars1.move:6:9
   │
 6 │         y = y + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars1.opt.exp
@@ -25,13 +25,13 @@ fun m::test() {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars1.move:4:9
   │
 4 │         x = x + 1;
   │         ^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars1.move:6:9
   │
 6 │         y = y + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.exp
@@ -25,13 +25,13 @@ fun m::test() {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars_diff_type.move:4:9
   │
 4 │         x = x + 1;
   │         ^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars_diff_type.move:6:9
   │
 6 │         y = y + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/non_overlapping_vars_diff_type.opt.exp
@@ -25,13 +25,13 @@ fun m::test() {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars_diff_type.move:4:9
   │
 4 │         x = x + 1;
   │         ^^^^^^^^^
 
-warning: Unused assignment to `y`. Consider removing or prefixing with an underscore: `_y`
+warning: Unused assignment/binding to `y`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_y`), or binding to `_`
   ┌─ tests/variable-coalescing/non_overlapping_vars_diff_type.move:6:9
   │
 6 │         y = y + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.exp
@@ -18,7 +18,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/reassigned_var.move:3:17
   │
 3 │         let a = 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/reassigned_var.opt.exp
@@ -18,7 +18,7 @@ fun m::test(): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/reassigned_var.move:3:17
   │
 3 │         let a = 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.exp
@@ -85,7 +85,7 @@ public fun m::test4($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/self_assigns.move:3:9
   │
 3 │         x = x;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/self_assigns.opt.exp
@@ -85,7 +85,7 @@ public fun m::test4($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
   ┌─ tests/variable-coalescing/self_assigns.move:3:9
   │
 3 │         x = x;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.exp
@@ -24,7 +24,7 @@ fun m::test($t0: u64): bool {
 
 
 Diagnostics:
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
   ┌─ tests/variable-coalescing/seq_kills_1.move:7:9
   │
 7 │         b = p + 1; // kill b := a, which removes the whole copy chain

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_1.opt.exp
@@ -24,7 +24,7 @@ fun m::test($t0: u64): bool {
 
 
 Diagnostics:
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
   ┌─ tests/variable-coalescing/seq_kills_1.move:7:9
   │
 7 │         b = p + 1; // kill b := a, which removes the whole copy chain

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.exp
@@ -24,7 +24,7 @@ fun m::test($t0: u64): bool {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/seq_kills_2.move:7:9
   │
 7 │         a = p + 1; // kill b := a

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/seq_kills_2.opt.exp
@@ -24,7 +24,7 @@ fun m::test($t0: u64): bool {
 
 
 Diagnostics:
-warning: Unused assignment to `a`. Consider removing or prefixing with an underscore: `_a`
+warning: Unused assignment/binding to `a`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_a`), or binding to `_`
   ┌─ tests/variable-coalescing/seq_kills_2.move:7:9
   │
 7 │         a = p + 1; // kill b := a

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.exp
@@ -22,7 +22,7 @@ fun m::copy_kill($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `p`. Consider removing or prefixing with an underscore: `_p`
+warning: Unused assignment/binding to `p`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_p`), or binding to `_`
   ┌─ tests/variable-coalescing/straight_line_kills.move:5:9
   │
 5 │         p = p + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/straight_line_kills.opt.exp
@@ -22,7 +22,7 @@ fun m::copy_kill($t0: u64): u64 {
 
 
 Diagnostics:
-warning: Unused assignment to `p`. Consider removing or prefixing with an underscore: `_p`
+warning: Unused assignment/binding to `p`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_p`), or binding to `_`
   ┌─ tests/variable-coalescing/straight_line_kills.move:5:9
   │
 5 │         p = p + 1;

--- a/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
+++ b/third_party/move/move-compiler-v2/tests/variable-coalescing/unused_add.exp
@@ -23,7 +23,7 @@ public fun m::test() {
 
 
 Diagnostics:
-warning: Unused assignment to `z`. Consider removing or prefixing with an underscore: `_z`
+warning: Unused assignment/binding to `z`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_z`), or binding to `_`
   ┌─ tests/variable-coalescing/unused_add.move:5:17
   │
 5 │         let z = x + y;

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed.exp
@@ -4,7 +4,7 @@ comparison between v1 and v2 failed:
 = task 0 'publish'. lines 1-19:
 - warning[W09003]: unused assignment
 -   ┌─ TEMPFILE:8:13
-+ warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
++ warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
 +   ┌─ TEMPFILE:8:17
 =   │
 = 8 │         let x = 1;

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed_param.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed_param.exp
@@ -4,7 +4,7 @@ comparison between v1 and v2 failed:
 = task 0 'publish'. lines 1-46:
 - warning[W09003]: unused assignment
 -    ┌─ TEMPFILE:23:13
-+ warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
++ warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
 +    ┌─ TEMPFILE:23:17
 =    │
 = 23 │         let x = q;

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed_param_typed.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed_param_typed.exp
@@ -4,7 +4,7 @@ comparison between v1 and v2 failed:
 = task 0 'publish'. lines 1-46:
 - Error: error[E01013]: unsupported language construct
 -    ┌─ TEMPFILE:11:14
-+ warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
++ warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
 +    ┌─ TEMPFILE:23:17
 =    │
 - 11 │         foo(|y: u64| {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed_typed.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/shadowing_renamed_typed.exp
@@ -4,7 +4,7 @@ comparison between v1 and v2 failed:
 = task 0 'publish'. lines 1-19:
 - Error: error[E01013]: unsupported language construct
 -   ┌─ TEMPFILE:9:14
-+ warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
++ warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
 +   ┌─ TEMPFILE:8:17
 =   │
 - 9 │         foo(|y: u64| {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.baseline.exp
@@ -19,13 +19,13 @@ warning: Unused local variable `b`. Consider removing or prefixing with an under
 35 │             Two{i, b} => 3,
    │                    ^
 
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,
    │             ^^^^^^^^^
 
-warning: Unused assignment to `i`. Consider removing or prefixing with an underscore: `_i`
+warning: Unused assignment/binding to `i`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_i`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.no-optimize.exp
@@ -19,19 +19,19 @@ warning: Unused local variable `b`. Consider removing or prefixing with an under
 35 │             Two{i, b} => 3,
    │                    ^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ TEMPFILE:20:21
    │
 20 │             let x = 4;
    │                     ^
 
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,
    │             ^^^^^^^^^
 
-warning: Unused assignment to `i`. Consider removing or prefixing with an underscore: `_i`
+warning: Unused assignment/binding to `i`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_i`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.optimize-no-simplify.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.optimize-no-simplify.exp
@@ -19,19 +19,19 @@ warning: Unused local variable `b`. Consider removing or prefixing with an under
 35 │             Two{i, b} => 3,
    │                    ^
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
    ┌─ TEMPFILE:20:21
    │
 20 │             let x = 4;
    │                     ^
 
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,
    │             ^^^^^^^^^
 
-warning: Unused assignment to `i`. Consider removing or prefixing with an underscore: `_i`
+warning: Unused assignment/binding to `i`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_i`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.optimize.exp
@@ -19,13 +19,13 @@ warning: Unused local variable `b`. Consider removing or prefixing with an under
 35 │             Two{i, b} => 3,
    │                    ^
 
-warning: Unused assignment to `b`. Consider removing or prefixing with an underscore: `_b`
+warning: Unused assignment/binding to `b`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_b`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,
    │             ^^^^^^^^^
 
-warning: Unused assignment to `i`. Consider removing or prefixing with an underscore: `_i`
+warning: Unused assignment/binding to `i`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_i`), or binding to `_`
    ┌─ TEMPFILE:35:13
    │
 35 │             Two{i, b} => 3,

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.exp
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/needless_mutable_reference_warn.exp
@@ -135,7 +135,7 @@ warning: [lint] Needless mutable reference or borrow: consider using immutable r
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_mutable_reference)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_mutable_reference.
 
-warning: Unused assignment to `x`. Consider removing or prefixing with an underscore: `_x`
+warning: Unused assignment/binding to `x`. Consider removing the assignment/binding, or prefixing with an underscore (e.g., `_x`), or binding to `_`
     ┌─ tests/stackless_bytecode_lints/needless_mutable_reference_warn.move:175:9
     │
 175 │         x = y; // Produces a cycle in the `derived_edges`.


### PR DESCRIPTION
## Description

Close #15713. The compiler warning here was indeed correct, but the warning text seems to have caused some confusion.

We clarify the warning text emitted when compiler finds unused assignments. 

## How Has This Been Tested?

Existing tests have been updated with the new baselines. The only changes are in the message text.

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
