### PR TITLE
[compiler-v2] Remove compiler v1 from the CLI

### DIFF
--- a/aptos-move/e2e-move-tests/src/lib.rs
+++ b/aptos-move/e2e-move-tests/src/lib.rs
@@ -11,8 +11,6 @@ pub mod stake;
 use anyhow::bail;
 use aptos_framework::{BuildOptions, BuiltPackage, UPGRADE_POLICY_CUSTOM_FIELD};
 pub use harness::*;
-#[cfg(test)]
-use move_model::metadata::CompilerVersion;
 use move_package::{package_hooks::PackageHooks, source_package::parsed_manifest::CustomDepInfo};
 use move_symbol_pool::Symbol;
 pub use stake::*;
@@ -45,17 +43,5 @@ pub(crate) fn build_package(
     package_path: PathBuf,
     options: BuildOptions,
 ) -> anyhow::Result<BuiltPackage> {
-    BuiltPackage::build(package_path.to_owned(), options)
-}
-
-#[cfg(test)]
-pub(crate) fn build_package_with_compiler_version(
-    package_path: PathBuf,
-    options: BuildOptions,
-    compiler_version: CompilerVersion,
-) -> anyhow::Result<BuiltPackage> {
-    let mut options = options;
-    options.language_version = Some(compiler_version.infer_stable_language_version());
-    options.compiler_version = Some(compiler_version);
     BuiltPackage::build(package_path.to_owned(), options)
 }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,7 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Compiler v1 is now deprecated. It is now removed from the Aptos CLI.
 
 ## [6.2.0]
 - Several compiler parsing bugs fixed, including in specifications for receiver style functions

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -48,7 +48,7 @@ use aptos_types::{
 };
 use aptos_vm_types::output::VMOutput;
 use async_trait::async_trait;
-use clap::{ArgGroup, Parser, ValueEnum};
+use clap::{Parser, ValueEnum};
 use hex::FromHexError;
 use indoc::indoc;
 use move_core_types::{
@@ -1110,7 +1110,6 @@ impl FromStr for OptimizationLevel {
 
 /// Options for compiling a move package dir
 #[derive(Debug, Clone, Parser)]
-#[clap(group = ArgGroup::new("move-version").args(&["move_1", "move_2"]).required(false))]
 pub struct MovePackageDir {
     /// Path to a move package (the folder with a Move.toml file).  Defaults to current directory.
     #[clap(long, value_parser)]
@@ -1174,41 +1173,27 @@ pub struct MovePackageDir {
 
     /// ...or --bytecode BYTECODE_VERSION
     /// Specify the version of the bytecode the compiler is going to emit.
-    /// Defaults to `7`.
+    /// If not provided, it is inferred from the language version.
     #[clap(long, alias = "bytecode", verbatim_doc_comment)]
     pub bytecode_version: Option<u32>,
 
     /// ...or --compiler COMPILER_VERSION
-    /// Specify the version of the compiler.
-    /// Defaults to the latest stable compiler version (at least 2)
-    /// Note: `aptos move prove` does not support v1
+    /// Specify the version of the compiler (must be at least 2).
+    /// Defaults to the latest stable compiler version.
     #[clap(long, value_parser = clap::value_parser!(CompilerVersion),
            alias = "compiler",
            default_value = LATEST_STABLE_COMPILER_VERSION,
-           default_value_if("move_2", "true", LATEST_STABLE_COMPILER_VERSION),
-           default_value_if("move_1", "true", "1"),
            verbatim_doc_comment)]
     pub compiler_version: Option<CompilerVersion>,
 
     /// ...or --language LANGUAGE_VERSION
     /// Specify the language version to be supported.
-    /// Defaults to the latest stable language version (at least 2)
+    /// Defaults to the latest stable language version.
     #[clap(long, value_parser = clap::value_parser!(LanguageVersion),
            alias = "language",
            default_value = LATEST_STABLE_LANGUAGE_VERSION,
-           default_value_if("move_2", "true", LATEST_STABLE_LANGUAGE_VERSION),
-           default_value_if("move_1", "true", "1"),
            verbatim_doc_comment)]
     pub language_version: Option<LanguageVersion>,
