### PR TITLE
[3/n] Move depth formulas and type tags out of loader

### DIFF
--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
@@ -31,7 +31,10 @@ use move_vm_runtime::{
 };
 use move_vm_types::{
     code::{ModuleBytesStorage, ModuleCode},
-    loaded_data::runtime_types::{StructType, Type},
+    loaded_data::{
+        runtime_types::{StructType, Type},
+        struct_name_indexing::StructNameIndex,
+    },
     module_storage_error,
 };
 use std::{ops::Deref, sync::Arc};

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -8,6 +8,7 @@ use crate::{
     loader::{Function, Loader, Resolver},
     module_traversal::TraversalContext,
     native_extensions::NativeContextExtensions,
+    storage::ty_tag_converter::TypeTagConverter,
 };
 use move_binary_format::errors::{
     ExecutionState, Location, PartialVMError, PartialVMResult, VMResult,
@@ -155,9 +156,9 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     }
 
     pub fn type_to_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
-        self.resolver
-            .loader()
-            .type_to_type_tag(ty, self.resolver.module_storage())
+        let ty_tag_builder =
+            TypeTagConverter::new(self.resolver.module_storage().runtime_environment());
+        ty_tag_builder.ty_to_ty_tag(ty)
     }
 
     pub fn type_to_type_layout(&self, ty: &Type) -> PartialVMResult<MoveTypeLayout> {

--- a/third_party/move/move-vm/runtime/src/storage/depth_formula_calculator.rs
+++ b/third_party/move/move-vm/runtime/src/storage/depth_formula_calculator.rs
@@ -1,0 +1,135 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::ModuleStorage;
+use move_binary_format::{
+    errors::{PartialVMError, PartialVMResult},
+    file_format::TypeParameterIndex,
+};
+use move_core_types::vm_status::StatusCode;
+use move_vm_types::loaded_data::{
+    runtime_types::{DepthFormula, StructLayout, Type},
+    struct_name_indexing::StructNameIndex,
+};
+use std::collections::{BTreeMap, HashMap};
+
+/// Calculates [DepthFormula] for struct types. Stores a cache of visited formulas.
+pub(crate) struct DepthFormulaCalculator<'a> {
+    module_storage: &'a dyn ModuleStorage,
+    visited_formulas: HashMap<StructNameIndex, DepthFormula>,
+}
+
+impl<'a> DepthFormulaCalculator<'a> {
+    pub(crate) fn new(module_storage: &'a dyn ModuleStorage) -> Self {
+        Self {
+            module_storage,
+            visited_formulas: HashMap::new(),
+        }
+    }
+
+    pub(crate) fn calculate_depth_of_struct(
+        &mut self,
+        struct_name_idx: &StructNameIndex,
+    ) -> PartialVMResult<DepthFormula> {
+        if let Some(depth_formula) = self.visited_formulas.get(struct_name_idx) {
+            return Ok(depth_formula.clone());
+        }
+
+        let struct_type = self
+            .module_storage
+            .fetch_struct_ty_by_idx(struct_name_idx)?;
+        let formulas = match &struct_type.layout {
+            StructLayout::Single(fields) => fields
+                .iter()
+                .map(|(_, field_ty)| self.calculate_depth_of_type(field_ty))
+                .collect::<PartialVMResult<Vec<_>>>()?,
+            StructLayout::Variants(variants) => variants
+                .iter()
+                .flat_map(|variant| variant.1.iter().map(|(_, ty)| ty))
+                .map(|field_ty| self.calculate_depth_of_type(field_ty))
+                .collect::<PartialVMResult<Vec<_>>>()?,
+        };
+
+        let formula = DepthFormula::normalize(formulas);
+        if self
+            .visited_formulas
+            .insert(*struct_name_idx, formula.clone())
+            .is_some()
+        {
+            // Same thread has put this entry previously, which means there is a recursion.
+            let struct_name = self
+                .module_storage
+                .runtime_environment()
+                .struct_name_index_map()
+                .idx_to_struct_name_ref(*struct_name_idx)?;
+            return Err(
+                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR).with_message(
+                    format!(
+                        "Depth formula for struct '{}' is already cached by the same thread",
+                        struct_name.as_ref(),
+                    ),
+                ),
+            );
+        }
+        Ok(formula)
+    }
+
+    fn calculate_depth_of_type(&mut self, ty: &Type) -> PartialVMResult<DepthFormula> {
+        Ok(match ty {
+            Type::Bool
+            | Type::U8
+            | Type::U64
+            | Type::U128
+            | Type::Address
+            | Type::Signer
+            | Type::U16
+            | Type::U32
+            | Type::U256 => DepthFormula::constant(1),
+            Type::Vector(ty) => {
+                let mut inner = self.calculate_depth_of_type(ty)?;
+                inner.scale(1);
+                inner
+            },
+            Type::Reference(ty) | Type::MutableReference(ty) => {
+                let mut inner = self.calculate_depth_of_type(ty)?;
+                inner.scale(1);
+                inner
+            },
+            Type::TyParam(ty_idx) => DepthFormula::type_parameter(*ty_idx),
+            Type::Struct { idx, .. } => {
+                let mut struct_formula = self.calculate_depth_of_struct(idx)?;
+                debug_assert!(struct_formula.terms.is_empty());
+                struct_formula.scale(1);
+                struct_formula
+            },
+            Type::StructInstantiation { idx, ty_args, .. } => {
+                let ty_arg_map = ty_args
+                    .iter()
+                    .enumerate()
+                    .map(|(idx, ty)| {
+                        let var = idx as TypeParameterIndex;
+                        Ok((var, self.calculate_depth_of_type(ty)?))
+                    })
+                    .collect::<PartialVMResult<BTreeMap<_, _>>>()?;
+                let struct_formula = self.calculate_depth_of_struct(idx)?;
+                let mut subst_struct_formula = struct_formula.subst(ty_arg_map)?;
+                subst_struct_formula.scale(1);
+                subst_struct_formula
+            },
+            Type::Function {
+                args,
+                results,
+                abilities: _,
+            } => {
+                let mut inner = DepthFormula::normalize(
+                    args.iter()
+                        .chain(results)
+                        .map(|arg_ty| self.calculate_depth_of_type(arg_ty))
+                        .collect::<PartialVMResult<Vec<_>>>()?,
+                );
+                inner.scale(1);
+                inner
+            },
+        })
+    }
+}

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
@@ -25,7 +25,10 @@ use move_core_types::{
 };
 use move_vm_types::{
     code::{ambassador_impl_ScriptCache, Code, ModuleBytesStorage, ScriptCache, UnsyncScriptCache},
-    loaded_data::runtime_types::{StructType, Type},
+    loaded_data::{
+        runtime_types::{StructType, Type},
+        struct_name_indexing::StructNameIndex,
+    },
 };
 use std::sync::Arc;
 

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
@@ -24,7 +24,10 @@ use move_vm_types::{
         ambassador_impl_ModuleCache, ModuleBytesStorage, ModuleCache, ModuleCode,
         ModuleCodeBuilder, UnsyncModuleCache, WithBytes, WithHash,
     },
