### PR TITLE
[Block Executor] Capturing MetadataAndSize, no default API forwarding. View changes [1/4]

### DIFF
--- a/aptos-move/aptos-vm-types/src/abstract_write_op.rs
+++ b/aptos-move/aptos-vm-types/src/abstract_write_op.rs
@@ -99,9 +99,9 @@ impl AbstractResourceWriteOp {
         use AbstractResourceWriteOp::*;
         let size = if fix_prev_materialized_size {
             match self {
-                Write(_) | WriteWithDelayedFields(_) => executor_view
-                    .get_resource_state_value_size(state_key)?
-                    .unwrap_or(0),
+                Write(_) | WriteWithDelayedFields(_) => {
+                    executor_view.get_resource_state_value_size(state_key)?
+                },
                 InPlaceDelayedFieldChange(InPlaceDelayedFieldChangeOp {
                     materialized_size,
                     ..
@@ -120,9 +120,9 @@ impl AbstractResourceWriteOp {
                 Write(_)
                 | WriteWithDelayedFields(WriteWithDelayedFieldsOp { .. })
                 | InPlaceDelayedFieldChange(_)
-                | ResourceGroupInPlaceDelayedFieldChange(_) => executor_view
-                    .get_resource_state_value_size(state_key)?
-                    .unwrap_or(0),
+                | ResourceGroupInPlaceDelayedFieldChange(_) => {
+                    executor_view.get_resource_state_value_size(state_key)?
+                },
                 WriteResourceGroup(GroupWrite {
                     prev_group_size, ..
                 }) => *prev_group_size,

--- a/aptos-move/aptos-vm-types/src/resolver.rs
+++ b/aptos-move/aptos-vm-types/src/resolver.rs
@@ -58,25 +58,16 @@ pub trait TResourceView {
         Ok(maybe_state_value.map(|state_value| state_value.bytes().clone()))
     }
 
+    // These methods should not be auto-implemented via get_resource_state_value, as they do not
+    // provide maybe_layout (and do not need know whether the resource contains delayed fields).
     fn get_resource_state_value_metadata(
         &self,
         state_key: &Self::Key,
-    ) -> PartialVMResult<Option<StateValueMetadata>> {
-        // For metadata, layouts are not important.
-        self.get_resource_state_value(state_key, None)
-            .map(|maybe_state_value| maybe_state_value.map(StateValue::into_metadata))
-    }
+    ) -> PartialVMResult<Option<StateValueMetadata>>;
 
-    fn get_resource_state_value_size(&self, state_key: &Self::Key) -> PartialVMResult<Option<u64>> {
-        self.get_resource_state_value(state_key, None)
-            .map(|maybe_state_value| maybe_state_value.map(|state_value| state_value.size() as u64))
-    }
+    fn get_resource_state_value_size(&self, state_key: &Self::Key) -> PartialVMResult<u64>;
 
-    fn resource_exists(&self, state_key: &Self::Key) -> PartialVMResult<bool> {
-        // For existence, layouts are not important.
-        self.get_resource_state_value(state_key, None)
-            .map(|maybe_state_value| maybe_state_value.is_some())
-    }
+    fn resource_exists(&self, state_key: &Self::Key) -> PartialVMResult<bool>;
 }
 
 /// Metadata and exists queries for the resource group, determined by a key, must be resolved
@@ -125,11 +116,7 @@ pub trait TResourceGroupView {
         &self,
         group_key: &Self::GroupKey,
         resource_tag: &Self::ResourceTag,
-    ) -> PartialVMResult<usize> {
-        Ok(self
-            .get_resource_from_group(group_key, resource_tag, None)?
-            .map_or(0, |bytes| bytes.len()))
-    }
+    ) -> PartialVMResult<usize>;
 
     /// Needed for backwards compatibility with the additional safety mechanism for resource
     /// groups, where the violation of the following invariant causes transaction failure:
@@ -145,10 +132,7 @@ pub trait TResourceGroupView {
         &self,
         group_key: &Self::GroupKey,
         resource_tag: &Self::ResourceTag,
-    ) -> PartialVMResult<bool> {
-        self.get_resource_from_group(group_key, resource_tag, None)
-            .map(|maybe_bytes| maybe_bytes.is_some())
-    }
+    ) -> PartialVMResult<bool>;
 
     fn release_group_cache(
         &self,
@@ -233,6 +217,26 @@ where
                 state_key, e
             ))
         })
+    }
+
+    fn get_resource_state_value_metadata(
+        &self,
+        state_key: &Self::Key,
+    ) -> PartialVMResult<Option<StateValueMetadata>> {
+        self.get_resource_state_value(state_key, None)
+            .map(|maybe_state_value| maybe_state_value.map(StateValue::into_metadata))
+    }
+
+    fn get_resource_state_value_size(&self, state_key: &Self::Key) -> PartialVMResult<u64> {
+        self.get_resource_state_value(state_key, None)
+            .map(|maybe_state_value| {
+                maybe_state_value.map_or(0, |state_value| state_value.size() as u64)
+            })
+    }
+
+    fn resource_exists(&self, state_key: &Self::Key) -> PartialVMResult<bool> {
+        self.get_resource_state_value(state_key, None)
+            .map(|maybe_state_value| maybe_state_value.is_some())
     }
 }
 

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/view_with_change_set.rs
@@ -17,10 +17,10 @@ use aptos_types::{
         state_value::{StateValue, StateValueMetadata},
         StateViewId,
     },
-    write_set::TransactionWrite,
+    write_set::{TransactionWrite, WriteOp},
 };
 use aptos_vm_types::{
-    abstract_write_op::{AbstractResourceWriteOp, WriteWithDelayedFieldsOp},
+    abstract_write_op::{AbstractResourceWriteOp, GroupWrite, WriteWithDelayedFieldsOp},
     change_set::{randomly_check_layout_matches, VMChangeSet},
     resolver::{
         ExecutorView, ResourceGroupSize, ResourceGroupView, StateStorageView, TResourceGroupView,
@@ -54,6 +54,59 @@ impl<'r> ExecutorViewWithChangeSet<'r> {
             base_resource_group_view,
             change_set,
         }
+    }
+
+    fn try_get_resource_write_op_from_change_set<'s>(
+        &'s self,
+        state_key: &StateKey,
+        calling_fn_name: &'static str,
+    ) -> PartialVMResult<Option<&'s WriteOp>> {
+        match self.change_set.resource_write_set().get(state_key) {
+            Some(
+                AbstractResourceWriteOp::Write(write_op)
+                | AbstractResourceWriteOp::WriteWithDelayedFields(WriteWithDelayedFieldsOp {
+                    write_op,
+                    ..
+                }),
+            ) => Ok(Some(write_op)),
+            Some(AbstractResourceWriteOp::InPlaceDelayedFieldChange(_)) => Ok(None), // Signal to forward
+            Some(AbstractResourceWriteOp::WriteResourceGroup(_))
+            | Some(AbstractResourceWriteOp::ResourceGroupInPlaceDelayedFieldChange(_)) => {
+                // In case this is a resource group, and feature is enabled that creates these ops,
+                // this should never be called.
+                // Call to metadata should go through get_resource_state_value_metadata(), and
+                // calls to individual tagged resources should go through resource group view trait.
+                Err(code_invariant_error(format!(
+                    "{} called for a resource group with key {:?}",
+                    calling_fn_name, state_key
+                ))
+                .into())
+            },
+            None => Ok(None), // Signal to forward
+        }
+    }
+
+    fn try_get_group_write_from_change_set<'s>(
+        &'s self,
+        group_key: &StateKey,
+        calling_fn_name: &'static str,
+    ) -> Result<Option<&'s GroupWrite>, PanicError> {
+        use AbstractResourceWriteOp::*;
+
+        self.change_set
+            .resource_write_set()
+            .get(group_key)
+            .and_then(|abstract_write_op| match abstract_write_op {
+                WriteResourceGroup(group_write) => Some(Ok(group_write)),
+                ResourceGroupInPlaceDelayedFieldChange(_) => None, // Will become Ok(None) after transpose
+                Write(_) | WriteWithDelayedFields(_) | InPlaceDelayedFieldChange(_) => {
+                    Some(Err(code_invariant_error(format!(
+                        "Non-ResourceGroup write found in {} call for key {:?}",
+                        calling_fn_name, group_key
+                    ))))
+                },
+            })
+            .transpose()
     }
 }
 
