### PR TITLE
[move-vm][rac] Add access specifiers to CompiledScript in binary format v8

### DIFF
--- a/third_party/move/move-binary-format/src/deserializer.rs
+++ b/third_party/move/move-binary-format/src/deserializer.rs
@@ -435,15 +435,21 @@ fn deserialize_compiled_script(
         &mut table_contents_buffer,
         content_len as usize,
     )?;
-
+    let type_parameters =
+        load_ability_sets(&mut cursor, AbilitySetPosition::FunctionTypeParameters)?;
+    let parameters = load_signature_index(&mut cursor)?;
+    let access_specifiers = if cursor.version() >= VERSION_8 {
+        load_access_specifiers(&mut cursor)?
+    } else {
+        None
+    };
+    let code = load_code_unit(&mut cursor)?;
     let mut script = CompiledScript {
         version: cursor.version(),
-        type_parameters: load_ability_sets(
-            &mut cursor,
-            AbilitySetPosition::FunctionTypeParameters,
-        )?,
-        parameters: load_signature_index(&mut cursor)?,
-        code: load_code_unit(&mut cursor)?,
+        type_parameters,
+        parameters,
+        access_specifiers,
+        code,
         ..Default::default()
     };
 

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -3001,6 +3001,8 @@ pub struct CompiledScript {
     pub type_parameters: Vec<AbilitySet>,
 
     pub parameters: SignatureIndex,
+
+    pub access_specifiers: Option<Vec<AccessSpecifier>>,
 }
 
 impl CompiledScript {
@@ -3121,6 +3123,8 @@ impl Arbitrary for CompiledScript {
                         metadata: vec![],
                         type_parameters,
                         parameters,
+                        // TODO(#16278): access specifiers
+                        access_specifiers: None,
                         code,
                     }
                 },
@@ -3403,6 +3407,7 @@ pub fn empty_script() -> CompiledScript {
 
         type_parameters: vec![],
         parameters: SignatureIndex(0),
+        access_specifiers: None,
         code: CodeUnit {
             locals: SignatureIndex(0),
             code: vec![Bytecode::Ret],

--- a/third_party/move/move-binary-format/src/serializer.rs
+++ b/third_party/move/move-binary-format/src/serializer.rs
@@ -1670,6 +1670,14 @@ impl ScriptSerializer {
     fn serialize_main(&mut self, binary: &mut BinaryData, script: &CompiledScript) -> Result<()> {
         serialize_ability_sets(binary, &script.type_parameters)?;
         serialize_signature_index(binary, &script.parameters)?;
+        if self.common.major_version >= VERSION_8 {
+            serialize_access_specifiers(binary, &script.access_specifiers)?
+        } else if script.access_specifiers.is_some() {
+            return Err(anyhow!(
+                "Access specifiers on scripts not supported in bytecode version {}",
+                self.common.major_version
+            ));
+        }
         serialize_code_unit(self.common.major_version(), binary, &script.code)?;
         Ok(())
     }

--- a/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
+++ b/third_party/move/move-bytecode-verifier/bytecode-verifier-tests/src/unit_tests/dependencies_tests.rs
@@ -248,6 +248,7 @@ fn mk_invoking_script(use_generic: bool) -> CompiledScript {
         }],
         type_parameters: vec![],
         parameters: SignatureIndex(0),
+        access_specifiers: None,
         code: CodeUnit {
             locals: SignatureIndex(0),
             code: vec![call, Bytecode::Ret],

--- a/third_party/move/move-bytecode-verifier/src/features.rs
+++ b/third_party/move/move-bytecode-verifier/src/features.rs
@@ -55,7 +55,14 @@ impl<'a> FeatureVerifier<'a> {
         };
         verifier.verify_signatures()?;
         verifier.verify_function_handles()?;
-        verifier.verify_function_defs()
+        verifier.verify_function_defs()?;
+
+        if !config.enable_resource_access_control && script.access_specifiers.is_some() {
+            Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
+                .with_message("resource access control feature not enabled".to_string()))
+        } else {
+            Ok(())
+        }
     }
 
     fn verify_struct_defs(&self) -> PartialVMResult<()> {

--- a/third_party/move/move-bytecode-verifier/src/features.rs
+++ b/third_party/move/move-bytecode-verifier/src/features.rs
@@ -10,7 +10,7 @@ use move_binary_format::{
     errors::{Location, PartialVMError, PartialVMResult, VMResult},
     file_format::{
         Bytecode, CompiledModule, CompiledScript, FieldDefinition, SignatureToken,
-        StructFieldInformation,
+        StructFieldInformation, TableIndex,
     },
     IndexKind,
 };
@@ -55,14 +55,11 @@ impl<'a> FeatureVerifier<'a> {
         };
         verifier.verify_signatures()?;
         verifier.verify_function_handles()?;
-        verifier.verify_function_defs()?;
-
         if !config.enable_resource_access_control && script.access_specifiers.is_some() {
-            Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
-                .with_message("resource access control feature not enabled".to_string()))
-        } else {
-            Ok(())
+            return Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
+                .with_message("resource access control feature not enabled".to_string()));
         }
