### PR TITLE
[move][closures] End-to-end tests and feature gating


### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -140,6 +140,7 @@ pub enum FeatureFlag {
     VMBinaryFormatV8,
     BulletproofsBatchNatives,
     DomainAccountAbstraction,
+    EnableFunctionValues,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -371,6 +372,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::AccountAbstraction => AptosFeatureFlag::ACCOUNT_ABSTRACTION,
             FeatureFlag::BulletproofsBatchNatives => AptosFeatureFlag::BULLETPROOFS_BATCH_NATIVES,
             FeatureFlag::DomainAccountAbstraction => AptosFeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION,
+            FeatureFlag::EnableFunctionValues => AptosFeatureFlag::ENABLE_FUNCTION_VALUES,
         }
     }
 }
@@ -529,6 +531,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::ACCOUNT_ABSTRACTION => FeatureFlag::AccountAbstraction,
             AptosFeatureFlag::BULLETPROOFS_BATCH_NATIVES => FeatureFlag::BulletproofsBatchNatives,
             AptosFeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION => FeatureFlag::DomainAccountAbstraction,
+            AptosFeatureFlag::ENABLE_FUNCTION_VALUES => FeatureFlag::EnableFunctionValues,
         }
     }
 }

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -76,6 +76,7 @@ pub fn aptos_prod_verifier_config(features: &Features) -> VerifierConfig {
     let enable_enum_types = features.is_enabled(FeatureFlag::ENABLE_ENUM_TYPES);
     let enable_resource_access_control =
         features.is_enabled(FeatureFlag::ENABLE_RESOURCE_ACCESS_CONTROL);
+    let enable_function_values = features.is_enabled(FeatureFlag::ENABLE_FUNCTION_VALUES);
 
     VerifierConfig {
         max_loop_depth: Some(5),
@@ -98,6 +99,7 @@ pub fn aptos_prod_verifier_config(features: &Features) -> VerifierConfig {
         sig_checker_v2_fix_script_ty_param_count,
         enable_enum_types,
         enable_resource_access_control,
+        enable_function_values,
     }
 }
 

--- a/aptos-move/e2e-benchmark/data/calibration_values.tsv
+++ b/aptos-move/e2e-benchmark/data/calibration_values.tsv
@@ -16,7 +16,7 @@ ResourceGroupsSenderWriteTag { string_length: 1024 }	10	0.922	1.031	21.9
 ResourceGroupsSenderMultiChange { string_length: 1024 }	10	0.968	1.071	38.9
 TokenV1MintAndTransferFT	10	0.972	1.059	646.3
 TokenV1MintAndTransferNFTSequential	10	0.934	1.027	968.7
-TokenV2AmbassadorMint { numbered: true }	10	0.915	1.042	735.1
+TokenV2AmbassadorMint { numbered: true }	10	0.915	1.042	660.0
 LiquidityPoolSwap { is_stable: true }	10	0.925	1.009	912.4
 LiquidityPoolSwap { is_stable: false }	10	0.965	1.037	837.8
 CoinInitAndMint	10	0.944	1.037	319.6

--- a/aptos-move/e2e-move-tests/src/tests/function_values.rs
+++ b/aptos-move/e2e-move-tests/src/tests/function_values.rs
@@ -1,0 +1,99 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Smoke tests for function values (closures) introduced in Move 2.2. (Functional
+//! tests are written as transactional tests elsewhere.)
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_package_builder::PackageBuilder;
+use aptos_types::account_address::AccountAddress;
+
+#[test]
+fn function_value_registry() {
+    let mut builder = PackageBuilder::new("Package");
+    let source = r#"
+        module 0x66::registry {
+          use 0x1::signer;
+          struct R<T>(T) has key;
+          public fun store<T: store>(s: &signer, x: T) {
+            move_to(s, R(x))
+          }
+          public fun remove<T: store>(s: &signer): T acquires R {
+            let R(x) = move_from<R<T>>(signer::address_of(s));
+            x
+          }
+        }
+
+        module 0x66::delayed_work {
+          use 0x66::registry;
+
+          entry fun initialize(s: &signer) {
+            registry::store< |u64|u64 has store >(s, id_fun)
+          }
+
+          entry fun add(s: &signer, amount: u64) {
+            let old = registry::remove< |u64|u64 has store >(s);
+            registry::store< |u64|u64 has store >(s, |x| add_fun(old, amount, x))
+          }
+
+          entry fun eval(s: &signer, amount: u64, expected: u64) {
+            let current = registry::remove< |u64|u64 has store >(s);
+            assert!(current(amount) == expected)
+          }
+
+          public fun add_fun(old: |u64|u64, x: u64, y: u64): u64 {
+            old(x) + y
+          }
+
+          public fun id_fun(x: u64): u64 {
+            x
+          }
+        }
+    "#;
+    builder.add_source("registry.move", source);
+    builder.add_local_dep(
+        "AptosFramework",
+        &common::framework_dir_path("aptos-framework").to_string_lossy(),
+    );
+    let path = builder.write_to_temp().unwrap();
+
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x66").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        path.path(),
+        BuildOptions::move_2().set_latest_language()
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x66::delayed_work::initialize").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x66::delayed_work::add").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&10u64).unwrap()],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x66::delayed_work::add").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&5u64).unwrap()],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x66::delayed_work::eval").unwrap(),
+        vec![],
+        vec![
+            bcs::to_bytes(&11u64).unwrap(),
+            bcs::to_bytes(&26u64).unwrap()
+        ],
+    ));
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -17,6 +17,7 @@ mod dependencies;
 mod enum_upgrade;
 mod error_map;
 mod fee_payer;
