### PR TITLE
get end version from api

### DIFF
--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -554,7 +554,14 @@ def read_skip_ranges(network: str) -> tuple[int, int, list[tuple[int, int]]]:
         (int(range["start_version"]), int(range["end_version"]))
         for range in data["skip_ranges"]
     ]
-    return (data["start"], data["end"], skip_ranges)
+
+    end = int(json.loads(
+        urllib.request.urlopen(f"https://fullnode.{network}.aptoslabs.com/v1")
+        .read()
+        .decode()
+    )["ledger_version"])
+
+    return (data["start"], end, skip_ranges)
 
 
 def parse_args() -> argparse.Namespace:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

replay-verify end versions are currently manually set in gcs and we are not actually updating it. 
This makes the scheduler get it from our fullnode rest api.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
manual run
https://github.com/aptos-labs/aptos-core/actions/runs/13662325606/job/38196109893

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature


## Which Components or Systems Does This Change Impact?

- [x] Developer Infrastructure -- replay-verify

