### PR TITLE
[13/n] Remove ModuleResolver as obsolete

### DIFF
--- a/aptos-move/aptos-release-builder/src/simulate.rs
+++ b/aptos-move/aptos-release-builder/src/simulate.rs
@@ -69,7 +69,7 @@ use move_core_types::{
     value::MoveValue,
 };
 use move_vm_runtime::module_traversal::{TraversalContext, TraversalStorage};
-use move_vm_types::{gas::UnmeteredGasMeter, resolver::ModuleResolver};
+use move_vm_types::gas::UnmeteredGasMeter;
 use once_cell::sync::Lazy;
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -338,9 +338,8 @@ fn patch_module<F>(
 where
     F: FnOnce(&mut CompiledModule) -> Result<()>,
 {
-    let resolver = state_view.as_move_resolver();
-    let blob = resolver
-        .get_module(module_id)?
+    let blob = state_view
+        .get_state_value_bytes(&StateKey::module_id(module_id))?
         .ok_or_else(|| anyhow!("module {} does not exist", module_id))?;
 
     let mut m = CompiledModule::deserialize_with_config(&blob, deserializer_config)?;

--- a/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/resolver.rs
@@ -10,7 +10,7 @@ use aptos_vm_types::resolver::{
 use bytes::Bytes;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::language_storage::StructTag;
-use move_vm_types::resolver::{ModuleResolver, ResourceResolver};
+use move_vm_types::resolver::ResourceResolver;
 use std::collections::{BTreeMap, HashMap};
 
 /// A general resolver used by AptosVM. Allows to implement custom hooks on
@@ -20,7 +20,6 @@ pub trait AptosMoveResolver:
     AggregatorV1Resolver
     + ConfigStorage
     + DelayedFieldResolver
-    + ModuleResolver
     + ResourceResolver
     + ResourceGroupResolver
     + StateStorageView<Key = StateKey>

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -18,11 +18,7 @@ use move_vm_runtime::{
     RuntimeEnvironment, WithRuntimeEnvironment,
 };
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::{
-    code::ModuleBytesStorage,
-    gas::UnmeteredGasMeter,
-    resolver::{ModuleResolver, ResourceResolver},
-};
+use move_vm_types::{code::ModuleBytesStorage, gas::UnmeteredGasMeter, resolver::ResourceResolver};
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -591,16 +587,6 @@ impl ModuleBytesStorage for BogusModuleStorage {
     }
 }
 
-impl ModuleResolver for BogusModuleStorage {
-    fn get_module_metadata(&self, _module_id: &ModuleId) -> Vec<Metadata> {
-        vec![]
-    }
-
-    fn get_module(&self, _module_id: &ModuleId) -> PartialVMResult<Option<Bytes>> {
-        Err(PartialVMError::new(self.bad_status_code))
-    }
-}
-
 impl ResourceResolver for BogusModuleStorage {
     fn get_resource_bytes_with_metadata_and_layout(
         &self,
@@ -617,16 +603,6 @@ impl ResourceResolver for BogusModuleStorage {
 struct BogusResourceStorage {
     module_storage: InMemoryStorage,
     bad_status_code: StatusCode,
-}
-
-impl ModuleResolver for BogusResourceStorage {
-    fn get_module_metadata(&self, module_id: &ModuleId) -> Vec<Metadata> {
-        self.module_storage.get_module_metadata(module_id)
-    }
-
-    fn get_module(&self, module_id: &ModuleId) -> PartialVMResult<Option<Bytes>> {
-        self.module_storage.get_module(module_id)
-    }
 }
 
 impl ResourceResolver for BogusResourceStorage {

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -18,7 +18,7 @@ use move_core_types::{
 };
 use move_vm_types::{
     loaded_data::runtime_types::Type,
-    resolver::MoveResolver,
+    resolver::ResourceResolver,
     value_serde::ValueSerDeContext,
     values::{GlobalValue, Value},
 };
@@ -52,14 +52,14 @@ impl AccountDataCache {
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
 pub(crate) struct TransactionDataCache<'r> {
-    remote: &'r dyn MoveResolver,
+    remote: &'r dyn ResourceResolver,
     account_map: BTreeMap<AccountAddress, AccountDataCache>,
 }
 
 impl<'r> TransactionDataCache<'r> {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: &'r impl MoveResolver) -> Self {
+    pub(crate) fn new(remote: &'r impl ResourceResolver) -> Self {
         TransactionDataCache {
             remote,
             account_map: BTreeMap::new(),

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -6,7 +6,7 @@ use crate::{
     data_cache::TransactionDataCache, native_extensions::NativeContextExtensions,
     runtime::VMRuntime, session::Session,
 };
-use move_vm_types::resolver::MoveResolver;
+use move_vm_types::resolver::ResourceResolver;
 
 pub struct MoveVM {
     pub(crate) runtime: VMRuntime,
@@ -35,14 +35,14 @@ impl MoveVM {
     ///     cases where this may not be necessary, with the most notable one being the common module
     ///     publishing flow: you can keep using the same Move VM if you publish some modules in a Session
     ///     and apply the effects to the storage when the Session ends.
-    pub fn new_session<'r>(&self, remote: &'r impl MoveResolver) -> Session<'r, '_> {
+    pub fn new_session<'r>(&self, remote: &'r impl ResourceResolver) -> Session<'r, '_> {
         self.new_session_with_extensions(remote, NativeContextExtensions::default())
     }
 
     /// Create a new session, as in `new_session`, but provide native context extensions.
     pub fn new_session_with_extensions<'r>(
         &self,
-        remote: &'r impl MoveResolver,
+        remote: &'r impl ResourceResolver,
         native_extensions: NativeContextExtensions<'r>,
     ) -> Session<'r, '_> {
         Session {

--- a/third_party/move/move-vm/test-utils/src/storage.rs
+++ b/third_party/move/move-vm/test-utils/src/storage.rs
@@ -24,7 +24,7 @@ use move_table_extension::{TableChangeSet, TableHandle, TableResolver};
 use move_vm_runtime::{RuntimeEnvironment, WithRuntimeEnvironment};
 use move_vm_types::{
     code::ModuleBytesStorage,
-    resolver::{resource_size, ModuleResolver, ResourceResolver},
+    resolver::{resource_size, ResourceResolver},
 };
 use std::{
     collections::{btree_map, BTreeMap},
@@ -47,16 +47,6 @@ impl ModuleBytesStorage for BlankStorage {
         _address: &AccountAddress,
         _module_name: &IdentStr,
     ) -> VMResult<Option<Bytes>> {
-        Ok(None)
-    }
-}
-
-impl ModuleResolver for BlankStorage {
-    fn get_module_metadata(&self, _module_id: &ModuleId) -> Vec<Metadata> {
-        vec![]
-    }
-
-    fn get_module(&self, _module_id: &ModuleId) -> PartialVMResult<Option<Bytes>> {
         Ok(None)
     }
 }
@@ -123,7 +113,7 @@ impl CompiledModuleView for InMemoryStorage {
     type Item = CompiledModule;
 
     fn view_compiled_module(&self, id: &ModuleId) -> anyhow::Result<Option<Self::Item>> {
-        Ok(match self.get_module(id)? {
+        Ok(match self.fetch_module_bytes(id.address(), id.name())? {
             Some(bytes) => {
                 let config = DeserializerConfig::new(VERSION_MAX, IDENTIFIER_SIZE_MAX);
                 Some(CompiledModule::deserialize_with_config(&bytes, &config)?)
@@ -296,19 +286,6 @@ impl InMemoryStorage {
     ) {
         let account = get_or_insert(&mut self.accounts, addr, InMemoryAccountStorage::new);
         account.resources.insert(struct_tag, blob.into());
-    }
-}
-
-impl ModuleResolver for InMemoryStorage {
-    fn get_module_metadata(&self, _module_id: &ModuleId) -> Vec<Metadata> {
-        vec![]
-    }
-
-    fn get_module(&self, module_id: &ModuleId) -> PartialVMResult<Option<Bytes>> {
-        if let Some(account_storage) = self.accounts.get(module_id.address()) {
-            return Ok(account_storage.modules.get(module_id.name()).cloned());
-        }
-        Ok(None)
     }
 }
 

--- a/third_party/move/move-vm/types/src/resolver.rs
+++ b/third_party/move/move-vm/types/src/resolver.rs
@@ -5,28 +5,9 @@
 use bytes::Bytes;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
-    account_address::AccountAddress,
-    language_storage::{ModuleId, StructTag},
-    metadata::Metadata,
+    account_address::AccountAddress, language_storage::StructTag, metadata::Metadata,
     value::MoveTypeLayout,
 };
-
-/// Traits for resolving Move modules and resources from persistent storage
-
-/// A persistent storage backend that can resolve modules by address + name.
-/// Storage backends should return
-///   - Ok(Some(..)) if the data exists
-///   - Ok(None)     if the data does not exist
-///   - Err(..)      only when something really wrong happens, for example
-///                    - invariants are broken and observable from the storage side
-///                      (this is not currently possible as ModuleId and StructTag
-///                       are always structurally valid)
-///                    - storage encounters internal error
-pub trait ModuleResolver {
-    fn get_module_metadata(&self, module_id: &ModuleId) -> Vec<Metadata>;
-
-    fn get_module(&self, id: &ModuleId) -> PartialVMResult<Option<Bytes>>;
-}
 
 pub fn resource_size(resource: &Option<Bytes>) -> usize {
     resource.as_ref().map(|bytes| bytes.len()).unwrap_or(0)
@@ -50,8 +31,3 @@ pub trait ResourceResolver {
         layout: Option<&MoveTypeLayout>,
     ) -> PartialVMResult<(Option<Bytes>, usize)>;
 }
-
-/// A persistent storage implementation that can resolve both resources and modules
-pub trait MoveResolver: ModuleResolver + ResourceResolver {}
-
-impl<T: ModuleResolver + ResourceResolver + ?Sized> MoveResolver for T {}


### PR DESCRIPTION
## Description

Modules are fetched from V2 loader (`ModuleStorage`, to be renamed), and `ModuleResolver` is removed because it is no longer used in V2.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
