### PR TITLE
[5/n] Move script loading to trait and switch to V2

### DIFF
--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/state_view_adapter.rs
@@ -25,9 +25,9 @@ use move_core_types::{
 };
 use move_vm_runtime::{
     ambassador_impl_CodeStorage, ambassador_impl_ModuleStorage,
-    ambassador_impl_WithRuntimeEnvironment, AsUnsyncCodeStorage, CodeStorage, Function, Module,
-    ModuleStorage, RuntimeEnvironment, Script, UnsyncCodeStorage, UnsyncModuleStorage,
-    WithRuntimeEnvironment,
+    ambassador_impl_WithRuntimeEnvironment, AsUnsyncCodeStorage, CodeStorage, Function,
+    LoadedFunction, Module, ModuleStorage, RuntimeEnvironment, Script, UnsyncCodeStorage,
+    UnsyncModuleStorage, WithRuntimeEnvironment,
 };
 use move_vm_types::{
     code::{ModuleBytesStorage, ModuleCode},

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -824,7 +824,7 @@ impl AptosVM {
             )?;
         }
 
-        let func = session.load_script(code_storage, script.code(), script.ty_args())?;
+        let func = code_storage.load_script(script.code(), script.ty_args())?;
 
         let compiled_script = match CompiledScript::deserialize_with_config(
             script.code(),

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -61,7 +61,7 @@ pub struct Function {
 
 /// For loaded function representation, specifies the owner: a script or a module.
 #[derive(Clone)]
-pub(crate) enum LoadedFunctionOwner {
+pub enum LoadedFunctionOwner {
     Script(Arc<Script>),
     Module(Arc<Module>),
 }
@@ -69,12 +69,12 @@ pub(crate) enum LoadedFunctionOwner {
 /// A loaded runtime function representation along with type arguments used to instantiate it.
 #[derive(Clone)]
 pub struct LoadedFunction {
-    pub(crate) owner: LoadedFunctionOwner,
+    pub owner: LoadedFunctionOwner,
     // A set of verified type arguments provided for this definition. If
     // function is not generic, an empty vector.
-    pub(crate) ty_args: Vec<Type>,
+    pub ty_args: Vec<Type>,
     // Definition of the loaded function.
-    pub(crate) function: Arc<Function>,
+    pub function: Arc<Function>,
 }
 
 /// A lazy loaded function, which can either be unresolved (as resulting

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -4,8 +4,7 @@
 
 use crate::{
     config::VMConfig, data_cache::TransactionDataCache, logging::expect_no_verification_errors,
-    module_traversal::TraversalContext, storage::module_storage::ModuleStorage, CodeStorage,
-    LayoutConverter,
+    module_traversal::TraversalContext, storage::module_storage::ModuleStorage, LayoutConverter,
 };
 use hashbrown::Equivalent;
 use lazy_static::lazy_static;
@@ -221,20 +220,6 @@ impl Loader {
         }
     }
 
-    pub(crate) fn load_script(
-        &self,
-        script_blob: &[u8],
-        ty_args: &[TypeTag],
-        data_store: &mut TransactionDataCache,
-        module_store: &LegacyModuleStorageAdapter,
-        code_storage: &impl CodeStorage,
-    ) -> VMResult<LoadedFunction> {
-        match self {
-            Self::V1(loader) => loader.load_script(script_blob, ty_args, data_store, module_store),
-            Self::V2(loader) => loader.load_script(code_storage, script_blob, ty_args),
-        }
-    }
-
     fn load_function_without_type_args(
         &self,
         module_id: &ModuleId,
@@ -397,6 +382,7 @@ impl LoaderV1 {
     // Entry point for script execution (`MoveVM::execute_script`).
     // Verifies the script if it is not in the cache of scripts loaded.
     // Type parameters are checked as well after every type is loaded.
+    #[allow(dead_code)]
     pub(crate) fn load_script(
         &self,
         script_blob: &[u8],

--- a/third_party/move/move-vm/runtime/src/runtime.rs
+++ b/third_party/move/move-vm/runtime/src/runtime.rs
@@ -501,13 +501,7 @@ impl VMRuntime {
         code_storage: &impl CodeStorage,
     ) -> VMResult<()> {
         // Load the script first, verify it, and then execute the entry-point main function.
-        let main = self.loader.load_script(
-            script.borrow(),
-            &ty_args,
-            data_store,
-            module_store,
-            code_storage,
-        )?;
+        let main = code_storage.load_script(script.borrow(), &ty_args)?;
 
         self.execute_function_impl(
             main,

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -350,22 +350,6 @@ impl<'r, 'l> Session<'r, 'l> {
         self.data_cache.exists_module(module_id)
     }
 
-    /// Load a script and all of its types into cache
-    pub fn load_script(
-        &mut self,
-        code_storage: &impl CodeStorage,
-        script: impl Borrow<[u8]>,
-        ty_args: &[TypeTag],
-    ) -> VMResult<LoadedFunction> {
-        self.move_vm.runtime.loader().load_script(
-            script.borrow(),
-            ty_args,
-            &mut self.data_cache,
-            &self.module_store,
-            code_storage,
-        )
-    }
-
     /// Load a module, a function, and all of its types into cache
     pub fn load_function_with_type_arg_inference(
         &mut self,

--- a/third_party/move/move-vm/runtime/src/storage/code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/code_storage.rs
@@ -1,11 +1,19 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{loader::Script, ModuleStorage};
+use crate::{
+    loader::{LoadedFunctionOwner, Script},
+    LoadedFunction, ModuleStorage,
+};
 use ambassador::delegatable_trait;
-use move_binary_format::{errors::VMResult, file_format::CompiledScript};
+use move_binary_format::{
+    errors::{Location, PartialVMResult, VMResult},
+    file_format::CompiledScript,
+};
+use move_core_types::language_storage::TypeTag;
 use move_vm_types::{
     code::{Code, ScriptCache},
+    loaded_data::runtime_types::Type,
     sha3_256,
 };
 use std::sync::Arc;
@@ -26,6 +34,39 @@ pub trait CodeStorage: ModuleStorage {
     /// Returns a verified script. If not yet cached, verified from scratch and cached. An error is
     /// returned if script fails to deserialize or verify.
     fn verify_and_cache_script(&self, serialized_script: &[u8]) -> VMResult<Arc<Script>>;
+
+    /// Loads the script:
+    ///   1. Fetches it from the cache (or deserializes and verifies it if it is not cached).
+    ///   2. Verifies type arguments (modules that define the type arguments are also loaded).
+    /// If both steps are successful, returns a [LoadedFunction] corresponding to the script's
+    /// entrypoint.
+    fn load_script(
+        &self,
+        serialized_script: &[u8],
+        ty_tag_args: &[TypeTag],
+    ) -> VMResult<LoadedFunction> {
+        // Step 1: Load script. During the loading process, if script has not been previously
+        // cached, it will be verified.
+        let script = self.verify_and_cache_script(serialized_script)?;
+
+        // Step 2: Load & verify types used as type arguments passed to this script. Note that
+        // arguments for scripts are verified on the client side.
+        let ty_args = ty_tag_args
+            .iter()
+            .map(|ty_tag| self.fetch_ty(ty_tag))
+            .collect::<PartialVMResult<Vec<_>>>()
+            .map_err(|err| err.finish(Location::Script))?;
+
+        let main = script.entry_point();
+        Type::verify_ty_arg_abilities(main.ty_param_abilities(), &ty_args)
+            .map_err(|err| err.finish(Location::Script))?;
+
+        Ok(LoadedFunction {
+            owner: LoadedFunctionOwner::Script(script),
+            ty_args,
+            function: main,
+        })
+    }
 }
 
 impl<T> CodeStorage for T

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    loader::{Function, Module, Script},
+    loader::{Function, LoadedFunction, Module, Script},
     storage::{
         code_storage::{ambassador_impl_CodeStorage, CodeStorage},
         environment::{

--- a/third_party/move/move-vm/runtime/src/storage/loader.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader.rs
@@ -1,10 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{config::VMConfig, loader::LoadedFunctionOwner, CodeStorage, LoadedFunction};
-use move_binary_format::errors::{Location, PartialVMResult, VMResult};
-use move_core_types::language_storage::TypeTag;
-use move_vm_types::loaded_data::runtime_types::{Type, TypeBuilder};
+use crate::config::VMConfig;
+use move_vm_types::loaded_data::runtime_types::TypeBuilder;
 
 /// V2 implementation of loader, which is stateless - i.e., it does not contain module or script
 /// cache. Instead, module and script storages are passed to all APIs by reference.
@@ -23,39 +21,5 @@ impl LoaderV2 {
 
     pub(crate) fn ty_builder(&self) -> &TypeBuilder {
         &self.vm_config.ty_builder
-    }
-
-    /// Loads the script:
-    ///   1. Fetches it from the cache (or deserializes and verifies it if it is not cached).
-    ///   2. Verifies type arguments (modules that define the type arguments are also loaded).
-    /// If both steps are successful, returns a [LoadedFunction] corresponding to the script's
-    /// entrypoint.
-    pub(crate) fn load_script(
-        &self,
-        code_storage: &impl CodeStorage,
-        serialized_script: &[u8],
-        ty_tag_args: &[TypeTag],
-    ) -> VMResult<LoadedFunction> {
-        // Step 1: Load script. During the loading process, if script has not been previously
-        // cached, it will be verified.
-        let script = code_storage.verify_and_cache_script(serialized_script)?;
-
-        // Step 2: Load & verify types used as type arguments passed to this script. Note that
-        // arguments for scripts are verified on the client side.
-        let ty_args = ty_tag_args
-            .iter()
-            .map(|ty_tag| code_storage.fetch_ty(ty_tag))
-            .collect::<PartialVMResult<Vec<_>>>()
-            .map_err(|err| err.finish(Location::Script))?;
-
-        let main = script.entry_point();
-        Type::verify_ty_arg_abilities(main.ty_param_abilities(), &ty_args)
-            .map_err(|err| err.finish(Location::Script))?;
-
-        Ok(LoadedFunction {
-            owner: LoadedFunctionOwner::Script(script),
-            ty_args,
-            function: main,
-        })
     }
 }


### PR DESCRIPTION
## Description

Move `load_script` to `CodeStorage` as a default member. Switch to V2 flow and remove V1 loader usage for script loading.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