-    loaded_data::runtime_types::{StructType, Type},
+    loaded_data::{
+        runtime_types::{StructType, Type},
+        struct_name_indexing::StructNameIndex,
+    },
     sha3_256,
 };
 use std::{borrow::Borrow, ops::Deref, sync::Arc};

--- a/third_party/move/move-vm/runtime/src/storage/mod.rs
+++ b/third_party/move/move-vm/runtime/src/storage/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+pub(crate) mod depth_formula_calculator;
 pub(crate) mod loader;
 pub(crate) mod ty_tag_converter;
 mod verified_module_cache;

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -24,7 +24,10 @@ use move_core_types::{
 use move_vm_metrics::{Timer, VM_TIMER};
 use move_vm_types::{
     code::{ModuleCache, ModuleCode, ModuleCodeBuilder, WithBytes, WithHash, WithSize},
-    loaded_data::runtime_types::{StructType, Type},
+    loaded_data::{
+        runtime_types::{StructType, Type},
+        struct_name_indexing::StructNameIndex,
+    },
     module_cyclic_dependency_error, module_linker_error,
     value_serde::FunctionValueExtension,
     values::{AbstractFunction, SerializedFunctionData},
@@ -152,6 +155,19 @@ pub trait ModuleStorage: WithRuntimeEnvironment {
             })?
             .definition_struct_type
             .clone())
+    }
+
+    fn fetch_struct_ty_by_idx(&self, idx: &StructNameIndex) -> PartialVMResult<Arc<StructType>> {
+        let struct_name = self
+            .runtime_environment()
+            .struct_name_index_map()
+            .idx_to_struct_name_ref(*idx)?;
+
+        self.fetch_struct_ty(
+            struct_name.module.address(),
+            struct_name.module.name(),
+            struct_name.name.as_ident_str(),
+        )
     }
 
     /// Returns a runtime type corresponding to the specified type tag (file format type

--- a/third_party/move/move-vm/runtime/src/storage/publishing.rs
+++ b/third_party/move/move-vm/runtime/src/storage/publishing.rs
@@ -23,7 +23,10 @@ use move_core_types::{
 };
 use move_vm_types::{
     code::ModuleBytesStorage,
-    loaded_data::runtime_types::{StructType, Type},
+    loaded_data::{
+        runtime_types::{StructType, Type},
+        struct_name_indexing::StructNameIndex,
+    },
     module_linker_error,
 };
 use std::{


### PR DESCRIPTION
## Description

Move depth formula checks from loader to a separate type / file, use V2 loader only. Change type tag construction to V2 only and move it out of loader.

## How Has This Been Tested?

Existing tests.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
