### PR TITLE
[cli] Remove Ubuntu 20.04 from release

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -21,23 +21,6 @@ on:
         description: "Dry run - If checked, the release will not be created"
 
 jobs:
-  # TODO: Deprecated, only supports OpenSSL v1, which is deprecated.
-  build-ubuntu20-binary:
-    name: "Build Ubuntu 20.04 binary"
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.inputs.source_git_ref_override }}
-      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-      - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "Ubuntu" "${{inputs.release_version}}"
-      - name: Upload Binary
-        uses: actions/upload-artifact@v4
-        with:
-          name: cli-builds-ubuntu-20.04
-          path: aptos-cli-*.zip
-
   # TODO: Deprecated, please use "Linux" instead as it's more straightforwardly named
   build-ubuntu22-binary:
     name: "Build Ubuntu 22.04 binary"
@@ -145,7 +128,6 @@ jobs:
   release-binaries:
     name: "Release binaries"
     needs:
-      - build-ubuntu20-binary
       - build-ubuntu22-binary
       - build-windows-binary
       - build-linux-binary

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 ## [6.2.0]
 - Several compiler parsing bugs fixed, including in specifications for receiver style functions
+- Remove support for OpenSSL 1.x.x and Ubuntu 20.04, add warning appropriately
 
 ## [6.1.1]
 - Added a new feature to `aptos workspace run`: The workspace server now listens for a "stop" command from

--- a/crates/aptos/src/update/aptos.rs
+++ b/crates/aptos/src/update/aptos.rs
@@ -141,8 +141,9 @@ impl BinaryUpdater for AptosUpdateTool {
                 // OpenSSL 3.x.x, meaning Ubuntu 22.04. Otherwise we use the one built
                 // on 20.04.
                 if version.starts_with('3') {
-                    "Ubuntu-22.04-x86_64"
+                    "Linux-x86_64"
                 } else {
+                    eprintln!("Warning: OpenSSL 1.x.x is deprecated, and so is the CLI associated.  It may not work or have future updates");
                     "Ubuntu-x86_64"
                 }
             },


### PR DESCRIPTION
## Description
Removes 20.04 from release, since it's blocking CLI release

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
