### PR TITLE
[prover] refactor enum representation in boogie

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
+++ b/third_party/move/move-prover/boogie-backend/src/boogie_helpers.rs
@@ -13,12 +13,15 @@ use move_core_types::account_address::AccountAddress;
 use move_model::{
     ast::{Address, MemoryLabel, TempIndex, Value},
     model::{
-        FieldEnv, FunctionEnv, GlobalEnv, ModuleEnv, QualifiedInstId, SpecFunId, StructEnv,
-        StructId, SCRIPT_MODULE_NAME,
+        FieldEnv, FieldId, FunctionEnv, GlobalEnv, ModuleEnv, QualifiedInstId, SpecFunId,
+        StructEnv, StructId, SCRIPT_MODULE_NAME,
     },
     pragmas::INTRINSIC_TYPE_MAP,
     symbol::Symbol,
     ty::{PrimitiveType, Type},
+};
+use move_prover_bytecode_pipeline::number_operation::{
+    GlobalNumberOperationState, NumOperation::Bitwise,
 };
 use move_stackless_bytecode::{function_target::FunctionTarget, stackless_bytecode::Constant};
 use num::BigUint;
@@ -80,9 +83,23 @@ pub fn boogie_struct_name_bv(struct_env: &StructEnv<'_>, inst: &[Type], bv_flag:
 /// Return field selector for given field.
 pub fn boogie_field_sel(field_env: &FieldEnv<'_>) -> String {
     let struct_env = &field_env.struct_env;
+    // Attach variant name to field name if it is an enum field
+    // to distinguish fields with the same name but different types in different variants
+    let variant = if field_env.get_variant().is_some() {
+        format!(
+            "_{}",
+            field_env
+                .get_variant()
+                .unwrap()
+                .display(struct_env.symbol_pool())
+        )
+    } else {
+        "".to_string()
+    };
     format!(
-        "${}",
+        "${}{}",
         field_env.get_name().display(struct_env.symbol_pool()),
+        variant
     )
 }
 
@@ -95,6 +112,65 @@ pub fn boogie_field_update(field_env: &FieldEnv<'_>, inst: &[Type]) -> String {
         suffix,
         field_env.get_name().display(struct_env.symbol_pool()),
     )
+}
+
+/// Return field update for given field in variant.
+pub fn boogie_variant_field_update(
+    field_env: &FieldEnv<'_>,
+    field_type_name: String,
+    inst: &[Type],
+) -> String {
+    let struct_env = &field_env.struct_env;
+    let suffix = boogie_type_suffix_for_struct(struct_env, inst, false);
+    format!(
+        "$Update'{}'_{}_{}",
+        suffix,
+        // remove parentheses and spaces from field type name
+        field_type_name.replace(['(', ')'], "").replace(' ', "_"),
+        field_env.get_name().display(struct_env.symbol_pool()),
+    )
+}
+
+/// Return true if the field is a bitwise field
+pub fn field_bv_flag_global_state(
+    global_state: &GlobalNumberOperationState,
+    field_env: &FieldEnv,
+) -> bool {
+    let operation_map = &global_state.struct_operation_map;
+    let mid = field_env.struct_env.module_env.get_id();
+    let sid = field_env.struct_env.get_id();
+    let field_id = if field_env.struct_env.has_variants() {
+        let variant = field_env
+            .get_variant()
+            .expect("each field of enum must have a corresponding variant");
+        let pool = field_env.struct_env.symbol_pool();
+        FieldId::new(pool.make(&FieldId::make_variant_field_id_str(
+            pool.string(variant).as_str(),
+            pool.string(field_env.get_name()).as_str(),
+        )))
+    } else {
+        field_env.get_id()
+    };
+    if let Some(struct_info) = operation_map.get(&(mid, sid)) {
+        matches!(struct_info.get(&field_id), Some(&Bitwise))
+    } else {
+        false
+    }
+}
+
+/// Return boogie type for given field
+pub fn boogie_type_for_struct_field(
+    global_state: &GlobalNumberOperationState,
+    field: &FieldEnv,
+    env: &GlobalEnv,
+    ty: &Type,
+) -> String {
+    let bv_flag = field_bv_flag_global_state(global_state, field);
+    if bv_flag {
+        boogie_bv_type(env, ty)
+    } else {
+        boogie_type(env, ty)
+    }
 }
 
 /// Return boogie name of given function.

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -13,10 +13,11 @@ use crate::{
         boogie_modifies_memory_name, boogie_num_literal, boogie_num_type_base,
         boogie_num_type_string_capital, boogie_reflection_type_info, boogie_reflection_type_name,
         boogie_resource_memory_name, boogie_struct_name, boogie_struct_variant_name, boogie_temp,
-        boogie_temp_from_suffix, boogie_type, boogie_type_param, boogie_type_suffix,
-        boogie_type_suffix_bv, boogie_type_suffix_for_struct,
-        boogie_type_suffix_for_struct_variant, boogie_well_formed_check,
-        boogie_well_formed_expr_bv, TypeIdentToken,
+        boogie_temp_from_suffix, boogie_type, boogie_type_for_struct_field, boogie_type_param,
+        boogie_type_suffix, boogie_type_suffix_bv, boogie_type_suffix_for_struct,
+        boogie_type_suffix_for_struct_variant, boogie_variant_field_update,
+        boogie_well_formed_check, boogie_well_formed_expr_bv, field_bv_flag_global_state,
+        TypeIdentToken,
     },
     options::BoogieOptions,
     spec_translator::SpecTranslator,