+        verifier.verify_code(&script.code.code, None)
     }
 
     fn verify_struct_defs(&self) -> PartialVMResult<()> {
@@ -132,18 +129,27 @@ impl<'a> FeatureVerifier<'a> {
         if !self.config.enable_function_values {
             for (idx, def) in self.code.function_defs().unwrap_or(&[]).iter().enumerate() {
                 if let Some(unit) = &def.code {
-                    for bc in &unit.code {
-                        if matches!(
-                            bc,
-                            Bytecode::PackClosure(..)
-                                | Bytecode::PackClosureGeneric(..)
-                                | Bytecode::CallClosure(..)
-                        ) {
-                            return Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED)
-                                .at_index(IndexKind::FunctionDefinition, idx as u16)
-                                .with_message("function value feature not enabled".to_string()));
-                        }
+                    self.verify_code(&unit.code, Some(idx as TableIndex))?
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn verify_code(&self, code: &[Bytecode], idx: Option<TableIndex>) -> PartialVMResult<()> {
+        if !self.config.enable_function_values {
+            for bc in code {
+                if matches!(
+                    bc,
+                    Bytecode::PackClosure(..)
+                        | Bytecode::PackClosureGeneric(..)
+                        | Bytecode::CallClosure(..)
+                ) {
+                    let mut err = PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED);
+                    if let Some(idx) = idx {
+                        err = err.at_index(IndexKind::FunctionDefinition, idx);
                     }
+                    return Err(err.with_message("function value feature not enabled".to_string()));
                 }
             }
         }

--- a/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
@@ -91,6 +91,8 @@ pub fn generate_file_format(
                     code,
                     type_parameters,
                     parameters,
+                    // TODO(#16278): support rac
+                    access_specifiers: None,
                 };
                 if options.experiment_on(Experiment::ATTACH_COMPILED_MODULE) {
                     let module_name =

--- a/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
+++ b/third_party/move/move-ir-compiler/move-ir-to-bytecode/src/compiler.rs
@@ -391,6 +391,7 @@ pub fn compile_script<'a>(
 
         type_parameters: sig.type_parameters,
         parameters: parameters_sig_idx,
+        access_specifiers: None,
         code,
     };
     Ok((script, source_map))

--- a/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/invariant_violation_tests.rs
@@ -67,6 +67,7 @@ fn merge_borrow_states_infinite_loop() {
         },
         type_parameters: vec![],
         parameters: SignatureIndex(0),
+        access_specifiers: None,
     };
 
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");

--- a/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/leak_tests.rs
@@ -43,6 +43,7 @@ fn leak_with_abort() {
         },
         type_parameters: vec![],
         parameters: SignatureIndex(0),
+        access_specifiers: None,
     };
 
     move_bytecode_verifier::verify_script(&cs).expect("verify failed");

--- a/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/vm_arguments_tests.rs
@@ -61,6 +61,7 @@ fn make_script(parameters: Signature) -> Vec<u8> {
             locals: SignatureIndex(0),
             code: vec![Bytecode::LdU64(0), Bytecode::Abort],
         },
+        access_specifiers: None,
     }
     .serialize(&mut blob)
     .expect("script must serialize");
@@ -123,6 +124,7 @@ fn make_script_with_non_linking_structs(parameters: Signature) -> Vec<u8> {
 
         type_parameters: vec![],
         parameters: parameters_idx,
+        access_specifiers: None,
         code: CodeUnit {
             locals: SignatureIndex(0),
             code: vec![Bytecode::LdU64(0), Bytecode::Abort],


### PR DESCRIPTION
## Description

This adds access specifiers to compiled scripts in binary format v8. They are not supported anywhere yet, but this change will allow us to add support later without breaking binary compatibility of scripts and requiring new v9 binary format.

Actual usage of this feature is gated by ENABLE_RESOURCE_ACCESS_CONTROL feature, which is not enabled.
