### PR TITLE
[move-vm][closures] Fix failing api test

### DIFF
--- a/api/src/tests/function_value_test.rs
+++ b/api/src/tests/function_value_test.rs
@@ -7,9 +7,7 @@ use aptos_api_test_context::{current_function_name, TestContext};
 use serde_json::json;
 use std::path::PathBuf;
 
-// TODO: figure why this broke after landing successfully
-// #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-#[allow(unused)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn test_function_values() {
     let mut context = new_test_context(current_function_name!());
     let mut account = context.create_account().await;

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -15,6 +15,7 @@ use move_binary_format::{
 };
 use move_core_types::{
     account_address::AccountAddress,
+    function::FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
     identifier::IdentStr,
     language_storage::{ModuleId, TypeTag},
     metadata::Metadata,
@@ -26,7 +27,7 @@ use move_vm_types::{
     loaded_data::runtime_types::{StructType, Type},
     module_cyclic_dependency_error, module_linker_error,
     value_serde::FunctionValueExtension,
-    values::{AbstractFunction, SerializedFunctionData, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
+    values::{AbstractFunction, SerializedFunctionData},
 };
 use std::sync::Arc;
 

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -5,7 +5,7 @@ use crate::values::{DeserializationSeed, SerializationReadyValue, VMValueCast, V
 use better_any::Tid;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    function::{ClosureMask, MoveFunctionLayout},
+    function::{ClosureMask, MoveFunctionLayout, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     value::MoveTypeLayout,
@@ -39,9 +39,6 @@ pub struct Closure(
     pub(crate) Box<dyn AbstractFunction>,
     pub(crate) Vec<ValueImpl>,
 );
-
-/// Version number for the serialization format of function data.
-pub const FUNCTION_DATA_SERIALIZATION_FORMAT_V1: u16 = 1;
 
 /// The representation of a function in storage.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -8,10 +8,7 @@ mod tests {
     use crate::{
         delayed_values::delayed_field_id::DelayedFieldID,
         value_serde::{MockFunctionValueExtension, ValueSerDeContext},
-        values::{
-            values_impl, AbstractFunction, SerializedFunctionData, Struct, Value,
-            FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
-        },
+        values::{values_impl, AbstractFunction, SerializedFunctionData, Struct, Value},
     };
     use better_any::{Tid, TidAble, TidExt};
     use claims::{assert_err, assert_ok, assert_some};
@@ -19,7 +16,9 @@ mod tests {
     use move_core_types::{
         ability::AbilitySet,
         account_address::AccountAddress,
-        function::{ClosureMask, MoveClosure, MoveFunctionLayout},
+        function::{
+            ClosureMask, MoveClosure, MoveFunctionLayout, FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
+        },
         identifier::Identifier,
         language_storage::{FunctionTag, ModuleId, StructTag, TypeTag},
         u256,


### PR DESCRIPTION
## Description

After adding version number to closure BCS, API test started to fail on main. Apparently those tests aren't triggered by changes in the VM. To my surprise, the serialization format in `move-core/types/value.rs` must match the one used in `move-vm/types/values_impl.rs`, a dependency which isn't documented anywhere and appears strange. In any case, the data in the DB put via values_impl.rs there, must be recognizable by the `MoveValue` serializers. This PR fixes this and re-enables the failing test.

## How Has This Been Tested?

Renabled failing test

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

