### PR TITLE
[compiler-v2] append free vars and params from inner lambda during lambda lifting

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/lambda_lifter.rs
@@ -232,10 +232,8 @@ impl<'a> LambdaLifter<'a> {
         let mut params = vec![];
         let mut saw_error = false;
 
-        for (used_param_count, (param, var_info)) in
-            mem::take(&mut self.free_params).into_iter().enumerate()
-        {
-            let name = self.fun_env.get_local_name(param);
+        for (used_param_count, (param, var_info)) in self.free_params.iter().enumerate() {
+            let name = self.fun_env.get_local_name(*param);
             let var_node_id = var_info.node_id;
             let ty = env.get_node_type(var_node_id);
             let loc = env.get_node_loc(var_node_id);
@@ -254,12 +252,12 @@ impl<'a> LambdaLifter<'a> {
             if let Some(inst) = env.get_node_instantiation_opt(var_node_id) {
                 env.set_node_instantiation(new_id, inst);
             }
-            closure_args.push(ExpData::Temporary(new_id, param).into_exp());
-            param_index_mapping.insert(param, used_param_count);
+            closure_args.push(ExpData::Temporary(new_id, *param).into_exp());
+            param_index_mapping.insert(*param, used_param_count);
         }
 
         // Add captured LocalVar parameters
-        for (name, var_info) in mem::take(&mut self.free_locals) {
+        for (name, var_info) in self.free_locals.iter() {
             let var_info_id = var_info.node_id;
             let ty = env.get_node_type(var_info_id);
             let loc = env.get_node_loc(var_info_id);
@@ -273,12 +271,12 @@ impl<'a> LambdaLifter<'a> {
                 );
                 saw_error = true;
             }
-            params.push(Parameter(name, ty.clone(), loc.clone()));
+            params.push(Parameter(*name, ty.clone(), loc.clone()));
             let new_id = env.new_node(loc, ty);
             if let Some(inst) = env.get_node_instantiation_opt(var_info_id) {
                 env.set_node_instantiation(new_id, inst);
             }
-            closure_args.push(ExpData::LocalVar(new_id, name).into_exp())
+            closure_args.push(ExpData::LocalVar(new_id, *name).into_exp())
         }
 
         if !saw_error {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16198.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16198.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16198.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16198.move
@@ -1,0 +1,32 @@
+//# publish
+module 0xc0ffee::m {
+    struct Func(|| | |u64) has copy, drop;
+    fun forty_two(): u64 {
+        42
+    }
+
+    public fun test(x: u64) {
+        let f: | | | | u64 has drop = || || x;
+        assert!(f()() == 42);
+        let y = forty_two();
+        let f2: | | | | u64 has drop = || || y;
+        assert!(f2()() == 42);
+        let f3: | | | | | | u64 has drop = || || || x;
+        assert!(f3()()() == 42);
+        let f4: | | | | | | | | u64 has drop = || {
+            let z = || x;
+            let a = z();
+            || || || a + y
+        };
+        assert!(f4()()()() == 84);
+        let f5: | | | | | | | | u64 has drop = || {
+            let z = || y;
+            let a = z();
+            || || || a + x
+        };
+        assert!(f5()()()() == 84);
+        let f = Func(|| ||x);
+        assert!(f()() == 42);
+    }
+}
+//# run 0xc0ffee::m::test --args 42

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16199.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16199.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16199.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16199.move
@@ -1,0 +1,8 @@
+//# publish
+module 0xc0ffee::m {
+    public fun test() {
+        let f = |x| |y| |z| x + y + z;
+        assert!(f(1)(2)(3) == 6);
+    }
+}
+//# run 0xc0ffee::m::test


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->


Lambda lifter uses the field `free_locals` and `free_params` to store locals and params to be captured when generating closure. However, for the code below, `x` is captured when analyzing the inner lambda and will be dropped when analyzing the outer one.  

```
let x = ...;
let f: | | | | u64 has drop = || || x;
```

This PR removes the logic to drop free locals and params so that free variables/params can also be captured in the outer lambda.

close #16198 
close #16199 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

1) existing tests pass;
2) added a new test case.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Whether the fix does not introduce new issues.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
