### PR TITLE
[move-vm][rac] Bytecode verification

### DIFF
--- a/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
+++ b/third_party/move/move-binary-format/serializer-tests/tests/serializer_tests.rs
@@ -42,11 +42,12 @@ proptest! {
     #[test]
     fn garbage_inputs(module in any_with::<CompiledModule>(16)) {
         let mut serialized = Vec::with_capacity(65536);
-        module.serialize_for_version(Some(VERSION_MAX), &mut serialized).expect("serialization should work");
-
-        let deserialized_module = CompiledModule::deserialize_no_check_bounds(&serialized)
-            .expect("deserialization should work");
-        prop_assert_eq!(module, deserialized_module);
+        if module.serialize_for_version(Some(VERSION_MAX), &mut serialized).is_ok() {
+            // Skip garbage module which cannot be serialized (e.g. out of bounds)
+            let deserialized_module = CompiledModule::deserialize_no_check_bounds(&serialized)
+                .expect("deserialization should work");
+            prop_assert_eq!(module, deserialized_module);
+        }
     }
 }
 

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -341,7 +341,8 @@ pub struct FunctionHandle {
     /// does not depend on any global state.
     #[cfg_attr(
         any(test, feature = "fuzzing"),
-        proptest(filter = "|x| x.as_ref().map(|v| v.len() <= 64).unwrap_or(true)")
+        // Keep the number of specifiers in range for tests which create arbitrary data
+        proptest(filter = "|x| x.as_ref().map(|v| v.len() <= 32).unwrap_or(true)")
     )]
     pub access_specifiers: Option<Vec<AccessSpecifier>>,
     /// A list of attributes the referenced function definition had at compilation time.
