### PR TITLE
[gha] continuous forge on main, composite action for wait images

### DIFF
--- a/.github/actions/wait-images-ci/action.yaml
+++ b/.github/actions/wait-images-ci/action.yaml
@@ -1,0 +1,27 @@
+name: Wait for Docker images used in CI
+description: Wait for Docker images used in CI to be available in the GCP artifact registry.
+inputs:
+  GIT_SHA:
+    description: "The git SHA to use for the images"
+    required: true
+  GCP_DOCKER_ARTIFACT_REPO:
+    description: "The GCP artifact registry to use for the images"
+    required: true
+  WAIT_FOR_IMAGE_SECONDS:
+    description: "The number of seconds to wait for the images to be available"
+    required: false
+    default: "1800" # a sane default based on the longest observed build time on the main branch
+runs:
+  using: composite
+  steps:
+    # Deps setup
+    - uses: actions/setup-node@v3
+      with:
+        node-version-file: .node-version
+    - uses: pnpm/action-setup@v4
+
+    # The source code must be checkout out by the workflow that invokes this action.
+    - name: Run wait-images-ci
+      run: |
+        GCP_DOCKER_ARTIFACT_REPO=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }} GIT_SHA=${{ inputs.GIT_SHA }} ./docker/wait-images-ci.mjs --wait-for-image-seconds=${{ inputs.WAIT_FOR_IMAGE_SECONDS }}
+      shell: bash

