### PR TITLE
[compiler-v2] Check test code by default

### DIFF
--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -127,7 +127,7 @@ impl Default for BuildOptions {
             compiler_version: None,
             language_version: None,
             skip_attribute_checks: false,
-            check_test_code: false,
+            check_test_code: true,
             known_attributes: extended_checks::get_all_attribute_names().clone(),
             experiments: vec![],
         }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 # Unreleased
 - Compiler v1 is now deprecated. It is now removed from the Aptos CLI.
 - Added a new option `aptos move compile --fail-on-warning` which fails the compilation if any warnings are found.
+- We now default to running extended checks when compiling test code (this was previously only done with the option `--check-test-code`, but this is no longer available). However, these checks can be now be skipped with `--skip-checks-on-test-code`.
 
 ## [6.2.0]
 - Several compiler parsing bugs fixed, including in specifications for receiver style functions

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1109,9 +1109,9 @@ impl FromStr for OptimizationLevel {
     }
 }
 
-/// Options for compiling a move package dir
+/// Options for compiling a move package.
 #[derive(Debug, Clone, Parser)]
-pub struct MovePackageDir {
+pub struct MovePackageOptions {
     /// Path to a move package (the folder with a Move.toml file).  Defaults to current directory.
     #[clap(long, value_parser)]
     pub package_dir: Option<PathBuf>,
@@ -1155,11 +1155,9 @@ pub struct MovePackageDir {
     #[clap(long)]
     pub dev: bool,
 
-    /// Do apply extended checks for Aptos (e.g. `#[view]` attribute) also on test code.
-    /// NOTE: this behavior will become the default in the future.
-    /// See <https://github.com/aptos-labs/aptos-core/issues/10335>
-    #[clap(long, env = "APTOS_CHECK_TEST_CODE")]
-    pub check_test_code: bool,
+    /// Skip extended checks (such as checks for the #[view] attribute) on test code.
+    #[clap(long, default_value = "false")]
+    pub skip_checks_on_test_code: bool,
 
     /// Select optimization level.  Choices are "none", "default", or "extra".
     /// Level "extra" may spend more time on expensive optimizations in the future.
@@ -1201,13 +1199,13 @@ pub struct MovePackageDir {
     pub fail_on_warning: bool,
 }
 
-impl Default for MovePackageDir {
+impl Default for MovePackageOptions {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl MovePackageDir {
+impl MovePackageOptions {
     pub fn new() -> Self {
         Self {
             dev: false,
@@ -1220,7 +1218,7 @@ impl MovePackageDir {
             compiler_version: Some(CompilerVersion::latest_stable()),
             language_version: Some(LanguageVersion::latest_stable()),
             skip_attribute_checks: false,
-            check_test_code: false,
+            skip_checks_on_test_code: false,
             optimize: None,
             fail_on_warning: false,
             experiments: vec![],

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -9,7 +9,7 @@ use crate::common::utils::read_from_file;
 use crate::{
     common::{
         types::{
-            CliError, CliTypedResult, MovePackageDir, PoolAddressArgs, ProfileOptions,
+            CliError, CliTypedResult, MovePackageOptions, PoolAddressArgs, ProfileOptions,
             PromptOptions, RestOptions, TransactionOptions, TransactionSummary,
         },
         utils::prompt_yes_with_override,
@@ -1008,7 +1008,7 @@ pub struct GenerateUpgradeProposal {
     pub(crate) next_execution_hash: String,
 
     #[clap(flatten)]
-    pub(crate) move_options: MovePackageDir,
+    pub(crate) move_options: MovePackageOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageDir},
+    common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageOptions},
     move_tool::fix_bytecode_version,
 };
 use aptos_framework::extended_checks;
@@ -35,7 +35,7 @@ pub struct SummaryCoverage {
     #[clap(long, short)]
     pub filter: Option<String>,
     #[clap(flatten)]
-    pub move_options: MovePackageDir,
+    pub move_options: MovePackageOptions,
 }
 
 impl SummaryCoverage {
@@ -106,7 +106,7 @@ pub struct SourceCoverage {
     pub tag: TextIndicator,
 
     #[clap(flatten)]
-    pub move_options: MovePackageDir,
+    pub move_options: MovePackageOptions,
 }
 
 #[async_trait]
@@ -147,7 +147,7 @@ pub struct BytecodeCoverage {
     #[clap(long = "module")]
     pub module_name: String,
     #[clap(flatten)]
-    pub move_options: MovePackageDir,
+    pub move_options: MovePackageOptions,
 }
 
 #[async_trait]
@@ -167,13 +167,13 @@ impl CliCommand<()> for BytecodeCoverage {
 }
 
 fn compile_coverage(
-    move_options: MovePackageDir,
+    move_options: MovePackageOptions,
 ) -> CliTypedResult<(CoverageMap, CompiledPackage)> {
     let config = BuildConfig {
         dev_mode: move_options.dev,
         additional_named_addresses: move_options.named_addresses(),
         test_mode: false,
-        full_model_generation: move_options.check_test_code,
+        full_model_generation: !move_options.skip_checks_on_test_code,
         install_dir: move_options.output_dir.clone(),
         skip_fetch_latest_git_deps: move_options.skip_fetch_latest_git_deps,
         compiler_config: CompilerConfig {

--- a/crates/aptos/src/move_tool/lint.rs
+++ b/crates/aptos/src/move_tool/lint.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::types::{AccountAddressWrapper, CliCommand, CliTypedResult, MovePackageDir},
+    common::types::{AccountAddressWrapper, CliCommand, CliTypedResult, MovePackageOptions},
     move_tool::IncludedArtifacts,
 };
 use aptos_framework::{BuildOptions, BuiltPackage};
@@ -70,19 +70,13 @@ pub struct LintPackage {
     #[clap(long)]
     pub dev: bool,
 
-    /// Do apply extended checks for Aptos (e.g. `#[view]` attribute) also on test code.
-    /// NOTE: this behavior will become the default in the future.
-    /// See <https://github.com/aptos-labs/aptos-core/issues/10335>
-    #[clap(long, env = "APTOS_CHECK_TEST_CODE")]
-    pub check_test_code: bool,
-
     /// Experiments
     #[clap(long, hide(true))]
     pub experiments: Vec<String>,
 }
 
 impl LintPackage {
-    fn to_move_options(&self) -> MovePackageDir {
+    fn to_move_options(&self) -> MovePackageOptions {
         let LintPackage {
             dev,
             package_dir,
@@ -92,10 +86,9 @@ impl LintPackage {
             skip_fetch_latest_git_deps,
             language_version,
             skip_attribute_checks,
-            check_test_code,
             experiments,
         } = self.clone();
-        MovePackageDir {
+        MovePackageOptions {
             dev,
             package_dir,
             output_dir,
@@ -104,9 +97,8 @@ impl LintPackage {
             skip_fetch_latest_git_deps,
             language_version,
             skip_attribute_checks,
-            check_test_code,
             experiments,
-            ..MovePackageDir::new()
+            ..MovePackageOptions::new()
         }
     }
 }
@@ -118,7 +110,7 @@ impl CliCommand<&'static str> for LintPackage {
     }
 
     async fn execute(self) -> CliTypedResult<&'static str> {
-        let move_options = MovePackageDir {
+        let move_options = MovePackageOptions {
             compiler_version: Some(CompilerVersion::latest_stable()),
             ..self.to_move_options()
         };

--- a/crates/aptos/src/move_tool/show.rs
+++ b/crates/aptos/src/move_tool/show.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::IncludedArtifactsArgs;
-use crate::common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageDir};
+use crate::common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageOptions};
 use anyhow::Context;
 use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_types::transaction::EntryABI;
@@ -43,7 +43,7 @@ pub struct ShowAbi {
     included_artifacts_args: IncludedArtifactsArgs,
 
     #[clap(flatten)]
-    move_options: MovePackageDir,
+    move_options: MovePackageOptions,
 }
 
 #[async_trait]

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -17,7 +17,7 @@ use crate::{
             account_address_from_public_key, AccountAddressWrapper, ArgWithTypeVec,
             AuthenticationKeyInputOptions, ChunkedPublishOption, CliError, CliTypedResult,
             EncodingOptions, EntryFunctionArguments, FaucetOptions, GasOptions, KeyType,
-            MoveManifestAccountWrapper, MovePackageDir, OptionalPoolAddressArgs,
+            MoveManifestAccountWrapper, MovePackageOptions, OptionalPoolAddressArgs,
             OverrideSizeCheckOption, PoolAddressArgs, PrivateKeyInputOptions, PromptOptions,
             PublicKeyInputOptions, RestOptions, RngArgs, SaveFile, ScriptFunctionArguments,
             TransactionOptions, TransactionSummary, TypeArgVec,
@@ -1106,12 +1106,12 @@ impl CliTestFramework {
             .join("aptos-framework")
     }
 
-    pub fn move_options(&self, account_strs: BTreeMap<&str, &str>) -> MovePackageDir {
-        MovePackageDir {
+    pub fn move_options(&self, account_strs: BTreeMap<&str, &str>) -> MovePackageOptions {
+        MovePackageOptions {
             dev: true,
             named_addresses: Self::named_addresses(account_strs),
             package_dir: Some(self.move_dir()),
-            ..MovePackageDir::new()
+            ..MovePackageOptions::new()
         }
     }
 

--- a/ecosystem/indexer-grpc/indexer-transaction-generator/src/script_transaction_generator.rs
+++ b/ecosystem/indexer-grpc/indexer-transaction-generator/src/script_transaction_generator.rs
@@ -8,7 +8,7 @@ use crate::{
 use anyhow::Context;
 use aptos::{
     account::fund::FundWithFaucet,
-    common::types::{CliCommand, MovePackageDir, ScriptFunctionArguments, TransactionOptions},
+    common::types::{CliCommand, MovePackageOptions, ScriptFunctionArguments, TransactionOptions},
     governance::CompileScriptFunction,
     move_tool::{CompileScript, RunScript},
 };
@@ -213,7 +213,7 @@ impl ScriptTransactions {
 }
 
 fn create_compile_script_cmd(package_dir: PathBuf) -> CompileScript {
-    let mut move_package_dir = MovePackageDir::default();
+    let mut move_package_dir = MovePackageOptions::default();
     move_package_dir.package_dir = Some(package_dir);
 
     CompileScript {


### PR DESCRIPTION
## Description

We now run extended checks by default on test code. Users can disable these checks with `--skip-checks-on-test-code` option.

Closes #10335.

Also, we rename `MovePackageDir` -> `MovePackageOptions`.

## How Has This Been Tested?

Existing tests.

## Type of Change
- [x] Breaking change

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
