### PR TITLE
[CO] fix pipeline futures

### DIFF
--- a/consensus/src/consensus_observer/observer/consensus_observer.rs
+++ b/consensus/src/consensus_observer/observer/consensus_observer.rs
@@ -272,22 +272,29 @@ impl ConsensusObserver {
         );
 
         if self.pipeline_enabled() {
-            for block in ordered_block.blocks() {
-                let commit_callback = self.active_observer_state.create_commit_callback(
-                    self.ordered_block_store.clone(),
-                    self.block_payload_store.clone(),
-                );
-                if let Some(futs) = self.get_parent_pipeline_futs(block) {
-                    self.pipeline_builder().build(block, futs, commit_callback);
-                } else {
-                    warn!(
+            let block = ordered_block.first_block();
+            let mut parent_fut = if let Some(futs) = self.get_parent_pipeline_futs(&block) {
+                Some(futs)
+            } else {
+                warn!(
                             LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                                 "Parent block's pipeline futures for ordered block is missing! Ignoring: {:?}",
                                 ordered_block.proof_block_info()
                             ))
                         );
-                    return;
-                }
+                return;
+            };
+            for block in ordered_block.blocks() {
+                let commit_callback = self.active_observer_state.create_commit_callback(
+                    self.ordered_block_store.clone(),
+                    self.block_payload_store.clone(),
+                );
+                self.pipeline_builder().build(
+                    block,
+                    parent_fut.take().expect("future should be set"),
+                    commit_callback,
+                );
+                parent_fut = Some(block.pipeline_futs().expect("pipeline futures just built"));
             }
         }
         // Create the commit callback (to be called after the execution pipeline)

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -399,7 +399,8 @@ impl BufferManager {
         } = ordered_blocks;
 
         info!(
-            "Receive ordered block {}, the queue size is {}",
+            "Receive {} ordered block ends with {}, the queue size is {}",
+            ordered_blocks.len(),
             ordered_proof.commit_info(),
             self.buffer.len() + 1,
         );


### PR DESCRIPTION
This commit properly sets parent futures when the ordered blocks have more than one block.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