-
-    /// Select bytecode, language, and compiler versions to support the latest Move 2.
-    #[clap(long, verbatim_doc_comment)]
-    pub move_2: bool,
-
-    /// Select bytecode, language, and compiler versions for Move 1.
-    /// Note: `aptos move prove` does not support v1
-    #[clap(long, verbatim_doc_comment)]
-    pub move_1: bool,
 }
 
 impl Default for MovePackageDir {
@@ -1231,8 +1216,6 @@ impl MovePackageDir {
             language_version: Some(LanguageVersion::latest_stable()),
             skip_attribute_checks: false,
             check_test_code: false,
-            move_2: true,
-            move_1: false,
             optimize: None,
             experiments: vec![],
         }

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -912,32 +912,20 @@ pub struct CompileScriptFunction {
     #[clap(flatten)]
     pub framework_package_args: FrameworkPackageArgs,
 
-    #[clap(long, default_value_if("move_2", "true", "7"))]
+    #[clap(long)]
     pub bytecode_version: Option<u32>,
 
     /// Specify the version of the compiler.
     /// Defaults to the latest stable compiler version (at least 2)
     #[clap(long, value_parser = clap::value_parser!(CompilerVersion),
-           default_value = LATEST_STABLE_COMPILER_VERSION,
-           default_value_if("move_2", "true", LATEST_STABLE_COMPILER_VERSION),
-           default_value_if("move_1", "true", "1"),)]
+           default_value = LATEST_STABLE_COMPILER_VERSION,)]
     pub compiler_version: Option<CompilerVersion>,
 
     /// Specify the language version to be supported.
     /// Defaults to the latest stable language version (at least 2)
     #[clap(long, value_parser = clap::value_parser!(LanguageVersion),
-           default_value = LATEST_STABLE_LANGUAGE_VERSION,
-           default_value_if("move_2", "true", LATEST_STABLE_LANGUAGE_VERSION),
-           default_value_if("move_1", "true", "1"),)]
+           default_value = LATEST_STABLE_LANGUAGE_VERSION,)]
     pub language_version: Option<LanguageVersion>,
