### PR TITLE
[api][closures] Support Closures in the REST API

### DIFF
--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,9 +12,6 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
-[lib]
-test = true
-
 [dependencies]
 anyhow = { workspace = true }
 aptos-api-types = { workspace = true }

--- a/api/Cargo.toml
+++ b/api/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[lib]
+test = true
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-api-types = { workspace = true }

--- a/api/src/tests/function_value_test.rs
+++ b/api/src/tests/function_value_test.rs
@@ -18,7 +18,7 @@ async fn test_function_values() {
     let txn = futures::executor::block_on(async move {
         let path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
             .join("../aptos-move/move-examples/function_values/calculator");
-        TestContext::build_package_latest_language(path, named_addresses)
+        TestContext::build_package_with_latest_language(path, named_addresses)
     });
     context.publish_package(&mut account, txn).await;
 

--- a/api/src/tests/function_value_test.rs
+++ b/api/src/tests/function_value_test.rs
@@ -1,0 +1,89 @@
+// Copyright © Aptos Foundation
+// Parts of the project are originally copyright © Meta Platforms, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use super::new_test_context;
+use aptos_api_test_context::{current_function_name, TestContext};
+use serde_json::json;
+use std::path::PathBuf;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_function_values() {
+    let mut context = new_test_context(current_function_name!());
+    let mut account = context.create_account().await;
+    let account_addr = account.address();
+
+    // Publish packages
+    let named_addresses = vec![("account".to_string(), account_addr)];
+    let txn = futures::executor::block_on(async move {
+        let path = PathBuf::from(std::env!("CARGO_MANIFEST_DIR"))
+            .join("../aptos-move/move-examples/function_values/calculator");
+        TestContext::build_package_latest_language(path, named_addresses)
+    });
+    context.publish_package(&mut account, txn).await;
+
+    let state_resource = format!("{}::{}::{}", account_addr, "calculator", "State");
+
+    let state = context
+        .gen_resource(&account_addr, &state_resource)
+        .await
+        .unwrap();
+    assert_eq!(state["data"]["__variant__"], "Empty");
+
+    context
+        .api_execute_entry_function(
+            &mut account,
+            &format!("0x{}::calculator::number", account_addr.to_hex()),
+            json!([]),
+            json!(["22"]),
+        )
+        .await;
+    let state = context
+        .gen_resource(&account_addr, &state_resource)
+        .await
+        .unwrap();
+    assert_eq!(state["data"]["__variant__"], "Value");
+    assert_eq!(state["data"]["_0"], "22");
+
+    context
+        .api_execute_entry_function(
+            &mut account,
+            &format!("0x{}::calculator::add", account_addr.to_hex()),
+            json!([]),
+            json!([]),
+        )
+        .await;
+    let state = context
+        .gen_resource(&account_addr, &state_resource)
+        .await
+        .unwrap();
+    assert_eq!(state["data"]["__variant__"], "WaitForNumber");
+    let closure = &state["data"]["_0"];
+    // Closure has the form:
+    // {
+    //     __fun_name__: string<qualified_name>,
+    //     __mask__    : string<number>,
+    //     __captured__: array<value>
+    // }
+    assert_eq!(
+        closure["__fun_name__"],
+        format!("{}::calculator::storable_add", account_addr)
+    );
+    assert_eq!(closure["__mask__"], "1");
+    assert_eq!(closure["__captured__"][0], "22");
+
+    context
+        .api_execute_entry_function(
+            &mut account,
+            &format!("0x{}::calculator::number", account_addr.to_hex()),
+            json!([]),
+            json!(["11"]),
+        )
+        .await;
+    let state = context
+        .gen_resource(&account_addr, &state_resource)
+        .await
+        .unwrap();
+    assert_eq!(state["data"]["__variant__"], "Value");
+    assert_eq!(state["data"]["_0"], "33");
+}

--- a/api/src/tests/mod.rs
+++ b/api/src/tests/mod.rs
@@ -8,6 +8,7 @@ mod blocks_test;
 mod converter_test;
 mod event_v2_translation_test;
 mod events_test;
+mod function_value_test;
 mod index_test;
 mod invalid_post_request_test;
 mod modules;

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -759,7 +759,7 @@ impl TestContext {
         Self::build_package_with_options(path, named_addresses, BuildOptions::default())
     }
 
-    pub fn build_package_latest_language(
+    pub fn build_package_with_latest_language(
         path: PathBuf,
         named_addresses: Vec<(String, AccountAddress)>,
     ) -> TransactionPayload {

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -19,7 +19,7 @@ use aptos_crypto::{ed25519::Ed25519PrivateKey, hash::HashValue, SigningKey};
 use aptos_db::AptosDB;
 use aptos_executor::{block_executor::BlockExecutor, db_bootstrapper};
 use aptos_executor_types::BlockExecutorTrait;
-use aptos_framework::BuiltPackage;
+use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_indexer_grpc_table_info::internal_indexer_db_service::MockInternalIndexerDBService;
 use aptos_mempool::mocks::MockSharedMempool;
 use aptos_mempool_notifications::MempoolNotificationSender;
@@ -756,11 +756,28 @@ impl TestContext {
         path: PathBuf,
         named_addresses: Vec<(String, AccountAddress)>,
     ) -> TransactionPayload {
-        let mut build_options = aptos_framework::BuildOptions::default();
+        Self::build_package_with_options(path, named_addresses, BuildOptions::default())
+    }
+
+    pub fn build_package_latest_language(
+        path: PathBuf,
+        named_addresses: Vec<(String, AccountAddress)>,
+    ) -> TransactionPayload {
+        Self::build_package_with_options(
+            path,
+            named_addresses,
+            BuildOptions::default().set_latest_language(),
+        )
+    }
+
+    fn build_package_with_options(
+        path: PathBuf,
+        named_addresses: Vec<(String, AccountAddress)>,
+        mut build_options: BuildOptions,
+    ) -> TransactionPayload {
         named_addresses.into_iter().for_each(|(name, address)| {
             build_options.named_addresses.insert(name, address);
         });
-
         let package = BuiltPackage::build(path, build_options).unwrap();
         let code = package.extract_code();
         let metadata = package.extract_metadata().unwrap();

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -4,7 +4,9 @@
 
 use crate::{Address, Bytecode, IdentifierWrapper, VerifyInput, VerifyInputWithRecursion};
 use anyhow::{bail, format_err};
-use aptos_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
+use aptos_resource_viewer::{
+    AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue, RawMoveStruct,
+};
 use aptos_types::{account_config::CORE_CODE_ADDRESS, event::EventKey, transaction::Module};
 use move_binary_format::{
     access::ModuleAccess,
@@ -14,7 +16,7 @@ use move_core_types::{
     ability::{Ability, AbilitySet},
     account_address::AccountAddress,
     identifier::Identifier,
-    language_storage::{ModuleId, StructTag, TypeTag},
+    language_storage::{FunctionTag, ModuleId, StructTag, TypeTag},
     parser::{parse_struct_tag, parse_type_tag},
     transaction_argument::TransactionArgument,
 };
@@ -215,7 +217,7 @@ impl HexEncodedBytes {
     }
 }
 
-/// A JSON map representation of a Move struct's inner types
+/// A JSON map representation of a Move struct's or closure's inner values
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MoveStructValue(pub BTreeMap<IdentifierWrapper, serde_json::Value>);
 
@@ -232,6 +234,81 @@ impl TryFrom<AnnotatedMoveStruct> for MoveStructValue {
         }
         for (id, val) in s.value {
             map.insert(id.into(), MoveValue::try_from(val)?.json()?);
+        }
+        Ok(Self(map))
+    }
+}
+
+impl TryFrom<RawMoveStruct> for MoveStructValue {
+    type Error = anyhow::Error;
+
+    fn try_from(s: RawMoveStruct) -> anyhow::Result<Self> {
+        let mut map = BTreeMap::new();
+        if let Some(tag) = s.variant_info {
+            map.insert(
+                IdentifierWrapper::from_str("__variant_tag__")?,
+                MoveValue::U16(tag).json()?,
+            );
+        }
+        for (pos, val) in s.field_values.into_iter().enumerate() {
+            map.insert(
+                IdentifierWrapper::from_str(&pos.to_string())?,
+                MoveValue::try_from(val)?.json()?,
+            );
+        }
+        Ok(Self(map))
+    }
+}
+
+impl TryFrom<AnnotatedMoveClosure> for MoveStructValue {
+    type Error = anyhow::Error;
+
+    fn try_from(s: AnnotatedMoveClosure) -> anyhow::Result<Self> {
+        let mut map = BTreeMap::new();
+        let AnnotatedMoveClosure {
+            module_id,
+            fun_id,
+            ty_args,
+            mask,
+            captured,
+        } = s;
+        map.insert(
+            IdentifierWrapper::from_str("__fun_name__")?,
+            MoveValue::String(format!(
+                "0x{}::{}::{}",
+                module_id.address.short_str_lossless(),
+                module_id.name,
+                fun_id
+            ))
+            .json()?,
+        );
+        if !ty_args.is_empty() {
+            map.insert(
+                IdentifierWrapper::from_str("__ty_args__")?,
+                MoveValue::Vector(
+                    ty_args
+                        .iter()
+                        .map(|ty| MoveValue::String(ty.to_canonical_string()))
+                        .collect(),
+                )
+                .json()?,
+            );
+        }
+        map.insert(
+            IdentifierWrapper::from_str("__mask__")?,
+            MoveValue::String(mask.to_string()).json()?,
+        );
+        if !captured.is_empty() {
+            map.insert(
+                IdentifierWrapper::from_str("__captured__")?,
+                MoveValue::Vector(
+                    captured
+                        .into_iter()
+                        .map(MoveValue::try_from)
+                        .collect::<anyhow::Result<Vec<_>>>()?,
+                )
+                .json()?,
+            );
         }
         Ok(Self(map))
     }
@@ -313,6 +390,8 @@ impl TryFrom<AnnotatedMoveValue> for MoveValue {
                     MoveValue::Struct(v.try_into()?)
                 }
             },
+            AnnotatedMoveValue::RawStruct(v) => MoveValue::Struct(v.try_into()?),
+            AnnotatedMoveValue::Closure(c) => MoveValue::Struct(c.try_into()?),
         })
     }
 }
