### PR TITLE
[cli] add network to show-profiles

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 - Compiler v1 is now deprecated. It is now removed from the Aptos CLI.
 - Added a new option `aptos move compile --fail-on-warning` which fails the compilation if any warnings are found.
 - We now default to running extended checks when compiling test code (this was previously only done with the option `--check-test-code`, but this is no longer available). However, these checks can be now be skipped with `--skip-checks-on-test-code`.
+- Add network to show profiles
 
 ## [6.2.0]
 - Several compiler parsing bugs fixed, including in specifications for receiver style functions

--- a/crates/aptos/e2e/cases/config.py
+++ b/crates/aptos/e2e/cases/config.py
@@ -26,6 +26,7 @@ def test_config_show_profiles(run_helper: RunHelper, test_name=None):
         profile["has_private_key"] != True
         or profile["public_key"] != expected_profile.public_key
         or profile["account"] != expected_profile.account_address
+        or profile["network"] != expected_profile.network
     ):
         raise TestError(
             f"[aptos config show-profiles] shows incorrect profile {profile} -- \n expected {expected_profile}"

--- a/crates/aptos/e2e/common.py
+++ b/crates/aptos/e2e/common.py
@@ -25,6 +25,7 @@ class AccountInfo:
     private_key: str
     public_key: str
     account_address: str
+    network: Network
 
 
 # This is an account that use for testing, for example to create it with the init
@@ -34,6 +35,7 @@ OTHER_ACCOUNT_ONE = AccountInfo(
     private_key="0x37368b46ce665362562c6d1d4ec01a08c8644c488690df5a17e13ba163e20221",
     public_key="0x25caf00522e4d4664ec0a27166a69e8a32b5078959d0fc398da70d40d2893e8f",
     account_address="0x585fc9f0f0c54183b039ffc770ca282ebd87307916c215a3e692f2f8e4305e82",
+    network=Network.DEVNET,
 )
 
 

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -200,6 +200,7 @@ class RunHelper:
         private_key = None
         public_key = None
         account_address = None
+        network = None
         for line in content:
             if "private_key: " in line:
                 private_key = line.split("private_key: ")[1].replace('"', "")
@@ -207,9 +208,12 @@ class RunHelper:
                 public_key = line.split("public_key: ")[1].replace('"', "")
             if "account: " in line:
                 account_address = line.split("account: ")[1].replace('"', "")
+            if "network: " in line:
+                network = line.split("network: ")[1].replace('"', "")
         if not private_key or not public_key or not account_address:
             raise RuntimeError(f"Failed to parse {path} to get account info")
         return AccountInfo(
+            network=network,
             private_key=private_key,
             public_key=public_key,
             account_address=account_address,

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -290,6 +290,8 @@ pub struct ProfileConfig {
 /// ProfileConfig but without the private parts
 #[derive(Debug, Serialize)]
 pub struct ProfileSummary {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub network: Option<Network>,
     pub has_private_key: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub public_key: Option<Ed25519PublicKey>,
@@ -304,6 +306,7 @@ pub struct ProfileSummary {
 impl From<&ProfileConfig> for ProfileSummary {
     fn from(config: &ProfileConfig) -> Self {
         ProfileSummary {
+            network: config.network.clone(),
             has_private_key: config.private_key.is_some(),
             public_key: config.public_key.clone(),
             account: config.account,

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -306,7 +306,7 @@ pub struct ProfileSummary {
 impl From<&ProfileConfig> for ProfileSummary {
     fn from(config: &ProfileConfig) -> Self {
         ProfileSummary {
-            network: config.network.clone(),
+            network: config.network,
             has_private_key: config.private_key.is_some(),
             public_key: config.public_key.clone(),
             account: config.account,


### PR DESCRIPTION
## Description
Added `network` to the output of `aptos config show-profiles`. 

Example output:
```
$ aptos config show-profiles
{
  "Result": {
    "default": {
      "network": "Devnet",
      "has_private_key": true,
      "public_key": "0xe8dee7e202b2f68d10faf2efb46ee7e2ca51655179cfab07ef54752c1f3e0818",
      "account": "4dc6729e92ad055050fd8afd85ebbc27d43e0503a4eadd670ede31cf5617f002",
      "rest_url": "https://fullnode.devnet.aptoslabs.com",
      "faucet_url": "https://faucet.devnet.aptoslabs.com"
    }
  }
}
```

## How Has This Been Tested?
- Updated `test_config_show_profiles` to also test the new network value.
- Also manually tested the CLI using the compiled binary, for both Aptos networks and custom networks.

## Key Areas to Review

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
