### PR TITLE
Replay-verify: set TTL on PVCs as well

### DIFF
--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -503,7 +503,7 @@ def parse_args() -> argparse.Namespace:
     ),
 )
 def create_one_pvc_from_snapshot(
-    pvc_name: str, snapshot_name: str, namespace: str, label: str
+    pvc_name: str, snapshot_name: str, namespace: str, label: str, ttl_secs: int
 ) -> str:
     config.load_kube_config()
     api_instance = client.CoreV1Api()
@@ -516,7 +516,8 @@ def create_one_pvc_from_snapshot(
         "metadata": {
             "name": f"{pvc_name}",
             "annotations": {
-                "volume.kubernetes.io/storage-provisioner": "pd.csi.storage.gke.io"
+                "volume.kubernetes.io/storage-provisioner": "pd.csi.storage.gke.io",
+                "k8s-ttl-controller.twin.sh/ttl": f"{ttl_secs}s",
             },
             "labels": {"run": f"{label}"},
         },
@@ -540,7 +541,7 @@ def create_one_pvc_from_snapshot(
 
 
 def create_replay_verify_pvcs_from_snapshot(
-    run_id: str, snapshot_name: str, namespace: str, pvc_num: int, label: str
+    run_id: str, snapshot_name: str, namespace: str, pvc_num: int, label: str, ttl_secs: int
 ) -> List[str]:
     config.load_kube_config()
     api_instance = client.CustomObjectsApi()
@@ -601,6 +602,7 @@ def create_replay_verify_pvcs_from_snapshot(
             snapshot_name,
             namespace,
             label,
+            ttl_secs,
         )
         for pvc_id in range(pvc_num)
     ]

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -28,6 +28,7 @@ SHARDING_ENABLED = True
 MAX_RETRIES = 5
 RETRY_DELAY = 20  # seconds
 QUERY_DELAY = 5  # seconds
+TEARDOWN_DELAY= 30 * 60 # 30 minutes slack to allow for pod setup and teardown
 
 REPLAY_CONCURRENCY_LEVEL = 1
 
@@ -206,7 +207,7 @@ class WorkerPod:
         pod_manifest["metadata"]["name"] = self.name  # Unique name for each pod
         pod_manifest["metadata"]["labels"]["run"] = self.label
         pod_manifest["spec"]["containers"][0]["image"] = self.image
-        pod_ttl = self.config.timeout_secs + 30 * 60 # 30 minutes slack to allow for pod setup and teardown
+        pod_ttl = self.config.timeout_secs + TEARDOWN_DELAY
         pod_manifest["metadata"]["annotations"]["k8s-ttl-controller.twin.sh/ttl"] = f"{pod_ttl}s"
         pod_manifest["spec"]["volumes"][0]["persistentVolumeClaim"][
             "claimName"
@@ -443,12 +444,17 @@ class ReplayScheduler:
             if self.network == Network.TESTNET
             else MAINNET_SNAPSHOT_NAME
         )
+        # Because PVCs can be shared among multiple replay-verify runs, a more correct TTL
+        # would be computed from the number of shards and the expected run time of the replay-verify
+        # run. However, for simplicity, we set the TTL to 3 hours.
+        pvc_ttl = 3 * 60 * 60  # 3 hours
         pvcs = create_replay_verify_pvcs_from_snapshot(
             self.id,
             snapshot_name,
             self.namespace,
             self.config.pvc_number,
             self.get_label(),
+            pvc_ttl,
         )
         assert len(pvcs) == self.config.pvc_number, "failed to create all pvcs"
         self.pvcs = pvcs


### PR DESCRIPTION
## Description

Cleanup stray PVCs too. The TTL is the same as the pod mounting the PVC.

## Testing

Will start a replay-verify workflow on the PR branch.
Test run: https://github.com/aptos-labs/aptos-core/actions/runs/13955750026