### PR TITLE
[12/n] Remove use_loader_v2 config, refactor block executor to use V2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -712,7 +712,6 @@ dependencies = [
  "concurrent-queue",
  "criterion",
  "crossbeam",
- "dashmap",
  "derivative",
  "fail",
  "hashbrown 0.14.3",

--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -146,7 +146,6 @@ pub fn aptos_prod_vm_config(
         ty_builder,
         disallow_dispatch_for_native: features.is_enabled(FeatureFlag::DISALLOW_USER_NATIVES),
         use_compatibility_checker_v2,
-        use_loader_v2: features.is_loader_v2_enabled(),
         use_call_tree_and_instruction_cache: features
             .is_call_tree_and_instruction_vm_cache_enabled(),
     }

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -32,7 +32,6 @@ claims = { workspace = true }
 concurrent-queue = { workspace = true }
 criterion = { workspace = true, optional = true }
 crossbeam = { workspace = true }
-dashmap = { workspace = true }
 derivative = { workspace = true }
 fail = { workspace = true }
 hashbrown = { workspace = true }

--- a/aptos-move/block-executor/src/code_cache_global_manager.rs
+++ b/aptos-move/block-executor/src/code_cache_global_manager.rs
@@ -198,11 +198,7 @@ impl AptosModuleCacheManager {
         // To avoid cold starts, fetch the framework code. This ensures the state with 0 modules
         // cached is not possible for block execution (as long as the config enables the framework
         // prefetch).
-        let environment = guard.environment();
-        if environment.features().is_loader_v2_enabled()
-            && guard.module_cache().num_modules() == 0
-            && config.prefetch_framework_code
-        {
+        if guard.module_cache().num_modules() == 0 && config.prefetch_framework_code {
             prefetch_aptos_framework(state_view, &mut guard).map_err(|err| {
                 alert_or_println!("Failed to load Aptos framework to module cache: {:?}", err);
                 VMError::from(err).into_vm_status()

--- a/aptos-move/block-executor/src/errors.rs
+++ b/aptos-move/block-executor/src/errors.rs
@@ -6,11 +6,6 @@ use aptos_types::error::PanicError;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum ParallelBlockExecutionError {
-    // The same module access path for module was both read & written during speculative executions.
-    // This may trigger a race due to the Move-VM loader cache implementation, and mitigation requires
-    // aborting the parallel execution pipeline and falling back to the sequential execution.
-    // TODO: provide proper multi-versioning for code (like data) for the cache.
-    ModulePathReadWriteError,
     /// unrecoverable VM error
     FatalVMError,
     // Incarnation number that is higher than a threshold is observed during parallel execution.

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -181,12 +181,6 @@ where
                             group_key,
                         )));
                     },
-                    Some(KeyKind::Module) => {
-                        return Err(code_invariant_error(format!(
-                            "Group key {:?} recorded as module KeyKind",
-                            group_key,
-                        )));
-                    },
                     None => {
                         // Previously no write to the group at all.
                         needs_suffix_validation = true;
@@ -217,7 +211,7 @@ where
 
             let resource_write_set = output.resource_write_set();
 
-            // Then, process resource & aggregator_v1 & module writes.
+            // Then, process resource & aggregator_v1 writes.
             for (k, v, maybe_layout) in resource_write_set.clone().into_iter().chain(
                 output
                     .aggregator_v1_write_set()
@@ -328,7 +322,6 @@ where
             use KeyKind::*;
             match kind {
                 Resource => versioned_cache.data().remove(&k, idx_to_execute),
-                Module => (),
                 Group(tags) => {
                     // A change in state observable during speculative execution
                     // (which includes group metadata and size) changes, suffix
@@ -417,7 +410,6 @@ where
                 use KeyKind::*;
                 match kind {
                     Resource => versioned_cache.data().mark_estimate(&k, txn_idx),
-                    Module => (),
                     Group(tags) => {
                         // Validation for both group size and metadata is based on values.
                         // Execution may wait for estimates.

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -27,7 +27,7 @@ use aptos_aggregator::{
     delta_change_set::serialize,
 };
 use aptos_drop_helper::DEFAULT_DROPPER;
-use aptos_logger::{debug, error, info};
+use aptos_logger::{error, info};
 use aptos_mvhashmap::{
     types::{Incarnation, MVDelayedFieldsError, TxnIndex, ValueWithLayout},
     unsync_map::UnsyncMap,
@@ -232,21 +232,6 @@ where
                     .write(k, idx_to_execute, incarnation, v, maybe_layout);
             }
 
-            for (k, v) in output.module_write_set().into_iter() {
-                if !runtime_environment.vm_config().use_loader_v2 {
-                    if prev_modified_keys.remove(&k).is_none() {
-                        needs_suffix_validation = true;
-                    }
-
-                    #[allow(deprecated)]
-                    versioned_cache.deprecated_modules().write(
-                        k,
-                        idx_to_execute,
-                        v.into_write_op(),
-                    );
-                }
-            }
-
             // Then, apply deltas.
             for (k, d) in output.aggregator_v1_delta_set().into_iter() {
                 if prev_modified_keys.remove(&k).is_none() {
@@ -343,14 +328,7 @@ where
             use KeyKind::*;
             match kind {
                 Resource => versioned_cache.data().remove(&k, idx_to_execute),
-                Module => {
-                    if !runtime_environment.vm_config().use_loader_v2 {
-                        #[allow(deprecated)]
-                        versioned_cache
-                            .deprecated_modules()
-                            .remove(&k, idx_to_execute);
-                    }
-                },
+                Module => (),
                 Group(tags) => {
                     // A change in state observable during speculative execution
                     // (which includes group metadata and size) changes, suffix
@@ -377,21 +355,13 @@ where
             versioned_cache.delayed_fields().remove(&id, idx_to_execute);
         }
 
-        if !last_input_output.record(
+        last_input_output.record(
             idx_to_execute,
             read_set,
             result,
             resource_write_set,
             group_keys_and_tags,
-            runtime_environment,
-        ) {
-            // Module R/W is an expected fallback behavior, no alert is required.
-            debug!("[Execution] At txn {}, Module read & write", idx_to_execute);
-
-            return Err(PanicOr::Or(
-                ParallelBlockExecutionError::ModulePathReadWriteError,
-            ));
-        }
+        );
         Ok(needs_suffix_validation)
     }
 
@@ -435,7 +405,6 @@ where
         txn_idx: TxnIndex,
         last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
         versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
-        runtime_environment: &RuntimeEnvironment,
     ) {
         counters::SPECULATIVE_ABORT_COUNT.inc();
 
@@ -448,16 +417,7 @@ where
                 use KeyKind::*;
                 match kind {
                     Resource => versioned_cache.data().mark_estimate(&k, txn_idx),
-                    Module => {
-                        // In V2 loader implementation, all modules writes are "estimates":
-                        // they are pending and not visible until committed.
-                        if !runtime_environment.vm_config().use_loader_v2 {
-                            #[allow(deprecated)]
-                            versioned_cache
-                                .deprecated_modules()
-                                .mark_estimate(&k, txn_idx)
-                        }
-                    },
+                    Module => (),
                     Group(tags) => {
                         // Validation for both group size and metadata is based on values.
                         // Execution may wait for estimates.
@@ -490,17 +450,11 @@ where
         last_input_output: &TxnLastInputOutput<T, E::Output, E::Error>,
         versioned_cache: &MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
         scheduler: &Scheduler,
-        runtime_environment: &RuntimeEnvironment,
     ) -> Result<SchedulerTask, PanicError> {
         let aborted = !valid && scheduler.try_abort(txn_idx, incarnation);
 
         if aborted {
-            Self::update_transaction_on_abort(
-                txn_idx,
-                last_input_output,
-                versioned_cache,
-                runtime_environment,
-            );
+            Self::update_transaction_on_abort(txn_idx, last_input_output, versioned_cache);
             scheduler.finish_abort(txn_idx, incarnation)
         } else {
             scheduler.finish_validation(txn_idx, validation_wave);
@@ -590,12 +544,7 @@ where
             )? {
                 // Transaction needs to be re-executed, one final time.
 
-                Self::update_transaction_on_abort(
-                    txn_idx,
-                    last_input_output,
-                    versioned_cache,
-                    runtime_environment,
-                );
+                Self::update_transaction_on_abort(txn_idx, last_input_output, versioned_cache);
                 // We are going to skip reducing validation index here, as we
                 // are executing immediately, and will reduce it unconditionally
                 // after execution, inside finish_execution_during_commit.
@@ -620,19 +569,17 @@ where
 
                 // Publish modules before we decrease validation index so that validations observe
                 // the new module writes as well.
-                if runtime_environment.vm_config().use_loader_v2 {
-                    let module_write_set = last_input_output.module_write_set(txn_idx);
-                    if !module_write_set.is_empty() {
-                        executed_at_commit = true;
-                        Self::publish_module_writes(
-                            txn_idx,
-                            module_write_set,
-                            global_module_cache,
-                            versioned_cache,
-                            scheduler,
-                            runtime_environment,
-                        )?;
-                    }
+                let module_write_set = last_input_output.module_write_set(txn_idx);
+                if !module_write_set.is_empty() {
+                    executed_at_commit = true;
+                    Self::publish_module_writes(
+                        txn_idx,
+                        module_write_set,
+                        global_module_cache,
+                        versioned_cache,
+                        scheduler,
+                        runtime_environment,
+                    )?;
                 }
 
                 scheduler.wake_dependencies_and_decrease_validation_idx(txn_idx)?;
@@ -663,7 +610,7 @@ where
             // If transaction was committed without delayed fields failing, i.e., without
             // re-execution, we make the published modules visible here. As a result, we need to
             // decrease the validation index to make sure the subsequent transactions see changes.
-            if !executed_at_commit && runtime_environment.vm_config().use_loader_v2 {
+            if !executed_at_commit {
                 let module_write_set = last_input_output.module_write_set(txn_idx);
                 if !module_write_set.is_empty() {
                     Self::publish_module_writes(
@@ -1047,7 +994,6 @@ where
                         last_input_output,
                         versioned_cache,
                         scheduler,
-                        runtime_environment,
                     )?
                 },
                 SchedulerTask::ExecutionTask(
@@ -1291,19 +1237,14 @@ where
             unsync_map.write(key, Arc::new(write_op), None);
         }
 
-        for (key, write) in output.module_write_set().into_iter() {
-            if runtime_environment.vm_config().use_loader_v2 {
-                Self::add_module_write_to_module_cache(
-                    write,
-                    txn_idx,
-                    runtime_environment,
-                    global_module_cache,
-                    unsync_map.module_cache(),
-                )?;
-            } else {
-                #[allow(deprecated)]
-                unsync_map.write_module(key, write.into_write_op());
-            }
+        for (_, write) in output.module_write_set().into_iter() {
+            Self::add_module_write_to_module_cache(
+                write,
+                txn_idx,
+                runtime_environment,
+                global_module_cache,
+                unsync_map.module_cache(),
+            )?;
         }
 
         let mut second_phase = Vec::new();
@@ -1378,9 +1319,6 @@ where
             self.config.onchain.block_gas_limit_type.clone(),
             num_txns,
         );
-
-        let last_input_output: TxnLastInputOutput<T, E::Output, E::Error> =
-            TxnLastInputOutput::new(num_txns as TxnIndex);
 
         for idx in 0..num_txns {
             let txn = signature_verified_block.get_txn(idx as TxnIndex);
@@ -1460,17 +1398,6 @@ where
                                 output.get_write_summary(),
                             )
                         });
-
-                    #[allow(clippy::collapsible_if)]
-                    if !runtime_environment.vm_config().use_loader_v2 {
-                        #[allow(deprecated)]
-                        if last_input_output.check_and_append_module_rw_conflict(
-                            sequential_reads.deprecated_module_reads.iter(),
-                            output.module_write_set().keys(),
-                        ) {
-                            block_limit_processor.process_module_rw_conflict();
-                        }
-                    }
 
                     block_limit_processor.accumulate_fee_statement(
                         fee_statement,

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -18,7 +18,6 @@ pub struct BlockGasLimitProcessor<T: Transaction> {
     accumulated_fee_statement: FeeStatement,
     txn_fee_statements: Vec<FeeStatement>,
     txn_read_write_summaries: Vec<ReadWriteSummary<T>>,
-    module_rw_conflict: bool,
     start_time: Instant,
 }
 
@@ -31,7 +30,6 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
             accumulated_fee_statement: FeeStatement::zero(),
             txn_fee_statements: Vec::with_capacity(init_size),
             txn_read_write_summaries: Vec::with_capacity(init_size),
-            module_rw_conflict: false,
             start_time: Instant::now(),
         }
     }
@@ -62,11 +60,7 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
                     txn_read_write_summary.collapse_resource_group_conflicts()
                 },
             );
-            if self.module_rw_conflict {
-                conflict_overlap_length as u64
-            } else {
-                self.compute_conflict_multiplier(conflict_overlap_length as usize)
-            }
+            self.compute_conflict_multiplier(conflict_overlap_length as usize)
         } else {
             assert_none!(txn_read_write_summary);
             1
@@ -89,33 +83,6 @@ impl<T: Transaction> BlockGasLimitProcessor<T> {
         } else {
             assert_none!(approx_output_size);
         }
-    }
-
-    pub(crate) fn process_module_rw_conflict(&mut self) {
-        if self.module_rw_conflict
-            || !self
-                .block_gas_limit_type
-                .use_module_publishing_block_conflict()
-        {
-            return;
-        }
-
-        let conflict_multiplier = if let Some(conflict_overlap_length) =
-            self.block_gas_limit_type.conflict_penalty_window()
-        {
-            conflict_overlap_length
-        } else {
-            return;
-        };
-
-        self.accumulated_effective_block_gas = conflict_multiplier as u64
-            * (self.accumulated_fee_statement.execution_gas_used()
-                * self
-                    .block_gas_limit_type
-                    .execution_gas_effective_multiplier()
-                + self.accumulated_fee_statement.io_gas_used()
-                    * self.block_gas_limit_type.io_gas_effective_multiplier());
-        self.module_rw_conflict = true;
     }
 
     fn should_end_block(&mut self, mode: &str) -> bool {
@@ -474,60 +441,5 @@ mod test {
         assert_eq!(1, processor.compute_conflict_multiplier(8));
         assert_eq!(processor.accumulated_effective_block_gas, 20);
         assert!(!processor.should_end_block_parallel());
-    }
-
-    #[test]
-    fn test_module_publishing_txn_conflict() {
-        let conflict_penalty_window = 4;
-        let block_gas_limit = BlockGasLimitType::ComplexLimitV1 {
-            effective_block_gas_limit: 1000,
-            execution_gas_effective_multiplier: 1,
-            io_gas_effective_multiplier: 1,
-            conflict_penalty_window,
-            use_module_publishing_block_conflict: true,
-            block_output_limit: None,
-            include_user_txn_size_in_block_output: true,
-            add_block_limit_outcome_onchain: false,
-            use_granular_resource_group_conflicts: true,
-        };
-
-        let mut processor = BlockGasLimitProcessor::<TestTxn>::new(block_gas_limit, 10);
-        processor.accumulate_fee_statement(
-            execution_fee(10),
-            Some(ReadWriteSummary::new(
-                to_map(&[InputOutputKey::Group(2, 2)]),
-                to_map(&[InputOutputKey::Group(2, 2)]),
-            )),
-            None,
-        );
-        processor.accumulate_fee_statement(
-            execution_fee(20),
-            Some(ReadWriteSummary::new(
-                to_map(&[InputOutputKey::Group(1, 1)]),
-                to_map(&[InputOutputKey::Group(1, 1)]),
-            )),
-            None,
-        );
-        assert_eq!(1, processor.compute_conflict_multiplier(8));
-        assert_eq!(processor.accumulated_effective_block_gas, 30);
-
-        processor.process_module_rw_conflict();
-        assert_eq!(
-            processor.accumulated_effective_block_gas,
-            30 * conflict_penalty_window as u64
-        );
-
-        processor.accumulate_fee_statement(
-            execution_fee(25),
-            Some(ReadWriteSummary::new(
-                to_map(&[InputOutputKey::Group(1, 1)]),
-                to_map(&[InputOutputKey::Group(1, 1)]),
-            )),
-            None,
-        );
-        assert_eq!(
-            processor.accumulated_effective_block_gas,
-            55 * conflict_penalty_window as u64
-        );
     }
 }

--- a/aptos-move/block-executor/src/proptest_types/tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/tests.rs
@@ -313,53 +313,6 @@ fn dynamic_read_writes_contended_with_block_gas_limit(
     );
 }
 
-fn module_publishing_fallback_with_block_gas_limit(
-    num_txns: usize,
-    maybe_block_gas_limit: Option<u64>,
-) {
-    let mut runner = TestRunner::default();
-
-    let universe = vec(any::<[u8; 32]>(), 100)
-        .new_tree(&mut runner)
-        .expect("creating a new value should succeed")
-        .current();
-    let transaction_gen = vec(
-        any_with::<TransactionGen<[u8; 32]>>(TransactionGenParams::new_dynamic()),
-        num_txns,
-    )
-    .new_tree(&mut runner)
-    .expect("creating a new value should succeed")
-    .current();
-
-    run_transactions::<[u8; 32], [u8; 32], MockEvent>(
-        &universe,
-        transaction_gen.clone(),
-        vec![],
-        vec![],
-        2,
-        (false, true),
-        maybe_block_gas_limit,
-    );
-    run_transactions::<[u8; 32], [u8; 32], MockEvent>(
-        &universe,
-        transaction_gen.clone(),
-        vec![],
-        vec![],
-        2,
-        (true, false),
-        maybe_block_gas_limit,
-    );
-    run_transactions::<[u8; 32], [u8; 32], MockEvent>(
-        &universe,
-        transaction_gen,
-        vec![],
-        vec![],
-        2,
-        (true, true),
-        maybe_block_gas_limit,
-    );
-}
-
 fn publishing_fixed_params_with_block_gas_limit(
     num_txns: usize,
     maybe_block_gas_limit: Option<u64>,
@@ -620,13 +573,6 @@ fn dynamic_read_writes_contended() {
 // TODO(loader_v2): Fix this test.
 #[test]
 #[ignore]
-fn module_publishing_fallback() {
-    module_publishing_fallback_with_block_gas_limit(3000, None);
-}
-
-// TODO(loader_v2): Fix this test.
-#[test]
-#[ignore]
 // Test a single transaction intersection interleaves with a lot of dependencies and
 // not overlapping module r/w keys.
 fn module_publishing_races() {
@@ -724,17 +670,6 @@ fn dynamic_read_writes_contended_with_block_gas_limit_test() {
         Some(rand::thread_rng().gen_range(0, 1000) as u64),
     );
     dynamic_read_writes_contended_with_block_gas_limit(1000, Some(0));
-}
-
-// TODO(loader_v2): Fix this test.
-#[test]
-#[ignore]
-fn module_publishing_fallback_with_block_gas_limit_test() {
-    module_publishing_fallback_with_block_gas_limit(
-        3000,
-        // Need to execute at least 2 txns to trigger module publishing fallback
-        Some(rand::thread_rng().gen_range(1, 3000 * MAX_GAS_PER_TXN / 2)),
-    );
 }
 
 // TODO(loader_v2): Fix this test.

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -21,10 +21,9 @@ use aptos_types::{
 use aptos_vm_types::module_write_set::ModuleWrite;
 use arc_swap::ArcSwapOption;
 use crossbeam::utils::CachePadded;
-use dashmap::DashSet;
 use move_binary_format::CompiledModule;
 use move_core_types::{language_storage::ModuleId, value::MoveTypeLayout};
-use move_vm_runtime::{Module, RuntimeEnvironment};
+use move_vm_runtime::Module;
 use move_vm_types::delayed_values::delayed_field_id::DelayedFieldID;
 use std::{
     collections::{BTreeMap, HashSet},
@@ -69,12 +68,6 @@ pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: 
     >,
     resource_group_keys_and_tags:
         Vec<CachePadded<ExplicitSyncWrapper<Vec<(T::Key, HashSet<T::Tag>)>>>>,
-
-    // Record all writes and reads to access paths corresponding to modules (code) in any
-    // (speculative) executions. Used to avoid a potential race with module publishing and
-    // Move-VM loader cache - see 'record' function comment for more information.
-    module_writes: DashSet<T::Key>,
-    module_reads: DashSet<T::Key>,
 }
 
 impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
@@ -94,40 +87,9 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
             resource_group_keys_and_tags: (0..num_txns)
                 .map(|_| CachePadded::new(ExplicitSyncWrapper::<Vec<_>>::new(vec![])))
                 .collect(),
-
-            module_writes: DashSet::new(),
-            module_reads: DashSet::new(),
         }
     }
 
-    fn append_and_check<'a>(
-        paths: impl Iterator<Item = &'a T::Key>,
-        set_to_append: &DashSet<T::Key>,
-        set_to_check: &DashSet<T::Key>,
-    ) -> bool {
-        for path in paths {
-            // Standard flags, first show, then look.
-            set_to_append.insert(path.clone());
-
-            if set_to_check.contains(path) {
-                return true;
-            }
-        }
-        false
-    }
-
-    /// Returns false on an error - if a module path that was read was previously written to, and vice versa.
-    /// Since parallel executor is instantiated per block, any module that is in the Move-VM loader
-    /// cache must previously be read and would be recorded in the 'module_reads' set. Any module
-    /// that is written (published or re-published) goes through transaction output write-set and
-    /// gets recorded in the 'module_writes' set. If these sets have an intersection, it is currently
-    /// possible that Move-VM loader cache loads a module and incorrectly uses it for another
-    /// transaction (e.g. a smaller transaction, or if the speculative execution of the publishing
-    /// transaction later aborts). The intersection is guaranteed to be found because we first
-    /// record the paths then check the other set (flags principle), and in this case we return an
-    /// error that ensures a fallback to a correct sequential execution.
-    /// When the sets do not have an intersection, it is impossible for the race to occur as any
-    /// module in the loader cache may not be published by a transaction in the ongoing block.
     pub(crate) fn record(
         &self,
         txn_idx: TxnIndex,
@@ -135,45 +97,11 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         output: ExecutionStatus<O, E>,
         arced_resource_writes: Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>,
         group_keys_and_tags: Vec<(T::Key, HashSet<T::Tag>)>,
-        runtime_environment: &RuntimeEnvironment,
-    ) -> bool {
-        if !runtime_environment.vm_config().use_loader_v2 {
-            // Loader V1 implementation does not support concurrent module publishing, and so
-            // we need to record if there is one and fall back to sequential execution.
-            let written_modules = match &output {
-                ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
-                    output.module_write_set()
-                },
-                ExecutionStatus::Abort(_)
-                | ExecutionStatus::SpeculativeExecutionAbortError(_)
-                | ExecutionStatus::DelayedFieldsCodeInvariantError(_) => BTreeMap::new(),
-            };
-
-            #[allow(deprecated)]
-            if self.check_and_append_module_rw_conflict(
-                input.deprecated_module_reads.iter(),
-                written_modules.keys(),
-            ) {
-                return false;
-            }
-        }
-
+    ) {
         *self.arced_resource_writes[txn_idx as usize].acquire() = arced_resource_writes;
         *self.resource_group_keys_and_tags[txn_idx as usize].acquire() = group_keys_and_tags;
         self.inputs[txn_idx as usize].store(Some(Arc::new(input)));
         self.outputs[txn_idx as usize].store(Some(Arc::new(output)));
-
-        true
-    }
-
-    pub(crate) fn check_and_append_module_rw_conflict<'a>(
-        &self,
-        module_reads_keys: impl Iterator<Item = &'a T::Key>,
-        module_writes_keys: impl Iterator<Item = &'a T::Key>,
-    ) -> bool {
-        // Check if adding new read & write modules leads to intersections.
-        Self::append_and_check(module_reads_keys, &self.module_reads, &self.module_writes)
-            || Self::append_and_check(module_writes_keys, &self.module_writes, &self.module_reads)
     }
 
     pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<TxnInput<T>>> {

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -50,7 +50,6 @@ macro_rules! forward_on_success_or_skip_rest {
 
 pub(crate) enum KeyKind<T> {
     Resource,
-    Module,
     // Contains the set of tags for the given group key.
     Group(HashSet<T>),
 }
@@ -212,7 +211,7 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         self.outputs[txn_idx as usize].load_full()
     }
 
-    // Extracts a set of paths (keys) written or updated during execution from transaction
+    // Extracts a set of resource paths (keys) written or updated during execution from transaction
     // output, with corresponding KeyKind. If take_group_tags is true, the final HashSet
     // of tags is moved for the group key - should be called once for each incarnation / record
     // due to 'take'. if false, stored modified group resource tags in the group are cloned out.
@@ -244,11 +243,6 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                                 .collect::<Vec<_>>(),
                         )
                         .map(|k| (k, KeyKind::Resource))
-                        .chain(
-                            t.module_write_set()
-                                .into_keys()
-                                .map(|k| (k, KeyKind::Module)),
-                        )
                         .chain(
                             group_keys_and_tags
                                 .into_iter()

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -1588,21 +1588,6 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> TModuleView for LatestView
             state_key,
         );
 
-        // Enforce feature gating V2 loader implementation: TModuleView is no longer used in
-        // V2 interfaces because we implement storage traits directly. Use a debug assert to
-        // panic in tests, adn invariant violation for non-debug builds.
-        if self.runtime_environment.vm_config().use_loader_v2 {
-            let msg =
-                "ModuleView trait should not be used when loader V2 implementation is enabled"
-                    .to_string();
-            let err = Err(
-                PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
-                    .with_message(msg),
-            );
-            debug_assert!(err.is_ok());
-            return err;
-        }
-
         match &self.latest_view {
             ViewState::Sync(state) => {
                 use MVModulesError::*;

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -904,8 +904,6 @@ fn publish_framework(
     hash_value: HashValue,
     framework: &ReleaseBundle,
 ) -> (VMChangeSet, ModuleWriteSet) {
-    assert!(genesis_runtime_environment.vm_config().use_loader_v2);
-
     // Reset state view to be empty, to make sure all module write ops are creations.
     let mut state_view = GenesisStateView::new();
 

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -26,7 +26,6 @@ pub struct VMConfig {
     pub ty_builder: TypeBuilder,
     pub disallow_dispatch_for_native: bool,
     pub use_compatibility_checker_v2: bool,
-    pub use_loader_v2: bool,
     pub use_call_tree_and_instruction_cache: bool,
 }
 
@@ -45,7 +44,6 @@ impl Default for VMConfig {
             ty_builder: TypeBuilder::with_limits(128, 20),
             disallow_dispatch_for_native: true,
             use_compatibility_checker_v2: true,
-            use_loader_v2: true,
             use_call_tree_and_instruction_cache: true,
         }
     }

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -38,13 +38,6 @@ use std::sync::Arc;
 /// implement their own module storage to pass to the VM to resolve code.
 #[delegatable_trait]
 pub trait ModuleStorage: WithRuntimeEnvironment {
-    /// Returns true if loader V2 implementation is enabled. Will be removed in the future, for now
-    /// it is simply a convenient way to check the feature flag if module storage is available.
-    // TODO(loader_v2): Remove this when loader V2 is enabled.
-    fn is_enabled(&self) -> bool {
-        self.runtime_environment().vm_config().use_loader_v2
-    }
-
     /// Returns true if the module exists, and false otherwise. An error is returned if there is a
     /// storage error.
     fn check_module_exists(

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -366,10 +366,6 @@ impl Features {
         self.is_enabled(FeatureFlag::NATIVE_MEMORY_OPERATIONS)
     }
 
-    pub fn is_loader_v2_enabled(&self) -> bool {
-        true
-    }
-
     pub fn is_call_tree_and_instruction_vm_cache_enabled(&self) -> bool {
         self.is_enabled(FeatureFlag::ENABLE_CALL_TREE_AND_INSTRUCTION_VM_CACHE)
     }


### PR DESCRIPTION
## Description

This PR removes `use_loader_v2` from VM config. Cleaned up few places where it was used - mostly block executor. Removed fallback for module publishes handling as this is no longer used.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
