### PR TITLE
[e2e move tests] simulate with remote states

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7742,7 +7742,9 @@ dependencies = [
  "aptos-gas-schedule",
  "aptos-language-e2e-tests",
  "aptos-package-builder",
+ "aptos-rest-client",
  "aptos-transaction-generator-lib",
+ "aptos-transaction-simulation",
  "aptos-transaction-workloads-lib",
  "aptos-types",
  "aptos-vm",
@@ -7764,6 +7766,7 @@ dependencies = [
  "serde",
  "sha3 0.9.1",
  "test-case",
+ "tokio",
 ]
 
 [[package]]

--- a/aptos-move/aptos-transaction-simulation/src/account.rs
+++ b/aptos-move/aptos-transaction-simulation/src/account.rs
@@ -128,6 +128,18 @@ impl Account {
         }
     }
 
+    pub fn new_from_addr_with_new_keypair_from_seed(
+        addr: AccountAddress,
+        seed: &mut KeyGen,
+    ) -> Self {
+        let (privkey, pubkey) = seed.generate_ed25519_keypair();
+        Self {
+            addr,
+            privkey,
+            pubkey: AccountPublicKey::Ed25519(pubkey),
+        }
+    }
+
     /// Creates a new account with the given keypair.
     ///
     /// Like with [`Account::new`], the account returned by this constructor is a purely logical

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -160,16 +160,20 @@ pub trait SimulationStateStore: TStateView<Key = StateKey> {
         Ok(Some(m))
     }
 
-    /// Sets the `ChainId` resource that is used to identify the blockchain network.
-    fn set_chain_id(&self, chain_id: ChainId) -> Result<()> {
-        let bytes = bcs::to_bytes(&chain_id)?;
-
-        self.set_state_value(
-            StateKey::resource(ChainId::address(), &ChainId::struct_tag()).unwrap(),
-            StateValue::new_legacy(bytes.into()),
-        )
+    /// Gets the [`ChainId`] resource that is used to identify the blockchain network.
+    fn get_chain_id(&self) -> Result<ChainId>
+    where
+        Self: Sized,
+    {
+        self.get_on_chain_config()
     }
 
+    /// Sets the [`ChainId`] resource that is used to identify the blockchain network.
+    fn set_chain_id(&self, chain_id: ChainId) -> Result<()> {
+        self.set_on_chain_config(&chain_id)
+    }
+
+    /// Gets the on-chain feature flags.
     fn get_features(&self) -> Result<Features>
     where
         Self: Sized,

--- a/aptos-move/e2e-move-tests/Cargo.toml
+++ b/aptos-move/e2e-move-tests/Cargo.toml
@@ -22,7 +22,9 @@ aptos-gas-profiling = { workspace = true }
 aptos-gas-schedule = { workspace = true, features = ["testing"] }
 aptos-language-e2e-tests = { workspace = true }
 aptos-package-builder = { workspace = true }
+aptos-rest-client = { workspace = true }
 aptos-transaction-generator-lib = { workspace = true }
+aptos-transaction-simulation = { workspace = true }
 aptos-transaction-workloads-lib = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true, features = ["testing"] }
@@ -48,6 +50,7 @@ test-case = { workspace = true }
 aptos-vm-types = { workspace = true }
 claims = { workspace = true }
 test-case = { workspace = true }
+tokio = { workspace = true }
 
 [lib]
 doctest = false

--- a/aptos-move/e2e-move-tests/src/harness.rs
+++ b/aptos-move/e2e-move-tests/src/harness.rs
@@ -12,6 +12,8 @@ use aptos_language_e2e_tests::{
     account::{Account, TransactionBuilder},
     executor::FakeExecutor,
 };
