### PR TITLE
[stateless acct] revert exist_at semantics and clean up

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -1891,7 +1891,9 @@ module aptos_framework::stake {
         should_end_epoch: bool,
     ) acquires AllowedValidators, AptosCoinCapabilities, OwnerCapability, StakePool, ValidatorConfig, ValidatorPerformance, ValidatorSet {
         let validator_address = signer::address_of(validator);
-        account::create_account_for_test(validator_address);
+        if (!account::exists_at(validator_address)) {
+            account::create_account_for_test(validator_address);
+        };
 
         let pk_bytes = bls12381::public_key_to_bytes(public_key);
         let pop_bytes = bls12381::proof_of_possession_to_bytes(proof_of_possession);

--- a/aptos-move/framework/aptos-framework/sources/vesting.move
+++ b/aptos-move/framework/aptos-framework/sources/vesting.move
@@ -1252,7 +1252,9 @@ module aptos_framework::vesting {
 
         vector::for_each_ref(accounts, |addr| {
             let addr: address = *addr;
-            create_account(addr);
+            if (!account::exists_at(addr)) {
+                create_account(addr);
+            }
         });
 
         // In the test environment, the periodical_reward_rate_decrease feature is initially turned off.

--- a/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
+++ b/aptos-move/framework/aptos-framework/tests/delegation_pool_integration_tests.move
@@ -84,7 +84,6 @@ module aptos_framework::delegation_pool_integration_tests {
 
     #[test_only]
     public fun mint_and_add_stake(account: &signer, amount: u64) {
-        account::create_account_for_test(signer::address_of(account));
         stake::mint(account, amount);
         dp::add_stake(account, dp::get_owned_pool_address(signer::address_of(account)), amount);
     }

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -1144,8 +1144,6 @@ mod tests {
                 assert_eq!(value, other_value, "different value for key: {:?}", key);
             }
         }
-        println!("{:?}", vm_writes);
-        println!("{:?}", other_writes);
         assert_eq!(vm_writes.len(), other_writes.len());
 
         if values_match {

--- a/testsuite/smoke-test/src/fullnode.rs
+++ b/testsuite/smoke-test/src/fullnode.rs
@@ -55,7 +55,6 @@ async fn test_indexer() {
 
     let account1 = swarm.aptos_public_info().random_account();
     let account2 = swarm.aptos_public_info().random_account();
-    println!("account1: {:?}", account1.address());
 
     let mut chain_info = swarm.chain_info().into_aptos_public_info();
     let factory = chain_info.transaction_factory();

--- a/testsuite/smoke-test/src/keyless.rs
+++ b/testsuite/smoke-test/src/keyless.rs
@@ -353,20 +353,22 @@ script {{
         0,
     );
 
-    info!(
-        "{} account does not exist. Creating...",
-        local_account.address().to_hex_literal()
-    );
-    info.sync_root_account_sequence_number().await;
-    info.create_user_account_with_any_key(&AnyPublicKey::FederatedKeyless {
-        public_key: federated_keyless_public_key,
-    })
-    .await
-    .unwrap();
-    info.sync_root_account_sequence_number().await;
-    info.mint(local_account.address(), 10_000_000_000)
+    // If the account does not exist, create it.
+    if info.account_exists(local_account.address()).await.is_err() {
+        info!(
+            "{} account does not exist. Creating...",
+            local_account.address().to_hex_literal()
+        );
+        info.sync_root_account_sequence_number().await;
+        info.create_user_account_with_any_key(&AnyPublicKey::FederatedKeyless {
+            public_key: federated_keyless_public_key,
+        })
         .await
         .unwrap();
+        info.mint(local_account.address(), 10_000_000_000)
+            .await
+            .unwrap();
+    }
     info.sync_root_account_sequence_number().await;
     let recipient = info
         .create_and_fund_user_account(20_000_000_000)


### PR DESCRIPTION
## Description
change back the semantics of `account::exists_at` to show the existence of resource only..
and clean up some print lines in tests.

## How Has This Been Tested?
ut


