### PR TITLE
[compiler-v2] Error on duplicate script function names

### DIFF
--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -44,9 +44,8 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
-    )
-    .unwrap();
-    if ok != UnitTestResult::Success {
+    );
+    if ok.is_err() || ok.is_ok_and(|r| r == UnitTestResult::Failure) {
         panic!("move unit tests failed")
     }
 }

--- a/aptos-move/move-examples/duplicate_scripts/.gitignore
+++ b/aptos-move/move-examples/duplicate_scripts/.gitignore
@@ -1,0 +1,2 @@
+.aptos/
+build/

--- a/aptos-move/move-examples/duplicate_scripts/Move.toml
+++ b/aptos-move/move-examples/duplicate_scripts/Move.toml
@@ -1,0 +1,8 @@
+[package]
+name = "duplicate_scripts"
+version = "1.0.0"
+authors = []
+
+[addresses]
+
+[dev-addresses]

--- a/aptos-move/move-examples/duplicate_scripts/scripts/first.move
+++ b/aptos-move/move-examples/duplicate_scripts/scripts/first.move
@@ -1,0 +1,6 @@
+script {
+    fun main() {
+        use 0xc0ffee::main::main;
+        main();
+    }
+}

--- a/aptos-move/move-examples/duplicate_scripts/scripts/second.move
+++ b/aptos-move/move-examples/duplicate_scripts/scripts/second.move
@@ -1,0 +1,7 @@
+script {
+    fun main() {
+        use 0xc0ffee::main::main;
+        main();
+        main();
+    }
+}

--- a/aptos-move/move-examples/duplicate_scripts/sources/main.move
+++ b/aptos-move/move-examples/duplicate_scripts/sources/main.move
@@ -1,0 +1,5 @@
+module 0xc0ffee::main {
+    public fun main() {
+        0; 1;
+    }
+}

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -50,9 +50,8 @@ pub fn run_tests_for_pkg(
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
-    )
-    .unwrap();
-    if ok != UnitTestResult::Success {
+    );
+    if ok.is_err() || ok.is_ok_and(|r| r == UnitTestResult::Failure) {
         panic!("move unit tests failed")
     }
 }
@@ -107,6 +106,12 @@ fn test_vector_pushback() {
 fn test_fixed_point64() {
     let named_address = BTreeMap::new();
     run_tests_for_pkg("fixed_point64", named_address);
+}
+
+#[test]
+#[should_panic(expected = "move unit tests failed")]
+fn test_duplicate_scripts() {
+    run_tests_for_pkg("duplicate_scripts", BTreeMap::new());
 }
 
 #[test]

--- a/third_party/move/extensions/move-table-extension/tests/move_unit_tests.rs
+++ b/third_party/move/extensions/move-table-extension/tests/move_unit_tests.rs
@@ -33,10 +33,9 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>) {
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
-    )
-    .unwrap();
-    if res != UnitTestResult::Success {
-        panic!("aborting because of Move unit test failures");
+    );
+    if res.is_err() || res.is_ok_and(|r| r == UnitTestResult::Failure) {
+        panic!("move unit tests failed")
     }
 }
 

--- a/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
@@ -10,10 +10,7 @@ use legacy_move_compiler::compiled_unit as CU;
 use module_generator::ModuleGenerator;
 use move_binary_format::{file_format as FF, internals::ModuleIndex};
 use move_command_line_common::{address::NumericalAddress, parser::NumberFormat};
-use move_model::{
-    ast::ModuleName,
-    model::{GlobalEnv, SCRIPT_MODULE_NAME},
-};
+use move_model::{ast::ModuleName, model::GlobalEnv};
 use move_stackless_bytecode::function_target_pipeline::FunctionTargetsHolder;
 use move_symbol_pool::Symbol;
 use std::collections::BTreeMap;
@@ -62,21 +59,7 @@ pub fn generate_file_format(
                     name,
                     ..
                 } = main_handle.expect("main handle defined");
