### PR TITLE
docs: fix typos in files

### DIFF
--- a/aptos-node/src/network.rs
+++ b/aptos-node/src/network.rs
@@ -580,7 +580,7 @@ fn transform_network_handles_into_interfaces(
     )
 }
 
-/// Creates an application network inteface using the given
+/// Creates an application network interface using the given
 /// handles and config.
 fn create_network_interfaces<
     T: Serialize + for<'de> Deserialize<'de> + Send + Sync + Clone + 'static,

--- a/consensus/consensus-types/src/quorum_cert.rs
+++ b/consensus/consensus-types/src/quorum_cert.rs
@@ -17,7 +17,7 @@ use std::fmt::{Display, Formatter};
 
 #[derive(Deserialize, Serialize, Clone, Debug, Eq, PartialEq)]
 pub struct QuorumCert {
-    /// The vote information certified by the quorum.
+    /// The vote information is certified by the quorum.
     vote_data: VoteData,
     /// The signed LedgerInfo of a committed block that carries the data about the certified block.
     signed_ledger_info: LedgerInfoWithSignatures,

--- a/consensus/consensus-types/src/timeout_2chain.rs
+++ b/consensus/consensus-types/src/timeout_2chain.rs
@@ -197,7 +197,7 @@ impl TwoChainTimeoutCertificate {
     }
 }
 
-/// Contains two chain timout with partial signatures from the validators. This is only used during
+/// Contains two chain timeout with partial signatures from the validators. This is only used during
 /// signature aggregation and does not go through the wire.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct TwoChainTimeoutWithPartialSignatures {

--- a/mempool/src/shared_mempool/priority.rs
+++ b/mempool/src/shared_mempool/priority.rs
@@ -409,7 +409,7 @@ impl PrioritizedPeersState {
         &mut self,
         peers_and_metadata: Vec<(PeerNetworkId, Option<&PeerMonitoringMetadata>)>,
         num_mempool_txns_received_since_peers_updated: u64,
-        num_committed_txns_recieved_since_peers_updated: u64,
+        num_committed_txns_received_since_peers_updated: u64,
     ) {
         let peer_monitoring_data: HashMap<PeerNetworkId, Option<&PeerMonitoringMetadata>> =
             peers_and_metadata.clone().into_iter().collect();
@@ -434,7 +434,7 @@ impl PrioritizedPeersState {
         self.update_sender_bucket_for_peers(
             &peer_monitoring_data,
             num_mempool_txns_received_since_peers_updated,
-            num_committed_txns_recieved_since_peers_updated,
+            num_committed_txns_received_since_peers_updated,
         );
 
         // Set the last peer priority update time

--- a/network/builder/src/builder.rs
+++ b/network/builder/src/builder.rs
@@ -70,7 +70,7 @@ pub struct NetworkBuilder {
 
 impl NetworkBuilder {
     /// Return a new NetworkBuilder initialized with default configuration values.
-    // TODO:  Remove `pub`.  NetworkBuilder should only be created thorugh `::create()`
+    // TODO:  Remove `pub`.  NetworkBuilder should only be created through `::create()`
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         chain_id: ChainId,


### PR DESCRIPTION
## Description

This PR fixes several typographical errors in documentation comments across multiple files in the repository. These changes improve the readability and clarity of the codebase without altering any functionality.

## Key Areas to Review

aptos-node/src/network.rs
- Fixed typo: inteface → interface

consensus/consensus-types/src/quorum_cert.rs
- Improved comment clarity: The vote information certified by the quorum. → The vote information is certified by the quorum.

consensus/consensus-types/src/timeout_2chain.rs
- Fixed typo: timout → timeout

mempool/src/shared_mempool/priority.rs
- Fixed typo: recieved → received

network/builder/src/builder.rs
- Fixed typo: thorugh → through

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests


## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