@@ -185,27 +238,14 @@ impl TResourceView for ExecutorViewWithChangeSet<'_> {
         state_key: &Self::Key,
         maybe_layout: Option<&Self::Layout>,
     ) -> PartialVMResult<Option<StateValue>> {
-        match self.change_set.resource_write_set().get(state_key) {
-            Some(
-                AbstractResourceWriteOp::Write(write_op)
-                | AbstractResourceWriteOp::WriteWithDelayedFields(WriteWithDelayedFieldsOp {
-                    write_op,
-                    ..
-                }),
-            ) => Ok(write_op.as_state_value()),
-            // We could either return from the read, or do the base read again.
-            Some(AbstractResourceWriteOp::InPlaceDelayedFieldChange(_)) | None => self
-                .base_executor_view
-                .get_resource_state_value(state_key, maybe_layout),
-            Some(AbstractResourceWriteOp::WriteResourceGroup(_))
-            | Some(AbstractResourceWriteOp::ResourceGroupInPlaceDelayedFieldChange(_)) => {
-                // In case this is a resource group, and feature is enabled that creates these ops,
-                // this should never be called.
-                // Call to metadata should go through get_resource_state_value_metadata(), and
-                // calls to individual tagged resources should go through their trait.
-                unreachable!("get_resource_state_value should never be called for resource group");
-            },
-        }
+        self.try_get_resource_write_op_from_change_set(state_key, "get_resource_state_value")?
+            .map_or_else(
+                || {
+                    self.base_executor_view
+                        .get_resource_state_value(state_key, maybe_layout)
+                },
+                |write_op| Ok(write_op.as_state_value()),
+            )
     }
 
     fn get_resource_state_value_metadata(
@@ -233,59 +273,22 @@ impl TResourceView for ExecutorViewWithChangeSet<'_> {
     }
 
     fn get_resource_state_value_size(&self, state_key: &Self::Key) -> PartialVMResult<u64> {
-        match self.change_set.resource_write_set().get(state_key) {
-            Some(
-                AbstractResourceWriteOp::Write(write_op)
-                | AbstractResourceWriteOp::WriteWithDelayedFields(WriteWithDelayedFieldsOp {
-                    write_op,
-                    ..
-                }),
-            ) => Ok(write_op.bytes_size() as u64),
-            // We could either return from the read, or do the base read again.
-            Some(AbstractResourceWriteOp::InPlaceDelayedFieldChange(_)) | None => self
-                .base_executor_view
-                .get_resource_state_value_size(state_key),
-            Some(AbstractResourceWriteOp::WriteResourceGroup(_))
-            | Some(AbstractResourceWriteOp::ResourceGroupInPlaceDelayedFieldChange(_)) => {
-                // In case this is a resource group, and feature is enabled that creates these ops,
-                // this should never be called.
-                // Call to metadata should go through get_resource_state_value_metadata(), and
-                // calls to individual tagged resources should go through their trait.
-                Err(code_invariant_error(format!(
-                    "get_resource_state_value_size called for resource group with key {:?}",
-                    state_key
-                ))
-                .into())
-            },
-        }
+        self.try_get_resource_write_op_from_change_set(state_key, "get_resource_state_value_size")?
+            .map_or_else(
+                || {
+                    self.base_executor_view
+                        .get_resource_state_value_size(state_key)
+                },
+                |write_op| Ok(write_op.bytes_size() as u64),
+            )
     }
 
     fn resource_exists(&self, state_key: &Self::Key) -> PartialVMResult<bool> {
-        match self.change_set.resource_write_set().get(state_key) {
-            Some(
-                AbstractResourceWriteOp::Write(write_op)
-                | AbstractResourceWriteOp::WriteWithDelayedFields(WriteWithDelayedFieldsOp {
-                    write_op,
-                    ..
-                }),
-            ) => Ok(write_op.bytes().is_some()),
-            // We could either return from the read, or do the base read again.
-            Some(AbstractResourceWriteOp::InPlaceDelayedFieldChange(_)) | None => {
-                self.base_executor_view.resource_exists(state_key)
-            },
-            Some(AbstractResourceWriteOp::WriteResourceGroup(_))
-            | Some(AbstractResourceWriteOp::ResourceGroupInPlaceDelayedFieldChange(_)) => {
-                // In case this is a resource group, and feature is enabled that creates these ops,
-                // this should never be called.
-                // Call to metadata should go through get_resource_state_value_metadata(), and
-                // calls to individual tagged resources should go through their trait.
-                Err(code_invariant_error(format!(
-                    "resource_exists called for resource group with key {:?}",
-                    state_key
-                ))
-                .into())
-            },
-        }
+        self.try_get_resource_write_op_from_change_set(state_key, "resource_exists")?
+            .map_or_else(
+                || self.base_executor_view.resource_exists(state_key),
+                |write_op| Ok(write_op.bytes().is_some()),
+            )
     }
 }
 
