### PR TITLE
[cli] Add move-mutation-test to `aptos update`

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 - Compiler v1 is now deprecated. It is now removed from the Aptos CLI.
 - Added a new option `aptos move compile --fail-on-warning` which fails the compilation if any warnings are found.
 - We now default to running extended checks when compiling test code (this was previously only done with the option `--check-test-code`, but this is no longer available). However, these checks can be now be skipped with `--skip-checks-on-test-code`.
-- Add network to show profiles
+- Add network to show profiles.
+- The new subcommand `aptos update move-mutation-test` will install/update the external binary `move-mutation-test`, which performs mutation testing on a Move project to find blind spots in Move unit tests.
 
 ## [6.2.0]
 - Several compiler parsing bugs fixed, including in specifications for receiver style functions

--- a/crates/aptos/src/update/mod.rs
+++ b/crates/aptos/src/update/mod.rs
@@ -6,6 +6,7 @@
 
 mod aptos;
 mod helpers;
+mod move_mutation_test;
 mod movefmt;
 mod prover_dependencies;
 mod prover_dependency_installer;
@@ -91,7 +92,7 @@ impl UpdateRequiredInfo {
         match self.current_version {
             Some(ref current_version) => {
                 // ignore ".beta" or ".rc" for version comparison
-                // because bump_is_greater only supports comparison bewteen `x.y.z`
+                // because bump_is_greater only supports comparison between `x.y.z`
                 // as a result, `1.0.0.rc1` cannot be updated to `1.0.0.rc2`
                 let target_version = if self.target_version.ends_with(".beta") {
                     &self.target_version[0..self.target_version.len() - 5]

--- a/crates/aptos/src/update/move_mutation_test.rs
+++ b/crates/aptos/src/update/move_mutation_test.rs
@@ -1,0 +1,136 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use super::{update_binary, BinaryUpdater, UpdateRequiredInfo};
+use crate::{
+    common::types::{CliCommand, CliTypedResult, PromptOptions},
+    update::update_helper::{build_updater, get_path},
+};
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use clap::Parser;
+use self_update::update::ReleaseUpdate;
+use std::path::PathBuf;
+
+const MUTATION_TEST_BINARY_NAME: &str = "move-mutation-test";
+const TARGET_MUTATION_TEST_VERSION: &str = "1.0.0";
+
+const MUTATION_TEST_EXE_ENV: &str = "MUTATION_TEST_EXE";
+#[cfg(target_os = "windows")]
+const MUTATION_TEST_EXE: &str = "move-mutation-test.exe";
+#[cfg(not(target_os = "windows"))]
+const MUTATION_TEST_EXE: &str = "move-mutation-test";
+
+/// Update move-mutation-test, the tool used for mutation testing of Move unit tests.
+#[derive(Debug, Parser)]
+pub struct MutationTestUpdaterTool {
+    /// The owner of the repo to download the binary from.
+    #[clap(long, default_value = "eigerco")]
+    repo_owner: String,
+
+    /// The name of the repo to download the binary from.
+    #[clap(long, default_value = "move-mutation-tools")]
+    repo_name: String,
+
+    /// The version to install, e.g. 1.0.0. Use with caution, the default value is a
+    /// version that is tested for compatibility with the version of the CLI you are
+    /// using.
+    #[clap(long, default_value = TARGET_MUTATION_TEST_VERSION)]
+    target_version: String,
+
+    /// Where to install the binary. Make sure this directory is on your PATH. If not
+    /// given we will put it in a standard location for your OS that the CLI will use
+    /// later when the tool is required.
+    #[clap(long)]
+    install_dir: Option<PathBuf>,
+
+    /// If set, it will check if there are updates for the tool, but not actually update
+    #[clap(long, default_value_t = false)]
+    check: bool,
+
+    #[clap(flatten)]
+    pub prompt_options: PromptOptions,
+}
+
+fn extract_move_mutation_test_version(input: &str) -> Option<String> {
+    use regex::Regex;
+    let re = Regex::new(r"move-mutation-test \d+\.\d+\.\d+").unwrap();
+    if let Some(caps) = re.captures(input) {
+        let version = caps.get(0).unwrap().as_str().to_string();
+        Some(
+            version
+                .trim_start_matches("move-mutation-test ")
+                .to_string(),
+        )
+    } else {
+        None
+    }
+}
+
+impl BinaryUpdater for MutationTestUpdaterTool {
+    fn check(&self) -> bool {
+        self.check
+    }
+
+    fn pretty_name(&self) -> String {
+        "move-mutation-test".to_string()
+    }
+
+    /// Return information about whether an update is required.
+    fn get_update_info(&self) -> Result<UpdateRequiredInfo> {
+        // Get the current version, if any.
+        let mutation_test_path = get_move_mutation_test_path();
+        let current_version = match mutation_test_path {
+            Ok(path) => {
+                let output = std::process::Command::new(path)
+                    .arg("--version")
+                    .output()
+                    .context("Failed to get current version of move-mutation-test")?;
+                let stdout = String::from_utf8(output.stdout)
+                    .context("Failed to parse current version of move-mutation-test as UTF-8")?;
+                extract_move_mutation_test_version(&stdout)
+            },
+            Err(_) => None,
+        };
+
+        Ok(UpdateRequiredInfo {
+            current_version,
+            target_version: self.target_version.trim_start_matches('v').to_string(),
+        })
+    }
+
+    fn build_updater(&self, info: &UpdateRequiredInfo) -> Result<Box<dyn ReleaseUpdate>> {
+        build_updater(
+            info,
+            self.install_dir.clone(),
+            self.repo_owner.clone(),
+            self.repo_name.clone(),
+            MUTATION_TEST_BINARY_NAME,
+            "unknown-linux-gnu",
+            "apple-darwin",
+            "windows",
+            self.prompt_options.assume_yes,
+        )
+    }
+}
+
+#[async_trait]
+impl CliCommand<String> for MutationTestUpdaterTool {
+    fn command_name(&self) -> &'static str {
+        "UpdateMoveMutationTest"
+    }
+
+    async fn execute(self) -> CliTypedResult<String> {
+        update_binary(self).await
+    }
+}
+
+pub fn get_move_mutation_test_path() -> Result<PathBuf> {
+    get_path(
+        MUTATION_TEST_BINARY_NAME,
+        MUTATION_TEST_EXE_ENV,
+        MUTATION_TEST_BINARY_NAME,
+        MUTATION_TEST_EXE,
+        true,
+    )
+}

--- a/crates/aptos/src/update/tool.rs
+++ b/crates/aptos/src/update/tool.rs
@@ -4,7 +4,10 @@
 use super::{aptos::AptosUpdateTool, revela::RevelaUpdateTool};
 use crate::{
     common::types::{CliCommand, CliResult},
-    update::{movefmt::FormatterUpdateTool, prover_dependencies::ProverDependencyInstaller},
+    update::{
+        move_mutation_test::MutationTestUpdaterTool, movefmt::FormatterUpdateTool,
+        prover_dependencies::ProverDependencyInstaller,
+    },
 };
 use clap::Subcommand;
 
@@ -14,6 +17,7 @@ pub enum UpdateTool {
     Aptos(AptosUpdateTool),
     Revela(RevelaUpdateTool),
     Movefmt(FormatterUpdateTool),
+    MoveMutationTest(MutationTestUpdaterTool),
     ProverDependencies(ProverDependencyInstaller),
 }
 
@@ -23,6 +27,7 @@ impl UpdateTool {
             UpdateTool::Aptos(tool) => tool.execute_serialized().await,
             UpdateTool::Revela(tool) => tool.execute_serialized().await,
             UpdateTool::Movefmt(tool) => tool.execute_serialized().await,
+            UpdateTool::MoveMutationTest(tool) => tool.execute_serialized().await,
             UpdateTool::ProverDependencies(tool) => tool.execute_serialized().await,
         }
     }


### PR DESCRIPTION
## Description

With this PR, we can run `aptos update move-mutation-test` to install the latest version of the move mutation test tool.

## How Has This Been Tested?

Manually. The tool's release on `eigerco/move-mutation-tools` still needs to be update to reflect the correct version number, after which I will test the update again. For now, it will always update when you run the command.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Aptos CLI/SDK
