### PR TITLE
 [Indexer-Grpc-V2] Fix the version tracking.

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-manager/src/metrics.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-manager/src/metrics.rs
@@ -16,6 +16,14 @@ pub static FILE_STORE_VERSION: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
+pub static FILE_STORE_VERSION_IN_CACHE: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "aptos_indexer_grpc_v2_file_store_version_in_cache",
+        "File store version in cache."
+    )
+    .unwrap()
+});
+
 pub static FILE_STORE_UPLOADED_BYTES: Lazy<IntCounter> = Lazy::new(|| {
     register_int_counter!(
         "aptos_indexer_grpc_v2_file_store_uploaded_bytes",

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator_v2/file_store_operator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/file_store_operator_v2/file_store_operator.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::file_store_operator_v2::common::{BatchMetadata, FileMetadata};
-use anyhow::Result;
+use anyhow::{ensure, Result};
 use aptos_protos::transaction::v1::Transaction;
 use prost::Message;
 use tokio::sync::mpsc::Sender;
@@ -47,6 +47,12 @@ impl FileStoreOperatorV2 {
     ) -> Result<()> {
         let end_batch = (transaction.version + 1) % self.num_txns_per_folder == 0;
         let size_bytes = transaction.encoded_len();
+        ensure!(
+            self.version == transaction.version,
+            "Gap is found when buffering transaction, expected: {}, actual: {}",
+            self.version,
+            transaction.version,
+        );
         self.buffer.push(transaction);
         self.buffer_size_in_bytes += size_bytes;
         self.version += 1;


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The file store version in cache (for gc purpose) need to be initialized after the file store uploader recovers.

Also added several logs and metrics.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