+mod function_values;
 mod fungible_asset;
 mod gas;
 mod generate_upgrade_script;

--- a/aptos-move/e2e-move-tests/src/tests/move_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/move_feature_gating.rs
@@ -82,23 +82,21 @@ fn resource_access_control(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>
 )]
 fn function_values(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {
     let positive_test = !enabled.is_empty();
-    let mut h = MoveHarness::new_with_features(enabled, disabled);
-    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x815").unwrap());
 
     let sources = &[
         r#"
-            module 0x815::m1 {
+            module 0x815::m {
                 fun test(_f: |u64| has drop) {
                 }
             }
         "#,
         r#"
-            module 0x815::m2 {
+            module 0x815::m {
                 struct S { f: |u64| }
             }
         "#,
         r#"
-            module 0x815::m3 {
+            module 0x815::m {
                 fun test(): u64 {
                     let f = |x| x + 1;
                     f(2)
@@ -110,6 +108,8 @@ fn function_values(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {
         let mut builder = PackageBuilder::new("Package");
         builder.add_source("m.move", source);
         let path = builder.write_to_temp().unwrap();
+        let mut h = MoveHarness::new_with_features(enabled.clone(), disabled.clone());
+        let acc = h.new_account_at(AccountAddress::from_hex_literal("0x815").unwrap());
         let result = h.publish_package_with_options(
             &acc,
             path.path(),

--- a/aptos-move/e2e-move-tests/src/tests/move_feature_gating.rs
+++ b/aptos-move/e2e-move-tests/src/tests/move_feature_gating.rs
@@ -75,3 +75,50 @@ fn resource_access_control(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>
         assert_vm_status!(result, StatusCode::FEATURE_NOT_ENABLED);
     }
 }
+
+#[rstest(enabled, disabled,
+    case(vec![], vec![FeatureFlag::ENABLE_FUNCTION_VALUES]),
+    case(vec![FeatureFlag::ENABLE_FUNCTION_VALUES], vec![]),
+)]
+fn function_values(enabled: Vec<FeatureFlag>, disabled: Vec<FeatureFlag>) {
+    let positive_test = !enabled.is_empty();
+    let mut h = MoveHarness::new_with_features(enabled, disabled);
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x815").unwrap());
+
+    let sources = &[
+        r#"
+            module 0x815::m1 {
+                fun test(_f: |u64| has drop) {
+                }
+            }
+        "#,
+        r#"
+            module 0x815::m2 {
+                struct S { f: |u64| }
+            }
+        "#,
+        r#"
+            module 0x815::m3 {
+                fun test(): u64 {
+                    let f = |x| x + 1;
+                    f(2)
+                }
+            }
+        "#,
+    ];
+    for source in sources {
+        let mut builder = PackageBuilder::new("Package");
+        builder.add_source("m.move", source);
+        let path = builder.write_to_temp().unwrap();
+        let result = h.publish_package_with_options(
+            &acc,
+            path.path(),
+            BuildOptions::move_2().set_latest_language(),
+        );
+        if positive_test {
+            assert_success!(result);
+        } else {
+            assert_vm_status!(result, StatusCode::FEATURE_NOT_ENABLED);
+        }
+    }
+}

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -579,7 +579,7 @@ Lifetime: transient
 We do not expect use from Move, so for now only for documentation purposes here
 
 
-<pre><code><b>const</b> <a href="features.md#0x1_features_ENABLE_FUNCTION_VALUES">ENABLE_FUNCTION_VALUES</a>: u64 = 88;
+<pre><code><b>const</b> <a href="features.md#0x1_features_ENABLE_FUNCTION_VALUES">ENABLE_FUNCTION_VALUES</a>: u64 = 89;
 </code></pre>
 
 
@@ -1008,7 +1008,7 @@ Lifetime: transient
 We do not expect use from Move, so for now only for documentation purposes here
 
 
-<pre><code><b>const</b> <a href="features.md#0x1_features_VM_BINARY_FORMAT_V8">VM_BINARY_FORMAT_V8</a>: u64 = 87;
+<pre><code><b>const</b> <a href="features.md#0x1_features_VM_BINARY_FORMAT_V8">VM_BINARY_FORMAT_V8</a>: u64 = 86;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -571,6 +571,19 @@ The provided signer has not a framework address.
 
 
 
+<a id="0x1_features_ENABLE_FUNCTION_VALUES"></a>
+
+Whether function values are enabled.
+Lifetime: transient
+
+We do not expect use from Move, so for now only for documentation purposes here
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_ENABLE_FUNCTION_VALUES">ENABLE_FUNCTION_VALUES</a>: u64 = 88;
+</code></pre>
+
+
+
 <a id="0x1_features_FEE_PAYER_ACCOUNT_OPTIONAL"></a>
 
 
@@ -983,6 +996,19 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_VM_BINARY_FORMAT_V7">VM_BINARY_FORMAT_V7</a>: u64 = 40;
+</code></pre>
+
+
+
+<a id="0x1_features_VM_BINARY_FORMAT_V8"></a>
+
+Whether bytecode version v8 is enabled.
+Lifetime: transient
+
+We do not expect use from Move, so for now only for documentation purposes here
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_VM_BINARY_FORMAT_V8">VM_BINARY_FORMAT_V8</a>: u64 = 87;
 </code></pre>
 
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -663,7 +663,7 @@ module std::features {
     /// Lifetime: transient
     ///
     /// We do not expect use from Move, so for now only for documentation purposes here
-    const ENABLE_FUNCTION_VALUES: u64 = 90;
+    const ENABLE_FUNCTION_VALUES: u64 = 89;
 
 
     // ============================================================================================

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -634,6 +634,12 @@ module std::features {
         is_enabled(ACCOUNT_ABSTRACTION)
     }
 
+    /// Whether bytecode version v8 is enabled.
+    /// Lifetime: transient
+    ///
+    /// We do not expect use from Move, so for now only for documentation purposes here
+    const VM_BINARY_FORMAT_V8: u64 = 86;
+
     /// Whether the batch Bulletproofs native functions are available. This is needed because of the introduction of a new native function.
     /// Lifetime: transient
     const BULLETPROOFS_BATCH_NATIVES: u64 = 87;
@@ -652,6 +658,13 @@ module std::features {
     public fun is_domain_account_abstraction_enabled(): bool acquires Features {
         is_enabled(DOMAIN_ACCOUNT_ABSTRACTION)
     }
+
+    /// Whether function values are enabled.
+    /// Lifetime: transient
+    ///
+    /// We do not expect use from Move, so for now only for documentation purposes here
+    const ENABLE_FUNCTION_VALUES: u64 = 90;
+
 
     // ============================================================================================
     // Feature Flag Implementation

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -16,7 +16,7 @@ use codespan_reporting::{
     term::termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor},
 };
 use itertools::Itertools;
-use move_binary_format::{file_format_common::VERSION_7, CompiledModule};
+use move_binary_format::{file_format_common, file_format_common::VERSION_7, CompiledModule};
 use move_command_line_common::files::MOVE_COMPILED_EXTENSION;
 use move_compiler::{
     compiled_unit::{CompiledUnit, NamedCompiledModule},
@@ -153,6 +153,15 @@ impl BuildOptions {
     pub fn with_experiment(mut self, exp: &str) -> Self {
         self.experiments.push(exp.to_string());
         self
+    }
+
+    pub fn set_latest_language(self) -> Self {
+        BuildOptions {
+            language_version: Some(LanguageVersion::latest()),
+            bytecode_version: Some(file_format_common::VERSION_MAX),
+            ..self
+        }
+        .with_experiment(Experiment::FUNCTION_VALUES)
     }
 }
 

--- a/storage/scratchpad/src/sparse_merkle/mod.rs
+++ b/storage/scratchpad/src/sparse_merkle/mod.rs
@@ -529,6 +529,7 @@ impl FrozenSparseMerkleTree {
     }
 
     /// Queries a `key` in this `SparseMerkleTree`.
+    #[cfg(any(feature = "fuzzing", feature = "bench", test))]
     fn get(&self, key: HashValue) -> StateStoreStatus {
         let mut subtree = self.smt.root_weak();
         let mut bits = key.iter_bits();

--- a/third_party/move/move-bytecode-verifier/src/features.rs
+++ b/third_party/move/move-bytecode-verifier/src/features.rs
@@ -8,7 +8,10 @@ use crate::VerifierConfig;
 use move_binary_format::{
     binary_views::BinaryIndexedView,
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
-    file_format::{CompiledModule, CompiledScript, StructFieldInformation},
+    file_format::{
+        Bytecode, CompiledModule, CompiledScript, FieldDefinition, SignatureToken,
+        StructFieldInformation,
+    },
     IndexKind,
 };
 use move_core_types::vm_status::StatusCode;
@@ -32,8 +35,10 @@ impl<'a> FeatureVerifier<'a> {
             config,
             code: BinaryIndexedView::Module(module),
         };
+        verifier.verify_signatures()?;
         verifier.verify_function_handles()?;
-        verifier.verify_struct_defs()
+        verifier.verify_struct_defs()?;
+        verifier.verify_function_defs()
     }
 
     pub fn verify_script(config: &'a VerifierConfig, module: &'a CompiledScript) -> VMResult<()> {
@@ -48,25 +53,52 @@ impl<'a> FeatureVerifier<'a> {
             config,
             code: BinaryIndexedView::Script(script),
         };
-        verifier.verify_function_handles()
+        verifier.verify_signatures()?;
+        verifier.verify_function_handles()?;
+        verifier.verify_function_defs()
     }
 
     fn verify_struct_defs(&self) -> PartialVMResult<()> {
-        if !self.config.enable_enum_types {
+        if !self.config.enable_enum_types || !self.config.enable_function_values {
             if let Some(defs) = self.code.struct_defs() {
                 for (idx, sdef) in defs.iter().enumerate() {
-                    if matches!(
-                        sdef.field_information,
-                        StructFieldInformation::DeclaredVariants(..)
-                    ) {
-                        return Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
-                            .at_index(IndexKind::StructDefinition, idx as u16)
-                            .with_message("enum type feature not enabled".to_string()));
+                    match &sdef.field_information {
+                        StructFieldInformation::Declared(fields) => {
+                            if !self.config.enable_function_values {
+                                for field in fields {
+                                    self.verify_field_definition(idx, field)?
+                                }
+                            }
+                        },
+                        StructFieldInformation::DeclaredVariants(variants) => {
+                            if !self.config.enable_enum_types {
+                                return Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
+                                    .at_index(IndexKind::StructDefinition, idx as u16)
+                                    .with_message("enum type feature not enabled".to_string()));
+                            }
+                            if !self.config.enable_function_values {
+                                for variant in variants {
+                                    for field in &variant.fields {
+                                        self.verify_field_definition(idx, field)?
+                                    }
+                                }
+                            }
+                        },
+                        StructFieldInformation::Native => {},
                     }
                 }
             }
         }
         Ok(())
+    }
+
+    fn verify_field_definition(
+        &self,
+        struct_idx: usize,
+        field: &FieldDefinition,
+    ) -> PartialVMResult<()> {
+        self.verify_signature_token(&field.signature.0)
+            .map_err(|e| e.at_index(IndexKind::StructDefinition, struct_idx as u16))
     }
 
     fn verify_function_handles(&self) -> PartialVMResult<()> {
@@ -80,5 +112,50 @@ impl<'a> FeatureVerifier<'a> {
             }
         }
         Ok(())
+    }
+
+    fn verify_function_defs(&self) -> PartialVMResult<()> {
+        if !self.config.enable_function_values {
+            for (idx, def) in self.code.function_defs().unwrap_or(&[]).iter().enumerate() {
+                if let Some(unit) = &def.code {
+                    for bc in &unit.code {
+                        if matches!(
+                            bc,
+                            Bytecode::PackClosure(..)
+                                | Bytecode::PackClosureGeneric(..)
+                                | Bytecode::CallClosure(..)
+                        ) {
+                            return Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
+                                .at_index(IndexKind::FunctionDefinition, idx as u16)
+                                .with_message("function value feature not enabled".to_string()));
+                        }
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn verify_signatures(&self) -> PartialVMResult<()> {
+        if !self.config.enable_function_values {
+            for (idx, sig) in self.code.signatures().iter().enumerate() {
+                for tok in &sig.0 {
+                    for t in tok.preorder_traversal() {
+                        self.verify_signature_token(t)
+                            .map_err(|e| e.at_index(IndexKind::Signature, idx as u16))?
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn verify_signature_token(&self, tok: &SignatureToken) -> PartialVMResult<()> {
+        if !self.config.enable_function_values && matches!(tok, SignatureToken::Function(..)) {
+            Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
+                .with_message("function value feature not enabled".to_string()))
+        } else {
+            Ok(())
+        }
     }
 }

--- a/third_party/move/move-bytecode-verifier/src/type_safety.rs
+++ b/third_party/move/move-bytecode-verifier/src/type_safety.rs
@@ -353,10 +353,10 @@ fn clos_pack(
     // Check the captured arguments on the stack
     let param_sgn = verifier.resolver.signature_at(func_handle.parameters);
     let captured_param_tys = mask.extract(&param_sgn.0, true);
-    let mut abilities = AbilitySet::ALL;
+    let mut abilities = AbilitySet::MAXIMAL_FUNCTIONS;
     for ty in captured_param_tys.into_iter().rev() {
-        abilities = abilities.intersect(verifier.abilities(ty)?);
         let arg = safe_unwrap!(verifier.stack.pop());
+        abilities = abilities.intersect(verifier.abilities(&arg)?);
         // For captured param type to argument, use assignability
         if (type_actuals.is_empty() && !ty.is_assignable_from(&arg))
             || (!type_actuals.is_empty() && !instantiate(ty, type_actuals).is_assignable_from(&arg))
@@ -393,7 +393,6 @@ fn clos_pack(
     if !is_storable {
         abilities.remove(Ability::Store);
     }
-    abilities.remove(Ability::Key);
 
     // Construct the resulting function type
     let not_captured_param_tys = mask

--- a/third_party/move/move-bytecode-verifier/src/verifier.rs
+++ b/third_party/move/move-bytecode-verifier/src/verifier.rs
@@ -42,6 +42,7 @@ pub struct VerifierConfig {
     pub sig_checker_v2_fix_script_ty_param_count: bool,
     pub enable_enum_types: bool,
     pub enable_resource_access_control: bool,
+    pub enable_function_values: bool,
 }
 
 /// Helper for a "canonical" verification of a module.
@@ -240,6 +241,7 @@ impl Default for VerifierConfig {
 
             enable_enum_types: true,
             enable_resource_access_control: true,
+            enable_function_values: true,
         }
     }
 }
@@ -284,6 +286,7 @@ impl VerifierConfig {
 
             enable_enum_types: true,
             enable_resource_access_control: true,
+            enable_function_values: true,
         }
     }
 }

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -117,6 +117,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Inherited(Experiment::FUNCTION_VALUES.to_string()),
         },
         Experiment {
+            name: Experiment::LAMBDA_LIFTING_INLINE.to_string(),
+            description: "Whether inline functions shall be included in lambda lifting".to_string(),
+            default: Given(false),
+        },
+        Experiment {
             name: Experiment::FUNCTION_VALUES.to_string(),
             description: "Turns on or off first-class function values".to_string(),
             default: Given(false),
@@ -281,12 +286,13 @@ impl Experiment {
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
     pub const FLUSH_WRITES_OPTIMIZATION: &'static str = "flush-writes-optimization";
-    pub const FUNCTION_VALUES: &'static str = "lambda-values";
+    pub const FUNCTION_VALUES: &'static str = "function-values";
     pub const GEN_ACCESS_SPECIFIERS: &'static str = "gen-access-specifiers";
     pub const INLINING: &'static str = "inlining";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
     pub const KEEP_UNINIT_ANNOTATIONS: &'static str = "keep-uninit-annotations";
     pub const LAMBDA_LIFTING: &'static str = "lambda-lifting";
+    pub const LAMBDA_LIFTING_INLINE: &'static str = "lambda-lifting-inline";
     pub const LINT_CHECKS: &'static str = "lint-checks";
     pub const MESSAGE_FORMAT_JSON: &'static str = "compiler-message-format-json";
     pub const OPTIMIZE: &'static str = "optimize";

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -379,10 +379,11 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
     }
 
     if options.experiment_on(Experiment::LAMBDA_LIFTING) {
-        env_pipeline.add("lambda-lifting", |env: &mut GlobalEnv| {
+        let include_inline_functions = options.experiment_on(Experiment::LAMBDA_LIFTING_INLINE);
+        env_pipeline.add("lambda-lifting", move |env: &mut GlobalEnv| {
             lambda_lifter::lift_lambdas(
                 LambdaLiftingOptions {
-                    include_inline_functions: true,
+                    include_inline_functions,
                 },
                 env,
             )

--- a/third_party/move/move-compiler-v2/tests/lambda/inline-parity/lambda_typed.lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda/inline-parity/lambda_typed.lambda.exp
@@ -46,7 +46,7 @@ module 0x42::LambdaTest2 {
         }, 2)
     }
     public inline fun inline_apply3(g: |u64|u64,c: u64): u64 {
-        Add<u64>(LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(closure#0LambdaTest2::__lambda__2__inline_apply3(), 3))), 4)
+        Add<u64>(LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64| LambdaTest1::inline_apply(|y: u64| y, x), 3))), 4)
     }
     public fun test_inline_lambda() {
         {
@@ -74,12 +74,6 @@ module 0x42::LambdaTest2 {
           };
           Tuple()
         }
-    }
-    private fun __lambda__1__inline_apply3(y: u64): u64 {
-        y
-    }
-    private fun __lambda__2__inline_apply3(x: u64): u64 {
-        LambdaTest1::inline_apply(closure#0LambdaTest2::__lambda__1__inline_apply3(), x)
     }
 } // end 0x42::LambdaTest2
 module 0x42::LambdaTest {
@@ -136,7 +130,7 @@ module 0x42::LambdaTest2 {
         } + 2
     }
     public inline fun inline_apply3(g: |u64|u64, c: u64): u64 {
-        LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|arg0| __lambda__2__inline_apply3(arg0), 3))) + 4
+        LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x| LambdaTest1::inline_apply(|y| y, x), 3))) + 4
     }
     public fun test_inline_lambda() {
         let product = 1;
@@ -154,12 +148,6 @@ module 0x42::LambdaTest2 {
                 i = i + 1;
             }
         };
-    }
-    fun __lambda__1__inline_apply3(y: u64): u64 {
-        y
-    }
-    fun __lambda__2__inline_apply3(x: u64): u64 {
-        LambdaTest1::inline_apply(|arg0| __lambda__1__inline_apply3(arg0), x)
     }
 }
 module 0x42::LambdaTest {
@@ -229,24 +217,6 @@ public fun LambdaTest2::test_inline_lambda() {
  28: goto 5
  29: label L1
  30: return ()
-}
-
-
-[variant baseline]
-fun LambdaTest2::__lambda__1__inline_apply3($t0: u64): u64 {
-     var $t1: u64
-  0: $t1 := infer($t0)
-  1: return $t1
-}
-
-
-[variant baseline]
-fun LambdaTest2::__lambda__2__inline_apply3($t0: u64): u64 {
-     var $t1: u64
-     var $t2: |u64|u64
-  0: $t2 := closure#0 LambdaTest2::__lambda__1__inline_apply3()
-  1: $t1 := LambdaTest1::inline_apply($t2, $t0)
-  2: return $t1
 }
 
 
@@ -342,27 +312,6 @@ public fun LambdaTest2::test_inline_lambda() {
 
 
 [variant baseline]
-fun LambdaTest2::__lambda__1__inline_apply3($t0: u64): u64 {
-     var $t1: u64 [unused]
-     # live vars: $t0
-  0: return $t0
-}
-
-
-[variant baseline]
-fun LambdaTest2::__lambda__2__inline_apply3($t0: u64): u64 {
-     var $t1: u64 [unused]
-     var $t2: |u64|u64
-     # live vars: $t0
-  0: $t2 := closure#0 LambdaTest2::__lambda__1__inline_apply3()
-     # live vars: $t0, $t2
-  1: $t0 := LambdaTest1::inline_apply($t2, $t0)
-     # live vars: $t0
-  2: return $t0
-}
-
-
-[variant baseline]
 fun LambdaTest::test_lambda() {
      var $t0: bool
      var $t1: u64
@@ -391,9 +340,6 @@ module 42.LambdaTest1 {
 
 }// Move bytecode v8
 module 42.LambdaTest2 {
-use 0000000000000000000000000000000000000000000000000000000000000042::LambdaTest1;
-
-
 
 
 public test_inline_lambda() /* def_idx: 0 */ {
@@ -438,18 +384,6 @@ B3:
 	27: MoveLoc[2]($t2: &vector<u64>)
 	28: Pop
 	29: Ret
-}
-__lambda__1__inline_apply3(y: u64): u64 /* def_idx: 1 */ {
-B0:
-	0: MoveLoc[0](y: u64)
-	1: Ret
-}
-__lambda__2__inline_apply3(x: u64): u64 /* def_idx: 2 */ {
-B0:
-	0: PackClosure#0 __lambda__1__inline_apply3(u64): u64
-	1: MoveLoc[0](x: u64)
-	2: Call LambdaTest1::inline_apply(|u64|u64, u64): u64
-	3: Ret
 }
 }// Move bytecode v8
 module 42.LambdaTest {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/registry.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/registry.exp
@@ -1,0 +1,1 @@
+processed 6 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/registry.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/registry.move
@@ -1,0 +1,47 @@
+//# publish
+module 0x66::registry {
+    use 0x1::signer;
+    struct R<T>(T) has key;
+    public fun store<T: store>(s: &signer, x: T) {
+        move_to(s, R(x))
+    }
+    public fun remove<T: store>(s: &signer): T acquires R {
+        let R(x) = move_from<R<T>>(signer::address_of(s));
+        x
+    }
+}
+
+//# publish
+module 0x66::delayed_work {
+    use 0x66::registry;
+
+    entry fun initialize(s: &signer) {
+        registry::store< |u64|u64 has store >(s, id_fun)
+    }
+
+    entry fun delayed_add(s: &signer, amount: u64) {
+        let current = registry::remove< |u64|u64 has store >(s);
+        registry::store< |u64|u64 has store >(s, |x| add_fun(current, amount, x))
+    }
+
+    entry fun eval(s: &signer, amount: u64, expected: u64) {
+        let current = registry::remove< |u64|u64 has store >(s);
+        assert!(current(amount) == expected)
+    }
+
+    public fun add_fun(old: |u64|u64, x: u64, y: u64): u64 {
+        old(x) + y
+    }
+
+    public fun id_fun(x: u64): u64 {
+        x
+    }
+}
+
+//# run 0x66::delayed_work::initialize --signers 0x66
+
+//# run 0x66::delayed_work::delayed_add --verbose --signers 0x66 --args 5
+
+//# run 0x66::delayed_work::delayed_add --verbose --signers 0x66 --args 7
+
+//# run 0x66::delayed_work::eval --signers 0x66 --args 3 15

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -100,7 +100,7 @@ pub fn verify_pack_closure(
     {
         with_instantiation(resolver, func, expected, |expected| {
             // Intersect the captured type with the accumulated abilities
-            abilities = abilities.intersect(expected.abilities()?);
+            abilities = abilities.intersect(given.abilities()?);
             given.paranoid_check_assignable(expected)
         })?
     }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -13,7 +13,7 @@ use move_core_types::{
 use serde::{Deserialize, Serialize};
 use strum_macros::{EnumString, FromRepr};
 
-/// The feature flags define in the Move source. This must stay aligned with the constants there.
+/// The feature flags defined in the Move source. This must stay aligned with the constants there.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, FromRepr, EnumString)]
 #[allow(non_camel_case_types)]
 pub enum FeatureFlag {
@@ -122,6 +122,8 @@ pub enum FeatureFlag {
     VM_BINARY_FORMAT_V8 = 86,
     BULLETPROOFS_BATCH_NATIVES = 87,
     DOMAIN_ACCOUNT_ABSTRACTION = 88,
+    /// Whether function values are enabled.
+    ENABLE_FUNCTION_VALUES = 89,
 }
 
 impl FeatureFlag {
@@ -209,6 +211,8 @@ impl FeatureFlag {
             FeatureFlag::ACCOUNT_ABSTRACTION,
             FeatureFlag::BULLETPROOFS_BATCH_NATIVES,
             FeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION,
+            FeatureFlag::VM_BINARY_FORMAT_V8,
+            FeatureFlag::ENABLE_FUNCTION_VALUES,
         ]
     }
 }


### PR DESCRIPTION
## Description

Adds move-e2e-test for smoke testing storable closures. Fixes a bug in bytecode verifier and paranoid mode regards computation of closure abilities.

Finishes closures in stackless bytecode generator as otherwise extended checker (move-model) doesn't work and e2e tests fail.

Also introduces a new feature flag ENABLE_FUNCTION_VALUES which allows to turn on and off this feature independent of the bytecode version. This is needed so we can roll out binary version v8 and pass the module upgrade test _before_ this feature is actually enabled. (With other words, guarding with the bytecode version alone doesn't work today.)


## How Has This Been Tested?

e2e test for feature gating, smoke test for storable functions, and new transactional test for verifying the bytecode verifier bug

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