+use aptos_rest_client::AptosBaseUrl;
+use aptos_transaction_simulation::SimulationStateStore;
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{
@@ -131,6 +133,27 @@ impl MoveHarness {
             executor: FakeExecutor::from_testnet_genesis(),
             txn_seq_no: BTreeMap::default(),
             default_gas_unit_price: DEFAULT_GAS_UNIT_PRICE,
+            max_gas_per_txn: Self::DEFAULT_MAX_GAS_PER_TXN,
+        }
+    }
+
+    pub fn new_with_remote_state(network_url: AptosBaseUrl, txn_id: u64) -> Self {
+        register_package_hooks(Box::new(AptosPackageHooks {}));
+
+        let executor = FakeExecutor::from_remote_state(network_url, txn_id);
+
+        let gas_schedule: GasScheduleV2 = executor.state_store().get_on_chain_config().unwrap();
+        let feature_version = gas_schedule.feature_version;
+        let gas_params = AptosGasParameters::from_on_chain_gas_schedule(
+            &gas_schedule.into_btree_map(),
+            feature_version,
+        )
+        .unwrap();
+
+        Self {
+            executor,
+            txn_seq_no: BTreeMap::default(),
+            default_gas_unit_price: gas_params.vm.txn.min_price_per_gas_unit.into(),
             max_gas_per_txn: Self::DEFAULT_MAX_GAS_PER_TXN,
         }
     }
