### PR TITLE
[move-vm][closures] Prepare serialization format and resolver for late binding

### DIFF
--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -26,7 +26,7 @@ use move_vm_types::{
     loaded_data::runtime_types::{StructType, Type},
     module_cyclic_dependency_error, module_linker_error,
     value_serde::FunctionValueExtension,
-    values::{AbstractFunction, SerializedFunctionData},
+    values::{AbstractFunction, SerializedFunctionData, SerializedFunctionKind},
 };
 use std::sync::Arc;
 
@@ -483,6 +483,7 @@ impl<'a> FunctionValueExtension for FunctionValueExtensionAdapter<'a> {
                     .map(|t| ty_converter.type_to_type_layout(&instantiate(t)?))
                     .collect::<PartialVMResult<Vec<_>>>()?;
                 Ok(SerializedFunctionData {
+                    kind: SerializedFunctionKind::CreatedByMove,
                     module_id: fun
                         .module_id()
                         .ok_or_else(|| {


### PR DESCRIPTION
## Description

This sets up closure serialization and resolution for late binding. While the feature is not yet connected to Move code, which happens in the future, setting up this functionality now prevents breaking changes in the serialization format.

Late binding, as used e.g. in FA dispatch, allows to programmatically create function values via their name.  Late binding is almost already supported. The only thing missing is (a) a way to specify the expected type when the function resolves and a runtime check that it does (b) a check that the resolved function is public.

Technically, there is a new `kind` field in serialized function data. That field will also allow us to evolve this data in the future via versioning.

This *also* removes the previous verification of the type layout stored with a closure against a loaded function's type. This check is not really needed since we generally already assume storage consistency. (For instance, we also do not verify the serialized data in a struct matches the types of the struct definition.) Verification is needed for late bound functions. Those two different use cases where previously mixed up, and are now cleanly seperated.

## How Has This Been Tested?

Serialization tests. The function resolution tests can not be tested before e2e tests with this feature are possible.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
