### PR TITLE
[Consensus Observer] Add buffer support for execution pool.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -49,6 +49,8 @@ pub struct ConsensusObserverConfig {
     /// Interval (in milliseconds) to refresh the subscription
     pub subscription_refresh_interval_ms: u64,
 
+    /// The multiplier for the block window (used to calculate the block buffer size)
+    pub observer_block_window_buffer_multiplier: u64,
     /// Duration (in milliseconds) to require state sync to synchronize when in fallback mode
     pub observer_fallback_duration_ms: u64,
     /// Duration (in milliseconds) we'll wait on startup before considering fallback mode
@@ -69,13 +71,14 @@ impl Default for ConsensusObserverConfig {
             max_parallel_serialization_tasks: num_cpus::get(), // Default to the number of CPUs
             network_request_timeout_ms: 5_000,                 // 5 seconds
             garbage_collection_interval_ms: 60_000,            // 60 seconds
-            max_num_pending_blocks: 100,                       // 100 blocks
+            max_num_pending_blocks: 200,                       // 200 blocks
             progress_check_interval_ms: 5_000,                 // 5 seconds
             max_concurrent_subscriptions: 2,                   // 2 streams should be sufficient
             max_subscription_sync_timeout_ms: 15_000,          // 15 seconds
             max_subscription_timeout_ms: 15_000,               // 15 seconds
             subscription_peer_change_interval_ms: 180_000,     // 3 minutes
             subscription_refresh_interval_ms: 600_000,         // 10 minutes
+            observer_block_window_buffer_multiplier: 2,        // Double the block window
             observer_fallback_duration_ms: 600_000,            // 10 minutes
             observer_fallback_startup_period_ms: 60_000,       // 60 seconds
             observer_fallback_progress_threshold_ms: 10_000,   // 10 seconds

--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -332,8 +332,9 @@ fn handle_committed_blocks(
     root: Arc<Mutex<LedgerInfoWithSignatures>>,
     ledger_info: LedgerInfoWithSignatures,
 ) {
-    // grab the lock for whole section to avoid inconsistent views
+    // Lock the root for the entire callback (to avoid inconsistent views across stores)
     let mut root = root.lock();
+
     // Remove the committed blocks from the payload and pending stores
     block_payload_store
         .lock()

--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -107,6 +107,7 @@ impl ActiveObserverState {
         &self,
         pending_ordered_blocks: Arc<Mutex<OrderedBlockStore>>,
         block_payload_store: Arc<Mutex<BlockPayloadStore>>,
+        execution_pool_window_size: Option<u64>,
     ) -> Box<dyn FnOnce(WrappedLedgerInfo, LedgerInfoWithSignatures) + Send + Sync> {
         // Clone the root pointer
         let root = self.root.clone();
@@ -116,6 +117,7 @@ impl ActiveObserverState {
             handle_committed_blocks(
                 pending_ordered_blocks,
                 block_payload_store,
+                execution_pool_window_size,
                 root,
                 ledger_info,
             );
@@ -127,12 +129,17 @@ impl ActiveObserverState {
         &self,
         pending_ordered_blocks: Arc<Mutex<OrderedBlockStore>>,
         block_payload_store: Arc<Mutex<BlockPayloadStore>>,
+        execution_pool_window_size: Option<u64>,
     ) -> StateComputerCommitCallBackType {
+        // Clone the root pointer
         let root = self.root.clone();
-        Box::new(move |_, ledger_info| {
+
+        // Create the commit callback
+        Box::new(move |_, ledger_info: LedgerInfoWithSignatures| {
             handle_committed_blocks(
                 pending_ordered_blocks,
                 block_payload_store,
+                execution_pool_window_size,
                 root,
                 ledger_info,
             );
@@ -315,16 +322,16 @@ async fn extract_on_chain_configs(
 fn handle_committed_blocks(
     pending_ordered_blocks: Arc<Mutex<OrderedBlockStore>>,
     block_payload_store: Arc<Mutex<BlockPayloadStore>>,
+    execution_pool_window_size: Option<u64>,
     root: Arc<Mutex<LedgerInfoWithSignatures>>,
     ledger_info: LedgerInfoWithSignatures,
 ) {
     // grab the lock for whole section to avoid inconsistent views
     let mut root = root.lock();
     // Remove the committed blocks from the payload and pending stores
-    block_payload_store.lock().remove_blocks_for_epoch_round(
-        ledger_info.commit_info().epoch(),
-        ledger_info.commit_info().round(),
-    );
+    block_payload_store
+        .lock()
+        .remove_block_payloads_for_commit(&ledger_info, execution_pool_window_size);
     pending_ordered_blocks
         .lock()
         .remove_blocks_for_commit(&ledger_info);
@@ -366,6 +373,7 @@ mod test {
         observer::execution_pool::ObservedOrderedBlock,
     };
     use aptos_channels::{aptos_channel, message_queues::QueueStyle};
+    use aptos_config::config::ConsensusObserverConfig;
     use aptos_consensus_types::{
         block::Block,
         block_data::{BlockData, BlockType},
@@ -456,6 +464,7 @@ mod test {
         handle_committed_blocks(
             ordered_block_store.clone(),
             block_payload_store.clone(),
+            None,
             root.clone(),
             create_ledger_info(epoch + 1, round + 1),
         );
@@ -465,6 +474,7 @@ mod test {
         handle_committed_blocks(
             ordered_block_store.clone(),
             block_payload_store.clone(),
+            None,
             root.clone(),
             create_ledger_info(epoch, round - 1),
         );
@@ -488,17 +498,11 @@ mod test {
         let commit_round = round + (num_ordered_blocks as Round) - 2;
         let committed_ledger_info = create_ledger_info(epoch, commit_round);
 
-        // Create the committed blocks and ledger info
-        let mut committed_blocks = vec![];
-        for ordered_block in ordered_blocks.iter().take(num_ordered_blocks - 1) {
-            let pipelined_block = create_pipelined_block(ordered_block.blocks()[0].block_info());
-            committed_blocks.push(pipelined_block);
-        }
-
-        // Handle the committed blocks
+        // Handle the committed blocks (without an execution pool window)
         handle_committed_blocks(
             ordered_block_store.clone(),
             block_payload_store.clone(),
+            None,
             root.clone(),
             committed_ledger_info.clone(),
         );
@@ -509,6 +513,82 @@ mod test {
             block_payload_store.lock().get_block_payloads().lock().len(),
             1
         );
+
+        // Verify the root is updated
+        assert_eq!(root.lock().clone(), committed_ledger_info);
+    }
+
+    #[test]
+    fn test_handle_committed_blocks_execution_pool() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let observer_block_window_buffer_multiplier = 2; // Buffer twice the window
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            observer_block_window_buffer_multiplier,
+            ..ConsensusObserverConfig::default()
+        };
+
+        // Create a node config using the observer config
+        let node_config = NodeConfig {
+            consensus_observer: consensus_observer_config,
+            ..NodeConfig::default()
+        };
+
+        // Create the root ledger info
+        let epoch = 10;
+        let round = 500;
+        let root = Arc::new(Mutex::new(create_ledger_info(epoch, round)));
+
+        // Create the ordered block store and block payload store
+        let ordered_block_store = Arc::new(Mutex::new(OrderedBlockStore::new(
+            node_config.consensus_observer,
+        )));
+        let block_payload_store = Arc::new(Mutex::new(BlockPayloadStore::new(
+            node_config.consensus_observer,
+        )));
+
+        // Add pending ordered blocks
+        let num_ordered_blocks = 50;
+        let ordered_blocks = create_and_add_ordered_blocks(
+            ordered_block_store.clone(),
+            num_ordered_blocks,
+            epoch,
+            round,
+        );
+
+        // Add block payloads for the ordered blocks
+        for ordered_block in &ordered_blocks {
+            create_and_add_payloads_for_ordered_block(block_payload_store.clone(), ordered_block);
+        }
+
+        // Create the commit ledger info (for the last block)
+        let commit_round = round + (num_ordered_blocks as Round) - 1;
+        let committed_ledger_info = create_ledger_info(epoch, commit_round);
+
+        // Handle the committed blocks (with an execution pool window)
+        let execution_pool_window_size = 10;
+        handle_committed_blocks(
+            ordered_block_store.clone(),
+            block_payload_store.clone(),
+            Some(execution_pool_window_size),
+            root.clone(),
+            committed_ledger_info.clone(),
+        );
+
+        // Verify that only some committed blocks are removed from the payload store
+        let execution_pool_buffer =
+            execution_pool_window_size as usize * observer_block_window_buffer_multiplier as usize;
+        assert_eq!(
+            block_payload_store.lock().get_block_payloads().lock().len(),
+            execution_pool_buffer
+        );
+
+        // Verify all the committed blocks are removed from the ordered block store
+        assert!(ordered_block_store
+            .lock()
+            .get_all_ordered_blocks()
+            .is_empty());
 
         // Verify the root is updated
         assert_eq!(root.lock().clone(), committed_ledger_info);

--- a/consensus/src/consensus_observer/observer/pending_blocks.rs
+++ b/consensus/src/consensus_observer/observer/pending_blocks.rs
@@ -8,7 +8,9 @@ use crate::{
             metrics,
         },
         network::observer_message::OrderedBlock,
-        observer::{execution_pool::ObservedOrderedBlock, payload_store::BlockPayloadStore},
+        observer::{
+            execution_pool, execution_pool::ObservedOrderedBlock, payload_store::BlockPayloadStore,
+        },
     },
     util::BlockStorage,
 };
@@ -17,7 +19,7 @@ use aptos_consensus_types::pipelined_block::PipelinedBlock;
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
 use aptos_logger::{error, info, warn};
-use aptos_types::block_info::Round;
+use aptos_types::{block_info::Round, ledger_info::LedgerInfoWithSignatures};
 use std::{
     collections::{btree_map::Entry, BTreeMap},
     sync::Arc,
@@ -56,40 +58,45 @@ impl PendingBlockWithMetadata {
         )
     }
 
+    /// Returns a reference to the observed ordered block
+    pub fn observed_ordered_block(&self) -> &ObservedOrderedBlock {
+        &self.observed_ordered_block
+    }
+
     /// Returns a reference to the ordered block
     pub fn ordered_block(&self) -> &OrderedBlock {
         self.observed_ordered_block.ordered_block()
     }
 }
 
-/// A simple struct to hold blocks that are waiting for payloads
+/// A simple struct to hold pending blocks with metadata
 pub struct PendingBlockStore {
     // The configuration of the consensus observer
     consensus_observer_config: ConsensusObserverConfig,
 
-    // A map of ordered blocks that are without payloads. The key is
-    // the (epoch, round) of the first block in the ordered block.
-    blocks_without_payloads: BTreeMap<(u64, Round), Arc<PendingBlockWithMetadata>>,
+    // A map of pending blocks with metadata. The key is the
+    // (epoch, round) of the first block in the ordered block.
+    pending_blocks: BTreeMap<(u64, Round), Arc<PendingBlockWithMetadata>>,
 
-    // A map of ordered blocks that are without payloads. The key is
-    // the hash of the first block in the ordered block.
-    // Note: this is the same as blocks_without_payloads, but with a different key.
-    blocks_without_payloads_by_hash: BTreeMap<HashValue, Arc<PendingBlockWithMetadata>>,
+    // A map of pending blocks with metadata. The key is the
+    // hash of the first block in the ordered block.
+    // Note: this is the same as pending_blocks, but with a different key.
+    pending_blocks_by_hash: BTreeMap<HashValue, Arc<PendingBlockWithMetadata>>,
 }
 
 impl PendingBlockStore {
     pub fn new(consensus_observer_config: ConsensusObserverConfig) -> Self {
         Self {
             consensus_observer_config,
-            blocks_without_payloads: BTreeMap::new(),
-            blocks_without_payloads_by_hash: BTreeMap::new(),
+            pending_blocks: BTreeMap::new(),
+            pending_blocks_by_hash: BTreeMap::new(),
         }
     }
 
-    /// Clears all missing blocks from the store
-    pub fn clear_missing_blocks(&mut self) {
-        self.blocks_without_payloads.clear();
-        self.blocks_without_payloads_by_hash.clear();
+    /// Clears all pending blocks from the store
+    pub fn clear_pending_blocks(&mut self) {
+        self.pending_blocks.clear();
+        self.pending_blocks_by_hash.clear();
     }
 
     /// Returns true iff the store contains an entry for the given ordered block
@@ -99,8 +106,13 @@ impl PendingBlockStore {
         let first_block_epoch_round = (first_block.epoch(), first_block.round());
 
         // Check if the block is already in the store by epoch and round
-        self.blocks_without_payloads
-            .contains_key(&first_block_epoch_round)
+        self.pending_blocks.contains_key(&first_block_epoch_round)
+    }
+
+    #[cfg(test)]
+    /// Returns all pending blocks in the store. This is only used for testing.
+    pub fn get_pending_blocks(&self) -> Vec<Arc<PendingBlockWithMetadata>> {
+        self.pending_blocks.values().cloned().collect()
     }
 
     /// Returns the pending block with the given hash (if it exists)
@@ -108,19 +120,43 @@ impl PendingBlockStore {
         &self,
         block_hash: HashValue,
     ) -> Option<Arc<PendingBlockWithMetadata>> {
-        self.blocks_without_payloads_by_hash
-            .get(&block_hash)
-            .cloned()
+        self.pending_blocks_by_hash.get(&block_hash).cloned()
     }
 
-    /// Inserts a pending block (without payloads) into the store
+    /// Inserts a pending block into the store
     pub fn insert_pending_block(&mut self, pending_block: Arc<PendingBlockWithMetadata>) {
+        // Verify that both stores have the same number of entries.
+        // If not, log an error as this should never happen.
+        let num_pending_blocks = self.pending_blocks.len();
+        let num_pending_blocks_by_hash = self.pending_blocks_by_hash.len();
+        if num_pending_blocks != num_pending_blocks_by_hash {
+            error!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "The pending block stores have different numbers of entries: {} and {} (by hash)",
+                    num_pending_blocks, num_pending_blocks_by_hash
+                ))
+            );
+        }
+
+        // Verify that the number of payloads doesn't exceed the maximum
+        let max_num_pending_blocks = self.consensus_observer_config.max_num_pending_blocks as usize;
+        if num_pending_blocks >= max_num_pending_blocks {
+            warn!(
+                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
+                    "Exceeded the maximum number of pending blocks: {:?}. Dropping block: {:?}!",
+                    max_num_pending_blocks,
+                    pending_block.ordered_block().first_block().block_info(),
+                ))
+            );
+            return; // Drop the block if we've exceeded the maximum
+        }
+
         // Get the first block in the ordered blocks
         let first_block = pending_block.ordered_block().first_block();
 
         // Insert the block into the store using the epoch round of the first block
         let first_block_epoch_round = (first_block.epoch(), first_block.round());
-        match self.blocks_without_payloads.entry(first_block_epoch_round) {
+        match self.pending_blocks.entry(first_block_epoch_round) {
             Entry::Occupied(_) => {
                 // The block is already in the store
                 warn!(
@@ -138,7 +174,7 @@ impl PendingBlockStore {
 
         // Insert the block into the hash store using the hash of the first block
         let first_block_hash = first_block.id();
-        match self.blocks_without_payloads_by_hash.entry(first_block_hash) {
+        match self.pending_blocks_by_hash.entry(first_block_hash) {
             Entry::Occupied(_) => {
                 // The block is already in the hash store
                 warn!(
@@ -153,50 +189,53 @@ impl PendingBlockStore {
                 entry.insert(pending_block);
             },
         }
-
-        // Perform garbage collection if the store is too large
-        self.garbage_collect_pending_blocks();
     }
 
-    /// Garbage collects the pending blocks store by removing
-    /// the oldest blocks if the store is too large.
-    fn garbage_collect_pending_blocks(&mut self) {
-        // Verify that both stores have the same number of entries.
-        // If not, log an error as this should never happen.
-        let num_pending_blocks = self.blocks_without_payloads.len() as u64;
-        let num_pending_blocks_by_hash = self.blocks_without_payloads_by_hash.len() as u64;
-        if num_pending_blocks != num_pending_blocks_by_hash {
-            error!(
-                LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                    "The pending block stores have different numbers of entries: {} and {} (by hash)",
-                    num_pending_blocks, num_pending_blocks_by_hash
-                ))
+    /// Removes the pending blocks for the given commit ledger info. If
+    /// the execution pool window size is None, all blocks up to (and
+    /// including) the epoch and round of the commit will be removed.
+    /// Otherwise, a buffer of blocks preceding the commit will be retained
+    /// (to ensure we have enough blocks to satisfy the execution window).
+    pub fn remove_blocks_for_commit(
+        &mut self,
+        commit_ledger_info: &LedgerInfoWithSignatures,
+        execution_pool_window_size: Option<u64>,
+    ) {
+        // Determine the epoch and round to split off
+        let window_buffer_multiplier = self
+            .consensus_observer_config
+            .observer_block_window_buffer_multiplier;
+        let (split_off_epoch, split_off_round) =
+            execution_pool::calculate_epoch_round_split_for_commit(
+                commit_ledger_info,
+                execution_pool_window_size,
+                window_buffer_multiplier,
             );
-        }
 
-        // Calculate the number of blocks to remove
-        let max_pending_blocks = self.consensus_observer_config.max_num_pending_blocks;
-        let num_blocks_to_remove = num_pending_blocks.saturating_sub(max_pending_blocks);
+        // Split the blocks at the epoch and round and identify the blocks to retain
+        let blocks_to_retain = self
+            .pending_blocks
+            .split_off(&(split_off_epoch, split_off_round));
 
-        // Remove the oldest blocks if the store is too large
-        for _ in 0..num_blocks_to_remove {
-            if let Some((oldest_epoch_round, pending_block)) =
-                self.blocks_without_payloads.pop_first()
+        // Remove the old blocks from the hash store
+        for pending_block in self.pending_blocks.values() {
+            let first_block = pending_block.ordered_block().first_block();
+            if self
+                .pending_blocks_by_hash
+                .remove(&first_block.id())
+                .is_none()
             {
-                // Log a warning message for the removed block
-                warn!(
+                error!(
                     LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
-                        "The pending block store is too large: {:?} blocks. Removing the block for the oldest epoch and round: {:?}",
-                        num_pending_blocks, oldest_epoch_round
+                        "Failed to remove pending block by hash for block: {:?}",
+                        first_block.block_info()
                     ))
                 );
-
-                // Remove the block from the hash store
-                let first_block = pending_block.ordered_block().first_block();
-                self.blocks_without_payloads_by_hash
-                    .remove(&first_block.id());
             }
         }
+
+        // Update the pending block store with the blocks to retain
+        self.pending_blocks = blocks_to_retain;
     }
 
     #[cfg(test)]
@@ -208,10 +247,10 @@ impl PendingBlockStore {
         let first_block_hash = first_block.id();
 
         // Remove the block from both stores
-        self.blocks_without_payloads
+        self.pending_blocks
             .remove(&first_block_epoch_round)
             .unwrap();
-        self.blocks_without_payloads_by_hash
+        self.pending_blocks_by_hash
             .remove(&first_block_hash)
             .unwrap();
     }
@@ -230,13 +269,13 @@ impl PendingBlockStore {
 
         // Split the blocks at the epoch and round
         let mut blocks_at_higher_rounds = self
-            .blocks_without_payloads
+            .pending_blocks
             .split_off(&(received_payload_epoch, split_round));
 
         // Check if the last block is ready (this should be the only ready block).
         // Any earlier blocks are considered out-of-date and will be dropped.
         let mut ready_block = None;
-        if let Some((epoch_and_round, pending_block)) = self.blocks_without_payloads.pop_last() {
+        if let Some((epoch_and_round, pending_block)) = self.pending_blocks.pop_last() {
             // If all payloads exist for the block, then the block is ready
             if block_payload_store
                 .lock()
@@ -253,11 +292,11 @@ impl PendingBlockStore {
         }
 
         // Check if any out-of-date blocks are going to be dropped
-        if !self.blocks_without_payloads.is_empty() {
+        if !self.pending_blocks.is_empty() {
             info!(
                 LogSchema::new(LogEntry::ConsensusObserver).message(&format!(
                     "Dropped {:?} out-of-date pending blocks before epoch and round: {:?}",
-                    self.blocks_without_payloads.len(),
+                    self.pending_blocks.len(),
                     (received_payload_epoch, received_payload_round)
                 ))
             );
@@ -266,13 +305,13 @@ impl PendingBlockStore {
         // TODO: optimize this flow!
 
         // Clear all blocks from the pending block stores
-        self.clear_missing_blocks();
+        self.clear_pending_blocks();
 
         // Update the pending block stores to only include the blocks at higher rounds
-        self.blocks_without_payloads = blocks_at_higher_rounds;
-        for pending_block in self.blocks_without_payloads.values() {
+        self.pending_blocks = blocks_at_higher_rounds;
+        for pending_block in self.pending_blocks.values() {
             let first_block = pending_block.ordered_block().first_block();
-            self.blocks_without_payloads_by_hash
+            self.pending_blocks_by_hash
                 .insert(first_block.id(), pending_block.clone());
         }
 
@@ -283,7 +322,7 @@ impl PendingBlockStore {
     /// Updates the metrics for the pending blocks
     pub fn update_pending_blocks_metrics(&self) {
         // Update the number of pending block entries
-        let num_entries = self.blocks_without_payloads.len() as u64;
+        let num_entries = self.pending_blocks.len() as u64;
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
             metrics::PENDING_BLOCK_ENTRIES_LABEL,
@@ -291,7 +330,7 @@ impl PendingBlockStore {
         );
 
         // Update the number of pending block by hash entries
-        let num_entries_by_hash = self.blocks_without_payloads_by_hash.len() as u64;
+        let num_entries_by_hash = self.pending_blocks_by_hash.len() as u64;
         metrics::set_gauge_with_label(
             &metrics::OBSERVER_NUM_PROCESSED_BLOCKS,
             metrics::PENDING_BLOCK_ENTRIES_BY_HASH_LABEL,
@@ -300,7 +339,7 @@ impl PendingBlockStore {
 
         // Update the total number of pending blocks
         let num_pending_blocks = self
-            .blocks_without_payloads
+            .pending_blocks
             .values()
             .map(|block| block.ordered_block().blocks().len() as u64)
             .sum();
@@ -312,7 +351,7 @@ impl PendingBlockStore {
 
         // Update the total number of pending blocks by hash
         let num_pending_blocks_by_hash = self
-            .blocks_without_payloads_by_hash
+            .pending_blocks_by_hash
             .values()
             .map(|block| block.ordered_block().blocks().len() as u64)
             .sum();
@@ -324,7 +363,7 @@ impl PendingBlockStore {
 
         // Update the highest round for the pending blocks
         let highest_pending_round = self
-            .blocks_without_payloads
+            .pending_blocks
             .last_key_value()
             .map(|(_, pending_block)| pending_block.ordered_block().last_block().round())
             .unwrap_or(0);
@@ -389,7 +428,7 @@ mod test {
     use rand::Rng;
 
     #[test]
-    fn test_clear_missing_blocks() {
+    fn test_clear_pending_blocks() {
         // Create a new pending block store
         let max_num_pending_blocks = 10;
         let consensus_observer_config = ConsensusObserverConfig {
@@ -419,19 +458,13 @@ mod test {
         );
 
         // Clear the missing blocks from the store
-        pending_block_store.lock().clear_missing_blocks();
+        pending_block_store.lock().clear_pending_blocks();
 
         // Verify that the store is now empty
-        assert!(pending_block_store
-            .lock()
-            .blocks_without_payloads
-            .is_empty());
+        assert!(pending_block_store.lock().pending_blocks.is_empty());
 
         // Verify that the hash store is now empty
-        assert!(pending_block_store
-            .lock()
-            .blocks_without_payloads_by_hash
-            .is_empty());
+        assert!(pending_block_store.lock().pending_blocks_by_hash.is_empty());
     }
 
     #[test]
@@ -549,7 +582,7 @@ mod test {
         for block in &pending_blocks[..2] {
             pending_block_store
                 .lock()
-                .blocks_without_payloads_by_hash
+                .pending_blocks_by_hash
                 .remove(&block.first_block().id());
         }
 
@@ -574,7 +607,7 @@ mod test {
         }
 
         // Clear the blocks from the store
-        pending_block_store.lock().clear_missing_blocks();
+        pending_block_store.lock().clear_pending_blocks();
 
         // Verify that all blocks are no longer in the store by hash
         for pending_block in &pending_blocks {
@@ -626,7 +659,7 @@ mod test {
         assert!(block.is_none());
 
         // Clear the blocks from the store
-        pending_block_store.lock().clear_missing_blocks();
+        pending_block_store.lock().clear_pending_blocks();
 
         // Reinsert the first block into the hash store (manually) using an incorrect hash
         let first_block = pending_blocks[0].clone();
@@ -638,7 +671,7 @@ mod test {
         );
         pending_block_store
             .lock()
-            .blocks_without_payloads_by_hash
+            .pending_blocks_by_hash
             .insert(incorrect_hash, pending_block_with_metadata);
 
         // Verify the block cannot be found (there is a hash mismatch the entry and pipelined block)
@@ -678,6 +711,9 @@ mod test {
             &pending_blocks,
         );
 
+        // Clear the blocks from the store
+        pending_block_store.lock().clear_pending_blocks();
+
         // Insert the maximum number of blocks into the store again
         let starting_round = (max_num_pending_blocks * 100) as Round;
         let pending_blocks = create_and_add_pending_blocks(
@@ -694,30 +730,12 @@ mod test {
             max_num_pending_blocks,
             &pending_blocks,
         );
-
-        // Insert one more block into the store (for the next epoch)
-        let next_epoch = 1;
-        let starting_round = 0;
-        let new_pending_block = create_and_add_pending_blocks(
-            pending_block_store.clone(),
-            1,
-            next_epoch,
-            starting_round,
-            5,
-        );
-
-        // Verify the new block was inserted correctly
-        verify_pending_blocks(
-            pending_block_store.clone(),
-            max_num_pending_blocks,
-            &new_pending_block,
-        );
     }
 
     #[test]
-    fn test_garbage_collect_pending_blocks() {
+    fn test_insert_pending_block_limit() {
         // Create a new pending block store
-        let max_num_pending_blocks = 100;
+        let max_num_pending_blocks = 10;
         let consensus_observer_config = ConsensusObserverConfig {
             max_num_pending_blocks: max_num_pending_blocks as u64,
             ..ConsensusObserverConfig::default()
@@ -728,8 +746,8 @@ mod test {
 
         // Insert the maximum number of blocks into the store
         let current_epoch = 0;
-        let starting_round = 200;
-        let mut pending_blocks = create_and_add_pending_blocks(
+        let starting_round = 0;
+        let pending_blocks = create_and_add_pending_blocks(
             pending_block_store.clone(),
             max_num_pending_blocks,
             current_epoch,
@@ -744,82 +762,66 @@ mod test {
             &pending_blocks,
         );
 
-        // Insert multiple blocks into the store (one at a time) and
-        // verify that the oldest block is garbage collected each time.
-        for i in 0..20 {
-            // Insert one more block into the store
-            let starting_round = ((max_num_pending_blocks * 10) + (i * 100)) as Round;
-            let new_pending_block = create_and_add_pending_blocks(
-                pending_block_store.clone(),
-                1,
-                current_epoch,
-                starting_round,
-                5,
-            );
+        // Insert the maximum number of blocks into the store (again)
+        let starting_round = (max_num_pending_blocks * 100) as Round;
+        let pending_blocks = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            5,
+        );
 
-            // Verify the new block was inserted correctly
-            verify_pending_blocks(
-                pending_block_store.clone(),
-                max_num_pending_blocks,
-                &new_pending_block,
-            );
-
-            // Get the oldest block (that was garbage collected)
-            let oldest_block = pending_blocks.remove(0);
-
-            // Verify that the oldest block was garbage collected
-            let oldest_block_round = oldest_block.first_block().round();
-            let blocks_without_payloads =
-                pending_block_store.lock().blocks_without_payloads.clone();
-            assert!(!blocks_without_payloads.contains_key(&(current_epoch, oldest_block_round)));
-
-            // Verify that the oldest block was garbage collected by hash
-            let oldest_block_hash = oldest_block.first_block().id();
-            let blocks_without_payloads_by_hash = pending_block_store
-                .lock()
-                .blocks_without_payloads_by_hash
-                .clone();
-            assert!(!blocks_without_payloads_by_hash.contains_key(&oldest_block_hash));
+        // Verify that none of the new blocks were inserted (as we've reached the limit)
+        for block in &pending_blocks {
+            assert!(!pending_block_store.lock().existing_pending_block(block));
         }
+        verify_num_pending_blocks(&pending_block_store, max_num_pending_blocks);
 
-        // Insert multiple blocks into the store (for the next epoch) and
-        // verify that the oldest block is garbage collected each time.
-        let next_epoch = 1;
-        for i in 0..20 {
-            // Insert one more block into the store
-            let starting_round = i;
-            let new_pending_block = create_and_add_pending_blocks(
-                pending_block_store.clone(),
-                1,
-                next_epoch,
-                starting_round,
-                5,
-            );
+        // Clear the blocks from the store
+        pending_block_store.lock().clear_pending_blocks();
 
-            // Verify the new block was inserted correctly
-            verify_pending_blocks(
-                pending_block_store.clone(),
-                max_num_pending_blocks,
-                &new_pending_block,
-            );
+        // Insert more than the maximum number of blocks into the store
+        let pending_blocks = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            max_num_pending_blocks * 2, // Double the limit
+            current_epoch,
+            starting_round,
+            5,
+        );
 
-            // Get the oldest block (that was garbage collected)
-            let oldest_block = pending_blocks.remove(0);
+        // Verify that only the first half of the blocks were inserted
+        verify_pending_blocks(
+            pending_block_store.clone(),
+            max_num_pending_blocks,
+            &pending_blocks[..max_num_pending_blocks].to_vec(),
+        );
 
-            // Verify that the oldest block was garbage collected
-            let oldest_block_round = oldest_block.first_block().round();
-            let blocks_without_payloads =
-                pending_block_store.lock().blocks_without_payloads.clone();
-            assert!(!blocks_without_payloads.contains_key(&(current_epoch, oldest_block_round)));
-
-            // Verify that the oldest block was garbage collected by hash
-            let oldest_block_hash = oldest_block.first_block().id();
-            let blocks_without_payloads_by_hash = pending_block_store
-                .lock()
-                .blocks_without_payloads_by_hash
-                .clone();
-            assert!(!blocks_without_payloads_by_hash.contains_key(&oldest_block_hash));
+        // Verify that the second half of the blocks were not inserted
+        for block in &pending_blocks[max_num_pending_blocks..] {
+            assert!(!pending_block_store.lock().existing_pending_block(block));
         }
+        verify_num_pending_blocks(&pending_block_store, max_num_pending_blocks);
+
+        // Clear the blocks from the store
+        pending_block_store.lock().clear_pending_blocks();
+
+        // Insert less than the number of blocks into the store
+        let num_pending_blocks = max_num_pending_blocks / 2; // Half the limit
+        let pending_blocks = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            num_pending_blocks,
+            current_epoch,
+            starting_round,
+            5,
+        );
+
+        // Verify that all blocks were inserted correctly
+        verify_pending_blocks(
+            pending_block_store.clone(),
+            num_pending_blocks,
+            &pending_blocks,
+        );
     }
 
     #[test]
@@ -898,6 +900,380 @@ mod test {
                 removed_block_with_metadata.ordered_block(),
                 expected_ordered_block.ordered_block()
             );
+        }
+    }
+
+    #[test]
+    fn test_remove_blocks_for_commit() {
+        // Create a new pending block store
+        let max_num_pending_blocks = 100;
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            ..ConsensusObserverConfig::default()
+        };
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 10;
+        let starting_round = 100;
+        let pending_blocks = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            1,
+        );
+
+        // Remove the pending blocks for a commit at the first round (without an execution pool window)
+        let commit_ledger_info = create_ledger_info_for_epoch_round(current_epoch, starting_round);
+        pending_block_store
+            .lock()
+            .remove_blocks_for_commit(&commit_ledger_info, None);
+
+        // Verify that the block is removed from the store
+        verify_pending_blocks(
+            pending_block_store.clone(),
+            max_num_pending_blocks - 1,
+            &pending_blocks[1..].to_vec(),
+        );
+
+        // Remove the pending blocks for a commit at the 10th round (without an execution pool window)
+        let commit_ledger_info =
+            create_ledger_info_for_epoch_round(current_epoch, starting_round + 10);
+        pending_block_store
+            .lock()
+            .remove_blocks_for_commit(&commit_ledger_info, None);
+
+        // Verify that the blocks are removed from the store
+        verify_pending_blocks(
+            pending_block_store.clone(),
+            max_num_pending_blocks - 11,
+            &pending_blocks[11..].to_vec(),
+        );
+
+        // Remove the pending blocks for a commit at the last round (without an execution pool window)
+        let commit_ledger_info =
+            create_ledger_info_for_epoch_round(current_epoch, starting_round + 99);
+        pending_block_store
+            .lock()
+            .remove_blocks_for_commit(&commit_ledger_info, None);
+
+        // Verify that the store is empty
+        verify_pending_blocks(pending_block_store.clone(), 0, &vec![]);
+    }
+
+    #[test]
+    fn test_remove_blocks_for_commit_execution_pool() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let observer_block_window_buffer_multiplier = 2; // Buffer twice the window
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            observer_block_window_buffer_multiplier,
+            ..ConsensusObserverConfig::default()
+        };
+
+        // Create a new pending block store
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
+
+        // Insert the maximum number of blocks into the store
+        let current_epoch = 10;
+        let starting_round = 0;
+        let pending_blocks = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            max_num_pending_blocks,
+            current_epoch,
+            starting_round,
+            1,
+        );
+
+        // Process commits for rounds less than the buffer (i.e., < window * 2)
+        let window_size = 7;
+        let buffer_size = window_size * (observer_block_window_buffer_multiplier as usize);
+        for commit_round in 0..buffer_size {
+            // Process a commit at the commit round
+            let pending_block = pending_blocks.get(commit_round).unwrap().first_block();
+            let commit_ledger_info =
+                create_ledger_info_for_epoch_round(pending_block.epoch(), pending_block.round());
+            pending_block_store
+                .lock()
+                .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+            // Verify that the block is not removed from the store
+            verify_contains_block(&pending_block_store, pending_block.clone(), true);
+        }
+
+        // Verify that no payloads were removed
+        verify_num_pending_blocks(&pending_block_store.clone(), max_num_pending_blocks);
+
+        // Process a commit for a round one greater than the buffer
+        let commit_round = buffer_size;
+        let pending_block = pending_blocks.get(commit_round).unwrap().first_block();
+        let commit_ledger_info =
+            create_ledger_info_for_epoch_round(pending_block.epoch(), pending_block.round());
+        pending_block_store
+            .lock()
+            .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+        // Verify the first payload was removed (it's outside the window)
+        let pending_block = pending_blocks.first().unwrap().first_block();
+        verify_contains_block(&pending_block_store, pending_block.clone(), false);
+        verify_num_pending_blocks(&pending_block_store, max_num_pending_blocks - 1);
+
+        // Process a commit for the last round
+        let commit_round = max_num_pending_blocks - 1;
+        let pending_block = pending_blocks.get(commit_round).unwrap().first_block();
+        let commit_ledger_info =
+            create_ledger_info_for_epoch_round(pending_block.epoch(), pending_block.round());
+        pending_block_store
+            .lock()
+            .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+        // Verify that all payloads before the buffer were removed
+        let buffer_start_round = commit_round - buffer_size + 1;
+        for removed_round in 0..buffer_start_round {
+            let pending_block = pending_blocks.get(removed_round).unwrap().first_block();
+            verify_contains_block(&pending_block_store, pending_block.clone(), false);
+        }
+
+        // Verify that all payloads after the buffer start were retained
+        for retained_round in buffer_start_round..max_num_pending_blocks {
+            let pending_block = pending_blocks.get(retained_round).unwrap().first_block();
+            verify_contains_block(&pending_block_store, pending_block.clone(), true);
+        }
+
+        // Verify that only the payloads in the buffer were retained
+        verify_num_pending_blocks(&pending_block_store.clone(), buffer_size);
+    }
+
+    #[test]
+    fn test_remove_blocks_for_commit_execution_pool_epoch() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 300;
+        let observer_block_window_buffer_multiplier = 3; // Buffer three times the window
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks: max_num_pending_blocks as u64,
+            observer_block_window_buffer_multiplier,
+            ..ConsensusObserverConfig::default()
+        };
+
+        // Create a new pending block store
+        let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+            consensus_observer_config,
+        )));
+
+        // Add some blocks to the store for the current epoch
+        let current_epoch = 15;
+        let num_pending_blocks = 50;
+        let pending_blocks = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            num_pending_blocks,
+            current_epoch,
+            0,
+            1,
+        );
+
+        // Add some blocks to the store for the next epoch
+        let next_epoch = current_epoch + 1;
+        let num_pending_blocks_next_epoch = 60;
+        let pending_blocks_next_epoch = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            num_pending_blocks_next_epoch,
+            next_epoch,
+            0,
+            1,
+        );
+
+        // Add some blocks to the store for a future epoch
+        let future_epoch = next_epoch + 1;
+        let num_pending_blocks_future_epoch = 70;
+        let pending_blocks_future_epoch = create_and_add_pending_blocks(
+            pending_block_store.clone(),
+            num_pending_blocks_future_epoch,
+            future_epoch,
+            0,
+            1,
+        );
+
+        // Verify the number of pending blocks
+        verify_num_pending_blocks(
+            &pending_block_store.clone(),
+            num_pending_blocks + num_pending_blocks_next_epoch + num_pending_blocks_future_epoch,
+        );
+
+        // Process commits for rounds less than the buffer in the next epoch (i.e., < window * 3)
+        let window_size = 8;
+        let buffer_size = window_size * (observer_block_window_buffer_multiplier as usize);
+        for commit_round in 0..buffer_size {
+            // Process a commit at the commit round
+            let pending_block = pending_blocks_next_epoch
+                .get(commit_round)
+                .unwrap()
+                .first_block();
+            let commit_ledger_info =
+                create_ledger_info_for_epoch_round(pending_block.epoch(), pending_block.round());
+            pending_block_store
+                .lock()
+                .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+            // Verify the block was not removed (it's within the window)
+            verify_contains_block(&pending_block_store, pending_block.clone(), true);
+        }
+
+        // Verify the pending blocks for the current epoch were all removed
+        for pending_block in &pending_blocks {
+            verify_contains_block(
+                &pending_block_store,
+                pending_block.first_block().clone(),
+                false,
+            );
+        }
+        verify_num_pending_blocks(
+            &pending_block_store.clone(),
+            num_pending_blocks_next_epoch + num_pending_blocks_future_epoch,
+        );
+
+        // Process a commit for the last round in the next epoch
+        let commit_round = num_pending_blocks_next_epoch - 1;
+        let pending_block = pending_blocks_next_epoch
+            .get(commit_round)
+            .unwrap()
+            .first_block();
+        let commit_ledger_info =
+            create_ledger_info_for_epoch_round(pending_block.epoch(), pending_block.round());
+        pending_block_store
+            .lock()
+            .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+        // Verify that all payloads before the buffer were removed
+        let buffer_start_round = commit_round - buffer_size + 1;
+        for removed_round in 0..buffer_start_round {
+            let pending_block = pending_blocks_next_epoch
+                .get(removed_round)
+                .unwrap()
+                .first_block();
+            verify_contains_block(&pending_block_store, pending_block.clone(), false);
+        }
+
+        // Verify that all payloads after the buffer start were retained
+        for retained_round in buffer_start_round..num_pending_blocks_next_epoch {
+            let pending_block = pending_blocks_next_epoch
+                .get(retained_round)
+                .unwrap()
+                .first_block();
+            verify_contains_block(&pending_block_store, pending_block.clone(), true);
+        }
+
+        // Verify the number of pending blocks
+        verify_num_pending_blocks(
+            &pending_block_store.clone(),
+            buffer_size + num_pending_blocks_future_epoch,
+        );
+
+        // Process a commit for the first round in the future epoch
+        let pending_block = pending_blocks_future_epoch.first().unwrap().first_block();
+        let commit_ledger_info =
+            create_ledger_info_for_epoch_round(pending_block.epoch(), pending_block.round());
+        pending_block_store
+            .lock()
+            .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+        // Verify the pending blocks for the next epoch were all removed
+        for pending_block in &pending_blocks_next_epoch {
+            verify_contains_block(
+                &pending_block_store,
+                pending_block.first_block().clone(),
+                false,
+            );
+        }
+
+        // Verify the pending blocks for the future epoch were all retained
+        for pending_block in &pending_blocks_future_epoch {
+            verify_contains_block(
+                &pending_block_store,
+                pending_block.first_block().clone(),
+                true,
+            );
+        }
+    }
+
+    #[test]
+    fn test_remove_payloads_for_commit_execution_pool_windows() {
+        // Create a new consensus observer config
+        let max_num_pending_blocks = 100;
+        let observer_block_window_buffer_multiplier = 1; // Buffer the exact window size
+        let consensus_observer_config = ConsensusObserverConfig {
+            max_num_pending_blocks,
+            observer_block_window_buffer_multiplier,
+            ..ConsensusObserverConfig::default()
+        };
+
+        // Test various window pool sizes
+        for window_size in 1..11 {
+            // Create a new pending block store
+            let pending_block_store = Arc::new(Mutex::new(PendingBlockStore::new(
+                consensus_observer_config,
+            )));
+
+            // Add some pending blocks to the store for the current epoch
+            let current_epoch = 10;
+            let num_pending_blocks = 50;
+            let pending_blocks = create_and_add_pending_blocks(
+                pending_block_store.clone(),
+                num_pending_blocks,
+                current_epoch,
+                0,
+                1,
+            );
+
+            // Process commits for rounds less than the buffer (i.e., < window)
+            for commit_round in 0..window_size {
+                // Process a commit for the pending block
+                let pending_block = pending_blocks.get(commit_round).unwrap().first_block();
+                let commit_ledger_info = create_ledger_info_for_epoch_round(
+                    pending_block.epoch(),
+                    pending_block.round(),
+                );
+                pending_block_store
+                    .lock()
+                    .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+                // Verify the block was not removed (it's within the window)
+                verify_contains_block(&pending_block_store, pending_block.clone(), true);
+            }
+
+            // Verify that no blocks were removed
+            verify_num_pending_blocks(&pending_block_store.clone(), num_pending_blocks);
+
+            // Process commits for rounds greater than the buffer (i.e., >= window)
+            for commit_round in window_size..num_pending_blocks {
+                // Process a commit for the pending block
+                let pending_block = pending_blocks.get(commit_round).unwrap().first_block();
+                let commit_ledger_info = create_ledger_info_for_epoch_round(
+                    pending_block.epoch(),
+                    pending_block.round(),
+                );
+                pending_block_store
+                    .lock()
+                    .remove_blocks_for_commit(&commit_ledger_info, Some(window_size as u64));
+
+                // Verify that all blocks before the window were removed
+                let window_start_round = commit_round - window_size + 1;
+                for removed_round in 0..window_start_round {
+                    let pending_block = pending_blocks.get(removed_round).unwrap().first_block();
+                    verify_contains_block(&pending_block_store, pending_block.clone(), false);
+                }
+
+                // Verify that all blocks after the window start were retained
+                for retained_round in window_start_round..num_pending_blocks {
+                    let pending_block = pending_blocks.get(retained_round).unwrap().first_block();
+                    verify_contains_block(&pending_block_store, pending_block.clone(), true);
+                }
+            }
         }
     }
 
@@ -1249,6 +1625,17 @@ mod test {
         pending_blocks
     }
 
+    /// Creates and returns a ledger info for the specified epoch and round
+    fn create_ledger_info_for_epoch_round(epoch: u64, round: u64) -> LedgerInfoWithSignatures {
+        LedgerInfoWithSignatures::new(
+            LedgerInfo::new(
+                BlockInfo::random_with_epoch(epoch, round),
+                HashValue::random(),
+            ),
+            AggregateSignature::empty(),
+        )
+    }
+
     /// Creates and returns an ordered block with the specified maximum number of pipelined blocks
     fn create_ordered_block(
         epoch: u64,
@@ -1318,6 +1705,44 @@ mod test {
         }
     }
 
+    /// Verifies the presence of the block in the pending payload store
+    fn verify_contains_block(
+        pending_block_store: &Arc<Mutex<PendingBlockStore>>,
+        block: Arc<PipelinedBlock>,
+        expect_contains: bool,
+    ) {
+        // Check the presence of the block in the store
+        let pending_block_store = pending_block_store.lock();
+        let block_found = pending_block_store
+            .pending_blocks
+            .contains_key(&(block.epoch(), block.round()));
+        assert_eq!(block_found, expect_contains);
+
+        // Check the presence of the block in the store by hash
+        let block_found_by_hash = pending_block_store
+            .pending_blocks_by_hash
+            .contains_key(&block.id());
+        assert_eq!(block_found_by_hash, expect_contains);
+    }
+
+    /// Verifies that the pending block store contains the expected number of blocks
+    fn verify_num_pending_blocks(
+        pending_block_store: &Arc<Mutex<PendingBlockStore>>,
+        max_num_pending_blocks: usize,
+    ) {
+        // Verify the number of pending blocks
+        assert_eq!(
+            pending_block_store.lock().pending_blocks.len(),
+            max_num_pending_blocks
+        );
+
+        // Verify the number of pending blocks by hash
+        assert_eq!(
+            pending_block_store.lock().pending_blocks_by_hash.len(),
+            max_num_pending_blocks
+        );
+    }
+
     /// Verifies that the pending block store contains the expected blocks
     fn verify_pending_blocks(
         pending_block_store: Arc<Mutex<PendingBlockStore>>,
@@ -1325,19 +1750,7 @@ mod test {
         pending_blocks: &Vec<OrderedBlock>,
     ) {
         // Check the number of pending blocks
-        assert_eq!(
-            pending_block_store.lock().blocks_without_payloads.len(),
-            num_expected_blocks
-        );
-
-        // Check the number of pending blocks by hash
-        assert_eq!(
-            pending_block_store
-                .lock()
-                .blocks_without_payloads_by_hash
-                .len(),
-            num_expected_blocks
-        );
+        verify_num_pending_blocks(&pending_block_store, num_expected_blocks);
 
         // Check that all pending blocks are in the stores
         for pending_block in pending_blocks {
@@ -1347,7 +1760,7 @@ mod test {
             // Get the pending block in the store
             let first_block = pending_block.first_block();
             let block_in_store = pending_block_store
-                .blocks_without_payloads
+                .pending_blocks
                 .get(&(first_block.epoch(), first_block.round()))
                 .unwrap();
 
@@ -1357,7 +1770,7 @@ mod test {
             // Get the pending block in the store by hash
             let first_block_hash = first_block.id();
             let block_in_store = pending_block_store
-                .blocks_without_payloads_by_hash
+                .pending_blocks_by_hash
                 .get(&first_block_hash)
                 .unwrap();
 


### PR DESCRIPTION
Notes:
- Most of this PR is new unit tests.
- This PR is built on: https://github.com/aptos-labs/aptos-core/pull/15909

## Description
This PR adds buffer support to consensus observer for execution pool. Now, when execution pool is enabled, consensus observer ensures that all pending blocks & payloads within the execution window are retained, and not prematurely cleared (e.g., after a commit). This allows consensus observer to retain enough block history to execute window blocks correctly.

The PR offers the following commits:
1. Add buffer support to the payload store. Here, we introduce new buffer window configurations, and ensure the store keeps around enough payloads to satisfy the window (plus a buffer). This includes new unit tests.
2. Add buffer support to the pending block store. This reuses some of the logic introduced in commit 1, and ensures the pending block store follows the same model (i.e., retain a buffer after a commit). This also includes unit tests.
3. Update consensus observer to check for block window dependencies before processing block and payload messages. This is required to ensure that we only process blocks if the window history is satisfied. 

In the next PR, I'll work on actually processing the block with window messages (e.g., via the execution client).

## Testing Plan
New and existing test infrastructure.