--- a/.github/workflows/forge-continuous-land-blocking-test.yaml
+++ b/.github/workflows/forge-continuous-land-blocking-test.yaml
@@ -1,0 +1,173 @@
+# Continuously run land blocking forge tests against the latest main branch.
+# This is meant to be a health check for Forge, to ensure it is working as expected.
+name: Continuous Forge Tests - Land Blocking
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+  id-token: write
+  actions: write #required for workflow cancellation via check-aptos-core
+
+on:
+  # Allow triggering manually
+  workflow_dispatch:
+  schedule:
+    - cron: "0 * * * *" # Run every hour
+  push:
+    branches:
+      # Use this branch for canary
+      - 03-27-_gha_continuous_forge_on_main_composite_action_for_wait_images
+
+concurrency:
+  group: forge-clbt-${{ format('{0}-{1}', github.event_name, github.sha) }}
+  cancel-in-progress: true
+
+env:
+  AWS_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
+  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+  AWS_REGION: us-west-2
+  # In case of pull_request events by default github actions merges main into the PR branch and then runs the tests etc
+  # on the prospective merge result instead of only on the tip of the PR.
+  # For more info also see https://github.com/actions/checkout#checkout-pull-request-head-commit-instead-of-merge-commit
+  GIT_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+  # NOTE: use a workflow-specific prefix to avoid collisions with other workflows
+  #       clbt stands for continuous land blocking test
+  TARGET_CACHE_ID: clbt-${{ format('{0}-{1}', github.event_name, github.sha) }}
+
+jobs:
+  permission-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check repository permission for user which triggered workflow
+        uses: sushichop/action-repository-permission@13d208f5ae7a6a3fc0e5a7c2502c214983f0241c
+        with:
+          required-permission: write
+          comment-not-permitted: Sorry, you don't have permission to trigger this workflow.
+
+  # Because the docker build happens in a reusable workflow, have a separate job that collects the right metadata
+  # for the subsequent docker builds. Reusable workflows do not currently have the "env" context: https://github.com/orgs/community/discussions/26671
+  determine-docker-build-metadata:
+    needs: [permission-check]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - uses: ./.github/actions/wait-images-ci
+        with:
+          GIT_SHA: ${{ env.GIT_SHA }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
+          WAIT_FOR_IMAGE_SECONDS: 1800
+      - name: Normalize outputs
+        id: normalize
+        run: |
+          TARGET_CACHE_ID_NORMALIZED=${TARGET_CACHE_ID:0:20}
+          echo "TARGET_CACHE_ID_NORMALIZED=${TARGET_CACHE_ID_NORMALIZED}" >> "$GITHUB_OUTPUT"
+          echo "TARGET_CACHE_ID_NORMALIZED=${TARGET_CACHE_ID_NORMALIZED}"
+    outputs:
+      gitSha: ${{ env.GIT_SHA }}
+      targetCacheId: ${{ env.TARGET_CACHE_ID }}
+      targetCacheIdNormalized: ${{ steps.normalize.outputs.TARGET_CACHE_ID_NORMALIZED }}
+
+  forge-e2e-test:
+    needs:
+      - permission-check
+      - determine-docker-build-metadata
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success'
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: realistic_env_max_load
+      IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_RUNNER_DURATION_SECS: 480
+      # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
+      # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
+      # by this GHA. If there is a Forge namespace collision, Forge will pre-empt the existing test running in the namespace.
+      FORGE_NAMESPACE: forge-e2e-${{ needs.determine-docker-build-metadata.outputs.targetCacheIdNormalized }}
+      SEND_RESULTS_TO_TRUNK: true
+
+  # This job determines the last released docker image tag, which is used by forge compat test.
+  fetch-last-released-docker-image-tag:
+    needs:
+      - permission-check
+    #  runs only when need to run forge-compat-test or forge-framework-upgrade-test
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+          ref: ${{ github.ref }}
+
+      # actions/get-latest-docker-image-tag requires docker utilities and having authenticated to internal docker image registries
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        id: docker-setup
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          EXPORT_GCP_PROJECT_VARIABLES: "false"
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      - name: Get Docker Image Tag
+        uses: ./.github/actions/determine-or-use-target-branch-and-get-last-released-image
+        id: get-docker-image-tag
+        with:
+          base-branch: ${{ github.base_ref }}
+          variants: "failpoints performance"
+
+      - name: Add Image Tag to Step Summary
+        run: |
+          echo "## Image Tag for compat tests" >> $GITHUB_STEP_SUMMARY
+          echo "IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}" >> $GITHUB_STEP_SUMMARY
+          echo "TARGET_BRANCH: ${{ steps.get-docker-image-tag.outputs.TARGET_BRANCH }}" >> $GITHUB_STEP_SUMMARY
+    outputs:
+      IMAGE_TAG: ${{ steps.get-docker-image-tag.outputs.IMAGE_TAG }}
+
+  forge-compat-test:
+    needs:
+      - permission-check
+      - fetch-last-released-docker-image-tag
+      - determine-docker-build-metadata
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success'
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: compat
+      IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheIdNormalized }}
+      SEND_RESULTS_TO_TRUNK: true
+
+  forge-framework-upgrade-test:
+    needs:
+      - permission-check
+      - fetch-last-released-docker-image-tag
+      - determine-docker-build-metadata
+    if: |
+      !failure() && !cancelled() && needs.permission-check.result == 'success'
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-forge.yaml@main
+    secrets: inherit
+    with:
+      GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
+      FORGE_TEST_SUITE: framework_upgrade
+      IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
+      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheIdNormalized }}
+      SEND_RESULTS_TO_TRUNK: true


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Add a new workflow that runs Forge land-blocking tests (e2e (realistic_env_max_load), compat, and framework upgrade) on the main branch every hour. 

This uses a new composite action that waits for the build (artifacts) on a given commit.

Note on the future of continuous Forge jobs:
- There's some amount of copy-pasta between where the land blocking tests are actually defined `docker-build-test.yaml` and the new workflow `forge-continuous-land-blocking-test.yaml`, but any additional factoring out at this point is complicated and error prone.
- In the future we might consider moving the logic of how to trigger these Forge runs outside of GHA such as in PIES

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Workflow dispatch on PR merge

Also canary on push to this branch

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

The test plan and the new workflow

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
