### PR TITLE
[api] Fix max gas estimation in simulation for fee payer

### DIFF
--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -74,6 +74,8 @@ type SubmitTransactionsBatchResult<T> =
 
 type SimulateTransactionResult<T> = poem::Result<BasicResponse<T>, SubmitTransactionError>;
 
+const TWO_APT: u64 = 200000000;
+
 // TODO: Consider making both content types accept either
 // SubmitTransactionRequest or SignedTransaction, the way
 // it is now is quite confusing.
@@ -563,26 +565,51 @@ impl TransactionsApi {
                             AptosErrorCode::InvalidInput,
                         )
                     })?;
-                let output = AptosVM::execute_view_function(
-                    &state_view,
-                    ModuleId::new(AccountAddress::ONE, ident_str!("coin").into()),
-                    ident_str!("balance").into(),
-                    vec![AptosCoinType::type_tag()],
-                    vec![signed_transaction.sender().to_vec()],
-                    context.node_config.api.max_gas_view_function,
-                );
-                let values = output.values.map_err(|err| {
-                    SubmitTransactionError::bad_request_with_code_no_info(
-                        err,
-                        AptosErrorCode::InvalidInput,
-                    )
-                })?;
-                let balance: u64 = bcs::from_bytes(&values[0]).map_err(|err| {
-                    SubmitTransactionError::bad_request_with_code_no_info(
-                        err,
-                        AptosErrorCode::InvalidInput,
-                    )
-                })?;
+
+                // To determine who to check the amount of, need to determine if there's a fee payer
+                let fee_payer_address = if let Some(address) =
+                    signed_transaction.authenticator_ref().fee_payer_address()
+                {
+                    if address.eq(&AccountAddress::ZERO) {
+                        // This means we don't know who the fee payer is, but there is one.
+                        // In this case, we'll have to estimate based on the max gas amount, though
+                        // it may fail
+                        None
+                    } else {
+                        // If it's defined, then use that address
+                        Some(address)
+                    }
+                } else {
+                    // If no fee payer, use the sender
+                    Some(signed_transaction.sender())
+                };
+
+                let balance: u64 = if let Some(fee_payer_address) = fee_payer_address {
+                    let output = AptosVM::execute_view_function(
+                        &state_view,
+                        ModuleId::new(AccountAddress::ONE, ident_str!("coin").into()),
+                        ident_str!("balance").into(),
+                        vec![AptosCoinType::type_tag()],
+                        vec![fee_payer_address.to_vec()],
+                        context.node_config.api.max_gas_view_function,
+                    );
+                    let values = output.values.map_err(|err| {
+                        SubmitTransactionError::bad_request_with_code_no_info(
+                            err,
+                            AptosErrorCode::InvalidInput,
+                        )
+                    })?;
+                    bcs::from_bytes(&values[0]).map_err(|err| {
+                        SubmitTransactionError::bad_request_with_code_no_info(
+                            err,
+                            AptosErrorCode::InvalidInput,
+                        )
+                    })?
+                } else {
+                    // If we don't know who's paying, we just have to put in an assumed number, right
+                    // now we'll assume 2 APT
+                    TWO_APT
+                };
 
                 let gas_unit_price =
                     estimated_gas_unit_price.unwrap_or_else(|| signed_transaction.gas_unit_price());

--- a/testsuite/smoke-test/src/rest_api.rs
+++ b/testsuite/smoke-test/src/rest_api.rs
@@ -15,12 +15,19 @@ use aptos_rest_client::{
     aptos_api_types::{MoveModuleId, TransactionData, ViewFunction, ViewRequest},
     Client,
 };
-use aptos_sdk::move_types::language_storage::StructTag;
+use aptos_sdk::{
+    move_types::language_storage::StructTag, transaction_builder::TransactionBuilder,
+    types::LocalAccount,
+};
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{AccountResource, CORE_CODE_ADDRESS},
+    chain_id::ChainId,
     on_chain_config::{ExecutionConfigV2, OnChainExecutionConfig, TransactionShufflerType},
