### PR TITLE
fix compat test

### DIFF
--- a/testsuite/testcases/src/compatibility_test.rs
+++ b/testsuite/testcases/src/compatibility_test.rs
@@ -2,23 +2,15 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{batch_update_gradually, create_emitter_and_request, generate_traffic};
+use crate::{batch_update_gradually, generate_traffic};
 use anyhow::bail;
 use aptos_forge::{
-    EmitJobRequest, NetworkContextSynchronizer, NetworkTest, Result, SwarmExt, Test, TxnEmitter,
-    TxnStats, Version,
+    EmitJobRequest, NetworkContextSynchronizer, NetworkTest, Result, SwarmExt, Test, Version,
 };
-use aptos_sdk::types::{LocalAccount, PeerId};
+use aptos_sdk::types::PeerId;
 use async_trait::async_trait;
 use log::info;
-use rand::SeedableRng;
-use std::{
-    ops::DerefMut,
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        Arc,
-    },
-};
+use std::ops::DerefMut;
 use tokio::time::Duration;
 
 pub struct SimpleValidatorUpgrade;
@@ -33,7 +25,6 @@ impl Test for SimpleValidatorUpgrade {
     }
 }
 
-
 fn upgrade(
     ctxa: NetworkContextSynchronizer,
     // upgrade args
@@ -42,8 +33,6 @@ fn upgrade(
     wait_until_healthy: bool,
     delay: Duration,
     max_wait: Duration,
-    // traffic args
-    nodes: &[PeerId],
 ) -> Result<()> {
     let mut upgrade_result: Result<()> = Ok(());
     tokio_scoped::scope(|scopev| {
@@ -161,7 +150,6 @@ impl NetworkTest for SimpleValidatorUpgrade {
             upgrade_wait_for_healthy,
             upgrade_node_delay,
             upgrade_max_wait,
-            &[first_node],
         )?;
         // Generate some traffic
         {
@@ -190,7 +178,6 @@ impl NetworkTest for SimpleValidatorUpgrade {
             upgrade_wait_for_healthy,
             upgrade_node_delay,
             upgrade_max_wait,
-            &first_batch,
         )?;
         {
             let mut ctx_locker = ctxa.ctx.lock().await;
@@ -210,14 +197,13 @@ impl NetworkTest for SimpleValidatorUpgrade {
             info!("{}", msg);
             ctx.report.report_text(msg);
         }
-         upgrade(
+        upgrade(
             ctxa.clone(),
             &second_batch,
             &new_version,
             upgrade_wait_for_healthy,
             upgrade_node_delay,
             upgrade_max_wait,
-            &second_batch,
         )?;
         {
             let mut ctx_locker = ctxa.ctx.lock().await;

--- a/testsuite/testcases/src/compatibility_test.rs
+++ b/testsuite/testcases/src/compatibility_test.rs
@@ -33,32 +33,8 @@ impl Test for SimpleValidatorUpgrade {
     }
 }
 
-async fn stat_gather_task(
-    emitter: TxnEmitter,
-    emit_job_request: EmitJobRequest,
-    source_account: Arc<LocalAccount>,
-    upgrade_traffic_chunk_duration: Duration,
-    done: Arc<AtomicBool>,
-) -> Result<Option<TxnStats>> {
-    let mut upgrade_stats = vec![];
-    while !done.load(Ordering::Relaxed) {
-        info!("stat_gather_task some traffic...");
-        let upgrading_stats = emitter
-            .clone()
-            .emit_txn_for(
-                source_account.clone(),
-                emit_job_request.clone(),
-                upgrade_traffic_chunk_duration,
-            )
-            .await?;
-        info!("stat_gather_task some stats: {}", &upgrading_stats);
-        upgrade_stats.push(upgrading_stats);
-    }
-    let statsum = upgrade_stats.into_iter().reduce(|a, b| &a + &b);
-    Ok(statsum)
-}
 
-fn upgrade_and_gather_stats(
+fn upgrade(
     ctxa: NetworkContextSynchronizer,
     // upgrade args
     validators_to_update: &[PeerId],
@@ -68,50 +44,9 @@ fn upgrade_and_gather_stats(
     max_wait: Duration,
     // traffic args
     nodes: &[PeerId],
-) -> Result<Option<TxnStats>> {
-    let upgrade_done = Arc::new(AtomicBool::new(false));
-    let emitter_ctx = ctxa.clone();
-    let mut stats_result: Result<Option<TxnStats>> = Ok(None);
+) -> Result<()> {
     let mut upgrade_result: Result<()> = Ok(());
     tokio_scoped::scope(|scopev| {
-        // emit trafic and gather stats
-        scopev.spawn(async {
-            info!("upgrade_and_gather_stats traffic thread start");
-            let (emitter, emit_job_request, source_account) = {
-                let mut ctx_locker = emitter_ctx.ctx.lock().await;
-                let ctx = ctx_locker.deref_mut();
-                let emit_job_request = ctx.emit_job.clone();
-                let rng = SeedableRng::from_rng(ctx.core().rng()).unwrap();
-                let (emitter, emit_job_request) = match create_emitter_and_request(
-                    ctx.swarm.clone(),
-                    emit_job_request,
-                    nodes,
-                    rng,
-                )
-                .await
-                {
-                    Ok(parts) => parts,
-                    Err(err) => {
-                        stats_result = Err(err);
-                        return;
-                    },
-                };
-                let source_account = ctx.swarm.read().await.chain_info().root_account;
-                (emitter, emit_job_request, source_account)
-                // release lock on network context
-            };
-            let upgrade_traffic_chunk_duration = Duration::from_secs(15);
-            info!("upgrade_and_gather_stats traffic thread 1");
-            stats_result = stat_gather_task(
-                emitter,
-                emit_job_request,
-                source_account,
-                upgrade_traffic_chunk_duration,
-                upgrade_done.clone(),
-            )
-            .await;
-            info!("upgrade_and_gather_stats traffic thread done");
-        });
         // do upgrade
         scopev.spawn(async {
             info!("upgrade_and_gather_stats upgrade thread start");
@@ -124,14 +59,12 @@ fn upgrade_and_gather_stats(
                 max_wait,
             )
             .await;
-            info!("upgrade_and_gather_stats upgrade thread 1");
-            upgrade_done.store(true, Ordering::Relaxed);
             info!("upgrade_and_gather_stats upgrade thread done");
         });
     });
 
     upgrade_result?;
-    stats_result
+    Ok(())
 }
 
 #[async_trait]
@@ -221,7 +154,7 @@ impl NetworkTest for SimpleValidatorUpgrade {
         );
         info!("{}", msg);
         ctxa.report_text(msg).await;
-        let upgrade_stats = upgrade_and_gather_stats(
+        upgrade(
             ctxa.clone(),
             &[first_node],
             &new_version,
@@ -230,14 +163,6 @@ impl NetworkTest for SimpleValidatorUpgrade {
             upgrade_max_wait,
             &[first_node],
         )?;
-        let upgrade_stats_sum = upgrade_stats.into_iter().reduce(|a, b| &a + &b);
-        if let Some(upgrade_stats_sum) = upgrade_stats_sum {
-            ctxa.ctx.lock().await.report.report_txn_stats(
-                format!("{}::single-validator-upgrading", self.name()),
-                &upgrade_stats_sum,
-            );
-        }
-
         // Generate some traffic
         {
             let mut ctx_locker = ctxa.ctx.lock().await;
@@ -258,7 +183,7 @@ impl NetworkTest for SimpleValidatorUpgrade {
         }
 
         // upgrade the rest of the first half
-        let upgrade2_stats = upgrade_and_gather_stats(
+        upgrade(
             ctxa.clone(),
             &first_batch,
             &new_version,
@@ -267,13 +192,6 @@ impl NetworkTest for SimpleValidatorUpgrade {
             upgrade_max_wait,
             &first_batch,
         )?;
-        let upgrade2_stats_sum = upgrade2_stats.into_iter().reduce(|a, b| &a + &b);
-        if let Some(upgrade2_stats_sum) = upgrade2_stats_sum {
-            ctxa.ctx.lock().await.report.report_txn_stats(
-                format!("{}::half-validator-upgrading", self.name()),
-                &upgrade2_stats_sum,
-            );
-        }
         {
             let mut ctx_locker = ctxa.ctx.lock().await;
             let ctx = ctx_locker.deref_mut();
@@ -292,7 +210,7 @@ impl NetworkTest for SimpleValidatorUpgrade {
             info!("{}", msg);
             ctx.report.report_text(msg);
         }
-        let upgrade3_stats = upgrade_and_gather_stats(
+         upgrade(
             ctxa.clone(),
             &second_batch,
             &new_version,
@@ -301,13 +219,6 @@ impl NetworkTest for SimpleValidatorUpgrade {
             upgrade_max_wait,
             &second_batch,
         )?;
-        let upgrade3_stats_sum = upgrade3_stats.into_iter().reduce(|a, b| &a + &b);
-        if let Some(upgrade3_stats_sum) = upgrade3_stats_sum {
-            ctxa.ctx.lock().await.report.report_txn_stats(
-                format!("{}::rest-validator-upgrading", self.name()),
-                &upgrade3_stats_sum,
-            );
-        }
         {
             let mut ctx_locker = ctxa.ctx.lock().await;
             let ctx = ctx_locker.deref_mut();

--- a/testsuite/testcases/src/compatibility_test.rs
+++ b/testsuite/testcases/src/compatibility_test.rs
@@ -38,7 +38,7 @@ fn upgrade(
     tokio_scoped::scope(|scopev| {
         // do upgrade
         scopev.spawn(async {
-            info!("upgrade_and_gather_stats upgrade thread start");
+            info!("upgrade thread start");
             upgrade_result = batch_update_gradually(
                 ctxa,
                 validators_to_update,
@@ -48,7 +48,7 @@ fn upgrade(
                 max_wait,
             )
             .await;
-            info!("upgrade_and_gather_stats upgrade thread done");
+            info!("upgrade thread done");
         });
     });
 

--- a/testsuite/testcases/src/compatibility_test.rs
+++ b/testsuite/testcases/src/compatibility_test.rs
@@ -4,9 +4,7 @@
 
 use crate::{batch_update_gradually, generate_traffic};
 use anyhow::bail;
-use aptos_forge::{
-    EmitJobRequest, NetworkContextSynchronizer, NetworkTest, Result, SwarmExt, Test, Version,
-};
+use aptos_forge::{NetworkContextSynchronizer, NetworkTest, Result, SwarmExt, Test, Version};
 use aptos_sdk::types::PeerId;
 use async_trait::async_trait;
 use log::info;


### PR DESCRIPTION
## Description

Compat test was failing because we were trying to send traffic to the node when the node was upgrading..some time this causes race condition and the emitter job can't start. Change the test to upgrade the node first before sending the traffic. 

## How Has This Been Tested?

Ran the compat tests few times and it succeeded.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
