### PR TITLE
[compiler-v2] Fail on warnings option

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -308,7 +308,10 @@ impl BuiltPackage {
             }
 
             if let Some(model_options) = model.get_extension::<Options>() {
-                if model_options.experiment_on(Experiment::STOP_AFTER_EXTENDED_CHECKS) {
+                if model_options.experiment_on(Experiment::FAIL_ON_WARNING) && model.has_warnings()
+                {
+                    bail!("found warning(s), and `--fail-on-warning` is set")
+                } else if model_options.experiment_on(Experiment::STOP_AFTER_EXTENDED_CHECKS) {
                     std::process::exit(if model.has_warnings() { 1 } else { 0 })
                 }
             }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 - Compiler v1 is now deprecated. It is now removed from the Aptos CLI.
+- Added a new option `aptos move compile --fail-on-warning` which fails the compilation if any warnings are found.
 
 ## [6.2.0]
 - Several compiler parsing bugs fixed, including in specifications for receiver style functions

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -3,7 +3,7 @@
 
 use crate::{
     common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageDir},
-    move_tool::{experiments_from_opt_level, fix_bytecode_version},
+    move_tool::fix_bytecode_version,
 };
 use aptos_framework::extended_checks;
 use async_trait::async_trait;
@@ -189,7 +189,7 @@ fn compile_coverage(
             language_version: move_options
                 .language_version
                 .or_else(|| Some(LanguageVersion::latest_stable())),
-            experiments: experiments_from_opt_level(&move_options.optimize),
+            experiments: move_options.compute_experiments(),
         },
         ..Default::default()
     };

--- a/crates/aptos/src/update/movefmt.rs
+++ b/crates/aptos/src/update/movefmt.rs
@@ -13,7 +13,7 @@ use self_update::update::ReleaseUpdate;
 use std::path::PathBuf;
 
 const FORMATTER_BINARY_NAME: &str = "movefmt";
-const TARGET_FORMATTER_VERSION: &str = "1.0.6";
+const TARGET_FORMATTER_VERSION: &str = "1.0.7";
 
 const FORMATTER_EXE_ENV: &str = "FORMATTER_EXE";
 #[cfg(target_os = "windows")]

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -255,6 +255,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             description: "Enable json format for compiler messages".to_string(),
             default: Given(false),
         },
+        Experiment {
+            name: Experiment::FAIL_ON_WARNING.to_string(),
+            description: "Fail compilation if there is a warning".to_string(),
+            default: Given(false),
+        },
     ];
     experiments
         .into_iter()
@@ -275,6 +280,7 @@ impl Experiment {
     pub const COPY_PROPAGATION: &'static str = "copy-propagation";
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
+    pub const FAIL_ON_WARNING: &'static str = "fail-on-warning";
     pub const FLUSH_WRITES_OPTIMIZATION: &'static str = "flush-writes-optimization";
     pub const GEN_ACCESS_SPECIFIERS: &'static str = "gen-access-specifiers";
     pub const INLINING: &'static str = "inlining";


### PR DESCRIPTION
## Description

Closes #13198.

This PR adds a new user provided option to the compiler: `--fail-on-warning`.

When running, e.g., `aptos move compile --fail-on-warning`, if there are one or more warnings produced by the compiler, then the compilation fails.

Note: [minor] we also update the move formatter target version to the latest available formatter version.

## How Has This Been Tested?
- Existing tests.
- Manually tested the CLI option.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK
- [x] Move Compiler
