### PR TITLE
[cleanup] remove old config and Payload variants

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -95,7 +95,6 @@ pub struct QuorumStoreConfig {
     pub back_pressure: QuorumStoreBackPressureConfig,
     pub num_workers_for_remote_batches: usize,
     pub batch_buckets: Vec<u64>,
-    pub allow_batches_without_pos_in_proposal: bool,
     pub enable_opt_quorum_store: bool,
     pub opt_qs_minimum_batch_age_usecs: u64,
     pub enable_payload_v2: bool,
@@ -136,7 +135,6 @@ impl Default for QuorumStoreConfig {
             // number of batch coordinators to handle QS batch messages, should be >= 1
             num_workers_for_remote_batches: 10,
             batch_buckets: DEFAULT_BUCKETS.to_vec(),
-            allow_batches_without_pos_in_proposal: true,
             enable_opt_quorum_store: false,
             opt_qs_minimum_batch_age_usecs: Duration::from_millis(20).as_micros() as u64,
             enable_payload_v2: false,

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -106,20 +106,10 @@ impl Block {
         self.block_data.payload()
     }
 
-    pub fn payload_size(&self) -> usize {
-        match self.block_data.payload() {
-            None => 0,
-            Some(payload) => match payload {
-                Payload::DirectMempool(_txns) => 0,
-                Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
-                | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
-                    inline_batches.len() + proof_with_data.proofs.len()
-                },
-                Payload::OptQuorumStore(opt_quorum_store_payload) => {
-                    opt_quorum_store_payload.num_txns()
-                },
-            },
-        }
+    pub fn num_batches(&self) -> usize {
+        self.block_data
+            .payload()
+            .map_or(0, |payload| payload.num_batches())
     }
 
     pub fn quorum_cert(&self) -> &QuorumCert {

--- a/consensus/consensus-types/src/block.rs
+++ b/consensus/consensus-types/src/block.rs
@@ -110,9 +110,7 @@ impl Block {
         match self.block_data.payload() {
             None => 0,
             Some(payload) => match payload {
-                Payload::InQuorumStore(pos) => pos.proofs.len(),
                 Payload::DirectMempool(_txns) => 0,
-                Payload::InQuorumStoreWithLimit(pos) => pos.proof_with_data.proofs.len(),
                 Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
                 | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                     inline_batches.len() + proof_with_data.proofs.len()

--- a/consensus/consensus-types/src/block_data.rs
+++ b/consensus/consensus-types/src/block_data.rs
@@ -235,7 +235,7 @@ impl BlockData {
     pub fn dummy_with_validator_txns(txns: Vec<ValidatorTransaction>) -> Self {
         Self::new_proposal_ext(
             txns,
-            Payload::empty(false, true),
+            Payload::empty(false),
             Author::ONE,
             vec![],
             1,
@@ -385,7 +385,7 @@ fn test_reconfiguration_suffix() {
         ),
     );
     let reconfig_suffix_block = BlockData::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         AccountAddress::random(),
         Vec::new(),
         2,

--- a/consensus/consensus-types/src/block_test.rs
+++ b/consensus/consensus-types/src/block_test.rs
@@ -72,7 +72,7 @@ fn test_nil_block() {
         nil_block_qc.certified_block().id()
     );
     let nil_block_child = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         2,
         aptos_infallible::duration_since_epoch().as_micros() as u64,
         nil_block_qc,
@@ -91,7 +91,7 @@ fn test_block_relation() {
     // Test genesis and the next block
     let genesis_block = Block::make_genesis_block();
     let quorum_cert = certificate_for_genesis();
-    let payload = Payload::empty(false, true);
+    let payload = Payload::empty(false);
     let next_block = Block::new_proposal(
         payload.clone(),
         1,
@@ -118,7 +118,7 @@ fn test_same_qc_different_authors() {
     let signer = signers.first().unwrap();
     let genesis_qc = certificate_for_genesis();
     let round = 1;
-    let payload = Payload::empty(false, true);
+    let payload = Payload::empty(false);
     let current_timestamp = aptos_infallible::duration_since_epoch().as_micros() as u64;
     let block_round_1 = Block::new_proposal(
         payload.clone(),
@@ -180,7 +180,7 @@ fn test_block_metadata_bitvec() {
         &ledger_info,
         Block::make_genesis_block_from_ledger_info(&ledger_info).id(),
     );
-    let payload = Payload::empty(false, true);
+    let payload = Payload::empty(false);
     let start_round = 1;
     let start_timestamp = aptos_infallible::duration_since_epoch().as_micros() as u64;
 
@@ -254,7 +254,7 @@ fn test_failed_authors_well_formed() {
     let other = Author::random();
     // Test genesis and the next block
     let quorum_cert = certificate_for_genesis();
-    let payload = Payload::empty(false, true);
+    let payload = Payload::empty(false);
 
     let create_block = |round: Round, failed_authors: Vec<(Round, Author)>| {
         Block::new_proposal(

--- a/consensus/consensus-types/src/block_test_utils.rs
+++ b/consensus/consensus-types/src/block_test_utils.rs
@@ -43,7 +43,7 @@ prop_compose! {
         parent_qc in Just(parent_qc)
     ) -> Block {
         Block::new_proposal(
-            Payload::empty(false, true),
+            Payload::empty(false),
             round,
             aptos_infallible::duration_since_epoch().as_micros() as u64,
             parent_qc,

--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -226,7 +226,7 @@ impl Payload {
     ) -> Self {
         match self {
             Payload::DirectMempool(_) => {
-                panic!("Payload is in direct mempool format");
+                unreachable!("Payload is in direct mempool format");
             },
             Payload::Legacy1 | Payload::Legacy2 => {
                 unreachable!("Payload is in legacy format");

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -347,6 +347,10 @@ impl OptQuorumStorePayload {
         self.opt_batches.num_txns() + self.proofs.num_txns() + self.inline_batches.num_txns()
     }
 
+    pub fn num_batches(&self) -> usize {
+        self.opt_batches.len() + self.proofs.len() + self.inline_batches.len()
+    }
+
     pub(crate) fn is_empty(&self) -> bool {
         self.opt_batches.is_empty() && self.proofs.is_empty() && self.inline_batches.is_empty()
     }

--- a/consensus/safety-rules/src/test_utils.rs
+++ b/consensus/safety-rules/src/test_utils.rs
@@ -80,7 +80,7 @@ pub fn make_proposal_with_qc(
     validator_signer: &ValidatorSigner,
 ) -> VoteProposal {
     make_proposal_with_qc_and_proof(
-        Payload::empty(false, true),
+        Payload::empty(false),
         round,
         empty_proof(),
         qc,

--- a/consensus/safety-rules/src/tests/suite.rs
+++ b/consensus/safety-rules/src/tests/suite.rs
@@ -34,13 +34,7 @@ fn make_proposal_with_qc_and_proof(
     qc: QuorumCert,
     signer: &ValidatorSigner,
 ) -> VoteProposal {
-    test_utils::make_proposal_with_qc_and_proof(
-        Payload::empty(false, true),
-        round,
-        proof,
-        qc,
-        signer,
-    )
+    test_utils::make_proposal_with_qc_and_proof(Payload::empty(false), round, proof, qc, signer)
 }
 
 fn make_proposal_with_parent(
@@ -49,13 +43,7 @@ fn make_proposal_with_parent(
     committed: Option<&VoteProposal>,
     signer: &ValidatorSigner,
 ) -> VoteProposal {
-    test_utils::make_proposal_with_parent(
-        Payload::empty(false, true),
-        round,
-        parent,
-        committed,
-        signer,
-    )
+    test_utils::make_proposal_with_parent(Payload::empty(false), round, parent, committed, signer)
 }
 
 pub type Callback = Box<dyn Fn() -> (Box<dyn TSafetyRules + Send + Sync>, ValidatorSigner)>;
@@ -430,7 +418,7 @@ fn test_voting_bad_epoch(safety_rules: &Callback) {
 
     let a1 = test_utils::make_proposal_with_qc(round + 1, genesis_qc, &signer);
     let a2 = test_utils::make_proposal_with_parent_and_overrides(
-        Payload::empty(false, true),
+        Payload::empty(false),
         round + 3,
         &a1,
         None,
@@ -598,7 +586,7 @@ fn test_validator_not_in_set(safety_rules: &Callback) {
     next_epoch_state.verifier =
         ValidatorVerifier::new_single(rand_signer.author(), rand_signer.public_key()).into();
     let a2 = test_utils::make_proposal_with_parent_and_overrides(
-        Payload::empty(false, true),
+        Payload::empty(false),
         round + 2,
         &a1,
         Some(&a1),
@@ -636,7 +624,7 @@ fn test_key_not_in_store(safety_rules: &Callback) {
     next_epoch_state.verifier =
         ValidatorVerifier::new_single(signer.author(), rand_signer.public_key()).into();
     let a2 = test_utils::make_proposal_with_parent_and_overrides(
-        Payload::empty(false, true),
+        Payload::empty(false),
         round + 2,
         &a1,
         Some(&a1),

--- a/consensus/src/block_storage/block_store_test.rs
+++ b/consensus/src/block_storage/block_store_test.rs
@@ -355,7 +355,7 @@ async fn test_illegal_timestamp() {
     let block_store = build_default_empty_tree();
     let genesis = block_store.ordered_root();
     let block_with_illegal_timestamp = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         0,
         // This timestamp is illegal, it is the same as genesis
         genesis.timestamp_usecs(),
@@ -458,7 +458,7 @@ async fn test_need_sync_for_ledger_info() {
             certificate_for_genesis(),
             1,
             round,
-            Payload::empty(false, true),
+            Payload::empty(false),
             vec![],
         );
         gen_test_certificate(

--- a/consensus/src/consensus_observer/observer/payload_store.rs
+++ b/consensus/src/consensus_observer/observer/payload_store.rs
@@ -283,6 +283,7 @@ mod test {
         block::Block,
         block_data::{BlockData, BlockType},
         common::{Author, Payload, ProofWithData},
+        payload::PayloadExecutionLimit,
         pipelined_block::OrderedBlockWindow,
         proof_of_store::{BatchId, BatchInfo, ProofOfStore},
         quorum_cert::QuorumCert,
@@ -1112,7 +1113,11 @@ mod test {
             block_payload_store.insert_block_payload(block_payload, verified_payload_signatures);
 
             // Create the block type
-            let payload = Payload::InQuorumStore(ProofWithData::new(proofs_of_store));
+            let payload = Payload::QuorumStoreInlineHybridV2(
+                vec![],
+                ProofWithData::new(proofs_of_store),
+                PayloadExecutionLimit::None,
+            );
             let block_type = BlockType::DAGBlock {
                 author: Author::random(),
                 failed_authors: vec![],

--- a/consensus/src/consensusdb/consensusdb_test.rs
+++ b/consensus/src/consensusdb/consensusdb_test.rs
@@ -100,7 +100,7 @@ fn test_dag() {
         Author::random(),
         123,
         vec![],
-        Payload::empty(false, true),
+        Payload::empty(false),
         vec![],
         Extensions::empty(),
     );

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1288,7 +1288,7 @@ pub fn update_counters_for_block(block: &Block) {
     if failed_rounds > 0 {
         COMMITTED_FAILED_ROUNDS_COUNT.inc_by(failed_rounds as u64);
     }
-    quorum_store::counters::NUM_BATCH_PER_BLOCK.observe(block.payload_size() as f64);
+    quorum_store::counters::NUM_BATCH_PER_BLOCK.observe(block.num_batches() as f64);
 }
 
 pub fn update_counters_for_compute_result(compute_result: &StateComputeResult) {

--- a/consensus/src/dag/adapter.rs
+++ b/consensus/src/dag/adapter.rs
@@ -100,7 +100,6 @@ pub(super) struct OrderedNotifierAdapter {
     epoch_state: Arc<EpochState>,
     ledger_info_provider: Arc<RwLock<LedgerInfoProvider>>,
     block_ordered_ts: Arc<RwLock<BTreeMap<Round, Instant>>>,
-    allow_batches_without_pos_in_proposal: bool,
 }
 
 impl OrderedNotifierAdapter {
@@ -110,7 +109,6 @@ impl OrderedNotifierAdapter {
         epoch_state: Arc<EpochState>,
         parent_block_info: BlockInfo,
         ledger_info_provider: Arc<RwLock<LedgerInfoProvider>>,
-        allow_batches_without_pos_in_proposal: bool,
     ) -> Self {
         Self {
             executor_channel,
@@ -119,7 +117,6 @@ impl OrderedNotifierAdapter {
             epoch_state,
             ledger_info_provider,
             block_ordered_ts: Arc::new(RwLock::new(BTreeMap::new())),
-            allow_batches_without_pos_in_proposal,
         }
     }
 
@@ -149,10 +146,7 @@ impl OrderedNotifier for OrderedNotifierAdapter {
         let timestamp = anchor.metadata().timestamp();
         let author = *anchor.author();
         let mut validator_txns = vec![];
-        let mut payload = Payload::empty(
-            !anchor.payload().is_direct(),
-            self.allow_batches_without_pos_in_proposal,
-        );
+        let mut payload = Payload::empty(!anchor.payload().is_direct());
         let mut node_digests = vec![];
         for node in &ordered_nodes {
             validator_txns.extend(node.validator_txns().clone());

--- a/consensus/src/dag/bootstrap.rs
+++ b/consensus/src/dag/bootstrap.rs
@@ -339,7 +339,6 @@ pub struct DagBootstrapper {
     randomness_config: OnChainRandomnessConfig,
     jwk_consensus_config: OnChainJWKConsensusConfig,
     executor: BoundedExecutor,
-    allow_batches_without_pos_in_proposal: bool,
 }
 
 impl DagBootstrapper {
@@ -364,7 +363,6 @@ impl DagBootstrapper {
         randomness_config: OnChainRandomnessConfig,
         jwk_consensus_config: OnChainJWKConsensusConfig,
         executor: BoundedExecutor,
-        allow_batches_without_pos_in_proposal: bool,
     ) -> Self {
         Self {
             self_peer,
@@ -386,7 +384,6 @@ impl DagBootstrapper {
             randomness_config,
             jwk_consensus_config,
             executor,
-            allow_batches_without_pos_in_proposal,
         }
     }
 
@@ -536,7 +533,6 @@ impl DagBootstrapper {
             self.epoch_state.clone(),
             parent_block_info,
             ledger_info_provider.clone(),
-            self.allow_batches_without_pos_in_proposal,
         ));
 
         let order_rule = Arc::new(Mutex::new(OrderRule::new(
@@ -649,7 +645,6 @@ impl DagBootstrapper {
             self.config.node_payload_config.clone(),
             health_backoff.clone(),
             self.quorum_store_enabled,
-            self.allow_batches_without_pos_in_proposal,
         );
         let rb_handler = NodeBroadcastHandler::new(
             dag_store.clone(),
@@ -768,7 +763,6 @@ pub(super) fn bootstrap_dag_for_test(
         OnChainRandomnessConfig::default_enabled(),
         OnChainJWKConsensusConfig::default_enabled(),
         BoundedExecutor::new(2, Handle::current()),
-        true,
     );
 
     let (_base_state, handler, fetch_service) = bootstraper.full_bootstrap();

--- a/consensus/src/dag/dag_driver.rs
+++ b/consensus/src/dag/dag_driver.rs
@@ -64,7 +64,6 @@ pub(crate) struct DagDriver {
     payload_config: DagPayloadConfig,
     health_backoff: HealthBackoff,
     quorum_store_enabled: bool,
-    allow_batches_without_pos_in_proposal: bool,
 }
 
 impl DagDriver {
@@ -85,7 +84,6 @@ impl DagDriver {
         payload_config: DagPayloadConfig,
         health_backoff: HealthBackoff,
         quorum_store_enabled: bool,
-        allow_batches_without_pos_in_proposal: bool,
     ) -> Self {
         let pending_node = storage
             .get_pending_node()
@@ -110,7 +108,6 @@ impl DagDriver {
             payload_config,
             health_backoff,
             quorum_store_enabled,
-            allow_batches_without_pos_in_proposal,
         };
 
         // If we were broadcasting the node for the round already, resume it
@@ -282,13 +279,7 @@ impl DagDriver {
             Ok(payload) => payload,
             Err(e) => {
                 error!("error pulling payload: {}", e);
-                (
-                    vec![],
-                    Payload::empty(
-                        self.quorum_store_enabled,
-                        self.allow_batches_without_pos_in_proposal,
-                    ),
-                )
+                (vec![], Payload::empty(self.quorum_store_enabled))
             },
         };
 

--- a/consensus/src/dag/tests/dag_driver_tests.rs
+++ b/consensus/src/dag/tests/dag_driver_tests.rs
@@ -208,7 +208,6 @@ fn setup(
             NoPipelineBackpressure::new(),
         ),
         false,
-        true,
     )
 }
 

--- a/consensus/src/dag/tests/helpers.rs
+++ b/consensus/src/dag/tests/helpers.rs
@@ -59,7 +59,7 @@ pub(crate) fn new_certified_node(
         author,
         0,
         vec![],
-        Payload::empty(false, true),
+        Payload::empty(false),
         parents,
         Extensions::empty(),
     );
@@ -78,7 +78,7 @@ pub(crate) fn new_node(
         author,
         timestamp,
         vec![],
-        Payload::empty(false, true),
+        Payload::empty(false),
         parents,
         Extensions::empty(),
     )

--- a/consensus/src/dag/tests/types_test.rs
+++ b/consensus/src/dag/tests/types_test.rs
@@ -24,7 +24,7 @@ fn test_node_verify() {
 
     let invalid_node = Node::new_for_test(
         NodeMetadata::new_for_test(0, 0, signers[0].author(), 0, HashValue::random()),
-        Payload::empty(false, true),
+        Payload::empty(false),
         vec![],
         Extensions::empty(),
     );
@@ -73,7 +73,7 @@ fn test_certified_node_verify() {
 
     let invalid_node = Node::new_for_test(
         NodeMetadata::new_for_test(0, 0, signers[0].author(), 0, HashValue::random()),
-        Payload::empty(false, true),
+        Payload::empty(false),
         vec![],
         Extensions::empty(),
     );

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -924,9 +924,6 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             chain_health_backoff_config,
             self.quorum_store_enabled,
             onchain_consensus_config.effective_validator_txn_config(),
-            self.config
-                .quorum_store
-                .allow_batches_without_pos_in_proposal,
             opt_qs_payload_param_provider,
         );
         let (round_manager_tx, round_manager_rx) = aptos_channel::new(
@@ -1463,9 +1460,6 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             onchain_randomness_config,
             onchain_jwk_consensus_config,
             self.bounded_executor.clone(),
-            self.config
-                .quorum_store
-                .allow_batches_without_pos_in_proposal,
         );
 
         let (dag_rpc_tx, dag_rpc_rx) = aptos_channel::new(QueueStyle::FIFO, 10, None);

--- a/consensus/src/liveness/proposal_generator.rs
+++ b/consensus/src/liveness/proposal_generator.rs
@@ -615,7 +615,7 @@ impl ProposalGenerator {
                     max_txns_from_block_to_execute,
                     block_gas_limit_override,
                 );
-            } else if block_gas_limit_override.is_some() {
+            } else if !payload.is_direct() && block_gas_limit_override.is_some() {
                 payload = payload.transform_to_payload_with_limits(None, block_gas_limit_override);
             }
             (validator_txns, payload, timestamp.as_micros() as u64)

--- a/consensus/src/liveness/proposal_generator_test.rs
+++ b/consensus/src/liveness/proposal_generator_test.rs
@@ -59,7 +59,6 @@ async fn test_proposal_generation_empty_tree() {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
         ValidatorTxnConfig::default_disabled(),
-        true,
         Arc::new(MockOptQSPayloadProvider {}),
     );
     let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(
@@ -106,7 +105,6 @@ async fn test_proposal_generation_parent() {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
         ValidatorTxnConfig::default_disabled(),
-        true,
         Arc::new(MockOptQSPayloadProvider {}),
     );
     let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(
@@ -183,7 +181,6 @@ async fn test_old_proposal_generation() {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
         ValidatorTxnConfig::default_disabled(),
-        true,
         Arc::new(MockOptQSPayloadProvider {}),
     );
     let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(
@@ -225,7 +222,6 @@ async fn test_correct_failed_authors() {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
         ValidatorTxnConfig::default_disabled(),
-        true,
         Arc::new(MockOptQSPayloadProvider {}),
     );
     let proposer_election = Arc::new(UnequivocalProposerElection::new(Arc::new(

--- a/consensus/src/liveness/unequivocal_proposer_election_test.rs
+++ b/consensus/src/liveness/unequivocal_proposer_election_test.rs
@@ -37,7 +37,7 @@ fn test_is_valid_proposal() {
     let quorum_cert = certificate_for_genesis();
 
     let good_proposal = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         quorum_cert.clone(),
@@ -46,7 +46,7 @@ fn test_is_valid_proposal() {
     )
     .unwrap();
     let bad_author_proposal = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         quorum_cert.clone(),
@@ -55,7 +55,7 @@ fn test_is_valid_proposal() {
     )
     .unwrap();
     let bad_duplicate_proposal = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         2,
         quorum_cert.clone(),
@@ -64,7 +64,7 @@ fn test_is_valid_proposal() {
     )
     .unwrap();
     let next_good_proposal = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         2,
         3,
         quorum_cert.clone(),
@@ -73,7 +73,7 @@ fn test_is_valid_proposal() {
     )
     .unwrap();
     let next_bad_duplicate_proposal = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         2,
         4,
         quorum_cert,

--- a/consensus/src/network_tests.rs
+++ b/consensus/src/network_tests.rs
@@ -692,7 +692,7 @@ mod tests {
         let previous_qc = certificate_for_genesis();
         let proposal = ProposalMsg::new(
             Block::new_proposal(
-                Payload::empty(false, true),
+                Payload::empty(false),
                 1,
                 1,
                 previous_qc.clone(),

--- a/consensus/src/payload_manager/quorum_store_payload_manager.rs
+++ b/consensus/src/payload_manager/quorum_store_payload_manager.rs
@@ -174,6 +174,9 @@ impl TPayloadManager for QuorumStorePayloadManager {
                 Payload::DirectMempool(_) => {
                     unreachable!("InQuorumStore should be used");
                 },
+                Payload::Legacy1 | Payload::Legacy2 => {
+                    unreachable!("Payload is in legacy format");
+                },
                 Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
                 | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                     inline_batches
@@ -243,12 +246,15 @@ impl TPayloadManager for QuorumStorePayloadManager {
         }
 
         match payload {
+            Payload::DirectMempool(_) => {
+                unreachable!()
+            },
+            Payload::Legacy1 | Payload::Legacy2 => {
+                unreachable!("Payload is in legacy format");
+            },
             Payload::QuorumStoreInlineHybrid(_, proof_with_data, _)
             | Payload::QuorumStoreInlineHybridV2(_, proof_with_data, _) => {
                 request_txns_and_update_status(proof_with_data, self.batch_reader.clone());
-            },
-            Payload::DirectMempool(_) => {
-                unreachable!()
             },
             Payload::OptQuorumStore(opt_qs_payload) => {
                 prefetch_helper(
@@ -277,6 +283,9 @@ impl TPayloadManager for QuorumStorePayloadManager {
         match payload {
             Payload::DirectMempool(_) => {
                 unreachable!("QuorumStore doesn't support DirectMempool payload")
+            },
+            Payload::Legacy1 | Payload::Legacy2 => {
+                unreachable!("Payload is in legacy format");
             },
             Payload::QuorumStoreInlineHybrid(inline_batches, proofs, _)
             | Payload::QuorumStoreInlineHybridV2(inline_batches, proofs, _) => {

--- a/consensus/src/pipeline/tests/execution_phase_tests.rs
+++ b/consensus/src/pipeline/tests/execution_phase_tests.rs
@@ -78,7 +78,7 @@ fn add_execution_phase_test_cases(
     let genesis_qc = certificate_for_genesis();
     let (signers, _validators) = random_validator_verifier(1, None, false);
     let block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc,
@@ -119,15 +119,8 @@ fn add_execution_phase_test_cases(
         &LedgerInfo::mock_genesis(None),
         random_hash_value,
     );
-    let bad_block = Block::new_proposal(
-        Payload::empty(false, true),
-        1,
-        1,
-        bad_qc,
-        &signers[0],
-        Vec::new(),
-    )
-    .unwrap();
+    let bad_block =
+        Block::new_proposal(Payload::empty(false), 1, 1, bad_qc, &signers[0], Vec::new()).unwrap();
     phase_tester.add_test_case(
         ExecutionRequest {
             ordered_blocks: vec![PipelinedBlock::new(

--- a/consensus/src/pipeline/tests/test_utils.rs
+++ b/consensus/src/pipeline/tests/test_utils.rs
@@ -70,13 +70,7 @@ pub fn prepare_executed_blocks_with_ledger_info(
     assert!(num_blocks > 0);
 
     let p1 = if let Some(parent) = some_parent {
-        make_proposal_with_parent(
-            Payload::empty(false, true),
-            init_round,
-            &parent,
-            None,
-            signer,
-        )
+        make_proposal_with_parent(Payload::empty(false), init_round, &parent, None, signer)
     } else {
         make_proposal_with_qc(init_round, init_qc.unwrap(), signer)
     };
@@ -86,13 +80,8 @@ pub fn prepare_executed_blocks_with_ledger_info(
     for i in 1..num_blocks {
         println!("Generating {}", i);
         let parent = proposals.last().unwrap();
-        let proposal = make_proposal_with_parent(
-            Payload::empty(false, true),
-            init_round + i,
-            parent,
-            None,
-            signer,
-        );
+        let proposal =
+            make_proposal_with_parent(Payload::empty(false), init_round + i, parent, None, signer);
         proposals.push(proposal);
     }
 

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -364,7 +364,6 @@ impl InnerBuilder {
                 .backlog_per_validator_batch_limit_count
                 * self.num_validators,
             self.batch_store.clone().unwrap(),
-            self.config.allow_batches_without_pos_in_proposal,
             self.config.enable_payload_v2,
             self.config.batch_expiry_gap_when_init_usecs,
         );

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -17,7 +17,7 @@ use std::{cmp::max, collections::HashSet};
 
 fn create_proof_manager() -> ProofManager {
     let batch_store = batch_store_for_test(5 * 1024 * 1024);
-    ProofManager::new(PeerId::random(), 10, 10, batch_store, true, true, 1)
+    ProofManager::new(PeerId::random(), 10, 10, batch_store, true, 1)
 }
 
 fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOfStore {
@@ -77,19 +77,6 @@ fn assert_payload_response(
     expected_block_gas_limit: Option<u64>,
 ) {
     match payload {
-        Payload::InQuorumStore(proofs) => {
-            assert_eq!(proofs.proofs.len(), expected.len());
-            for proof in proofs.proofs {
-                assert!(expected.contains(&proof));
-            }
-        },
-        Payload::InQuorumStoreWithLimit(proofs) => {
-            assert_eq!(proofs.proof_with_data.proofs.len(), expected.len());
-            for proof in proofs.proof_with_data.proofs {
-                assert!(expected.contains(&proof));
-            }
-            assert_eq!(proofs.max_txns_to_execute, max_txns_from_block_to_execute);
-        },
         Payload::QuorumStoreInlineHybrid(_inline_batches, proofs, max_txns_to_execute) => {
             assert_eq!(proofs.proofs.len(), expected.len());
             for proof in proofs.proofs {
@@ -148,7 +135,7 @@ async fn test_max_txns_from_block_to_execute() {
     let max_txns_from_block_to_execute = 10;
     let block_gas_limit = 10_000;
     assert_payload_response(
-        payload.transform_to_quorum_store_v2(
+        payload.transform_to_payload_with_limits(
             Some(max_txns_from_block_to_execute),
             Some(block_gas_limit),
         ),

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -184,7 +184,6 @@ fn create_node_for_fuzzing() -> RoundManager {
         ChainHealthBackoffConfig::new_no_backoff(),
         false,
         ValidatorTxnConfig::default_disabled(),
-        true,
         Arc::new(MockOptQSPayloadProvider {}),
     );
 

--- a/consensus/src/round_manager_test.rs
+++ b/consensus/src/round_manager_test.rs
@@ -317,7 +317,6 @@ impl NodeSetup {
             ChainHealthBackoffConfig::new_no_backoff(),
             false,
             onchain_consensus_config.effective_validator_txn_config(),
-            true,
             Arc::new(MockOptQSPayloadProvider {}),
         );
 
@@ -787,7 +786,7 @@ fn vote_on_successful_proposal() {
         node.next_proposal().await;
 
         let proposal = Block::new_proposal(
-            Payload::empty(false, true),
+            Payload::empty(false),
             1,
             1,
             genesis_qc.clone(),
@@ -837,7 +836,7 @@ fn delay_proposal_processing_in_sync_only() {
             .block_store
             .set_back_pressure_for_test(true);
         let proposal = Block::new_proposal(
-            Payload::empty(false, true),
+            Payload::empty(false),
             1,
             1,
             genesis_qc.clone(),
@@ -898,7 +897,7 @@ fn no_vote_on_old_proposal() {
     let node = &mut nodes[0];
     let genesis_qc = certificate_for_genesis();
     let new_block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -908,7 +907,7 @@ fn no_vote_on_old_proposal() {
     .unwrap();
     let new_block_id = new_block.id();
     let old_block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         2,
         genesis_qc,
@@ -957,7 +956,7 @@ fn no_vote_on_mismatch_round() {
     .unwrap();
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -966,7 +965,7 @@ fn no_vote_on_mismatch_round() {
     )
     .unwrap();
     let block_skip_round = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         2,
         2,
         genesis_qc.clone(),
@@ -1088,7 +1087,7 @@ fn no_vote_on_invalid_proposer() {
     let mut node = nodes.pop().unwrap();
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -1097,7 +1096,7 @@ fn no_vote_on_invalid_proposer() {
     )
     .unwrap();
     let block_incorrect_proposer = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -1156,7 +1155,7 @@ fn new_round_on_timeout_certificate() {
     .unwrap();
     let genesis_qc = certificate_for_genesis();
     let correct_block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -1165,7 +1164,7 @@ fn new_round_on_timeout_certificate() {
     )
     .unwrap();
     let block_skip_round = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         2,
         2,
         genesis_qc.clone(),
@@ -1247,7 +1246,7 @@ fn reject_invalid_failed_authors() {
 
     let create_proposal = |round: Round, failed_authors: Vec<(Round, Author)>| {
         let block = Block::new_proposal(
-            Payload::empty(false, true),
+            Payload::empty(false),
             round,
             2,
             genesis_qc.clone(),
@@ -1331,7 +1330,7 @@ fn response_on_block_retrieval() {
 
     let genesis_qc = certificate_for_genesis();
     let block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -1459,7 +1458,7 @@ fn recover_on_restart() {
             genesis_qc.clone(),
             i,
             i,
-            Payload::empty(false, true),
+            Payload::empty(false),
             (std::cmp::max(1, i.saturating_sub(10))..i)
                 .map(|i| (i, inserter.signer().author()))
                 .collect(),
@@ -2403,7 +2402,7 @@ fn no_vote_on_proposal_ext_when_feature_disabled() {
 
     let invalid_block = Block::new_proposal_ext(
         vec![ValidatorTransaction::dummy(vec![0xFF]); 5],
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -2413,7 +2412,7 @@ fn no_vote_on_proposal_ext_when_feature_disabled() {
     .unwrap();
 
     let valid_block = Block::new_proposal(
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc,
@@ -2487,7 +2486,7 @@ fn assert_process_proposal_result(
     let genesis_qc = certificate_for_genesis();
     let block = Block::new_proposal_ext(
         vtxns,
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),
@@ -2585,7 +2584,7 @@ fn no_vote_on_proposal_ext_when_receiving_limit_exceeded() {
 
     let block_vtxns_too_large = Block::new_proposal_ext(
         vec![ValidatorTransaction::dummy(vec![0xFF; 200]); 5], // total_bytes >= 200 * 5 = 1000
-        Payload::empty(false, true),
+        Payload::empty(false),
         1,
         1,
         genesis_qc.clone(),

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -131,10 +131,7 @@ impl TExecutionClient for MockExecutionClient {
         for block in blocks {
             self.block_cache.lock().insert(
                 block.id(),
-                block
-                    .payload()
-                    .unwrap_or(&Payload::empty(false, true))
-                    .clone(),
+                block.payload().unwrap_or(&Payload::empty(false)).clone(),
             );
         }
 

--- a/consensus/src/test_utils/mod.rs
+++ b/consensus/src/test_utils/mod.rs
@@ -213,7 +213,7 @@ impl TreeInserter {
                 parent_qc,
                 parent.timestamp_usecs() + 1,
                 round,
-                Payload::empty(false, true),
+                Payload::empty(false),
                 vec![],
             ))
             .await

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -89,18 +89,6 @@ pub fn extract_txns_from_block<'a>(
             Payload::DirectMempool(_) => {
                 bail!("DirectMempool is not supported.");
             },
-            Payload::InQuorumStore(proof_with_data) => extract_txns_from_quorum_store(
-                proof_with_data.proofs.iter().map(|proof| *proof.digest()),
-                all_batches,
-            ),
-            Payload::InQuorumStoreWithLimit(proof_with_data) => extract_txns_from_quorum_store(
-                proof_with_data
-                    .proof_with_data
-                    .proofs
-                    .iter()
-                    .map(|proof| *proof.digest()),
-                all_batches,
-            ),
             Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
             | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 let mut all_txns = extract_txns_from_quorum_store(

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -89,6 +89,12 @@ pub fn extract_txns_from_block<'a>(
             Payload::DirectMempool(_) => {
                 bail!("DirectMempool is not supported.");
             },
+            Payload::Legacy1 => {
+                bail!("Payload is in legacy format: Legacy1");
+            },
+            Payload::Legacy2 => {
+                bail!("Payload is in legacy format: Legacy2");
+            },
             Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
             | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                 let mut all_txns = extract_txns_from_quorum_store(

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -766,13 +766,9 @@ Payload:
           SEQ:
             TYPENAME: SignedTransaction
     1:
-      InQuorumStore:
-        NEWTYPE:
-          TYPENAME: ProofWithData
+      Legacy1: UNIT
     2:
-      InQuorumStoreWithLimit:
-        NEWTYPE:
-          TYPENAME: ProofWithDataWithTxnLimit
+      Legacy2: UNIT
     3:
       QuorumStoreInlineHybrid:
         TUPLE:
@@ -829,12 +825,6 @@ ProofWithData:
     - proofs:
         SEQ:
           TYPENAME: ProofOfStore
-ProofWithDataWithTxnLimit:
-  STRUCT:
-    - proof_with_data:
-        TYPENAME: ProofWithData
-    - max_txns_to_execute:
-        OPTION: U64
 ProposalExt:
   ENUM:
     0:


### PR DESCRIPTION
## Description

Removes config `allow_batches_without_pos_in_proposal` and keep the logic for when this was `true`.
Removes the Payload/BlockTransactionPayload variants `InQuorumStore` and `InQuorumStoreWithLimits`; removal is safe as these were (a) not in the logic for `true` above and (b) not being used in production.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
