### PR TITLE
[compiler-v2] Fix bytecode verification error by canonicalizing constants

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -973,10 +973,11 @@ impl ModuleGenerator {
         cons: &Constant,
         ty: &Type,
     ) -> FF::ConstantPoolIndex {
-        if let Some(idx) = self.cons_to_idx.get(&(cons.clone(), ty.clone())) {
+        let canonical_const = cons.to_canonical();
+        if let Some(idx) = self.cons_to_idx.get(&(canonical_const.clone(), ty.clone())) {
             return *idx;
         }
-        let data = cons
+        let data = canonical_const
             .to_move_value()
             .simple_serialize()
             .expect("serialization succeeds");
@@ -991,7 +992,7 @@ impl ModuleGenerator {
             "constant",
         ));
         self.module.constant_pool.push(ff_cons);
-        self.cons_to_idx.insert((cons.clone(), ty.clone()), idx);
+        self.cons_to_idx.insert((canonical_const, ty.clone()), idx);
         idx
     }
 }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/const_vec.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/const_vec.exp
@@ -1,0 +1,7 @@
+processed 3 tasks
+
+task 1 'run'. lines 14-14:
+return values: 0
+
+task 2 'run'. lines 16-16:
+return values: 0

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/const_vec.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/const_vec.move
@@ -1,0 +1,16 @@
+//# publish
+module 0xc0ffee::m {
+    public fun test1(): u8 {
+        let a = vector[0u8, 128u8];
+        a[0]
+    }
+
+    public fun test2(): u8 {
+        let b = x"0080";
+        b[0]
+    }
+}
+
+//# run 0xc0ffee::m::test1
+
+//# run 0xc0ffee::m::test2

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -168,6 +168,16 @@ impl Constant {
             },
         }
     }
+
+    /// Canonicalizes the constant.
+    pub fn to_canonical(&self) -> Constant {
+        use Constant::*;
+        match self {
+            ByteArray(v) => Vector(v.iter().map(|e| U8(*e)).collect()),
+            AddressArray(v) => Vector(v.iter().map(|e| Address(e.clone())).collect()),
+            _ => self.clone(),
+        }
+    }
 }
 
 /// An operation -- target of a call. This contains user functions, builtin functions, and


### PR DESCRIPTION
## Description

When we compile the following code:

```move
module 0xc0ffee::m {
    public fun test1(): u8 {
        let a = vector[0u8, 128u8];
        a[0]
    }

    public fun test2(): u8 {
        let b = x"0080";
        b[0]
    }
}
```

We get the following bytecode verification error due to a compiler bug.

```
Error: compilation errors:
 bug: bytecode verification failed with unexpected status code `DUPLICATE_ELEMENT`. This is a compiler bug, consider reporting it.
Error message: none
   ┌─ TEMPFILE:2:1
   │  
 2 │ ╭ module 0xc0ffee::m {
 3 │ │     public fun test1(): u8 {
 4 │ │         let a = vector[0u8, 128u8];
 5 │ │         a[0]
   · │
10 │ │     }
11 │ │ }
   │ ╰─^
```

In this PR, we fix this bug. Specifically, we use a canonical representation to check if a const has already been added to the const pool during code generation.


## How Has This Been Tested?

Added new test to showcase the bug has been fixed.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