-    transaction::{authenticator::AuthenticationKey, SignedTransaction, Transaction},
+    transaction::{
+        authenticator::{AccountAuthenticator, AuthenticationKey},
+        EntryFunction, SignedTransaction, Transaction, TransactionPayload,
+    },
 };
 use move_core_types::{
     ident_str,
@@ -584,4 +591,85 @@ async fn test_view_function() {
         .into_inner();
     assert_eq!(bcs_ret_values.len(), 1);
     assert!(!bcs_ret_values[0]);
+}
+
+#[tokio::test]
+async fn test_simulation() {
+    let swarm = new_local_swarm_with_aptos(1).await;
+    let mut info = swarm.aptos_public_info();
+
+    let fee_payer = info
+        .create_and_fund_user_account(10_000_000_000)
+        .await
+        .unwrap();
+
+    let client: &Client = info.client();
+
+    // -- First test with a fee payer, and no fee payer specified -- //
+
+    // Create a local account, and not fund it
+    let mut rng = rand::thread_rng();
+    let sender = LocalAccount::generate(&mut rng);
+    let account_to_create = LocalAccount::generate(&mut rng);
+
+    // Create body to simulate
+    let txn_builder = TransactionBuilder::new(
+        TransactionPayload::EntryFunction(EntryFunction::new(
+            ModuleId::new(AccountAddress::ONE, ident_str!("aptos_account").into()),
+            ident_str!("create").into(),
+            vec![],
+            vec![account_to_create.address().to_vec()],
+        )),
+        30,
+        ChainId::test(),
+    );
+
+    // TODO: TransactionBuilder or RawTransaction signing functions aren't built to handle this properly
+    // So the raw txn and signed transaction have to be built manually
+    let raw_txn = txn_builder
+        .sender(sender.address())
+        .gas_unit_price(100)
+        .max_gas_amount(200000000)
+        .expiration_timestamp_secs(17429208930)
+        .sequence_number(0)
+        .build();
+
+    let signed_txn = SignedTransaction::new_fee_payer(
+        raw_txn.clone(),
+        AccountAuthenticator::NoAccountAuthenticator,
+        vec![],
+        vec![],
+        AccountAddress::ZERO,
+        AccountAuthenticator::NoAccountAuthenticator,
+    );
+
+    let bcs_simulate_response = client.simulate_bcs(&signed_txn).await;
+    assert!(bcs_simulate_response.is_ok());
+    let bcs_simulation = bcs_simulate_response.unwrap().into_inner();
+    assert!(bcs_simulation.info.status().is_success());
+
+    let json_simulate_response = client.simulate(&signed_txn).await;
+    assert!(json_simulate_response.is_ok());
+    let json_simulation = json_simulate_response.unwrap().into_inner();
+    assert!(json_simulation.first().unwrap().info.success);
+
+    // -- Now test with a fee payer, and a fee payer specified -- //
+    let signed_txn_2 = SignedTransaction::new_fee_payer(
+        raw_txn,
+        AccountAuthenticator::NoAccountAuthenticator,
+        vec![],
+        vec![],
+        fee_payer.address(),
+        AccountAuthenticator::NoAccountAuthenticator,
+    );
+
+    let bcs_simulate_response_2 = client.simulate_bcs(&signed_txn_2).await;
+    assert!(bcs_simulate_response_2.is_ok());
+    let bcs_simulation_2 = bcs_simulate_response_2.unwrap().into_inner();
+    assert!(bcs_simulation_2.info.status().is_success());
+
+    let json_simulate_response_2 = client.simulate(&signed_txn_2).await;
+    assert!(json_simulate_response_2.is_ok());
+    let json_simulation_2 = json_simulate_response_2.unwrap().into_inner();
+    assert!(json_simulation_2.first().unwrap().info.success);
 }


### PR DESCRIPTION
## Description
This fixes estimation of max gas amount for fee payer transactions.  Previously it would look at the owner's balance vs the fee payer's balance.  For unknown fee payers, we make the value up as 2 APT, assuming that is the max amount of gas at the lowest price.  Will likely need to tune that in the future, but also a safe amount to assume gas stations will have minimally.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
TBD: Need to write a test for it or test with similar circumstances.  Likely will test as a testnet node.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