@@ -509,6 +588,12 @@ pub enum MoveType {
     Vector { items: Box<MoveType> },
     /// A struct of [`MoveStructTag`]
     Struct(MoveStructTag),
+    /// A function
+    Function {
+        args: Vec<MoveType>,
+        results: Vec<MoveType>,
+        abilities: AbilitySet,
+    },
     /// A generic type param with index
     GenericTypeParam { index: u16 },
     /// A reference
@@ -536,6 +621,12 @@ impl VerifyInputWithRecursion for MoveType {
         match self {
             MoveType::Vector { items } => items.verify(recursion_count + 1),
             MoveType::Struct(struct_tag) => struct_tag.verify(recursion_count + 1),
+            MoveType::Function { args, results, .. } => {
+                for ty in args.iter().chain(results) {
+                    ty.verify(recursion_count + 1)?
+                }
+                Ok(())
+            },
             MoveType::GenericTypeParam { .. } => Ok(()),
             MoveType::Reference { to, .. } => to.verify(recursion_count + 1),
             MoveType::Unparsable(inner) => bail!("Unable to parse move type {}", inner),
@@ -571,6 +662,10 @@ impl MoveType {
             MoveType::Struct(_) | MoveType::GenericTypeParam { index: _ } => {
                 "string<move_struct_tag_id>".to_owned()
             },
+            MoveType::Function { .. } => {
+                // TODO(#15664): what to put here for functions?
+                "string<move_function_id>".to_owned()
+            },
             MoveType::Reference { mutable: _, to } => to.json_type_name(),
             MoveType::Unparsable(string) => string.to_string(),
         }
@@ -598,6 +693,21 @@ impl fmt::Display for MoveType {
                 } else {
                     write!(f, "&{}", to)
                 }
+            },
+            MoveType::Function { args, results, .. } => {
+                write!(
+                    f,
+                    "|{}|{}",
+                    args.iter()
+                        .map(|ty| ty.to_string())
+                        .collect::<Vec<_>>()
+                        .join(","),
+                    results
+                        .iter()
+                        .map(|ty| ty.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",")
+                )
             },
             MoveType::Unparsable(string) => write!(f, "unparsable<{}>", string),
         }
@@ -686,11 +796,22 @@ impl From<&TypeTag> for MoveType {
                 items: Box::new(MoveType::from(v.as_ref())),
             },
             TypeTag::Struct(v) => MoveType::Struct(v.as_ref().into()),
-            TypeTag::Function(..) => {
-                // TODO(#15664): support function values
-                MoveType::Unparsable("Function types are not supported".to_string())
-            },
+            TypeTag::Function(f) => from_function_tag(f),
         }
+    }
+}
+
+fn from_function_tag(f: &FunctionTag) -> MoveType {
+    let FunctionTag {
+        args,
+        results,
+        abilities,
+    } = f;
+    let from_vec = |tys: &[TypeTag]| tys.iter().map(MoveType::from).collect::<Vec<_>>();
+    MoveType::Function {
+        args: from_vec(args),
+        results: from_vec(results),
+        abilities: *abilities,
     }
 }
 
