### PR TITLE
[compiler][trivial] fix type instantiation for receiver style syntax

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors.exp
@@ -41,9 +41,3 @@ error: the receiver function takes 1 type argument but 2 were provided
    │
 26 │         s.receiver_ref_mut::<u8, u8>(1);
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
-   ┌─ tests/checking/receiver/call_errors.move:27:9
-   │
-27 │         s.receiver_needs_type_args(x)
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors.move
@@ -24,6 +24,5 @@ module 0x42::m {
         s.receiver_ref_mut(1u8);
         s.receiver_ref_mut::<u8>(1);
         s.receiver_ref_mut::<u8, u8>(1);
-        s.receiver_needs_type_args(x)
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors_2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors_2.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: unable to infer instantiation of type `_` (consider providing type arguments or annotating the type)
+   ┌─ tests/checking/receiver/call_errors_2.move:12:9
+   │
+12 │         s.receiver_needs_type_args(x)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors_2.move
+++ b/third_party/move/move-compiler-v2/tests/checking/receiver/call_errors_2.move
@@ -1,0 +1,14 @@
+module 0x42::m {
+
+    struct S<T> { x: T }
+
+    // Call styles
+
+    fun receiver_needs_type_args<T, R>(self: S<T>, _y: T) {
+        abort 1
+    }
+
+    fun test_call_styles(s: S<u64>, x: u64) {
+        s.receiver_needs_type_args(x)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_16057.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_16057.exp
@@ -1,7 +1,99 @@
 
-Diagnostics:
-bug: unexpected type: _
-   ┌─ tests/file-format-generator/bug_16057.move:32:16
-   │
-32 │     public fun test() {
-   │                ^^^^
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+struct S<K, V> has store {
+	keys: vector<K>,
+	values: vector<V>,
+	num: u64
+}
+
+add<K, V>(self: &mut S<K, V>, k: K, v: V) /* def_idx: 0 */ {
+L3:	$t1: &mut u64
+B0:
+	0: CopyLoc[0](self: &mut S<K, V>)
+	1: MutBorrowFieldGeneric[0](S.keys: vector<K>)
+	2: MoveLoc[1](k: K)
+	3: VecPushBack(3)
+	4: CopyLoc[0](self: &mut S<K, V>)
+	5: MutBorrowFieldGeneric[1](S.values: vector<V>)
+	6: MoveLoc[2](v: V)
+	7: VecPushBack(4)
+	8: MoveLoc[0](self: &mut S<K, V>)
+	9: MutBorrowFieldGeneric[2](S.num: u64)
+	10: StLoc[3]($t1: &mut u64)
+	11: CopyLoc[3]($t1: &mut u64)
+	12: ReadRef
+	13: LdU64(1)
+	14: Add
+	15: MoveLoc[3]($t1: &mut u64)
+	16: WriteRef
+	17: Ret
+}
+destroy<K: drop, V: drop>(self: S<K, V>) /* def_idx: 1 */ {
+L1:	values: vector<V>
+L2:	keys: vector<K>
+B0:
+	0: MutBorrowLoc[0](self: S<K, V>)
+	1: MutBorrowFieldGeneric[0](S.keys: vector<K>)
+	2: VecPopBack(3)
+	3: MutBorrowLoc[0](self: S<K, V>)
+	4: MutBorrowFieldGeneric[1](S.values: vector<V>)
+	5: VecPopBack(4)
+	6: MoveLoc[0](self: S<K, V>)
+	7: UnpackGeneric[0](S<K, V>)
+	8: Pop
+	9: StLoc[1](values: vector<V>)
+	10: StLoc[2](keys: vector<K>)
+	11: MoveLoc[2](keys: vector<K>)
+	12: VecUnpack(3, 0)
+	13: MoveLoc[1](values: vector<V>)
+	14: VecUnpack(4, 0)
+	15: Pop
+	16: Pop
+	17: Ret
+}
+kp<K: copy + drop + store, V: copy + store>(self: &S<K, V>, i: u64): vector<K> * u64 /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[0](self: &S<K, V>)
+	1: ImmBorrowFieldGeneric[0](S.keys: vector<K>)
+	2: ReadRef
+	3: MoveLoc[1](i: u64)
+	4: Ret
+}
+new<K: copy + drop + store, V: store>(): S<K, V> /* def_idx: 3 */ {
+B0:
+	0: VecPack(3, 0)
+	1: VecPack(4, 0)
+	2: LdU64(0)
+	3: PackGeneric[0](S<K, V>)
+	4: Ret
+}
+public test() /* def_idx: 4 */ {
+L0:	t: S<u64, u64>
+L1:	$t9: &S<u64, u64>
+L2:	n: u64
+B0:
+	0: Call new<u64, u64>(): S<u64, u64>
+	1: StLoc[0](t: S<u64, u64>)
+	2: MutBorrowLoc[0](t: S<u64, u64>)
+	3: LdU64(1)
+	4: LdU64(0)
+	5: Call add<u64, u64>(&mut S<u64, u64>, u64, u64)
+	6: ImmBorrowLoc[0](t: S<u64, u64>)
+	7: ImmBorrowFieldGeneric[3](S.num: u64)
+	8: ReadRef
+	9: ImmBorrowLoc[0](t: S<u64, u64>)
+	10: StLoc[1]($t9: &S<u64, u64>)
+	11: StLoc[2](n: u64)
+	12: MoveLoc[1]($t9: &S<u64, u64>)
+	13: MoveLoc[2](n: u64)
+	14: Call kp<u64, u64>(&S<u64, u64>, u64): vector<u64> * u64
+	15: MoveLoc[0](t: S<u64, u64>)
+	16: Call destroy<u64, u64>(S<u64, u64>)
+	17: Pop
+	18: Pop
+	19: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/lambda/inline-parity/bug_16091.exp
+++ b/third_party/move/move-compiler-v2/tests/lambda/inline-parity/bug_16091.exp
@@ -1,0 +1,125 @@
+// -- Model dump before bytecode pipeline
+module 0x42::Test {
+    struct T {
+        t: S<u64>,
+    }
+    struct S<T1> {
+        t1: T1,
+    }
+    private inline fun foo<T1>(self: &S<T1>,f: |&S<T1>|) {
+        (f)(self)
+    }
+    public fun test() {
+        {
+          let t: S<u64> = pack Test::S<u64>(2);
+          {
+            let (self: &S<u64>): (&S<u64>) = Tuple(Borrow(Immutable)(t));
+            {
+              let (t2: &S<u64>): (&S<u64>) = Tuple(self);
+              {
+                let (self: &S<u64>): (&S<u64>) = Tuple(t2);
+                {
+                  let (_t4: &S<u64>): (&S<u64>) = Tuple(self);
+                  Tuple()
+                }
+              };
+              Tuple()
+            }
+          };
+          Tuple()
+        }
+    }
+} // end 0x42::Test
+
+// -- Sourcified model before bytecode pipeline
+module 0x42::Test {
+    struct T has drop, key {
+        t: S<u64>,
+    }
+    struct S<T1> has drop, store {
+        t1: T1,
+    }
+    inline fun foo<T1>(self: &S<T1>, f: |&S<T1>|) {
+        f(self)
+    }
+    public fun test() {
+        let t = S<u64>{t1: 2};
+        {
+            let (self) = (&t);
+            let (t2) = (self);
+            {
+                let (self) = (t2);
+                let (_t4) = (self);
+            };
+        };
+    }
+}
+
+============ initial bytecode ================
+
+[variant baseline]
+public fun Test::test() {
+     var $t0: 0x42::Test::S<u64>
+     var $t1: u64
+     var $t2: &0x42::Test::S<u64>
+     var $t3: &0x42::Test::S<u64>
+     var $t4: &0x42::Test::S<u64>
+     var $t5: &0x42::Test::S<u64>
+     var $t6: &0x42::Test::S<u64>
+  0: $t1 := 2
+  1: $t0 := pack 0x42::Test::S<u64>($t1)
+  2: $t3 := borrow_local($t0)
+  3: $t2 := infer($t3)
+  4: $t4 := infer($t2)
+  5: $t5 := infer($t4)
+  6: $t6 := infer($t5)
+  7: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun Test::test() {
+     var $t0: 0x42::Test::S<u64>
+     var $t1: u64
+     var $t2: &0x42::Test::S<u64> [unused]
+     var $t3: &0x42::Test::S<u64>
+     var $t4: &0x42::Test::S<u64> [unused]
+     var $t5: &0x42::Test::S<u64> [unused]
+     var $t6: &0x42::Test::S<u64> [unused]
+     # live vars:
+  0: $t1 := 2
+     # live vars: $t1
+  1: $t0 := pack 0x42::Test::S<u64>($t1)
+     # live vars: $t0
+  2: $t3 := borrow_local($t0)
+     # live vars: $t3
+  3: drop($t3)
+     # live vars:
+  4: return ()
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module 42.Test {
+struct T has drop, key {
+	t: S<u64>
+}
+struct S<T1> has drop, store {
+	t1: T1
+}
+
+public test() /* def_idx: 0 */ {
+L0:	t: S<u64>
+L1:	$t3: &S<u64>
+B0:
+	0: LdU64(2)
+	1: PackGeneric[0](S<u64>)
+	2: StLoc[0](t: S<u64>)
+	3: ImmBorrowLoc[0](t: S<u64>)
+	4: Pop
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/lambda/inline-parity/bug_16091.move
+++ b/third_party/move/move-compiler-v2/tests/lambda/inline-parity/bug_16091.move
@@ -1,0 +1,25 @@
+module 0x42::Test {
+    struct S<T1> has drop, store {
+        t1: T1,
+    }
+
+    inline fun foo<T1>(self: &S<T1>, f:|&S<T1>|) {
+        f(self)
+    }
+
+    struct T has key, drop {
+        t: S<u64>
+    }
+
+
+    public fun test() {
+        let t = S {
+            t1: 2 as u64,
+        };
+        t.foo(|t2| {
+            t2.foo(|_t4| {
+                // do nothing
+            });
+        });
+    }
+}

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1432,8 +1432,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             }
             let access_specifiers = et.translate_access_specifiers(&def.access_specifiers);
             let result = et.translate_seq(&loc, seq, &result_type, &ErrorMessageContext::Return);
-            et.finalize_types();
             let translated = et.post_process_body(result.into_exp());
+            et.finalize_types();
             et.check_mutable_borrow_field(&translated);
             assert!(self.fun_defs.insert(full_name.symbol, translated).is_none());
             if let Some(specifiers) = access_specifiers {
@@ -2249,12 +2249,12 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 (et.translate_exp(exp, &expected_type).into_exp(), vec![])
             },
         };
-        et.finalize_types();
         let translated = et.post_process_body(translated);
         let translated_additional = translated_additional
             .into_iter()
             .map(|e| et.post_process_body(e))
             .collect();
+        et.finalize_types();
         self.add_conditions_to_context(
             context,
             loc,
@@ -2411,8 +2411,8 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
                 }
                 let translated =
                     et.translate_seq(&loc, seq, &result_type, &ErrorMessageContext::Return);
-                et.finalize_types();
                 let translated = et.post_process_body(translated.into_exp());
+                et.finalize_types();
                 self.spec_funs[self.spec_fun_index].body = Some(translated);
             },
             EA::FunctionBody_::Native => {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds the logic to run `finalize_types` before and after `post_process_body` and only generates error in the second time so that type can be instantiated in receiver style syntax before finalizing types.

Close #16091 
Close #16057

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests;
2) added a new test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
