### PR TITLE
add test daa auth function to the experimental framework

### DIFF
--- a/aptos-move/framework/aptos-experimental/doc/overview.md
+++ b/aptos-move/framework/aptos-experimental/doc/overview.md
@@ -14,6 +14,7 @@ This is the reference documentation of the Aptos experimental framework.
 
 -  [`0x7::helpers`](helpers.md#0x7_helpers)
 -  [`0x7::sigma_protos`](sigma_protos.md#0x7_sigma_protos)
+-  [`0x7::test_derivable_account_abstraction_ed25519_hex`](test_derivable_account_abstraction_ed25519_hex.md#0x7_test_derivable_account_abstraction_ed25519_hex)
 -  [`0x7::veiled_coin`](veiled_coin.md#0x7_veiled_coin)
 
 

--- a/aptos-move/framework/aptos-experimental/doc/test_derivable_account_abstraction_ed25519_hex.md
+++ b/aptos-move/framework/aptos-experimental/doc/test_derivable_account_abstraction_ed25519_hex.md
@@ -1,0 +1,80 @@
+
+<a id="0x7_test_derivable_account_abstraction_ed25519_hex"></a>
+
+# Module `0x7::test_derivable_account_abstraction_ed25519_hex`
+
+Domain account abstraction using ed25519 hex for signing.
+
+Authentication takes digest, converts to hex (prefixed with 0x, with lowercase letters),
+and then expects that to be signed.
+authenticator is expected to be signature: vector<u8>
+account_identity is raw public_key.
+
+
+-  [Constants](#@Constants_0)
+-  [Function `authenticate`](#0x7_test_derivable_account_abstraction_ed25519_hex_authenticate)
+
+
+<pre><code><b>use</b> <a href="../../aptos-framework/doc/auth_data.md#0x1_auth_data">0x1::auth_data</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/doc/ed25519.md#0x1_ed25519">0x1::ed25519</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/doc/string_utils.md#0x1_string_utils">0x1::string_utils</a>;
+</code></pre>
+
+
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x7_test_derivable_account_abstraction_ed25519_hex_EINVALID_SIGNATURE"></a>
+
+
+
+<pre><code><b>const</b> <a href="test_derivable_account_abstraction_ed25519_hex.md#0x7_test_derivable_account_abstraction_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x7_test_derivable_account_abstraction_ed25519_hex_authenticate"></a>
+
+## Function `authenticate`
+
+Authorization function for domain account abstraction.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="test_derivable_account_abstraction_ed25519_hex.md#0x7_test_derivable_account_abstraction_ed25519_hex_authenticate">authenticate</a>(<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: <a href="../../aptos-framework/doc/auth_data.md#0x1_auth_data_AbstractionAuthData">auth_data::AbstractionAuthData</a>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="test_derivable_account_abstraction_ed25519_hex.md#0x7_test_derivable_account_abstraction_ed25519_hex_authenticate">authenticate</a>(<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, aa_auth_data: AbstractionAuthData): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+    <b>let</b> hex_digest = <a href="../../aptos-framework/../aptos-stdlib/doc/string_utils.md#0x1_string_utils_to_string">string_utils::to_string</a>(aa_auth_data.digest());
+
+    <b>let</b> public_key = new_unvalidated_public_key_from_bytes(*aa_auth_data.derivable_abstract_public_key());
+    <b>let</b> signature = new_signature_from_bytes(*aa_auth_data.derivable_abstract_signature());
+    <b>assert</b>!(
+        <a href="../../aptos-framework/../aptos-stdlib/doc/ed25519.md#0x1_ed25519_signature_verify_strict">ed25519::signature_verify_strict</a>(
+            &signature,
+            &public_key,
+            *hex_digest.bytes(),
+        ),
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="test_derivable_account_abstraction_ed25519_hex.md#0x7_test_derivable_account_abstraction_ed25519_hex_EINVALID_SIGNATURE">EINVALID_SIGNATURE</a>)
+    );
+
+    <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-experimental/sources/test_derivable_account_abstraction_ed25519_hex.move
+++ b/aptos-move/framework/aptos-experimental/sources/test_derivable_account_abstraction_ed25519_hex.move
@@ -1,0 +1,36 @@
+/// Domain account abstraction using ed25519 hex for signing.
+///
+/// Authentication takes digest, converts to hex (prefixed with 0x, with lowercase letters),
+/// and then expects that to be signed.
+/// authenticator is expected to be signature: vector<u8>
+/// account_identity is raw public_key.
+module aptos_experimental::test_derivable_account_abstraction_ed25519_hex {
+    use std::error;
+    use aptos_std::string_utils;
+    use aptos_std::ed25519::{
+        Self,
+        new_signature_from_bytes,
+        new_unvalidated_public_key_from_bytes,
+    };
+    use aptos_framework::auth_data::AbstractionAuthData;
+
+    const EINVALID_SIGNATURE: u64 = 1;
+
+    /// Authorization function for domain account abstraction.
+    public fun authenticate(account: signer, aa_auth_data: AbstractionAuthData): signer {
+        let hex_digest = string_utils::to_string(aa_auth_data.digest());
+
+        let public_key = new_unvalidated_public_key_from_bytes(*aa_auth_data.derivable_abstract_public_key());
+        let signature = new_signature_from_bytes(*aa_auth_data.derivable_abstract_signature());
+        assert!(
+            ed25519::signature_verify_strict(
+                &signature,
+                &public_key,
+                *hex_digest.bytes(),
+            ),
+            error::permission_denied(EINVALID_SIGNATURE)
+        );
+
+        account
+    }
+}

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -600,6 +600,22 @@ fn initialize_account_abstraction(
         vec![],
         serialize_values(&vec![MoveValue::Signer(CORE_CODE_ADDRESS)]),
     );
+
+    exec_function(
+        session,
+        module_storage,
+        ACCOUNT_ABSTRACTION_MODULE_NAME,
+        "register_derivable_authentication_function",
+        vec![],
+        serialize_values(&vec![
+            MoveValue::Signer(CORE_CODE_ADDRESS),
+            MoveValue::Address(AccountAddress::SEVEN),
+            "test_derivable_account_abstraction_ed25519_hex"
+                .to_string()
+                .as_move_value(),
+            "authenticate".to_string().as_move_value(),
+        ]),
+    );
 }
 
 fn initialize_reconfiguration_state(

--- a/third_party/move/move-core/types/src/account_address.rs
+++ b/third_party/move/move-core/types/src/account_address.rs
@@ -26,6 +26,8 @@ impl AccountAddress {
     pub const MAX_ADDRESS: Self = Self([0xFF; Self::LENGTH]);
     /// Hex address: 0x1
     pub const ONE: Self = Self::get_hex_address_one();
+    /// Hex address: 0x7
+    pub const SEVEN: Self = Self::get_hex_address_seven();
     /// Hex address: 0xA
     pub const TEN: Self = Self::get_hex_address_ten();
     /// Hex address: 0x3
@@ -66,6 +68,12 @@ impl AccountAddress {
     const fn get_hex_address_four() -> Self {
         let mut addr = [0u8; AccountAddress::LENGTH];
         addr[AccountAddress::LENGTH - 1] = 4u8;
+        Self(addr)
+    }
+
+    const fn get_hex_address_seven() -> Self {
+        let mut addr = [0u8; AccountAddress::LENGTH];
+        addr[AccountAddress::LENGTH - 1] = 7u8;
         Self(addr)
     }
 


### PR DESCRIPTION
## Description
Adds a DAA authentication function to be later used by the aptos-ts-sdk in tests
Related to https://github.com/aptos-labs/aptos-ts-sdk/pull/648

## How Has This Been Tested?
With a local build against the aptos-ts-sdk

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify) - Experimental Framework

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
