### PR TITLE
[CO] fix a race of inconsistent data view

### DIFF
--- a/consensus/src/consensus_observer/observer/active_state.rs
+++ b/consensus/src/consensus_observer/observer/active_state.rs
@@ -310,6 +310,8 @@ fn handle_committed_blocks(
     root: Arc<Mutex<LedgerInfoWithSignatures>>,
     ledger_info: LedgerInfoWithSignatures,
 ) {
+    // grab the lock for whole section to avoid inconsistent views
+    let mut root = root.lock();
     // Remove the committed blocks from the payload and pending stores
     block_payload_store.lock().remove_blocks_for_epoch_round(
         ledger_info.commit_info().epoch(),
@@ -320,7 +322,6 @@ fn handle_committed_blocks(
         .remove_blocks_for_commit(&ledger_info);
 
     // Verify the ledger info is for the same epoch
-    let mut root = root.lock();
     if ledger_info.commit_info().epoch() != root.commit_info().epoch() {
         warn!(
             LogSchema::new(LogEntry::ConsensusObserver).message(&format!(


### PR DESCRIPTION
it's possible to have an interesting race in this gc function with get_last_ordered_block
1. handle_committed_blocks gc'ed round 6499 in ordered block store
2. get_last_ordered_block reads the ordered block store and see None
3. get_last_ordered_block reads the root and see 6498 (old one)
4. it decides to forward block 6499 again to pipeline
5. handle_committed_block updates the root to 6499