@@ -893,7 +894,6 @@ pub enum AddressSpecifier {
         /// The index of a parameter of the current function. If `modifier` is not given, the
         /// parameter must have address type. Otherwise `modifier` must be a function which takes
         /// a value (or reference) of the parameter type and delivers an address.
-        #[cfg_attr(any(test, feature = "fuzzing"), proptest(strategy = "0u8..63"))]
         LocalIndex,
         /// If given, a function applied to the parameter. This is a well-known function which
         /// extracts an address from a value, e.g. `object::address_of`.

--- a/third_party/move/move-vm/integration-tests/src/tests/access_specifier_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/access_specifier_tests.rs
@@ -1,0 +1,293 @@
+// Copyright (c) The Diem Core Contributors
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::tests::execute_function_with_single_storage_for_test;
+use claims::assert_err;
+use move_binary_format::{
+    errors::VMResult,
+    file_format::{
+        AccessKind, AccessSpecifier, AddressIdentifierIndex, AddressSpecifier, Bytecode, CodeUnit,
+        CompiledModule, FieldDefinition, FunctionDefinition, FunctionHandle, FunctionHandleIndex,
+        IdentifierIndex, ModuleHandle, ModuleHandleIndex, ResourceSpecifier, Signature,
+        SignatureIndex, SignatureToken, StructDefinition, StructFieldInformation, StructHandle,
+        StructHandleIndex, TableIndex, TypeSignature, Visibility,
+    },
+};
+use move_core_types::{
+    ability::AbilitySet, account_address::AccountAddress, identifier::Identifier,
+    language_storage::TypeTag, value::MoveValue, vm_status::StatusCode,
+};
+use move_vm_test_utils::InMemoryStorage;
+
+fn make_module_with_function(
+    parameters: Signature,
+    return_: Signature,
+    type_parameters: Vec<AbilitySet>,
+    access_specifiers: Vec<AccessSpecifier>,
+) -> (CompiledModule, Identifier) {
+    let function_name = Identifier::new("foo").unwrap();
+    let mut signatures = vec![Signature(vec![])];
+    let parameters_idx = match signatures
+        .iter()
+        .enumerate()
+        .find(|(_, s)| *s == &parameters)
+    {
+        Some((idx, _)) => SignatureIndex(idx as TableIndex),
+        None => {
+            signatures.push(parameters);
+            SignatureIndex((signatures.len() - 1) as TableIndex)
+        },
+    };
+    let return_idx = match signatures.iter().enumerate().find(|(_, s)| *s == &return_) {
+        Some((idx, _)) => SignatureIndex(idx as TableIndex),
+        None => {
+            signatures.push(return_);
+            SignatureIndex((signatures.len() - 1) as TableIndex)
+        },
+    };
+    let module = CompiledModule {
+        version: move_binary_format::file_format_common::VERSION_MAX,
+        self_module_handle_idx: ModuleHandleIndex(0),
+        module_handles: vec![ModuleHandle {
+            address: AddressIdentifierIndex(0),
+            name: IdentifierIndex(0),
+        }],
+        struct_handles: vec![StructHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(1),
+            abilities: AbilitySet::EMPTY,
+            type_parameters: vec![],
+        }],
+        function_handles: vec![FunctionHandle {
+            module: ModuleHandleIndex(0),
+            name: IdentifierIndex(2),
+            parameters: parameters_idx,
+            return_: return_idx,
+            type_parameters,
+            access_specifiers: Some(access_specifiers),
+            attributes: vec![],
+        }],
+        field_handles: vec![],
+        friend_decls: vec![],
+
+        struct_def_instantiations: vec![],
+        function_instantiations: vec![],
+        field_instantiations: vec![],
+
+        signatures,
+
+        identifiers: vec![
+            Identifier::new("M").unwrap(),
+            Identifier::new("X").unwrap(),
+            function_name.clone(),
+        ],
+        address_identifiers: vec![AccountAddress::random()],
+        constant_pool: vec![],
+        metadata: vec![],
+
+        struct_defs: vec![StructDefinition {
+            struct_handle: StructHandleIndex(0),
+            field_information: StructFieldInformation::Declared(vec![FieldDefinition {
+                name: IdentifierIndex(1),
+                signature: TypeSignature(SignatureToken::Bool),
+            }]),
+        }],
+        function_defs: vec![FunctionDefinition {
+            function: FunctionHandleIndex(0),
+            visibility: Visibility::Public,
+            is_entry: false,
+            acquires_global_resources: vec![],
+            code: Some(CodeUnit {
+                locals: SignatureIndex(0),
+                code: vec![Bytecode::LdU64(0), Bytecode::Abort],
+            }),
+        }],
+        struct_variant_handles: vec![],
+        struct_variant_instantiations: vec![],
+        variant_field_handles: vec![],
+        variant_field_instantiations: vec![],
+    };
+    (module, function_name)
+}
+
+fn load_and_call_function(
+    module: CompiledModule,
+    function_name: Identifier,
+    non_signer_args: Vec<Vec<u8>>,
+    ty_args: Vec<TypeTag>,
+    signers: Vec<AccountAddress>,
+) -> VMResult<()> {
+    let mut storage = InMemoryStorage::new();
+
+    let module_id = module.self_id();
+    let mut module_blob = vec![];
+    module.serialize(&mut module_blob).unwrap();
+
+    storage.add_module_bytes(module_id.address(), module_id.name(), module_blob.into());
+
+    execute_function_with_single_storage_for_test(
+        &storage,
+        &module_id,
+        function_name.as_ident_str(),
+        &ty_args,
+        signers
+            .into_iter()
+            .map(|s| MoveValue::Signer(s).simple_serialize().unwrap())
+            .chain(non_signer_args)
+            .collect(),
+    )?;
+    Ok(())
+}
+
+#[test]
+fn rac_declared_at_ok() {
+    let (module, function_name) =
+        make_module_with_function(Signature::default(), Signature::default(), vec![], vec![
+            AccessSpecifier {
+                kind: AccessKind::Reads,
+                negated: false,
+                resource: ResourceSpecifier::DeclaredAtAddress(AddressIdentifierIndex::new(0)),
+                address: AddressSpecifier::Any,
+            },
+        ]);
+    let err = assert_err!(load_and_call_function(
+        module,
+        function_name,
+        vec![],
+        vec![],
+        vec![]
+    ));
+    // aborted means function executed
+    assert_eq!(err.major_status(), StatusCode::ABORTED)
+}
+
+#[test]
+fn rac_declared_at_fail() {
+    let (module, function_name) =
+        make_module_with_function(Signature::default(), Signature::default(), vec![], vec![
+            AccessSpecifier {
+                kind: AccessKind::Reads,
+                negated: false,
+                resource: ResourceSpecifier::DeclaredAtAddress(AddressIdentifierIndex::new(1)),
+                address: AddressSpecifier::Any,
+            },
+        ]);
+    let err = assert_err!(load_and_call_function(
+        module,
+        function_name,
+        vec![],
+        vec![],
+        vec![]
+    ));
+    // bounds checker error surfaces as serialization error
+    assert_eq!(
+        err.major_status(),
+        StatusCode::UNEXPECTED_DESERIALIZATION_ERROR,
+        "{:?}",
+        err
+    )
+}
+
+#[test]
+fn rac_declared_in_module_fail() {
+    let (module, function_name) =
+        make_module_with_function(Signature::default(), Signature::default(), vec![], vec![
+            AccessSpecifier {
+                kind: AccessKind::Reads,
+                negated: false,
+                resource: ResourceSpecifier::DeclaredInModule(ModuleHandleIndex::new(1)),
+                address: AddressSpecifier::Any,
+            },
+        ]);
+    let err = assert_err!(load_and_call_function(
+        module,
+        function_name,
+        vec![],
+        vec![],
+        vec![]
+    ));
+    // bounds checker error surfaces as serialization error
+    assert_eq!(
+        err.major_status(),
+        StatusCode::UNEXPECTED_DESERIALIZATION_ERROR,
+        "{:?}",
+        err
+    )
+}
+
+#[test]
+fn rac_resource_ok() {
+    let (module, function_name) =
+        make_module_with_function(Signature::default(), Signature::default(), vec![], vec![
+            AccessSpecifier {
+                kind: AccessKind::Reads,
+                negated: false,
+                resource: ResourceSpecifier::Resource(StructHandleIndex::new(0)),
+                address: AddressSpecifier::Any,
+            },
+        ]);
+    let err = assert_err!(load_and_call_function(
+        module,
+        function_name,
+        vec![],
+        vec![],
+        vec![]
+    ));
+    assert_eq!(err.major_status(), StatusCode::ABORTED, "{:?}", err)
+}
+
+#[test]
+fn rac_resource_fail() {
+    let (module, function_name) =
+        make_module_with_function(Signature::default(), Signature::default(), vec![], vec![
+            AccessSpecifier {
+                kind: AccessKind::Reads,
+                negated: false,
+                resource: ResourceSpecifier::Resource(StructHandleIndex::new(1)),
+                address: AddressSpecifier::Any,
+            },
+        ]);
+    let err = assert_err!(load_and_call_function(
+        module,
+        function_name,
+        vec![],
+        vec![],
+        vec![]
+    ));
+    assert_eq!(
+        err.major_status(),
+        StatusCode::UNEXPECTED_DESERIALIZATION_ERROR,
+        "{:?}",
+        err
+    )
+}
+
+#[test]
+fn rac_resource_instantiation_fail() {
+    let (module, function_name) =
+        make_module_with_function(Signature::default(), Signature::default(), vec![], vec![
+            AccessSpecifier {
+                kind: AccessKind::Reads,
+                negated: false,
+                resource: ResourceSpecifier::ResourceInstantiation(
+                    StructHandleIndex::new(0),
+                    SignatureIndex::new(2),
+                ),
+                address: AddressSpecifier::Any,
+            },
+        ]);
+    let err = assert_err!(load_and_call_function(
+        module,
+        function_name,
+        vec![],
+        vec![],
+        vec![]
+    ));
+    assert_eq!(
+        err.major_status(),
+        StatusCode::UNEXPECTED_DESERIALIZATION_ERROR,
+        "{:?}",
+        err
+    )
+}

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -18,6 +18,7 @@ use move_vm_runtime::{
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{gas::UnmeteredGasMeter, resolver::ResourceResolver};
 
+mod access_specifier_tests;
 mod bad_entry_point_tests;
 mod bad_storage_tests;
 mod binary_format_version;

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -30,6 +30,7 @@ use move_vm_types::{
     loaded_data::{
         runtime_access_specifier::AccessSpecifier,
         runtime_types::{StructIdentifier, Type},
+        struct_name_indexing::StructNameIndexMap,
     },
     resolver::ResourceResolver,
     values::{AbstractFunction, SerializedFunctionData},
@@ -451,6 +452,7 @@ impl Debug for Function {
 impl Function {
     pub(crate) fn new(
         natives: &NativeFunctions,
+        struct_name_index_map: &StructNameIndexMap,
         index: FunctionDefinitionIndex,
         module: &CompiledModule,
         signature_table: &[Vec<Type>],
@@ -492,14 +494,14 @@ impl Function {
             vec![]
         };
         let param_tys = signature_table[handle.parameters.0 as usize].clone();
-
         let access_specifier = load_access_specifier(
             BinaryIndexedView::Module(module),
+            &param_tys,
             signature_table,
             struct_names,
+            struct_name_index_map,
             &handle.access_specifiers,
         )?;
-
         Ok(Self {
             file_format_version: module.version(),
             index,

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -245,6 +245,7 @@ impl Module {
                 let findex = FunctionDefinitionIndex(idx as TableIndex);
                 let function = Function::new(
                     natives,
+                    struct_name_index_map,
                     findex,
                     &module,
                     signature_table.as_slice(),


### PR DESCRIPTION
## Description

This adds bound checking bytecode verification to access specifiers. Besides this, no further action the verifier is needed for RAC specifiers.


## How Has This Been Tested?

Unit tests have been added for verification failures.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

