### PR TITLE
[compiler-v2][trivial] Allow receiver call for spec fun

### DIFF
--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -2598,7 +2598,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 let translated =
                     et.translate_seq(&loc, seq, &result_type, &ErrorMessageContext::Return);
                 et.finalize_types();
-                self.spec_funs[self.spec_fun_index].body = Some(translated.into_exp());
+                let translated = et.post_process_body(translated.into_exp());
+                self.spec_funs[self.spec_fun_index].body = Some(translated);
             },
             EA::FunctionBody_::Native => {
                 if !uninterpreted {

--- a/third_party/move/move-prover/tests/sources/functional/bug_15969.exp
+++ b/third_party/move/move-prover/tests/sources/functional/bug_15969.exp
@@ -1,0 +1,18 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/bug_15969.move:23:9
+   │
+23 │         ensures result != spec_empty(s); // this does not verify
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/bug_15969.move:18: test_empty
+   =         s = <redacted>
+   =     at tests/sources/functional/bug_15969.move:19: test_empty
+   =     at tests/sources/functional/bug_15969.move:9: empty
+   =         self = <redacted>
+   =     at tests/sources/functional/bug_15969.move:10: empty
+   =         result = <redacted>
+   =     at tests/sources/functional/bug_15969.move:11: empty
+   =         result = <redacted>
+   =     at tests/sources/functional/bug_15969.move:20: test_empty
+   =     at tests/sources/functional/bug_15969.move:23: test_empty (spec)

--- a/third_party/move/move-prover/tests/sources/functional/bug_15969.move
+++ b/third_party/move/move-prover/tests/sources/functional/bug_15969.move
@@ -1,0 +1,28 @@
+module 0x42::m {
+    use std::vector;
+
+    struct S {
+        v: vector<u64>
+    }
+
+
+    fun empty(self: &S) : bool {
+        vector::length(&self.v) == 0
+    }
+
+
+    spec fun spec_empty(self: S): bool {
+        self.empty()
+    }
+
+    fun test_empty(s: &S): bool {
+        s.empty()
+    }
+
+    spec test_empty {
+        ensures result != spec_empty(s); // this does not verify
+    }
+
+
+
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR fixes the bug in exp_builder to allow using receiver-style call in spec functions. 

Close #15969 


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests;
2) add a new test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
