### PR TITLE
Better resource cleanup for `replay-verify`

### DIFF
--- a/testsuite/replay-verify/archive-pvc-template.yaml
+++ b/testsuite/replay-verify/archive-pvc-template.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     requests:
       storage: 10Ti
-  storageClassName: ssd-data-xfs
+  storageClassName: ssd-data-xfs-immediate
   volumeMode: Filesystem
   dataSourceRef:
     name: testnet-archive

--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -17,6 +17,7 @@ from typing import Tuple, List, Optional, Any
 
 # Constants
 DISK_COPIES = 1
+STORAGE_CLASS = "ssd-data-xfs-immediate"
 
 # Logging configuration
 logging.basicConfig(level=logging.INFO)
@@ -418,7 +419,7 @@ def create_persistent_volume(
                 read_only=read_only,
             ),
             persistent_volume_reclaim_policy="Delete",
-            storage_class_name="ssd-data-xfs",
+            storage_class_name=STORAGE_CLASS,
         ),
     )
 
@@ -433,7 +434,7 @@ def create_persistent_volume(
         spec=client.V1PersistentVolumeClaimSpec(
             access_modes=[access_mode],
             resources=client.V1ResourceRequirements(requests={"storage": storage_size}),
-            storage_class_name="ssd-data-xfs",
+            storage_class_name=STORAGE_CLASS,
             volume_name=pv_name,
             # Remove the selector since we're using volume_name for direct binding
         ),
@@ -522,7 +523,7 @@ def create_one_pvc_from_snapshot(
         "spec": {
             "accessModes": ["ReadOnlyMany"],
             "resources": {"requests": {"storage": storage_size}},
-            "storageClassName": "ssd-data-xfs",
+            "storageClassName": STORAGE_CLASS,
             "volumeMode": "Filesystem",
             "dataSource": {
                 "name": f"{snapshot_name}",

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -206,6 +206,8 @@ class WorkerPod:
         pod_manifest["metadata"]["name"] = self.name  # Unique name for each pod
         pod_manifest["metadata"]["labels"]["run"] = self.label
         pod_manifest["spec"]["containers"][0]["image"] = self.image
+        pod_ttl = self.config.timeout_secs + 30 * 60 # 30 minutes slack to allow for pod setup and teardown
+        pod_manifest["metadata"]["annotations"]["k8s-ttl-controller.twin.sh/ttl"] = f"{pod_ttl}s"
         pod_manifest["spec"]["volumes"][0]["persistentVolumeClaim"][
             "claimName"
         ] = self.get_claim_name()

--- a/testsuite/replay-verify/replay-verify-worker-template.yaml
+++ b/testsuite/replay-verify/replay-verify-worker-template.yaml
@@ -4,6 +4,7 @@ metadata:
   name: worker-pod-9
   labels:
     run: some-label
+  annotations: {}
 spec:  
   serviceAccountName: default  
   restartPolicy: Never  # Pod restarts only if it fails  


### PR DESCRIPTION
## Description

Set a TTL upon worker pod creation to ensure they get cleaned up in case the scheduler fails to do so.
Set PVC storage class to `ssd-data-xfs-immediate` to ensure the underlying PVs are deleted promptly.