### PR TITLE
[forge] compat simplify

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4265,7 +4265,6 @@ dependencies = [
  "rand 0.7.3",
  "reqwest 0.11.23",
  "tokio",
- "tokio-scoped",
 ]
 
 [[package]]

--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -58,8 +58,8 @@ spec:
           value: "1"
         - name: KUBECONFIG
           value: {KUBECONFIG}
-      # - name: RUST_LOG
-      #   value: debug
+        - name: RUST_LOG
+          value: info
       volumeMounts:
         - name: multiregion-kubeconfig
           readOnly: true

--- a/testsuite/testcases/Cargo.toml
+++ b/testsuite/testcases/Cargo.toml
@@ -36,7 +36,6 @@ log = { workspace = true }
 rand = { workspace = true }
 reqwest = { workspace = true }
 tokio = { workspace = true }
-tokio-scoped = { workspace = true }
 
 [dev-dependencies]
 assert_approx_eq = { workspace = true }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Few changes to simplify and fix compat test:
* Removing tokio_scoped
* Also explicitly add `RUST_LOG=info` in the test runner to get more logs
* Increase the upgrade delay to 60s to account for cold start of a new container/image

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Run Forge tests on PR 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Test output

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
