### PR TITLE
[cli] Add straightforward linux CLI releases

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -38,9 +38,27 @@ jobs:
           name: cli-builds-ubuntu-22.04
           path: aptos-cli-*.zip
 
+  # Add one for 24.04 to be clear
+  build-ubuntu24-binary:
+    name: "Build Ubuntu 24.04 binary"
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.source_git_ref_override }}
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+      - name: Build CLI
+        run: scripts/cli/build_cli_release.sh "Ubuntu-24.04" "${{inputs.release_version}}"
+      - name: Upload Binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: cli-builds-ubuntu-24.04
+          path: aptos-cli-*.zip
+
+  # Generic linux should be the older version, more likely compatible
   build-linux-binary:
     name: "Build Linux binary"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,9 +72,10 @@ jobs:
           name: cli-builds-linux
           path: aptos-cli-*.zip
 
+  # Generic linux arm should be the older version, more likely compatible
   build-linux-arm-binary:
     name: "Build Linux ARM binary"
-    runs-on: ubuntu-24.04-arm
+    runs-on: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v4
         with:
@@ -70,41 +89,41 @@ jobs:
           name: cli-builds-linux-arm
           path: aptos-cli-*.zip
 
-#  build-macos-x86_64-binary:
-#    name: "Build MacOS x86_64 binary"
-#    runs-on: macos-13
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.event.inputs.source_git_ref_override }}
-#      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-#        with:
-#          macos: true
-#      - name: Build CLI
-#        run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}"
-#      - name: Upload Binary
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cli-builds-macos-x86-64
-#          path: aptos-cli-*.zip
+  # build-macos-x86_64-binary:
+  #   name: "Build MacOS x86_64 binary"
+  #   runs-on: macos-13
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.inputs.source_git_ref_override }}
+  #     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+  #       with:
+  #         macos: true
+  #     - name: Build CLI
+  #       run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}"
+  #     - name: Upload Binary
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: cli-builds-macos-x86-64
+  #         path: aptos-cli-*.zip
 
-#  build-macos-arm-binary:
-#    name: "Build MacOS ARM binary"
-#    runs-on: macos-latest
-#    steps:
-#      - uses: actions/checkout@v4
-#        with:
-#          ref: ${{ github.event.inputs.source_git_ref_override }}
-#      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
-#        with:
-#          macos: true
-#      - name: Build CLI
-#        run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}"
-#      - name: Upload Binary
-#        uses: actions/upload-artifact@v4
-#        with:
-#          name: cli-builds-macos-arm
-#          path: aptos-cli-*.zip
+  # build-macos-arm-binary:
+  #   name: "Build MacOS ARM binary"
+  #   runs-on: macos-latest
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         ref: ${{ github.event.inputs.source_git_ref_override }}
+  #     - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+  #       with:
+  #         macos: true
+  #     - name: Build CLI
+  #       run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}"
+  #     - name: Upload Binary
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: cli-builds-macos-arm
+  #         path: aptos-cli-*.zip
 
   build-windows-binary:
     name: "Build Windows binary"
@@ -129,11 +148,12 @@ jobs:
     name: "Release binaries"
     needs:
       - build-ubuntu22-binary
+      - build-ubuntu24-binary
       - build-windows-binary
       - build-linux-binary
       - build-linux-arm-binary
-#      - build-macos-arm-binary
-#      - build-macos-x86_64-binary
+      #- build-macos-arm-binary
+      #- build-macos-x86_64-binary
     runs-on: ubuntu-latest
     permissions:
       contents: "write"


### PR DESCRIPTION


## Description
Now, there's a 24.04 build, and the basic Linux and Linux ARM use 22.04 to build.

## How Has This Been Tested?
https://github.com/gregnazario/aptos-core/actions/runs/13799396090/job/38602285101

Ignore the mac builds

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