@@ -31,10 +32,7 @@ use move_model::{
     ast::{Attribute, TempIndex, TraceKind},
     code_writer::CodeWriter,
     emit, emitln,
-    model::{
-        FieldEnv, FieldId, FunctionEnv, GlobalEnv, Loc, NodeId, QualifiedInstId, StructEnv,
-        StructId,
-    },
+    model::{FieldEnv, FunctionEnv, GlobalEnv, Loc, NodeId, QualifiedInstId, StructEnv, StructId},
     pragmas::{
         ADDITION_OVERFLOW_UNCHECKED_PRAGMA, SEED_PRAGMA, TIMEOUT_PRAGMA,
         VERIFY_DURATION_ESTIMATE_PRAGMA,
@@ -444,7 +442,7 @@ impl<'env> StructTranslator<'env> {
         &self,
         struct_env: &StructEnv,
         variant: Symbol,
-        field_variant_map: &mut BTreeMap<(String, String), Vec<String>>,
+        field_variant_map: &mut BTreeMap<(String, (String, String)), Vec<String>>,
     ) {
         let writer = self.parent.writer;
         let env = self.parent.env;
@@ -461,15 +459,31 @@ impl<'env> StructTranslator<'env> {
                 env,
                 &self.inst(&field_env.get_type()),
             );
-            if field_variant_map.contains_key(&(field_name.clone(), field_type_name.clone())) {
+            // The type name of the field is required when generating the corresponding update function
+            // cannot use inst here because the caller side does not know the type instantiation info
+            let field_type_name_uninst =
+                self.boogie_type_for_struct_field(&field_env, env, &field_env.get_type());
+            if field_variant_map.contains_key(&(
+                field_name.clone(),
+                (field_type_name.clone(), field_type_name_uninst.clone()),
+            )) {
                 let variants_vec = field_variant_map
-                    .get_mut(&(field_name.clone(), field_type_name.clone()))
+                    .get_mut(&(
+                        field_name.clone(),
+                        (field_type_name.clone(), field_type_name_uninst.clone()),
+                    ))
                     .unwrap();
                 variants_vec.push(struct_variant_name.clone());
             } else {
                 let variants_vec = vec![struct_variant_name.clone()];
                 field_variant_map.insert(
-                    (field_name.to_string(), field_type_name.to_string()),
+                    (
+                        field_name.to_string(),
+                        (
+                            field_type_name.to_string(),
+                            field_type_name_uninst.to_string(),
+                        ),
+                    ),
                     variants_vec,
                 );
             }
@@ -509,10 +523,12 @@ impl<'env> StructTranslator<'env> {
                     emitln!(writer, "true")
                 } else {
                     let mut sep = "";
+                    emitln!(writer, "if s is {} then", suffix_variant);
                     for field in &fields {
                         emitln!(writer, "{}", self.boogie_field_is_valid(field, sep));
                         sep = "  && ";
                     }
+                    emitln!(writer, "else false");
                 }
             },
         );
@@ -537,7 +553,8 @@ impl<'env> StructTranslator<'env> {
     /// Emit $Update and $IsValid for enum
     fn emit_update_is_valid_for_enum(&self, struct_env: &StructEnv, struct_name: &str) {
         let writer = self.parent.writer;
-        let mut field_variant_map: BTreeMap<(String, String), Vec<String>> = BTreeMap::new();
+        let mut field_variant_map: BTreeMap<(String, (String, String)), Vec<String>> =
+            BTreeMap::new();
         for variant in struct_env.get_variants() {
             self.emit_struct_variant_is_valid_and_update(
                 struct_env,
@@ -545,11 +562,19 @@ impl<'env> StructTranslator<'env> {
                 &mut field_variant_map,
             );
         }
-        for ((field, field_type), variant_name) in field_variant_map {
+        for ((field, (field_type, field_type_uninst)), variant_name) in field_variant_map {
             self.emit_function(
                 &format!(
-                    "$Update'{}'_{}(s: {}, x: {}): {}",
-                    struct_name, field, struct_name, field_type, struct_name
+                    "$Update'{}'_{}_{}(s: {}, x: {}): {}",
+                    struct_name,
+                    // type name is needed in the update function name
+                    // to distinguish fields with the same name but different types in different variants
+                    // remove parentheses and spaces from field type name
+                    field_type_uninst.replace(['(', ')'], "").replace(' ', "_"),
+                    field,
+                    struct_name,
+                    field_type,
+                    struct_name
                 ),
                 || {
                     let mut else_symbol = "";
@@ -623,26 +648,7 @@ impl<'env> StructTranslator<'env> {
             .env
             .get_extension::<GlobalNumberOperationState>()
             .expect("global number operation state");
-        let operation_map = &global_state.struct_operation_map;
-        let mid = self.struct_env.module_env.get_id();
-        let sid = self.struct_env.get_id();
-        let field_id = if field_env.struct_env.has_variants() {
-            let variant = field_env
-                .get_variant()
-                .expect("each field of enum must have a corresponding variant");
-            let pool = self.struct_env.symbol_pool();
-            FieldId::new(pool.make(&FieldId::make_variant_field_id_str(
-                pool.string(variant).as_str(),
-                pool.string(field_env.get_name()).as_str(),
-            )))
-        } else {
-            field_env.get_id()
-        };
-        if let Some(struct_info) = operation_map.get(&(mid, sid)) {
-            matches!(struct_info.get(&field_id), Some(&Bitwise))
-        } else {
-            false
-        }
+        field_bv_flag_global_state(global_state, field_env)
     }
 
     /// Return boogie type for a struct
@@ -1755,28 +1761,33 @@ impl<'env> FunctionTranslator<'env> {
                         let dest_str = str_local(dests[0]);
                         let struct_env = env.get_module(*mid).into_struct(*sid);
                         self.check_intrinsic_select(attr_id, &struct_env);
-                        emit!(writer, "if (");
-                        let mut select_condition = vec![];
+                        let mut else_symbol = "";
+                        // Need to go through all variants to find the correct field
                         for variant in variants {
+                            emit!(writer, "{} if (", else_symbol);
                             let struct_variant_name =
                                 boogie_struct_variant_name(&struct_env, inst, *variant);
-                            let call = format!("{} is {}", deref_src_str, struct_variant_name);
-                            select_condition.push(call.clone());
+                            let field_env = struct_env.get_field_by_offset_optional_variant(
+                                Some(*variant),
+                                *field_offset,
+                            );
+                            let field_sel = boogie_field_sel(&field_env);
+                            emitln!(writer, "{} is {}) {{", deref_src_str, struct_variant_name);
+                            emitln!(
+                                writer,
+                                "{} := $ChildMutation({}, {}, {}->{});",
+                                dest_str,
+                                src_str,
+                                field_offset,
+                                deref_src_str,
+                                field_sel,
+                            );
+                            emitln!(writer, "}");
+                            if else_symbol.is_empty() {
+                                else_symbol = " else ";
+                            }
                         }
-                        let field_env = struct_env
-                            .get_field_by_offset_optional_variant(Some(variants[0]), *field_offset);
-                        let field_sel = boogie_field_sel(&field_env);
-                        emitln!(writer, "{}) {{", select_condition.join(" || "));
-                        emitln!(
-                            writer,
-                            "{} := $ChildMutation({}, {}, {}->{});",
-                            dest_str,
-                            src_str,
-                            field_offset,
-                            deref_src_str,
-                            field_sel,
-                        );
-                        emitln!(writer, "} else { call $ExecFailureAbort(); }");
+                        emitln!(writer, "else { call $ExecFailureAbort(); }");
                     },
                     GetField(mid, sid, _, field_offset) => {
                         let src = srcs[0];
@@ -1798,23 +1809,28 @@ impl<'env> FunctionTranslator<'env> {
                         let dest_str = str_local(dests[0]);
                         let struct_env = env.get_module(*mid).into_struct(*sid);
                         self.check_intrinsic_select(attr_id, &struct_env);
-                        emit!(writer, "if (");
-                        let mut select_condition = vec![];
+                        let mut else_symbol = "";
+                        // Need to go through all variants to find the correct field
                         for variant in variants {
-                            let struct_variant_name =
-                                boogie_struct_variant_name(&struct_env, inst, *variant);
+                            emitln!(writer, "{} if (", else_symbol);
                             if self.get_local_type(src).is_reference() {
                                 src_str = format!("$Dereference({})", src_str);
                             };
-                            let call = format!("{} is {}", src_str, struct_variant_name);
-                            select_condition.push(call.clone());
+                            let struct_variant_name =
+                                boogie_struct_variant_name(&struct_env, inst, *variant);
+                            let field_env = struct_env.get_field_by_offset_optional_variant(
+                                Some(*variant),
+                                *field_offset,
+                            );
+                            let field_sel = boogie_field_sel(&field_env);
+                            emit!(writer, "{} is {}) {{", src_str, struct_variant_name);
+                            emitln!(writer, "{} := {}->{};", dest_str, src_str, field_sel);
+                            emitln!(writer, "}");
+                            if else_symbol.is_empty() {
+                                else_symbol = " else ";
+                            }
                         }
-                        let field_env = struct_env
-                            .get_field_by_offset_optional_variant(Some(variants[0]), *field_offset);
-                        let field_sel = boogie_field_sel(&field_env);
-                        emitln!(writer, "{}) {{", select_condition.join(" || "));
-                        emitln!(writer, "{} := {}->{};", dest_str, src_str, field_sel);
-                        emitln!(writer, "} else { call $ExecFailureAbort(); }");
+                        emitln!(writer, "else { call $ExecFailureAbort(); }");
                     },
                     Exists(mid, sid, inst) => {
                         let inst = self.inst_slice(inst);
@@ -2798,7 +2814,25 @@ impl<'env> FunctionTranslator<'env> {
                         edges,
                         at + 1,
                     );
-                    let update_fun = boogie_field_update(&field_env, &memory.inst);
+                    let update_fun = if variant.is_none() {
+                        boogie_field_update(&field_env, &memory.inst)
+                    } else {
+                        // When updating a field of an enum variant,
+                        // the type of the field is required to call the correct update function
+                        let global_state = &self
+                            .parent
+                            .env
+                            .get_extension::<GlobalNumberOperationState>()
+                            .expect("global number operation state");
+                        let type_name = boogie_type_for_struct_field(
+                            global_state,
+                            &field_env,
+                            self.parent.env,
+                            &field_env.get_type(),
+                        );
+                        boogie_variant_field_update(&field_env, type_name, &memory.inst)
+                    };
+
                     if new_dest_needed {
                         format!(
                             "(var $$sel{} := {}; {}({}, {}))",

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -881,7 +881,7 @@ impl<'env> SpecTranslator<'env> {
                 self.translate_select(node_id, *module_id, *struct_id, *field_id, args)
             },
             Operation::SelectVariants(module_id, struct_id, field_ids) => {
-                self.translate_select(node_id, *module_id, *struct_id, field_ids[0], args);
+                self.translate_select_variant(node_id, *module_id, *struct_id, field_ids, args);
             },
             Operation::TestVariants(module_id, struct_id, variants) => {
                 self.translate_test_variants(node_id, *module_id, *struct_id, variants, args);
@@ -1271,6 +1271,59 @@ impl<'env> SpecTranslator<'env> {
         let field_env = struct_env.get_field(field_id);
         self.translate_exp(&args[0]);
         emit!(self.writer, "->{}", boogie_field_sel(&field_env));
+    }
+
+    fn translate_select_variant(
+        &self,
+        node_id: NodeId,
+        module_id: ModuleId,
+        struct_id: StructId,
+        field_ids: &[FieldId],
+        args: &[Exp],
+    ) {
+        let struct_env = self.env.get_module(module_id).into_struct(struct_id);
+        if struct_env.is_intrinsic() || field_ids.is_empty() {
+            self.env.error(
+                &self.env.get_node_loc(node_id),
+                "cannot select field of intrinsic struct",
+            );
+        }
+        let struct_type = &self.get_node_type(args[0].node_id());
+        let (_, _, inst) = struct_type.skip_reference().require_struct();
+        let l = self.fresh_var_name("l");
+        emit!(self.writer, "(var {} := ", l);
+        self.translate_exp(&args[0]);
+        emit!(self.writer, ";");
+        let mut else_symbol = "";
+        // When translating into boogie representation,
+        // field with the same name is attached with the corresponding variant name
+        // to avoid type error when they have different types in different variants
+        for field_id in field_ids.iter() {
+            let field_env = struct_env.get_field(*field_id);
+
+            let struct_variant_name =
+                boogie_struct_variant_name(&struct_env, inst, field_env.get_variant().unwrap());
+            let match_condition = format!("{} is {}", l, struct_variant_name);
+            emit!(self.writer, "{} if {} then ", else_symbol, match_condition);
+            emit!(self.writer, "{} -> {}", l, boogie_field_sel(&field_env));
+            if else_symbol.is_empty() {
+                else_symbol = " else ";
+            }
+        }
+        emit!(self.writer, " else ");
+        let global_state = &self
+            .env
+            .get_extension::<GlobalNumberOperationState>()
+            .expect("global number operation state");
+        let exp_bv_flag = global_state.get_node_num_oper(node_id) == Bitwise;
+        emit!(
+            self.writer,
+            &format!(
+                "$Arbitrary_value_of'{}'()",
+                boogie_type_suffix_bv(self.env, &self.get_node_type(node_id), exp_bv_flag)
+            )
+        );
+        emit!(self.writer, ")");
     }
 
     fn translate_test_variants(

--- a/third_party/move/move-prover/tests/sources/functional/enum_diff_type.exp
+++ b/third_party/move/move-prover/tests/sources/functional/enum_diff_type.exp
@@ -1,0 +1,19 @@
+Move prover returns: exiting with verification errors
+error: data invariant does not hold
+   ┌─ tests/sources/functional/enum_diff_type.move:17:9
+   │
+17 │         invariant (self is CommonFields::Bar) ==> self.z > 10;
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/enum_diff_type.move:23: test_data_invariant
+   =     at tests/sources/functional/enum_diff_type.move:24: test_data_invariant
+   =     at tests/sources/functional/enum_diff_type.move:22: test_data_invariant
+   =     at tests/sources/functional/enum_diff_type.move:21: test_data_invariant
+   =     at tests/sources/functional/enum_diff_type.move:17
+   =     at tests/sources/functional/enum_diff_type.move:21: test_data_invariant
+   =         common = <redacted>
+   =     at tests/sources/functional/enum_diff_type.move:26: test_data_invariant
+   =         <redacted> = <redacted>
+   =     at tests/sources/functional/enum_diff_type.move:27: test_data_invariant
+   =         z = <redacted>
+   =     at tests/sources/functional/enum_diff_type.move:17

--- a/third_party/move/move-prover/tests/sources/functional/enum_diff_type.move
+++ b/third_party/move/move-prover/tests/sources/functional/enum_diff_type.move
@@ -1,0 +1,81 @@
+module 0x815::m {
+
+    enum TestNoField has copy, drop {
+        NoField
+    }
+
+    fun test_no_field(): TestNoField {
+        TestNoField::NoField
+    }
+
+    enum CommonFields has copy, drop {
+        Foo{x: u64, y: u8},
+        Bar{y: u8, z: u32, x: u8}
+    }
+
+    spec CommonFields {
+        invariant (self is CommonFields::Bar) ==> self.z > 10;
+    }
+
+    fun test_data_invariant() {
+        let common = CommonFields::Bar {
+            x: 30,
+            y: 40,
+            z: 50
+        };
+        let CommonFields::Bar {x: _x, y: _y, z} = &mut common;
+        *z = 9; // struct invariant fails
+    }
+
+    fun test_match_ref(): u64 {
+        let common = CommonFields::Bar {
+            x: 30,
+            y: 40,
+            z: 50
+        };
+        match (&common) {
+            Foo {x, y: _} => *x,
+            Bar {x, y: _, z: _ } => (*x + 1) as u64
+        }
+    }
+
+    spec test_match_ref {
+        ensures result == 31;
+    }
+
+    enum CommonFieldsVector has drop {
+        Foo{x: vector<u8>},
+        Bar{x: vector<u8>, y: vector<CommonFields>}
+    }
+
+    fun test_enum_vector() {
+        let _common_vector_1 = CommonFieldsVector::Foo {
+            x: vector[2]
+        };
+        let _common_fields = CommonFields::Bar {
+            x: 30,
+            y: 40,
+            z: 50
+        };
+        let _common_vector_2 = CommonFieldsVector::Bar {
+            x: vector[2],
+            y: vector[_common_fields]
+        };
+        spec {
+            assert _common_vector_2.y[0] == CommonFields::Bar {
+                x: 30,
+                y: 40,
+                z: 50
+            };
+        };
+        let _common_vector_3 = CommonFieldsVector::Bar {
+            x: vector[2],
+            y: vector[_common_fields]
+        };
+        spec {
+            assert _common_vector_2 == _common_vector_3;
+        };
+
+    }
+
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR changes the encoding of enum in boogie data representation to allow enum to define field with same name but different types in different variants.


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests pass;
2) added a new test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Move prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
