### PR TITLE
[9/n] Move function loading to module storages

### DIFF
--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/module_storage.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/module_storage.rs
@@ -25,7 +25,7 @@ pub trait AptosModuleStorage: ModuleStorage {
         &self,
         module_id: &ModuleId,
         function_name: &IdentStr,
-        expected_return_type: &Type,
+        expected_return_ty: &Type,
     ) -> VMResult<LoadedFunction> {
         let (module, function) =
             self.fetch_function_definition(module_id.address(), module_id.name(), function_name)?;
@@ -36,7 +36,7 @@ pub trait AptosModuleStorage: ModuleStorage {
         }
 
         let mut map = BTreeMap::new();
-        if !match_return_type(&function.return_tys()[0], expected_return_type, &mut map) {
+        if !match_return_type(&function.return_tys()[0], expected_return_ty, &mut map) {
             // For functions that are marked constructor this should not happen.
             return Err(
                 PartialVMError::new(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE)
@@ -45,8 +45,8 @@ pub trait AptosModuleStorage: ModuleStorage {
         }
 
         // Construct the type arguments from the match.
-        let mut ty_args = vec![];
         let num_ty_args = function.ty_param_abilities().len();
+        let mut ty_args = Vec::with_capacity(num_ty_args);
         for i in 0..num_ty_args {
             if let Some(t) = map.get(&(i as u16)) {
                 ty_args.push((*t).clone());

--- a/aptos-move/aptos-vm-types/src/module_and_script_storage/module_storage.rs
+++ b/aptos-move/aptos-vm-types/src/module_and_script_storage/module_storage.rs
@@ -2,9 +2,14 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_types::state_store::state_value::StateValueMetadata;
-use move_binary_format::errors::PartialVMResult;
-use move_core_types::{account_address::AccountAddress, identifier::IdentStr};
-use move_vm_runtime::ModuleStorage;
+use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::ModuleId,
+    vm_status::StatusCode,
+};
+use move_vm_runtime::{LoadedFunction, LoadedFunctionOwner, ModuleStorage};
+use move_vm_types::loaded_data::runtime_types::Type;
+use std::collections::{btree_map, BTreeMap};
 
 /// Represents module storage used by the Aptos blockchain.
 pub trait AptosModuleStorage: ModuleStorage {
@@ -15,4 +20,164 @@ pub trait AptosModuleStorage: ModuleStorage {
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> PartialVMResult<Option<StateValueMetadata>>;
+
+    fn load_function_with_type_arg_inference(
+        &self,
+        module_id: &ModuleId,
+        function_name: &IdentStr,
+        expected_return_type: &Type,
+    ) -> VMResult<LoadedFunction> {
+        let (module, function) =
+            self.fetch_function_definition(module_id.address(), module_id.name(), function_name)?;
+
+        if function.return_tys().len() != 1 {
+            // For functions that are marked constructor this should not happen.
+            return Err(PartialVMError::new(StatusCode::ABORTED).finish(Location::Undefined));
+        }
+
+        let mut map = BTreeMap::new();
+        if !match_return_type(&function.return_tys()[0], expected_return_type, &mut map) {
+            // For functions that are marked constructor this should not happen.
+            return Err(
+                PartialVMError::new(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE)
+                    .finish(Location::Undefined),
+            );
+        }
+
+        // Construct the type arguments from the match.
+        let mut ty_args = vec![];
+        let num_ty_args = function.ty_param_abilities().len();
+        for i in 0..num_ty_args {
+            if let Some(t) = map.get(&(i as u16)) {
+                ty_args.push((*t).clone());
+            } else {
+                // Unknown type argument we are not able to infer the type arguments.
+                // For functions that are marked constructor this should not happen.
+                return Err(
+                    PartialVMError::new(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE)
+                        .finish(Location::Undefined),
+                );
+            }
+        }
+
+        Type::verify_ty_arg_abilities(function.ty_param_abilities(), &ty_args)
+            .map_err(|e| e.finish(Location::Module(module_id.clone())))?;
+
+        Ok(LoadedFunction {
+            owner: LoadedFunctionOwner::Module(module),
+            ty_args,
+            function,
+        })
+    }
+}
+
+/// Matches the actual returned type to the expected type, binding any type args to the necessary
+/// type as stored in the map. The expected type must be a concrete type (no [Type::TyParam]).
+/// Returns true if a successful match is made.
+// TODO: is this really needed in presence of paranoid mode? This does a deep structural
+//   comparison and is expensive.
+fn match_return_type<'a>(
+    returned: &Type,
+    expected: &'a Type,
+    map: &mut BTreeMap<u16, &'a Type>,
+) -> bool {
+    match (returned, expected) {
+        // The important case, deduce the type params.
+        (Type::TyParam(idx), _) => match map.entry(*idx) {
+            btree_map::Entry::Vacant(vacant_entry) => {
+                vacant_entry.insert(expected);
+                true
+            },
+            btree_map::Entry::Occupied(occupied_entry) => *occupied_entry.get() == expected,
+        },
+        // Recursive types we need to recurse the matching types.
+        (Type::Reference(ret_inner), Type::Reference(expected_inner))
+        | (Type::MutableReference(ret_inner), Type::MutableReference(expected_inner)) => {
+            match_return_type(ret_inner, expected_inner, map)
+        },
+        (Type::Vector(ret_inner), Type::Vector(expected_inner)) => {
+            match_return_type(ret_inner, expected_inner, map)
+        },
+        // Function types, the expected abilities need to be equal to the provided ones,
+        // and recursively argument and result types need to match.
+        (
+            Type::Function {
+                args,
+                results,
+                abilities,
+            },
+            Type::Function {
+                args: exp_args,
+                results: exp_results,
+                abilities: exp_abilities,
+            },
+        ) if abilities == exp_abilities
+            && args.len() == exp_args.len()
+            && results.len() == exp_results.len() =>
+        {
+            args.iter()
+                .zip(exp_args)
+                .all(|(t, e)| match_return_type(t, e, map))
+                && results
+                    .iter()
+                    .zip(exp_results)
+                    .all(|(t, e)| match_return_type(t, e, map))
+        },
+        // Abilities should not contribute to the equality check as they just serve for caching
+        // computations. For structs the both need to be the same struct.
+        (
+            Type::Struct { idx: ret_idx, .. },
+            Type::Struct {
+                idx: expected_idx, ..
+            },
+        ) => *ret_idx == *expected_idx,
+        // For struct instantiations we need to additionally match all type arguments.
+        (
+            Type::StructInstantiation {
+                idx: ret_idx,
+                ty_args: ret_fields,
+                ..
+            },
+            Type::StructInstantiation {
+                idx: expected_idx,
+                ty_args: expected_fields,
+                ..
+            },
+        ) => {
+            *ret_idx == *expected_idx
+                && ret_fields.len() == expected_fields.len()
+                && ret_fields
+                    .iter()
+                    .zip(expected_fields.iter())
+                    .all(|types| match_return_type(types.0, types.1, map))
+        },
+        // For primitive types we need to assure the types match.
+        (Type::U8, Type::U8)
+        | (Type::U16, Type::U16)
+        | (Type::U32, Type::U32)
+        | (Type::U64, Type::U64)
+        | (Type::U128, Type::U128)
+        | (Type::U256, Type::U256)
+        | (Type::Bool, Type::Bool)
+        | (Type::Address, Type::Address)
+        | (Type::Signer, Type::Signer) => true,
+        // Otherwise the types do not match, and we can't match return type to the expected type.
+        // Note we don't use the _ pattern but spell out all cases, so that the compiler will
+        // bark when a case is missed upon future updates to the types.
+        (Type::U8, _)
+        | (Type::U16, _)
+        | (Type::U32, _)
+        | (Type::U64, _)
+        | (Type::U128, _)
+        | (Type::U256, _)
+        | (Type::Bool, _)
+        | (Type::Address, _)
+        | (Type::Signer, _)
+        | (Type::Struct { .. }, _)
+        | (Type::StructInstantiation { .. }, _)
+        | (Type::Function { .. }, _)
+        | (Type::Vector(_), _)
+        | (Type::MutableReference(_), _)
+        | (Type::Reference(_), _) => false,
+    }
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -891,8 +891,7 @@ impl AptosVM {
             )?;
         }
 
-        let function = session.load_function(
-            module_storage,
+        let function = module_storage.load_function(
             entry_fn.module(),
             entry_fn.function(),
             entry_fn.ty_args(),
@@ -2564,7 +2563,7 @@ impl AptosVM {
         gas_meter: &mut impl AptosGasMeter,
         module_storage: &impl AptosModuleStorage,
     ) -> anyhow::Result<Vec<Vec<u8>>> {
-        let func = session.load_function(module_storage, &module_id, &func_name, &type_args)?;
+        let func = module_storage.load_function(&module_id, &func_name, &type_args)?;
         let metadata = vm.extract_module_metadata(module_storage, &module_id);
         let arguments = verifier::view_function::validate_view_function(
             session,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
@@ -103,8 +103,8 @@ impl<'r, 'l> UserSession<'r, 'l> {
 
             self.session.execute(|session| {
                 let module_id = module.self_id();
-                let init_function_exists = session
-                    .load_function(&staging_module_storage, &module_id, init_func_name, &[])
+                let init_function_exists = staging_module_storage
+                    .load_function(&module_id, init_func_name, &[])
                     .is_ok();
 
                 if init_function_exists {

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -459,8 +459,7 @@ fn validate_and_construct(
         *max_invocations -= 1;
     }
 
-    let function = session.load_function_with_type_arg_inference(
-        module_storage,
+    let function = module_storage.load_function_with_type_arg_inference(
         &constructor.module_id,
         constructor.func_name,
         expected_type,

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -1031,8 +1031,7 @@ impl FakeExecutor {
             let mut session = vm.new_session(&resolver, SessionId::void(), None);
 
             // load function name into cache to ensure cache is hot
-            let _ = session.load_function(
-                &module_storage,
+            let _ = module_storage.load_function(
                 module,
                 &Self::name(function_name),
                 &type_params.clone(),

--- a/third_party/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/instantiation_tests.rs
@@ -16,8 +16,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
-    config::VMConfig, move_vm::MoveVM, session::Session, AsUnsyncCodeStorage, ModuleStorage,
-    RuntimeEnvironment, StagingModuleStorage, WithRuntimeEnvironment,
+    config::VMConfig, AsUnsyncCodeStorage, ModuleStorage, RuntimeEnvironment, StagingModuleStorage,
 };
 use move_vm_test_utils::InMemoryStorage;
 
@@ -117,9 +116,7 @@ fn instantiation_err() {
     let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
     let storage: InMemoryStorage =
         InMemoryStorage::new_with_runtime_environment(runtime_environment);
-    let vm = MoveVM::new_with_runtime_environment(storage.runtime_environment());
 
-    let mut session = vm.new_session(&storage);
     let mut mod_bytes = vec![];
     cm.serialize(&mut mod_bytes).unwrap();
 
@@ -140,16 +137,11 @@ fn instantiation_err() {
     let new_module_storage =
         StagingModuleStorage::create(&addr, &module_storage, vec![mod_bytes.into()])
             .expect("Module must publish");
-    load_function(&mut session, &new_module_storage, &cm.self_id(), &[ty_arg])
+    load_function(&new_module_storage, &cm.self_id(), &[ty_arg])
 }
 
-fn load_function(
-    session: &mut Session,
-    module_storage: &impl ModuleStorage,
-    module_id: &ModuleId,
-    ty_args: &[TypeTag],
-) {
-    let res = session.load_function(module_storage, module_id, ident_str!("f"), ty_args);
+fn load_function(module_storage: &impl ModuleStorage, module_id: &ModuleId, ty_args: &[TypeTag]) {
+    let res = module_storage.load_function(module_id, ident_str!("f"), ty_args);
     assert!(
         res.is_err(),
         "Instantiation must fail at load time when converting from type tag to type "

--- a/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -187,9 +187,8 @@ fn load_phantom_module() {
     let module_storage = InMemoryStorage::new().into_unsync_module_storage();
     let new_module_storage = adapter.publish_modules_using_loader_v2(&module_storage, modules);
 
-    let mut session = adapter.vm.new_session(&adapter.store);
-    let _ = session
-        .load_function(&new_module_storage, &module_id, ident_str!("foo"), &[])
+    let _ = new_module_storage
+        .load_function(&module_id, ident_str!("foo"), &[])
         .unwrap();
 }
 
@@ -248,9 +247,8 @@ fn load_with_extra_ability() {
     let module_storage = InMemoryStorage::new().into_unsync_module_storage();
     let new_module_storage = adapter.publish_modules_using_loader_v2(&module_storage, modules);
 
-    let mut session = adapter.vm.new_session(&adapter.store);
-    let _ = session
-        .load_function(&new_module_storage, &module_id, ident_str!("foo"), &[])
+    let _ = new_module_storage
+        .load_function(&module_id, ident_str!("foo"), &[])
         .unwrap();
 }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -93,13 +93,8 @@ fn load_and_run_functions(
     traversal_storage: &TraversalStorage,
     module_id: &ModuleId,
 ) {
-    let func = session
-        .load_function(
-            module_storage,
-            module_id,
-            &Identifier::new("foo").unwrap(),
-            &[],
-        )
+    let func = module_storage
+        .load_function(module_id, &Identifier::new("foo").unwrap(), &[])
         .unwrap();
     let err1 = session
         .execute_entry_function(
@@ -113,13 +108,8 @@ fn load_and_run_functions(
 
     assert!(err1.exec_state().unwrap().stack_trace().is_empty());
 
-    let func = session
-        .load_function(
-            module_storage,
-            module_id,
-            &Identifier::new("foo2").unwrap(),
-            &[],
-        )
+    let func = module_storage
+        .load_function(module_id, &Identifier::new("foo2").unwrap(), &[])
         .unwrap();
     let err2 = session
         .execute_entry_function(

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -35,7 +35,7 @@ mod reentrancy_checker;
 mod runtime_type_checks;
 mod storage;
 
-pub use loader::{Function, LoadedFunction, Module, Script};
+pub use loader::{Function, LoadedFunction, LoadedFunctionOwner, Module, Script};
 pub use storage::{
     code_storage::{ambassador_impl_CodeStorage, CodeStorage},
     dependencies_gas_charging::{

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -37,7 +37,7 @@ use move_vm_types::{
 };
 use parking_lot::{Mutex, RwLock};
 use std::{
-    collections::{btree_map, BTreeMap, BTreeSet},
+    collections::{BTreeMap, BTreeSet},
     hash::Hash,
     sync::Arc,
 };
@@ -58,10 +58,9 @@ use crate::{
         ty_tag_converter::TypeTagCache,
     },
 };
-pub use function::{Function, LoadedFunction};
+pub use function::{Function, LoadedFunction, LoadedFunctionOwner};
 pub(crate) use function::{
     FunctionHandle, FunctionInstantiation, LazyLoadedFunction, LazyLoadedFunctionState,
-    LoadedFunctionOwner,
 };
 pub use modules::Module;
 pub(crate) use modules::{LegacyModuleCache, LegacyModuleStorage, LegacyModuleStorageAdapter};
@@ -164,49 +163,6 @@ impl Loader {
 
     pub(crate) fn v2(vm_config: VMConfig) -> Self {
         Self::V2(LoaderV2::new(vm_config))
-    }
-
-    fn load_function_without_type_args(
-        &self,
-        module_id: &ModuleId,
-        function_name: &IdentStr,
-        data_store: &mut TransactionDataCache,
-        module_store: &LegacyModuleStorageAdapter,
-        module_storage: &impl ModuleStorage,
-    ) -> VMResult<(Arc<Module>, Arc<Function>)> {
-        match self {
-            Loader::V1(loader) => {
-                // Need to load the module first, before resolving it and the function.
-                loader.load_module(module_id, data_store, module_store)?;
-                module_store
-                    .resolve_module_and_function_by_name(module_id, function_name)
-                    .map_err(|err| err.finish(Location::Undefined))
-            },
-            Loader::V2(_) => module_storage.fetch_function_definition(
-                module_id.address(),
-                module_id.name(),
-                function_name,
-            ),
-        }
-    }
-
-    //
-    // Helpers for loading and verification
-    //
-
-    pub(crate) fn load_type(
-        &self,
-        ty_tag: &TypeTag,
-        data_store: &mut TransactionDataCache,
-        module_store: &LegacyModuleStorageAdapter,
-        module_storage: &impl ModuleStorage,
-    ) -> VMResult<Type> {
-        match self {
-            Self::V1(loader) => loader.load_type(ty_tag, data_store, module_store),
-            Self::V2(_) => module_storage
-                .fetch_ty(ty_tag)
-                .map_err(|e| e.finish(Location::Undefined)),
-        }
     }
 }
 
@@ -384,115 +340,7 @@ impl LoaderV1 {
     //
     // Module verification and loading
     //
-}
 
-impl Loader {
-    // Loading verifies the module if it was never loaded.
-    // Type parameters are inferred from the expected return type. Returns an error if it's not
-    // possible to infer the type parameters or return type cannot be matched.
-    // The type parameters are verified with capabilities.
-    pub(crate) fn load_function_with_type_arg_inference(
-        &self,
-        module_id: &ModuleId,
-        function_name: &IdentStr,
-        expected_return_type: &Type,
-        data_store: &mut TransactionDataCache,
-        module_store: &LegacyModuleStorageAdapter,
-        module_storage: &impl ModuleStorage,
-    ) -> VMResult<LoadedFunction> {
-        let (module, function) = self.load_function_without_type_args(
-            module_id,
-            function_name,
-            data_store,
-            module_store,
-            module_storage,
-        )?;
-
-        if function.return_tys().len() != 1 {
-            // For functions that are marked constructor this should not happen.
-            return Err(PartialVMError::new(StatusCode::ABORTED).finish(Location::Undefined));
-        }
-
-        let mut map = BTreeMap::new();
-        if !match_return_type(&function.return_tys()[0], expected_return_type, &mut map) {
-            // For functions that are marked constructor this should not happen.
-            return Err(
-                PartialVMError::new(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE)
-                    .finish(Location::Undefined),
-            );
-        }
-
-        // Construct the type arguments from the match
-        let mut ty_args = vec![];
-        let num_ty_args = function.ty_param_abilities().len();
-        for i in 0..num_ty_args {
-            if let Some(t) = map.get(&(i as u16)) {
-                ty_args.push((*t).clone());
-            } else {
-                // Unknown type argument we are not able to infer the type arguments.
-                // For functions that are marked constructor this should not happen.
-                return Err(
-                    PartialVMError::new(StatusCode::INVALID_MAIN_FUNCTION_SIGNATURE)
-                        .finish(Location::Undefined),
-                );
-            }
-        }
-
-        Type::verify_ty_arg_abilities(function.ty_param_abilities(), &ty_args)
-            .map_err(|e| e.finish(Location::Module(module_id.clone())))?;
-
-        Ok(LoadedFunction {
-            owner: LoadedFunctionOwner::Module(module),
-            ty_args,
-            function,
-        })
-    }
-
-    // Loading verifies the module if it was never loaded.
-    // Type parameters are checked as well after every type is loaded.
-    pub(crate) fn load_function(
-        &self,
-        module_id: &ModuleId,
-        function_name: &IdentStr,
-        ty_args: &[TypeTag],
-        data_store: &mut TransactionDataCache,
-        module_store: &LegacyModuleStorageAdapter,
-        module_storage: &impl ModuleStorage,
-    ) -> VMResult<LoadedFunction> {
-        let _timer = VM_TIMER.timer_with_label("Loader::load_function");
-
-        let (module, function) = self.load_function_without_type_args(
-            module_id,
-            function_name,
-            data_store,
-            module_store,
-            module_storage,
-        )?;
-
-        let ty_args = ty_args
-            .iter()
-            .map(|ty_arg| self.load_type(ty_arg, data_store, module_store, module_storage))
-            .collect::<VMResult<Vec<_>>>()
-            .map_err(|mut err| {
-                // User provided type argument failed to load. Set extra sub status to distinguish from internal type loading error.
-                if StatusCode::TYPE_RESOLUTION_FAILURE == err.major_status() {
-                    err.set_sub_status(move_core_types::vm_status::sub_status::type_resolution_failure::EUSER_TYPE_LOADING_FAILURE);
-                }
-                err
-            })?;
-
-        Type::verify_ty_arg_abilities(function.ty_param_abilities(), &ty_args)
-            .map_err(|e| e.finish(Location::Module(module_id.clone())))?;
-
-        Ok(LoadedFunction {
-            owner: LoadedFunctionOwner::Module(module),
-            ty_args,
-            function,
-        })
-    }
-}
-
-impl LoaderV1 {
     // Entry point for module publishing (`MoveVM::publish_module_bundle`).
     //
     // All modules in the bundle to be published must be loadable. This function performs all
@@ -1502,117 +1350,6 @@ impl<'a> FunctionValueExtension for Resolver<'a> {
             module_storage: self.module_storage,
         };
         function_value_extension.get_serialization_data(fun)
-    }
-}
-
-// Matches the actual returned type to the expected type, binding any type args to the
-// necessary type as stored in the map. The expected type must be a concrete type (no TyParam).
-// Returns true if a successful match is made.
-// TODO: is this really needed in presence of paranoid mode? This does a deep structural
-//   comparison and is expensive.
-fn match_return_type<'a>(
-    returned: &Type,
-    expected: &'a Type,
-    map: &mut BTreeMap<u16, &'a Type>,
-) -> bool {
-    match (returned, expected) {
-        // The important case, deduce the type params
-        (Type::TyParam(idx), _) => match map.entry(*idx) {
-            btree_map::Entry::Vacant(vacant_entry) => {
-                vacant_entry.insert(expected);
-                true
-            },
-            btree_map::Entry::Occupied(occupied_entry) => *occupied_entry.get() == expected,
-        },
-        // Recursive types we need to recurse the matching types
-        (Type::Reference(ret_inner), Type::Reference(expected_inner))
-        | (Type::MutableReference(ret_inner), Type::MutableReference(expected_inner)) => {
-            match_return_type(ret_inner, expected_inner, map)
-        },
-        (Type::Vector(ret_inner), Type::Vector(expected_inner)) => {
-            match_return_type(ret_inner, expected_inner, map)
-        },
-        // Function types, the expected abilities need to be equal to the provided ones,
-        // and recursively argument and result types need to match.
-        (
-            Type::Function {
-                args,
-                results,
-                abilities,
-            },
-            Type::Function {
-                args: exp_args,
-                results: exp_results,
-                abilities: exp_abilities,
-            },
-        ) if abilities == exp_abilities
-            && args.len() == exp_args.len()
-            && results.len() == exp_results.len() =>
-        {
-            args.iter()
-                .zip(exp_args)
-                .all(|(t, e)| match_return_type(t, e, map))
-                && results
-                    .iter()
-                    .zip(exp_results)
-                    .all(|(t, e)| match_return_type(t, e, map))
-        },
-        // Abilities should not contribute to the equality check as they just serve for caching computations.
-        // For structs the both need to be the same struct.
-        (
-            Type::Struct { idx: ret_idx, .. },
-            Type::Struct {
-                idx: expected_idx, ..
-            },
-        ) => *ret_idx == *expected_idx,
-        // For struct instantiations we need to additionally match all type arguments
-        (
-            Type::StructInstantiation {
-                idx: ret_idx,
-                ty_args: ret_fields,
-                ..
-            },
-            Type::StructInstantiation {
-                idx: expected_idx,
-                ty_args: expected_fields,
-                ..
-            },
-        ) => {
-            *ret_idx == *expected_idx
-                && ret_fields.len() == expected_fields.len()
-                && ret_fields
-                    .iter()
-                    .zip(expected_fields.iter())
-                    .all(|types| match_return_type(types.0, types.1, map))
-        },
-        // For primitive types we need to assure the types match
-        (Type::U8, Type::U8)
-        | (Type::U16, Type::U16)
-        | (Type::U32, Type::U32)
-        | (Type::U64, Type::U64)
-        | (Type::U128, Type::U128)
-        | (Type::U256, Type::U256)
-        | (Type::Bool, Type::Bool)
-        | (Type::Address, Type::Address)
-        | (Type::Signer, Type::Signer) => true,
-        // Otherwise the types do not match and we can't match return type to the expected type.
-        // Note we don't use the _ pattern but spell out all cases, so that the compiler will
-        // bark when a case is missed upon future updates to the types.
-        (Type::U8, _)
-        | (Type::U16, _)
-        | (Type::U32, _)
-        | (Type::U64, _)
-        | (Type::U128, _)
-        | (Type::U256, _)
-        | (Type::Bool, _)
-        | (Type::Address, _)
-        | (Type::Signer, _)
-        | (Type::Struct { .. }, _)
-        | (Type::StructInstantiation { .. }, _)
-        | (Type::Function { .. }, _)
-        | (Type::Vector(_), _)
-        | (Type::MutableReference(_), _)
-        | (Type::Reference(_), _) => false,
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -157,6 +157,7 @@ impl LegacyModuleStorageAdapter {
 
     /// Given module address/name and the function name, returns the corresponding module
     /// and function if they exist in module store cache. If not, an error is returned.
+    #[allow(dead_code)]
     pub(crate) fn resolve_module_and_function_by_name(
         &self,
         module_id: &ModuleId,

--- a/third_party/move/move-vm/runtime/src/session.rs
+++ b/third_party/move/move-vm/runtime/src/session.rs
@@ -98,14 +98,7 @@ impl<'r, 'l> Session<'r, 'l> {
         traversal_context: &mut TraversalContext,
         module_storage: &impl ModuleStorage,
     ) -> VMResult<SerializedReturnValues> {
-        let func = self.move_vm.runtime.loader().load_function(
-            module_id,
-            function_name,
-            &ty_args,
-            &mut self.data_cache,
-            &self.module_store,
-            module_storage,
-        )?;
+        let func = module_storage.load_function(module_id, function_name, &ty_args)?;
 
         self.move_vm.runtime.execute_function_instantiation(
             func,
@@ -243,58 +236,6 @@ impl<'r, 'l> Session<'r, 'l> {
         ty: &Type,
     ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)> {
         self.data_cache.load_resource(module_storage, addr, ty)
-    }
-
-    /// Load a module, a function, and all of its types into cache
-    pub fn load_function_with_type_arg_inference(
-        &mut self,
-        module_storage: &impl ModuleStorage,
-        module_id: &ModuleId,
-        function_name: &IdentStr,
-        expected_return_type: &Type,
-    ) -> VMResult<LoadedFunction> {
-        self.move_vm
-            .runtime
-            .loader()
-            .load_function_with_type_arg_inference(
-                module_id,
-                function_name,
-                expected_return_type,
-                &mut self.data_cache,
-                &self.module_store,
-                module_storage,
-            )
-    }
-
-    /// Load a module, a function, and all of its types into cache
-    pub fn load_function(
-        &mut self,
-        module_storage: &impl ModuleStorage,
-        module_id: &ModuleId,
-        function_name: &IdentStr,
-        ty_args: &[TypeTag],
-    ) -> VMResult<LoadedFunction> {
-        self.move_vm.runtime.loader().load_function(
-            module_id,
-            function_name,
-            ty_args,
-            &mut self.data_cache,
-            &self.module_store,
-            module_storage,
-        )
-    }
-
-    pub fn load_type(
-        &mut self,
-        type_tag: &TypeTag,
-        module_storage: &impl ModuleStorage,
-    ) -> VMResult<Type> {
-        self.move_vm.runtime.loader().load_type(
-            type_tag,
-            &mut self.data_cache,
-            &self.module_store,
-            module_storage,
-        )
     }
 
     pub fn get_type_tag(

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_code_storage.rs
@@ -20,7 +20,9 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_core_types::{
-    account_address::AccountAddress, identifier::IdentStr, language_storage::TypeTag,
+    account_address::AccountAddress,
+    identifier::IdentStr,
+    language_storage::{ModuleId, TypeTag},
     metadata::Metadata,
 };
 use move_vm_types::{

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
@@ -5,7 +5,7 @@ use crate::{
     ambassador_impl_ModuleStorage, ambassador_impl_WithRuntimeEnvironment,
     loader::Module,
     storage::environment::{RuntimeEnvironment, WithRuntimeEnvironment},
-    Function, ModuleStorage,
+    Function, LoadedFunction, ModuleStorage,
 };
 use ambassador::Delegate;
 use bytes::Bytes;

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -2,9 +2,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    loader::{Function, LazyLoadedFunction, LazyLoadedFunctionState, Module},
+    loader::{Function, LazyLoadedFunction, LazyLoadedFunctionState, LoadedFunctionOwner, Module},
     logging::expect_no_verification_errors,
-    LayoutConverter, StorageLayoutConverter, WithRuntimeEnvironment,
+    LayoutConverter, LoadedFunction, StorageLayoutConverter, WithRuntimeEnvironment,
 };
 use ambassador::delegatable_trait;
 use bytes::Bytes;
@@ -215,6 +215,39 @@ pub trait ModuleStorage: WithRuntimeEnvironment {
             })?
             .clone();
         Ok((module, function))
+    }
+
+    fn load_function(
+        &self,
+        module_id: &ModuleId,
+        function_name: &IdentStr,
+        ty_args: &[TypeTag],
+    ) -> VMResult<LoadedFunction> {
+        let _timer = VM_TIMER.timer_with_label("Loader::load_function");
+
+        let (module, function) =
+            self.fetch_function_definition(module_id.address(), module_id.name(), function_name)?;
+
+        let ty_args = ty_args
+            .iter()
+            .map(|ty_arg| self.fetch_ty(ty_arg).map_err(|e| e.finish(Location::Undefined)))
+            .collect::<VMResult<Vec<_>>>()
+            .map_err(|mut err| {
+                // User provided type argument failed to load. Set extra sub status to distinguish from internal type loading error.
+                if StatusCode::TYPE_RESOLUTION_FAILURE == err.major_status() {
+                    err.set_sub_status(move_core_types::vm_status::sub_status::type_resolution_failure::EUSER_TYPE_LOADING_FAILURE);
+                }
+                err
+            })?;
+
+        Type::verify_ty_arg_abilities(function.ty_param_abilities(), &ty_args)
+            .map_err(|e| e.finish(Location::Module(module_id.clone())))?;
+
+        Ok(LoadedFunction {
+            owner: LoadedFunctionOwner::Module(module),
+            ty_args,
+            function,
+        })
     }
 }
 

--- a/third_party/move/move-vm/runtime/src/storage/publishing.rs
+++ b/third_party/move/move-vm/runtime/src/storage/publishing.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     ambassador_impl_ModuleStorage, ambassador_impl_WithRuntimeEnvironment, loader::Function,
-    AsUnsyncModuleStorage, Module, ModuleStorage, RuntimeEnvironment, UnsyncModuleStorage,
-    WithRuntimeEnvironment,
+    AsUnsyncModuleStorage, LoadedFunction, Module, ModuleStorage, RuntimeEnvironment,
+    UnsyncModuleStorage, WithRuntimeEnvironment,
 };
 use ambassador::Delegate;
 use bytes::Bytes;


### PR DESCRIPTION
## Description

Moves loading of instantiated functions to V2 loader trait (module storages). This completes API transitions and V1 loader can be fully removed (next PR).

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine


## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
