### PR TITLE
[release] fix crane install for release images

### DIFF
--- a/docker/image-helpers.js
+++ b/docker/image-helpers.js
@@ -40,6 +40,7 @@ export async function installCrane() {
     }
     crane = "crane";
   }
+  return crane;
 }
 
 // This is kinda gross but means we can just run the script directly and it will

--- a/docker/release-images.mjs
+++ b/docker/release-images.mjs
@@ -107,7 +107,6 @@ const IMAGES_TO_RELEASE = {
 };
 
 
-
 async function main() {
   const REQUIRED_ARGS = ["GIT_SHA", "GCP_DOCKER_ARTIFACT_REPO", "AWS_ACCOUNT_ID", "IMAGE_TAG_PREFIX"];
   const OPTIONAL_ARGS = ["WAIT_FOR_IMAGE_SECONDS", "DRY_RUN"];
@@ -115,8 +114,10 @@ async function main() {
   const parsedArgs = parseArgsFromFlagOrEnv(REQUIRED_ARGS, OPTIONAL_ARGS);
 
   await assertExecutingInRepoRoot();
-  await installCrane();
-
+  const crane = await installCrane();
+  const craneVersion = await $`${crane} version`;
+  console.log(`INFO: crane version: ${craneVersion}`);
+  
   const AWS_ECR = `${parsedArgs.AWS_ACCOUNT_ID}.dkr.ecr.us-west-2.amazonaws.com/aptos`;
   const GCP_ARTIFACT_REPO = parsedArgs.GCP_DOCKER_ARTIFACT_REPO;
   const DOCKERHUB = "docker.io/aptoslabs";


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fix a bug where `crane` is not referenced properly in the release scripts

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Dry run exercises a codepath with `crane` CLI: namely check that `crane version` runs correctly and doesn't have a reference error

```
$ IMAGE_TAG_PREFIX=devnet AWS_ACCOUNT_ID=bla GCP_DOCKER_ARTIFACT_REPO=us-docker.pkg.dev/aptos-registry/docker GIT_SHA=$(git fetch && git rev-parse origin/main) ./docker/release-images.mjs --wait-for-image-seconds=3600 --dry-run

Lockfile is up to date, resolution step is skipped
Already up to date
Done in 413ms
$ git rev-parse --show-toplevel
/Users/rustielin/Code/aptos-core
$ command -v crane
/opt/homebrew/bin/crane
$ crane version
0.12.1
INFO: crane version: 0.12.1

INFO: dry run: true
INFO: image release group: aptos-node
INFO: image names to release: ["validator","validator-testing","faucet","tools"]
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to us-docker.pkg.dev/aptos-registry/docker/validator:devnet_performance due to dry run
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator:devnet_performance due to dry run
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to docker.io/aptoslabs/validator:devnet_performance due to dry run
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator:8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator:8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to us-docker.pkg.dev/aptos-registry/docker/validator:devnet due to dry run
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator:8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator:8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator:devnet due to dry run
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator:8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator:8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to docker.io/aptoslabs/validator:devnet due to dry run
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator-testing:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator-testing:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to us-docker.pkg.dev/aptos-registry/docker/validator-testing:devnet_performance due to dry run
INFO: image us-docker.pkg.dev/aptos-registry/docker/validator-testing:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f is available
INFO: skipping copy of us-docker.pkg.dev/aptos-registry/docker/validator-testing:performance_8751a30a3f2eb207b23de8f0d9e3557caf86fe4f to bla.dkr.ecr.us-west-2.amazonaws.com/aptos/validator-testing:devnet_performance due to dry run
...
```