@@ -298,25 +301,15 @@ impl TResourceGroupView for ExecutorViewWithChangeSet<'_> {
         &self,
         group_key: &Self::GroupKey,
     ) -> PartialVMResult<ResourceGroupSize> {
-        use AbstractResourceWriteOp::*;
-
-        if let Some(size) = self
-            .change_set
-            .resource_write_set()
-            .get(group_key)
-            .and_then(|write| match write {
-                WriteResourceGroup(group_write) => Some(Ok(group_write.maybe_group_op_size().unwrap_or(ResourceGroupSize::zero_combined()))),
-                ResourceGroupInPlaceDelayedFieldChange(_) => None,
-                Write(_) | WriteWithDelayedFields(_) | InPlaceDelayedFieldChange(_) => {
-                    // There should be no collisions, we cannot have group key refer to a resource.
-                    Some(Err(code_invariant_error(format!("Non-ResourceGroup write found for key in get_resource_from_group call for key {group_key:?}"))))
+        self.try_get_group_write_from_change_set(group_key, "resource_group_size")?
+            .map_or_else(
+                || self.base_resource_group_view.resource_group_size(group_key),
+                |group_write| {
+                    Ok(group_write
+                        .maybe_group_op_size()
+                        .unwrap_or(ResourceGroupSize::zero_combined()))
                 },
-            })
-            .transpose()? {
-                return Ok(size);
-            }
-
-        self.base_resource_group_view.resource_group_size(group_key)
+            )
     }
 
     fn get_resource_from_group(
@@ -325,32 +318,21 @@ impl TResourceGroupView for ExecutorViewWithChangeSet<'_> {
         resource_tag: &Self::ResourceTag,
         maybe_layout: Option<&Self::Layout>,
     ) -> PartialVMResult<Option<Bytes>> {
-        use AbstractResourceWriteOp::*;
-
-        if let Some((write_op, layout)) = self
-            .change_set
-            .resource_write_set()
-            .get(group_key)
-            .and_then(|write| match write {
-                WriteResourceGroup(group_write) => Some(Ok(group_write)),
-                ResourceGroupInPlaceDelayedFieldChange(_) => None,
-                Write(_) | WriteWithDelayedFields(_) | InPlaceDelayedFieldChange(_) => {
-                    // There should be no collisions, we cannot have group key refer to a resource.
-                    Some(Err(code_invariant_error(format!("Non-ResourceGroup write found for key in get_resource_from_group call for key {group_key:?}"))))
+        self.try_get_group_write_from_change_set(group_key, "get_resource_from_group")?
+            .and_then(|group_write| group_write.inner_ops().get(resource_tag))
+            .map_or_else(
+                || {
+                    self.base_resource_group_view.get_resource_from_group(
+                        group_key,
+                        resource_tag,
+                        maybe_layout,
+                    )
                 },
-            })
-            .transpose()?
-            .and_then(|g| g.inner_ops().get(resource_tag))
-        {
-            randomly_check_layout_matches(maybe_layout, layout.as_deref())?;
-            Ok(write_op.extract_raw_bytes())
-        } else {
-            self.base_resource_group_view.get_resource_from_group(
-                group_key,
-                resource_tag,
-                maybe_layout,
+                |(write_op, layout)| {
+                    randomly_check_layout_matches(maybe_layout, layout.as_deref())?;
+                    Ok(write_op.extract_raw_bytes())
+                },
             )
-        }
     }
 
     fn resource_size_in_group(
@@ -358,30 +340,15 @@ impl TResourceGroupView for ExecutorViewWithChangeSet<'_> {
         group_key: &Self::GroupKey,
         resource_tag: &Self::ResourceTag,
     ) -> PartialVMResult<usize> {
-        use AbstractResourceWriteOp::*;
-
-        if let Some((write_op, _)) = self
-            .change_set
-            .resource_write_set()
-            .get(group_key)
-            .and_then(|write| match write {
-                WriteResourceGroup(group_write) => Some(Ok(group_write)),
-                ResourceGroupInPlaceDelayedFieldChange(_) => None,
-                Write(_) | WriteWithDelayedFields(_) | InPlaceDelayedFieldChange(_) => {
-                    // There should be no collisions, we cannot have group key refer to a resource.
-                    Some(Err(code_invariant_error(format!("Non-ResourceGroup write found for key in resource_size_in_group call for key {group_key:?}"))))
+        self.try_get_group_write_from_change_set(group_key, "resource_size_in_group")?
+            .and_then(|group_write| group_write.inner_ops().get(resource_tag))
+            .map_or_else(
+                || {
+                    self.base_resource_group_view
+                        .resource_size_in_group(group_key, resource_tag)
                 },
-            })
-            .transpose()?
-            .and_then(|g| g.inner_ops().get(resource_tag))
-        {
-            Ok(write_op.bytes_size())
-        } else {
-            self.base_resource_group_view.resource_size_in_group(
-                group_key,
-                resource_tag,
+                |(write_op, _layout)| Ok(write_op.bytes_size()),
             )
-        }
     }
 
     fn resource_exists_in_group(
@@ -389,30 +356,15 @@ impl TResourceGroupView for ExecutorViewWithChangeSet<'_> {
         group_key: &Self::GroupKey,
         resource_tag: &Self::ResourceTag,
     ) -> PartialVMResult<bool> {
-        use AbstractResourceWriteOp::*;
-
-        if let Some((write_op, _)) = self
-            .change_set
-            .resource_write_set()
-            .get(group_key)
-            .and_then(|write| match write {
-                WriteResourceGroup(group_write) => Some(Ok(group_write)),
-                ResourceGroupInPlaceDelayedFieldChange(_) => None,
-                Write(_) | WriteWithDelayedFields(_) | InPlaceDelayedFieldChange(_) => {
-                    // There should be no collisions, we cannot have group key refer to a resource.
-                    Some(Err(code_invariant_error(format!("Non-ResourceGroup write found for key in resource_exists_in_group call for key {group_key:?}"))))
+        self.try_get_group_write_from_change_set(group_key, "resource_exists_in_group")?
+            .and_then(|group_write| group_write.inner_ops().get(resource_tag))
+            .map_or_else(
+                || {
+                    self.base_resource_group_view
+                        .resource_exists_in_group(group_key, resource_tag)
                 },
-            })
-            .transpose()?
-            .and_then(|g| g.inner_ops().get(resource_tag))
-        {
-            Ok(write_op.bytes().is_some())
-        } else {
-            self.base_resource_group_view.resource_exists_in_group(
-                group_key,
-                resource_tag,
+                |(write_op, _layout)| Ok(write_op.bytes().is_some()),
             )
-        }
     }
 
     fn release_group_cache(

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -1561,7 +1561,7 @@ where
                     // If dynamic change set is disabled, this can be used to assert nothing needs patching instead:
                     //   output.set_txn_output_for_non_dynamic_change_set();
 
-                    if latest_view.is_incorrect_use() {
+                    if sequential_reads.incorrect_use {
                         return Err(
                             code_invariant_error("Incorrect use in sequential execution").into(),
                         );

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -23,8 +23,8 @@ use aptos_aggregator::{
 use aptos_logger::error;
 use aptos_mvhashmap::{
     types::{
-        GroupReadResult, MVDataError, MVDataOutput, MVDelayedFieldsError, MVGroupError,
-        StorageVersion, TxnIndex, UnknownOrLayout, UnsyncGroupError, ValueWithLayout,
+        MVDataError, MVDataOutput, MVDelayedFieldsError, MVGroupError, StorageVersion, TxnIndex,
+        UnknownOrLayout, UnsyncGroupError, ValueWithLayout,
     },
     unsync_map::UnsyncMap,
     versioned_delayed_fields::TVersionedDelayedFieldView,
@@ -70,12 +70,16 @@ use std::{
     },
 };
 
+/// ReadResult wraps the result of MVHashMap's data map, while GroupReadResult
+/// is for the groups' MVHHashMap. TODO: Needs re-organization and clean-up.
+
 /// A struct which describes the result of the read from the proxy. The client
 /// can interpret these types to further resolve the reads.
 #[derive(Debug)]
 pub(crate) enum ReadResult {
     Value(Option<StateValue>, Option<Arc<MoveTypeLayout>>),
     Metadata(Option<StateValueMetadata>),
+    ResourceSize(Option<u64>),
     Exists(bool),
     Uninitialized,
     // Must halt the execution of the calling transaction. This might be because
@@ -86,35 +90,37 @@ pub(crate) enum ReadResult {
 }
 
 impl ReadResult {
-    fn from_data_read<V: TransactionWrite>(data: DataRead<V>) -> Self {
+    pub(crate) fn from_value<T: Transaction>(
+        value: ValueWithLayout<T::Value>,
+        kind: &ReadKind,
+    ) -> Result<Self, PanicError> {
+        // We set an arbitrary version, as in the end ReadResult does not require version
+        // so it can be anything. Re-uses the implementation pattern from capture_read
+        // and capture_group_read in the captured_reads.rs file.
+        match DataRead::from_value_with_layout(Err(StorageVersion), value).convert_to(kind) {
+            Some(data_read) => Ok(Self::from_data_read(data_read)),
+            None => Err(code_invariant_error(format!(
+                "Could not convert value to kind {:?} ReadResult",
+                kind
+            ))),
+        }
+    }
+
+    // Should not be passed a MetadataAndResourceSize variant.
+    pub(crate) fn from_data_read<V: TransactionWrite>(data: DataRead<V>) -> Self {
         match data {
             DataRead::Versioned(_, v, layout) => ReadResult::Value(v.as_state_value(), layout),
             DataRead::Resolved(v) => {
                 // TODO[agg_v1](cleanup): Move AggV1 to Delayed fields, and then handle the layout if needed
                 ReadResult::Value(Some(StateValue::new_legacy(serialize(&v).into())), None)
             },
+            DataRead::MetadataAndResourceSize(_, _) => {
+                // Should be a Metadata or ResourceSize variant, not both.
+                unreachable!("Target read result for MetadataAndResourceSize is ambiguous");
+            },
             DataRead::Metadata(maybe_metadata) => ReadResult::Metadata(maybe_metadata),
+            DataRead::ResourceSize(maybe_size) => ReadResult::ResourceSize(maybe_size),
             DataRead::Exists(exists) => ReadResult::Exists(exists),
-        }
-    }
-
-    fn from_value_with_layout<V: TransactionWrite>(
-        value: ValueWithLayout<V>,
-        kind: ReadKind,
-    ) -> Option<Self> {
-        match (value, kind) {
-            (ValueWithLayout::Exchanged(v, layout), ReadKind::Value) => {
-                Some(ReadResult::Value(v.as_state_value(), layout))
-            },
-            (ValueWithLayout::RawFromStorage(_), ReadKind::Value) => None,
-            (ValueWithLayout::Exchanged(v, _), ReadKind::Metadata)
-            | (ValueWithLayout::RawFromStorage(v), ReadKind::Metadata) => {
-                Some(ReadResult::Metadata(v.as_state_value_metadata()))
-            },
-            (ValueWithLayout::Exchanged(v, _), ReadKind::Exists)
-            | (ValueWithLayout::RawFromStorage(v), ReadKind::Exists) => {
-                Some(ReadResult::Exists(!v.is_deletion()))
-            },
         }
     }
 
@@ -123,6 +129,87 @@ impl ReadResult {
             v
         } else {
             unreachable!("Read result must be Value kind")
+        }
+    }
+}
+
+#[derive(Debug, Eq, PartialEq)]
+pub enum GroupReadResult {
+    Value(Option<Bytes>, Option<Arc<MoveTypeLayout>>),
+    GroupSize(ResourceGroupSize),
+    ResourceSize(Option<u64>),
+    Exists(bool),
+    Uninitialized,
+}
+
+impl GroupReadResult {
+    pub(crate) fn from_value<T: Transaction>(
+        value: ValueWithLayout<T::Value>,
+        kind: &ReadKind,
+    ) -> Result<Self, PanicError> {
+        // We set an arbitrary version, as below (from_data_read) internally ignores it.
+        match DataRead::from_value_with_layout(Err(StorageVersion), value).convert_to(kind) {
+            Some(data_read) => Ok(Self::from_data_read(data_read)),
+            None => Err(code_invariant_error(format!(
+                "Could not convert value to kind {:?} ReadResult",
+                kind
+            ))),
+        }
+    }
+
+    pub(crate) fn from_data_read<V: TransactionWrite>(data: DataRead<V>) -> Self {
+        match data {
+            DataRead::Versioned(_, v, layout) => {
+                GroupReadResult::Value(v.extract_raw_bytes(), layout)
+            },
+            DataRead::Resolved(_) => {
+                // Resolved is only available in data MVHashMap for legacy AggregatorV1.
+                unreachable!("Resolved is not a possible group read result");
+            },
+            DataRead::MetadataAndResourceSize(_, _) | DataRead::Metadata(_) => {
+                // Metadata for the group does not go through the group MVHashMap and is handled
+                // separately in view.rs (it's stored in the data MVHashMap).
+                unreachable!("Metadata may not be queried for resource group members");
+            },
+            DataRead::ResourceSize(maybe_size) => GroupReadResult::ResourceSize(maybe_size),
+            DataRead::Exists(exists) => GroupReadResult::Exists(exists),
+        }
+    }
+
+    pub fn into_value(self) -> Option<Bytes> {
+        match self {
+            GroupReadResult::Value(maybe_bytes, _) => maybe_bytes,
+            GroupReadResult::GroupSize(_) => {
+                unreachable!("Expected group value, found size")
+            },
+            GroupReadResult::Uninitialized => {
+                unreachable!("Expected group value, found uninitialized")
+            },
+            GroupReadResult::ResourceSize(_) => {
+                unreachable!("Expected group value, found resource size")
+            },
+            GroupReadResult::Exists(_) => {
+                unreachable!("Expected group value, found exists")
+            },
+        }
+    }
+
+    pub fn into_group_size(self) -> ResourceGroupSize {
+        match self {
+            GroupReadResult::GroupSize(size) => size,
+            GroupReadResult::Value(maybe_bytes, maybe_layout) => unreachable!(
+                "Expected group size, found value bytes = {:?}, layout = {:?}",
+                maybe_bytes, maybe_layout
+            ),
+            GroupReadResult::Uninitialized => {
+                unreachable!("Expected group size, found uninitialized")
+            },
+            GroupReadResult::ResourceSize(_) => {
+                unreachable!("Expected group size, found resource size")
+            },
+            GroupReadResult::Exists(_) => {
+                unreachable!("Expected group size, found exists")
+            },
         }
     }
 }
@@ -137,7 +224,7 @@ trait ResourceState<T: Transaction> {
         target_kind: ReadKind,
         layout: UnknownOrLayout,
         patch_base_value: &dyn Fn(&T::Value, Option<&MoveTypeLayout>) -> PartialVMResult<T::Value>,
-    ) -> ReadResult;
+    ) -> PartialVMResult<ReadResult>;
 }
 
 trait ResourceGroupState<T: Transaction> {
@@ -147,12 +234,13 @@ trait ResourceGroupState<T: Transaction> {
         base_values: Vec<(T::Tag, T::Value)>,
     ) -> PartialVMResult<()>;
 
-    fn read_cached_group_tagged_data(
+    fn read_cached_group_tagged_data_by_kind(
         &self,
         txn_idx: TxnIndex,
         group_key: &T::Key,
         resource_tag: &T::Tag,
-        maybe_layout: Option<&MoveTypeLayout>,
+        target_kind: ReadKind,
+        layout: UnknownOrLayout,
         patch_base_value: &dyn Fn(&T::Value, Option<&MoveTypeLayout>) -> PartialVMResult<T::Value>,
     ) -> PartialVMResult<GroupReadResult>;
 }
@@ -478,7 +566,7 @@ impl<'a, T: Transaction> ParallelState<'a, T> {
         use MVGroupError::*;
 
         if let Some(group_size) = self.captured_reads.borrow().group_size(group_key) {
-            return Ok(GroupReadResult::Size(group_size));
+            return Ok(GroupReadResult::GroupSize(group_size));
         }
 
         loop {
@@ -495,7 +583,7 @@ impl<'a, T: Transaction> ParallelState<'a, T> {
                         "Group size may not be inconsistent: must be recorded once"
                     );
 
-                    return Ok(GroupReadResult::Size(group_size));
+                    return Ok(GroupReadResult::GroupSize(group_size));
                 },
                 Err(Uninitialized) => {
                     return Ok(GroupReadResult::Uninitialized);
@@ -530,16 +618,16 @@ impl<T: Transaction> ResourceState<T> for ParallelState<'_, T> {
         target_kind: ReadKind,
         layout: UnknownOrLayout,
         patch_base_value: &dyn Fn(&T::Value, Option<&MoveTypeLayout>) -> PartialVMResult<T::Value>,
-    ) -> ReadResult {
+    ) -> PartialVMResult<ReadResult> {
         use MVDataError::*;
         use MVDataOutput::*;
 
         if let Some(data) = self
             .captured_reads
             .borrow()
-            .get_by_kind(key, None, target_kind.clone())
+            .get_by_kind(key, None, target_kind)
         {
-            return ReadResult::from_data_read(data);
+            return Ok(ReadResult::from_data_read(data));
         }
 
         loop {
@@ -564,82 +652,49 @@ impl<T: Transaction> ResourceState<T> for ParallelState<'_, T> {
                                 Err(e) => {
                                     error!("Couldn't patch value from versioned map: {}", e);
                                     self.captured_reads.borrow_mut().mark_incorrect_use();
-                                    return ReadResult::HaltSpeculativeExecution(
+                                    return Ok(ReadResult::HaltSpeculativeExecution(
                                         "Couldn't patch value from versioned map".to_string(),
-                                    );
+                                    ));
                                 },
                             }
                         }
                     }
 
-                    let data_read = match DataRead::from_value_with_layout(version, value)
-                        .downcast(target_kind)
-                    {
-                        Some(data_read) => data_read,
-                        None => {
-                            error!("Couldn't downcast value from versioned map");
-                            self.captured_reads.borrow_mut().mark_incorrect_use();
-                            return ReadResult::HaltSpeculativeExecution(
-                                "Couldn't downcast value from versioned map".to_string(),
-                            );
-                        },
-                    };
-
-                    if self
-                        .captured_reads
-                        .borrow_mut()
-                        .capture_read(key.clone(), None, data_read.clone())
-                        .is_err()
-                    {
-                        // Inconsistency in recorded reads.
-                        return ReadResult::HaltSpeculativeExecution(
-                            "Inconsistency in reads (must be due to speculation)".to_string(),
-                        );
-                    }
-
-                    return ReadResult::from_data_read(data_read);
+                    return Ok(self.captured_reads.borrow_mut().capture_data_read(
+                        key.clone(),
+                        DataRead::from_value_with_layout(version, value),
+                        &target_kind,
+                    )?);
                 },
                 Ok(Resolved(value)) => {
-                    let data_read = DataRead::Resolved(value)
-                        .downcast(target_kind)
-                        .expect("Downcast from Resolved must succeed");
-
-                    if self
-                        .captured_reads
-                        .borrow_mut()
-                        .capture_read(key.clone(), None, data_read.clone())
-                        .is_err()
-                    {
-                        // Inconsistency in recorded reads.
-                        return ReadResult::HaltSpeculativeExecution(
-                            "Inconsistency in reads (must be due to speculation)".to_string(),
-                        );
-                    }
-
-                    return ReadResult::from_data_read(data_read);
+                    return Ok(self.captured_reads.borrow_mut().capture_data_read(
+                        key.clone(),
+                        DataRead::Resolved(value),
+                        &target_kind,
+                    )?);
                 },
                 Err(Uninitialized) | Err(Unresolved(_)) => {
                     // The underlying assumption here for not recording anything about the read is
                     // that the caller is expected to initialize the contents and serve the reads
                     // solely via the 'fetch_read' interface. Thus, the later, successful read,
                     // will make the needed recordings.
-                    return ReadResult::Uninitialized;
+                    return Ok(ReadResult::Uninitialized);
                 },
                 Err(Dependency(dep_idx)) => {
                     match wait_for_dependency(self.scheduler, txn_idx, dep_idx) {
                         Err(e) => {
                             error!("Error {:?} in wait for dependency", e);
                             self.captured_reads.borrow_mut().mark_incorrect_use();
-                            return ReadResult::HaltSpeculativeExecution(format!(
+                            return Ok(ReadResult::HaltSpeculativeExecution(format!(
                                 "Error {:?} in wait for dependency",
                                 e
-                            ));
+                            )));
                         },
                         Ok(false) => {
                             self.captured_reads.borrow_mut().mark_failure(false);
-                            return ReadResult::HaltSpeculativeExecution(
+                            return Ok(ReadResult::HaltSpeculativeExecution(
                                 "Interrupted as block execution was halted".to_string(),
-                            );
+                            ));
                         },
                         Ok(true) => {
                             //dependency resolved
@@ -649,9 +704,9 @@ impl<T: Transaction> ResourceState<T> for ParallelState<'_, T> {
                 Err(DeltaApplicationFailure) => {
                     // AggregatorV1 may have delta application failure due to speculation.
                     self.captured_reads.borrow_mut().mark_failure(false);
-                    return ReadResult::HaltSpeculativeExecution(
+                    return Ok(ReadResult::HaltSpeculativeExecution(
                         "Delta application failure (must be speculative)".to_string(),
-                    );
+                    ));
                 },
             };
         }
@@ -674,22 +729,23 @@ impl<T: Transaction> ResourceGroupState<T> for ParallelState<'_, T> {
             })
     }
 
-    fn read_cached_group_tagged_data(
+    fn read_cached_group_tagged_data_by_kind(
         &self,
         txn_idx: TxnIndex,
         group_key: &T::Key,
         resource_tag: &T::Tag,
-        maybe_layout: Option<&MoveTypeLayout>,
+        target_kind: ReadKind,
+        layout: UnknownOrLayout,
         patch_base_value: &dyn Fn(&T::Value, Option<&MoveTypeLayout>) -> PartialVMResult<T::Value>,
     ) -> PartialVMResult<GroupReadResult> {
         use MVGroupError::*;
 
-        if let Some(DataRead::Versioned(_, v, layout)) =
+        if let Some(data_read) =
             self.captured_reads
                 .borrow()
-                .get_by_kind(group_key, Some(resource_tag), ReadKind::Value)
+                .get_by_kind(group_key, Some(resource_tag), target_kind)
         {
-            return Ok(GroupReadResult::Value(v.extract_raw_bytes(), layout));
+            return Ok(GroupReadResult::from_data_read(data_read));
         }
 
         loop {
@@ -700,57 +756,54 @@ impl<T: Transaction> ResourceGroupState<T> for ParallelState<'_, T> {
             ) {
                 Ok((version, value_with_layout)) => {
                     // If we have a known layout, upgrade RawFromStorage value to Exchanged.
-                    match value_with_layout {
-                        ValueWithLayout::RawFromStorage(v) => {
-                            let patched_value = patch_base_value(v.as_ref(), maybe_layout)?;
+                    if let UnknownOrLayout::Known(layout) = layout {
+                        if let ValueWithLayout::RawFromStorage(v) = value_with_layout {
+                            assert_eq!(version, Err(StorageVersion),
+                            "Fetched resource has unknown layout but the version is not Err(StorageVersion)"
+                            );
+                            let patched_value = patch_base_value(v.as_ref(), layout)?;
+
                             self.versioned_map
                                 .group_data()
                                 .update_tagged_base_value_with_layout(
                                     group_key.clone(),
                                     resource_tag.clone(),
                                     patched_value,
-                                    maybe_layout.cloned().map(Arc::new),
+                                    layout.cloned().map(Arc::new),
                                 );
                             // Re-fetch in case a concurrent change went through.
                             continue;
-                        },
-                        ValueWithLayout::Exchanged(value, layout) => {
-                            let data_read =
-                                DataRead::Versioned(version, value.clone(), layout.clone());
-                            assert_ok!(
-                                self.captured_reads.borrow_mut().capture_read(
-                                    group_key.clone(),
-                                    Some(resource_tag.clone()),
-                                    data_read
-                                ),
-                                "Resource read in group recorded once: may not be inconsistent"
-                            );
-                            return Ok(GroupReadResult::Value(
-                                value.extract_raw_bytes(),
-                                layout.clone(),
-                            ));
-                        },
+                        }
                     }
+
+                    return self.captured_reads.borrow_mut().capture_group_read(
+                        group_key.clone(),
+                        resource_tag.clone(),
+                        DataRead::from_value_with_layout(version, value_with_layout),
+                        &target_kind,
+                    );
                 },
                 Err(Uninitialized) => {
                     return Ok(GroupReadResult::Uninitialized);
                 },
                 Err(TagNotFound) => {
-                    let data_read = DataRead::Versioned(
+                    let empty_data_read = DataRead::Versioned(
                         Err(StorageVersion),
                         Arc::<T::Value>::new(TransactionWrite::from_state_value(None)),
                         None,
                     );
-                    assert_ok!(
-                        self.captured_reads.borrow_mut().capture_read(
-                            group_key.clone(),
-                            Some(resource_tag.clone()),
-                            data_read
-                        ),
-                        "Resource read in group recorded once: may not be inconsistent"
-                    );
-
-                    return Ok(GroupReadResult::Value(None, None));
+                    // Capture empty / deletion as a read.
+                    self.captured_reads.borrow_mut().capture_group_read(
+                        group_key.clone(),
+                        resource_tag.clone(),
+                        empty_data_read.clone(),
+                        &target_kind,
+                    )?;
+                    return Ok(GroupReadResult::from_data_read(
+                        empty_data_read
+                            .convert_to(&target_kind)
+                            .expect("Converting from value must succeed"),
+                    ));
                 },
                 Err(Dependency(dep_idx)) => {
                     if !wait_for_dependency(self.scheduler, txn_idx, dep_idx)? {
@@ -772,8 +825,6 @@ pub(crate) struct SequentialState<'a, T: Transaction> {
     pub(crate) read_set: RefCell<UnsyncReadSet<T, ModuleId>>,
     pub(crate) start_counter: u32,
     pub(crate) counter: &'a RefCell<u32>,
-    // TODO: Move to UnsyncMap.
-    pub(crate) incorrect_use: RefCell<bool>,
 }
 
 impl<'a, T: Transaction> SequentialState<'a, T> {
@@ -787,7 +838,6 @@ impl<'a, T: Transaction> SequentialState<'a, T> {
             read_set: RefCell::new(UnsyncReadSet::default()),
             start_counter,
             counter,
-            incorrect_use: RefCell::new(false),
         }
     }
 
@@ -816,59 +866,50 @@ impl<T: Transaction> ResourceState<T> for SequentialState<'_, T> {
         target_kind: ReadKind,
         layout: UnknownOrLayout,
         patch_base_value: &dyn Fn(&T::Value, Option<&MoveTypeLayout>) -> PartialVMResult<T::Value>,
-    ) -> ReadResult {
+    ) -> PartialVMResult<ReadResult> {
         match self.unsync_map.fetch_data(key) {
             Some(mut value) => {
                 // If we have a known layout, upgrade RawFromStorage value to Exchanged.
                 if let UnknownOrLayout::Known(layout) = layout {
                     if let ValueWithLayout::RawFromStorage(v) = value {
-                        match patch_base_value(v.as_ref(), layout) {
-                            Ok(patched_value) => {
-                                let exchanged_value = ValueWithLayout::Exchanged(
-                                    Arc::new(patched_value.clone()),
-                                    layout.cloned().map(Arc::new),
-                                );
-                                self.unsync_map
-                                    .set_base_value(key.clone(), exchanged_value.clone());
+                        let patched_value = patch_base_value(v.as_ref(), layout)?;
+                        let exchanged_value = ValueWithLayout::Exchanged(
+                            Arc::new(patched_value.clone()),
+                            layout.cloned().map(Arc::new),
+                        );
+                        self.unsync_map
+                            .set_base_value(key.clone(), exchanged_value.clone());
 
-                                // sequential execution doesn't need to worry about concurrent change going through.
-                                value = exchanged_value;
-                            },
-                            Err(_) => {
-                                // TODO[agg_v2](cleanup): `patch_base_value` already marks as incorrect use
-                                //               and logs an error! We need to make this uniform across
-                                //               resources and groups.
-                                *self.incorrect_use.borrow_mut() = true;
-                                error!("Unsync map couldn't patch base value");
-                                return ReadResult::HaltSpeculativeExecution(
-                                    "Unsync map couldn't patch base value".to_string(),
-                                );
-                            },
-                        }
+                        // sequential execution doesn't need to worry about concurrent change going through.
+                        value = exchanged_value;
                     }
                 }
 
-                if let Some(ret) = ReadResult::from_value_with_layout(value, target_kind.clone()) {
-                    if target_kind == ReadKind::Value {
-                        self.read_set
-                            .borrow_mut()
-                            .resource_reads
-                            .insert(key.clone());
-                    }
-
-                    ret
-                } else {
-                    *self.incorrect_use.borrow_mut() = true;
-                    error!(
-                        "Unsync map has RawFromStorage value type, while we are requesting value"
-                    );
-                    ReadResult::HaltSpeculativeExecution(
-                        "Unsync map has RawFromStorage value type, while we are requesting value"
-                            .to_string(),
-                    )
+                match ReadResult::from_value::<T>(value, &target_kind) {
+                    Ok(read_result) => {
+                        // Get read summary in CapturedReads filters only value reads,
+                        // to be consistent, UnsyncReadSet does not record other kinds.
+                        if target_kind == ReadKind::Value {
+                            self.read_set
+                                .borrow_mut()
+                                .resource_reads
+                                .insert(key.clone());
+                        }
+                        Ok(read_result)
+                    },
+                    Err(_) => {
+                        self.read_set.borrow_mut().incorrect_use = true;
+                        error!(
+                            "Unsync map has RawFromStorage value type, while we are requesting value"
+                        );
+                        Ok(ReadResult::HaltSpeculativeExecution(
+                            "Unsync map has RawFromStorage value type, while we are requesting value"
+                                .to_string(),
+                        ))
+                    },
                 }
             },
-            None => ReadResult::Uninitialized,
+            None => Ok(ReadResult::Uninitialized),
         }
     }
 }
@@ -882,18 +923,19 @@ impl<T: Transaction> ResourceGroupState<T> for SequentialState<'_, T> {
         self.unsync_map
             .set_group_base_values(group_key.clone(), base_values)
             .map_err(|e| {
-                *self.incorrect_use.borrow_mut() = true;
+                self.read_set.borrow_mut().incorrect_use = true;
                 PartialVMError::new(StatusCode::UNEXPECTED_DESERIALIZATION_ERROR)
                     .with_message(e.to_string())
             })
     }
 
-    fn read_cached_group_tagged_data(
+    fn read_cached_group_tagged_data_by_kind(
         &self,
         _txn_idx: TxnIndex,
         group_key: &T::Key,
         resource_tag: &T::Tag,
-        maybe_layout: Option<&MoveTypeLayout>,
+        target_kind: ReadKind,
+        layout: UnknownOrLayout,
         patch_base_value: &dyn Fn(&T::Value, Option<&MoveTypeLayout>) -> PartialVMResult<T::Value>,
     ) -> PartialVMResult<GroupReadResult> {
         match self
@@ -902,46 +944,58 @@ impl<T: Transaction> ResourceGroupState<T> for SequentialState<'_, T> {
         {
             Ok(mut value) => {
                 // If we have a known layout, upgrade RawFromStorage value to Exchanged.
-                if let ValueWithLayout::RawFromStorage(v) = value {
-                    let patched_value = patch_base_value(v.as_ref(), maybe_layout)?;
-                    let maybe_layout = maybe_layout.cloned().map(Arc::new);
-                    self.unsync_map.update_tagged_base_value_with_layout(
-                        group_key.clone(),
-                        resource_tag.clone(),
-                        patched_value.clone(),
-                        maybe_layout.clone(),
-                    );
+                if let UnknownOrLayout::Known(layout) = layout {
+                    if let ValueWithLayout::RawFromStorage(v) = value {
+                        let patched_value = patch_base_value(v.as_ref(), layout)?;
+                        let arced_layout = layout.cloned().map(Arc::new);
+                        self.unsync_map.update_tagged_base_value_with_layout(
+                            group_key.clone(),
+                            resource_tag.clone(),
+                            patched_value.clone(),
+                            arced_layout.clone(),
+                        );
 
-                    // Sequential execution doesn't need to worry about concurrent change going through.
-                    value = ValueWithLayout::Exchanged(Arc::new(patched_value), maybe_layout);
+                        value = ValueWithLayout::Exchanged(Arc::new(patched_value), arced_layout);
+                    }
                 }
 
-                if let ValueWithLayout::Exchanged(v, l) = value {
-                    let bytes = v.extract_raw_bytes();
-                    self.read_set
-                        .borrow_mut()
-                        .group_reads
-                        .entry(group_key.clone())
-                        .or_default()
-                        .insert(resource_tag.clone());
-                    Ok(GroupReadResult::Value(bytes, l.clone()))
-                } else {
-                    *self.incorrect_use.borrow_mut() = true;
-                    error!(
-                        "Unsync map has RawFromStorage value type, while we are requesting value"
-                    );
-                    Ok(GroupReadResult::Uninitialized)
+                match GroupReadResult::from_value::<T>(value, &target_kind) {
+                    Ok(group_read_result) => {
+                        if target_kind == ReadKind::Value {
+                            self.read_set
+                                .borrow_mut()
+                                .group_reads
+                                .entry(group_key.clone())
+                                .or_default()
+                                .insert(resource_tag.clone());
+                        }
+                        Ok(group_read_result)
+                    },
+                    Err(e) => {
+                        self.read_set.borrow_mut().incorrect_use = true;
+                        error!("Unsync map group read from value error {:?}", e);
+                        Err(e.into())
+                    },
                 }
             },
             Err(UnsyncGroupError::Uninitialized) => Ok(GroupReadResult::Uninitialized),
             Err(UnsyncGroupError::TagNotFound) => {
+                let empty_data_read = DataRead::Versioned(
+                    Err(StorageVersion),
+                    Arc::<T::Value>::new(TransactionWrite::from_state_value(None)),
+                    None,
+                );
                 self.read_set
                     .borrow_mut()
                     .group_reads
                     .entry(group_key.clone())
                     .or_default()
                     .insert(resource_tag.clone());
-                Ok(GroupReadResult::Value(None, None))
+                Ok(GroupReadResult::from_data_read(
+                    empty_data_read
+                        .convert_to(&target_kind)
+                        .expect("Converting from value must succeed"),
+                ))
             },
         }
     }
@@ -1037,7 +1091,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
     fn mark_incorrect_use(&self) {
         match &self.latest_view {
             ViewState::Sync(state) => state.captured_reads.borrow_mut().mark_incorrect_use(),
-            ViewState::Unsync(state) => *state.incorrect_use.borrow_mut() = true,
+            ViewState::Unsync(state) => state.read_set.borrow_mut().incorrect_use = true,
         }
     }
 
@@ -1048,7 +1102,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
                 true
             },
             // TODO: store incorrect use in UnsyncMap and eliminate this API.
-            ViewState::Unsync(state) => *state.incorrect_use.borrow(),
+            ViewState::Unsync(state) => state.read_set.borrow().incorrect_use,
         }
     }
 
@@ -1249,16 +1303,17 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
 
                 match self.get_resource_state_value_metadata(&key)? {
                     Some(metadata) => match parallel_state.read_group_size(&key, self.txn_idx)? {
-                        GroupReadResult::Size(group_size) => {
+                        GroupReadResult::GroupSize(group_size) => {
                             Ok(Some((key, (metadata, group_size.get()))))
                         },
-                        GroupReadResult::Value(_, _) | GroupReadResult::Uninitialized => {
-                            Err(code_invariant_error(format!(
-                                "Cannot compute metadata op size for the group read {:?}",
-                                key
-                            ))
-                            .into())
-                        },
+                        GroupReadResult::Value(_, _)
+                        | GroupReadResult::Exists(_)
+                        | GroupReadResult::ResourceSize(_)
+                        | GroupReadResult::Uninitialized => Err(code_invariant_error(format!(
+                            "Cannot compute metadata op size for the group read {:?}",
+                            key
+                        ))
+                        .into()),
                     },
                     None => Err(code_invariant_error(format!(
                         "Metadata op not present for the group read {:?}",
@@ -1307,15 +1362,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
                     }
                     match self.get_resource_state_value_metadata(key)? {
                         Some(metadata) => match unsync_map.get_group_size(key) {
-                            GroupReadResult::Size(group_size) => {
+                            Some(group_size) => {
                                 Ok(Some((key.clone(), (metadata, group_size.get()))))
                             },
-                            GroupReadResult::Value(_, _) => {
-                                unreachable!(
-                                    "get_group_size cannot return GroupReadResult::Value type"
-                                )
-                            },
-                            GroupReadResult::Uninitialized => Err(code_invariant_error(format!(
+                            None => Err(code_invariant_error(format!(
                                 "Sequential cannot find metadata op size for the group read {:?}",
                                 key
                             ))
@@ -1335,6 +1385,44 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
             .collect()
     }
 
+    fn get_resource_from_group_impl(
+        &self,
+        group_key: &T::Key,
+        resource_tag: &T::Tag,
+        layout: UnknownOrLayout,
+        kind: ReadKind,
+    ) -> PartialVMResult<GroupReadResult> {
+        let mut group_read = self
+            .latest_view
+            .get_resource_group_state()
+            .read_cached_group_tagged_data_by_kind(
+                self.txn_idx,
+                group_key,
+                resource_tag,
+                kind,
+                layout.clone(),
+                &|value, layout| self.patch_base_value(value, layout),
+            )?;
+
+        if matches!(group_read, GroupReadResult::Uninitialized) {
+            self.initialize_mvhashmap_base_group_contents(group_key)?;
+
+            group_read = self
+                .latest_view
+                .get_resource_group_state()
+                .read_cached_group_tagged_data_by_kind(
+                    self.txn_idx,
+                    group_key,
+                    resource_tag,
+                    kind,
+                    layout,
+                    &|value, layout| self.patch_base_value(value, layout),
+                )?;
+        };
+
+        Ok(group_read)
+    }
+
     fn get_resource_state_value_impl(
         &self,
         state_key: &T::Key,
@@ -1352,10 +1440,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
         let mut ret = state.read_cached_data_by_kind(
             self.txn_idx,
             state_key,
-            kind.clone(),
+            kind,
             layout.clone(),
             &|value, layout| self.patch_base_value(value, layout),
-        );
+        )?;
         if matches!(ret, ReadResult::Uninitialized) {
             let from_storage =
                 TransactionWrite::from_state_value(self.get_raw_base_value(state_key)?);
@@ -1372,7 +1460,7 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
                 kind,
                 layout.clone(),
                 &|value, layout| self.patch_base_value(value, layout),
-            );
+            )?;
         }
 
         match ret {
@@ -1390,7 +1478,10 @@ impl<'a, T: Transaction, S: TStateView<Key = T::Key>> LatestView<'a, T, S> {
                 "base value must already be recorded in the MV data structure",
             )
             .into()),
-            ReadResult::Exists(_) | ReadResult::Metadata(_) | ReadResult::Value(_, _) => Ok(ret),
+            ReadResult::Exists(_)
+            | ReadResult::Metadata(_)
+            | ReadResult::Value(_, _)
+            | ReadResult::ResourceSize(_) => Ok(ret),
         }
     }
 
@@ -1472,6 +1563,21 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> TResourceView for LatestView<'
             })
     }
 
+    fn get_resource_state_value_size(&self, state_key: &Self::Key) -> PartialVMResult<u64> {
+        self.get_resource_state_value_impl(
+            state_key,
+            UnknownOrLayout::Unknown,
+            ReadKind::ResourceSize,
+        )
+        .map(|res| {
+            if let ReadResult::ResourceSize(v) = res {
+                v.unwrap_or(0)
+            } else {
+                unreachable!("Read result must be ResourceSize kind")
+            }
+        })
+    }
+
     fn resource_exists(&self, state_key: &Self::Key) -> PartialVMResult<bool> {
         self.get_resource_state_value_impl(state_key, UnknownOrLayout::Unknown, ReadKind::Exists)
             .map(|res| {
@@ -1495,7 +1601,10 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> TResourceGroupView for LatestV
     ) -> PartialVMResult<ResourceGroupSize> {
         let mut group_read = match &self.latest_view {
             ViewState::Sync(state) => state.read_group_size(group_key, self.txn_idx)?,
-            ViewState::Unsync(state) => state.unsync_map.get_group_size(group_key),
+            ViewState::Unsync(state) => match state.unsync_map.get_group_size(group_key) {
+                Some(group_size) => GroupReadResult::GroupSize(group_size),
+                None => GroupReadResult::Uninitialized,
+            },
         };
 
         if matches!(group_read, GroupReadResult::Uninitialized) {
@@ -1503,11 +1612,14 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> TResourceGroupView for LatestV
 
             group_read = match &self.latest_view {
                 ViewState::Sync(state) => state.read_group_size(group_key, self.txn_idx)?,
-                ViewState::Unsync(state) => state.unsync_map.get_group_size(group_key),
+                ViewState::Unsync(state) => match state.unsync_map.get_group_size(group_key) {
+                    Some(group_size) => GroupReadResult::GroupSize(group_size),
+                    None => GroupReadResult::Uninitialized,
+                },
             }
         };
 
-        Ok(group_read.into_size())
+        Ok(group_read.into_group_size())
     }
 
     fn get_resource_from_group(
@@ -1516,33 +1628,53 @@ impl<T: Transaction, S: TStateView<Key = T::Key>> TResourceGroupView for LatestV
         resource_tag: &Self::ResourceTag,
         maybe_layout: Option<&Self::Layout>,
     ) -> PartialVMResult<Option<Bytes>> {
-        let mut group_read = self
-            .latest_view
-            .get_resource_group_state()
-            .read_cached_group_tagged_data(
-                self.txn_idx,
-                group_key,
-                resource_tag,
-                maybe_layout,
-                &|value, layout| self.patch_base_value(value, layout),
-            )?;
+        self.get_resource_from_group_impl(
+            group_key,
+            resource_tag,
+            UnknownOrLayout::Known(maybe_layout),
+            ReadKind::Value,
+        )
+        .map(|group_read| group_read.into_value())
+    }
 
-        if matches!(group_read, GroupReadResult::Uninitialized) {
-            self.initialize_mvhashmap_base_group_contents(group_key)?;
+    fn resource_size_in_group(
+        &self,
+        group_key: &Self::GroupKey,
+        resource_tag: &Self::ResourceTag,
+    ) -> PartialVMResult<usize> {
+        self.get_resource_from_group_impl(
+            group_key,
+            resource_tag,
+            UnknownOrLayout::Unknown,
+            ReadKind::ResourceSize,
+        )
+        .map(|group_read| {
+            if let GroupReadResult::ResourceSize(maybe_size) = group_read {
+                maybe_size.unwrap_or(0) as usize
+            } else {
+                unreachable!("Group read result must be ResourceSize kind")
+            }
+        })
+    }
 
-            group_read = self
-                .latest_view
-                .get_resource_group_state()
-                .read_cached_group_tagged_data(
-                    self.txn_idx,
-                    group_key,
-                    resource_tag,
-                    maybe_layout,
-                    &|value, layout| self.patch_base_value(value, layout),
-                )?;
-        };
-
-        Ok(group_read.into_value().0)
+    fn resource_exists_in_group(
+        &self,
+        group_key: &Self::GroupKey,
+        resource_tag: &Self::ResourceTag,
+    ) -> PartialVMResult<bool> {
+        self.get_resource_from_group_impl(
+            group_key,
+            resource_tag,
+            UnknownOrLayout::Unknown,
+            ReadKind::Exists,
+        )
+        .map(|group_read| {
+            if let GroupReadResult::Exists(exists) = group_read {
+                exists
+            } else {
+                unreachable!("Group read result must be Exists kind")
+            }
+        })
     }
 
     fn release_group_cache(
@@ -2892,7 +3024,7 @@ mod test {
         let holder = ComparisonHolder::new(data, 1000);
         let views = holder.new_view();
 
-        assert_ok_eq!(views.resource_exists(&KeyType::<u32>(1, false)), true,);
+        assert_ok_eq!(views.resource_exists(&KeyType::<u32>(1, false)), true);
         assert!(views
             .get_resource_state_value_metadata(&KeyType::<u32>(1, false))
             .unwrap()

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -71,7 +71,7 @@ use std::{
 };
 
 /// [ReadResult] wraps the result of MVHashMap's data map, while [GroupReadResult]
-/// is for the groups' MVHHashMap. The client can interpret these types to
+/// is for the groups' MVHashMap. The client can interpret these types to
 /// further resolve the reads. TODO: Needs re-organization and clean-up.
 
 #[derive(Debug)]

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -177,6 +177,7 @@ impl<V: TransactionWrite> ValueWithLayout<V> {
 #[derive(Clone, Debug)]
 pub enum UnknownOrLayout<'a> {
     Unknown,
+    // TODO: Make this Arc<MoveTypeLayout> to avoid deep cloning.
     Known(Option<&'a MoveTypeLayout>),
 }
 

--- a/aptos-move/mvhashmap/src/types.rs
+++ b/aptos-move/mvhashmap/src/types.rs
@@ -6,8 +6,6 @@ use aptos_types::{
     error::PanicOr,
     write_set::{TransactionWrite, WriteOpKind},
 };
-use aptos_vm_types::resolver::ResourceGroupSize;
-use bytes::Bytes;
 use move_core_types::value::MoveTypeLayout;
 use std::sync::{atomic::AtomicU32, Arc};
 
@@ -45,40 +43,6 @@ pub enum MVDataError {
     Dependency(TxnIndex),
     /// Delta application failed, txn execution should fail.
     DeltaApplicationFailure,
-}
-
-#[derive(Debug, Eq, PartialEq)]
-pub enum GroupReadResult {
-    Value(Option<Bytes>, Option<Arc<MoveTypeLayout>>),
-    Size(ResourceGroupSize),
-    Uninitialized,
-}
-
-impl GroupReadResult {
-    pub fn into_value(self) -> (Option<Bytes>, Option<Arc<MoveTypeLayout>>) {
-        match self {
-            GroupReadResult::Value(maybe_bytes, maybe_layout) => (maybe_bytes, maybe_layout),
-            GroupReadResult::Size(size) => {
-                unreachable!("Expected group value, found size {:?}", size)
-            },
-            GroupReadResult::Uninitialized => {
-                unreachable!("Expected group value, found uninitialized")
-            },
-        }
-    }
-
-    pub fn into_size(self) -> ResourceGroupSize {
-        match self {
-            GroupReadResult::Size(size) => size,
-            GroupReadResult::Value(maybe_bytes, maybe_layout) => unreachable!(
-                "Expected size, found value bytes = {:?}, layout = {:?}",
-                maybe_bytes, maybe_layout
-            ),
-            GroupReadResult::Uninitialized => {
-                unreachable!("Expected group size, found uninitialized")
-            },
-        }
-    }
 }
 
 /// Returned as Ok(..) when read successfully from the multi-version data-structure.

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -549,8 +549,7 @@ impl NativeVMExecutorTask {
         );
         let materialized_size = view
             .get_resource_state_value_size(&apt_metadata_object_state_key)
-            .map_err(hide_error)?
-            .unwrap();
+            .map_err(hide_error)?;
         let metadata = view
             .get_resource_state_value_metadata(&apt_metadata_object_state_key)
             .map_err(hide_error)?


### PR DESCRIPTION
Do not default forward APIs at the trait level, pass appropriate ReadKind in view implementations and enhance CapturedReads to easily handle RawFromStorage, as well as its Size and Metadata properties: allows granular access and prepares for the case when such accesses will happen without the read (to avoid read-write conflicts).

Added tests to CapturedReads for MetadataAndSize variant. Pass existing tests.

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
