### PR TITLE
[aptos-debugger] Fix aptos debugger crash

### DIFF
--- a/aptos-move/aptos-debugger/src/aptos_debugger.rs
+++ b/aptos-move/aptos-debugger/src/aptos_debugger.rs
@@ -74,7 +74,10 @@ impl AptosDebugger {
         print_transaction_stats(txn_provider.get_txns(), version);
 
         let mut result = None;
-
+        assert!(
+            !concurrency_levels.is_empty(),
+            "concurrency_levels cannot be empty"
+        );
         for concurrency_level in concurrency_levels {
             for i in 0..repeat_execution_times {
                 let start_time = Instant::now();

--- a/aptos-move/aptos-debugger/src/common.rs
+++ b/aptos-move/aptos-debugger/src/common.rs
@@ -27,7 +27,7 @@ pub struct Opts {
     #[clap(flatten)]
     pub(crate) target: Target,
 
-    #[clap(long, num_args = 0..)]
+    #[clap(long, num_args = 0.., default_values_t = [1])]
     pub(crate) concurrency_level: Vec<usize>,
 }
 


### PR DESCRIPTION
## Description

Right now, the aptos debugger panics if we don't explicitly provide the `--concurrency-level` argument.

For example, the following crashes:
`aptos-debugger move execute-past-transactions --begin-version 2367592035 --limit 1 --rest-endpoint https://mainnet.aptoslabs.com/v1`

In this PR, we set a default value for the concurrency level, so that we don't panic. Also added an assert to make it easier to catch similar bugs in using `execute_transactions_at_version` incorrectly.

## How Has This Been Tested?

Manually.

## Key Areas to Review

Is the default value reasonable?

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos Debugger
