### PR TITLE
per-key jwk consensus 1: types

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/feature_flags.rs
+++ b/aptos-move/aptos-release-builder/src/components/feature_flags.rs
@@ -143,6 +143,7 @@ pub enum FeatureFlag {
     EnableFunctionValues,
     NewAccountsDefaultToFaStore,
     DefaultAccountResource,
+    JwkConsensusPerKeyMode,
 }
 
 fn generate_features_blob(writer: &CodeWriter, data: &[u64]) {
@@ -381,6 +382,7 @@ impl From<FeatureFlag> for AptosFeatureFlag {
                 AptosFeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_STORE
             },
             FeatureFlag::DefaultAccountResource => AptosFeatureFlag::DEFAULT_ACCOUNT_RESOURCE,
+            FeatureFlag::JwkConsensusPerKeyMode => AptosFeatureFlag::JWK_CONSENSUS_PER_KEY_MODE,
         }
     }
 }
@@ -546,6 +548,7 @@ impl From<AptosFeatureFlag> for FeatureFlag {
                 FeatureFlag::NewAccountsDefaultToFaStore
             },
             AptosFeatureFlag::DEFAULT_ACCOUNT_RESOURCE => FeatureFlag::DefaultAccountResource,
+            AptosFeatureFlag::JWK_CONSENSUS_PER_KEY_MODE => FeatureFlag::JwkConsensusPerKeyMode,
         }
     }
 }

--- a/consensus/src/dag/rb_handler.rs
+++ b/consensus/src/dag/rb_handler.rs
@@ -123,7 +123,7 @@ impl NodeBroadcastHandler {
             ensure!(
                 is_vtxn_expected(&self.randomness_config, &self.jwk_consensus_config, vtxn),
                 "unexpected validator transaction: {:?}",
-                vtxn.topic()
+                vtxn.type_name()
             );
         }
         let vtxn_total_bytes = node

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -904,7 +904,7 @@ impl RoundManager {
                 ensure!(
                     is_vtxn_expected(&self.randomness_config, &self.jwk_consensus_config, vtxn),
                     "unexpected validator txn: {:?}",
-                    vtxn.topic()
+                    vtxn.type_name()
                 );
             }
         }

--- a/types/src/jwks/jwk/mod.rs
+++ b/types/src/jwks/jwk/mod.rs
@@ -4,7 +4,7 @@
 #![allow(clippy::match_result_ok)]
 
 use crate::{
-    jwks::{rsa::RSA_JWK, unsupported::UnsupportedJWK},
+    jwks::{rsa::RSA_JWK, unsupported::UnsupportedJWK, KID},
     move_any::{Any as MoveAny, AsMoveAny},
     move_utils::as_move_value::AsMoveValue,
 };
@@ -57,7 +57,7 @@ pub enum JWK {
 }
 
 impl JWK {
-    pub fn id(&self) -> Vec<u8> {
+    pub fn id(&self) -> KID {
         match self {
             JWK::RSA(rsa) => rsa.id(),
             JWK::Unsupported(unsupported) => unsupported.id(),

--- a/types/src/jwks/unsupported/mod.rs
+++ b/types/src/jwks/unsupported/mod.rs
@@ -1,7 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{move_any::AsMoveAny, move_utils::as_move_value::AsMoveValue};
+use crate::{jwks::KID, move_any::AsMoveAny, move_utils::as_move_value::AsMoveValue};
 use aptos_crypto::HashValue;
 use move_core_types::value::{MoveStruct, MoveValue};
 use poem_openapi_derive::Object;
@@ -43,7 +43,7 @@ impl UnsupportedJWK {
         }
     }
 
-    pub fn id(&self) -> Vec<u8> {
+    pub fn id(&self) -> KID {
         self.id.clone()
     }
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -135,6 +135,8 @@ pub enum FeatureFlag {
     ENABLE_FUNCTION_VALUES = 89,
     NEW_ACCOUNTS_DEFAULT_TO_FA_STORE = 90,
     DEFAULT_ACCOUNT_RESOURCE = 91,
+
+    JWK_CONSENSUS_PER_KEY_MODE = 92,
 }
 
 impl FeatureFlag {

--- a/types/src/validator_txn.rs
+++ b/types/src/validator_txn.rs
@@ -32,15 +32,6 @@ impl ValidatorTransaction {
         bcs::serialized_size(self).unwrap()
     }
 
-    pub fn topic(&self) -> Topic {
-        match self {
-            ValidatorTransaction::DKGResult(_) => Topic::DKG,
-            ValidatorTransaction::ObservedJWKUpdate(update) => {
-                Topic::JWK_CONSENSUS(update.update.issuer.clone())
-            },
-        }
-    }
-
     pub fn type_name(&self) -> &'static str {
         match self {
             ValidatorTransaction::DKGResult(_) => "validator_transaction__dkg_result",
@@ -56,4 +47,8 @@ impl ValidatorTransaction {
 pub enum Topic {
     DKG,
     JWK_CONSENSUS(jwks::Issuer),
+    JWK_CONSENSUS_PER_KEY_MODE {
+        issuer: jwks::Issuer,
+        kid: jwks::KID,
+    },
 }


### PR DESCRIPTION
## Description

Adding some types needed for per-key JWK consensus.

### Background
Currently the jwk consensus is per-issuer: validators agree on the key set returned by provider API. This may not be enough, especially if the provider:
- rolls out a key one region by another, and
- allows concurrent rollouts of multiple keys.

In per-key JWK consensus, validators agree on key-level diffs like "provider A key 1 should be removed", "provider B key 2 should be upserted", which should ensure progress even if the provider equivocates as described above.

## How Has This Been Tested?
UT

## Key Areas to Review
n/a

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
