### PR TITLE
[vm] function value resolution with  generic captured arguments

### DIFF
--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/resolve_from_storage.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/resolve_from_storage.exp
@@ -1,0 +1,1 @@
+processed 3 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/resolve_from_storage.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/resolve_from_storage.move
@@ -1,0 +1,23 @@
+//# publish
+module 0x66::test {
+    struct Func has key {
+        f: |()|u64 has store + copy,
+    }
+
+    public fun identity<T>(x: T): T { x }
+
+    public fun init(account: &signer) {
+        let f = || 0x66::test::identity(23);
+        move_to(account, Func { f });
+    }
+
+    public fun call(addr: address) acquires Func {
+        let f = &borrow_global<Func>(addr).f;
+        let value = (*f)();
+        assert!(value == 23, 777);
+    }
+}
+
+//# run 0x66::test::init --signers 0x66
+
+//# run 0x66::test::call --args @0x66


### PR DESCRIPTION
## Description

Function values if coming from storage are resolved, and layouts of captured arguments are constructed and checked. If captured argument is generic, the function parameter is generic as well and needs to be instantiated.

Commenting out instantiation results in test failing with:
```
thread 'tests::function_value_tests::test_function_value_resolution' panicked at third_party/move/move-vm/integration-tests/src/tests/function_value_tests.rs:71:7:
Call must succeed: VMError { major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR, sub_status: None, message: Some("No type layout for TyParam(0) @Unknown invariant violation generated:\nIn function backtrace::backtrace::libunwind::trace::h62ffc7317c823599 at /Users/george/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/libunwind.rs:93\nIn function backtrace::backtrace::trace_unsynchronized::hf57708df16e96ddb at /Users/george/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/mod.rs:66\nIn function backtrace::backtrace::trace::hf73fa643f6fb70bb at /Users/george/.cargo/registry/src/index.crates.io-6f17d22bba15001f/backtrace-0.3.69/src/backtrace/mod.rs:53\nIn function move_binary_format::errors::PartialVMError::new::hd1799e98632e043c at /Users/george/Desktop/aptos-core/third_party/move/move-binary-format/src/errors.rs:412\nIn function move_vm_runtime::storage::ty_layout_converter::LayoutConverterBase::type_to_type_layout_impl::hc55181692e3268a6 at /Users/george/Desktop/aptos-core/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs:188\nIn function move_vm_runtime::storage::ty_layout_converter::LayoutConverter::type_to_type_layout::h23a47d2eb082a8bb at /Users/george/Desktop/aptos-core/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs:34\n"), exec_state: None, location: Module(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("test") }), indices: [], offsets: [(FunctionDefinitionIndex(0), 4)] }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
test tests::function_value_tests::test_function_value_resolution ... FAILED
```

## How Has This Been Tested?

Unit test 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
