### PR TITLE
[rust api] add get_account_balance() using new api endpoint

### DIFF
--- a/crates/aptos-rest-client/examples/account/main.rs
+++ b/crates/aptos-rest-client/examples/account/main.rs
@@ -74,6 +74,25 @@ async fn main() -> Result<()> {
         .context("Failed get_account_resource")?;
     info!("Successfully retrieved resource {} with JSON", resource);
 
+    let balance_from_new_api = client
+        .get_account_balance(address, "0x1::aptos_coin::AptosCoin")
+        .await
+        .context("Failed get_account_balance")?;
+    info!(
+        "Successfully retrieved balance {}",
+        balance_from_new_api.inner()
+    );
+
+    let balance_from_old_api = client
+        .view_apt_account_balance(address)
+        .await
+        .context("Failed view_apt_account_balance")?;
+    info!(
+        "Successfully retrieved balance {}",
+        balance_from_old_api.inner()
+    );
+    assert_eq!(balance_from_new_api.inner(), balance_from_old_api.inner());
+
     client
         .get_account_resource_bcs::<ChainId>(address, resource)
         .await

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -314,7 +314,29 @@ impl Client {
         }
     }
 
-    async fn view_account_balance_bcs_impl(
+    /// Gets the balance of a specific asset type for an account.
+    /// The `asset_type` parameter can be either:
+    /// * A coin type (e.g. "0x1::aptos_coin::AptosCoin")
+    /// * A fungible asset metadata address (e.g. "0xa")
+    /// For more details, see: https://aptos.dev/en/build/apis/fullnode-rest-api-reference#tag/accounts/GET/accounts/{address}/balance/{asset_type}
+    pub async fn get_account_balance(
+        &self,
+        address: AccountAddress,
+        asset_type: &str,
+    ) -> AptosResult<Response<u64>> {
+        let url = self.build_path(&format!(
+            "accounts/{}/balance/{}",
+            address.to_hex(),
+            asset_type
+        ))?;
+        let response = self.inner.get(url).send().await?;
+        self.json(response).await
+    }
+
+    /// Internal implementation for viewing coin balance at a specific version.
+    /// Note: This function should only be used when you need to check coin balance at a specific version.
+    /// This function does not support fungible assets - use `get_account_balance` instead for fungible assets.
+    pub async fn view_account_balance_bcs_impl(
         &self,
         address: AccountAddress,
         coin_type: &str,


### PR DESCRIPTION
## Description
add get_account_balance() to get balance of coin/fa.

## How Has This Been Tested?
```
aptos node run-local-testnet --with-indexer-api
cargo run --example account -- --api-url http://127.0.0.1:8080
```
```
2025-03-26T00:30:34.330986Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:38 Successfully retrieved 52 account resources with JSON
2025-03-26T00:30:34.373258Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:47 Successfully retrieved 52 account resources with BCS
2025-03-26T00:30:34.525277Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:56 Successfully retrieved 114 account modules with JSON
2025-03-26T00:30:34.578263Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:65 Successfully retrieved 114 account modules with BCS
2025-03-26T00:30:34.580279Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:76 Successfully retrieved resource 0x1::chain_id::ChainId with JSON
2025-03-26T00:30:34.581735Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:82 Successfully retrieved balance 0
2025-03-26T00:30:34.661024Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:91 Successfully retrieved balance 0
2025-03-26T00:30:34.662246Z [main] INFO crates/aptos-rest-client/examples/account/main.rs:101 Successfully retrieved resource 0x1::chain_id::ChainId with BCS
```


