### PR TITLE
[move-vm][closures] Add a version field to closure serialization data

### DIFF
--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -171,6 +171,7 @@ impl LazyLoadedFunction {
             LazyLoadedFunctionState::Unresolved {
                 data:
                     SerializedFunctionData {
+                        format_version: _,
                         module_id,
                         fun_id,
                         ty_args,

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -26,7 +26,7 @@ use move_vm_types::{
     loaded_data::runtime_types::{StructType, Type},
     module_cyclic_dependency_error, module_linker_error,
     value_serde::FunctionValueExtension,
-    values::{AbstractFunction, SerializedFunctionData},
+    values::{AbstractFunction, SerializedFunctionData, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
 };
 use std::sync::Arc;
 
@@ -483,6 +483,7 @@ impl<'a> FunctionValueExtension for FunctionValueExtensionAdapter<'a> {
                     .map(|t| ty_converter.type_to_type_layout(&instantiate(t)?))
                     .collect::<PartialVMResult<Vec<_>>>()?;
                 Ok(SerializedFunctionData {
+                    format_version: FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
                     module_id: fun
                         .module_id()
                         .ok_or_else(|| {

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -8,7 +8,10 @@ mod tests {
     use crate::{
         delayed_values::delayed_field_id::DelayedFieldID,
         value_serde::{MockFunctionValueExtension, ValueSerDeContext},
-        values::{values_impl, AbstractFunction, SerializedFunctionData, Struct, Value},
+        values::{
+            values_impl, AbstractFunction, SerializedFunctionData, Struct, Value,
+            FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
+        },
     };
     use better_any::{Tid, TidAble, TidExt};
     use claims::{assert_err, assert_ok, assert_some};
@@ -353,6 +356,7 @@ mod tests {
         ) -> MockAbstractFunction {
             Self {
                 data: SerializedFunctionData {
+                    format_version: FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
                     module_id: ModuleId::new(AccountAddress::TWO, Identifier::new("m").unwrap()),
                     fun_id: Identifier::new(fun_name).unwrap(),
                     ty_args,


### PR DESCRIPTION
## Description

The version will allow us to evolve the format how closures are represented in storage.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