-
-    /// Select bytecode, language, compiler for Move 2
-    #[clap(long, default_value_t = true)]
-    pub move_2: bool,
-
-    /// Select bytecode, language, and compiler versions for Move 1.
-    #[clap(long, default_value_t = false)]
-    pub move_1: bool,
 }
 
 impl CompileScriptFunction {

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -932,20 +932,6 @@ impl IncludedArtifacts {
         experiments.append(&mut move_options.experiments.clone());
         experiments.append(&mut more_experiments);
 
-        if matches!(compiler_version, Some(CompilerVersion::V1)) {
-            if !matches!(optimize, Option::None | Some(OptimizationLevel::Default)) {
-                return Err(CliError::CommandArgumentError(
-                    "`--optimization-level`/`--optimize` flag is not compatible with Move Compiler V1"
-                        .to_string(),
-                ));
-            };
-            if !move_options.experiments.is_empty() {
-                return Err(CliError::CommandArgumentError(
-                    "`--experiments` flag is not compatible with Move Compiler V1".to_string(),
-                ));
-            };
-        }
-
         let base_options = BuildOptions {
             dev,
             // Always enable error map bytecode injection

--- a/third_party/move/move-command-line-common/src/env.rs
+++ b/third_party/move/move-command-line-common/src/env.rs
@@ -28,24 +28,6 @@ pub fn get_bytecode_version_from_env(from_input: Option<u32>) -> Option<u32> {
     }
 }
 
-/// An environment variable which can be set to force use of the move-compiler-v2
-/// in all contexts where the V1 compiler is currently used.
-const MOVE_COMPILER_V2_ENV_VAR: &str = "MOVE_COMPILER_V2";
-const MVC_V2_ENV_VAR: &str = "MVC_V2";
-
-pub fn get_move_compiler_v2_from_env() -> bool {
-    read_bool_env_var(MOVE_COMPILER_V2_ENV_VAR) || read_bool_env_var(MVC_V2_ENV_VAR)
-}
-
-/// An environment variable which can be set to force use of the move-compiler-v1
-/// in all contexts where the V2 compiler is currently used.
-const MOVE_COMPILER_V1_ENV_VAR: &str = "MOVE_COMPILER_V1";
-const MVC_V1_ENV_VAR: &str = "MVC_V1";
-
-pub fn get_move_compiler_v1_from_env() -> bool {
-    read_bool_env_var(MOVE_COMPILER_V1_ENV_VAR) || read_bool_env_var(MVC_V1_ENV_VAR)
-}
-
 /// An environment variable which can be set to cause a panic if the V1 Move compiler is run (past
 /// parsing and expansion phases, which are currently used by V2) as part of another toolchain or
 /// testing process.  This is useful for debugging whether V2 is being invoked properly.

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -230,7 +230,7 @@ pub fn run_checker_and_rewriters(options: Options) -> anyhow::Result<GlobalEnv> 
     } else {
         RewritingScope::CompilationTarget
     };
-    let env_pipeline = check_and_rewrite_pipeline(&options, false, scope);
+    let env_pipeline = check_and_rewrite_pipeline(&options, scope);
     let mut env = run_checker(options)?;
     if !env.has_errors() {
         if whole_program {
@@ -287,16 +287,14 @@ pub fn run_file_format_gen(
 
 /// Constructs the env checking and rewriting processing pipeline. `inlining_scope` can be set to
 /// `Everything` for use with the Move Prover, otherwise `CompilationTarget`
-/// should be used. If the model this is run on is produced via the v1 pipeline, the code
-/// can be assumed already checked by the v1 compiler, so we skip some steps.
+/// should be used.
 pub fn check_and_rewrite_pipeline<'a, 'b>(
     options: &'a Options,
-    for_v1_model: bool,
     inlining_scope: RewritingScope,
 ) -> EnvProcessorPipeline<'b> {
     let mut env_pipeline = EnvProcessorPipeline::<'b>::default();
 
-    if !for_v1_model && options.experiment_on(Experiment::USAGE_CHECK) {
+    if options.experiment_on(Experiment::USAGE_CHECK) {
         env_pipeline.add(
             "unused checks",
             flow_insensitive_checkers::check_for_unused_vars_and_params,
@@ -307,7 +305,7 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
         );
     }
 
-    if !for_v1_model && options.experiment_on(Experiment::RECURSIVE_TYPE_CHECK) {
+    if options.experiment_on(Experiment::RECURSIVE_TYPE_CHECK) {
         env_pipeline.add("check recursive struct definition", |env| {
             recursive_struct_checker::check_recursive_struct(env)
         });
@@ -316,13 +314,13 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
         });
     }
 
-    if !for_v1_model && options.experiment_on(Experiment::UNUSED_STRUCT_PARAMS_CHECK) {
+    if options.experiment_on(Experiment::UNUSED_STRUCT_PARAMS_CHECK) {
         env_pipeline.add("unused struct params check", |env| {
             unused_params_checker::unused_params_checker(env)
         });
     }
 
-    if !for_v1_model && options.experiment_on(Experiment::ACCESS_CHECK) {
+    if options.experiment_on(Experiment::ACCESS_CHECK) {
         env_pipeline.add(
             "access and use check before inlining",
             |env: &mut GlobalEnv| function_checker::check_access_and_use(env, true),
@@ -335,14 +333,14 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
         .is_at_least(LanguageVersion::V2_0)
         && options.experiment_on(Experiment::SEQS_IN_BINOPS_CHECK);
 
-    if !for_v1_model && check_seqs_in_binops {
+    if check_seqs_in_binops {
         env_pipeline.add("binop side effect check", |env| {
             // This check should be done before inlining.
             seqs_in_binop_checker::checker(env)
         });
     }
 
-    if !for_v1_model && options.experiment_on(Experiment::LINT_CHECKS) {
+    if options.experiment_on(Experiment::LINT_CHECKS) {
         // Perform all the model AST lint checks before AST transformations, to be closer
         // in form to the user code.
         env_pipeline.add("model AST lints", model_ast_lints::checker);
@@ -355,14 +353,14 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
         });
     }
 
-    if !for_v1_model && options.experiment_on(Experiment::ACCESS_CHECK) {
+    if options.experiment_on(Experiment::ACCESS_CHECK) {
         env_pipeline.add(
             "access and use check after inlining",
             |env: &mut GlobalEnv| function_checker::check_access_and_use(env, false),
         );
     }
 
-    if !for_v1_model && options.experiment_on(Experiment::ACQUIRES_CHECK) {
+    if options.experiment_on(Experiment::ACQUIRES_CHECK) {
         env_pipeline.add("acquires check", |env| {
             acquires_checker::acquires_checker(env)
         });

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -795,7 +795,6 @@ fn run_test(path: &Path, config: TestConfig) -> datatest_stable::Result<()> {
         // Run env processor pipeline.
         let env_pipeline = move_compiler_v2::check_and_rewrite_pipeline(
             &options,
-            false,
             RewritingScope::CompilationTarget,
         );
         if config.dump_ast == DumpLevel::AllStages {

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -5,9 +5,8 @@ use anyhow::bail;
 use move_binary_format::file_format_common::{
     VERSION_DEFAULT, VERSION_DEFAULT_LANG_V2, VERSION_MAX,
 };
-use move_command_line_common::{env, env::get_move_compiler_v1_from_env};
+use move_command_line_common::env;
 use move_compiler::shared::LanguageVersion as CompilerLanguageVersion;
-use once_cell::sync::Lazy;
 use serde::{Deserialize, Serialize};
 use std::{
     fmt,
@@ -80,7 +79,7 @@ impl CompilationMetadata {
 /// a different/largely refactored compiler. This we have versions `1, 2.0, 2.1, 2.2, .., `.
 #[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord)]
 pub enum CompilerVersion {
-    /// The legacy v1 Move compiler
+    /// The legacy v1 Move compiler, no longer supported.
     V1,
     /// The v2 compiler, starting with 2.0-unstable. Each new released version of the compiler
     /// should get an enum entry here.
@@ -90,14 +89,8 @@ pub enum CompilerVersion {
 }
 
 impl Default for CompilerVersion {
-    /// We allow the default to be set via an environment variable.
     fn default() -> Self {
-        static MOVE_COMPILER_V1: Lazy<bool> = Lazy::new(get_move_compiler_v1_from_env);
-        if *MOVE_COMPILER_V1 {
-            Self::V1
-        } else {
-            Self::latest_stable()
-        }
+        Self::latest_stable()
     }
 }
 
@@ -160,25 +153,12 @@ impl CompilerVersion {
 
     /// Check whether the compiler version supports the given language version,
     /// generates an error if not.
-    pub fn check_language_support(self, version: LanguageVersion) -> anyhow::Result<()> {
+    pub fn check_language_support(self, _version: LanguageVersion) -> anyhow::Result<()> {
         match self {
             CompilerVersion::V1 => {
-                if version != LanguageVersion::V1 {
-                    bail!("compiler v1 does only support Move language version 1")
-                } else {
-                    Ok(())
-                }
+                bail!("compiler v1 is no longer supported")
             },
             _ => Ok(()),
-        }
-    }
-
-    /// Infer the latest stable language version based on the compiler version
-    pub fn infer_stable_language_version(&self) -> LanguageVersion {
-        if *self == CompilerVersion::V1 {
-            LanguageVersion::V1
-        } else {
-            LanguageVersion::latest_stable()
         }
     }
 
@@ -223,12 +203,7 @@ impl LanguageVersion {
 
 impl Default for LanguageVersion {
     fn default() -> Self {
-        static MOVE_COMPILER_V1: Lazy<bool> = Lazy::new(get_move_compiler_v1_from_env);
-        if *MOVE_COMPILER_V1 {
-            Self::V1
-        } else {
-            Self::latest_stable()
-        }
+        Self::latest_stable()
     }
 }
 

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -8,10 +8,8 @@ use clap::*;
 use codespan_reporting::term::{termcolor, termcolor::StandardStream};
 use move_command_line_common::files::{FileHash, MOVE_COVERAGE_MAP_EXTENSION};
 use move_compiler::{
-    diagnostics::{self, codes::Severity},
     shared::{NumberFormat, NumericalAddress},
-    unit_test::{plan_builder::construct_test_plan, TestPlan},
-    PASS_CFGIR,
+    unit_test::TestPlan,
 };
 use move_compiler_v2::plan_builder as plan_builder_v2;
 use move_core_types::effects::ChangeSet;
@@ -182,9 +180,6 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
     writer: &mut W,
     factory: F,
 ) -> Result<UnitTestResult> {
-    let mut test_plan = None;
-    let mut test_plan_v2 = None;
-
     build_config.test_mode = true;
     build_config.dev_mode = true;
     build_config.generate_move_model = test_validation::needs_validation();
@@ -226,6 +221,7 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
         .collect();
     let root_package = resolution_graph.root_package.package.name;
     let build_plan = BuildPlan::create(resolution_graph)?;
+    let mut test_plan = None;
     // Compile the package. We need to intercede in the compilation, process being performed by the
     // Move package system, to first grab the compilation env, construct the test plan from it, and
     // then save it, before resuming the rest of the compilation and returning the results and
@@ -234,38 +230,14 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
         writer,
         &build_config.compiler_config,
         vec![],
-        |compiler| {
-            let (files, comments_and_compiler_res) = compiler.run::<PASS_CFGIR>().unwrap();
-            let (_, compiler) =
-                diagnostics::unwrap_or_report_diagnostics(&files, comments_and_compiler_res);
-            let (mut compiler, cfgir) = compiler.into_ast();
-            let compilation_env = compiler.compilation_env();
-            let built_test_plan = construct_test_plan(compilation_env, Some(root_package), &cfgir);
-            if let Err(diags) = compilation_env.check_diags_at_or_above_severity(
-                if unit_test_config.ignore_compile_warnings {
-                    Severity::NonblockingError
-                } else {
-                    Severity::Warning
-                },
-            ) {
-                diagnostics::report_diagnostics_exit_on_error(&files, diags);
-            }
-
-            let compilation_result = compiler.at_cfgir(cfgir).build();
-
-            let (units, _) = diagnostics::unwrap_or_report_diagnostics(&files, compilation_result);
-            test_plan = Some((built_test_plan, files.clone(), units.clone()));
-            Ok((files, units, None))
-        },
         |options| {
-            let (files, units, opt_env) = build_and_report_v2_driver(options).unwrap();
-            let env = opt_env.expect("v2 driver should return env");
+            let (files, units, env) = build_and_report_v2_driver(options).unwrap();
             let root_package_in_model = env.symbol_pool().make(root_package.deref());
             let built_test_plan =
                 plan_builder_v2::construct_test_plan(&env, Some(root_package_in_model));
 
-            test_plan_v2 = Some((built_test_plan, files.clone(), units.clone()));
-            Ok((files, units, Some(env)))
+            test_plan = Some((built_test_plan, files.clone(), units.clone()));
+            Ok((files, units, env))
         },
     )?;
 
@@ -284,12 +256,6 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
             }
         }
     }
-
-    let test_plan = if test_plan.is_some() {
-        test_plan
-    } else {
-        test_plan_v2
-    };
 
     let (test_plan, mut files, units) = test_plan.unwrap();
     files.extend(dep_file_map);

--- a/third_party/move/tools/move-package/src/compilation/build_plan.rs
+++ b/third_party/move/tools/move-package/src/compilation/build_plan.rs
@@ -13,11 +13,7 @@ use crate::{
     CompilerConfig,
 };
 use anyhow::{Context, Result};
-use move_compiler::{
-    compiled_unit::AnnotatedCompiledUnit,
-    diagnostics::{report_diagnostics_to_color_buffer, report_warnings, FilesSourceText},
-    Compiler,
-};
+use move_compiler::{compiled_unit::AnnotatedCompiledUnit, diagnostics::FilesSourceText};
 use move_compiler_v2::external_checks::ExternalChecks;
 use move_model::model;
 use petgraph::algo::toposort;
@@ -38,7 +34,7 @@ pub type CompilerDriverResult = anyhow::Result<(
     // The compilation artifacts, including V1 intermediate ASTs.
     Vec<AnnotatedCompiledUnit>,
     // For compilation with V2, compiled program model.
-    Option<model::GlobalEnv>,
+    model::GlobalEnv,
 )>;
 
 impl BuildPlan {
@@ -66,22 +62,12 @@ impl BuildPlan {
         config: &CompilerConfig,
         writer: &mut W,
     ) -> Result<CompiledPackage> {
-        self.compile_with_driver(
-            writer,
-            config,
-            vec![],
-            |compiler| {
-                let (files, units) = compiler.build_and_report()?;
-                Ok((files, units, None))
-            },
-            build_and_report_v2_driver,
-        )
-        .map(|(package, _)| package)
+        self.compile_with_driver(writer, config, vec![], build_and_report_v2_driver)
+            .map(|(package, _)| package)
     }
 
     /// Compilation process does not exit even if warnings/failures are encountered.
-    /// External checks on Move code can be provided via `external_checks`, these checks
-    /// are only run when using the compiler v2.
+    /// External checks on Move code can be provided via `external_checks`.
     pub fn compile_no_exit<W: Write>(
         &self,
         config: &CompilerConfig,
@@ -92,23 +78,6 @@ impl BuildPlan {
             writer,
             config,
             external_checks,
-            |compiler| {
-                let (files, units_res) = compiler.build()?;
-                match units_res {
-                    Ok((units, warning_diags)) => {
-                        report_warnings(&files, warning_diags);
-                        Ok((files, units, None))
-                    },
-                    Err(error_diags) => {
-                        assert!(!error_diags.is_empty());
-                        let diags_buf = report_diagnostics_to_color_buffer(&files, error_diags);
-                        if let Err(err) = std::io::stdout().write_all(&diags_buf) {
-                            anyhow::bail!("Cannot output compiler diagnostics: {}", err);
-                        }
-                        anyhow::bail!("Compilation error");
-                    },
-                }
-            },
             build_and_report_no_exit_v2_driver,
         )
     }
@@ -118,8 +87,7 @@ impl BuildPlan {
         writer: &mut W,
         config: &CompilerConfig,
         external_checks: Vec<Arc<dyn ExternalChecks>>,
-        compiler_driver_v1: impl FnMut(Compiler) -> CompilerDriverResult,
-        compiler_driver_v2: impl FnMut(move_compiler_v2::Options) -> CompilerDriverResult,
+        driver: impl FnMut(move_compiler_v2::Options) -> CompilerDriverResult,
     ) -> Result<(CompiledPackage, Option<model::GlobalEnv>)> {
         let root_package = &self.resolution_graph.package_table[&self.root];
         let project_root = match &self.resolution_graph.build_options.install_dir {
@@ -164,8 +132,7 @@ impl BuildPlan {
             config,
             external_checks,
             &self.resolution_graph,
-            compiler_driver_v1,
-            compiler_driver_v2,
+            driver,
         )?;
 
         Self::clean(

--- a/third_party/move/tools/move-package/src/compilation/compiled_package.rs
+++ b/third_party/move/tools/move-package/src/compilation/compiled_package.rs
@@ -27,14 +27,10 @@ use move_compiler::{
         known_attributes::{AttributeKind, KnownAttribute},
         Flags, NamedAddressMap, NumericalAddress, PackagePaths,
     },
-    Compiler,
 };
 use move_compiler_v2::{external_checks::ExternalChecks, Experiment};
 use move_docgen::{Docgen, DocgenOptions};
-use move_model::{
-    model::GlobalEnv, options::ModelBuilderOptions,
-    run_model_builder_with_options_and_compilation_flags,
-};
+use move_model::model::GlobalEnv;
 use move_symbol_pool::Symbol;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -549,8 +545,7 @@ impl CompiledPackage {
         config: &CompilerConfig,
         external_checks: Vec<Arc<dyn ExternalChecks>>,
         resolution_graph: &ResolvedGraph,
-        mut compiler_driver_v1: impl FnMut(Compiler) -> CompilerDriverResult,
-        mut compiler_driver_v2: impl FnMut(move_compiler_v2::Options) -> CompilerDriverResult,
+        mut compiler_driver: impl FnMut(move_compiler_v2::Options) -> CompilerDriverResult,
     ) -> Result<(CompiledPackage, Option<GlobalEnv>)> {
         let immediate_dependencies = transitive_dependencies
             .iter()
@@ -626,19 +621,9 @@ impl CompiledPackage {
         let effective_language_version = config.language_version.unwrap_or_default();
         effective_compiler_version.check_language_support(effective_language_version)?;
 
-        let (file_map, all_compiled_units, optional_global_env) =
+        let (file_map, all_compiled_units, model) =
             match config.compiler_version.unwrap_or_default() {
-                CompilerVersion::V1 => {
-                    let mut paths = src_deps;
-                    paths.push(sources_package_paths.clone());
-                    let compiler = Compiler::from_package_paths(
-                        paths,
-                        bytecode_deps.clone(),
-                        flags,
-                        &known_attributes,
-                    );
-                    compiler_driver_v1(compiler)?
-                },
+                CompilerVersion::V1 => anyhow::bail!("Compiler v1 is no longer supported"),
                 version @ CompilerVersion::V2_0 | version @ CompilerVersion::V2_1 => {
                     let to_str_vec = |ps: &[Symbol]| {
                         ps.iter()
@@ -693,7 +678,7 @@ impl CompiledPackage {
                         ..Default::default()
                     };
                     options = options.set_experiment(Experiment::ATTACH_COMPILED_MODULE, true);
-                    compiler_driver_v2(options)?
+                    compiler_driver(options)?
                 },
             };
         let mut root_compiled_units = vec![];
@@ -744,31 +729,6 @@ impl CompiledPackage {
             || resolution_graph.build_options.generate_abis
             || resolution_graph.build_options.generate_move_model
         {
-            let mut flags = if resolution_graph.build_options.full_model_generation {
-                Flags::all_functions()
-            } else {
-                // Include verification functions as this has been legacy behavior.
-                Flags::verification()
-            };
-
-            if skip_attribute_checks {
-                flags = flags.set_skip_attribute_checks(true)
-            }
-
-            let model = if let Some(env) = optional_global_env {
-                env
-            } else {
-                run_model_builder_with_options_and_compilation_flags(
-                    // Otherwise, use V1 generated model
-                    vec![sources_package_paths],
-                    vec![],
-                    deps_package_paths.into_iter().map(|(p, _)| p).collect_vec(),
-                    ModelBuilderOptions::default(),
-                    flags,
-                    &known_attributes,
-                )?
-            };
-
             if resolution_graph.build_options.generate_docs {
                 compiled_docs = Some(Self::build_docs(
                     resolved_package.source_package.package.name,
@@ -1130,11 +1090,7 @@ pub fn build_and_report_v2_driver(options: move_compiler_v2::Options) -> Compile
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
     let mut emitter = options.error_emitter(&mut stderr);
     match move_compiler_v2::run_move_compiler(emitter.as_mut(), options) {
-        Ok((env, units)) => Ok((
-            move_compiler_v2::make_files_source_text(&env),
-            units,
-            Some(env),
-        )),
+        Ok((env, units)) => Ok((move_compiler_v2::make_files_source_text(&env), units, env)),
         Err(_) => {
             // Error reported, exit
             std::process::exit(1);
@@ -1149,11 +1105,7 @@ pub fn build_and_report_no_exit_v2_driver(
     let mut stderr = StandardStream::stderr(ColorChoice::Auto);
     let mut emitter = options.error_emitter(&mut stderr);
     let (env, units) = move_compiler_v2::run_move_compiler(emitter.as_mut(), options)?;
-    Ok((
-        move_compiler_v2::make_files_source_text(&env),
-        units,
-        Some(env),
-    ))
+    Ok((move_compiler_v2::make_files_source_text(&env), units, env))
 }
 
 /// Returns the deserialized module from the bytecode file

--- a/third_party/move/tools/move-package/src/compilation/model_builder.rs
+++ b/third_party/move/tools/move-package/src/compilation/model_builder.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use itertools::Itertools;
 use move_compiler::shared::PackagePaths;
 use move_compiler_v2::Options;
-use move_model::{model::GlobalEnv, options::ModelBuilderOptions, run_model_builder_with_options};
+use move_model::model::GlobalEnv;
 use termcolor::{ColorChoice, StandardStream};
 
 #[derive(Debug, Clone)]
@@ -128,14 +128,7 @@ impl ModelBuilder {
             .compiler_config
             .known_attributes;
         match self.model_config.compiler_version {
-            CompilerVersion::V1 => run_model_builder_with_options(
-                all_targets,
-                vec![],
-                all_deps,
-                ModelBuilderOptions::default(),
-                skip_attribute_checks,
-                known_attributes,
-            ),
+            CompilerVersion::V1 => anyhow::bail!("Compiler v1 is no longer supported"),
             CompilerVersion::V2_0 | CompilerVersion::V2_1 => {
                 let mut options = make_options_for_v2_compiler(all_targets, all_deps);
                 options.language_version = self

--- a/third_party/move/tools/move-unit-test/src/lib.rs
+++ b/third_party/move/tools/move-unit-test/src/lib.rs
@@ -162,8 +162,7 @@ impl UnitTestingConfig {
                     .collect(),
                 ..Default::default()
             };
-            let (files, units, opt_env) = build_and_report_v2_driver(options).unwrap();
-            let env = opt_env.expect("v2 driver should return env");
+            let (files, units, env) = build_and_report_v2_driver(options).unwrap();
             let test_plan = plan_builder_v2::construct_test_plan(&env, None);
             (test_plan, files, units)
         };


### PR DESCRIPTION
## Description

In this PR, we remove compiler v1 from the CLI.

Notes:
1. Once this PR merges, we will tag with `compiler-v1-alive` or similar, as after this PR, compiler v1 will not be available through the CLI and certain APIs.
2. The next CLI release after this PR gets merged should bump up the main version (i.e., `7.0.0`).
3. Aptos end-to-end comparison testing will not work because compiling with v1 will bail. I have discussed this with @rahxephon89.

## How Has This Been Tested?

- Existing tests.
- Certain tests (in e2e-move-tests) have been modified to reflect not being able to call into compiler v1.

## Key Areas to Review

Any general concerns about the manner of removal.

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK
- [x] Move Compiler
