### PR TITLE
[forge] Remove SenderAware shuffler from forge and tests

### DIFF
--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -439,11 +439,19 @@ pub(crate) fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                     }
                     OnChainExecutionConfig::V4(config_v4) => {
                         config_v4.block_gas_limit_type = BlockGasLimitType::NoLimit;
-                        config_v4.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
+                        config_v4.transaction_shuffler_type = TransactionShufflerType::UseCaseAware {
+                            sender_spread_factor: 256,
+                            platform_use_case_spread_factor: 0,
+                            user_use_case_spread_factor: 0,
+                        };
                     }
                     OnChainExecutionConfig::V5(config_v5) => {
                         config_v5.block_gas_limit_type = BlockGasLimitType::NoLimit;
-                        config_v5.transaction_shuffler_type = TransactionShufflerType::SenderAwareV2(256);
+                        config_v5.transaction_shuffler_type = TransactionShufflerType::UseCaseAware {
+                            sender_spread_factor: 256,
+                            platform_use_case_spread_factor: 0,
+                            user_use_case_spread_factor: 0,
+                        };
                     }
                 }
                 helm_values["chain"]["on_chain_execution_config"] =

--- a/types/src/on_chain_config/execution_config.rs
+++ b/types/src/on_chain_config/execution_config.rs
@@ -432,7 +432,11 @@ mod test {
     #[test]
     fn test_config_onchain_payload() {
         let execution_config = OnChainExecutionConfig::V1(ExecutionConfigV1 {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            transaction_shuffler_type: TransactionShufflerType::UseCaseAware {
+                sender_spread_factor: 32,
+                platform_use_case_spread_factor: 0,
+                user_use_case_spread_factor: 0,
+            },
         });
 
         let mut configs = HashMap::new();
@@ -447,13 +451,20 @@ mod test {
         let result: OnChainExecutionConfig = payload.get().unwrap();
         assert!(matches!(
             result.transaction_shuffler_type(),
-            TransactionShufflerType::SenderAwareV2(32)
+            TransactionShufflerType::UseCaseAware {
+                sender_spread_factor: 32,
+                ..
+            }
         ));
 
         // V2 test with random per-block gas limit
         let rand_gas_limit = rand::thread_rng().gen_range(0, 1000000) as u64;
         let execution_config = OnChainExecutionConfig::V2(ExecutionConfigV2 {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            transaction_shuffler_type: TransactionShufflerType::UseCaseAware {
+                sender_spread_factor: 32,
+                platform_use_case_spread_factor: 0,
+                user_use_case_spread_factor: 0,
+            },
             block_gas_limit: Some(rand_gas_limit),
         });
 
@@ -469,7 +480,10 @@ mod test {
         let result: OnChainExecutionConfig = payload.get().unwrap();
         assert!(matches!(
             result.transaction_shuffler_type(),
-            TransactionShufflerType::SenderAwareV2(32)
+            TransactionShufflerType::UseCaseAware {
+                sender_spread_factor: 32,
+                ..
+            }
         ));
         assert_eq!(
             result.block_gas_limit_type(),
@@ -478,7 +492,11 @@ mod test {
 
         // V2 test with no per-block gas limit
         let execution_config = OnChainExecutionConfig::V2(ExecutionConfigV2 {
-            transaction_shuffler_type: TransactionShufflerType::SenderAwareV2(32),
+            transaction_shuffler_type: TransactionShufflerType::UseCaseAware {
+                sender_spread_factor: 32,
+                platform_use_case_spread_factor: 0,
+                user_use_case_spread_factor: 0,
+            },
             block_gas_limit: None,
         });
 
@@ -494,7 +512,10 @@ mod test {
         let result: OnChainExecutionConfig = payload.get().unwrap();
         assert!(matches!(
             result.transaction_shuffler_type(),
-            TransactionShufflerType::SenderAwareV2(32)
+            TransactionShufflerType::UseCaseAware {
+                sender_spread_factor: 32,
+                ..
+            }
         ));
         assert_eq!(result.block_gas_limit_type(), BlockGasLimitType::NoLimit);
     }


### PR DESCRIPTION
## Context

In a previous PR (https://github.com/aptos-labs/aptos-core/pull/15613) I had deprecated the [`SenderAwareV2` shuffler](https://github.com/aptos-labs/aptos-core/blob/11ddec440cc34b58a35aded6ef2c4e77a144b561/types/src/on_chain_config/execution_config.rs#L175-L175) given that we had made the `UseCaseAwareShuffler` the default going forward.

Unfortunately, I forgot to remove all instances of the `SenderAwareV2` shuffler, including places where it was used in forge. Because of this the `forge-realistic-network-tuned-for-throughput` test (which you can find in [`realistic_network_tuned_for_throughput_test()` for aptos-core here](https://github.com/aptos-labs/aptos-core/blob/11ddec440cc34b58a35aded6ef2c4e77a144b561/testsuite/forge-cli/src/suites/realistic_environment.rs#L431-L431)) was failing.

```bash
details = """
panicked at consensus/src/transaction_shuffler/mod.rs:79:13:
internal error: entered unreachable code: SenderAware shuffler is no longer supported."""
```

## Resolution

In forge I changed from `TransactionShufflerType::SenderAwareV2(256)` to 

```rust
TransactionShufflerType::UseCaseAware {
    sender_spread_factor: 256,
    platform_use_case_spread_factor: 0,
    user_use_case_spread_factor: 0,
},
```

I also changed tests where appropriate

## Test Plan

IDE Find Usages for `TransactionShufflerType::SenderAwareV2`  now only returns the following:
1. [`create_transaction_shuffler`](https://github.com/aptos-labs/aptos-core/blob/11ddec440cc34b58a35aded6ef2c4e77a144b561/consensus/src/transaction_shuffler/mod.rs#L78-L78) -> this has an `unreachable!` branch for `SenderAwareV2`
5. [`user_use_case_spread_factor`](https://github.com/aptos-labs/aptos-core/blob/11ddec440cc34b58a35aded6ef2c4e77a144b561/types/src/on_chain_config/execution_config.rs#L193-L193) -> returns `None` for all deprecated shufflers

(No longer used in tests and forge)