### PR TITLE
[DelayedFields] Get exchange ID->value from local captured reads [2/4]

### DIFF
--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -824,7 +824,7 @@ where
         let resource_writes_to_materialize = resource_writes_to_materialize!(
             resource_write_set,
             last_input_output,
-            versioned_cache.data(),
+            last_input_output,
             txn_idx
         )?;
         let materialized_resource_write_set =

--- a/aptos-move/block-executor/src/executor_utilities.rs
+++ b/aptos-move/block-executor/src/executor_utilities.rs
@@ -49,37 +49,27 @@ macro_rules! groups_to_finalize {
 macro_rules! resource_writes_to_materialize {
     ($writes:expr, $outputs:expr, $data_source:expr, $($txn_idx:expr),*) => {{
 	$outputs
-            .reads_needing_delayed_field_exchange($($txn_idx),*)
-            .into_iter()
-	    .map(|(key, metadata, layout)| {
-		match $data_source.fetch_exchanged_data(&key, $($txn_idx),*) {
-		    Some((value, existing_layout)) => {
-			randomly_check_layout_matches(
-			    Some(&existing_layout),
-			    Some(layout.as_ref()),
-			)?;
-			let new_value = Arc::new(TransactionWrite::from_state_value(Some(
-			    StateValue::new_with_metadata(
-				value.bytes().cloned().unwrap_or_else(Bytes::new), metadata)
-			    )));
-			Ok((key, new_value, layout))
-		    },
-		    None => {
-			Err(code_invariant_error(
-			    "Read value needing exchange not in Exchanged format".to_string()
-			))
-		    }
-		}}).chain(
-		$writes.into_iter().filter_map(|(key, value, maybe_layout)| {
-		    // layout is Some(_) if it contains a delayed field
-		    if let Some(layout) = maybe_layout {
-			// No need to exchange anything if a resource with delayed field is deleted.
-			if !value.is_deletion() {
-			    return Some(Ok((key, value, layout)))
-			}
-		    }
-		    None
-		})).collect::<std::result::Result<Vec<_>, _>>()
+        .reads_needing_delayed_field_exchange($($txn_idx),*)
+        .into_iter()
+	    .map(|(key, metadata, layout)| -> Result<_, PanicError> {
+	        let (value, existing_layout) = $data_source.fetch_exchanged_data(&key, $($txn_idx),*)?;
+            randomly_check_layout_matches(Some(&existing_layout), Some(layout.as_ref()))?;
+            let new_value = Arc::new(TransactionWrite::from_state_value(Some(
+                StateValue::new_with_metadata(
+                    value.bytes().cloned().unwrap_or_else(Bytes::new),
+                    metadata,
+                ))
+            ));
+            Ok((key, new_value, layout))
+        })
+        .chain(
+	        $writes.into_iter().filter_map(|(key, value, maybe_layout)| {
+		        maybe_layout.map(|layout| {
+                    (!value.is_deletion()).then_some(Ok((key, value, layout)))
+                }).flatten()
+            })
+        )
+        .collect::<Result<Vec<_>, _>>()
     }};
 }
 

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    captured_reads::CapturedReads,
+    captured_reads::{CapturedReads, DataRead, ReadKind},
     errors::ParallelBlockExecutionError,
     explicit_sync_wrapper::ExplicitSyncWrapper,
     task::{ExecutionStatus, TransactionOutput},
@@ -102,6 +102,31 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
         *self.resource_group_keys_and_tags[txn_idx as usize].acquire() = group_keys_and_tags;
         self.inputs[txn_idx as usize].store(Some(Arc::new(input)));
         self.outputs[txn_idx as usize].store(Some(Arc::new(output)));
+    }
+
+    pub fn fetch_exchanged_data(
+        &self,
+        key: &T::Key,
+        txn_idx: TxnIndex,
+    ) -> Result<(Arc<T::Value>, Arc<MoveTypeLayout>), PanicError> {
+        self.inputs[txn_idx as usize].load().as_ref().map_or_else(
+            || {
+                Err(code_invariant_error(
+                    "Read must be recorded before fetching exchanged data".to_string(),
+                ))
+            },
+            |input| {
+                let data_read = input.get_by_kind(key, None, ReadKind::Value);
+                if let Some(DataRead::Versioned(_, value, Some(layout))) = data_read {
+                    Ok((value, layout))
+                } else {
+                    Err(code_invariant_error(format!(
+                        "Read value needing exchange {:?} not in Exchanged format",
+                        data_read
+                    )))
+                }
+            },
+        )
     }
 
     pub(crate) fn read_set(&self, txn_idx: TxnIndex) -> Option<Arc<TxnInput<T>>> {

--- a/aptos-move/mvhashmap/src/unsync_map.rs
+++ b/aptos-move/mvhashmap/src/unsync_map.rs
@@ -272,11 +272,18 @@ impl<
         self.resource_map.borrow().get(key).cloned()
     }
 
-    pub fn fetch_exchanged_data(&self, key: &K) -> Option<(Arc<V>, Arc<MoveTypeLayout>)> {
-        if let Some(ValueWithLayout::Exchanged(value, Some(layout))) = self.fetch_data(key) {
-            Some((value, layout))
+    pub fn fetch_exchanged_data(
+        &self,
+        key: &K,
+    ) -> Result<(Arc<V>, Arc<MoveTypeLayout>), PanicError> {
+        let data = self.fetch_data(key);
+        if let Some(ValueWithLayout::Exchanged(value, Some(layout))) = data {
+            Ok((value, layout))
         } else {
-            None
+            Err(code_invariant_error(format!(
+                "Read value needing exchange {:?} does not exist or not in Exchanged format",
+                data
+            )))
         }
     }
 

--- a/aptos-move/mvhashmap/src/versioned_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_data.rs
@@ -277,20 +277,6 @@ impl<K: Hash + Clone + Debug + Eq, V: TransactionWrite> VersionedData<K, V> {
             .unwrap_or(Err(MVDataError::Uninitialized))
     }
 
-    pub fn fetch_exchanged_data(
-        &self,
-        key: &K,
-        txn_idx: TxnIndex,
-    ) -> Option<(Arc<V>, Arc<MoveTypeLayout>)> {
-        if let Ok(MVDataOutput::Versioned(_, ValueWithLayout::Exchanged(value, Some(layout)))) =
-            self.fetch_data(key, txn_idx)
-        {
-            Some((value, layout))
-        } else {
-            None
-        }
-    }
-
     pub fn set_base_value(&self, key: K, value: ValueWithLayout<V>) {
         let mut v = self.values.entry(key).or_default();
         // For base value, incarnation is irrelevant, and is always set to 0.


### PR DESCRIPTION
The values were obtained from a shared multi-versioned data-structure, but they should also be cached in local captured reads. Should be more logical and better performance wise.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