@@ -259,6 +282,10 @@ impl MoveHarness {
         *seq_no_ref = seq_no + 1;
         account
             .transaction()
+            .chain_id(self.executor.get_chain_id())
+            .ttl(
+                self.executor.get_block_time() + 3_600_000_000, /* an hour after the current time */
+            )
             .sequence_number(seq_no)
             .max_gas_amount(self.max_gas_per_txn)
             .gas_unit_price(self.default_gas_unit_price)

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -42,6 +42,7 @@ mod offer_rotation_capability;
 mod offer_signer_capability;
 mod per_category_gas_limits;
 mod randomness_test_and_abort;
+mod remote_state;
 mod resource_groups;
 mod rotate_auth_key;
 mod scripts;

--- a/aptos-move/e2e-move-tests/src/tests/remote_state.rs
+++ b/aptos-move/e2e-move-tests/src/tests/remote_state.rs
@@ -1,0 +1,144 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Overview
+//! This module contains tests demonstrating how to use [`MoveHarness`]'s
+//! network-forking feature, allowing simulations on top of the current state
+//! of a remote Aptos network.
+//!
+//! It should be emphasized that such simulations are done entirely locally --
+//! they do not modify the states of the remote network in any ways.
+//!
+//! This workflow is particularly useful for testing critical changes or bug fixes
+//! in a realistic environment before deploying them.
+//!
+//! # Dummy Account Setup
+//! The tests rely on a dummy account on testnet, which has some APT balance.
+//!
+//! # Running Tests Manually
+//! These tests are marked `#[ignore]` to prevent execution in CI.
+//! This avoids CI failures when the referenced transaction version
+//! falls outside the fullnode's pruning window, which will inevitably occur over time.
+//!
+//! To run these tests manually, append `-- --ignored` to the `cargo test` command.
+//! Additionally, [`TEST_TXN_VERSION`] may need to be updated if it gets too old.
+
+use crate::{assert_success, MoveHarness};
+use aptos_rest_client::AptosBaseUrl;
+use aptos_types::account_address::AccountAddress;
+use move_core_types::{language_storage::TypeTag, value::MoveValue};
+use std::str::FromStr;
+
+const APTOS_COIN_STRUCT_STRING: &str = "0x1::aptos_coin::AptosCoin";
+
+const TESTNET_TXN_VERSION: u64 = 6660862455;
+const TESTNET_ACCOUNT_ADDR: &str =
+    "0x3f9e0589ca0668a5273b86bfcb5f357164408a889bc733b309cf1901098c8ce5";
+const TEST_ACCOUNT_APT_BALANCE: u64 = 91_8316_5250;
+
+/// Helper that fetches the APT balance of a given account.
+fn get_account_apt_balance(h: &mut MoveHarness, addr: AccountAddress) -> u64 {
+    let bytes = h
+        .execute_view_function(
+            str::parse("0x1::coin::balance").unwrap(),
+            vec![TypeTag::from_str(APTOS_COIN_STRUCT_STRING).unwrap()],
+            vec![addr.to_vec()],
+        )
+        .values
+        .unwrap()
+        .pop()
+        .unwrap();
+    bcs::from_bytes::<u64>(bytes.as_slice()).unwrap()
+}
+
+/// Simple test that reads the APT balance of the test account.
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn view_existing_account_balance() {
+    let mut h = MoveHarness::new_with_remote_state(AptosBaseUrl::Testnet, TESTNET_TXN_VERSION);
+
+    let existing_account_addr = AccountAddress::from_hex_literal(TESTNET_ACCOUNT_ADDR).unwrap();
+
+    assert_eq!(
+        get_account_apt_balance(&mut h, existing_account_addr),
+        TEST_ACCOUNT_APT_BALANCE
+    )
+}
+
+/// Transfers 1 APT from a newly created account to the existing test account
+/// and verifies that the recipient's balance increases accordingly.
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn transfer_to_existing_account() {
+    let mut h = MoveHarness::new_with_remote_state(AptosBaseUrl::Testnet, TESTNET_TXN_VERSION);
+
+    let existing_account_addr = AccountAddress::from_hex_literal(TESTNET_ACCOUNT_ADDR).unwrap();
+
+    // Create a new account and fund it with 10 APT.
+    let new_account =
+        h.new_account_with_balance_and_sequence_number(10_0000_0000 /* 10 APT */, 0);
+
+    // Transfer 1 APT to the existing account.
+    let status = h.run_entry_function(
+        &new_account,
+        str::parse("0x1::coin::transfer").unwrap(),
+        vec![TypeTag::from_str("0x1::aptos_coin::AptosCoin").unwrap()],
+        vec![
+            MoveValue::Address(existing_account_addr)
+                .simple_serialize()
+                .unwrap(),
+            MoveValue::U64(1_0000_0000).simple_serialize().unwrap(),
+        ],
+    );
+    assert_success!(status);
+
+    // Verify that the recipient's balance has increased by 1 APT.
+    assert_eq!(
+        get_account_apt_balance(&mut h, existing_account_addr),
+        TEST_ACCOUNT_APT_BALANCE + 1_0000_0000
+    )
+}
+
+/// Attempts to transfer 1 APT from the existing test account to a newly created account,
+/// verifying that the sender's balance decreases appropriately.
+#[ignore]
+#[tokio::test(flavor = "multi_thread")]
+async fn transfer_from_existing_account() {
+    let mut h = MoveHarness::new_with_remote_state(AptosBaseUrl::Testnet, TESTNET_TXN_VERSION);
+
+    let existing_account_addr = AccountAddress::from_hex_literal(TESTNET_ACCOUNT_ADDR).unwrap();
+
+    // Create a new account.
+    let new_account =
+        h.new_account_with_balance_and_sequence_number(10_0000_0000 /* 10 APT */, 0);
+
+    // Rotate the authentication key of the existing account so that we can authenticate transactions
+    // without using or exposing the real private key.
+    //
+    // This is a recommended security practice to prevent accidental leakage of the original private key,
+    // such as pushing to github accidentally.
+    let existing_account = h
+        .executor
+        .rotate_account_authentication_key(existing_account_addr);
+
+    // Transfer 1 APT from the existing account to the new account.
+    let status = h.run_entry_function(
+        &existing_account,
+        str::parse("0x1::coin::transfer").unwrap(),
+        vec![TypeTag::from_str("0x1::aptos_coin::AptosCoin").unwrap()],
+        vec![
+            MoveValue::Address(*new_account.address())
+                .simple_serialize()
+                .unwrap(),
+            MoveValue::U64(1_0000_0000).simple_serialize().unwrap(),
+        ],
+    );
+    assert_success!(status);
+
+    // Assert that the sender's balance has decreased
+    // (but due to gas fees, the exact value will be slightly less).
+    assert!(
+        get_account_apt_balance(&mut h, existing_account_addr)
+            < TEST_ACCOUNT_APT_BALANCE - 1_0000_0000
+    );
+}


### PR DESCRIPTION
This introduces a few e2e Move tests demonstrating how to use `MoveHarness`'s newly-added network-forking feature, allowing simulations on top of the current state of a remote Aptos network.