-                // Because two scripts can have the same function name, we need to use
-                // the suffix of the script module name ("_0", "_1"...) to avoid the name conflict
-                let script_module_name = ctx.symbol_to_str(module_env.get_name().name());
-                let suffix = if script_module_name == SCRIPT_MODULE_NAME
-                    || script_module_name.len() <= SCRIPT_MODULE_NAME.len()
-                {
-                    ""
-                } else {
-                    &script_module_name[SCRIPT_MODULE_NAME.len()..]
-                };
-                let name = Symbol::from(format!(
-                    "{}{}",
-                    identifiers[name.into_index()].as_str(),
-                    suffix
-                ));
+                let name = Symbol::from(identifiers[name.into_index()].as_str());
                 let script = FF::CompiledScript {
                     version,
                     module_handles,

--- a/third_party/move/move-stdlib/tests/move_unit_test.rs
+++ b/third_party/move/move-stdlib/tests/move_unit_test.rs
@@ -39,10 +39,9 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, include_nursery_natives: bo
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
-    )
-    .unwrap();
-    if result != UnitTestResult::Success {
-        panic!("aborting because of Move unit test failures");
+    );
+    if result.is_err() || result.is_ok_and(|r| r == UnitTestResult::Failure) {
+        panic!("aborting because of Move unit test failures")
     }
 }
 

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -15,7 +15,7 @@ use move_compiler_v2::plan_builder as plan_builder_v2;
 use move_core_types::effects::ChangeSet;
 use move_coverage::coverage_map::{output_map_to_file, CoverageMap};
 use move_package::{
-    compilation::{build_plan::BuildPlan, compiled_package::build_and_report_v2_driver},
+    compilation::{build_plan::BuildPlan, compiled_package::build_and_report_no_exit_v2_driver},
     BuildConfig,
 };
 use move_unit_test::{
@@ -231,7 +231,7 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
         &build_config.compiler_config,
         vec![],
         |options| {
-            let (files, units, env) = build_and_report_v2_driver(options).unwrap();
+            let (files, units, env) = build_and_report_no_exit_v2_driver(options)?;
             let root_package_in_model = env.symbol_pool().make(root_package.deref());
             let built_test_plan =
                 plan_builder_v2::construct_test_plan(&env, Some(root_package_in_model));

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/case_insensitive_check/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/case_insensitive_check/Move.exp
@@ -1,6 +1,10 @@
 Module and/or script names found that would cause failures on case insensitive file systems when compiling package 'case_insensitive_check':
+The following modules and/or scripts would collide as 'a' on the file system:
+	Module 'A' at path 'tests/test_sources/compilation/case_insensitive_check/sources/a.move'
+	Script 'a' at path 'tests/test_sources/compilation/case_insensitive_check/sources/a_script.move'
 The following modules and/or scripts would collide as 'set' on the file system:
 	Module 'Set' at path 'tests/test_sources/compilation/case_insensitive_check/sources/Set.move'
 	Module 'set' at path 'tests/test_sources/compilation/case_insensitive_check/sources/foo.move'
 	Module 'seT' at path 'tests/test_sources/compilation/case_insensitive_check/sources/otherModule.move'
+	Script 'sEt' at path 'tests/test_sources/compilation/case_insensitive_check/sources/script.move'
 Please rename these scripts and/or modules to resolve these conflicts.

--- a/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
+++ b/third_party/move/tools/move-package/tests/test_sources/compilation/one_dep_with_scripts/Move.exp
@@ -1,46 +1,7 @@
-CompiledPackageInfo {
-    package_name: "Root",
-    address_alias_instantiation: {
-        "A": 0000000000000000000000000000000000000000000000000000000000000001,
-    },
-    source_digest: Some(
-        "ELIDED_FOR_TEST",
-    ),
-    build_flags: BuildConfig {
-        dev_mode: true,
-        test_mode: false,
-        override_std: None,
-        generate_docs: false,
-        generate_abis: false,
-        generate_move_model: false,
-        full_model_generation: false,
-        install_dir: Some(
-            "ELIDED_FOR_TEST",
-        ),
-        force_recompilation: false,
-        additional_named_addresses: {},
-        fetch_deps_only: false,
-        skip_fetch_latest_git_deps: false,
-        compiler_config: CompilerConfig {
-            bytecode_version: None,
-            known_attributes: {
-                "bytecode_instruction",
-                "deprecated",
-                "expected_failure",
-                "lint::skip",
-                "module_lock",
-                "native_interface",
-                "persistent",
-                "test",
-                "test_only",
-                "verify_only",
-            },
-            skip_attribute_checks: false,
-            compiler_version: Some(
-                V2_0,
-            ),
-            language_version: None,
-            experiments: [],
-        },
-    },
-}
+Script function name `a_script` duplicated in the following files:
+	`tests/test_sources/compilation/one_dep_with_scripts/sources/a_script.move`
+	`tests/test_sources/compilation/one_dep_with_scripts/sources/a_script.move`
+Script function name `b_script` duplicated in the following files:
+	`tests/test_sources/compilation/one_dep_with_scripts/sources/b_script.move`
+	`tests/test_sources/compilation/one_dep_with_scripts/sources/b_script.move`
+Please rename script functions to remove duplication

--- a/third_party/move/tools/move-unit-test/tests/pkg_tests.rs
+++ b/third_party/move/tools/move-unit-test/tests/pkg_tests.rs
@@ -49,10 +49,9 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, v2: bool) {
         /* cost_table */ None,
         /* compute_coverage */ false,
         &mut std::io::stdout(),
-    )
-    .unwrap();
-    if result != UnitTestResult::Success {
-        panic!("aborting because of Move unit test failures");
+    );
+    if result.is_err() || result.is_ok_and(|r| r == UnitTestResult::Failure) {
+        panic!("aborting because of Move unit test failures")
     }
 }
 


### PR DESCRIPTION
## Description

With this PR, the compiler now throws an error if there are script functions in a package that have duplicate names.

Note: the bytecode files generated for scripts no longer have an "_<number>" suffix.

In addition, this PR contains some behavioral changes to some unit testing APIs that exited on error instead of returning an `Result::Err`.

## How Has This Been Tested?
- Added a new test that shows that the compiler throws an error.

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