@@ -710,6 +831,22 @@ impl TryFrom<&MoveType> for TypeTag {
             MoveType::Signer => TypeTag::Signer,
             MoveType::Vector { items } => TypeTag::Vector(Box::new(items.as_ref().try_into()?)),
             MoveType::Struct(v) => TypeTag::Struct(Box::new(v.try_into()?)),
+            MoveType::Function {
+                args,
+                results,
+                abilities,
+            } => {
+                let try_vec = |tys: &[MoveType]| {
+                    tys.iter()
+                        .map(Self::try_from)
+                        .collect::<anyhow::Result<_>>()
+                };
+                TypeTag::Function(Box::new(FunctionTag {
+                    args: try_vec(args)?,
+                    results: try_vec(results)?,
+                    abilities: *abilities,
+                }))
+            },
             MoveType::GenericTypeParam { index: _ } => TypeTag::Address, // Dummy type, allows for Object<T>
             _ => {
                 return Err(anyhow::anyhow!(

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -19,7 +19,9 @@ use move_core_types::{
     value::{MoveTypeLayout, MoveValue},
 };
 use move_resource_viewer::MoveValueAnnotator;
-pub use move_resource_viewer::{AnnotatedMoveStruct, AnnotatedMoveValue};
+pub use move_resource_viewer::{
+    AnnotatedMoveClosure, AnnotatedMoveStruct, AnnotatedMoveValue, RawMoveStruct,
+};
 use std::sync::Arc;
 
 pub struct AptosValueAnnotator<'a, S>(MoveValueAnnotator<ModuleView<'a, S>>);

--- a/aptos-move/framework/src/built_package.rs
+++ b/aptos-move/framework/src/built_package.rs
@@ -161,7 +161,6 @@ impl BuildOptions {
             bytecode_version: Some(file_format_common::VERSION_MAX),
             ..self
         }
-        .with_experiment(Experiment::FUNCTION_VALUES)
     }
 }
 

--- a/aptos-move/move-examples/function_values/calculator/Move.toml
+++ b/aptos-move/move-examples/function_values/calculator/Move.toml
@@ -1,0 +1,10 @@
+[package]
+name = "calculator"
+version = "0.0.0"
+
+[addresses]
+account = "_"
+
+[dependencies]
+AptosFramework = { local = "../../../framework/aptos-framework" }
+AptosStdlib = { local = "../../../framework/aptos-stdlib" }

--- a/aptos-move/move-examples/function_values/calculator/sources/calculator.move
+++ b/aptos-move/move-examples/function_values/calculator/sources/calculator.move
@@ -1,0 +1,68 @@
+module account::calculator {
+    use std::signer::address_of;
+
+    const EINVALID_INPUT: u64 = 1;
+
+    /// Input to the calculator
+    enum Input {
+        Number(u64),
+        Add,
+        Sub,
+    }
+
+    /// State of the calculator
+    enum State has key, copy, drop {
+        Empty,
+        Value(u64),
+        WaitForNumber(|u64|u64)
+    }
+
+    /// Process input in the current state.
+    fun process(s: &signer, input: Input) acquires State {
+        let addr = address_of(s);
+        match ((move_from<State>(addr), input)) {
+            (Empty, Number(x)) => move_to(s, State::Value(x)),
+            (Value(_), Number(x)) => move_to(s, State::Value(x)),
+            (Value(x), Add) => move_to(s, State::WaitForNumber(|y| storable_add(x, y))),
+            (Value(x), Sub) => move_to(s, State::WaitForNumber(|y| storable_sub(x, y))),
+            (WaitForNumber(f), Number(x)) => move_to(s, State::Value(f(x))),
+            (_, _) => abort EINVALID_INPUT
+        }
+    }
+
+    #[persistent]
+    fun storable_add(x: u64, y: u64): u64 {
+        x + y
+    }
+
+    #[persistent]
+    fun storable_sub(x: u64, y: u64): u64 {
+        x - y
+    }
+
+    fun init_module(s: &signer) {
+        move_to(s, State::Empty)
+    }
+
+
+    /// Entry point functions
+    entry fun number(s: &signer, x: u64) acquires State {
+        process(s, Input::Number(x))
+    }
+
+    entry fun add(s: &signer) acquires State {
+        process(s, Input::Add)
+    }
+
+    entry fun sub(s: &signer) acquires State {
+        process(s, Input::Sub)
+    }
+
+    #[view]
+    fun view(a: address): u64 acquires State {
+        match (&State[a]) {
+            Value(x) => *x,
+            _ => abort EINVALID_INPUT
+        }
+    }
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/convert.rs
@@ -241,6 +241,7 @@ pub fn convert_move_type(move_type: &MoveType) -> transaction::MoveType {
         MoveType::Struct(_) => transaction::MoveTypes::Struct,
         MoveType::GenericTypeParam { .. } => transaction::MoveTypes::GenericTypeParam,
         MoveType::Reference { .. } => transaction::MoveTypes::Reference,
+        MoveType::Function { .. } => transaction::MoveTypes::Unparsable,
         MoveType::Unparsable(_) => transaction::MoveTypes::Unparsable,
     };
     let content = match move_type {
@@ -267,6 +268,9 @@ pub fn convert_move_type(move_type: &MoveType) -> transaction::MoveType {
                 mutable: *mutable,
                 to: Some(Box::new(convert_move_type(to))),
             }),
+        )),
+        MoveType::Function { .. } => Some(transaction::move_type::Content::Unparsable(
+            "function".to_string(),
         )),
         MoveType::Unparsable(string) => {
             Some(transaction::move_type::Content::Unparsable(string.clone()))

--- a/storage/indexer/src/db_v2.rs
+++ b/storage/indexer/src/db_v2.rs
@@ -323,6 +323,16 @@ impl<'a, R: StateView> TableInfoParser<'a, R> {
                     }
                 }
             },
+            AnnotatedMoveValue::RawStruct(struct_value) => {
+                for val in &struct_value.field_values {
+                    self.parse_move_value(val)?
+                }
+            },
+            AnnotatedMoveValue::Closure(closure_value) => {
+                for capture in &closure_value.captured {
+                    self.parse_move_value(capture)?
+                }
+            },
 
             // there won't be tables in primitives
             AnnotatedMoveValue::U8(_) => {},

--- a/storage/indexer/src/lib.rs
+++ b/storage/indexer/src/lib.rs
@@ -251,6 +251,16 @@ impl<'a, R: StateView> TableInfoParser<'a, R> {
                     }
                 }
             },
