### PR TITLE
[docgen] Windows build improvements

### DIFF
--- a/aptos-move/framework/src/docgen.rs
+++ b/aptos-move/framework/src/docgen.rs
@@ -105,6 +105,7 @@ impl DocgenOptions {
             include_call_diagrams: false,
             compile_relative_to_output_dir: false,
             output_format: self.output_format,
+            ensure_unix_paths: true,
         };
         let output = move_docgen::Docgen::new(model, &options).gen();
         if model.diag_count(Severity::Warning) > 0 {

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -73,6 +73,10 @@ pub fn set_aptos_vm_configurations(node_config: &NodeConfig) {
     }
 }
 
+#[cfg(not(unix))]
+pub fn ensure_max_open_files_limit(_required: u64, _assert_success: bool) {}
+
+#[cfg(unix)]
 pub fn ensure_max_open_files_limit(required: u64, assert_success: bool) {
     if required == 0 {
         return;

--- a/third_party/move/move-prover/move-docgen/src/docgen.rs
+++ b/third_party/move/move-prover/move-docgen/src/docgen.rs
@@ -96,7 +96,7 @@ pub struct DocgenOptions {
     /// documentation.
     ///
     /// A root document is a markdown file which contains placeholders for generated
-    /// documentation content. It is also processed following the same rules than
+    /// documentation content. It is also processed following the same rules as 
     /// documentation comments in Move, including creation of cross-references and
     /// Move code highlighting.
     ///
@@ -117,7 +117,7 @@ pub struct DocgenOptions {
     /// module/script content work transparently.
     pub root_doc_templates: Vec<String>,
     /// An optional file containing reference definitions. The content of this file will
-    /// be added to each generated markdown doc.
+    /// be added to each generated Markdown doc.
     pub references_file: Option<String>,
     /// Whether to include dependency diagrams in the generated docs.
     pub include_dep_diagrams: bool,
@@ -878,7 +878,7 @@ impl<'env> Docgen<'env> {
     fn convert_to_anchor(&self, input: &str) -> String {
         // Regular expression to match Markdown link format [text](link)
         let re = Regex::new(r"\[(.*?)\]\((.*?)\)").unwrap();
-        re.replace_all(input, |caps: &regex::Captures| {
+        re.replace_all(input, |caps: &Captures| {
             let tag = &caps[1];
             let text = &caps[2];
 
@@ -968,7 +968,7 @@ impl<'env> Docgen<'env> {
             .join(format!(
                 "{}_{}_call_graph.svg",
                 fun_env.get_name_string().to_string().replace("::", "_"),
-                (if is_forward { "forward" } else { "backward" })
+                if is_forward { "forward" } else { "backward" }
             ));
 
         self.gen_svg_file(&out_file_path, &dot_src_lines.join("\n"));
@@ -1016,7 +1016,7 @@ impl<'env> Docgen<'env> {
             .join(format!(
                 "{}_{}_dep.svg",
                 module_name,
-                (if is_forward { "forward" } else { "backward" })
+                if is_forward { "forward" } else { "backward" }
             ));
 
         self.gen_svg_file(&out_file_path, &dot_src_lines.join("\n"));
@@ -1143,7 +1143,7 @@ impl<'env> Docgen<'env> {
         for (id, _) in sorted_infos {
             let module_env = self.env.get_module(*id);
             if !module_env.is_primary_target() {
-                // Do not include modules which are not target (outside of the package)
+                // Do not include modules which are not target (outside the package)
                 // into the index.
                 continue;
             }
@@ -1720,7 +1720,7 @@ impl<'env> Docgen<'env> {
         *self.section_nest.borrow_mut() += 1;
     }
 
-    /// Decrements section nest, committing sub-sections to the table-of-contents map.
+    /// Decrements section nest, committing subsections to the table-of-contents map.
     fn decrement_section_nest(&self) {
         *self.section_nest.borrow_mut() -= 1;
     }
@@ -1894,11 +1894,11 @@ impl<'env> Docgen<'env> {
         decorated_text
     }
 
-    /// Begins a code block. This uses html, not markdown code blocks, so we are able to
+    /// Begins a code block. This uses html, not Markdown code blocks, so we are able to
     /// insert style and links into the code.
     fn begin_code(&self) {
         emitln!(self.writer);
-        // If we newline after <pre><code>, an empty line will be created. So we don't.
+        // If we add a newline after <pre><code>, an empty line will be created. So we don't.
         // This, however, creates some ugliness with indented code.
         emit!(self.writer, "<pre><code>");
     }
@@ -1950,7 +1950,7 @@ impl<'env> Docgen<'env> {
         r
     }
 
-    /// Decorates a code fragment, for use in an html block. Replaces < and >, bolds keywords and
+    /// Decorates a code fragment, for use in a html block. Replaces < and >, bolds keywords and
     /// tries to resolve and cross-link references.
     /// If the output format is MDX, replace all html entities to make the doc mdx compatible
     fn decorate_code(&self, code: &str) -> String {
@@ -2052,7 +2052,7 @@ impl<'env> Docgen<'env> {
             |module: &ModuleEnv<'_>, name: Symbol, is_qualified: bool| {
                 // Below we only resolve a simple name to a hyperref if it is followed by a ( or <,
                 // or if it is a named constant in the module.
-                // Otherwise we get too many false positives where names are resolved to functions
+                // Otherwise, we get too many false positives where names are resolved to functions
                 // but are actually fields.
                 if module.find_struct(name).is_some()
                     || module.find_named_constant(name).is_some()
@@ -2222,7 +2222,7 @@ impl<'env> Docgen<'env> {
     }
 
     /// Retrieves source of code fragment with adjusted indentation.
-    /// Typically code has the first line unindented because location tracking starts
+    /// Typically, code has the first line unindented because location tracking starts
     /// at the first keyword of the item (e.g. `public fun`), but subsequent lines are then
     /// indented. This uses a heuristic by guessing the indentation from the context.
     fn get_source_with_indent(&self, loc: &Loc) -> String {


### PR DESCRIPTION
## Description
I've been building the aptos core on my gaming computer, and I realized that Windows would cause a bunch of files to have different paths, and warnings that weren't present on Unix.  This ensures that paths will always be the same.

## How Has This Been Tested?
Tested on the Windows machine, doesn't add a whole bunch of random files.  CI will test Unix.

## Key Areas to Review
Just check that the `cfg` parts match up

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify) Move Docgen

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
