### PR TITLE
[vm] Remove MoveVm session APIs

### DIFF
--- a/aptos-move/aptos-native-interface/src/context.rs
+++ b/aptos-move/aptos-native-interface/src/context.rs
@@ -19,8 +19,8 @@ use std::ops::{Deref, DerefMut};
 /// Major features include incremental gas charging and less ambiguous error handling. For this
 /// reason, native functions should always use [`SafeNativeContext`] instead of [`NativeContext`].
 #[allow(unused)]
-pub struct SafeNativeContext<'a, 'b, 'c, 'd> {
-    pub(crate) inner: &'c mut NativeContext<'a, 'b, 'd>,
+pub struct SafeNativeContext<'a, 'b, 'c> {
+    pub(crate) inner: &'c mut NativeContext<'a, 'b>,
 
     pub(crate) timed_features: &'c TimedFeatures,
     pub(crate) features: &'c Features,
@@ -37,21 +37,21 @@ pub struct SafeNativeContext<'a, 'b, 'c, 'd> {
     pub(crate) gas_hook: Option<&'c (dyn Fn(DynamicExpression) + Send + Sync)>,
 }
 
-impl<'a, 'b, 'c, 'd> Deref for SafeNativeContext<'a, 'b, 'c, 'd> {
-    type Target = NativeContext<'a, 'b, 'd>;
+impl<'a, 'b, 'c> Deref for SafeNativeContext<'a, 'b, 'c> {
+    type Target = NativeContext<'a, 'b>;
 
     fn deref(&self) -> &Self::Target {
         self.inner
     }
 }
 
-impl<'a, 'b, 'c, 'd> DerefMut for SafeNativeContext<'a, 'b, 'c, 'd> {
+impl<'a, 'b, 'c> DerefMut for SafeNativeContext<'a, 'b, 'c> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         self.inner
     }
 }
 
-impl<'a, 'b, 'c, 'd> SafeNativeContext<'a, 'b, 'c, 'd> {
+impl<'a, 'b, 'c> SafeNativeContext<'a, 'b, 'c> {
     /// Always remember: first charge gas, then execute!
     ///
     /// In other words, this function **MUST** always be called **BEFORE** executing **any**

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -52,7 +52,7 @@ use move_transactional_test_runner::{
     tasks::{InitCommand, SyntaxChoice, TaskInput},
     vm_test_harness::{PrecompiledFilesModules, TestRunConfig},
 };
-use move_vm_runtime::session::SerializedReturnValues;
+use move_vm_runtime::move_vm::SerializedReturnValues;
 use once_cell::sync::Lazy;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},

--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -13,14 +13,9 @@ use move_core_types::{
 };
 use move_ir_compiler::Compiler;
 use move_vm_runtime::{
-<<<<<<< HEAD
-    module_traversal::*, move_vm::MoveVM, native_extensions::NativeContextExtensions,
-    native_functions::NativeFunction, AsUnsyncCodeStorage, RuntimeEnvironment,
-=======
-    data_cache::TransactionDataCache, module_traversal::*, move_vm::MoveVm,
+    data_cache::TransactionDataCache, module_traversal::*, move_vm::MoveVM,
     native_extensions::NativeContextExtensions, native_functions::NativeFunction,
     AsUnsyncCodeStorage, CodeStorage, ModuleStorage, RuntimeEnvironment,
->>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{
@@ -202,7 +197,7 @@ fn main() -> Result<()> {
     };
     let args: Vec<Vec<u8>> = vec![];
 
-    let return_values = MoveVm::execute_loaded_function(
+    let return_values = MoveVM::execute_loaded_function(
         func,
         args,
         &mut TransactionDataCache::empty(),

--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -184,7 +184,7 @@ fn main() -> Result<()> {
 
     let mut extensions = NativeContextExtensions::default();
     extensions.add(NativeTableContext::new([0; 32], &storage));
-    let mut sess = MoveVM::new_session_with_extensions(&storage, extensions);
+    let mut sess = MoveVm::new_session_with_extensions(extensions);
 
     let traversal_storage = TraversalStorage::new();
     let code_storage = storage.as_unsync_code_storage();
@@ -199,6 +199,7 @@ fn main() -> Result<()> {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &code_storage,
+                &storage,
             )?;
         },
         Entrypoint::Module(module_id) => {
@@ -210,6 +211,7 @@ fn main() -> Result<()> {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &code_storage,
+                &storage,
             )?;
             println!("{:?}", res);
         },

--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -13,8 +13,14 @@ use move_core_types::{
 };
 use move_ir_compiler::Compiler;
 use move_vm_runtime::{
+<<<<<<< HEAD
     module_traversal::*, move_vm::MoveVM, native_extensions::NativeContextExtensions,
     native_functions::NativeFunction, AsUnsyncCodeStorage, RuntimeEnvironment,
+=======
+    data_cache::TransactionDataCache, module_traversal::*, move_vm::MoveVm,
+    native_extensions::NativeContextExtensions, native_functions::NativeFunction,
+    AsUnsyncCodeStorage, CodeStorage, ModuleStorage, RuntimeEnvironment,
+>>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{
@@ -184,38 +190,29 @@ fn main() -> Result<()> {
 
     let mut extensions = NativeContextExtensions::default();
     extensions.add(NativeTableContext::new([0; 32], &storage));
-    let mut sess = MoveVm::new_session_with_extensions(extensions);
 
     let traversal_storage = TraversalStorage::new();
     let code_storage = storage.as_unsync_code_storage();
 
-    let args: Vec<Vec<u8>> = vec![];
-    match entrypoint {
-        Entrypoint::Script(script_blob) => {
-            sess.load_and_execute_script(
-                script_blob,
-                vec![],
-                args,
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &code_storage,
-                &storage,
-            )?;
-        },
+    let func = match &entrypoint {
+        Entrypoint::Script(script_blob) => code_storage.load_script(script_blob, &[])?,
         Entrypoint::Module(module_id) => {
-            let res = sess.execute_function_bypass_visibility(
-                &module_id,
-                ident_str!("run"),
-                vec![],
-                args,
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &code_storage,
-                &storage,
-            )?;
-            println!("{:?}", res);
+            code_storage.load_function(module_id, ident_str!("run"), &[])?
         },
-    }
+    };
+    let args: Vec<Vec<u8>> = vec![];
+
+    let return_values = MoveVm::execute_loaded_function(
+        func,
+        args,
+        &mut TransactionDataCache::empty(),
+        &mut UnmeteredGasMeter,
+        &mut TraversalContext::new(&traversal_storage),
+        &mut extensions,
+        &code_storage,
+        &storage,
+    )?;
+    println!("{:?}", return_values);
 
     Ok(())
 }

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -33,10 +33,7 @@ use aptos_block_executor::{
     txn_provider::{default::DefaultTxnProvider, TxnProvider},
 };
 use aptos_crypto::HashValue;
-use aptos_framework::{
-    natives::{code::PublishRequest, randomness::RandomnessContext},
-    RuntimeModuleMetadataV1,
-};
+use aptos_framework::{natives::code::PublishRequest, RuntimeModuleMetadataV1};
 use aptos_gas_algebra::{Gas, GasQuantity, NumBytes, Octa};
 use aptos_gas_meter::{AptosGasMeter, GasAlgebra};
 use aptos_gas_schedule::{
@@ -129,7 +126,7 @@ use move_vm_runtime::{
     check_type_tag_dependencies_and_charge_gas,
     logging::expect_no_verification_errors,
     module_traversal::{TraversalContext, TraversalStorage},
-    ModuleStorage, RuntimeEnvironment, WithRuntimeEnvironment,
+    LoadedFunctionOwner, ModuleStorage, RuntimeEnvironment, WithRuntimeEnvironment,
 };
 use move_vm_types::gas::{GasMeter, UnmeteredGasMeter};
 use num_cpus;
@@ -201,7 +198,7 @@ pub(crate) fn serialized_signer(account_address: &AccountAddress) -> Vec<u8> {
 }
 
 pub(crate) fn get_system_transaction_output(
-    session: SessionExt,
+    session: SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     change_set_configs: &ChangeSetConfigs,
 ) -> Result<VMOutput, VMStatus> {
@@ -276,12 +273,12 @@ impl AptosVM {
         }
     }
 
-    pub fn new_session<'r, S: AptosMoveResolver>(
+    pub fn new_session<'r, R: AptosMoveResolver>(
         &self,
-        resolver: &'r S,
+        resolver: &'r R,
         session_id: SessionId,
         user_transaction_context_opt: Option<UserTransactionContext>,
-    ) -> SessionExt<'r> {
+    ) -> SessionExt<'r, R> {
         self.move_vm
             .new_session(resolver, session_id, user_transaction_context_opt)
     }
@@ -756,20 +753,20 @@ impl AptosVM {
 
     fn validate_and_execute_script<'a>(
         &self,
-        session: &mut SessionExt,
+        session: &mut SessionExt<impl AptosMoveResolver>,
         serialized_signers: &SerializedSigners,
         code_storage: &impl AptosCodeStorage,
         // Note: cannot use AptosGasMeter because it is not implemented for
         //       UnmeteredGasMeter.
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext<'a>,
-        script: &'a Script,
+        serialized_script: &'a Script,
     ) -> Result<(), VMStatus> {
         if !self
             .features()
             .is_enabled(FeatureFlag::ALLOW_SERIALIZED_SCRIPT_ARGS)
         {
-            for arg in script.args() {
+            for arg in serialized_script.args() {
                 if let TransactionArgument::Serialized(_) = arg {
                     return Err(PartialVMError::new(StatusCode::FEATURE_UNDER_GATING)
                         .finish(Location::Script)
@@ -786,7 +783,7 @@ impl AptosVM {
                 code_storage,
                 gas_meter,
                 traversal_context,
-                script.code(),
+                serialized_script.code(),
             )?;
         }
         if self.gas_feature_version() >= RELEASE_V1_27 {
@@ -794,23 +791,16 @@ impl AptosVM {
                 code_storage,
                 gas_meter,
                 traversal_context,
-                script.ty_args(),
+                serialized_script.ty_args(),
             )?;
         }
 
-        let func = code_storage.load_script(script.code(), script.ty_args())?;
-
-        let compiled_script = match CompiledScript::deserialize_with_config(
-            script.code(),
-            self.deserializer_config(),
-        ) {
-            Ok(script) => script,
-            Err(err) => {
-                let msg = format!("[VM] deserializer for script returned error: {:?}", err);
-                let partial_err = PartialVMError::new(StatusCode::CODE_DESERIALIZATION_ERROR)
-                    .with_message(msg)
-                    .finish(Location::Script);
-                return Err(partial_err.into_vm_status());
+        let func =
+            code_storage.load_script(serialized_script.code(), serialized_script.ty_args())?;
+        let script = match func.owner() {
+            LoadedFunctionOwner::Script(script) => script,
+            LoadedFunctionOwner::Module(_) => {
+                unreachable!("Function loaded from script cannot come from module")
             },
         };
 
@@ -819,36 +809,29 @@ impl AptosVM {
             .features()
             .is_enabled(FeatureFlag::REJECT_UNSTABLE_BYTECODE_FOR_SCRIPT)
         {
-            self.reject_unstable_bytecode_for_script(&compiled_script)?;
+            self.reject_unstable_bytecode_for_script(script)?;
         }
 
         // TODO(Gerardo): consolidate the extended validation to verifier.
-        verifier::event_validation::verify_no_event_emission_in_compiled_script(&compiled_script)?;
+        verifier::event_validation::verify_no_event_emission_in_compiled_script(script)?;
 
         let args = verifier::transaction_arg_validation::validate_combine_signer_and_txn_args(
             session,
             code_storage,
             serialized_signers,
-            convert_txn_args(script.args()),
+            convert_txn_args(serialized_script.args()),
             &func,
             self.features().is_enabled(FeatureFlag::STRUCT_CONSTRUCTORS),
         )?;
 
-        session.load_and_execute_script(
-            script.code(),
-            script.ty_args().to_vec(),
-            args,
-            gas_meter,
-            traversal_context,
-            code_storage,
-        )?;
+        session.execute_loaded_function(func, args, gas_meter, traversal_context, code_storage)?;
         Ok(())
     }
 
     fn validate_and_execute_entry_function(
         &self,
         module_storage: &impl AptosModuleStorage,
-        session: &mut SessionExt,
+        session: &mut SessionExt<impl AptosMoveResolver>,
         serialized_signers: &SerializedSigners,
         gas_meter: &mut impl AptosGasMeter,
         traversal_context: &mut TraversalContext,
@@ -902,10 +885,7 @@ impl AptosVM {
         if function.is_friend_or_private()
             && get_randomness_annotation(module_storage, entry_fn)?.is_some()
         {
-            let txn_context = session
-                .get_native_extensions()
-                .get_mut::<RandomnessContext>();
-            txn_context.mark_unbiasable();
+            session.mark_unbiasable();
         }
 
         let struct_constructors_enabled =
@@ -1252,16 +1232,29 @@ impl AptosVM {
             MoveValue::vector_u8(payload_bytes),
         ]);
 
-        let epilogue_session = match execution_result {
-            Err(execution_error) => self.failure_multisig_payload_cleanup(
-                resolver,
-                module_storage,
-                prologue_session_change_set,
-                execution_error,
-                txn_data,
-                cleanup_args,
-                traversal_context,
-            )?,
+        match execution_result {
+            Err(execution_error) => {
+                let epilogue_session = self.failure_multisig_payload_cleanup(
+                    resolver,
+                    module_storage,
+                    prologue_session_change_set,
+                    execution_error,
+                    txn_data,
+                    cleanup_args,
+                    traversal_context,
+                )?;
+                // TODO(Gas): Charge for aggregator writes
+                self.success_transaction_cleanup(
+                    epilogue_session,
+                    module_storage,
+                    serialized_signers,
+                    gas_meter,
+                    txn_data,
+                    log_context,
+                    change_set_configs,
+                    traversal_context,
+                )
+            },
             Ok(user_session_change_set) => {
                 // Charge gas for write set before we do cleanup. This ensures we don't charge gas for
                 // cleanup write set changes, which is consistent with outer-level success cleanup
@@ -1286,21 +1279,19 @@ impl AptosVM {
                         )
                         .map_err(|e| e.into_vm_status())
                 })?;
-                epilogue_session
+                // TODO(Gas): Charge for aggregator writes
+                self.success_transaction_cleanup(
+                    epilogue_session,
+                    module_storage,
+                    serialized_signers,
+                    gas_meter,
+                    txn_data,
+                    log_context,
+                    change_set_configs,
+                    traversal_context,
+                )
             },
-        };
-
-        // TODO(Gas): Charge for aggregator writes
-        self.success_transaction_cleanup(
-            epilogue_session,
-            module_storage,
-            serialized_signers,
-            gas_meter,
-            txn_data,
-            log_context,
-            change_set_configs,
-            traversal_context,
-        )
+        }
     }
 
     fn execute_or_simulate_multisig_transaction<'a, 'r>(
@@ -1357,7 +1348,7 @@ impl AptosVM {
         &self,
         resolver: &impl AptosMoveResolver,
         module_storage: &impl AptosModuleStorage,
-        mut session: UserSession<'_>,
+        mut session: UserSession,
         gas_meter: &mut impl AptosGasMeter,
         traversal_context: &mut TraversalContext,
         multisig_address: AccountAddress,
@@ -1454,7 +1445,7 @@ impl AptosVM {
     /// Resolve a pending code publish request registered via the NativeCodeContext.
     fn resolve_pending_code_publish_and_finish_user_session(
         &self,
-        mut session: UserSession<'_>,
+        mut session: UserSession,
         resolver: &impl AptosMoveResolver,
         module_storage: &impl AptosModuleStorage,
         gas_meter: &mut impl AptosGasMeter,
@@ -1697,8 +1688,7 @@ impl AptosVM {
 
     fn validate_signed_transaction(
         &self,
-        session: &mut SessionExt,
-        resolver: &impl AptosMoveResolver,
+        session: &mut SessionExt<impl AptosMoveResolver>,
         module_storage: &impl ModuleStorage,
         transaction: &SignedTransaction,
         transaction_data: &TransactionMetadata,
@@ -1724,7 +1714,7 @@ impl AptosVM {
                 &self.pvk,
                 &keyless_authenticators,
                 self.features(),
-                resolver,
+                session.resolver,
                 module_storage,
             )?;
         }
@@ -1820,7 +1810,6 @@ impl AptosVM {
         // end up skipping validation.
         self.run_prologue_with_payload(
             session,
-            resolver,
             module_storage,
             &serialized_signers,
             transaction.payload(),
@@ -1882,7 +1871,6 @@ impl AptosVM {
         let serialized_signers = unwrap_or_discard!(prologue_session.execute(|session| {
             self.validate_signed_transaction(
                 session,
-                resolver,
                 code_storage,
                 txn,
                 &txn_data,
@@ -1910,14 +1898,7 @@ impl AptosVM {
         let storage_gas_params = unwrap_or_discard!(self.storage_gas_params(log_context));
         let change_set_configs = &storage_gas_params.change_set_configs;
         let (prologue_change_set, mut user_session) = unwrap_or_discard!(prologue_session
-            .into_user_session(
-                self,
-                &txn_data,
-                resolver,
-                self.gas_feature_version(),
-                change_set_configs,
-                code_storage,
-            ));
+            .into_user_session(self, &txn_data, resolver, change_set_configs, code_storage,));
 
         let account_init_for_sponsored_transaction_timer =
             VM_TIMER.timer_with_label("AptosVM::account_init_for_sponsored_transaction");
@@ -2475,8 +2456,13 @@ impl AptosVM {
     }
 
     fn execute_view_function_in_vm(
+<<<<<<< HEAD
         session: &mut SessionExt,
         vm: &AptosVM,
+=======
+        session: &mut SessionExt<impl AptosMoveResolver>,
+        vm: &AptosVm,
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         module_id: ModuleId,
         func_name: Identifier,
         type_args: Vec<TypeTag>,
@@ -2517,8 +2503,7 @@ impl AptosVM {
 
     fn run_prologue_with_payload(
         &self,
-        session: &mut SessionExt,
-        resolver: &impl AptosMoveResolver,
+        session: &mut SessionExt<impl AptosMoveResolver>,
         module_storage: &impl ModuleStorage,
         serialized_signers: &SerializedSigners,
         payload: &TransactionPayload,
@@ -2530,7 +2515,7 @@ impl AptosVM {
         check_gas(
             self.gas_params(log_context)?,
             self.gas_feature_version(),
-            resolver,
+            session.resolver,
             module_storage,
             txn_data,
             self.features(),
@@ -2959,7 +2944,6 @@ impl VMValidator for AptosVM {
         // Increment the counter for transactions verified.
         let (counter_label, result) = match self.validate_signed_transaction(
             &mut session,
-            &resolver,
             module_storage,
             &txn,
             &txn_data,
@@ -3021,7 +3005,7 @@ impl AptosSimulationVM {
 }
 
 fn create_account_if_does_not_exist(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     gas_meter: &mut impl GasMeter,
     account: AccountAddress,
@@ -3040,7 +3024,7 @@ fn create_account_if_does_not_exist(
 }
 
 fn dispatchable_authenticate(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     gas_meter: &mut impl GasMeter,
     account: AccountAddress,
     function_info: FunctionInfo,

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2452,13 +2452,8 @@ impl AptosVM {
     }
 
     fn execute_view_function_in_vm(
-<<<<<<< HEAD
-        session: &mut SessionExt,
-        vm: &AptosVM,
-=======
         session: &mut SessionExt<impl AptosMoveResolver>,
-        vm: &AptosVm,
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+        vm: &AptosVM,
         module_id: ModuleId,
         func_name: Identifier,
         type_args: Vec<TypeTag>,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -148,8 +148,13 @@ where
         if !func.is_entry() {
             let module_id = func
                 .module_id()
-                .cloned()
-                .expect("Entry function always has module id");
+                .ok_or_else(|| {
+                    let msg = "Entry function always has module id".to_string();
+                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR)
+                        .with_message(msg)
+                        .finish(Location::Undefined)
+                })?
+                .clone();
             return Err(PartialVMError::new(
                 StatusCode::EXECUTE_ENTRY_FUNCTION_CALLED_ON_NON_ENTRY_FUNCTION,
             )

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -37,23 +37,12 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_runtime::{
-<<<<<<< HEAD
-    config::VMConfig, move_vm::MoveVM, native_extensions::NativeContextExtensions,
-    session::Session, AsFunctionValueExtension, ModuleStorage, VerifiedModuleBundle,
-};
-use move_vm_types::{value_serde::ValueSerDeContext, values::Value};
-use std::{
-    collections::BTreeMap,
-    ops::{Deref, DerefMut},
-    sync::Arc,
-=======
     config::VMConfig,
     data_cache::TransactionDataCache,
     module_traversal::TraversalContext,
-    move_vm::{MoveVm, SerializedReturnValues},
+    move_vm::{MoveVM, SerializedReturnValues},
     native_extensions::NativeContextExtensions,
     AsFunctionValueExtension, LoadedFunction, ModuleStorage, VerifiedModuleBundle,
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 };
 use move_vm_types::{gas::GasMeter, value_serde::ValueSerDeContext, values::Value};
 use std::{borrow::Borrow, collections::BTreeMap, sync::Arc};
@@ -122,16 +111,8 @@ where
 
         let is_storage_slot_metadata_enabled = features.is_storage_slot_metadata_enabled();
         Self {
-<<<<<<< HEAD
-<<<<<<< HEAD
-            inner: MoveVM::new_session_with_extensions(resolver, extensions),
-=======
-            inner: MoveVm::new_session_with_extensions(extensions),
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
             data_cache: TransactionDataCache::empty(),
             extensions,
->>>>>>> 35ea878580 (remove move vm session)
             resolver,
             is_storage_slot_metadata_enabled,
         }
@@ -161,7 +142,7 @@ where
             .finish(Location::Module(module_id)));
         }
 
-        MoveVm::execute_loaded_function(
+        MoveVM::execute_loaded_function(
             func,
             args,
             &mut self.data_cache,
@@ -185,7 +166,7 @@ where
         module_storage: &impl ModuleStorage,
     ) -> VMResult<SerializedReturnValues> {
         let func = module_storage.load_function(module_id, function_name, &ty_args)?;
-        MoveVm::execute_loaded_function(
+        MoveVM::execute_loaded_function(
             func,
             args,
             &mut self.data_cache,
@@ -205,7 +186,7 @@ where
         traversal_context: &mut TraversalContext,
         module_storage: &impl ModuleStorage,
     ) -> VMResult<SerializedReturnValues> {
-        MoveVm::execute_loaded_function(
+        MoveVM::execute_loaded_function(
             func,
             args,
             &mut self.data_cache,

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
@@ -31,7 +31,7 @@ pub struct RespawnedSession<'r> {
     resolver: StorageAdapter<'this, ExecutorViewWithChangeSet<'r>>,
     #[borrows(resolver)]
     #[not_covariant]
-    session: Option<SessionExt<'this>>,
+    session: Option<SessionExt<'this, StorageAdapter<'this, ExecutorViewWithChangeSet<'r>>>>,
 }
 
 impl<'r> RespawnedSession<'r> {
@@ -41,7 +41,7 @@ impl<'r> RespawnedSession<'r> {
         base: &'r impl AptosMoveResolver,
         previous_session_change_set: VMChangeSet,
         user_transaction_context_opt: Option<UserTransactionContext>,
-    ) -> Self {
+    ) -> RespawnedSession<'r> {
         let executor_view = ExecutorViewWithChangeSet::new(
             base.as_executor_view(),
             base.as_resource_group_view(),
@@ -58,7 +58,10 @@ impl<'r> RespawnedSession<'r> {
         .build()
     }
 
-    pub fn execute<T>(&mut self, fun: impl FnOnce(&mut SessionExt) -> T) -> T {
+    pub fn execute<T>(
+        &mut self,
+        fun: impl FnOnce(&mut SessionExt<StorageAdapter<'_, ExecutorViewWithChangeSet<'_>>>) -> T,
+    ) -> T {
         self.with_session_mut(|session| {
             fun(session
                 .as_mut()

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/prologue.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/prologue.rs
@@ -29,15 +29,9 @@ pub struct PrologueSession<'r> {
 }
 
 impl<'r> PrologueSession<'r> {
-<<<<<<< HEAD
-    pub fn new<'m>(
-        vm: &AptosVM,
-        txn_meta: &'m TransactionMetadata,
-=======
     pub fn new(
-        vm: &AptosVm,
+        vm: &AptosVM,
         txn_meta: &TransactionMetadata,
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         resolver: &'r impl AptosMoveResolver,
     ) -> Self {
         let session_id = SessionId::prologue_meta(txn_meta);

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/prologue.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/prologue.rs
@@ -29,9 +29,15 @@ pub struct PrologueSession<'r> {
 }
 
 impl<'r> PrologueSession<'r> {
+<<<<<<< HEAD
     pub fn new<'m>(
         vm: &AptosVM,
         txn_meta: &'m TransactionMetadata,
+=======
+    pub fn new(
+        vm: &AptosVm,
+        txn_meta: &TransactionMetadata,
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         resolver: &'r impl AptosMoveResolver,
     ) -> Self {
         let session_id = SessionId::prologue_meta(txn_meta);
@@ -51,13 +57,12 @@ impl<'r> PrologueSession<'r> {
         vm: &AptosVM,
         txn_meta: &TransactionMetadata,
         resolver: &'r impl AptosMoveResolver,
-        gas_feature_version: u64,
         change_set_configs: &ChangeSetConfigs,
         module_storage: &impl AptosModuleStorage,
     ) -> Result<(SystemSessionChangeSet, UserSession<'r>), VMStatus> {
         let Self { session } = self;
 
-        if gas_feature_version >= 1 {
+        if vm.gas_feature_version() >= 1 {
             // Create a new session so that the data cache is flushed.
             // This is to ensure we correctly charge for loading certain resources, even if they
             // have been previously cached in the prologue.

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -84,7 +84,7 @@ impl GenesisMoveVm {
         &self,
         resolver: &'r R,
         genesis_id: HashValue,
-    ) -> SessionExt<'r> {
+    ) -> SessionExt<'r, R> {
         let session_id = SessionId::genesis(genesis_id);
         SessionExt::new(
             session_id,
@@ -122,7 +122,7 @@ impl MoveVmExt {
         resolver: &'r R,
         session_id: SessionId,
         maybe_user_transaction_context: Option<UserTransactionContext>,
-    ) -> SessionExt<'r> {
+    ) -> SessionExt<'r, R> {
         SessionExt::new(
             session_id,
             self.env.chain_id(),

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -4,7 +4,7 @@
 use crate::{
     aptos_vm::SerializedSigners,
     errors::{convert_epilogue_error, convert_prologue_error, expect_only_successful_execution},
-    move_vm_ext::SessionExt,
+    move_vm_ext::{AptosMoveResolver, SessionExt},
     system_module_names::{
         EMIT_FEE_STATEMENT, MULTISIG_ACCOUNT_MODULE, TRANSACTION_FEE_MODULE,
         VALIDATE_MULTISIG_TRANSACTION,
@@ -92,7 +92,7 @@ impl TransactionValidation {
 }
 
 pub(crate) fn run_script_prologue(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     serialized_signers: &SerializedSigners,
     txn_data: &TransactionMetadata,
@@ -345,7 +345,7 @@ pub(crate) fn run_script_prologue(
 /// 3. If only the payload hash was stored on chain, the provided payload in execution should
 /// match that hash.
 pub(crate) fn run_multisig_prologue(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     txn_data: &TransactionMetadata,
     payload: &Multisig,
@@ -385,7 +385,7 @@ pub(crate) fn run_multisig_prologue(
 }
 
 fn run_epilogue(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     serialized_signers: &SerializedSigners,
     gas_remaining: Gas,
@@ -521,7 +521,7 @@ fn run_epilogue(
 }
 
 fn emit_fee_statement(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     fee_statement: FeeStatement,
     traversal_context: &mut TraversalContext,
@@ -541,7 +541,7 @@ fn emit_fee_statement(
 /// Run the epilogue of a transaction by calling into `EPILOGUE_NAME` function stored
 /// in the `ACCOUNT_MODULE` on chain.
 pub(crate) fn run_success_epilogue(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     serialized_signers: &SerializedSigners,
     gas_remaining: Gas,
@@ -576,7 +576,7 @@ pub(crate) fn run_success_epilogue(
 /// Run the failure epilogue of a transaction by calling into `USER_EPILOGUE_NAME` function
 /// stored in the `ACCOUNT_MODULE` on chain.
 pub(crate) fn run_failure_epilogue(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     serialized_signers: &SerializedSigners,
     gas_remaining: Gas,

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -6,7 +6,11 @@
 //! TODO: we should not only validate the types but also the actual values, e.g.
 //! for strings whether they consist of correct characters.
 
-use crate::{aptos_vm::SerializedSigners, move_vm_ext::SessionExt, VMStatus};
+use crate::{
+    aptos_vm::SerializedSigners,
+    move_vm_ext::{AptosMoveResolver, SessionExt},
+    VMStatus,
+};
 use aptos_vm_types::module_and_script_storage::module_storage::AptosModuleStorage;
 use move_binary_format::{
     errors::{Location, PartialVMError},
@@ -103,7 +107,7 @@ pub(crate) fn get_allowed_structs(
 ///
 /// after validation, add senders and non-signer arguments to generate the final args
 pub(crate) fn validate_combine_signer_and_txn_args(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     serialized_signers: &SerializedSigners,
     args: Vec<Vec<u8>>,
@@ -228,7 +232,7 @@ pub(crate) fn is_valid_txn_arg(
 // construct arguments that require so.
 // TODO: This needs a more solid story and a tighter integration with the VM.
 pub(crate) fn construct_args(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     types: &[Type],
     args: Vec<Vec<u8>>,
@@ -266,7 +270,7 @@ fn invalid_signature() -> VMStatus {
 }
 
 fn construct_arg(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     ty: &Type,
     allowed_structs: &ConstructorMap,
@@ -322,7 +326,7 @@ fn construct_arg(
 // are parsing the BCS serialized implicit constructor invocation tree, while serializing the
 // constructed types into the output parameter arg.
 pub(crate) fn recursively_construct_arg(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     ty: &Type,
     allowed_structs: &ConstructorMap,
@@ -400,7 +404,7 @@ pub(crate) fn recursively_construct_arg(
 // said struct as a parameter. In this function we execute the constructor constructing the
 // value and returning the BCS serialized representation.
 fn validate_and_construct(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     expected_type: &Type,
     constructor: &FunctionId,

--- a/aptos-move/aptos-vm/src/verifier/view_function.rs
+++ b/aptos-move/aptos-vm/src/verifier/view_function.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    move_vm_ext::SessionExt,
+    move_vm_ext::{AptosMoveResolver, SessionExt},
     verifier::{transaction_arg_validation, transaction_arg_validation::get_allowed_structs},
 };
 use aptos_framework::RuntimeModuleMetadataV1;
@@ -30,7 +30,7 @@ pub fn determine_is_view(
 /// Validate view function call. This checks whether the function is marked as a view
 /// function, and validates the arguments.
 pub(crate) fn validate_view_function(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     args: Vec<Vec<u8>>,
     fun_name: &IdentStr,

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -57,8 +57,13 @@ use aptos_vm::{
     block_executor::{AptosTransactionOutput, AptosVMBlockExecutorWrapper},
     data_cache::AsMoveResolver,
     gas::make_prod_gas_meter,
+<<<<<<< HEAD
     move_vm_ext::{MoveVmExt, SessionExt, SessionId},
     AptosVM, VMValidator,
+=======
+    move_vm_ext::{AptosMoveResolver, MoveVmExt, SessionExt, SessionId},
+    AptosVm, VMValidator,
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 };
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_genesis::{generate_genesis_change_set_for_testing_with_count, GenesisOptions};
@@ -1313,7 +1318,7 @@ impl FakeExecutor {
 /// Finishes the session, and asserts there has been no modules published (publishing is the
 /// responsibility of the adapter, i.e., [AptosVM]).
 fn finish_session_assert_no_modules(
-    session: SessionExt,
+    session: SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     change_set_configs: &ChangeSetConfigs,
 ) -> (WriteSet, Vec<ContractEvent>) {

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -57,13 +57,8 @@ use aptos_vm::{
     block_executor::{AptosTransactionOutput, AptosVMBlockExecutorWrapper},
     data_cache::AsMoveResolver,
     gas::make_prod_gas_meter,
-<<<<<<< HEAD
-    move_vm_ext::{MoveVmExt, SessionExt, SessionId},
-    AptosVM, VMValidator,
-=======
     move_vm_ext::{AptosMoveResolver, MoveVmExt, SessionExt, SessionId},
-    AptosVm, VMValidator,
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+    AptosVM, VMValidator,
 };
 use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_genesis::{generate_genesis_change_set_for_testing_with_count, GenesisOptions};

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -99,7 +99,7 @@ fn create_string_value(value: Vec<u8>) -> Value {
 }
 
 fn get_context_data<'t, 'b>(
-    context: &'t mut SafeNativeContext<'_, 'b, '_, '_>,
+    context: &'t mut SafeNativeContext<'_, 'b, '_>,
 ) -> Option<(&'b dyn DelayedFieldResolver, RefMut<'t, DelayedFieldData>)> {
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
     if aggregator_context.delayed_field_optimization_enabled {

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -28,8 +28,8 @@ const EARGS_MISMATCH: u64 = 1;
 const EINVALID_FORMAT: u64 = 2;
 const EUNABLE_TO_FORMAT_DELAYED_FIELD: u64 = 3;
 
-struct FormatContext<'a, 'b, 'c, 'd, 'e> {
-    context: &'d mut SafeNativeContext<'a, 'b, 'c, 'e>,
+struct FormatContext<'a, 'b, 'c, 'd> {
+    context: &'d mut SafeNativeContext<'a, 'b, 'c>,
     should_charge_gas: bool,
     max_depth: usize,
     max_len: usize,

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -43,7 +43,8 @@ use aptos_types::{
 use aptos_vm::{
     data_cache::AsMoveResolver,
     move_vm_ext::{
-        convert_modules_into_write_ops, GenesisMoveVm, GenesisRuntimeBuilder, SessionExt,
+        convert_modules_into_write_ops, AptosMoveResolver, GenesisMoveVm, GenesisRuntimeBuilder,
+        SessionExt,
     },
 };
 use aptos_vm_types::{
@@ -373,7 +374,7 @@ fn validate_genesis_config(genesis_config: &GenesisConfiguration) {
 }
 
 fn exec_function(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     module_name: &str,
     function_name: &str,
@@ -403,7 +404,7 @@ fn exec_function(
 }
 
 fn initialize(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     chain_id: ChainId,
     genesis_config: &GenesisConfiguration,
@@ -457,7 +458,7 @@ fn initialize(
 }
 
 fn initialize_features(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     features_override: Option<Vec<FeatureFlag>>,
 ) {
@@ -481,7 +482,10 @@ fn initialize_features(
     );
 }
 
-fn initialize_aptos_coin(session: &mut SessionExt, module_storage: &impl AptosModuleStorage) {
+fn initialize_aptos_coin(
+    session: &mut SessionExt<impl AptosMoveResolver>,
+    module_storage: &impl AptosModuleStorage,
+) {
     exec_function(
         session,
         module_storage,
@@ -492,7 +496,10 @@ fn initialize_aptos_coin(session: &mut SessionExt, module_storage: &impl AptosMo
     );
 }
 
-fn initialize_config_buffer(session: &mut SessionExt, module_storage: &impl AptosModuleStorage) {
+fn initialize_config_buffer(
+    session: &mut SessionExt<impl AptosMoveResolver>,
+    module_storage: &impl AptosModuleStorage,
+) {
     exec_function(
         session,
         module_storage,
@@ -503,7 +510,10 @@ fn initialize_config_buffer(session: &mut SessionExt, module_storage: &impl Apto
     );
 }
 
-fn initialize_dkg(session: &mut SessionExt, module_storage: &impl AptosModuleStorage) {
+fn initialize_dkg(
+    session: &mut SessionExt<impl AptosMoveResolver>,
+    module_storage: &impl AptosModuleStorage,
+) {
     exec_function(
         session,
         module_storage,
@@ -515,7 +525,7 @@ fn initialize_dkg(session: &mut SessionExt, module_storage: &impl AptosModuleSto
 }
 
 fn initialize_randomness_config_seqnum(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
 ) {
     exec_function(
@@ -529,7 +539,7 @@ fn initialize_randomness_config_seqnum(
 }
 
 fn initialize_randomness_api_v0_config(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
 ) {
     exec_function(
@@ -547,7 +557,7 @@ fn initialize_randomness_api_v0_config(
 }
 
 fn initialize_randomness_config(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     randomness_config: OnChainRandomnessConfig,
 ) {
@@ -565,7 +575,7 @@ fn initialize_randomness_config(
 }
 
 fn initialize_randomness_resources(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
 ) {
     exec_function(
@@ -579,7 +589,7 @@ fn initialize_randomness_resources(
 }
 
 fn initialize_account_abstraction(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
 ) {
     exec_function(
@@ -593,7 +603,7 @@ fn initialize_account_abstraction(
 }
 
 fn initialize_reconfiguration_state(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
 ) {
     exec_function(
@@ -607,7 +617,7 @@ fn initialize_reconfiguration_state(
 }
 
 fn initialize_jwk_consensus_config(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     jwk_consensus_config: &OnChainJWKConsensusConfig,
 ) {
@@ -624,7 +634,10 @@ fn initialize_jwk_consensus_config(
     );
 }
 
-fn initialize_jwks_resources(session: &mut SessionExt, module_storage: &impl AptosModuleStorage) {
+fn initialize_jwks_resources(
+    session: &mut SessionExt<impl AptosMoveResolver>,
+    module_storage: &impl AptosModuleStorage,
+) {
     exec_function(
         session,
         module_storage,
@@ -635,7 +648,10 @@ fn initialize_jwks_resources(session: &mut SessionExt, module_storage: &impl Apt
     );
 }
 
-fn set_genesis_end(session: &mut SessionExt, module_storage: &impl AptosModuleStorage) {
+fn set_genesis_end(
+    session: &mut SessionExt<impl AptosMoveResolver>,
+    module_storage: &impl AptosModuleStorage,
+) {
     exec_function(
         session,
         module_storage,
@@ -647,7 +663,7 @@ fn set_genesis_end(session: &mut SessionExt, module_storage: &impl AptosModuleSt
 }
 
 fn initialize_core_resources_and_aptos_coin(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     core_resources_key: &Ed25519PublicKey,
 ) {
@@ -667,7 +683,7 @@ fn initialize_core_resources_and_aptos_coin(
 
 /// Create and initialize Association and Core Code accounts.
 fn initialize_on_chain_governance(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     genesis_config: &GenesisConfiguration,
 ) {
@@ -687,7 +703,7 @@ fn initialize_on_chain_governance(
 }
 
 fn initialize_keyless_accounts(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     chain_id: ChainId,
     mut initial_jwks: Vec<IssuerJWK>,
@@ -753,7 +769,7 @@ fn initialize_keyless_accounts(
 }
 
 fn create_accounts(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     accounts: &[AccountBalance],
 ) {
@@ -771,7 +787,7 @@ fn create_accounts(
 }
 
 fn create_employee_validators(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     employees: &[EmployeePool],
     genesis_config: &GenesisConfiguration,
@@ -797,7 +813,7 @@ fn create_employee_validators(
 /// the required accounts, sets the validator operators for each validator owner, and sets the
 /// validator config on-chain.
 fn create_and_initialize_validators(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     validators: &[Validator],
 ) {
@@ -815,7 +831,7 @@ fn create_and_initialize_validators(
 }
 
 fn create_and_initialize_validators_with_commission(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
     validators: &[ValidatorWithCommissionRate],
 ) {
@@ -836,7 +852,7 @@ fn create_and_initialize_validators_with_commission(
 }
 
 fn allow_core_resources_to_set_version(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
 ) {
     exec_function(
@@ -850,7 +866,7 @@ fn allow_core_resources_to_set_version(
 }
 
 fn initialize_package(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl ModuleStorage,
     addr: AccountAddress,
     package: &ReleasePackage,
@@ -967,7 +983,7 @@ fn publish_framework(
 
 /// Trigger a reconfiguration. This emits an event that will be passed along to the storage layer.
 fn emit_new_block_and_epoch_event(
-    session: &mut SessionExt,
+    session: &mut SessionExt<impl AptosMoveResolver>,
     module_storage: &impl AptosModuleStorage,
 ) {
     exec_function(

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -20,7 +20,11 @@ const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGT
 fn call_non_existent_module() {
     let storage = InMemoryStorage::new();
 
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
+=======
+    let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
     let traversal_storage = TraversalStorage::new();
@@ -35,6 +39,7 @@ fn call_non_existent_module() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap_err();
 
@@ -57,7 +62,11 @@ fn call_non_existent_function() {
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     storage.add_module_bytes(module_id.address(), module_id.name(), blob.into());
 
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
+=======
+    let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let fun_name = Identifier::new("foo").unwrap();
 
@@ -73,6 +82,7 @@ fn call_non_existent_function() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -14,10 +14,6 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::StatusType,
 };
-<<<<<<< HEAD
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncModuleStorage};
-=======
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -25,15 +21,6 @@ const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGT
 #[test]
 fn call_non_existent_module() {
     let storage = InMemoryStorage::new();
-<<<<<<< HEAD
-
-<<<<<<< HEAD
-    let mut sess = MoveVM::new_session(&storage);
-=======
-    let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
->>>>>>> 35ea878580 (remove move vm session)
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
 
     let args = serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]);
@@ -65,32 +52,6 @@ fn call_non_existent_function() {
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     storage.add_module_bytes(module_id.address(), module_id.name(), blob.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut sess = MoveVM::new_session(&storage);
-=======
-    let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-
-    let fun_name = Identifier::new("foo").unwrap();
-
-    let traversal_storage = TraversalStorage::new();
-    let module_storage = storage.as_unsync_module_storage();
-
-    let err = sess
-        .execute_function_bypass_visibility(
-            &module_id,
-            &fun_name,
-            vec![],
-            serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap_err();
-
-=======
     let args = serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]);
     let err = execute_function_with_single_storage_for_test(
         &storage,
@@ -100,6 +61,5 @@ fn call_non_existent_function() {
         args,
     )
     .unwrap_err();
->>>>>>> 35ea878580 (remove move vm session)
     assert_eq!(err.status_type(), StatusType::Verification);
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_entry_point_tests.rs
@@ -2,46 +2,49 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, compile_units};
+use crate::{
+    compiler::{as_module, compile_units},
+    tests::execute_function_with_single_storage_for_test,
+};
 use move_core_types::{
     account_address::AccountAddress,
+    ident_str,
     identifier::Identifier,
     language_storage::ModuleId,
     value::{serialize_values, MoveValue},
     vm_status::StatusType,
 };
+<<<<<<< HEAD
 use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncModuleStorage};
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
 #[test]
 fn call_non_existent_module() {
     let storage = InMemoryStorage::new();
+<<<<<<< HEAD
 
 <<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
 =======
     let mut sess = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+>>>>>>> 35ea878580 (remove move vm session)
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
-    let fun_name = Identifier::new("foo").unwrap();
-    let traversal_storage = TraversalStorage::new();
-    let module_storage = storage.as_unsync_module_storage();
 
-    let err = sess
-        .execute_function_bypass_visibility(
-            &module_id,
-            &fun_name,
-            vec![],
-            serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap_err();
+    let args = serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]);
+    let err = execute_function_with_single_storage_for_test(
+        &storage,
+        &module_id,
+        ident_str!("foo"),
+        &[],
+        args,
+    )
+    .unwrap_err();
 
     assert_eq!(err.status_type(), StatusType::Verification);
 }
@@ -63,6 +66,7 @@ fn call_non_existent_function() {
     storage.add_module_bytes(module_id.address(), module_id.name(), blob.into());
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
 =======
     let mut sess = MoveVm::new_session();
@@ -86,5 +90,16 @@ fn call_non_existent_function() {
         )
         .unwrap_err();
 
+=======
+    let args = serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]);
+    let err = execute_function_with_single_storage_for_test(
+        &storage,
+        &module_id,
+        ident_str!("foo"),
+        &[],
+        args,
+    )
+    .unwrap_err();
+>>>>>>> 35ea878580 (remove move vm session)
     assert_eq!(err.status_type(), StatusType::Verification);
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -21,14 +21,7 @@ use move_core_types::{
     value::{serialize_values, MoveTypeLayout, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
-<<<<<<< HEAD
-use move_vm_runtime::{
-    module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage, AsUnsyncModuleStorage,
-    RuntimeEnvironment, WithRuntimeEnvironment,
-};
-=======
 use move_vm_runtime::{AsUnsyncModuleStorage, RuntimeEnvironment, WithRuntimeEnvironment};
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::{code::ModuleBytesStorage, resolver::ResourceResolver};
 
@@ -107,14 +100,6 @@ fn test_malformed_resource() {
     // Execute the first script to publish a resource Foo.
     let mut script_blob = vec![];
     s1.serialize(&mut script_blob).unwrap();
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut sess = MoveVM::new_session(&storage);
-=======
-    let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
->>>>>>> 35ea878580 (remove move vm session)
 
     let args = vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()];
     let result = execute_script_and_commit_change_set_for_test(
@@ -131,26 +116,8 @@ fn test_malformed_resource() {
     let mut script_blob = vec![];
     s2.serialize(&mut script_blob).unwrap();
     {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        sess.load_and_execute_script(
-            script_blob.clone(),
-            vec![],
-            vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap();
-=======
         let result = execute_script_for_test(&storage, &script_blob, &[], args.clone());
         assert_ok!(result);
->>>>>>> 35ea878580 (remove move vm session)
     }
 
     // Corrupt the resource in the storage.
@@ -168,30 +135,10 @@ fn test_malformed_resource() {
     // Run the second script again.
     // The test will be successful if it fails with an invariant violation.
     {
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let err = sess
-            .load_and_execute_script(
-                script_blob,
-                vec![],
-                vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &code_storage,
-                &storage,
-            )
-            .unwrap_err();
-        assert_eq!(err.status_type(), StatusType::InvariantViolation);
-=======
         let status_type = execute_script_for_test(&storage, &script_blob, &[], args)
             .unwrap_err()
             .status_type();
         assert_eq!(status_type, StatusType::InvariantViolation);
->>>>>>> 35ea878580 (remove move vm session)
     }
 }
 
@@ -219,20 +166,9 @@ fn test_malformed_module() {
     {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.clone().into());
-<<<<<<< HEAD
 
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        sess.execute_function_bypass_visibility(
-=======
         let result = execute_function_with_single_storage_for_test(
             &storage,
->>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
             &[],
@@ -256,27 +192,6 @@ fn test_malformed_module() {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        let err = sess
-            .execute_function_bypass_visibility(
-                &module_id,
-                &fun_name,
-                vec![],
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &module_storage,
-                &storage,
-            )
-            .unwrap_err();
-=======
         let err = execute_function_with_single_storage_for_test(
             &storage,
             &module_id,
@@ -285,7 +200,6 @@ fn test_malformed_module() {
             vec![],
         )
         .unwrap_err();
->>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -314,19 +228,8 @@ fn test_unverifiable_module() {
         m.serialize(&mut blob).unwrap();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        sess.execute_function_bypass_visibility(
-=======
         let result = execute_function_with_single_storage_for_test(
             &storage,
->>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
             &[],
@@ -346,28 +249,6 @@ fn test_unverifiable_module() {
         m.serialize(&mut blob).unwrap();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        let err = sess
-            .execute_function_bypass_visibility(
-                &module_id,
-                &fun_name,
-                vec![],
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &module_storage,
-                &storage,
-            )
-            .unwrap_err();
-
-=======
         let err = execute_function_with_single_storage_for_test(
             &storage,
             &module_id,
@@ -376,7 +257,6 @@ fn test_unverifiable_module() {
             vec![],
         )
         .unwrap_err();
->>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -415,19 +295,8 @@ fn test_missing_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        sess.execute_function_bypass_visibility(
-=======
         let result = execute_function_with_single_storage_for_test(
             &storage,
->>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
             &[],
@@ -442,28 +311,6 @@ fn test_missing_module_dependency() {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        let err = sess
-            .execute_function_bypass_visibility(
-                &module_id,
-                &fun_name,
-                vec![],
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &module_storage,
-                &storage,
-            )
-            .unwrap_err();
-
-=======
         let err = execute_function_with_single_storage_for_test(
             &storage,
             &module_id,
@@ -472,7 +319,6 @@ fn test_missing_module_dependency() {
             vec![],
         )
         .unwrap_err();
->>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -510,19 +356,8 @@ fn test_malformed_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.clone().into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        sess.execute_function_bypass_visibility(
-=======
         let result = execute_function_with_single_storage_for_test(
             &storage,
->>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
             &[],
@@ -542,28 +377,6 @@ fn test_malformed_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        let err = sess
-            .execute_function_bypass_visibility(
-                &module_id,
-                &fun_name,
-                vec![],
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &module_storage,
-                &storage,
-            )
-            .unwrap_err();
-
-=======
         let err = execute_function_with_single_storage_for_test(
             &storage,
             &module_id,
@@ -572,7 +385,6 @@ fn test_malformed_module_dependency() {
             vec![],
         )
         .unwrap_err();
->>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -611,19 +423,8 @@ fn test_unverifiable_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        sess.execute_function_bypass_visibility(
-=======
         let result = execute_function_with_single_storage_for_test(
             &storage,
->>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
             &[],
@@ -643,28 +444,6 @@ fn test_unverifiable_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        let err = sess
-            .execute_function_bypass_visibility(
-                &module_id,
-                &fun_name,
-                vec![],
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &module_storage,
-                &storage,
-            )
-            .unwrap_err();
-
-=======
         let err = execute_function_with_single_storage_for_test(
             &storage,
             &module_id,
@@ -673,7 +452,6 @@ fn test_unverifiable_module_dependency() {
             vec![],
         )
         .unwrap_err();
->>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -750,27 +528,6 @@ fn test_storage_returns_bogus_error_when_loading_module() {
         };
         let module_storage = data_storage.as_unsync_module_storage();
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let module_storage = storage.as_unsync_module_storage();
-
-        let err = sess
-            .execute_function_bypass_visibility(
-                &module_id,
-                &fun_name,
-                vec![],
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &module_storage,
-                &storage,
-            )
-            .unwrap_err();
-=======
         let err = execute_function_for_test(
             &data_storage,
             &module_storage,
@@ -780,7 +537,6 @@ fn test_storage_returns_bogus_error_when_loading_module() {
             vec![],
         )
         .unwrap_err();
->>>>>>> 35ea878580 (remove move vm session)
 
         // TODO(loader_v2):
         //   Loader V2 remaps all deserialization and verification errors. Loader V1 does not
@@ -855,15 +611,6 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             module_storage,
             bad_status_code: *error_code,
         };
-<<<<<<< HEAD
-
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
->>>>>>> 35ea878580 (remove move vm session)
         let module_storage = storage.module_storage.as_unsync_module_storage();
 
         let result =

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -95,7 +95,11 @@ fn test_malformed_resource() {
     // Execute the first script to publish a resource Foo.
     let mut script_blob = vec![];
     s1.serialize(&mut script_blob).unwrap();
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
+=======
+    let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let traversal_storage = TraversalStorage::new();
     let code_storage = storage.clone().into_unsync_code_storage();
@@ -107,8 +111,8 @@ fn test_malformed_resource() {
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
         &code_storage,
+        &storage,
     )
-    .map(|_| ())
     .unwrap();
     let changeset = sess.finish(&code_storage).unwrap();
     storage.apply(changeset).unwrap();
@@ -119,7 +123,11 @@ fn test_malformed_resource() {
     let mut script_blob = vec![];
     s2.serialize(&mut script_blob).unwrap();
     {
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         sess.load_and_execute_script(
             script_blob.clone(),
             vec![],
@@ -127,8 +135,8 @@ fn test_malformed_resource() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
-        .map(|_| ())
         .unwrap();
     }
 
@@ -147,7 +155,11 @@ fn test_malformed_resource() {
     // Run the second script again.
     // The test will be successful if it fails with an invariant violation.
     {
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let err = sess
             .load_and_execute_script(
                 script_blob,
@@ -156,8 +168,8 @@ fn test_malformed_resource() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &code_storage,
+                &storage,
             )
-            .map(|_| ())
             .unwrap_err();
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
@@ -189,7 +201,11 @@ fn test_malformed_module() {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.clone().into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
@@ -200,6 +216,7 @@ fn test_malformed_module() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap();
     }
@@ -218,7 +235,11 @@ fn test_malformed_module() {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         let err = sess
@@ -230,6 +251,7 @@ fn test_malformed_module() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_storage,
+                &storage,
             )
             .unwrap_err();
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
@@ -261,7 +283,11 @@ fn test_unverifiable_module() {
         m.serialize(&mut blob).unwrap();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
@@ -272,6 +298,7 @@ fn test_unverifiable_module() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap();
     }
@@ -287,7 +314,11 @@ fn test_unverifiable_module() {
         m.serialize(&mut blob).unwrap();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         let err = sess
@@ -299,6 +330,7 @@ fn test_unverifiable_module() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_storage,
+                &storage,
             )
             .unwrap_err();
 
@@ -341,7 +373,11 @@ fn test_missing_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
@@ -352,6 +388,7 @@ fn test_missing_module_dependency() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap();
     }
@@ -362,7 +399,11 @@ fn test_missing_module_dependency() {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         let err = sess
@@ -374,6 +415,7 @@ fn test_missing_module_dependency() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_storage,
+                &storage,
             )
             .unwrap_err();
 
@@ -416,7 +458,11 @@ fn test_malformed_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.clone().into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
@@ -427,6 +473,7 @@ fn test_malformed_module_dependency() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap();
     }
@@ -443,7 +490,11 @@ fn test_malformed_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         let err = sess
@@ -455,6 +506,7 @@ fn test_malformed_module_dependency() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_storage,
+                &storage,
             )
             .unwrap_err();
 
@@ -498,7 +550,11 @@ fn test_unverifiable_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
@@ -509,6 +565,7 @@ fn test_unverifiable_module_dependency() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap();
     }
@@ -525,7 +582,11 @@ fn test_unverifiable_module_dependency() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         let err = sess
@@ -537,6 +598,7 @@ fn test_unverifiable_module_dependency() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_storage,
+                &storage,
             )
             .unwrap_err();
 
@@ -617,7 +679,11 @@ fn test_storage_returns_bogus_error_when_loading_module() {
             bad_status_code: *error_code,
         };
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.as_unsync_module_storage();
 
         let err = sess
@@ -629,6 +695,7 @@ fn test_storage_returns_bogus_error_when_loading_module() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_storage,
+                &storage,
             )
             .unwrap_err();
 
@@ -707,7 +774,11 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             bad_status_code: *error_code,
         };
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let module_storage = storage.module_storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
@@ -718,6 +789,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap();
 
@@ -730,6 +802,7 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &module_storage,
+                &storage,
             )
             .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/bad_storage_tests.rs
@@ -2,23 +2,35 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, as_script, compile_units};
+use crate::{
+    compiler::{as_module, as_script, compile_units},
+    tests::{
+        execute_function_for_test, execute_function_with_single_storage_for_test,
+        execute_script_and_commit_change_set_for_test, execute_script_for_test,
+    },
+};
 use bytes::Bytes;
+use claims::assert_ok;
 use move_binary_format::errors::{Location, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
+    ident_str,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag},
     metadata::Metadata,
     value::{serialize_values, MoveTypeLayout, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
+<<<<<<< HEAD
 use move_vm_runtime::{
     module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage, AsUnsyncModuleStorage,
     RuntimeEnvironment, WithRuntimeEnvironment,
 };
+=======
+use move_vm_runtime::{AsUnsyncModuleStorage, RuntimeEnvironment, WithRuntimeEnvironment};
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::{code::ModuleBytesStorage, gas::UnmeteredGasMeter, resolver::ResourceResolver};
+use move_vm_types::{code::ModuleBytesStorage, resolver::ResourceResolver};
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -96,26 +108,22 @@ fn test_malformed_resource() {
     let mut script_blob = vec![];
     s1.serialize(&mut script_blob).unwrap();
 <<<<<<< HEAD
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
 =======
     let mut sess = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 
-    let traversal_storage = TraversalStorage::new();
-    let code_storage = storage.clone().into_unsync_code_storage();
-
-    sess.load_and_execute_script(
-        script_blob,
-        vec![],
-        vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()],
-        &mut UnmeteredGasMeter,
-        &mut TraversalContext::new(&traversal_storage),
-        &code_storage,
-        &storage,
-    )
-    .unwrap();
-    let changeset = sess.finish(&code_storage).unwrap();
-    storage.apply(changeset).unwrap();
+    let args = vec![MoveValue::Signer(TEST_ADDR).simple_serialize().unwrap()];
+    let result = execute_script_and_commit_change_set_for_test(
+        &mut storage,
+        &script_blob,
+        &[],
+        args.clone(),
+    );
+    assert_ok!(result);
 
     // Execute the second script and make sure it succeeds. This script simply checks
     // that the published resource is what we expect it to be. This initial run is to ensure
@@ -123,6 +131,7 @@ fn test_malformed_resource() {
     let mut script_blob = vec![];
     s2.serialize(&mut script_blob).unwrap();
     {
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -138,6 +147,10 @@ fn test_malformed_resource() {
             &storage,
         )
         .unwrap();
+=======
+        let result = execute_script_for_test(&storage, &script_blob, &[], args.clone());
+        assert_ok!(result);
+>>>>>>> 35ea878580 (remove move vm session)
     }
 
     // Corrupt the resource in the storage.
@@ -156,6 +169,7 @@ fn test_malformed_resource() {
     // The test will be successful if it fails with an invariant violation.
     {
 <<<<<<< HEAD
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
         let mut sess = MoveVm::new_session();
@@ -172,6 +186,12 @@ fn test_malformed_resource() {
             )
             .unwrap_err();
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
+=======
+        let status_type = execute_script_for_test(&storage, &script_blob, &[], args)
+            .unwrap_err()
+            .status_type();
+        assert_eq!(status_type, StatusType::InvariantViolation);
+>>>>>>> 35ea878580 (remove move vm session)
     }
 }
 
@@ -194,12 +214,12 @@ fn test_malformed_module() {
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     // Publish M and call M::foo. No errors should be thrown.
     {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.clone().into());
+<<<<<<< HEAD
 
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
@@ -209,16 +229,16 @@ fn test_malformed_module() {
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
+=======
+        let result = execute_function_with_single_storage_for_test(
+            &storage,
+>>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
+            &[],
             vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap();
+        );
+        assert_ok!(result);
     }
 
     // Start over with a fresh storage and publish a corrupted version of M.
@@ -232,9 +252,11 @@ fn test_malformed_module() {
         blob[1] = 0xAD;
         blob[2] = 0xBE;
         blob[3] = 0xEF;
+
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -254,6 +276,16 @@ fn test_malformed_module() {
                 &storage,
             )
             .unwrap_err();
+=======
+        let err = execute_function_with_single_storage_for_test(
+            &storage,
+            &module_id,
+            &fun_name,
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+>>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -273,7 +305,6 @@ fn test_unverifiable_module() {
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("M").unwrap());
     let fun_name = Identifier::new("foo").unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     // Publish M and call M::foo to make sure it works.
     {
@@ -284,6 +315,7 @@ fn test_unverifiable_module() {
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
 <<<<<<< HEAD
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
         let mut sess = MoveVm::new_session();
@@ -291,16 +323,16 @@ fn test_unverifiable_module() {
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
+=======
+        let result = execute_function_with_single_storage_for_test(
+            &storage,
+>>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
+            &[],
             vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap();
+        );
+        assert_ok!(result);
     }
 
     // Erase the body of M::foo to make it fail verification.
@@ -314,6 +346,7 @@ fn test_unverifiable_module() {
         m.serialize(&mut blob).unwrap();
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -334,6 +367,16 @@ fn test_unverifiable_module() {
             )
             .unwrap_err();
 
+=======
+        let err = execute_function_with_single_storage_for_test(
+            &storage,
+            &module_id,
+            &fun_name,
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+>>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -364,7 +407,6 @@ fn test_missing_module_dependency() {
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
     let fun_name = Identifier::new("bar").unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     // Publish M and N and call N::bar. Everything should work.
     {
@@ -374,6 +416,7 @@ fn test_missing_module_dependency() {
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
 <<<<<<< HEAD
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
         let mut sess = MoveVm::new_session();
@@ -381,16 +424,16 @@ fn test_missing_module_dependency() {
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
+=======
+        let result = execute_function_with_single_storage_for_test(
+            &storage,
+>>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
+            &[],
             vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap();
+        );
+        assert_ok!(result);
     }
 
     // Publish only N and try to call N::bar. The VM should fail to find M and raise
@@ -399,6 +442,7 @@ fn test_missing_module_dependency() {
         let mut storage = InMemoryStorage::new();
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -419,6 +463,16 @@ fn test_missing_module_dependency() {
             )
             .unwrap_err();
 
+=======
+        let err = execute_function_with_single_storage_for_test(
+            &storage,
+            &module_id,
+            &fun_name,
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+>>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -449,15 +503,14 @@ fn test_malformed_module_dependency() {
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
     let fun_name = Identifier::new("bar").unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     // Publish M and N and call N::bar. Everything should work.
     {
         let mut storage = InMemoryStorage::new();
-
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.clone().into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -466,16 +519,16 @@ fn test_malformed_module_dependency() {
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
+=======
+        let result = execute_function_with_single_storage_for_test(
+            &storage,
+>>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
+            &[],
             vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap();
+        );
+        assert_ok!(result);
     }
 
     // Publish N and a corrupted version of M and try to call N::bar, the VM should fail to load M.
@@ -486,10 +539,10 @@ fn test_malformed_module_dependency() {
         blob_m[3] = 0xEF;
 
         let mut storage = InMemoryStorage::new();
-
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -510,6 +563,16 @@ fn test_malformed_module_dependency() {
             )
             .unwrap_err();
 
+=======
+        let err = execute_function_with_single_storage_for_test(
+            &storage,
+            &module_id,
+            &fun_name,
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+>>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -538,7 +601,6 @@ fn test_unverifiable_module_dependency() {
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
     let fun_name = Identifier::new("bar").unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     // Publish M and N and call N::bar. Everything should work.
     {
@@ -546,10 +608,10 @@ fn test_unverifiable_module_dependency() {
         m.serialize(&mut blob_m).unwrap();
 
         let mut storage = InMemoryStorage::new();
-
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.clone().into());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -558,16 +620,16 @@ fn test_unverifiable_module_dependency() {
         let module_storage = storage.as_unsync_module_storage();
 
         sess.execute_function_bypass_visibility(
+=======
+        let result = execute_function_with_single_storage_for_test(
+            &storage,
+>>>>>>> 35ea878580 (remove move vm session)
             &module_id,
             &fun_name,
+            &[],
             vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap();
+        );
+        assert_ok!(result);
     }
 
     // Publish N and an unverifiable version of M and try to call N::bar, the VM should fail to load M.
@@ -578,10 +640,10 @@ fn test_unverifiable_module_dependency() {
         m.serialize(&mut blob_m).unwrap();
 
         let mut storage = InMemoryStorage::new();
-
         storage.add_module_bytes(m.self_addr(), m.self_name(), blob_m.into());
         storage.add_module_bytes(n.self_addr(), n.self_name(), blob_n.into());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -602,6 +664,16 @@ fn test_unverifiable_module_dependency() {
             )
             .unwrap_err();
 
+=======
+        let err = execute_function_with_single_storage_for_test(
+            &storage,
+            &module_id,
+            &fun_name,
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+>>>>>>> 35ea878580 (remove move vm session)
         assert_eq!(err.status_type(), StatusType::InvariantViolation);
     }
 }
@@ -670,15 +742,15 @@ const LIST_OF_ERROR_CODES: &[StatusCode] = &[
 #[test]
 fn test_storage_returns_bogus_error_when_loading_module() {
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("N").unwrap());
-    let fun_name = Identifier::new("bar").unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     for error_code in LIST_OF_ERROR_CODES {
-        let storage = BogusModuleStorage {
+        let data_storage = BogusModuleStorage {
             runtime_environment: RuntimeEnvironment::new(vec![]),
             bad_status_code: *error_code,
         };
+        let module_storage = data_storage.as_unsync_module_storage();
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
@@ -698,6 +770,17 @@ fn test_storage_returns_bogus_error_when_loading_module() {
                 &storage,
             )
             .unwrap_err();
+=======
+        let err = execute_function_for_test(
+            &data_storage,
+            &module_storage,
+            &module_id,
+            ident_str!("bar"),
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+>>>>>>> 35ea878580 (remove move vm session)
 
         // TODO(loader_v2):
         //   Loader V2 remaps all deserialization and verification errors. Loader V1 does not
@@ -756,7 +839,6 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
     let m_id = m.self_id();
     let foo_name = Identifier::new("foo").unwrap();
     let bar_name = Identifier::new("bar").unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     for error_code in LIST_OF_ERROR_CODES {
         let natives = move_stdlib::natives::all_natives(
@@ -773,38 +855,30 @@ fn test_storage_returns_bogus_error_when_loading_resource() {
             module_storage,
             bad_status_code: *error_code,
         };
+<<<<<<< HEAD
 
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
         let mut sess = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+>>>>>>> 35ea878580 (remove move vm session)
         let module_storage = storage.module_storage.as_unsync_module_storage();
 
-        sess.execute_function_bypass_visibility(
-            &m_id,
-            &foo_name,
-            vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap();
+        let result =
+            execute_function_for_test(&storage, &module_storage, &m_id, &foo_name, &[], vec![]);
+        assert_ok!(result);
 
-        let err = sess
-            .execute_function_bypass_visibility(
-                &m_id,
-                &bar_name,
-                vec![],
-                serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &module_storage,
-                &storage,
-            )
-            .unwrap_err();
+        let err = execute_function_for_test(
+            &storage,
+            &module_storage,
+            &m_id,
+            &bar_name,
+            &[],
+            serialize_values(&vec![MoveValue::Signer(TEST_ADDR)]),
+        )
+        .unwrap_err();
 
         if *error_code == StatusCode::UNKNOWN_VERIFICATION_ERROR {
             // MoveVM maps `UNKNOWN_VERIFICATION_ERROR` to `VERIFICATION_ERROR`.

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -1,6 +1,8 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::tests::execute_script_for_test;
+use claims::assert_ok;
 use move_binary_format::{
     deserializer::DeserializerConfig,
     file_format::{basic_test_module, basic_test_script},
@@ -8,27 +10,43 @@ use move_binary_format::{
 };
 use move_core_types::vm_status::StatusCode;
 use move_vm_runtime::{
+<<<<<<< HEAD
     config::VMConfig, module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage,
     AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
+=======
+    config::VMConfig, AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
+>>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
+
+fn initialize_storage_with_binary_format_version(binary_format_version: u32) -> InMemoryStorage {
+    let vm_config = VMConfig {
+        deserializer_config: DeserializerConfig::new(binary_format_version, IDENTIFIER_SIZE_MAX),
+        ..Default::default()
+    };
+    let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
+    InMemoryStorage::new_with_runtime_environment(runtime_environment)
+}
 
 #[test]
 fn test_publish_module_with_custom_max_binary_format_version() {
     let m = basic_test_module();
+
+    let new_version = VERSION_MAX;
     let mut b_new = vec![];
-    let mut b_old = vec![];
-    m.serialize_for_version(Some(VERSION_MAX), &mut b_new)
+    m.serialize_for_version(Some(new_version), &mut b_new)
         .unwrap();
-    m.serialize_for_version(Some(VERSION_MAX.checked_sub(1).unwrap()), &mut b_old)
+
+    let old_version = new_version - 1;
+    let mut b_old = vec![];
+    m.serialize_for_version(Some(old_version), &mut b_old)
         .unwrap();
 
     // Should accept both modules with the default settings
     {
-        let storage = InMemoryStorage::new();
-
+        let storage = initialize_storage_with_binary_format_version(new_version);
         let module_storage = storage.as_unsync_module_storage();
+
         let new_module_storage =
             StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_new
                 .clone()
@@ -42,43 +60,39 @@ fn test_publish_module_with_custom_max_binary_format_version() {
 
     // Should reject the module with newer version with max binary format version being set to VERSION_MAX - 1
     {
-        let vm_config = VMConfig {
-            deserializer_config: DeserializerConfig::new(
-                VERSION_MAX.checked_sub(1).unwrap(),
-                IDENTIFIER_SIZE_MAX,
-            ),
-            ..Default::default()
-        };
-        let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
-        let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
-
+        let storage = initialize_storage_with_binary_format_version(old_version);
         let module_storage = storage.as_unsync_module_storage();
-        let result = StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_new
+
+        let result_new = StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_new
             .clone()
             .into()]);
-        if let Err(err) = result {
+        if let Err(err) = result_new {
             assert_eq!(err.major_status(), StatusCode::UNKNOWN_VERSION);
         } else {
-            panic!("Module publishing should fail")
+            panic!("New module should not be publishable")
         }
         StagingModuleStorage::create(m.self_addr(), &module_storage, vec![b_old.clone().into()])
-            .unwrap();
+            .expect("Old module should be publishable");
     }
 }
 
 #[test]
 fn test_run_script_with_custom_max_binary_format_version() {
     let s = basic_test_script();
-    let mut b_new = vec![];
-    let mut b_old = vec![];
-    s.serialize_for_version(Some(VERSION_MAX), &mut b_new)
-        .unwrap();
-    s.serialize_for_version(Some(VERSION_MAX.checked_sub(1).unwrap()), &mut b_old)
-        .unwrap();
-    let traversal_storage = TraversalStorage::new();
 
-    // Should accept both modules with the default settings
+    let new_version = VERSION_MAX;
+    let mut b_new = vec![];
+    s.serialize_for_version(Some(new_version), &mut b_new)
+        .unwrap();
+
+    let old_version = new_version - 1;
+    let mut b_old = vec![];
+    s.serialize_for_version(Some(old_version), &mut b_old)
+        .unwrap();
+
+    // Should accept both modules with the default settings.
     {
+<<<<<<< HEAD
         let storage = InMemoryStorage::new();
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
@@ -109,10 +123,18 @@ fn test_run_script_with_custom_max_binary_format_version() {
             &storage,
         )
         .unwrap();
+=======
+        let storage = initialize_storage_with_binary_format_version(new_version);
+        let result_new = execute_script_for_test(&storage, &b_new, &[], vec![]);
+        let result_old = execute_script_for_test(&storage, &b_old, &[], vec![]);
+        assert!(result_new.is_ok() && result_old.is_ok());
+>>>>>>> 35ea878580 (remove move vm session)
     }
 
-    // Should reject the module with newer version with max binary format version being set to VERSION_MAX - 1
+    // Should reject the module with newer version with max binary format version being set to the
+    // smaller one.
     {
+<<<<<<< HEAD
         let vm_config = VMConfig {
             deserializer_config: DeserializerConfig::new(
                 VERSION_MAX.checked_sub(1).unwrap(),
@@ -140,20 +162,15 @@ fn test_run_script_with_custom_max_binary_format_version() {
                 &code_storage,
                 &storage,
             )
+=======
+        let storage = initialize_storage_with_binary_format_version(old_version);
+        let status_new = execute_script_for_test(&storage, &b_new, &[], vec![])
+>>>>>>> 35ea878580 (remove move vm session)
             .unwrap_err()
-            .major_status(),
-            StatusCode::CODE_DESERIALIZATION_ERROR
-        );
+            .major_status();
+        assert_eq!(status_new, StatusCode::CODE_DESERIALIZATION_ERROR);
 
-        sess.load_and_execute_script(
-            b_old.clone(),
-            vec![],
-            args,
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap();
+        let result_old = execute_script_for_test(&storage, &b_old, &[], vec![]);
+        assert_ok!(result_old);
     }
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -80,7 +80,11 @@ fn test_run_script_with_custom_max_binary_format_version() {
     // Should accept both modules with the default settings
     {
         let storage = InMemoryStorage::new();
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let code_storage = storage.as_unsync_code_storage();
 
         let args: Vec<Vec<u8>> = vec![];
@@ -91,6 +95,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .unwrap();
 
@@ -101,6 +106,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .unwrap();
     }
@@ -116,7 +122,11 @@ fn test_run_script_with_custom_max_binary_format_version() {
         };
         let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
         let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let code_storage = storage.as_unsync_code_storage();
 
         let args: Vec<Vec<u8>> = vec![];
@@ -128,6 +138,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 &code_storage,
+                &storage,
             )
             .unwrap_err()
             .major_status(),
@@ -141,6 +152,7 @@ fn test_run_script_with_custom_max_binary_format_version() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .unwrap();
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/binary_format_version.rs
@@ -10,12 +10,7 @@ use move_binary_format::{
 };
 use move_core_types::vm_status::StatusCode;
 use move_vm_runtime::{
-<<<<<<< HEAD
-    config::VMConfig, module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage,
-    AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
-=======
     config::VMConfig, AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
->>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
 
@@ -92,80 +87,17 @@ fn test_run_script_with_custom_max_binary_format_version() {
 
     // Should accept both modules with the default settings.
     {
-<<<<<<< HEAD
-        let storage = InMemoryStorage::new();
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let code_storage = storage.as_unsync_code_storage();
-
-        let args: Vec<Vec<u8>> = vec![];
-        sess.load_and_execute_script(
-            b_new.clone(),
-            vec![],
-            args.clone(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap();
-
-        sess.load_and_execute_script(
-            b_old.clone(),
-            vec![],
-            args,
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap();
-=======
         let storage = initialize_storage_with_binary_format_version(new_version);
         let result_new = execute_script_for_test(&storage, &b_new, &[], vec![]);
         let result_old = execute_script_for_test(&storage, &b_old, &[], vec![]);
         assert!(result_new.is_ok() && result_old.is_ok());
->>>>>>> 35ea878580 (remove move vm session)
     }
 
     // Should reject the module with newer version with max binary format version being set to the
     // smaller one.
     {
-<<<<<<< HEAD
-        let vm_config = VMConfig {
-            deserializer_config: DeserializerConfig::new(
-                VERSION_MAX.checked_sub(1).unwrap(),
-                IDENTIFIER_SIZE_MAX,
-            ),
-            ..Default::default()
-        };
-        let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
-        let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let code_storage = storage.as_unsync_code_storage();
-
-        let args: Vec<Vec<u8>> = vec![];
-        assert_eq!(
-            sess.load_and_execute_script(
-                b_new.clone(),
-                vec![],
-                args.clone(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &code_storage,
-                &storage,
-            )
-=======
         let storage = initialize_storage_with_binary_format_version(old_version);
         let status_new = execute_script_for_test(&storage, &b_new, &[], vec![])
->>>>>>> 35ea878580 (remove move vm session)
             .unwrap_err()
             .major_status();
         assert_eq!(status_new, StatusCode::CODE_DESERIALIZATION_ERROR);

--- a/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -96,7 +96,11 @@ fn run(
     let mut storage = InMemoryStorage::new();
     compile_modules(&mut storage, &modules);
 
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let fun_name = Identifier::new(fun_name).unwrap();
     let traversal_storage = TraversalStorage::new();
@@ -111,6 +115,7 @@ fn run(
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .and_then(|ret_values| {
             let change_set = session.finish(&module_storage)?;

--- a/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -2,22 +2,27 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, compile_units};
+use crate::{
+    compiler::{as_module, compile_units},
+    tests::execute_function_with_single_storage_for_test,
+};
 use move_binary_format::errors::VMResult;
 use move_core_types::{
     account_address::AccountAddress,
-    effects::ChangeSet,
     identifier::Identifier,
     language_storage::ModuleId,
     u256::U256,
     value::{serialize_values, MoveValue},
     vm_status::StatusCode,
 };
+<<<<<<< HEAD
 use move_vm_runtime::{
     module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues, AsUnsyncModuleStorage,
 };
+=======
+use move_vm_runtime::move_vm::SerializedReturnValues;
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 const TEST_MODULE_ID: &str = "M";
@@ -41,23 +46,19 @@ fn fail_arg_deserialize() {
     ];
     for value in values {
         for name in FUN_NAMES {
-            let err = run(&mod_code, name, value.clone())
-                .map(|_| ())
-                .expect_err("Should have failed to deserialize non-u64 type to u64");
-            assert_eq!(
-                err.major_status(),
-                StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT
-            );
+            let status = run(&mod_code, name, value.clone())
+                .expect_err("Should have failed to deserialize non-u64 type to u64")
+                .major_status();
+            assert_eq!(status, StatusCode::FAILED_TO_DESERIALIZE_ARGUMENT);
         }
     }
 }
 
-// check happy path for writing to mut ref args - may be unecessary / covered by other tests
+// check happy path for writing to mut ref args - may be unnecessary / covered by other tests
 #[test]
 fn mutref_output_success() {
     let mod_code = setup_module();
-    let result = run(&mod_code, USE_MUTREF_LABEL, MoveValue::U64(1));
-    let (_, ret_values) = result.unwrap();
+    let ret_values = run(&mod_code, USE_MUTREF_LABEL, MoveValue::U64(1)).unwrap();
     assert_eq!(1, ret_values.mutable_reference_outputs.len());
     let parsed = parse_u64_arg(&ret_values.mutable_reference_outputs.first().unwrap().1);
     assert_eq!(EXPECT_MUTREF_OUT_VALUE, parsed);
@@ -90,12 +91,15 @@ fn run(
     module: &ModuleCode,
     fun_name: &str,
     arg_val0: MoveValue,
-) -> VMResult<(ChangeSet, SerializedReturnValues)> {
+) -> VMResult<SerializedReturnValues> {
     let module_id = &module.0;
+    let function_name = Identifier::new(fun_name).unwrap();
+
     let modules = vec![module.clone()];
     let mut storage = InMemoryStorage::new();
     compile_modules(&mut storage, &modules);
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
 =======
@@ -121,6 +125,15 @@ fn run(
             let change_set = session.finish(&module_storage)?;
             Ok((change_set, ret_values))
         })
+=======
+    execute_function_with_single_storage_for_test(
+        &storage,
+        module_id,
+        &function_name,
+        &[],
+        serialize_values(&vec![arg_val0]),
+    )
+>>>>>>> 35ea878580 (remove move vm session)
 }
 
 type ModuleCode = (ModuleId, String);

--- a/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/exec_func_effects_tests.rs
@@ -15,13 +15,7 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::StatusCode,
 };
-<<<<<<< HEAD
-use move_vm_runtime::{
-    module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues, AsUnsyncModuleStorage,
-};
-=======
 use move_vm_runtime::move_vm::SerializedReturnValues;
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -87,11 +81,7 @@ fn setup_module() -> ModuleCode {
     (module_id, code)
 }
 
-fn run(
-    module: &ModuleCode,
-    fun_name: &str,
-    arg_val0: MoveValue,
-) -> VMResult<SerializedReturnValues> {
+fn run(module: &ModuleCode, fun_name: &str, arg: MoveValue) -> VMResult<SerializedReturnValues> {
     let module_id = &module.0;
     let function_name = Identifier::new(fun_name).unwrap();
 
@@ -99,41 +89,13 @@ fn run(
     let mut storage = InMemoryStorage::new();
     compile_modules(&mut storage, &modules);
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-
-    let fun_name = Identifier::new(fun_name).unwrap();
-    let traversal_storage = TraversalStorage::new();
-    let module_storage = storage.as_unsync_module_storage();
-
-    session
-        .execute_function_bypass_visibility(
-            module_id,
-            &fun_name,
-            vec![],
-            serialize_values(&vec![arg_val0]),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .and_then(|ret_values| {
-            let change_set = session.finish(&module_storage)?;
-            Ok((change_set, ret_values))
-        })
-=======
     execute_function_with_single_storage_for_test(
         &storage,
         module_id,
         &function_name,
         &[],
-        serialize_values(&vec![arg_val0]),
+        serialize_values(&vec![arg]),
     )
->>>>>>> 35ea878580 (remove move vm session)
 }
 
 type ModuleCode = (ModuleId, String);

--- a/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -58,7 +58,11 @@ fn run(
     let mut storage = InMemoryStorage::new();
     storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
+=======
+    let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let fun_name = Identifier::new("foo").unwrap();
     let traversal_storage = TraversalStorage::new();
@@ -77,6 +81,7 @@ fn run(
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
         &module_storage,
+        &storage,
     )?;
 
     Ok(())

--- a/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -2,7 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, compile_units};
+use crate::{
+    compiler::{as_module, compile_units},
+    tests::execute_function_with_single_storage_for_test,
+};
 use move_binary_format::errors::VMResult;
 use move_core_types::{
     account_address::AccountAddress,
@@ -12,9 +15,11 @@ use move_core_types::{
     value::{MoveStruct, MoveValue},
     vm_status::StatusCode,
 };
+<<<<<<< HEAD
 use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncModuleStorage};
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -44,7 +49,7 @@ fn run(
 
             fun foo<{}>({}) {{ }}
         }}
-    "#,
+        "#,
         TEST_ADDR.to_hex(),
         ty_params,
         params
@@ -59,29 +64,25 @@ fn run(
     storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
 =======
     let mut sess = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
+=======
+>>>>>>> 35ea878580 (remove move vm session)
     let fun_name = Identifier::new("foo").unwrap();
-    let traversal_storage = TraversalStorage::new();
-    let module_storage = storage.as_unsync_module_storage();
-
     let args: Vec<_> = args
         .into_iter()
         .map(|val| val.simple_serialize().unwrap())
         .collect();
-
-    sess.execute_function_bypass_visibility(
+    execute_function_with_single_storage_for_test(
+        &storage,
         &m.self_id(),
         &fun_name,
-        ty_args,
+        &ty_args,
         args,
-        &mut UnmeteredGasMeter,
-        &mut TraversalContext::new(&traversal_storage),
-        &module_storage,
-        &storage,
     )?;
 
     Ok(())

--- a/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/function_arg_tests.rs
@@ -15,10 +15,6 @@ use move_core_types::{
     value::{MoveStruct, MoveValue},
     vm_status::StatusCode,
 };
-<<<<<<< HEAD
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncModuleStorage};
-=======
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -63,15 +59,6 @@ fn run(
     let mut storage = InMemoryStorage::new();
     storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut sess = MoveVM::new_session(&storage);
-=======
-    let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-
-=======
->>>>>>> 35ea878580 (remove move vm session)
     let fun_name = Identifier::new("foo").unwrap();
     let args: Vec<_> = args
         .into_iter()

--- a/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
@@ -1,14 +1,17 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::tests::execute_script_for_test;
 use move_binary_format::file_format::{
     Bytecode::*, CodeUnit, CompiledScript, Constant, ConstantPoolIndex, Signature, SignatureIndex,
     SignatureToken::*,
 };
 use move_core_types::vm_status::StatusCode;
+<<<<<<< HEAD
 use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage};
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 #[test]
 fn merge_borrow_states_infinite_loop() {
@@ -71,33 +74,21 @@ fn merge_borrow_states_infinite_loop() {
     };
 
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");
-    let storage = InMemoryStorage::new();
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
 =======
     let mut session = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+>>>>>>> 35ea878580 (remove move vm session)
     let mut script_bytes = vec![];
     cs.serialize(&mut script_bytes).unwrap();
 
-    let traversal_storage = TraversalStorage::new();
-    let code_storage = storage.as_unsync_code_storage();
-
-    let err = session
-        .load_and_execute_script(
-            script_bytes.as_slice(),
-            vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap_err();
-
-    assert_eq!(
-        err.major_status(),
-        StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
-    );
+    let storage = InMemoryStorage::new();
+    let status = execute_script_for_test(&storage, &script_bytes, &[], vec![])
+        .unwrap_err()
+        .major_status();
+    assert_eq!(status, StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR);
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
@@ -7,10 +7,6 @@ use move_binary_format::file_format::{
     SignatureToken::*,
 };
 use move_core_types::vm_status::StatusCode;
-<<<<<<< HEAD
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage};
-=======
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 
 #[test]
@@ -75,14 +71,6 @@ fn merge_borrow_states_infinite_loop() {
 
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
->>>>>>> 35ea878580 (remove move vm session)
     let mut script_bytes = vec![];
     cs.serialize(&mut script_bytes).unwrap();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
@@ -73,7 +73,11 @@ fn merge_borrow_states_infinite_loop() {
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");
     let storage = InMemoryStorage::new();
 
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
     let mut script_bytes = vec![];
     cs.serialize(&mut script_bytes).unwrap();
 
@@ -88,6 +92,7 @@ fn merge_borrow_states_infinite_loop() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
@@ -48,7 +48,11 @@ fn leak_with_abort() {
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");
     let storage = InMemoryStorage::new();
 
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
     let mut script_bytes = vec![];
     cs.serialize(&mut script_bytes).unwrap();
 
@@ -63,6 +67,7 @@ fn leak_with_abort() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         );
     }
 

--- a/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
@@ -6,10 +6,6 @@ use claims::assert_ok;
 use move_binary_format::file_format::{
     Bytecode::*, CodeUnit, CompiledScript, Signature, SignatureIndex, SignatureToken::*,
 };
-<<<<<<< HEAD
-use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage};
-=======
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 
 #[ignore] // TODO: figure whether to reactive this test
@@ -51,14 +47,6 @@ fn leak_with_abort() {
 
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
->>>>>>> 35ea878580 (remove move vm session)
     let mut script_bytes = vec![];
     cs.serialize(&mut script_bytes).unwrap();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
@@ -1,12 +1,16 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::tests::execute_script_for_test;
+use claims::assert_ok;
 use move_binary_format::file_format::{
     Bytecode::*, CodeUnit, CompiledScript, Signature, SignatureIndex, SignatureToken::*,
 };
+<<<<<<< HEAD
 use move_vm_runtime::{module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage};
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 #[ignore] // TODO: figure whether to reactive this test
 #[test]
@@ -46,29 +50,22 @@ fn leak_with_abort() {
     };
 
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");
-    let storage = InMemoryStorage::new();
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
 =======
     let mut session = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+>>>>>>> 35ea878580 (remove move vm session)
     let mut script_bytes = vec![];
     cs.serialize(&mut script_bytes).unwrap();
 
-    let traversal_storage = TraversalStorage::new();
-    let code_storage = storage.as_unsync_code_storage();
-
+    let storage = InMemoryStorage::new();
     for _ in 0..100_000 {
-        let _ = session.load_and_execute_script(
-            script_bytes.as_slice(),
-            vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        );
+        let result = execute_script_for_test(&storage, &script_bytes, &[], vec![]);
+        assert_ok!(result);
     }
 
     let mem_stats = memory_stats::memory_stats().unwrap();

--- a/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -92,7 +92,11 @@ impl Adapter {
         name: &IdentStr,
         module_storage: &impl ModuleStorage,
     ) {
+<<<<<<< HEAD
         let mut session = MoveVM::new_session(&self.store);
+=======
+        let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let traversal_storage = TraversalStorage::new();
         session
             .execute_function_bypass_visibility(
@@ -103,6 +107,7 @@ impl Adapter {
                 &mut UnmeteredGasMeter,
                 &mut TraversalContext::new(&traversal_storage),
                 module_storage,
+                &self.store,
             )
             .unwrap_or_else(|_| panic!("Failure executing {:?}::{:?}", module, name));
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -2,7 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::compile_modules_in_file;
+use crate::{compiler::compile_modules_in_file, tests::execute_function_for_test};
 use move_binary_format::{
     file_format::{
         empty_module, AddressIdentifierIndex, Bytecode, CodeUnit, FunctionDefinition,
@@ -12,18 +12,18 @@ use move_binary_format::{
     CompiledModule,
 };
 use move_core_types::{
-    ability::AbilitySet,
-    account_address::AccountAddress,
-    ident_str,
-    identifier::{IdentStr, Identifier},
+    ability::AbilitySet, account_address::AccountAddress, ident_str, identifier::Identifier,
     language_storage::ModuleId,
 };
+<<<<<<< HEAD
 use move_vm_runtime::{
     module_traversal::*, move_vm::MoveVM, AsUnsyncModuleStorage, ModuleStorage,
     StagingModuleStorage,
 };
+=======
+use move_vm_runtime::{AsUnsyncModuleStorage, ModuleStorage, StagingModuleStorage};
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 use std::path::PathBuf;
 
 const WORKING_ACCOUNT: AccountAddress = AccountAddress::TWO;
@@ -82,9 +82,11 @@ impl Adapter {
 
     fn call_functions(&self, module_storage: &impl ModuleStorage) {
         for (module_id, name) in &self.functions {
-            self.call_function(module_id, name, module_storage);
+            execute_function_for_test(&self.store, module_storage, module_id, name, &[], vec![])
+                .unwrap_or_else(|_| panic!("Failure executing {:?}::{:?}", module_id, name));
         }
     }
+<<<<<<< HEAD
 
     fn call_function(
         &self,
@@ -111,6 +113,8 @@ impl Adapter {
             )
             .unwrap_or_else(|_| panic!("Failure executing {:?}::{:?}", module, name));
     }
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 }
 
 fn get_modules() -> Vec<CompiledModule> {

--- a/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/loader_tests.rs
@@ -15,14 +15,7 @@ use move_core_types::{
     ability::AbilitySet, account_address::AccountAddress, ident_str, identifier::Identifier,
     language_storage::ModuleId,
 };
-<<<<<<< HEAD
-use move_vm_runtime::{
-    module_traversal::*, move_vm::MoveVM, AsUnsyncModuleStorage, ModuleStorage,
-    StagingModuleStorage,
-};
-=======
 use move_vm_runtime::{AsUnsyncModuleStorage, ModuleStorage, StagingModuleStorage};
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 use std::path::PathBuf;
 
@@ -86,35 +79,6 @@ impl Adapter {
                 .unwrap_or_else(|_| panic!("Failure executing {:?}::{:?}", module_id, name));
         }
     }
-<<<<<<< HEAD
-
-    fn call_function(
-        &self,
-        module: &ModuleId,
-        name: &IdentStr,
-        module_storage: &impl ModuleStorage,
-    ) {
-<<<<<<< HEAD
-        let mut session = MoveVM::new_session(&self.store);
-=======
-        let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let traversal_storage = TraversalStorage::new();
-        session
-            .execute_function_bypass_visibility(
-                module,
-                name,
-                vec![],
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                module_storage,
-                &self.store,
-            )
-            .unwrap_or_else(|_| panic!("Failure executing {:?}::{:?}", module, name));
-    }
-=======
->>>>>>> 35ea878580 (remove move vm session)
 }
 
 fn get_modules() -> Vec<CompiledModule> {

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -11,7 +11,7 @@ use move_core_types::{
 use move_vm_runtime::{
     data_cache::TransactionDataCache,
     module_traversal::{TraversalContext, TraversalStorage},
-    move_vm::{MoveVm, SerializedReturnValues},
+    move_vm::{MoveVM, SerializedReturnValues},
     native_extensions::NativeContextExtensions,
     AsUnsyncCodeStorage, AsUnsyncModuleStorage, CodeStorage, ModuleStorage,
 };
@@ -91,7 +91,7 @@ fn execute_function_for_test(
     let traversal_storage = TraversalStorage::new();
 
     let func = module_storage.load_function(module_id, function_name, ty_args)?;
-    MoveVm::execute_loaded_function(
+    MoveVM::execute_loaded_function(
         func,
         args,
         &mut TransactionDataCache::empty(),
@@ -115,7 +115,7 @@ fn execute_script_impl(
     let function = code_storage.load_script(script, ty_args)?;
     let mut data_cache = TransactionDataCache::empty();
 
-    MoveVm::execute_loaded_function(
+    MoveVM::execute_loaded_function(
         function,
         args,
         &mut data_cache,

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -2,6 +2,22 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use move_binary_format::errors::{Location, VMResult};
+use move_core_types::{
+    effects::ChangeSet,
+    identifier::IdentStr,
+    language_storage::{ModuleId, TypeTag},
+};
+use move_vm_runtime::{
+    data_cache::TransactionDataCache,
+    module_traversal::{TraversalContext, TraversalStorage},
+    move_vm::{MoveVm, SerializedReturnValues},
+    native_extensions::NativeContextExtensions,
+    AsUnsyncCodeStorage, AsUnsyncModuleStorage, CodeStorage, ModuleStorage,
+};
+use move_vm_test_utils::InMemoryStorage;
+use move_vm_types::{gas::UnmeteredGasMeter, resolver::ResourceResolver};
+
 mod bad_entry_point_tests;
 mod bad_storage_tests;
 mod binary_format_version;
@@ -18,3 +34,99 @@ mod regression_tests;
 mod return_value_tests;
 mod runtime_reentrancy_check_tests;
 mod vm_arguments_tests;
+
+/// Executes a Move script on top of the provided storage state, with the given arguments and type
+/// arguments.
+fn execute_script_for_test(
+    storage: &InMemoryStorage,
+    script: &[u8],
+    ty_args: &[TypeTag],
+    args: Vec<Vec<u8>>,
+) -> VMResult<()> {
+    execute_script_impl(storage, script, ty_args, args)?;
+    Ok(())
+}
+
+/// Executes a Move script on top of the provided storage state, and commits changes to resources
+/// to the storage.
+fn execute_script_and_commit_change_set_for_test(
+    storage: &mut InMemoryStorage,
+    script: &[u8],
+    ty_args: &[TypeTag],
+    args: Vec<Vec<u8>>,
+) -> VMResult<()> {
+    let change_set = execute_script_impl(storage, script, ty_args, args)?;
+    storage
+        .apply(change_set)
+        .map_err(|err| err.finish(Location::Undefined))?;
+    Ok(())
+}
+
+fn execute_function_with_single_storage_for_test(
+    storage: &InMemoryStorage,
+    module_id: &ModuleId,
+    function_name: &IdentStr,
+    ty_args: &[TypeTag],
+    args: Vec<Vec<u8>>,
+) -> VMResult<SerializedReturnValues> {
+    let module_storage = storage.as_unsync_module_storage();
+    execute_function_for_test(
+        storage,
+        &module_storage,
+        module_id,
+        function_name,
+        ty_args,
+        args,
+    )
+}
+
+fn execute_function_for_test(
+    data_storage: &impl ResourceResolver,
+    module_storage: &impl ModuleStorage,
+    module_id: &ModuleId,
+    function_name: &IdentStr,
+    ty_args: &[TypeTag],
+    args: Vec<Vec<u8>>,
+) -> VMResult<SerializedReturnValues> {
+    let traversal_storage = TraversalStorage::new();
+
+    let func = module_storage.load_function(module_id, function_name, ty_args)?;
+    MoveVm::execute_loaded_function(
+        func,
+        args,
+        &mut TransactionDataCache::empty(),
+        &mut UnmeteredGasMeter,
+        &mut TraversalContext::new(&traversal_storage),
+        &mut NativeContextExtensions::default(),
+        module_storage,
+        data_storage,
+    )
+}
+
+fn execute_script_impl(
+    storage: &InMemoryStorage,
+    script: &[u8],
+    ty_args: &[TypeTag],
+    args: Vec<Vec<u8>>,
+) -> VMResult<ChangeSet> {
+    let code_storage = storage.as_unsync_code_storage();
+    let traversal_storage = TraversalStorage::new();
+
+    let function = code_storage.load_script(script, ty_args)?;
+    let mut data_cache = TransactionDataCache::empty();
+
+    MoveVm::execute_loaded_function(
+        function,
+        args,
+        &mut data_cache,
+        &mut UnmeteredGasMeter,
+        &mut TraversalContext::new(&traversal_storage),
+        &mut NativeContextExtensions::default(),
+        &code_storage,
+        storage,
+    )?;
+    let change_set = data_cache
+        .into_effects(&code_storage)
+        .map_err(|err| err.finish(Location::Undefined))?;
+    Ok(change_set)
+}

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -12,7 +12,6 @@ mod invariant_violation_tests;
 mod leak_tests;
 mod loader_tests;
 mod module_storage_tests;
-mod mutated_accounts_tests;
 mod native_tests;
 mod nested_loop_tests;
 mod regression_tests;

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -10,17 +10,7 @@ use move_core_types::{
     account_address::AccountAddress, gas_algebra::InternalGas, ident_str, identifier::Identifier,
 };
 use move_vm_runtime::{
-<<<<<<< HEAD
-<<<<<<< HEAD
-    config::VMConfig, module_traversal::*, move_vm::MoveVM, native_functions::NativeFunction,
-    session::Session, AsUnsyncCodeStorage, ModuleStorage, RuntimeEnvironment, StagingModuleStorage,
-=======
-    config::VMConfig, module_traversal::*, move_vm::MoveVm, native_functions::NativeFunction,
-    AsUnsyncCodeStorage, ModuleStorage, RuntimeEnvironment, StagingModuleStorage,
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
     native_functions::NativeFunction, AsUnsyncCodeStorage, RuntimeEnvironment, StagingModuleStorage,
->>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::natives::function::NativeResult;
@@ -73,14 +63,6 @@ fn test_failed_native() {
         let runtime_environment = RuntimeEnvironment::new(natives);
         let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
->>>>>>> 35ea878580 (remove move vm session)
         let module_storage = storage.as_unsync_code_storage();
         let new_module_storage =
             StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob.clone().into()])

--- a/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/native_tests.rs
@@ -1,13 +1,16 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, compile_units};
+use crate::{
+    compiler::{as_module, compile_units},
+    tests::execute_function_for_test,
+};
 use move_binary_format::errors::PartialVMResult;
-use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
-    account_address::AccountAddress, gas_algebra::InternalGas, identifier::Identifier,
+    account_address::AccountAddress, gas_algebra::InternalGas, ident_str, identifier::Identifier,
 };
 use move_vm_runtime::{
+<<<<<<< HEAD
 <<<<<<< HEAD
     config::VMConfig, module_traversal::*, move_vm::MoveVM, native_functions::NativeFunction,
     session::Session, AsUnsyncCodeStorage, ModuleStorage, RuntimeEnvironment, StagingModuleStorage,
@@ -15,9 +18,12 @@ use move_vm_runtime::{
     config::VMConfig, module_traversal::*, move_vm::MoveVm, native_functions::NativeFunction,
     AsUnsyncCodeStorage, ModuleStorage, RuntimeEnvironment, StagingModuleStorage,
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+    native_functions::NativeFunction, AsUnsyncCodeStorage, RuntimeEnvironment, StagingModuleStorage,
+>>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::{gas::UnmeteredGasMeter, natives::function::NativeResult};
+use move_vm_types::natives::function::NativeResult;
 use std::sync::Arc;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -32,14 +38,14 @@ fn make_failed_native() -> NativeFunction {
 }
 
 #[test]
-fn test_publish_module_with_nested_loops() {
+fn test_failed_native() {
     let code = r#"
         module {{ADDR}}::M {
-            entry fun foo() {
+            fun foo() {
                 Self::bar();
             }
 
-            entry fun foo2() {
+            fun foo2() {
                 Self::foo1();
             }
 
@@ -56,7 +62,6 @@ fn test_publish_module_with_nested_loops() {
     let m = as_module(units.pop().unwrap());
     let mut m_blob = vec![];
     m.serialize(&mut m_blob).unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     {
         let natives = vec![(
@@ -65,56 +70,42 @@ fn test_publish_module_with_nested_loops() {
             Identifier::new("bar").unwrap(),
             make_failed_native(),
         )];
-        let vm_config = VMConfig {
-            verifier_config: VerifierConfig {
-                max_loop_depth: Some(2),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let runtime_environment = RuntimeEnvironment::new_with_config(natives, vm_config);
+        let runtime_environment = RuntimeEnvironment::new(natives);
         let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
 
+<<<<<<< HEAD
 <<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
 =======
         let mut session = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+>>>>>>> 35ea878580 (remove move vm session)
         let module_storage = storage.as_unsync_code_storage();
         let new_module_storage =
             StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob.clone().into()])
                 .expect("Module should be publishable");
 
-        let func = module_storage
-            .load_function(&m.self_id(), &Identifier::new("foo").unwrap(), &[])
-            .unwrap();
-        let err1 = session
-            .execute_entry_function(
-                func,
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &new_module_storage,
-                &storage,
-            )
-            .unwrap_err();
+        let err = execute_function_for_test(
+            &storage,
+            &new_module_storage,
+            &m.self_id(),
+            ident_str!("foo"),
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+        assert!(err.exec_state().unwrap().stack_trace().is_empty());
 
-        assert!(err1.exec_state().unwrap().stack_trace().is_empty());
-
-        let func = module_storage
-            .load_function(&m.self_id(), &Identifier::new("foo2").unwrap(), &[])
-            .unwrap();
-        let err2 = session
-            .execute_entry_function(
-                func,
-                Vec::<Vec<u8>>::new(),
-                &mut UnmeteredGasMeter,
-                &mut TraversalContext::new(&traversal_storage),
-                &new_module_storage,
-                &storage,
-            )
-            .unwrap_err();
-
-        assert_eq!(err2.exec_state().unwrap().stack_trace().len(), 1);
+        let err = execute_function_for_test(
+            &storage,
+            &new_module_storage,
+            &m.self_id(),
+            ident_str!("foo2"),
+            &[],
+            vec![],
+        )
+        .unwrap_err();
+        assert_eq!(err.exec_state().unwrap().stack_trace().len(), 1);
     }
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -1,17 +1,36 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, as_script, compile_units};
+use crate::{
+    compiler::{as_module, as_script, compile_units},
+    tests::execute_script_for_test,
+};
+use claims::{assert_err, assert_ok};
 use move_bytecode_verifier::VerifierConfig;
 use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::{
+<<<<<<< HEAD
     config::VMConfig, module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage,
     AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
+=======
+    config::VMConfig, AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
+>>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
+
+fn initialize_storage(max_loop_depth: usize) -> InMemoryStorage {
+    let vm_config = VMConfig {
+        verifier_config: VerifierConfig {
+            max_loop_depth: Some(max_loop_depth),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
+    InMemoryStorage::new_with_runtime_environment(runtime_environment)
+}
 
 #[test]
 fn test_publish_module_with_nested_loops() {
@@ -38,33 +57,17 @@ fn test_publish_module_with_nested_loops() {
 
     // Should succeed with max_loop_depth = 2
     {
-        let vm_config = VMConfig {
-            verifier_config: VerifierConfig {
-                max_loop_depth: Some(2),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
-        let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
+        let storage = initialize_storage(2);
 
         let module_storage = storage.as_unsync_module_storage();
         let result =
             StagingModuleStorage::create(&TEST_ADDR, &module_storage, vec![m_blob.clone().into()]);
-        assert!(result.is_ok());
+        assert_ok!(result);
     }
 
     // Should fail with max_loop_depth = 1
     {
-        let vm_config = VMConfig {
-            verifier_config: VerifierConfig {
-                max_loop_depth: Some(1),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
-        let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
+        let storage = initialize_storage(1);
 
         let module_storage = storage.as_unsync_module_storage();
         let result =
@@ -95,10 +98,10 @@ fn test_run_script_with_nested_loops() {
     let s = as_script(units.pop().unwrap());
     let mut s_blob: Vec<u8> = vec![];
     s.serialize(&mut s_blob).unwrap();
-    let traversal_storage = TraversalStorage::new();
 
     // Should succeed with max_loop_depth = 2
     {
+<<<<<<< HEAD
         let vm_config = VMConfig {
             verifier_config: VerifierConfig {
                 max_loop_depth: Some(2),
@@ -126,10 +129,16 @@ fn test_run_script_with_nested_loops() {
             &storage,
         )
         .unwrap();
+=======
+        let storage = initialize_storage(2);
+        let result = execute_script_for_test(&storage, &s_blob, &[], vec![]);
+        assert_ok!(result);
+>>>>>>> 35ea878580 (remove move vm session)
     }
 
     // Should fail with max_loop_depth = 1
     {
+<<<<<<< HEAD
         let vm_config = VMConfig {
             verifier_config: VerifierConfig {
                 max_loop_depth: Some(1),
@@ -157,5 +166,10 @@ fn test_run_script_with_nested_loops() {
             &storage,
         )
         .unwrap_err();
+=======
+        let storage = initialize_storage(1);
+        let result = execute_script_for_test(&storage, &s_blob, &[], vec![]);
+        assert_err!(result);
+>>>>>>> 35ea878580 (remove move vm session)
     }
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -110,7 +110,11 @@ fn test_run_script_with_nested_loops() {
         let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
         let code_storage = storage.as_unsync_code_storage();
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let args: Vec<Vec<u8>> = vec![];
         sess.load_and_execute_script(
             s_blob.clone(),
@@ -119,6 +123,7 @@ fn test_run_script_with_nested_loops() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .unwrap();
     }
@@ -136,7 +141,11 @@ fn test_run_script_with_nested_loops() {
         let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
         let code_storage = storage.as_unsync_code_storage();
 
+<<<<<<< HEAD
         let mut sess = MoveVM::new_session(&storage);
+=======
+        let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let args: Vec<Vec<u8>> = vec![];
         sess.load_and_execute_script(
             s_blob,
@@ -145,6 +154,7 @@ fn test_run_script_with_nested_loops() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .unwrap_err();
     }

--- a/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/nested_loop_tests.rs
@@ -9,12 +9,7 @@ use claims::{assert_err, assert_ok};
 use move_bytecode_verifier::VerifierConfig;
 use move_core_types::account_address::AccountAddress;
 use move_vm_runtime::{
-<<<<<<< HEAD
-    config::VMConfig, module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage,
-    AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
-=======
     config::VMConfig, AsUnsyncModuleStorage, RuntimeEnvironment, StagingModuleStorage,
->>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::InMemoryStorage;
 
@@ -101,75 +96,15 @@ fn test_run_script_with_nested_loops() {
 
     // Should succeed with max_loop_depth = 2
     {
-<<<<<<< HEAD
-        let vm_config = VMConfig {
-            verifier_config: VerifierConfig {
-                max_loop_depth: Some(2),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
-        let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
-        let code_storage = storage.as_unsync_code_storage();
-
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let args: Vec<Vec<u8>> = vec![];
-        sess.load_and_execute_script(
-            s_blob.clone(),
-            vec![],
-            args,
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap();
-=======
         let storage = initialize_storage(2);
         let result = execute_script_for_test(&storage, &s_blob, &[], vec![]);
         assert_ok!(result);
->>>>>>> 35ea878580 (remove move vm session)
     }
 
     // Should fail with max_loop_depth = 1
     {
-<<<<<<< HEAD
-        let vm_config = VMConfig {
-            verifier_config: VerifierConfig {
-                max_loop_depth: Some(1),
-                ..Default::default()
-            },
-            ..Default::default()
-        };
-        let runtime_environment = RuntimeEnvironment::new_with_config(vec![], vm_config);
-        let storage = InMemoryStorage::new_with_runtime_environment(runtime_environment);
-        let code_storage = storage.as_unsync_code_storage();
-
-<<<<<<< HEAD
-        let mut sess = MoveVM::new_session(&storage);
-=======
-        let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        let args: Vec<Vec<u8>> = vec![];
-        sess.load_and_execute_script(
-            s_blob,
-            vec![],
-            args,
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap_err();
-=======
         let storage = initialize_storage(1);
         let result = execute_script_for_test(&storage, &s_blob, &[], vec![]);
         assert_err!(result);
->>>>>>> 35ea878580 (remove move vm session)
     }
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
@@ -1,7 +1,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, as_script, compile_units_with_stdlib};
+use crate::{
+    compiler::{as_module, as_script, compile_units_with_stdlib},
+    tests::execute_script_for_test,
+};
 use move_binary_format::file_format::{Bytecode, CompiledModule, CompiledScript, SignatureIndex};
 use move_bytecode_verifier::VerifierConfig;
 use move_core_types::{
@@ -10,11 +13,14 @@ use move_core_types::{
     language_storage::{StructTag, TypeTag},
     vm_status::StatusCode,
 };
+<<<<<<< HEAD
 use move_vm_runtime::{
     config::VMConfig, module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage, RuntimeEnvironment,
 };
+=======
+use move_vm_runtime::{config::VMConfig, RuntimeEnvironment};
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 use std::time::Instant;
 
 fn get_nested_struct_type(
@@ -127,7 +133,7 @@ fn script_large_ty() {
     // constructs a type with about 25^3 nodes
     let num_type_args = 25;
     let struct_name = Identifier::new(format!("Struct{}TyArgs", num_type_args)).unwrap();
-    let input_type = get_nested_struct_type(
+    let input_ty = get_nested_struct_type(
         3,
         num_type_args,
         module_address,
@@ -135,6 +141,7 @@ fn script_large_ty() {
         struct_name,
     );
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
 =======
@@ -153,6 +160,11 @@ fn script_large_ty() {
             &storage,
         )
         .unwrap_err();
+=======
+    let status = execute_script_for_test(&storage, &script, &[input_ty], vec![])
+        .unwrap_err()
+        .major_status();
+>>>>>>> 35ea878580 (remove move vm session)
 
-    assert_eq!(res.major_status(), StatusCode::TOO_MANY_TYPE_NODES);
+    assert_eq!(status, StatusCode::TOO_MANY_TYPE_NODES);
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
@@ -13,13 +13,7 @@ use move_core_types::{
     language_storage::{StructTag, TypeTag},
     vm_status::StatusCode,
 };
-<<<<<<< HEAD
-use move_vm_runtime::{
-    config::VMConfig, module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage, RuntimeEnvironment,
-};
-=======
 use move_vm_runtime::{config::VMConfig, RuntimeEnvironment};
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 use std::time::Instant;
 
@@ -141,30 +135,8 @@ fn script_large_ty() {
         struct_name,
     );
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-    let code_storage = storage.as_unsync_code_storage();
-    let traversal_storage = TraversalStorage::new();
-    let res = session
-        .load_and_execute_script(
-            script.as_ref(),
-            vec![input_type],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .unwrap_err();
-=======
     let status = execute_script_for_test(&storage, &script, &[input_ty], vec![])
         .unwrap_err()
         .major_status();
->>>>>>> 35ea878580 (remove move vm session)
-
     assert_eq!(status, StatusCode::TOO_MANY_TYPE_NODES);
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/regression_tests.rs
@@ -135,7 +135,11 @@ fn script_large_ty() {
         struct_name,
     );
 
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
     let code_storage = storage.as_unsync_code_storage();
     let traversal_storage = TraversalStorage::new();
     let res = session
@@ -146,6 +150,7 @@ fn script_large_ty() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .unwrap_err();
 

--- a/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -51,7 +51,11 @@ fn run(
     let mut storage = InMemoryStorage::new();
     storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
+=======
+    let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let fun_name = Identifier::new("foo").unwrap();
 
@@ -74,6 +78,7 @@ fn run(
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
         &module_storage,
+        &storage,
     )?;
 
     Ok(return_values

--- a/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -2,7 +2,10 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, compile_units};
+use crate::{
+    compiler::{as_module, compile_units},
+    tests::execute_function_with_single_storage_for_test,
+};
 use move_binary_format::errors::VMResult;
 use move_core_types::{
     account_address::AccountAddress,
@@ -10,11 +13,14 @@ use move_core_types::{
     language_storage::TypeTag,
     value::{MoveTypeLayout, MoveValue},
 };
+<<<<<<< HEAD
 use move_vm_runtime::{
     module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues, AsUnsyncModuleStorage,
 };
+=======
+use move_vm_runtime::move_vm::SerializedReturnValues;
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
 
@@ -52,33 +58,29 @@ fn run(
     storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
 <<<<<<< HEAD
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
 =======
     let mut sess = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
+=======
+>>>>>>> 35ea878580 (remove move vm session)
     let fun_name = Identifier::new("foo").unwrap();
-
     let args: Vec<_> = args
         .into_iter()
         .map(|val| val.simple_serialize().unwrap())
         .collect();
 
-    let module_storage = storage.as_unsync_module_storage();
-    let traversal_storage = TraversalStorage::new();
-
     let SerializedReturnValues {
         return_values,
         mutable_reference_outputs: _,
-    } = sess.execute_function_bypass_visibility(
+    } = execute_function_with_single_storage_for_test(
+        &storage,
         &m.self_id(),
         &fun_name,
-        ty_args,
+        &ty_args,
         args,
-        &mut UnmeteredGasMeter,
-        &mut TraversalContext::new(&traversal_storage),
-        &module_storage,
-        &storage,
     )?;
 
     Ok(return_values

--- a/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/return_value_tests.rs
@@ -13,13 +13,7 @@ use move_core_types::{
     language_storage::TypeTag,
     value::{MoveTypeLayout, MoveValue},
 };
-<<<<<<< HEAD
-use move_vm_runtime::{
-    module_traversal::*, move_vm::MoveVM, session::SerializedReturnValues, AsUnsyncModuleStorage,
-};
-=======
 use move_vm_runtime::move_vm::SerializedReturnValues;
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 
 const TEST_ADDR: AccountAddress = AccountAddress::new([42; AccountAddress::LENGTH]);
@@ -57,15 +51,6 @@ fn run(
     let mut storage = InMemoryStorage::new();
     storage.add_module_bytes(m.self_addr(), m.self_name(), blob.into());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut sess = MoveVM::new_session(&storage);
-=======
-    let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-
-=======
->>>>>>> 35ea878580 (remove move vm session)
     let fun_name = Identifier::new("foo").unwrap();
     let args: Vec<_> = args
         .into_iter()

--- a/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
@@ -161,7 +161,11 @@ fn runtime_reentrancy_check() {
     let args: Vec<Vec<u8>> = vec![];
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("A").unwrap());
 
+<<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
+=======
+    let mut sess = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
     let module_storage = storage.as_unsync_module_storage();
     let traversal_storage = TraversalStorage::new();
 
@@ -176,6 +180,7 @@ fn runtime_reentrancy_check() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap_err()
         .major_status(),
@@ -195,6 +200,7 @@ fn runtime_reentrancy_check() {
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
         &module_storage,
+        &storage,
     )
     .unwrap();
 
@@ -210,6 +216,7 @@ fn runtime_reentrancy_check() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
         .unwrap_err()
         .major_status(),

--- a/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
@@ -2,18 +2,26 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::compiler::{as_module, compile_units};
+use crate::{
+    compiler::{as_module, compile_units},
+    tests::execute_function_with_single_storage_for_test,
+};
+use claims::assert_ok;
 use move_binary_format::errors::PartialVMResult;
 use move_core_types::{
-    account_address::AccountAddress, gas_algebra::GasQuantity, identifier::Identifier,
+    account_address::AccountAddress, gas_algebra::GasQuantity, ident_str, identifier::Identifier,
     language_storage::ModuleId, vm_status::StatusCode,
 };
+<<<<<<< HEAD
 use move_vm_runtime::{
     module_traversal::*, move_vm::MoveVM, native_functions::NativeFunction, AsUnsyncModuleStorage,
     RuntimeEnvironment,
 };
+=======
+use move_vm_runtime::{native_functions::NativeFunction, RuntimeEnvironment};
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::{gas::UnmeteredGasMeter, natives::function::NativeResult};
+use move_vm_types::natives::function::NativeResult;
 use smallvec::SmallVec;
 use std::sync::Arc;
 
@@ -157,10 +165,9 @@ fn runtime_reentrancy_check() {
 
     compile_and_publish(&mut storage, code_3);
 
-    let fun_name = Identifier::new("foo1").unwrap();
-    let args: Vec<Vec<u8>> = vec![];
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("A").unwrap());
 
+<<<<<<< HEAD
 <<<<<<< HEAD
     let mut sess = MoveVM::new_session(&storage);
 =======
@@ -169,57 +176,44 @@ fn runtime_reentrancy_check() {
     let module_storage = storage.as_unsync_module_storage();
     let traversal_storage = TraversalStorage::new();
 
+=======
+>>>>>>> 35ea878580 (remove move vm session)
     // Call stack look like following:
     // A::foo1 -> B::foo1 -> B::dispatch -> A::foo3, Re-entrancy happens at foo3.
-    assert_eq!(
-        sess.execute_function_bypass_visibility(
-            &module_id,
-            &fun_name,
-            vec![],
-            args.clone(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap_err()
-        .major_status(),
-        StatusCode::RUNTIME_DISPATCH_ERROR
-    );
+    let status = execute_function_with_single_storage_for_test(
+        &storage,
+        &module_id,
+        ident_str!("foo1"),
+        &[],
+        vec![],
+    )
+    .unwrap_err()
+    .major_status();
+    assert_eq!(status, StatusCode::RUNTIME_DISPATCH_ERROR);
 
     // Call stack look like following:
     // A::foo2 -> B::foo2 -> B::dispatch_c -> C::foo3, No reentrancy, executed successfully.
     //
     // Note that C needs to be loaded into module cache at runtime.
-    let fun_name = Identifier::new("foo2").unwrap();
-    sess.execute_function_bypass_visibility(
-        &module_id,
-        &fun_name,
-        vec![],
-        args.clone(),
-        &mut UnmeteredGasMeter,
-        &mut TraversalContext::new(&traversal_storage),
-        &module_storage,
+    let result = execute_function_with_single_storage_for_test(
         &storage,
-    )
-    .unwrap();
+        &module_id,
+        ident_str!("foo2"),
+        &[],
+        vec![],
+    );
+    assert_ok!(result);
 
     // Call stack look like following:
     // A::foo3 -> B::foo3 -> B::dispatch_d -> D::foo3, D doesn't exist, thus an error.
-    let fun_name = Identifier::new("foo3").unwrap();
-    assert_eq!(
-        sess.execute_function_bypass_visibility(
-            &module_id,
-            &fun_name,
-            vec![],
-            args,
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap_err()
-        .major_status(),
-        StatusCode::FUNCTION_RESOLUTION_FAILURE
-    );
+    let status = execute_function_with_single_storage_for_test(
+        &storage,
+        &module_id,
+        ident_str!("foo3"),
+        &[],
+        vec![],
+    )
+    .unwrap_err()
+    .major_status();
+    assert_eq!(status, StatusCode::FUNCTION_RESOLUTION_FAILURE);
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/runtime_reentrancy_check_tests.rs
@@ -12,14 +12,7 @@ use move_core_types::{
     account_address::AccountAddress, gas_algebra::GasQuantity, ident_str, identifier::Identifier,
     language_storage::ModuleId, vm_status::StatusCode,
 };
-<<<<<<< HEAD
-use move_vm_runtime::{
-    module_traversal::*, move_vm::MoveVM, native_functions::NativeFunction, AsUnsyncModuleStorage,
-    RuntimeEnvironment,
-};
-=======
 use move_vm_runtime::{native_functions::NativeFunction, RuntimeEnvironment};
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 use move_vm_types::natives::function::NativeResult;
 use smallvec::SmallVec;
@@ -167,17 +160,6 @@ fn runtime_reentrancy_check() {
 
     let module_id = ModuleId::new(TEST_ADDR, Identifier::new("A").unwrap());
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-    let mut sess = MoveVM::new_session(&storage);
-=======
-    let mut sess = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-    let module_storage = storage.as_unsync_module_storage();
-    let traversal_storage = TraversalStorage::new();
-
-=======
->>>>>>> 35ea878580 (remove move vm session)
     // Call stack look like following:
     // A::foo1 -> B::foo1 -> B::dispatch -> A::foo3, Re-entrancy happens at foo3.
     let status = execute_function_with_single_storage_for_test(

--- a/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
@@ -23,12 +23,6 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
-<<<<<<< HEAD
-use move_vm_runtime::{
-    module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage, AsUnsyncModuleStorage,
-};
-=======
->>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
 
 // make a script with a given signature for main.
@@ -260,31 +254,8 @@ fn call_script_with_args_ty_args_signers(
     signers: Vec<AccountAddress>,
 ) -> VMResult<()> {
     let storage = InMemoryStorage::new();
-<<<<<<< HEAD
-    let code_storage = storage.as_unsync_code_storage();
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-
-    let traversal_storage = TraversalStorage::new();
-
-    session
-        .load_and_execute_script(
-            script,
-            ty_args,
-            combine_signers_and_args(signers, non_signer_args),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &code_storage,
-            &storage,
-        )
-        .map(|_| ())
-=======
     let args = combine_signers_and_args(signers, non_signer_args);
     execute_script_for_test(&storage, &script, &ty_args, args)
->>>>>>> 35ea878580 (remove move vm session)
 }
 
 fn call_script(script: Vec<u8>, args: Vec<Vec<u8>>) -> VMResult<()> {
@@ -305,15 +276,6 @@ fn call_function_with_args_ty_args_signers(
     module.serialize(&mut module_blob).unwrap();
 
     storage.add_module_bytes(module_id.address(), module_id.name(), module_blob.into());
-<<<<<<< HEAD
-    let module_storage = storage.as_unsync_module_storage();
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
->>>>>>> 35ea878580 (remove move vm session)
 
     execute_function_with_single_storage_for_test(
         &storage,
@@ -794,36 +756,6 @@ fn call_missing_item() {
 
     // missing module
     let mut storage = InMemoryStorage::new();
-<<<<<<< HEAD
-    let module_storage = storage.as_unsync_module_storage();
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-
-    let traversal_storage = TraversalStorage::new();
-    let error = session
-        .execute_function_bypass_visibility(
-            &module_id,
-            function_name,
-            vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap_err();
-    assert_eq!(
-        error.major_status(),
-        StatusCode::LINKER_ERROR,
-        "Linker Error: Call to item at a non-existent external module {:?}",
-        module
-    );
-    assert_eq!(error.status_type(), StatusType::Verification);
-    drop(session);
-=======
     let err = execute_function_with_single_storage_for_test(
         &storage,
         &module_id,
@@ -834,37 +766,9 @@ fn call_missing_item() {
     .unwrap_err();
     assert_eq!(err.major_status(), StatusCode::LINKER_ERROR);
     assert_eq!(err.status_type(), StatusType::Verification);
->>>>>>> 35ea878580 (remove move vm session)
 
     // missing function
     storage.add_module_bytes(module_id.address(), module_id.name(), module_blob.into());
-<<<<<<< HEAD
-    let module_storage = storage.as_unsync_module_storage();
-<<<<<<< HEAD
-    let mut session = MoveVM::new_session(&storage);
-=======
-    let mut session = MoveVm::new_session();
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-
-    let traversal_storage = TraversalStorage::new();
-    let error = session
-        .execute_function_bypass_visibility(
-            &module_id,
-            function_name,
-            vec![],
-            Vec::<Vec<u8>>::new(),
-            &mut UnmeteredGasMeter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &storage,
-        )
-        .unwrap_err();
-    assert_eq!(
-        error.major_status(),
-        StatusCode::FUNCTION_RESOLUTION_FAILURE
-    );
-    assert_eq!(error.status_type(), StatusType::Verification);
-=======
     let err = execute_function_with_single_storage_for_test(
         &storage,
         &module_id,
@@ -875,5 +779,4 @@ fn call_missing_item() {
     .unwrap_err();
     assert_eq!(err.major_status(), StatusCode::FUNCTION_RESOLUTION_FAILURE);
     assert_eq!(err.status_type(), StatusType::Verification);
->>>>>>> 35ea878580 (remove move vm session)
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
@@ -2,6 +2,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::tests::{execute_function_with_single_storage_for_test, execute_script_for_test};
 use move_binary_format::{
     errors::VMResult,
     file_format::{
@@ -22,11 +23,13 @@ use move_core_types::{
     value::{serialize_values, MoveValue},
     vm_status::{StatusCode, StatusType},
 };
+<<<<<<< HEAD
 use move_vm_runtime::{
     module_traversal::*, move_vm::MoveVM, AsUnsyncCodeStorage, AsUnsyncModuleStorage,
 };
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 use move_vm_test_utils::InMemoryStorage;
-use move_vm_types::gas::UnmeteredGasMeter;
 
 // make a script with a given signature for main.
 fn make_script(parameters: Signature) -> Vec<u8> {
@@ -257,6 +260,7 @@ fn call_script_with_args_ty_args_signers(
     signers: Vec<AccountAddress>,
 ) -> VMResult<()> {
     let storage = InMemoryStorage::new();
+<<<<<<< HEAD
     let code_storage = storage.as_unsync_code_storage();
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
@@ -277,6 +281,10 @@ fn call_script_with_args_ty_args_signers(
             &storage,
         )
         .map(|_| ())
+=======
+    let args = combine_signers_and_args(signers, non_signer_args);
+    execute_script_for_test(&storage, &script, &ty_args, args)
+>>>>>>> 35ea878580 (remove move vm session)
 }
 
 fn call_script(script: Vec<u8>, args: Vec<Vec<u8>>) -> VMResult<()> {
@@ -297,23 +305,22 @@ fn call_function_with_args_ty_args_signers(
     module.serialize(&mut module_blob).unwrap();
 
     storage.add_module_bytes(module_id.address(), module_id.name(), module_blob.into());
+<<<<<<< HEAD
     let module_storage = storage.as_unsync_module_storage();
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
 =======
     let mut session = MoveVm::new_session();
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+>>>>>>> 35ea878580 (remove move vm session)
 
-    let traversal_storage = TraversalStorage::new();
-    session.execute_function_bypass_visibility(
+    execute_function_with_single_storage_for_test(
+        &storage,
         &module_id,
         function_name.as_ident_str(),
-        ty_args,
+        &ty_args,
         combine_signers_and_args(signers, non_signer_args),
-        &mut UnmeteredGasMeter,
-        &mut TraversalContext::new(&traversal_storage),
-        &module_storage,
-        &storage,
     )?;
     Ok(())
 }
@@ -786,9 +793,8 @@ fn call_missing_item() {
     module.serialize(&mut module_blob).unwrap();
 
     // missing module
-    let function_name = ident_str!("foo");
-
     let mut storage = InMemoryStorage::new();
+<<<<<<< HEAD
     let module_storage = storage.as_unsync_module_storage();
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
@@ -817,10 +823,22 @@ fn call_missing_item() {
     );
     assert_eq!(error.status_type(), StatusType::Verification);
     drop(session);
+=======
+    let err = execute_function_with_single_storage_for_test(
+        &storage,
+        &module_id,
+        ident_str!("foo"),
+        &[],
+        vec![],
+    )
+    .unwrap_err();
+    assert_eq!(err.major_status(), StatusCode::LINKER_ERROR);
+    assert_eq!(err.status_type(), StatusType::Verification);
+>>>>>>> 35ea878580 (remove move vm session)
 
     // missing function
-
     storage.add_module_bytes(module_id.address(), module_id.name(), module_blob.into());
+<<<<<<< HEAD
     let module_storage = storage.as_unsync_module_storage();
 <<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
@@ -846,4 +864,16 @@ fn call_missing_item() {
         StatusCode::FUNCTION_RESOLUTION_FAILURE
     );
     assert_eq!(error.status_type(), StatusType::Verification);
+=======
+    let err = execute_function_with_single_storage_for_test(
+        &storage,
+        &module_id,
+        ident_str!("foo"),
+        &[],
+        vec![],
+    )
+    .unwrap_err();
+    assert_eq!(err.major_status(), StatusCode::FUNCTION_RESOLUTION_FAILURE);
+    assert_eq!(err.status_type(), StatusType::Verification);
+>>>>>>> 35ea878580 (remove move vm session)
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
@@ -258,7 +258,11 @@ fn call_script_with_args_ty_args_signers(
 ) -> VMResult<()> {
     let storage = InMemoryStorage::new();
     let code_storage = storage.as_unsync_code_storage();
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let traversal_storage = TraversalStorage::new();
 
@@ -270,6 +274,7 @@ fn call_script_with_args_ty_args_signers(
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &code_storage,
+            &storage,
         )
         .map(|_| ())
 }
@@ -293,7 +298,11 @@ fn call_function_with_args_ty_args_signers(
 
     storage.add_module_bytes(module_id.address(), module_id.name(), module_blob.into());
     let module_storage = storage.as_unsync_module_storage();
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let traversal_storage = TraversalStorage::new();
     session.execute_function_bypass_visibility(
@@ -304,6 +313,7 @@ fn call_function_with_args_ty_args_signers(
         &mut UnmeteredGasMeter,
         &mut TraversalContext::new(&traversal_storage),
         &module_storage,
+        &storage,
     )?;
     Ok(())
 }
@@ -780,7 +790,11 @@ fn call_missing_item() {
 
     let mut storage = InMemoryStorage::new();
     let module_storage = storage.as_unsync_module_storage();
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let traversal_storage = TraversalStorage::new();
     let error = session
@@ -792,9 +806,9 @@ fn call_missing_item() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
-        .err()
-        .unwrap();
+        .unwrap_err();
     assert_eq!(
         error.major_status(),
         StatusCode::LINKER_ERROR,
@@ -808,7 +822,11 @@ fn call_missing_item() {
 
     storage.add_module_bytes(module_id.address(), module_id.name(), module_blob.into());
     let module_storage = storage.as_unsync_module_storage();
+<<<<<<< HEAD
     let mut session = MoveVM::new_session(&storage);
+=======
+    let mut session = MoveVm::new_session();
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
 
     let traversal_storage = TraversalStorage::new();
     let error = session
@@ -820,9 +838,9 @@ fn call_missing_item() {
             &mut UnmeteredGasMeter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &storage,
         )
-        .err()
-        .unwrap();
+        .unwrap_err();
     assert_eq!(
         error.major_status(),
         StatusCode::FUNCTION_RESOLUTION_FAILURE

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -51,17 +51,15 @@ impl AccountDataCache {
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache<'r> {
-    remote: &'r dyn ResourceResolver,
+pub(crate) struct TransactionDataCache {
     account_map: BTreeMap<AccountAddress, AccountDataCache>,
 }
 
-impl<'r> TransactionDataCache<'r> {
+impl TransactionDataCache {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn new(remote: &'r impl ResourceResolver) -> Self {
+    pub(crate) fn empty() -> Self {
         TransactionDataCache {
-            remote,
             account_map: BTreeMap::new(),
         }
     }
@@ -125,17 +123,6 @@ impl<'r> TransactionDataCache<'r> {
         Ok(change_set)
     }
 
-    pub(crate) fn num_mutated_resources(&self, sender: &AccountAddress) -> u64 {
-        // The sender's account will always be mutated.
-        let mut total_mutated_accounts: u64 = 1;
-        for (addr, entry) in self.account_map.iter() {
-            if addr != sender && entry.data_map.values().any(|(_, v, _)| v.is_mutated()) {
-                total_mutated_accounts += 1;
-            }
-        }
-        total_mutated_accounts
-    }
-
     fn get_mut_or_insert_with<'a, K, V, F>(map: &'a mut BTreeMap<K, V>, k: &K, gen: F) -> &'a mut V
     where
         F: FnOnce() -> (K, V),
@@ -154,6 +141,7 @@ impl<'r> TransactionDataCache<'r> {
     pub(crate) fn load_resource(
         &mut self,
         module_storage: &dyn ModuleStorage,
+        resource_resolver: &dyn ResourceResolver,
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)> {
@@ -185,7 +173,7 @@ impl<'r> TransactionDataCache<'r> {
                 // If we need to process aggregator lifting, we pass type layout to remote.
                 // Remote, in turn ensures that all aggregator values are lifted if the resolved
                 // resource comes from storage.
-                self.remote.get_resource_bytes_with_metadata_and_layout(
+                resource_resolver.get_resource_bytes_with_metadata_and_layout(
                     &addr,
                     &ty_tag,
                     &metadata,

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -51,14 +51,14 @@ impl AccountDataCache {
 /// The Move VM takes a `DataStore` in input and this is the default and correct implementation
 /// for a data store related to a transaction. Clients should create an instance of this type
 /// and pass it to the Move VM.
-pub(crate) struct TransactionDataCache {
+pub struct TransactionDataCache {
     account_map: BTreeMap<AccountAddress, AccountDataCache>,
 }
 
 impl TransactionDataCache {
     /// Create a `TransactionDataCache` with a `RemoteCache` that provides access to data
     /// not updated in the transaction.
-    pub(crate) fn empty() -> Self {
+    pub fn empty() -> Self {
         TransactionDataCache {
             account_map: BTreeMap::new(),
         }
@@ -68,10 +68,7 @@ impl TransactionDataCache {
     /// published modules.
     ///
     /// Gives all proper guarantees on lifetime of global data as well.
-    pub(crate) fn into_effects(
-        self,
-        module_storage: &dyn ModuleStorage,
-    ) -> PartialVMResult<ChangeSet> {
+    pub fn into_effects(self, module_storage: &dyn ModuleStorage) -> PartialVMResult<ChangeSet> {
         let resource_converter =
             |value: Value, layout: MoveTypeLayout, _: bool| -> PartialVMResult<Bytes> {
                 let function_value_extension = FunctionValueExtensionAdapter { module_storage };
@@ -89,7 +86,7 @@ impl TransactionDataCache {
 
     /// Same like `into_effects`, but also allows clients to select the format of
     /// produced effects for resources.
-    pub(crate) fn into_custom_effects<Resource>(
+    pub fn into_custom_effects<Resource>(
         self,
         resource_converter: &dyn Fn(Value, MoveTypeLayout, bool) -> PartialVMResult<Resource>,
         module_storage: &dyn ModuleStorage,

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -46,6 +46,7 @@ use move_vm_types::{
         runtime_types::Type,
     },
     natives::function::NativeResult,
+    resolver::ResourceResolver,
     values::{
         self, AbstractFunction, Closure, GlobalValue, IntegerValue, Locals, Reference, SignerRef,
         Struct, StructRef, VMValueCast, Value, Vector, VectorRef,
@@ -117,6 +118,7 @@ impl Interpreter {
         args: Vec<Value>,
         data_store: &mut TransactionDataCache,
         module_storage: &impl ModuleStorage,
+        resource_resolver: &impl ResourceResolver,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
@@ -126,6 +128,7 @@ impl Interpreter {
             args,
             data_store,
             module_storage,
+            resource_resolver,
             gas_meter,
             traversal_context,
             extensions,
@@ -141,6 +144,7 @@ impl InterpreterImpl<'_> {
         args: Vec<Value>,
         data_store: &mut TransactionDataCache,
         module_storage: &impl ModuleStorage,
+        resource_resolver: &impl ResourceResolver,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
@@ -159,6 +163,7 @@ impl InterpreterImpl<'_> {
         if interpreter.vm_config.paranoid_type_checks {
             interpreter.dispatch_execute_main::<FullRuntimeTypeCheck>(
                 data_store,
+                resource_resolver,
                 module_storage,
                 gas_meter,
                 traversal_context,
@@ -169,6 +174,7 @@ impl InterpreterImpl<'_> {
         } else {
             interpreter.dispatch_execute_main::<NoRuntimeTypeCheck>(
                 data_store,
+                resource_resolver,
                 module_storage,
                 gas_meter,
                 traversal_context,
@@ -220,6 +226,7 @@ impl InterpreterImpl<'_> {
     fn dispatch_execute_main<RTTCheck: RuntimeTypeCheck>(
         self,
         data_store: &mut TransactionDataCache,
+        resource_resolver: &impl ResourceResolver,
         module_storage: &impl ModuleStorage,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
@@ -230,6 +237,7 @@ impl InterpreterImpl<'_> {
         if self.vm_config.use_call_tree_and_instruction_cache {
             self.execute_main::<RTTCheck, AllRuntimeCaches>(
                 data_store,
+                resource_resolver,
                 module_storage,
                 gas_meter,
                 traversal_context,
@@ -240,6 +248,7 @@ impl InterpreterImpl<'_> {
         } else {
             self.execute_main::<RTTCheck, NoRuntimeCaches>(
                 data_store,
+                resource_resolver,
                 module_storage,
                 gas_meter,
                 traversal_context,
@@ -259,6 +268,7 @@ impl InterpreterImpl<'_> {
     fn execute_main<RTTCheck: RuntimeTypeCheck, RTCaches: RuntimeCacheTraits>(
         mut self,
         data_store: &mut TransactionDataCache,
+        resource_resolver: &impl ResourceResolver,
         module_storage: &impl ModuleStorage,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
@@ -299,7 +309,7 @@ impl InterpreterImpl<'_> {
             .map_err(|e| self.set_location(e))?;
 
         loop {
-            let resolver = current_frame.resolver(module_storage);
+            let resolver = current_frame.resolver(module_storage, resource_resolver);
             let exit_code = current_frame
                 .execute_code::<RTTCheck, RTCaches>(&resolver, &mut self, data_store, gas_meter)
                 .map_err(|err| self.attach_state_if_invariant_violation(err, &current_frame))?;
@@ -1113,7 +1123,12 @@ impl InterpreterImpl<'_> {
         addr: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<&'c mut GlobalValue> {
-        match data_store.load_resource(resolver.module_storage(), addr, ty) {
+        match data_store.load_resource(
+            resolver.module_storage(),
+            resolver.resource_resolver(),
+            addr,
+            ty,
+        ) {
             Ok((gv, load_res)) => {
                 if let Some(bytes_loaded) = load_res {
                     gas_meter.charge_load_resource(
@@ -2720,8 +2735,13 @@ impl Frame {
         }
     }
 
-    fn resolver<'a>(&self, module_storage: &'a impl ModuleStorage) -> Resolver<'a> {
-        self.function.get_resolver(module_storage)
+    fn resolver<'a>(
+        &self,
+        module_storage: &'a impl ModuleStorage,
+        resource_resolver: &'a impl ResourceResolver,
+    ) -> Resolver<'a> {
+        self.function
+            .get_resolver(module_storage, resource_resolver)
     }
 
     fn location(&self) -> Location {

--- a/third_party/move/move-vm/runtime/src/lib.rs
+++ b/third_party/move/move-vm/runtime/src/lib.rs
@@ -14,7 +14,6 @@ pub mod logging;
 pub mod move_vm;
 pub mod native_extensions;
 pub mod native_functions;
-pub mod session;
 #[macro_use]
 pub mod tracing;
 pub mod config;

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -355,7 +355,7 @@ impl LoadedFunction {
     }
 
     /// Returns true if the loaded function is an entry function.
-    pub(crate) fn is_entry(&self) -> bool {
+    pub fn is_entry(&self) -> bool {
         self.function.is_entry()
     }
 

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -43,6 +43,8 @@ pub(crate) use function::{
 };
 mod modules;
 pub use modules::Module;
+use move_vm_types::resolver::ResourceResolver;
+
 mod script;
 pub use script::Script;
 mod type_loader;
@@ -59,22 +61,33 @@ enum BinaryType {
 pub(crate) struct Resolver<'a> {
     binary: BinaryType,
     module_storage: &'a dyn ModuleStorage,
+    resource_resolver: &'a dyn ResourceResolver,
 }
 
 impl<'a> Resolver<'a> {
-    fn for_module(module_storage: &'a dyn ModuleStorage, module: Arc<Module>) -> Self {
+    fn for_module(
+        module: Arc<Module>,
+        module_storage: &'a dyn ModuleStorage,
+        resource_resolver: &'a dyn ResourceResolver,
+    ) -> Self {
         let binary = BinaryType::Module(module);
         Self {
             binary,
             module_storage,
+            resource_resolver,
         }
     }
 
-    fn for_script(module_storage: &'a dyn ModuleStorage, script: Arc<Script>) -> Self {
+    fn for_script(
+        script: Arc<Script>,
+        module_storage: &'a dyn ModuleStorage,
+        resource_resolver: &'a dyn ResourceResolver,
+    ) -> Self {
         let binary = BinaryType::Script(script);
         Self {
             binary,
             module_storage,
+            resource_resolver,
         }
     }
 
@@ -490,6 +503,10 @@ impl<'a> Resolver<'a> {
 
     pub(crate) fn module_storage(&self) -> &dyn ModuleStorage {
         self.module_storage
+    }
+
+    pub(crate) fn resource_resolver(&self) -> &dyn ResourceResolver {
+        self.resource_resolver
     }
 
     pub(crate) fn vm_config(&self) -> &VMConfig {

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -36,11 +36,7 @@ pub struct SerializedReturnValues {
 /// arguments fully instantiated.
 pub struct MoveVM;
 
-<<<<<<< HEAD
 impl MoveVM {
-    pub(crate) fn execute_loaded_function(
-=======
-impl MoveVm {
     /// Executes provided function with the specified arguments. The arguments are serialized, and
     /// are not checked by the VM. It is the responsibility of the caller of this function to
     /// verify that they are well-formed.
@@ -53,7 +49,6 @@ impl MoveVm {
     /// When execution finishes, the return values of the function are returned. Additionally, if
     /// there are any mutable references passed as arguments, these values are also returned.
     pub fn execute_loaded_function(
->>>>>>> 35ea878580 (remove move vm session)
         function: LoadedFunction,
         serialized_args: Vec<impl Borrow<[u8]>>,
         data_cache: &mut TransactionDataCache,

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -39,6 +39,7 @@ impl MoveVM {
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
         module_storage: &impl ModuleStorage,
+        resource_resolver: &impl ResourceResolver,
     ) -> VMResult<SerializedReturnValues> {
         let vm_config = module_storage.runtime_environment().vm_config();
         let ty_builder = &vm_config.ty_builder;
@@ -64,6 +65,7 @@ impl MoveVM {
                 deserialized_args,
                 data_store,
                 module_storage,
+                resource_resolver,
                 gas_meter,
                 traversal_context,
                 extensions,
@@ -112,17 +114,14 @@ impl MoveVM {
     ///     cases where this may not be necessary, with the most notable one being the common module
     ///     publishing flow: you can keep using the same Move VM if you publish some modules in a Session
     ///     and apply the effects to the storage when the Session ends.
-    pub fn new_session(remote: &impl ResourceResolver) -> Session {
-        Self::new_session_with_extensions(remote, NativeContextExtensions::default())
+    pub fn new_session() -> Session<'static> {
+        Self::new_session_with_extensions(NativeContextExtensions::default())
     }
 
     /// Create a new session, as in `new_session`, but provide native context extensions.
-    pub fn new_session_with_extensions<'r>(
-        remote: &'r impl ResourceResolver,
-        native_extensions: NativeContextExtensions<'r>,
-    ) -> Session<'r> {
+    pub fn new_session_with_extensions(native_extensions: NativeContextExtensions) -> Session {
         Session {
-            data_cache: TransactionDataCache::new(remote),
+            data_cache: TransactionDataCache::empty(),
             native_extensions,
         }
     }

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -97,9 +97,9 @@ impl NativeFunctions {
     }
 }
 
-pub struct NativeContext<'a, 'b, 'c> {
+pub struct NativeContext<'a, 'b> {
     interpreter: &'a mut dyn InterpreterDebugInterface,
-    data_store: &'a mut TransactionDataCache<'c>,
+    data_store: &'a mut TransactionDataCache,
     resolver: &'a Resolver<'a>,
     extensions: &'a mut NativeContextExtensions<'b>,
     gas_balance: InternalGas,
@@ -113,10 +113,10 @@ pub struct NativeContext<'a, 'b, 'c> {
     heap_memory_usage: u64,
 }
 
-impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
+impl<'a, 'b> NativeContext<'a, 'b> {
     pub(crate) fn new(
         interpreter: &'a mut dyn InterpreterDebugInterface,
-        data_store: &'a mut TransactionDataCache<'c>,
+        data_store: &'a mut TransactionDataCache,
         resolver: &'a Resolver<'a>,
         extensions: &'a mut NativeContextExtensions<'b>,
         gas_balance: InternalGas,
@@ -135,7 +135,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     }
 }
 
-impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
+impl<'a, 'b> NativeContext<'a, 'b> {
     pub fn print_stack_trace(&self, buf: &mut String) -> PartialVMResult<()> {
         self.interpreter.debug_print_stack_trace(buf, self.resolver)
     }
@@ -150,7 +150,12 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
         //                     need to actually load bytes.
         let (value, num_bytes) = self
             .data_store
-            .load_resource(self.resolver.module_storage(), address, ty)
+            .load_resource(
+                self.resolver.module_storage(),
+                self.resolver.resource_resolver(),
+                address,
+                ty,
+            )
             .map_err(|err| err.finish(Location::Undefined))?;
         let exists = value
             .exists()

--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -35,7 +35,7 @@ use move_disassembler::disassembler::{Disassembler, DisassemblerOptions};
 use move_ir_types::location::Spanned;
 use move_model::{metadata::LanguageVersion, model::GlobalEnv};
 use move_symbol_pool::Symbol;
-use move_vm_runtime::session::SerializedReturnValues;
+use move_vm_runtime::move_vm::SerializedReturnValues;
 use move_vm_types::value_serde::ValueSerDeContext;
 use std::{
     collections::{BTreeMap, BTreeSet, VecDeque},

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -287,16 +287,15 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .collect();
         let verbose = extra_args.verbose;
 
-        let result = {
-            let func = code_storage.load_script(&script_bytes, &type_args)?;
-            self.execute_loaded_function(func, args, gas_budget, &code_storage)
-        };
-        result.map_err(|vm_error| {
-            anyhow!(
-                "Script execution failed with VMError: {}",
-                vm_error.format_test_output(move_test_debug() || verbose)
-            )
-        })?;
+        code_storage
+            .load_script(&script_bytes, &type_args)
+            .and_then(|func| self.execute_loaded_function(func, args, gas_budget, &code_storage))
+            .map_err(|err| {
+                anyhow!(
+                    "Script execution failed with VMError: {}",
+                    err.format_test_output(move_test_debug() || verbose)
+                )
+            })?;
         Ok(None)
     }
 
@@ -329,16 +328,15 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .collect();
         let verbose = extra_args.verbose;
 
-        let result = {
-            let func = module_storage.load_function(module, function, &type_args)?;
-            self.execute_loaded_function(func, args, gas_budget, &module_storage)
-        };
-        let serialized_return_values = result.map_err(|vm_error| {
-            anyhow!(
-                "Function execution failed with VMError: {}",
-                vm_error.format_test_output(move_test_debug() || verbose)
-            )
-        })?;
+        let serialized_return_values = module_storage
+            .load_function(module, function, &type_args)
+            .and_then(|func| self.execute_loaded_function(func, args, gas_budget, &module_storage))
+            .map_err(|err| {
+                anyhow!(
+                    "Function execution failed with VMError: {}",
+                    err.format_test_output(move_test_debug() || verbose)
+                )
+            })?;
         Ok((None, serialized_return_values))
     }
 

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -13,8 +13,11 @@ use legacy_move_compiler::{
     shared::known_attributes::KnownAttribute,
 };
 use move_binary_format::{
-    access::ModuleAccess, compatibility::Compatibility, errors::VMResult,
-    file_format::CompiledScript, file_format_common, CompiledModule,
+    access::ModuleAccess,
+    compatibility::Compatibility,
+    errors::{Location, VMResult},
+    file_format::CompiledScript,
+    file_format_common, CompiledModule,
 };
 use move_bytecode_verifier::VerifierConfig;
 use move_command_line_common::{
@@ -33,11 +36,19 @@ use move_stdlib::move_stdlib_named_addresses;
 use move_symbol_pool::Symbol;
 use move_vm_runtime::{
     config::VMConfig,
+    data_cache::TransactionDataCache,
     module_traversal::*,
+<<<<<<< HEAD
     move_vm::MoveVM,
     session::{SerializedReturnValues, Session},
     AsUnsyncCodeStorage, AsUnsyncModuleStorage, ModuleStorage, RuntimeEnvironment,
     StagingModuleStorage,
+=======
+    move_vm::{MoveVm, SerializedReturnValues},
+    native_extensions::NativeContextExtensions,
+    AsUnsyncCodeStorage, AsUnsyncModuleStorage, CodeStorage, LoadedFunction, ModuleStorage,
+    RuntimeEnvironment, StagingModuleStorage,
+>>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::{
     gas_schedule::{CostTable, Gas, GasStatus},
@@ -275,19 +286,12 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .chain(args)
             .collect();
         let verbose = extra_args.verbose;
-        let traversal_storage = TraversalStorage::new();
-        self.perform_session_action(gas_budget, &code_storage, |session, storage, gas_status| {
-            session.load_and_execute_script(
-                script_bytes,
-                type_args,
-                args,
-                gas_status,
-                &mut TraversalContext::new(&traversal_storage),
-                &code_storage,
-                storage,
-            )
-        })
-        .map_err(|vm_error| {
+
+        let result = {
+            let func = code_storage.load_script(&script_bytes, &type_args)?;
+            self.execute_loaded_function(func, args, gas_budget, &code_storage)
+        };
+        result.map_err(|vm_error| {
             anyhow!(
                 "Script execution failed with VMError: {}",
                 vm_error.format_test_output(move_test_debug() || verbose)
@@ -324,30 +328,17 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
             .chain(args)
             .collect();
         let verbose = extra_args.verbose;
-        let traversal_storage = TraversalStorage::new();
-        let serialized_return_values = self
-            .perform_session_action(
-                gas_budget,
-                &module_storage,
-                |session, storage, gas_status| {
-                    session.execute_function_bypass_visibility(
-                        module,
-                        function,
-                        type_args,
-                        args,
-                        gas_status,
-                        &mut TraversalContext::new(&traversal_storage),
-                        &module_storage,
-                        storage,
-                    )
-                },
+
+        let result = {
+            let func = module_storage.load_function(module, function, &type_args)?;
+            self.execute_loaded_function(func, args, gas_budget, &module_storage)
+        };
+        let serialized_return_values = result.map_err(|vm_error| {
+            anyhow!(
+                "Function execution failed with VMError: {}",
+                vm_error.format_test_output(move_test_debug() || verbose)
             )
-            .map_err(|vm_error| {
-                anyhow!(
-                    "Function execution failed with VMError: {}",
-                    vm_error.format_test_output(move_test_debug() || verbose)
-                )
-            })?;
+        })?;
         Ok((None, serialized_return_values))
     }
 
@@ -385,10 +376,13 @@ impl<'a> MoveTestAdapter<'a> for SimpleVMTestAdapter<'a> {
 }
 
 impl<'a> SimpleVMTestAdapter<'a> {
-    fn perform_session_action<Ret>(
+    fn execute_loaded_function(
         &mut self,
+        function: LoadedFunction,
+        args: Vec<Vec<u8>>,
         gas_budget: Option<u64>,
         module_storage: &impl ModuleStorage,
+<<<<<<< HEAD
         f: impl FnOnce(&mut Session, &InMemoryStorage, &mut GasStatus) -> VMResult<Ret>,
     ) -> VMResult<Ret> {
         let (mut session, mut gas_status) = {
@@ -404,14 +398,35 @@ impl<'a> SimpleVMTestAdapter<'a> {
             (MoveVm::new_session(), gas_status)
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         };
+=======
+    ) -> VMResult<SerializedReturnValues> {
+        let mut gas_status = get_gas_status(
+            &move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE,
+            gas_budget,
+        )
+        .unwrap();
+>>>>>>> 35ea878580 (remove move vm session)
 
-        // perform op
-        let res = f(&mut session, &self.storage, &mut gas_status)?;
+        let traversal_storage = TraversalStorage::new();
+        let mut extensions = NativeContextExtensions::default();
 
-        // save changeset
-        let changeset = session.finish(module_storage)?;
-        self.storage.apply(changeset).unwrap();
-        Ok(res)
+        let mut data_cache = TransactionDataCache::empty();
+        let return_values = MoveVm::execute_loaded_function(
+            function,
+            args,
+            &mut data_cache,
+            &mut gas_status,
+            &mut TraversalContext::new(&traversal_storage),
+            &mut extensions,
+            module_storage,
+            &self.storage,
+        )?;
+
+        let change_set = data_cache
+            .into_effects(module_storage)
+            .map_err(|err| err.finish(Location::Undefined))?;
+        self.storage.apply(change_set).unwrap();
+        Ok(return_values)
     }
 }
 

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -38,17 +38,10 @@ use move_vm_runtime::{
     config::VMConfig,
     data_cache::TransactionDataCache,
     module_traversal::*,
-<<<<<<< HEAD
-    move_vm::MoveVM,
-    session::{SerializedReturnValues, Session},
-    AsUnsyncCodeStorage, AsUnsyncModuleStorage, ModuleStorage, RuntimeEnvironment,
-    StagingModuleStorage,
-=======
-    move_vm::{MoveVm, SerializedReturnValues},
+    move_vm::{MoveVM, SerializedReturnValues},
     native_extensions::NativeContextExtensions,
     AsUnsyncCodeStorage, AsUnsyncModuleStorage, CodeStorage, LoadedFunction, ModuleStorage,
     RuntimeEnvironment, StagingModuleStorage,
->>>>>>> 35ea878580 (remove move vm session)
 };
 use move_vm_test_utils::{
     gas_schedule::{CostTable, Gas, GasStatus},
@@ -380,36 +373,18 @@ impl<'a> SimpleVMTestAdapter<'a> {
         args: Vec<Vec<u8>>,
         gas_budget: Option<u64>,
         module_storage: &impl ModuleStorage,
-<<<<<<< HEAD
-        f: impl FnOnce(&mut Session, &InMemoryStorage, &mut GasStatus) -> VMResult<Ret>,
-    ) -> VMResult<Ret> {
-        let (mut session, mut gas_status) = {
-            let gas_status = get_gas_status(
-                &move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE,
-                gas_budget,
-            )
-            .unwrap();
-<<<<<<< HEAD
-            let session = MoveVM::new_session(&self.storage);
-            (session, gas_status)
-=======
-            (MoveVm::new_session(), gas_status)
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-        };
-=======
     ) -> VMResult<SerializedReturnValues> {
         let mut gas_status = get_gas_status(
             &move_vm_test_utils::gas_schedule::INITIAL_COST_SCHEDULE,
             gas_budget,
         )
         .unwrap();
->>>>>>> 35ea878580 (remove move vm session)
 
         let traversal_storage = TraversalStorage::new();
         let mut extensions = NativeContextExtensions::default();
 
         let mut data_cache = TransactionDataCache::empty();
-        let return_values = MoveVm::execute_loaded_function(
+        let return_values = MoveVM::execute_loaded_function(
             function,
             args,
             &mut data_cache,

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -14,7 +14,10 @@ use colored::*;
 use legacy_move_compiler::unit_test::{
     ExpectedFailure, ModuleTestPlan, NamedOrBytecodeModule, TestCase, TestPlan,
 };
-use move_binary_format::{errors::VMResult, file_format::CompiledModule};
+use move_binary_format::{
+    errors::{Location, VMResult},
+    file_format::CompiledModule,
+};
 use move_bytecode_utils::Modules;
 use move_core_types::{
     account_address::AccountAddress,
@@ -25,11 +28,12 @@ use move_core_types::{
 };
 use move_resource_viewer::MoveValueAnnotator;
 use move_vm_runtime::{
+    data_cache::TransactionDataCache,
     module_traversal::{TraversalContext, TraversalStorage},
     move_vm::MoveVM,
     native_extensions::NativeContextExtensions,
     native_functions::NativeFunctionTable,
-    AsFunctionValueExtension, AsUnsyncModuleStorage, RuntimeEnvironment,
+    AsFunctionValueExtension, AsUnsyncModuleStorage, ModuleStorage, RuntimeEnvironment,
 };
 use move_vm_test_utils::InMemoryStorage;
 use rayon::prelude::*;
@@ -248,6 +252,7 @@ impl SharedTestingConfig {
     ) {
         let module_storage = self.starting_storage_state.as_unsync_module_storage();
 
+<<<<<<< HEAD
         let extensions = extensions::new_extensions();
 <<<<<<< HEAD
         let mut session =
@@ -255,23 +260,39 @@ impl SharedTestingConfig {
 =======
         let mut session = MoveVm::new_session_with_extensions(extensions);
 >>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
+=======
+        let mut extensions = extensions::new_extensions();
+>>>>>>> 35ea878580 (remove move vm session)
         let mut gas_meter = factory.lock().unwrap().new_gas_meter();
+        let traversal_storage = TraversalStorage::new();
+        let mut traversal_context = TraversalContext::new(&traversal_storage);
+        let mut data_cache = TransactionDataCache::empty();
 
         // TODO: collect VM logs if the verbose flag (i.e, `self.verbose`) is set
 
         let now = Instant::now();
-        let traversal_storage = TraversalStorage::new();
-        let serialized_return_values_result = session.execute_function_bypass_visibility(
-            &test_plan.module_id,
-            IdentStr::new(function_name).unwrap(),
-            vec![], // no ty args, at least for now
-            serialize_values(test_info.arguments.iter()),
-            &mut gas_meter,
-            &mut TraversalContext::new(&traversal_storage),
-            &module_storage,
-            &self.starting_storage_state,
-        );
-        let mut return_result = serialized_return_values_result.map(|res| {
+        let result = module_storage
+            .load_function(
+                &test_plan.module_id,
+                IdentStr::new(function_name).unwrap(),
+                // No type args for now.
+                &[],
+            )
+            .and_then(|function| {
+                let args = serialize_values(test_info.arguments.iter());
+                MoveVm::execute_loaded_function(
+                    function,
+                    args,
+                    &mut data_cache,
+                    &mut gas_meter,
+                    &mut traversal_context,
+                    &mut extensions,
+                    &module_storage,
+                    &self.starting_storage_state,
+                )
+            });
+
+        let mut return_result = result.map(|res| {
             res.return_values
                 .into_iter()
                 .map(|(bytes, _layout)| bytes)
@@ -284,17 +305,21 @@ impl SharedTestingConfig {
         }
 
         let test_run_info = TestRunInfo::new(function_name.to_string(), now.elapsed());
-        match session.finish_with_extensions(&module_storage) {
-            Ok((cs, mut extensions)) => {
+
+        let result = data_cache
+            .into_effects(&module_storage)
+            .map_err(|err| err.finish(Location::Undefined));
+        match result {
+            Ok(change_set) => {
                 let finalized_test_run_info = factory.lock().unwrap().finalize_test_run_info(
-                    &cs,
+                    &change_set,
                     &mut extensions,
                     gas_meter,
                     test_run_info,
                 );
 
                 (
-                    Ok(cs),
+                    Ok(change_set),
                     Ok(extensions),
                     return_result,
                     finalized_test_run_info,

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -249,8 +249,12 @@ impl SharedTestingConfig {
         let module_storage = self.starting_storage_state.as_unsync_module_storage();
 
         let extensions = extensions::new_extensions();
+<<<<<<< HEAD
         let mut session =
             MoveVM::new_session_with_extensions(&self.starting_storage_state, extensions);
+=======
+        let mut session = MoveVm::new_session_with_extensions(extensions);
+>>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
         let mut gas_meter = factory.lock().unwrap().new_gas_meter();
 
         // TODO: collect VM logs if the verbose flag (i.e, `self.verbose`) is set
@@ -265,6 +269,7 @@ impl SharedTestingConfig {
             &mut gas_meter,
             &mut TraversalContext::new(&traversal_storage),
             &module_storage,
+            &self.starting_storage_state,
         );
         let mut return_result = serialized_return_values_result.map(|res| {
             res.return_values

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -252,17 +252,7 @@ impl SharedTestingConfig {
     ) {
         let module_storage = self.starting_storage_state.as_unsync_module_storage();
 
-<<<<<<< HEAD
-        let extensions = extensions::new_extensions();
-<<<<<<< HEAD
-        let mut session =
-            MoveVM::new_session_with_extensions(&self.starting_storage_state, extensions);
-=======
-        let mut session = MoveVm::new_session_with_extensions(extensions);
->>>>>>> 7bae6066b8 ([refactoring] Remove resolver from session, use impl in sesson_ext and respawned)
-=======
         let mut extensions = extensions::new_extensions();
->>>>>>> 35ea878580 (remove move vm session)
         let mut gas_meter = factory.lock().unwrap().new_gas_meter();
         let traversal_storage = TraversalStorage::new();
         let mut traversal_context = TraversalContext::new(&traversal_storage);
@@ -280,7 +270,7 @@ impl SharedTestingConfig {
             )
             .and_then(|function| {
                 let args = serialize_values(test_info.arguments.iter());
-                MoveVm::execute_loaded_function(
+                MoveVM::execute_loaded_function(
                     function,
                     args,
                     &mut data_cache,


### PR DESCRIPTION
## Description

This PR removes Move VM's `Session` type in favour of stateless VM execution:
```rust
MoveVm::execute_loaded_function(
  // Different context information passed here.
  ...
) -> VMresult<...> { ... }
```

The benefits of this approach are:
1. In theory, we can "merge" data cache and resource resolver under single trait, so that how data is cached is oblivious to the VM. This way VM implementation can be swapped without any worries to session set ups, etc. - the adapter will manage these.
2. The callers set up the data caches, and the baseline data & module states, and control data lifetimes. This means there is no need to respawn session anymore (not in this PR): e.g., AptosVM own the data cache data and can decide what to do with it. 
3. The callers can add more checks, e.g., for arguments, so we can change the interface to take `Vec<Value>` in the future.

Additional things happening in this PR:
- Refactored integration tests because it is very tiring to change all 100+ places where the same duplicated code is used.
- Refactored Aptos VM and `SessionExt` to use type parameters over `dyn` traits to make it possible to pass `AptosMoveResolver` as `ResourceResolver` to the VM execution layer.
- Avoid repeated deserialization of scripts because we have loaded the function beforehand (see changes in `aptos_vm.rs`).

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
