### PR TITLE
Allow dAA before AA

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -139,7 +139,7 @@ pub enum FeatureFlag {
     AccountAbstraction,
     VMBinaryFormatV8,
     BulletproofsBatchNatives,
-    DomainAccountAbstraction,
+    DerivableAccountAbstraction,
     EnableFunctionValues,
     NewAccountsDefaultToFaStore,
 }
@@ -372,7 +372,9 @@ impl From<FeatureFlag> for AptosFeatureFlag {
             FeatureFlag::PermissionedSigner => AptosFeatureFlag::PERMISSIONED_SIGNER,
             FeatureFlag::AccountAbstraction => AptosFeatureFlag::ACCOUNT_ABSTRACTION,
             FeatureFlag::BulletproofsBatchNatives => AptosFeatureFlag::BULLETPROOFS_BATCH_NATIVES,
-            FeatureFlag::DomainAccountAbstraction => AptosFeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION,
+            FeatureFlag::DerivableAccountAbstraction => {
+                AptosFeatureFlag::DERIVABLE_ACCOUNT_ABSTRACTION
+            },
             FeatureFlag::EnableFunctionValues => AptosFeatureFlag::ENABLE_FUNCTION_VALUES,
             FeatureFlag::NewAccountsDefaultToFaStore => {
                 AptosFeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_STORE
@@ -534,7 +536,9 @@ impl From<AptosFeatureFlag> for FeatureFlag {
             AptosFeatureFlag::PERMISSIONED_SIGNER => FeatureFlag::PermissionedSigner,
             AptosFeatureFlag::ACCOUNT_ABSTRACTION => FeatureFlag::AccountAbstraction,
             AptosFeatureFlag::BULLETPROOFS_BATCH_NATIVES => FeatureFlag::BulletproofsBatchNatives,
-            AptosFeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION => FeatureFlag::DomainAccountAbstraction,
+            AptosFeatureFlag::DERIVABLE_ACCOUNT_ABSTRACTION => {
+                FeatureFlag::DerivableAccountAbstraction
+            },
             AptosFeatureFlag::ENABLE_FUNCTION_VALUES => FeatureFlag::EnableFunctionValues,
             AptosFeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_STORE => {
                 FeatureFlag::NewAccountsDefaultToFaStore

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -1624,7 +1624,7 @@ impl AptosVM {
                             self.features().is_account_abstraction_enabled()
                         },
                         AbstractionAuthData::DerivableV1 { .. } => {
-                            self.features().is_domain_account_abstraction_enabled()
+                            self.features().is_derivable_account_abstraction_enabled()
                         },
                     };
                     if enabled {
@@ -1664,7 +1664,7 @@ impl AptosVM {
                             self.features().is_account_abstraction_enabled()
                         },
                         AbstractionAuthData::DerivableV1 { .. } => {
-                            self.features().is_domain_account_abstraction_enabled()
+                            self.features().is_derivable_account_abstraction_enabled()
                         },
                     };
                     if enabled {
@@ -1770,7 +1770,9 @@ impl AptosVM {
             )
         }));
 
-        if self.features().is_account_abstraction_enabled() {
+        if self.features().is_account_abstraction_enabled()
+            || self.features().is_derivable_account_abstraction_enabled()
+        {
             let max_aa_gas = unwrap_or_discard!(self.gas_params(log_context))
                 .vm
                 .txn
@@ -1895,7 +1897,9 @@ impl AptosVM {
 
         let vm_params = self.gas_params(log_context)?.vm.clone();
 
-        let initial_balance = if self.features().is_account_abstraction_enabled() {
+        let initial_balance = if self.features().is_account_abstraction_enabled()
+            || self.features().is_derivable_account_abstraction_enabled()
+        {
             vm_params.txn.max_aa_gas.min(txn.max_gas_amount().into())
         } else {
             txn.max_gas_amount().into()
@@ -2812,7 +2816,9 @@ impl VMValidator for AptosVM {
             },
         };
 
-        let initial_balance = if self.features().is_account_abstraction_enabled() {
+        let initial_balance = if self.features().is_account_abstraction_enabled()
+            || self.features().is_derivable_account_abstraction_enabled()
+        {
             vm_params.txn.max_aa_gas.min(txn_data.max_gas_amount())
         } else {
             txn_data.max_gas_amount()

--- a/aptos-move/aptos-vm/src/transaction_validation.rs
+++ b/aptos-move/aptos-vm/src/transaction_validation.rs
@@ -109,7 +109,9 @@ pub(crate) fn run_script_prologue(
     let chain_id = txn_data.chain_id();
     let mut gas_meter = UnmeteredGasMeter;
     // Use the new prologues that takes signer from both sender and optional gas payer
-    if features.is_account_abstraction_enabled() {
+    if features.is_account_abstraction_enabled()
+        || features.is_derivable_account_abstraction_enabled()
+    {
         let secondary_auth_keys: Vec<MoveValue> = txn_data
             .secondary_authentication_proofs
             .iter()
@@ -398,7 +400,9 @@ fn run_epilogue(
     let txn_gas_price = txn_data.gas_unit_price();
     let txn_max_gas_units = txn_data.max_gas_amount();
 
-    if features.is_account_abstraction_enabled() {
+    if features.is_account_abstraction_enabled()
+        || features.is_derivable_account_abstraction_enabled()
+    {
         let serialize_args = vec![
             serialized_signers.sender(),
             serialized_signers

--- a/aptos-move/framework/aptos-framework/doc/account_abstraction.md
+++ b/aptos-move/framework/aptos-framework/doc/account_abstraction.md
@@ -39,6 +39,7 @@
 <b>use</b> <a href="create_signer.md#0x1_create_signer">0x1::create_signer</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="event.md#0x1_event">0x1::event</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features">0x1::features</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/from_bcs.md#0x1_from_bcs">0x1::from_bcs</a>;
 <b>use</b> <a href="function_info.md#0x1_function_info">0x1::function_info</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_hash">0x1::hash</a>;
@@ -271,6 +272,15 @@ source is defined in Scheme enum in types/src/transaction/authenticator.rs
 
 
 
+<a id="0x1_account_abstraction_EACCOUNT_ABSTRACTION_NOT_ENABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="account_abstraction.md#0x1_account_abstraction_EACCOUNT_ABSTRACTION_NOT_ENABLED">EACCOUNT_ABSTRACTION_NOT_ENABLED</a>: u64 = 8;
+</code></pre>
+
+
+
 <a id="0x1_account_abstraction_EAUTH_FUNCTION_SIGNATURE_MISMATCH"></a>
 
 
@@ -293,7 +303,16 @@ source is defined in Scheme enum in types/src/transaction/authenticator.rs
 
 
 
-<pre><code><b>const</b> <a href="account_abstraction.md#0x1_account_abstraction_EDERIVABLE_AA_NOT_INITIALIZED">EDERIVABLE_AA_NOT_INITIALIZED</a>: u64 = 6;
+<pre><code><b>const</b> <a href="account_abstraction.md#0x1_account_abstraction_EDERIVABLE_AA_NOT_INITIALIZED">EDERIVABLE_AA_NOT_INITIALIZED</a>: u64 = 7;
+</code></pre>
+
+
+
+<a id="0x1_account_abstraction_EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="account_abstraction.md#0x1_account_abstraction_EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED">EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED</a>: u64 = 9;
 </code></pre>
 
 
@@ -474,6 +493,7 @@ Note: it is a private entry function that can only be called directly from trans
     module_name: String,
     function_name: String,
 ) <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DispatchableAuthenticator">DispatchableAuthenticator</a> {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account_abstraction.md#0x1_account_abstraction_EACCOUNT_ABSTRACTION_NOT_ENABLED">EACCOUNT_ABSTRACTION_NOT_ENABLED</a>));
     <b>assert</b>!(!is_permissioned_signer(<a href="account.md#0x1_account">account</a>), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="account_abstraction.md#0x1_account_abstraction_ENOT_MASTER_SIGNER">ENOT_MASTER_SIGNER</a>));
     <a href="account_abstraction.md#0x1_account_abstraction_update_dispatchable_authenticator_impl">update_dispatchable_authenticator_impl</a>(
         <a href="account.md#0x1_account">account</a>,
@@ -591,6 +611,7 @@ only be obtained as a part of the governance script.
     module_name: String,
     function_name: String,
 ) <b>acquires</b> <a href="account_abstraction.md#0x1_account_abstraction_DerivableDispatchableAuthenticator">DerivableDispatchableAuthenticator</a> {
+    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_derivable_account_abstraction_enabled">features::is_derivable_account_abstraction_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account_abstraction.md#0x1_account_abstraction_EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED">EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED</a>));
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(aptos_framework);
 
     <a href="account_abstraction.md#0x1_account_abstraction_DerivableDispatchableAuthenticator">DerivableDispatchableAuthenticator</a>[@aptos_framework].auth_functions.add(
@@ -806,11 +827,14 @@ only be obtained as a part of the governance script.
     <b>let</b> master_signer_addr = <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(&<a href="account.md#0x1_account">account</a>);
 
     <b>if</b> (signing_data.is_derivable()) {
+        <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_derivable_account_abstraction_enabled">features::is_derivable_account_abstraction_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account_abstraction.md#0x1_account_abstraction_EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED">EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED</a>));
         <b>assert</b>!(master_signer_addr == <a href="account_abstraction.md#0x1_account_abstraction_derive_account_address">derive_account_address</a>(func_info, signing_data.derivable_abstract_public_key()), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account_abstraction.md#0x1_account_abstraction_EINCONSISTENT_SIGNER_ADDRESS">EINCONSISTENT_SIGNER_ADDRESS</a>));
 
         <b>let</b> func_infos = <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_derivable_authenticator_internal">dispatchable_derivable_authenticator_internal</a>();
         <b>assert</b>!(func_infos.contains(&func_info), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EFUNCTION_INFO_EXISTENCE">EFUNCTION_INFO_EXISTENCE</a>));
     } <b>else</b> {
+        <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="account_abstraction.md#0x1_account_abstraction_EACCOUNT_ABSTRACTION_NOT_ENABLED">EACCOUNT_ABSTRACTION_NOT_ENABLED</a>));
+
         <b>let</b> func_infos = <a href="account_abstraction.md#0x1_account_abstraction_dispatchable_authenticator_internal">dispatchable_authenticator_internal</a>(master_signer_addr);
         <b>assert</b>!(func_infos.contains(&func_info), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="account_abstraction.md#0x1_account_abstraction_EFUNCTION_INFO_EXISTENCE">EFUNCTION_INFO_EXISTENCE</a>));
     };

--- a/aptos-move/framework/aptos-framework/doc/domain_account_abstraction_ed25519_hex.md
+++ b/aptos-move/framework/aptos-framework/doc/domain_account_abstraction_ed25519_hex.md
@@ -1,7 +1,7 @@
 
-<a id="0x1_domain_account_abstraction_ed25519_hex"></a>
+<a id="0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex"></a>
 
-# Module `0x1::domain_account_abstraction_ed25519_hex`
+# Module `0x1::DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex`
 
 Domain account abstraction using ed25519 hex for signing.
 
@@ -12,7 +12,7 @@ account_identity is raw public_key.
 
 
 -  [Constants](#@Constants_0)
--  [Function `authenticate`](#0x1_domain_account_abstraction_ed25519_hex_authenticate)
+-  [Function `authenticate`](#0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex_authenticate)
 
 
 <pre><code><b>use</b> <a href="auth_data.md#0x1_auth_data">0x1::auth_data</a>;
@@ -29,23 +29,23 @@ account_identity is raw public_key.
 ## Constants
 
 
-<a id="0x1_domain_account_abstraction_ed25519_hex_EINVALID_SIGNATURE"></a>
+<a id="0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex_EINVALID_SIGNATURE"></a>
 
 
 
-<pre><code><b>const</b> <a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>: u64 = 1;
+<pre><code><b>const</b> <a href="DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex.md#0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>: u64 = 1;
 </code></pre>
 
 
 
-<a id="0x1_domain_account_abstraction_ed25519_hex_authenticate"></a>
+<a id="0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex_authenticate"></a>
 
 ## Function `authenticate`
 
 Authorization function for domain account abstraction.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_authenticate">authenticate</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: <a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+<pre><code><b>public</b> <b>fun</b> <a href="DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex.md#0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex_authenticate">authenticate</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: <a href="auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
 </code></pre>
 
 
@@ -54,7 +54,7 @@ Authorization function for domain account abstraction.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_authenticate">authenticate</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: AbstractionAuthData): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex.md#0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex_authenticate">authenticate</a>(<a href="account.md#0x1_account">account</a>: <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: AbstractionAuthData): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
     <b>let</b> hex_digest = <a href="../../aptos-stdlib/doc/string_utils.md#0x1_string_utils_to_string">string_utils::to_string</a>(aa_auth_data.digest());
 
     <b>let</b> public_key = new_unvalidated_public_key_from_bytes(*aa_auth_data.domain_account_identity());
@@ -65,7 +65,7 @@ Authorization function for domain account abstraction.
             &public_key,
             *hex_digest.bytes(),
         ),
-        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="domain_account_abstraction_ed25519_hex.md#0x1_domain_account_abstraction_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>)
+        <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex.md#0x1_DERIVABLE_ACCOUNT_ABSTRACTION_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>)
     );
 
     <a href="account.md#0x1_account">account</a>

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -406,9 +406,8 @@ Only called during genesis to initialize system resources for this module.
 
 <pre><code>inline <b>fun</b> <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(transaction_sender: <b>address</b>): bool {
     // aa verifies authentication itself
-    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>() &&
-    (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_domain_account_abstraction_enabled">features::is_domain_account_abstraction_enabled</a>()
-        || <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">account_abstraction::using_dispatchable_authenticator</a>(transaction_sender))
+    <a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_derivable_account_abstraction_enabled">features::is_derivable_account_abstraction_enabled</a>()
+        || (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_account_abstraction_enabled">features::is_account_abstraction_enabled</a>() && <a href="account_abstraction.md#0x1_account_abstraction_using_dispatchable_authenticator">account_abstraction::using_dispatchable_authenticator</a>(transaction_sender))
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
+++ b/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
@@ -11,6 +11,7 @@ module aptos_framework::account_abstraction {
     use aptos_std::big_ordered_map::{Self, BigOrderedMap};
     use aptos_framework::create_signer;
     use aptos_framework::event;
+    use aptos_framework::features;
     use aptos_framework::function_info::{Self, FunctionInfo};
     use aptos_framework::object;
     use aptos_framework::auth_data::AbstractionAuthData;
@@ -31,7 +32,10 @@ module aptos_framework::account_abstraction {
     const ENOT_MASTER_SIGNER: u64 = 4;
     const EINCONSISTENT_SIGNER_ADDRESS: u64 = 5;
     const EDEPRECATED_FUNCTION: u64 = 6;
-    const EDERIVABLE_AA_NOT_INITIALIZED: u64 = 6;
+    const EDERIVABLE_AA_NOT_INITIALIZED: u64 = 7;
+
+    const EACCOUNT_ABSTRACTION_NOT_ENABLED: u64 = 8;
+    const EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED: u64 = 9;
 
     /// derivable_aa_account_address uses this for domain separation within its native implementation
     /// source is defined in Scheme enum in types/src/transaction/authenticator.rs
@@ -121,6 +125,7 @@ module aptos_framework::account_abstraction {
         module_name: String,
         function_name: String,
     ) acquires DispatchableAuthenticator {
+        assert!(features::is_account_abstraction_enabled(), error::invalid_state(EACCOUNT_ABSTRACTION_NOT_ENABLED));
         assert!(!is_permissioned_signer(account), error::permission_denied(ENOT_MASTER_SIGNER));
         update_dispatchable_authenticator_impl(
             account,
@@ -178,6 +183,7 @@ module aptos_framework::account_abstraction {
         module_name: String,
         function_name: String,
     ) acquires DerivableDispatchableAuthenticator {
+        assert!(features::is_derivable_account_abstraction_enabled(), error::invalid_state(EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED));
         system_addresses::assert_aptos_framework(aptos_framework);
 
         DerivableDispatchableAuthenticator[@aptos_framework].auth_functions.add(
@@ -273,11 +279,14 @@ module aptos_framework::account_abstraction {
         let master_signer_addr = signer::address_of(&account);
 
         if (signing_data.is_derivable()) {
+            assert!(features::is_derivable_account_abstraction_enabled(), error::invalid_state(EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED));
             assert!(master_signer_addr == derive_account_address(func_info, signing_data.derivable_abstract_public_key()), error::invalid_state(EINCONSISTENT_SIGNER_ADDRESS));
 
             let func_infos = dispatchable_derivable_authenticator_internal();
             assert!(func_infos.contains(&func_info), error::not_found(EFUNCTION_INFO_EXISTENCE));
         } else {
+            assert!(features::is_account_abstraction_enabled(), error::invalid_state(EACCOUNT_ABSTRACTION_NOT_ENABLED));
+
             let func_infos = dispatchable_authenticator_internal(master_signer_addr);
             assert!(func_infos.contains(&func_info), error::not_found(EFUNCTION_INFO_EXISTENCE));
         };

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -102,9 +102,8 @@ module aptos_framework::transaction_validation {
     // TODO: can be removed after features have been rolled out.
     inline fun allow_missing_txn_authentication_key(transaction_sender: address): bool {
         // aa verifies authentication itself
-        features::is_account_abstraction_enabled() &&
-        (features::is_domain_account_abstraction_enabled()
-            || account_abstraction::using_dispatchable_authenticator(transaction_sender))
+        features::is_derivable_account_abstraction_enabled()
+            || (features::is_account_abstraction_enabled() && account_abstraction::using_dispatchable_authenticator(transaction_sender))
     }
 
     fun prologue_common(

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -141,6 +141,7 @@ return true.
 -  [Function `is_account_abstraction_enabled`](#0x1_features_is_account_abstraction_enabled)
 -  [Function `get_bulletproofs_batch_feature`](#0x1_features_get_bulletproofs_batch_feature)
 -  [Function `bulletproofs_batch_enabled`](#0x1_features_bulletproofs_batch_enabled)
+-  [Function `is_derivable_account_abstraction_enabled`](#0x1_features_is_derivable_account_abstraction_enabled)
 -  [Function `is_domain_account_abstraction_enabled`](#0x1_features_is_domain_account_abstraction_enabled)
 -  [Function `get_new_accounts_default_to_fa_store_feature`](#0x1_features_get_new_accounts_default_to_fa_store_feature)
 -  [Function `new_accounts_default_to_fa_store_enabled`](#0x1_features_new_accounts_default_to_fa_store_enabled)
@@ -500,6 +501,18 @@ Lifetime: transient
 
 
 
+<a id="0x1_features_DERIVABLE_ACCOUNT_ABSTRACTION"></a>
+
+Whether the account abstraction is enabled.
+
+Lifetime: transient
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_DERIVABLE_ACCOUNT_ABSTRACTION">DERIVABLE_ACCOUNT_ABSTRACTION</a>: u64 = 88;
+</code></pre>
+
+
+
 <a id="0x1_features_DISPATCHABLE_FUNGIBLE_ASSET"></a>
 
 Whether the dispatchable fungible asset standard feature is enabled.
@@ -508,18 +521,6 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_DISPATCHABLE_FUNGIBLE_ASSET">DISPATCHABLE_FUNGIBLE_ASSET</a>: u64 = 63;
-</code></pre>
-
-
-
-<a id="0x1_features_DOMAIN_ACCOUNT_ABSTRACTION"></a>
-
-Whether the account abstraction is enabled.
-
-Lifetime: transient
-
-
-<pre><code><b>const</b> <a href="features.md#0x1_features_DOMAIN_ACCOUNT_ABSTRACTION">DOMAIN_ACCOUNT_ABSTRACTION</a>: u64 = 88;
 </code></pre>
 
 
@@ -3560,13 +3561,13 @@ Deprecated feature
 
 </details>
 
-<a id="0x1_features_is_domain_account_abstraction_enabled"></a>
+<a id="0x1_features_is_derivable_account_abstraction_enabled"></a>
 
-## Function `is_domain_account_abstraction_enabled`
+## Function `is_derivable_account_abstraction_enabled`
 
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_domain_account_abstraction_enabled">is_domain_account_abstraction_enabled</a>(): bool
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_derivable_account_abstraction_enabled">is_derivable_account_abstraction_enabled</a>(): bool
 </code></pre>
 
 
@@ -3575,8 +3576,33 @@ Deprecated feature
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_domain_account_abstraction_enabled">is_domain_account_abstraction_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
-    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_DOMAIN_ACCOUNT_ABSTRACTION">DOMAIN_ACCOUNT_ABSTRACTION</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_derivable_account_abstraction_enabled">is_derivable_account_abstraction_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_DERIVABLE_ACCOUNT_ABSTRACTION">DERIVABLE_ACCOUNT_ABSTRACTION</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_is_domain_account_abstraction_enabled"></a>
+
+## Function `is_domain_account_abstraction_enabled`
+
+
+
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_domain_account_abstraction_enabled">is_domain_account_abstraction_enabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_domain_account_abstraction_enabled">is_domain_account_abstraction_enabled</a>(): bool {
+    <b>false</b>
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -653,10 +653,15 @@ module std::features {
     /// Whether the account abstraction is enabled.
     ///
     /// Lifetime: transient
-    const DOMAIN_ACCOUNT_ABSTRACTION: u64 = 88;
+    const DERIVABLE_ACCOUNT_ABSTRACTION: u64 = 88;
 
-    public fun is_domain_account_abstraction_enabled(): bool acquires Features {
-        is_enabled(DOMAIN_ACCOUNT_ABSTRACTION)
+    public fun is_derivable_account_abstraction_enabled(): bool acquires Features {
+        is_enabled(DERIVABLE_ACCOUNT_ABSTRACTION)
+    }
+
+    #[deprecated]
+    public fun is_domain_account_abstraction_enabled(): bool {
+        false
     }
 
     /// Whether function values are enabled.

--- a/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
+++ b/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
@@ -25,7 +25,11 @@ pub(crate) fn native_dispatch(
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let (module_name, func_name) = extract_function_info(&mut arguments)?;
     // Check if the module is already properly charged in this transaction.
-    let is_err = if context.get_feature_flags().is_account_abstraction_enabled() {
+    let is_err = if context.get_feature_flags().is_account_abstraction_enabled()
+        || context
+            .get_feature_flags()
+            .is_derivable_account_abstraction_enabled()
+    {
         !module_name.address().is_special()
             && !context
                 .traversal_context()

--- a/aptos-move/framework/src/natives/function_info.rs
+++ b/aptos-move/framework/src/natives/function_info.rs
@@ -83,7 +83,11 @@ fn native_check_dispatch_type_compatibility_impl(
 
     let (rhs, rhs_id) = {
         let (module, func) = extract_function_info(&mut arguments)?;
-        let is_err = if context.get_feature_flags().is_account_abstraction_enabled() {
+        let is_err = if context.get_feature_flags().is_account_abstraction_enabled()
+            || context
+                .get_feature_flags()
+                .is_derivable_account_abstraction_enabled()
+        {
             !module.address().is_special()
                 && !context
                     .traversal_context()

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -124,7 +124,7 @@ pub enum FeatureFlag {
     /// Enables bytecode version v8
     VM_BINARY_FORMAT_V8 = 86,
     BULLETPROOFS_BATCH_NATIVES = 87,
-    DOMAIN_ACCOUNT_ABSTRACTION = 88,
+    DERIVABLE_ACCOUNT_ABSTRACTION = 88,
     /// Whether function values are enabled.
     ENABLE_FUNCTION_VALUES = 89,
     NEW_ACCOUNTS_DEFAULT_TO_FA_STORE = 90,
@@ -212,7 +212,7 @@ impl FeatureFlag {
             FeatureFlag::ENABLE_CALL_TREE_AND_INSTRUCTION_VM_CACHE,
             FeatureFlag::ACCOUNT_ABSTRACTION,
             FeatureFlag::BULLETPROOFS_BATCH_NATIVES,
-            FeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION,
+            FeatureFlag::DERIVABLE_ACCOUNT_ABSTRACTION,
             FeatureFlag::VM_BINARY_FORMAT_V8,
             FeatureFlag::ENABLE_FUNCTION_VALUES,
         ]
@@ -294,8 +294,8 @@ impl Features {
         self.is_enabled(FeatureFlag::ACCOUNT_ABSTRACTION)
     }
 
-    pub fn is_domain_account_abstraction_enabled(&self) -> bool {
-        self.is_enabled(FeatureFlag::DOMAIN_ACCOUNT_ABSTRACTION)
+    pub fn is_derivable_account_abstraction_enabled(&self) -> bool {
+        self.is_enabled(FeatureFlag::DERIVABLE_ACCOUNT_ABSTRACTION)
     }
 
     pub fn is_module_event_enabled(&self) -> bool {


### PR DESCRIPTION
Gating was requiring AA to be enabled before dAA. 

Based on recent discussions, we want to enable dAA first, so adjusting gating that way.

One detail - AA registration wasn't gated, only usage, I added gating for it now. Once we decide to enable AA, we should see if any changes we make need to be applied to anything already registered 

Tested on a stacked PR, with disabling AA flag, and enabling dAA flag, confirming dAA flow works e2e (igor/daa_example_test)