### PR TITLE
[crypto] Add AIP-80 output for crypto materials

### DIFF
--- a/crates/aptos-crypto-derive/src/unions.rs
+++ b/crates/aptos-crypto-derive/src/unions.rs
@@ -90,6 +90,8 @@ pub fn impl_enum_valid_crypto_material(name: &Ident, variants: &DataEnum) -> Tok
     try_from.extend(quote! {
 
         impl aptos_crypto::ValidCryptoMaterial for #name {
+            const AIP_80_PREFIX: &'static str = "";
+
             fn to_bytes(&self) -> Vec<u8> {
                 match self {
                     #to_bytes_arms

--- a/crates/aptos-crypto/src/bls12381/bls12381_keys.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_keys.rs
@@ -129,6 +129,8 @@ impl traits::SigningKey for PrivateKey {
 }
 
 impl traits::ValidCryptoMaterial for PrivateKey {
+    const AIP_80_PREFIX: &'static str = "bls12381-priv-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
@@ -209,6 +211,8 @@ impl VerifyingKey for PublicKey {
 }
 
 impl ValidCryptoMaterial for PublicKey {
+    const AIP_80_PREFIX: &'static str = "bls12381-pub-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }

--- a/crates/aptos-crypto/src/bls12381/bls12381_pop.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_pop.rs
@@ -107,6 +107,8 @@ impl ProofOfPossession {
 //////////////////////////////
 
 impl ValidCryptoMaterial for ProofOfPossession {
+    const AIP_80_PREFIX: &'static str = "bls12381-pop-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }

--- a/crates/aptos-crypto/src/bls12381/bls12381_sigs.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_sigs.rs
@@ -171,6 +171,8 @@ impl traits::Signature for Signature {
 }
 
 impl ValidCryptoMaterial for Signature {
+    const AIP_80_PREFIX: &'static str = "bls12381-sig-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }

--- a/crates/aptos-crypto/src/bls12381/bls12381_validatable.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_validatable.rs
@@ -44,6 +44,8 @@ impl TryFrom<&[u8]> for UnvalidatedPublicKey {
 }
 
 impl ValidCryptoMaterial for UnvalidatedPublicKey {
+    const AIP_80_PREFIX: &'static str = "bls12381-pub-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/crates/aptos-crypto/src/ed25519/ed25519_keys.rs
+++ b/crates/aptos-crypto/src/ed25519/ed25519_keys.rs
@@ -224,6 +224,8 @@ impl Length for Ed25519PrivateKey {
 }
 
 impl ValidCryptoMaterial for Ed25519PrivateKey {
+    const AIP_80_PREFIX: &'static str = "ed25519-priv-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
@@ -309,6 +311,8 @@ impl Length for Ed25519PublicKey {
 }
 
 impl ValidCryptoMaterial for Ed25519PublicKey {
+    const AIP_80_PREFIX: &'static str = "ed25519-pub-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes().to_vec()
     }

--- a/crates/aptos-crypto/src/ed25519/ed25519_sigs.rs
+++ b/crates/aptos-crypto/src/ed25519/ed25519_sigs.rs
@@ -151,6 +151,8 @@ impl Length for Ed25519Signature {
 }
 
 impl ValidCryptoMaterial for Ed25519Signature {
+    const AIP_80_PREFIX: &'static str = "ed25519-sig-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }

--- a/crates/aptos-crypto/src/multi_ed25519.rs
+++ b/crates/aptos-crypto/src/multi_ed25519.rs
@@ -234,6 +234,8 @@ impl Length for MultiEd25519PrivateKey {
 }
 
 impl ValidCryptoMaterial for MultiEd25519PrivateKey {
+    const AIP_80_PREFIX: &'static str = "multied25519-priv-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }
@@ -339,6 +341,8 @@ impl Length for MultiEd25519PublicKey {
 }
 
 impl ValidCryptoMaterial for MultiEd25519PublicKey {
+    const AIP_80_PREFIX: &'static str = "multied25519-pub-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }
@@ -478,6 +482,8 @@ impl fmt::Debug for MultiEd25519Signature {
 }
 
 impl ValidCryptoMaterial for MultiEd25519Signature {
+    const AIP_80_PREFIX: &'static str = "multied25519-sig-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -117,6 +117,8 @@ impl traits::Uniform for PrivateKey {
 }
 
 impl ValidCryptoMaterial for PrivateKey {
+    const AIP_80_PREFIX: &'static str = "secp256k1-priv-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
@@ -181,6 +183,8 @@ impl traits::Length for PublicKey {
 }
 
 impl ValidCryptoMaterial for PublicKey {
+    const AIP_80_PREFIX: &'static str = "secp256k1-pub-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
@@ -282,6 +286,8 @@ impl traits::Length for Signature {
 }
 
 impl ValidCryptoMaterial for Signature {
+    const AIP_80_PREFIX: &'static str = "secp256k1-sig-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }

--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_keys.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_keys.rs
@@ -172,6 +172,8 @@ impl Length for PrivateKey {
 }
 
 impl ValidCryptoMaterial for PrivateKey {
+    const AIP_80_PREFIX: &'static str = "secp256r1-priv-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }
@@ -254,6 +256,8 @@ impl Length for PublicKey {
 }
 
 impl ValidCryptoMaterial for PublicKey {
+    const AIP_80_PREFIX: &'static str = "secp256r1-pub-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }

--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
@@ -152,6 +152,8 @@ impl Length for Signature {
 }
 
 impl ValidCryptoMaterial for Signature {
+    const AIP_80_PREFIX: &'static str = "secp256r1-sig-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes().to_vec()
     }

--- a/crates/aptos-crypto/src/x25519.rs
+++ b/crates/aptos-crypto/src/x25519.rs
@@ -185,6 +185,8 @@ impl traits::Uniform for PrivateKey {
 
 // TODO: should this be gated under test flag? (mimoo)
 impl traits::ValidCryptoMaterial for PrivateKey {
+    const AIP_80_PREFIX: &'static str = "x25519-priv-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_bytes().to_vec()
     }
@@ -240,6 +242,8 @@ impl traits::PublicKey for PublicKey {
 }
 
 impl traits::ValidCryptoMaterial for PublicKey {
+    const AIP_80_PREFIX: &'static str = "x25519-pub-";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.0.to_vec()
     }

--- a/crates/aptos-dkg/src/pvss/das/public_parameters.rs
+++ b/crates/aptos-dkg/src/pvss/das/public_parameters.rs
@@ -83,6 +83,8 @@ impl PublicParameters {
 }
 
 impl ValidCryptoMaterial for PublicParameters {
+    const AIP_80_PREFIX: &'static str = "";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_bytes()
     }

--- a/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
@@ -54,6 +54,8 @@ pub struct Transcript {
 }
 
 impl ValidCryptoMaterial for Transcript {
+    const AIP_80_PREFIX: &'static str = "";
+
     fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).expect("unexpected error during PVSS transcript serialization")
     }

--- a/crates/aptos-dkg/src/pvss/das/weighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/weighted_protocol.rs
@@ -67,6 +67,8 @@ pub struct Transcript {
 }
 
 impl ValidCryptoMaterial for Transcript {
+    const AIP_80_PREFIX: &'static str = "";
+
     fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).expect("unexpected error during PVSS transcript serialization")
     }

--- a/crates/aptos-dkg/src/pvss/dealt_pub_key.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_pub_key.rs
@@ -39,6 +39,8 @@ macro_rules! dealt_pub_key_impl {
         }
 
         impl ValidCryptoMaterial for DealtPubKey {
+            const AIP_80_PREFIX: &'static str = "";
+
             fn to_bytes(&self) -> Vec<u8> {
                 self.to_bytes().to_vec()
             }

--- a/crates/aptos-dkg/src/pvss/dealt_pub_key_share.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_pub_key_share.rs
@@ -40,6 +40,8 @@ macro_rules! dealt_pub_key_share_impl {
         }
 
         impl ValidCryptoMaterial for DealtPubKeyShare {
+            const AIP_80_PREFIX: &'static str = "";
+
             fn to_bytes(&self) -> Vec<u8> {
                 self.to_bytes().to_vec()
             }

--- a/crates/aptos-dkg/src/pvss/dealt_secret_key_share.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_secret_key_share.rs
@@ -39,6 +39,7 @@ macro_rules! dealt_secret_key_share_impl {
         }
 
         impl ValidCryptoMaterial for DealtSecretKeyShare {
+            const AIP_80_PREFIX: &'static str = "";
             fn to_bytes(&self) -> Vec<u8> {
                 self.to_bytes().to_vec()
             }

--- a/crates/aptos-dkg/src/pvss/encryption_dlog.rs
+++ b/crates/aptos-dkg/src/pvss/encryption_dlog.rs
@@ -36,6 +36,8 @@ macro_rules! encryption_dlog_pp_impl {
         }
 
         impl ValidCryptoMaterial for PublicParameters {
+            const AIP_80_PREFIX: &'static str = "";
+
             fn to_bytes(&self) -> Vec<u8> {
                 self.to_bytes().to_vec()
             }
@@ -132,6 +134,7 @@ macro_rules! encryption_dlog_keys_impl {
         // }
 
         impl ValidCryptoMaterial for DecryptPrivKey {
+            const AIP_80_PREFIX: &'static str = "";
             fn to_bytes(&self) -> Vec<u8> {
                 self.to_bytes().to_vec()
             }
@@ -192,6 +195,7 @@ macro_rules! encryption_dlog_keys_impl {
         }
 
         impl ValidCryptoMaterial for EncryptPubKey {
+            const AIP_80_PREFIX: &'static str = "";
             fn to_bytes(&self) -> Vec<u8> {
                 self.to_bytes().to_vec()
             }

--- a/crates/aptos-dkg/src/pvss/encryption_elgamal.rs
+++ b/crates/aptos-dkg/src/pvss/encryption_elgamal.rs
@@ -60,6 +60,8 @@ macro_rules! encryption_elgamal_pp_impl {
         }
 
         impl ValidCryptoMaterial for PublicParameters {
+            const AIP_80_PREFIX: &'static str = "";
+
             fn to_bytes(&self) -> Vec<u8> {
                 self.to_bytes().to_vec()
             }

--- a/crates/aptos-dkg/src/pvss/insecure_field/transcript.rs
+++ b/crates/aptos-dkg/src/pvss/insecure_field/transcript.rs
@@ -33,6 +33,8 @@ pub struct Transcript {
 }
 
 impl ValidCryptoMaterial for Transcript {
+    const AIP_80_PREFIX: &'static str = "";
+
     fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).expect("unexpected error during PVSS transcript serialization")
     }

--- a/crates/aptos-dkg/src/pvss/weighted/generic_weighting.rs
+++ b/crates/aptos-dkg/src/pvss/weighted/generic_weighting.rs
@@ -54,6 +54,8 @@ impl<SK: Reconstructable<ThresholdConfig>> Reconstructable<WeightedConfig> for S
 }
 
 impl<T: Transcript> ValidCryptoMaterial for GenericWeighting<T> {
+    const AIP_80_PREFIX: &'static str = "";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.trx.to_bytes()
     }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,13 +4,15 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+- Add CLI outputs and on-disk storage to be stored in AIP-80 format.  Will allow for legacy formats to be taken in as well
+- Changes config output for Address to include leading 0x
+
 ## [7.0.0]
 - Compiler v1 is now deprecated. It is now removed from the Aptos CLI.
 - Added a new option `aptos move compile --fail-on-warning` which fails the compilation if any warnings are found.
 - We now default to running extended checks when compiling test code (this was previously only done with the option `--check-test-code`, but this is no longer available). However, these checks can be now be skipped with `--skip-checks-on-test-code`.
 - Add network to show profiles.
 - The new subcommand `aptos update move-mutation-test` will install/update the external binary `move-mutation-test`, which performs mutation testing on a Move project to find blind spots in Move unit tests.
-
 - Add beta simulate command to simulate any transaction from anyone
 
 ## [6.2.0]

--- a/crates/aptos/e2e/cases/config.py
+++ b/crates/aptos/e2e/cases/config.py
@@ -24,7 +24,7 @@ def test_config_show_profiles(run_helper: RunHelper, test_name=None):
     profile = json.loads(response.stdout)["Result"]["default"]
     if (
         profile["has_private_key"] != True
-        or profile["public_key"] != expected_profile.public_key
+        or profile["public_key"].replace("ed25519-pub-", "") != expected_profile.public_key
         or profile["account"] != expected_profile.account_address
         or profile["network"] != expected_profile.network
     ):

--- a/crates/aptos/e2e/test_helpers.py
+++ b/crates/aptos/e2e/test_helpers.py
@@ -203,9 +203,9 @@ class RunHelper:
         network = None
         for line in content:
             if "private_key: " in line:
-                private_key = line.split("private_key: ")[1].replace('"', "")
+                private_key = line.split("private_key: ")[1].replace('"', "").replace("ed25519-priv-", "")
             if "public_key: " in line:
-                public_key = line.split("public_key: ")[1].replace('"', "")
+                public_key = line.split("public_key: ")[1].replace('"', "").replace("ed25519-pub-", "")
             if "account: " in line:
                 account_address = line.split("account: ")[1].replace('"', "")
             if "network: " in line:

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -7,10 +7,11 @@ use crate::{
         init::Network,
         local_simulation,
         utils::{
-            check_if_file_exists, create_dir_if_not_exist, deserialize_private_key_with_prefix,
-            dir_default_to_current, get_account_with_state, get_auth_key, get_sequence_number,
-            parse_json_file, prompt_yes_with_override, read_from_file, start_logger,
-            to_common_result, to_common_success_result, write_to_file, write_to_file_with_opts,
+            check_if_file_exists, create_dir_if_not_exist, deserialize_address_str,
+            deserialize_material_with_prefix, dir_default_to_current, get_account_with_state,
+            get_auth_key, get_sequence_number, parse_json_file, prompt_yes_with_override,
+            read_from_file, serialize_material_with_prefix, start_logger, to_common_result,
+            to_common_success_result, write_to_file, write_to_file_with_opts,
             write_to_user_only_file,
         },
     },
@@ -267,14 +268,22 @@ pub struct ProfileConfig {
     #[serde(
         skip_serializing_if = "Option::is_none",
         default,
-        deserialize_with = "deserialize_private_key_with_prefix"
+        serialize_with = "serialize_material_with_prefix",
+        deserialize_with = "deserialize_material_with_prefix"
     )]
     pub private_key: Option<Ed25519PrivateKey>,
     /// Public key for commands
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_material_with_prefix",
+        deserialize_with = "deserialize_material_with_prefix"
+    )]
     pub public_key: Option<Ed25519PublicKey>,
     /// Account for commands
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_address_str"
+    )]
     pub account: Option<AccountAddress>,
     /// URL for the Aptos rest endpoint
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -293,9 +302,16 @@ pub struct ProfileSummary {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network: Option<Network>,
     pub has_private_key: bool,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        serialize_with = "serialize_material_with_prefix",
+        deserialize_with = "deserialize_material_with_prefix"
+    )]
     pub public_key: Option<Ed25519PublicKey>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    #[serde(
+        skip_serializing_if = "Option::is_none",
+        deserialize_with = "deserialize_address_str"
+    )]
     pub account: Option<AccountAddress>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub rest_url: Option<String>,

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -13,6 +13,7 @@ use crate::{
     Tool,
 };
 use aptos_cli_common::generate_cli_completions;
+use aptos_crypto::ValidCryptoMaterialStringExt;
 use async_trait::async_trait;
 use clap::{Parser, ValueEnum};
 use clap_complete::Shell;
@@ -25,13 +26,13 @@ use std::{collections::BTreeMap, fmt::Formatter, path::PathBuf, str::FromStr};
 /// default configuration, and user specific settings.
 #[derive(Parser)]
 pub enum ConfigTool {
-    DeleteProfile(DeleteProfile),
     GenerateShellCompletions(GenerateShellCompletions),
-    RenameProfile(RenameProfile),
-    SetGlobalConfig(SetGlobalConfig),
     ShowGlobalConfig(ShowGlobalConfig),
-    ShowPrivateKey(ShowPrivateKey),
+    SetGlobalConfig(SetGlobalConfig),
     ShowProfiles(ShowProfiles),
+    ShowPrivateKey(ShowPrivateKey),
+    RenameProfile(RenameProfile),
+    DeleteProfile(DeleteProfile),
 }
 
 impl ConfigTool {
@@ -138,7 +139,7 @@ impl CliCommand<String> for ShowPrivateKey {
         if let Some(profiles) = &config.profiles {
             if let Some(profile) = profiles.get(&self.profile.clone()) {
                 if let Some(private_key) = &profile.private_key {
-                    Ok(format!("0x{}", hex::encode(private_key.to_bytes())))
+                    Ok(private_key.to_aip_80_string()?)
                 } else {
                     Err(CliError::CommandArgumentError(format!(
                         "Profile {} does not have a private key",

--- a/types/src/keyless/mod.rs
+++ b/types/src/keyless/mod.rs
@@ -121,6 +121,8 @@ impl TryFrom<&[u8]> for KeylessSignature {
 }
 
 impl ValidCryptoMaterial for KeylessSignature {
+    const AIP_80_PREFIX: &'static str = "";
+
     fn to_bytes(&self) -> Vec<u8> {
         bcs::to_bytes(&self).expect("Only unhandleable errors happen here.")
     }

--- a/types/src/transaction/authenticator.rs
+++ b/types/src/transaction/authenticator.rs
@@ -839,6 +839,8 @@ impl AuthenticationKey {
 }
 
 impl ValidCryptoMaterial for AuthenticationKey {
+    const AIP_80_PREFIX: &'static str = "";
+
     fn to_bytes(&self) -> Vec<u8> {
         self.to_vec()
     }


### PR DESCRIPTION
## Description
Adds native AIP-80 support for all future key types.  Uses it for both private and public keys, and defaults to saving them in the CLI.

Note here, this does not change the key serialization format, but just adds a string AIP-80 format.  This is specifically used for the CLI and other clients.

The node configs will also take this format, but are not used by default in this way, as that's less of an issue in this case.

## How Has This Been Tested?
Generated keys still use the old format, that will be changed in the future, but requires loading to work for all downstream nodes.  So, that will be at a later time.

This has been tested locally with a conversion.  Note that this will change the format for users on disk storage.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