+            AnnotatedMoveValue::RawStruct(struct_value) => {
+                for val in &struct_value.field_values {
+                    self.parse_move_value(val)?
+                }
+            },
+            AnnotatedMoveValue::Closure(closure_value) => {
+                for capture in &closure_value.captured {
+                    self.parse_move_value(capture)?
+                }
+            },
 
             // there won't be tables in primitives
             AnnotatedMoveValue::U8(_) => {},

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -2,7 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{Experiment, Options};
+use crate::Options;
 use codespan_reporting::diagnostic::Severity;
 use ethnum::U256;
 use itertools::Itertools;
@@ -10,6 +10,7 @@ use move_core_types::ability::Ability;
 use move_model::{
     ast::{Exp, ExpData, MatchArm, Operation, Pattern, SpecBlockTarget, TempIndex, Value},
     exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
+    metadata::LanguageVersion,
     model::{
         FieldId, FunId, FunctionEnv, GlobalEnv, Loc, NodeId, Parameter, QualifiedId,
         QualifiedInstId, StructId,
@@ -330,7 +331,10 @@ impl<'env> Generator<'env> {
             .env()
             .get_extension::<Options>()
             .expect("Options is available");
-        options.experiment_on(Experiment::FUNCTION_VALUES)
+        options
+            .language_version
+            .unwrap_or_default()
+            .is_at_least(LanguageVersion::V2_2)
     }
 
     fn expect_function_values_enabled(&self, id: NodeId) {

--- a/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
@@ -3,11 +3,12 @@
 
 //! Do a few checks of functions and function calls.
 
-use crate::{experiments::Experiment, Options};
+use crate::Options;
 use codespan_reporting::diagnostic::Severity;
 use move_binary_format::file_format::Visibility;
 use move_model::{
     ast::{ExpData, Operation, Pattern},
+    metadata::LanguageVersion,
     model::{FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, NodeId, Parameter, QualifiedId},
     ty::Type,
 };
@@ -60,8 +61,12 @@ pub fn check_for_function_typed_parameters(env: &mut GlobalEnv) {
     let options = env
         .get_extension::<Options>()
         .expect("Options is available");
-    let lambda_params_ok = options.experiment_on(Experiment::FUNCTION_VALUES);
-    let lambda_return_ok = options.experiment_on(Experiment::FUNCTION_VALUES);
+
+    let lambda_params_ok = options
+        .language_version
+        .unwrap_or_default()
+        .is_at_least(LanguageVersion::V2_2);
+    let lambda_return_ok = lambda_params_ok;
     if lambda_params_ok && lambda_return_ok {
         return;
     }

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -112,18 +112,8 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(false),
         },
         Experiment {
-            name: Experiment::LAMBDA_LIFTING.to_string(),
-            description: "Turns on or off lambda lifting".to_string(),
-            default: Inherited(Experiment::FUNCTION_VALUES.to_string()),
-        },
-        Experiment {
             name: Experiment::LAMBDA_LIFTING_INLINE.to_string(),
             description: "Whether inline functions shall be included in lambda lifting".to_string(),
-            default: Given(false),
-        },
-        Experiment {
-            name: Experiment::FUNCTION_VALUES.to_string(),
-            description: "Turns on or off first-class function values".to_string(),
             default: Given(false),
         },
         Experiment {
@@ -286,12 +276,10 @@ impl Experiment {
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
     pub const FLUSH_WRITES_OPTIMIZATION: &'static str = "flush-writes-optimization";
-    pub const FUNCTION_VALUES: &'static str = "function-values";
     pub const GEN_ACCESS_SPECIFIERS: &'static str = "gen-access-specifiers";
     pub const INLINING: &'static str = "inlining";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
     pub const KEEP_UNINIT_ANNOTATIONS: &'static str = "keep-uninit-annotations";
-    pub const LAMBDA_LIFTING: &'static str = "lambda-lifting";
     pub const LAMBDA_LIFTING_INLINE: &'static str = "lambda-lifting-inline";
     pub const LINT_CHECKS: &'static str = "lint-checks";
     pub const MESSAGE_FORMAT_JSON: &'static str = "compiler-message-format-json";

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -378,7 +378,11 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
         });
     }
 
-    if options.experiment_on(Experiment::LAMBDA_LIFTING) {
+    if options
+        .language_version
+        .unwrap_or_default()
+        .is_at_least(LanguageVersion::V2_2)
+    {
         let include_inline_functions = options.experiment_on(Experiment::LAMBDA_LIFTING_INLINE);
         env_pipeline.add("lambda-lifting", move |env: &mut GlobalEnv| {
             lambda_lifter::lift_lambdas(
@@ -389,7 +393,11 @@ pub fn check_and_rewrite_pipeline<'a, 'b>(
             )
         });
     }
-    if options.experiment_on(Experiment::FUNCTION_VALUES) {
+    if options
+        .language_version
+        .unwrap_or_default()
+        .is_at_least(LanguageVersion::V2_2)
+    {
         env_pipeline.add("closure-ability-checker", |env: &mut GlobalEnv| {
             closure_checker::check_closures(env)
         });

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -170,8 +170,6 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             options: opts
                 .clone()
                 // .set_experiment(Experiment::AST_SIMPLIFY, true)
-                .set_experiment(Experiment::FUNCTION_VALUES, true)
-                .set_experiment(Experiment::LAMBDA_LIFTING, true)
                 .set_language_version(LanguageVersion::V2_LAMBDA),
             stop_after: StopAfter::FileFormat,
             dump_ast: DumpLevel::EndStage,

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -106,7 +106,6 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[
             (Experiment::OPTIMIZE, true),
             (Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS, true),
-            (Experiment::FUNCTION_VALUES, true),
         ],
         language_version: LanguageVersion::V2_2,
         include: &["/closures/"],

--- a/third_party/move/move-core/types/src/account_address.rs
+++ b/third_party/move/move-core/types/src/account_address.rs
@@ -21,7 +21,6 @@ impl AccountAddress {
     /// Hex address: 0x4
     pub const FOUR: Self = Self::get_hex_address_four();
     /// The number of bytes in an address.
-    /// Default to 16 bytes, can be set to 20 bytes with address20 feature.
     pub const LENGTH: usize = 32;
     /// Max address: 0xff....
     pub const MAX_ADDRESS: Self = Self([0xFF; Self::LENGTH]);

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -244,6 +244,7 @@ impl FromStr for LanguageVersion {
             "1" => Ok(Self::V1),
             "2.0" => Ok(Self::V2_0),
             "2" | "2.1" => Ok(Self::V2_1),
+            "2.2" => Ok(Self::V2_2),
             _ => bail!(
                 "unrecognized language version `{}` (supported versions: `1`, `2`, `2.0`, `2.1`)",
                 s

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -343,7 +343,7 @@ impl FatType {
         Ok(res)
     }
 
-    pub(crate) fn from_layout(
+    pub(crate) fn from_runtime_layout(
         layout: &MoveTypeLayout,
         limit: &mut Limiter,
     ) -> PartialVMResult<FatType> {
@@ -358,7 +358,7 @@ impl FatType {
             U256 => FatType::U256,
             Address => FatType::Address,
             Signer => FatType::Signer,
-            Vector(ty) => FatType::Vector(Box::new(Self::from_layout(ty, limit)?)),
+            Vector(ty) => FatType::Vector(Box::new(Self::from_runtime_layout(ty, limit)?)),
             Struct(MoveStructLayout::Runtime(tys)) => {
                 FatType::Runtime(Self::from_layout_slice(tys, limit)?)
             },
@@ -389,7 +389,7 @@ impl FatType {
     ) -> PartialVMResult<Vec<FatType>> {
         layouts
             .iter()
-            .map(|l| Self::from_layout(l, limit))
+            .map(|l| Self::from_runtime_layout(l, limit))
             .collect()
     }
 }

--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -8,8 +8,9 @@ use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
     ability::AbilitySet,
     account_address::AccountAddress,
+    function::MoveFunctionLayout,
     identifier::Identifier,
-    language_storage::{StructTag, TypeTag},
+    language_storage::{FunctionTag, StructTag, TypeTag},
     value::{MoveStructLayout, MoveTypeLayout},
     vm_status::StatusCode,
 };
@@ -58,6 +59,13 @@ pub(crate) enum FatStructLayout {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct FatFunctionType {
+    pub args: Vec<FatType>,
+    pub results: Vec<FatType>,
+    pub abilities: AbilitySet,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub(crate) enum FatType {
     Bool,
     U8,
@@ -74,6 +82,13 @@ pub(crate) enum FatType {
     U16,
     U32,
     U256,
+    // NOTE: Added in bytecode version v8, do not reorder!
+    Function(Box<FatFunctionType>),
+    // `Runtime` and `RuntimeVariants` are used for typing
+    // captured structures in closures, for which we only know
+    // the raw layout (no struct name, no field names).
+    Runtime(Vec<FatType>),
+    RuntimeVariants(Vec<Vec<FatType>>),
 }
 
 impl FatStructType {
@@ -174,6 +189,47 @@ impl FatStructType {
     }
 }
 
+impl FatFunctionType {
+    fn clone_with_limit(&self, limiter: &mut Limiter) -> PartialVMResult<Self> {
+        let clone_slice = |limiter: &mut Limiter, tys: &[FatType]| {
+            tys.iter()
+                .map(|ty| ty.clone_with_limit(limiter))
+                .collect::<PartialVMResult<Vec<_>>>()
+        };
+        Ok(FatFunctionType {
+            args: clone_slice(limiter, &self.args)?,
+            results: clone_slice(limiter, &self.results)?,
+            abilities: self.abilities,
+        })
+    }
+
+    pub fn subst(&self, ty_args: &[FatType], limiter: &mut Limiter) -> PartialVMResult<Self> {
+        let subst_slice = |limiter: &mut Limiter, tys: &[FatType]| {
+            tys.iter()
+                .map(|ty| ty.subst(ty_args, limiter))
+                .collect::<PartialVMResult<Vec<_>>>()
+        };
+        Ok(FatFunctionType {
+            args: subst_slice(limiter, &self.args)?,
+            results: subst_slice(limiter, &self.results)?,
+            abilities: self.abilities,
+        })
+    }
+
+    pub fn fun_tag(&self, limiter: &mut Limiter) -> PartialVMResult<FunctionTag> {
+        let tag_slice = |limiter: &mut Limiter, tys: &[FatType]| {
+            tys.iter()
+                .map(|ty| ty.type_tag(limiter))
+                .collect::<PartialVMResult<Vec<_>>>()
+        };
+        Ok(FunctionTag {
+            args: tag_slice(limiter, &self.args)?,
+            results: tag_slice(limiter, &self.results)?,
+            abilities: self.abilities,
+        })
+    }
+}
+
 impl FatType {
     fn clone_with_limit(&self, limit: &mut Limiter) -> PartialVMResult<Self> {
         use FatType::*;
@@ -192,7 +248,18 @@ impl FatType {
             Reference(ty) => Reference(Box::new(ty.clone_with_limit(limit)?)),
             MutableReference(ty) => MutableReference(Box::new(ty.clone_with_limit(limit)?)),
             Struct(struct_ty) => Struct(Box::new(struct_ty.clone_with_limit(limit)?)),
+            Function(fun_ty) => Function(Box::new(fun_ty.clone_with_limit(limit)?)),
+            Runtime(tys) => Runtime(Self::clone_with_limit_slice(tys, limit)?),
+            RuntimeVariants(vars) => RuntimeVariants(
+                vars.iter()
+                    .map(|tys| Self::clone_with_limit_slice(tys, limit))
+                    .collect::<PartialVMResult<Vec<_>>>()?,
+            ),
         })
+    }
+
+    fn clone_with_limit_slice(tys: &[Self], limit: &mut Limiter) -> PartialVMResult<Vec<Self>> {
+        tys.iter().map(|ty| ty.clone_with_limit(limit)).collect()
     }
 
     pub fn subst(&self, ty_args: &[FatType], limit: &mut Limiter) -> PartialVMResult<FatType> {
@@ -227,6 +294,22 @@ impl FatType {
             MutableReference(ty) => MutableReference(Box::new(ty.subst(ty_args, limit)?)),
 
             Struct(struct_ty) => Struct(Box::new(struct_ty.subst(ty_args, limit)?)),
+
+            Function(fun_ty) => Function(Box::new(fun_ty.subst(ty_args, limit)?)),
+            Runtime(tys) => Runtime(
+                tys.iter()
+                    .map(|ty| ty.subst(ty_args, limit))
+                    .collect::<PartialVMResult<Vec<_>>>()?,
+            ),
+            RuntimeVariants(vars) => RuntimeVariants(
+                vars.iter()
+                    .map(|tys| {
+                        tys.iter()
+                            .map(|ty| ty.subst(ty_args, limit))
+                            .collect::<PartialVMResult<Vec<_>>>()
+                    })
+                    .collect::<PartialVMResult<Vec<Vec<_>>>>()?,
+            ),
         };
 
         Ok(res)
@@ -247,8 +330,9 @@ impl FatType {
             Signer => TypeTag::Signer,
             Vector(ty) => TypeTag::Vector(Box::new(ty.type_tag(limit)?)),
             Struct(struct_ty) => TypeTag::Struct(Box::new(struct_ty.struct_tag(limit)?)),
+            Function(fun_ty) => TypeTag::Function(Box::new(fun_ty.fun_tag(limit)?)),
 
-            Reference(_) | MutableReference(_) | TyParam(_) => {
+            Reference(_) | MutableReference(_) | TyParam(_) | RuntimeVariants(_) | Runtime(..) => {
                 return Err(
                     PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
                         .with_message(format!("cannot derive type tag for {:?}", self)),
@@ -257,6 +341,56 @@ impl FatType {
         };
 
         Ok(res)
+    }
+
+    pub(crate) fn from_layout(
+        layout: &MoveTypeLayout,
+        limit: &mut Limiter,
+    ) -> PartialVMResult<FatType> {
+        use MoveTypeLayout::*;
+        Ok(match layout {
+            Bool => FatType::Bool,
+            U8 => FatType::U8,
+            U16 => FatType::U16,
+            U32 => FatType::U32,
+            U64 => FatType::U64,
+            U128 => FatType::U128,
+            U256 => FatType::U256,
+            Address => FatType::Address,
+            Signer => FatType::Signer,
+            Vector(ty) => FatType::Vector(Box::new(Self::from_layout(ty, limit)?)),
+            Struct(MoveStructLayout::Runtime(tys)) => {
+                FatType::Runtime(Self::from_layout_slice(tys, limit)?)
+            },
+            Struct(MoveStructLayout::RuntimeVariants(vars)) => FatType::RuntimeVariants(
+                vars.iter()
+                    .map(|tys| Self::from_layout_slice(tys, limit))
+                    .collect::<PartialVMResult<Vec<Vec<_>>>>()?,
+            ),
+            Function(MoveFunctionLayout(args, results, abilities)) => {
+                FatType::Function(Box::new(FatFunctionType {
+                    args: Self::from_layout_slice(args, limit)?,
+                    results: Self::from_layout_slice(results, limit)?,
+                    abilities: *abilities,
+                }))
+            },
+            Native(..) | Struct(_) => {
+                return Err(PartialVMError::new_invariant_violation(format!(
+                    "cannot derive fat type for {:?}",
+                    layout
+                )))
+            },
+        })
+    }
+
+    fn from_layout_slice(
+        layouts: &[MoveTypeLayout],
+        limit: &mut Limiter,
+    ) -> PartialVMResult<Vec<FatType>> {
+        layouts
+            .iter()
+            .map(|l| Self::from_layout(l, limit))
+            .collect()
     }
 }
 
@@ -274,11 +408,8 @@ impl From<&TypeTag> for FatType {
             TypeTag::Signer => Signer,
             TypeTag::Vector(inner) => Vector(Box::new(inner.as_ref().into())),
             TypeTag::Struct(inner) => Struct(Box::new(inner.as_ref().into())),
+            TypeTag::Function(inner) => Function(Box::new(inner.as_ref().into())),
             TypeTag::U256 => U256,
-            TypeTag::Function(..) => {
-                // TODO(#15664): implement functions for fat types
-                todo!("functions not supported by fat types")
-            },
         }
     }
 }
@@ -300,6 +431,17 @@ impl From<&StructTag> for FatStructType {
     }
 }
 
+impl From<&FunctionTag> for FatFunctionType {
+    fn from(fun_tag: &FunctionTag) -> FatFunctionType {
+        let into_slice = |tys: &[TypeTag]| tys.iter().map(|ty| ty.into()).collect::<Vec<FatType>>();
+        FatFunctionType {
+            args: into_slice(&fun_tag.args),
+            results: into_slice(&fun_tag.results),
+            abilities: fun_tag.abilities,
+        }
+    }
+}
+
 impl TryInto<MoveStructLayout> for &FatStructType {
     type Error = PartialVMError;
 
@@ -316,6 +458,18 @@ impl TryInto<MoveStructLayout> for &FatStructType {
     }
 }
 
+impl TryInto<MoveFunctionLayout> for &FatFunctionType {
+    type Error = PartialVMError;
+
+    fn try_into(self) -> Result<MoveFunctionLayout, Self::Error> {
+        Ok(MoveFunctionLayout(
+            into_types(self.args.iter())?,
+            into_types(self.results.iter())?,
+            self.abilities,
+        ))
+    }
+}
+
 fn into_types<'a>(
     types: impl Iterator<Item = &'a FatType>,
 ) -> PartialVMResult<Vec<MoveTypeLayout>> {
@@ -328,6 +482,11 @@ impl TryInto<MoveTypeLayout> for &FatType {
     type Error = PartialVMError;
 
     fn try_into(self) -> Result<MoveTypeLayout, Self::Error> {
+        let slice_into = |tys: &[FatType]| {
+            tys.iter()
+                .map(|ty| ty.try_into())
+                .collect::<PartialVMResult<Vec<MoveTypeLayout>>>()
+        };
         Ok(match self {
             FatType::Address => MoveTypeLayout::Address,
             FatType::U8 => MoveTypeLayout::U8,
@@ -339,6 +498,17 @@ impl TryInto<MoveTypeLayout> for &FatType {
             FatType::Bool => MoveTypeLayout::Bool,
             FatType::Vector(v) => MoveTypeLayout::Vector(Box::new(v.as_ref().try_into()?)),
             FatType::Struct(s) => MoveTypeLayout::Struct(s.as_ref().try_into()?),
+            FatType::Function(f) => MoveTypeLayout::Function(f.as_ref().try_into()?),
+            FatType::Runtime(tys) => {
+                MoveTypeLayout::Struct(MoveStructLayout::Runtime(slice_into(tys)?))
+            },
+            FatType::RuntimeVariants(vars) => {
+                MoveTypeLayout::Struct(MoveStructLayout::RuntimeVariants(
+                    vars.iter()
+                        .map(|tys| slice_into(tys))
+                        .collect::<Result<Vec<_>, _>>()?,
+                ))
+            },
             FatType::Signer => MoveTypeLayout::Signer,
             FatType::Reference(_) | FatType::MutableReference(_) | FatType::TyParam(_) => {
                 return Err(PartialVMError::new(StatusCode::ABORT_TYPE_MISMATCH_ERROR))

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -615,7 +615,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         let captured = captured
             .iter()
             .map(|(layout, value)| {
-                let fat_type = FatType::from_layout(layout, limit)
+                let fat_type = FatType::from_runtime_layout(layout, limit)
                     .map_err(|e| anyhow!("failed to annotate captured value: {}", e))?;
                 self.annotate_value(value, &fat_type, limit)
             })

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -2,7 +2,9 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::fat_type::{FatStructLayout, FatStructType, FatType, WrappedAbilitySet};
+use crate::fat_type::{
+    FatFunctionType, FatStructLayout, FatStructType, FatType, WrappedAbilitySet,
+};
 use anyhow::{anyhow, bail};
 pub use limit::Limiter;
 use move_binary_format::{
@@ -20,6 +22,7 @@ use move_bytecode_utils::{compiled_module_viewer::CompiledModuleView, layout::Ty
 use move_core_types::{
     ability::{Ability, AbilitySet},
     account_address::AccountAddress,
+    function::{ClosureMask, MoveClosure},
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     transaction_argument::{convert_txn_args, TransactionArgument},
@@ -45,6 +48,25 @@ pub struct AnnotatedMoveStruct {
     pub value: Vec<(Identifier, AnnotatedMoveValue)>,
 }
 
+/// Used to represent raw struct data, with struct name and field names. This stems
+/// from closure capture values for which only the serialization layout is known.
+#[derive(Clone, Debug)]
+pub struct RawMoveStruct {
+    pub variant_info: Option<u16>,
+    pub field_values: Vec<AnnotatedMoveValue>,
+}
+
+/// Used to represent an annotated closure. The `captured` values will have only
+/// `RawMoveStruct` information and are not fully decorated.
+#[derive(Clone, Debug)]
+pub struct AnnotatedMoveClosure {
+    pub module_id: ModuleId,
+    pub fun_id: Identifier,
+    pub ty_args: Vec<TypeTag>,
+    pub mask: ClosureMask,
+    pub captured: Vec<AnnotatedMoveValue>,
+}
+
 /// AnnotatedMoveValue is a fully expanded version of on chain Move data. This should only be used
 /// for debugging/client purpose right now and just for a better visualization of on chain data. In
 /// the long run, we would like to transform this struct to a Json value so that we can have a cross
@@ -63,25 +85,9 @@ pub enum AnnotatedMoveValue {
     U16(u16),
     U32(u32),
     U256(u256::U256),
-}
-
-impl AnnotatedMoveValue {
-    pub fn ty_tag(&self) -> TypeTag {
-        use AnnotatedMoveValue::*;
-        match self {
-            U8(_) => TypeTag::U8,
-            U16(_) => TypeTag::U16,
-            U32(_) => TypeTag::U32,
-            U64(_) => TypeTag::U64,
-            U128(_) => TypeTag::U128,
-            U256(_) => TypeTag::U256,
-            Bool(_) => TypeTag::Bool,
-            Address(_) => TypeTag::Address,
-            Vector(t, _) => t.clone(),
-            Bytes(_) => TypeTag::Vector(Box::new(TypeTag::U8)),
-            Struct(s) => TypeTag::Struct(Box::new(s.ty_tag.clone())),
-        }
-    }
+    // NOTE: Added in v8
+    Closure(AnnotatedMoveClosure),
+    RawStruct(RawMoveStruct),
 }
 
 pub struct MoveValueAnnotator<V> {
@@ -162,7 +168,10 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         let types: Vec<&FatType> = param_tys
             .iter()
             .filter(|t| match t {
-                FatType::Signer => false,
+                FatType::Signer
+                | FatType::Function(_)
+                | FatType::Runtime(_)
+                | FatType::RuntimeVariants(_) => false,
                 FatType::Reference(inner) => !matches!(&**inner, FatType::Signer),
                 FatType::Bool
                 | FatType::U8
@@ -363,6 +372,11 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         sig: &SignatureToken,
         limit: &mut Limiter,
     ) -> anyhow::Result<FatType> {
+        let resolve_slice = |toks: &[SignatureToken], limit: &mut Limiter| {
+            toks.iter()
+                .map(|tok| self.resolve_signature(module, tok, limit))
+                .collect::<anyhow::Result<Vec<_>>>()
+        };
         Ok(match sig {
             SignatureToken::Bool => FatType::Bool,
             SignatureToken::U8 => FatType::U8,
@@ -376,19 +390,19 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             SignatureToken::Vector(ty) => {
                 FatType::Vector(Box::new(self.resolve_signature(module, ty, limit)?))
             },
-            SignatureToken::Function(..) => {
-                // TODO(#15664): implement
-                bail!("function types NYI by fat types")
+            SignatureToken::Function(args, results, abilities) => {
+                FatType::Function(Box::new(FatFunctionType {
+                    args: resolve_slice(args, limit)?,
+                    results: resolve_slice(results, limit)?,
+                    abilities: *abilities,
+                }))
             },
             SignatureToken::Struct(idx) => {
                 FatType::Struct(Box::new(self.resolve_struct_handle(module, *idx, limit)?))
             },
             SignatureToken::StructInstantiation(idx, toks) => {
                 let struct_ty = self.resolve_struct_handle(module, *idx, limit)?;
-                let args = toks
-                    .iter()
-                    .map(|tok| self.resolve_signature(module, tok, limit))
-                    .collect::<anyhow::Result<Vec<_>>>()?;
+                let args = resolve_slice(toks, limit)?;
                 FatType::Struct(Box::new(
                     struct_ty
                         .subst(&args, limit)
@@ -553,6 +567,68 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
         }
     }
 
+    fn annotate_raw_struct(
+        &self,
+        move_struct: &MoveStruct,
+        ty: &FatType,
+        limit: &mut Limiter,
+    ) -> anyhow::Result<RawMoveStruct> {
+        let annotate_values = |values: &[MoveValue], tys: &[FatType], limit: &mut Limiter| {
+            values
+                .iter()
+                .zip(tys)
+                .map(|(v, ty)| self.annotate_value(v, ty, limit))
+                .collect::<anyhow::Result<Vec<_>>>()
+        };
+        match (move_struct, ty) {
+            (MoveStruct::Runtime(values), FatType::Runtime(tys)) if values.len() == tys.len() => {
+                Ok(RawMoveStruct {
+                    variant_info: None,
+                    field_values: annotate_values(values, tys, limit)?,
+                })
+            },
+            (MoveStruct::RuntimeVariant(tag, values), FatType::RuntimeVariants(vars))
+                if (*tag as usize) < vars.len() && values.len() == vars[*tag as usize].len() =>
+            {
+                Ok(RawMoveStruct {
+                    variant_info: Some(*tag),
+                    field_values: annotate_values(values, &vars[*tag as usize], limit)?,
+                })
+            },
+            _ => bail!("type and value mismatch: inconsistent raw struct information"),
+        }
+    }
+
+    fn annotate_closure(
+        &self,
+        move_closure: &MoveClosure,
+        _ty: &FatFunctionType,
+        limit: &mut Limiter,
+    ) -> anyhow::Result<AnnotatedMoveClosure> {
+        let MoveClosure {
+            module_id,
+            fun_id,
+            ty_args,
+            mask,
+            captured,
+        } = move_closure;
+        let captured = captured
+            .iter()
+            .map(|(layout, value)| {
+                let fat_type = FatType::from_layout(layout, limit)
+                    .map_err(|e| anyhow!("failed to annotate captured value: {}", e))?;
+                self.annotate_value(value, &fat_type, limit)
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(AnnotatedMoveClosure {
+            module_id: module_id.clone(),
+            fun_id: fun_id.clone(),
+            ty_args: ty_args.to_vec(),
+            mask: *mask,
+            captured,
+        })
+    }
+
     fn annotate_value(
         &self,
         value: &MoveValue,
@@ -587,9 +663,11 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             (MoveValue::Struct(s), FatType::Struct(ty)) => {
                 AnnotatedMoveValue::Struct(self.annotate_struct(s, ty.as_ref(), limit)?)
             },
-            (MoveValue::Closure(..), _) => {
-                // TODO(#15664) implement functions for annotated move values
-                todo!("functions not implemented")
+            (MoveValue::Struct(s), FatType::Runtime(_) | FatType::RuntimeVariants(_)) => {
+                AnnotatedMoveValue::RawStruct(self.annotate_raw_struct(s, ty, limit)?)
+            },
+            (MoveValue::Closure(c), FatType::Function(ty)) => {
+                AnnotatedMoveValue::Closure(self.annotate_closure(c, ty, limit)?)
             },
             (MoveValue::U8(_), _)
             | (MoveValue::U64(_), _)
@@ -598,6 +676,7 @@ impl<V: CompiledModuleView> MoveValueAnnotator<V> {
             | (MoveValue::Address(_), _)
             | (MoveValue::Vector(_), _)
             | (MoveValue::Struct(_), _)
+            | (MoveValue::Closure(_), _)
             | (MoveValue::Signer(_), _)
             | (MoveValue::U16(_), _)
             | (MoveValue::U32(_), _)
@@ -666,6 +745,8 @@ fn pretty_print_value(
         },
         AnnotatedMoveValue::Bytes(v) => write!(f, "{}", hex::encode(v)),
         AnnotatedMoveValue::Struct(s) => pretty_print_struct(f, s, indent),
+        AnnotatedMoveValue::RawStruct(s) => pretty_print_raw_struct(f, s, indent),
+        AnnotatedMoveValue::Closure(c) => pretty_print_closure(f, c, indent),
     }
 }
 
@@ -688,6 +769,78 @@ fn pretty_print_struct(
     }
     write_indent(f, indent)?;
     write!(f, "}}")
+}
+
+fn pretty_print_raw_struct(
+    f: &mut Formatter,
+    value: &RawMoveStruct,
+    indent: u64,
+) -> std::fmt::Result {
+    let RawMoveStruct {
+        variant_info,
+        field_values: value,
+    } = value;
+    if let Some(var) = variant_info {
+        write!(f, "#{}", var)?
+    }
+    writeln!(f, "{{")?;
+    for elem in value {
+        write_indent(f, indent + 4)?;
+        pretty_print_value(f, elem, indent + 4)?;
+        writeln!(f)?
+    }
+    write!(f, "}}")
+}
+
+fn pretty_print_closure(
+    f: &mut Formatter,
+    value: &AnnotatedMoveClosure,
+    indent: u64,
+) -> std::fmt::Result {
+    let AnnotatedMoveClosure {
+        module_id,
+        fun_id,
+        ty_args,
+        mask,
+        captured,
+        ..
+    } = value;
+    write!(
+        f,
+        "0x{}::{}::{}",
+        module_id.address.short_str_lossless(),
+        module_id.name,
+        fun_id
+    )?;
+    if !ty_args.is_empty() {
+        let mut last_sep = "<";
+        for ty in ty_args {
+            f.write_str(last_sep)?;
+            last_sep = ", ";
+            write!(f, "{}", ty)?
+        }
+        write!(f, ">")?
+    }
+    write!(f, "(")?;
+    let mut iter_captured = captured.iter();
+    let mut first = true;
+    for i in 0..mask.max_captured().unwrap_or_default() {
+        if first {
+            first = false
+        } else {
+            write!(f, ", ")?
+        }
+        if mask.is_captured(i) {
+            if let Some(val) = iter_captured.next() {
+                pretty_print_value(f, val, indent)?
+            } else {
+                write!(f, "<invalid closure mask>")?
+            }
+        } else {
+            write!(f, "_")?
+        }
+    }
+    write!(f, ")")
 }
 
 fn pretty_print_ability_modifiers(f: &mut Formatter, abilities: AbilitySet) -> std::fmt::Result {
@@ -713,6 +866,60 @@ impl serde::Serialize for AnnotatedMoveStruct {
         }
         for (f, v) in &self.value {
             s.serialize_entry(f, v)?
+        }
+        s.end()
+    }
+}
+
+impl serde::Serialize for RawMoveStruct {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let mut s;
+        if let Some(tag) = &self.variant_info {
+            s = serializer.serialize_map(Some(self.field_values.len() + 1))?;
+            s.serialize_entry("$variant_tag", tag)?;
+        } else {
+            s = serializer.serialize_map(Some(self.field_values.len()))?;
+        }
+        for (i, v) in self.field_values.iter().enumerate() {
+            s.serialize_entry(&i, v)?
+        }
+        s.end()
+    }
+}
+
+impl serde::Serialize for AnnotatedMoveClosure {
+    fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
+        let AnnotatedMoveClosure {
+            module_id,
+            fun_id,
+            ty_args,
+            mask,
+            captured,
+            ..
+        } = self;
+        let mut count = 2;
+        if !ty_args.is_empty() {
+            count += 1
+        }
+        if !captured.is_empty() {
+            count += 1
+        }
+        let mut s = serializer.serialize_map(Some(count))?;
+        s.serialize_entry(
+            "$fun_name",
+            &format!(
+                "0x{}::{}::{}",
+                module_id.address.short_str_lossless(),
+                module_id.name,
+                fun_id
+            ),
+        )?;
+        if !ty_args.is_empty() {
+            s.serialize_entry("$ty_args", ty_args)?;
+        }
+        s.serialize_entry("$mask", &mask.to_string())?;
+        if !captured.is_empty() {
+            s.serialize_entry("$captured", captured)?
         }
         s.end()
     }
@@ -769,6 +976,8 @@ impl serde::Serialize for AnnotatedMoveValue {
                 }
             },
             Struct(s) => s.serialize(serializer),
+            RawStruct(s) => s.serialize(serializer),
+            Closure(c) => c.serialize(serializer),
         }
     }
 }


### PR DESCRIPTION
## Description

This connects closure values to the REST API:

- Supports `aptos move compiler/... --language 2.2` to access function values
- Supports closures and function types in AnnotatedMoveValue
- Supports closures and function types in APIs MoveType/MoveValue
- Adds the move-examples/function_value/calculator and builds an API e2e test on top of it.
- Also verified manually with CLI.

## How Has This Been Tested?

e2e API test

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [x] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

