### PR TITLE
per-key jwk consensus 4: no-op refactoring per-issuer logic

### DIFF
--- a/crates/aptos-jwk-consensus/src/lib.rs
+++ b/crates/aptos-jwk-consensus/src/lib.rs
@@ -45,7 +45,9 @@ pub fn start_jwk_consensus_runtime(
 pub mod counters;
 pub mod epoch_manager;
 pub mod jwk_manager;
+// pub mod jwk_manager_per_key;
 pub mod jwk_observer;
+pub mod mode;
 pub mod network;
 pub mod network_interface;
 pub mod observation_aggregation;

--- a/crates/aptos-jwk-consensus/src/mode/mod.rs
+++ b/crates/aptos-jwk-consensus/src/mode/mod.rs
@@ -1,0 +1,27 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::types::JWKConsensusMsg;
+use aptos_types::jwks::{ProviderJWKs, QuorumCertifiedUpdate};
+use std::hash::Hash;
+
+/// This trait captures the differences between per-issuer mode and per-key mode.
+pub trait TConsensusMode: Send + Sync + 'static {
+    type ReliableBroadcastRequest: Clone
+        + Sync
+        + Send
+        + Into<JWKConsensusMsg>
+        + TryFrom<JWKConsensusMsg>;
+    type ConsensusSessionKey: Eq + Hash + Clone + Send;
+    fn log_certify_start(epoch: u64, payload: &ProviderJWKs);
+    fn new_rb_request(
+        epoch: u64,
+        payload: &ProviderJWKs,
+    ) -> anyhow::Result<Self::ReliableBroadcastRequest>;
+    fn log_certify_done(epoch: u64, qc: &QuorumCertifiedUpdate);
+    fn session_key_from_qc(qc: &QuorumCertifiedUpdate)
+        -> anyhow::Result<Self::ConsensusSessionKey>;
+}
+
+pub mod per_issuer;
+// pub mod per_key;

--- a/crates/aptos-jwk-consensus/src/mode/per_issuer.rs
+++ b/crates/aptos-jwk-consensus/src/mode/per_issuer.rs
@@ -1,0 +1,42 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{mode::TConsensusMode, types::ObservedUpdateRequest};
+use aptos_logger::info;
+use aptos_types::jwks::{Issuer, ProviderJWKs, QuorumCertifiedUpdate};
+
+pub struct PerIssuerMode {}
+
+impl TConsensusMode for PerIssuerMode {
+    type ConsensusSessionKey = Issuer;
+    type ReliableBroadcastRequest = ObservedUpdateRequest;
+
+    fn log_certify_start(epoch: u64, payload: &ProviderJWKs) {
+        info!(
+            epoch = epoch,
+            issuer = String::from_utf8(payload.issuer.clone()).ok(),
+            version = payload.version,
+            "Start certifying update."
+        );
+    }
+
+    fn new_rb_request(epoch: u64, payload: &ProviderJWKs) -> anyhow::Result<ObservedUpdateRequest> {
+        Ok(ObservedUpdateRequest {
+            epoch,
+            issuer: payload.issuer.clone(),
+        })
+    }
+
+    fn log_certify_done(epoch: u64, qc: &QuorumCertifiedUpdate) {
+        info!(
+            epoch = epoch,
+            issuer = String::from_utf8(qc.update.issuer.clone()).ok(),
+            version = qc.update.version,
+            "Certified update obtained."
+        );
+    }
+
+    fn session_key_from_qc(qc: &QuorumCertifiedUpdate) -> anyhow::Result<Issuer> {
+        Ok(qc.update.issuer.clone())
+    }
+}

--- a/crates/aptos-jwk-consensus/src/observation_aggregation/tests.rs
+++ b/crates/aptos-jwk-consensus/src/observation_aggregation/tests.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    mode::per_issuer::PerIssuerMode,
     observation_aggregation::ObservationAggregationState,
     types::{ObservedUpdate, ObservedUpdateResponse},
 };
@@ -52,7 +53,7 @@ fn test_observation_aggregation_state() {
             UnsupportedJWK::new_for_testing("id2", "payload2"),
         ))],
     };
-    let ob_agg_state = Arc::new(ObservationAggregationState::new(
+    let ob_agg_state = Arc::new(ObservationAggregationState::<PerIssuerMode>::new(
         epoch_state.clone(),
         view_0.clone(),
     ));

--- a/crates/aptos-jwk-consensus/src/types.rs
+++ b/crates/aptos-jwk-consensus/src/types.rs
@@ -1,19 +1,25 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use anyhow::{ensure, Context};
 use aptos_crypto::bls12381::Signature;
 use aptos_enum_conversion_derive::EnumConversion;
 use aptos_reliable_broadcast::RBMessage;
 use aptos_types::{
     account_address::AccountAddress,
-    jwks::{Issuer, ProviderJWKs},
+    jwks::{jwk::JWK, Issuer, KeyLevelUpdate, ProviderJWKs, QuorumCertifiedUpdate, KID},
 };
+use aptos_validator_transaction_pool::TxnGuard;
+use futures_util::future::AbortHandle;
 use serde::{Deserialize, Serialize};
+use std::fmt::Debug;
 
 #[derive(Clone, Debug, EnumConversion, Deserialize, Serialize, PartialEq)]
 pub enum JWKConsensusMsg {
     ObservationRequest(ObservedUpdateRequest),
     ObservationResponse(ObservedUpdateResponse),
+    KeyLevelObservationRequest(ObservedKeyLevelUpdateRequest),
+    // In per-key mode we can reuse `ObservationResponse` and don't have a `KeyLevelObservationResponse`.
 }
 
 impl JWKConsensusMsg {
@@ -21,6 +27,7 @@ impl JWKConsensusMsg {
         match self {
             JWKConsensusMsg::ObservationRequest(_) => "ObservationRequest",
             JWKConsensusMsg::ObservationResponse(_) => "ObservationResponse",
+            JWKConsensusMsg::KeyLevelObservationRequest(_) => "KeyLevelObservationResponse",
         }
     }
 
@@ -28,6 +35,7 @@ impl JWKConsensusMsg {
         match self {
             JWKConsensusMsg::ObservationRequest(request) => request.epoch,
             JWKConsensusMsg::ObservationResponse(response) => response.epoch,
+            JWKConsensusMsg::KeyLevelObservationRequest(request) => request.epoch,
         }
     }
 }
@@ -41,6 +49,13 @@ pub struct ObservedUpdate {
     pub signature: Signature,
 }
 
+#[derive(Clone, Debug, Deserialize, Serialize, Eq, PartialEq)]
+pub struct ObservedKeyLevelUpdate {
+    pub author: AccountAddress,
+    pub observed: KeyLevelUpdate,
+    pub signature: Signature,
+}
+
 #[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
 pub struct ObservedUpdateRequest {
     pub epoch: u64,
@@ -51,4 +66,107 @@ pub struct ObservedUpdateRequest {
 pub struct ObservedUpdateResponse {
     pub epoch: u64,
     pub update: ObservedUpdate,
+}
+
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+pub struct ObservedKeyLevelUpdateRequest {
+    pub epoch: u64,
+    pub issuer: Issuer,
+    pub kid: KID,
+}
+
+/// An instance of this resource is created when `JWKManager` starts the QC update building process for an issuer.
+/// Then `JWKManager` needs to hold it. Once this resource is dropped, the corresponding QC update process will be cancelled.
+#[derive(Clone, Debug)]
+pub struct QuorumCertProcessGuard {
+    pub handle: AbortHandle,
+}
+
+impl QuorumCertProcessGuard {
+    pub fn new(handle: AbortHandle) -> Self {
+        Self { handle }
+    }
+
+    #[cfg(test)]
+    pub fn dummy() -> Self {
+        let (handle, _) = AbortHandle::new_pair();
+        Self { handle }
+    }
+}
+
+impl Drop for QuorumCertProcessGuard {
+    fn drop(&mut self) {
+        let QuorumCertProcessGuard { handle } = self;
+        handle.abort();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum ConsensusState<T: Debug + Clone + Eq + PartialEq> {
+    NotStarted,
+    InProgress {
+        my_proposal: T,
+        abort_handle_wrapper: QuorumCertProcessGuard,
+    },
+    Finished {
+        vtxn_guard: TxnGuard,
+        my_proposal: T,
+        quorum_certified: QuorumCertifiedUpdate,
+    },
+}
+
+impl<T: Debug + Clone + Eq + PartialEq> PartialEq for ConsensusState<T> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (ConsensusState::NotStarted, ConsensusState::NotStarted) => true,
+            (
+                ConsensusState::InProgress {
+                    my_proposal: update_0,
+                    ..
+                },
+                ConsensusState::InProgress {
+                    my_proposal: update_1,
+                    ..
+                },
+            ) if update_0 == update_1 => true,
+            (
+                ConsensusState::Finished {
+                    my_proposal: update_0,
+                    ..
+                },
+                ConsensusState::Finished {
+                    my_proposal: update_1,
+                    ..
+                },
+            ) if update_0 == update_1 => true,
+            _ => false,
+        }
+    }
+}
+
+impl<T: Debug + Clone + Eq + PartialEq> Eq for ConsensusState<T> {}
+
+impl<T: Debug + Clone + Eq + PartialEq> ConsensusState<T> {
+    pub fn name(&self) -> &str {
+        match self {
+            ConsensusState::NotStarted => "NotStarted",
+            ConsensusState::InProgress { .. } => "InProgress",
+            ConsensusState::Finished { .. } => "Finished",
+        }
+    }
+
+    #[cfg(test)]
+    pub fn my_proposal_cloned(&self) -> T {
+        match self {
+            ConsensusState::InProgress { my_proposal, .. }
+            | ConsensusState::Finished { my_proposal, .. } => my_proposal.clone(),
+            _ => panic!("my_proposal unavailable"),
+        }
+    }
+}
+
+impl<T: Debug + Clone + Eq + PartialEq> Default for ConsensusState<T> {
+    fn default() -> Self {
+        Self::NotStarted
+    }
 }

--- a/crates/aptos-jwk-consensus/src/types.rs
+++ b/crates/aptos-jwk-consensus/src/types.rs
@@ -1,13 +1,12 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use anyhow::{ensure, Context};
 use aptos_crypto::bls12381::Signature;
 use aptos_enum_conversion_derive::EnumConversion;
 use aptos_reliable_broadcast::RBMessage;
 use aptos_types::{
     account_address::AccountAddress,
-    jwks::{jwk::JWK, Issuer, KeyLevelUpdate, ProviderJWKs, QuorumCertifiedUpdate, KID},
+    jwks::{Issuer, KeyLevelUpdate, ProviderJWKs, QuorumCertifiedUpdate, KID},
 };
 use aptos_validator_transaction_pool::TxnGuard;
 use futures_util::future::AbortHandle;

--- a/types/src/jwks/mod.rs
+++ b/types/src/jwks/mod.rs
@@ -330,6 +330,15 @@ pub struct KeyLevelUpdate {
 }
 
 impl KeyLevelUpdate {
+    pub fn unknown() -> Self {
+        Self {
+            issuer: issuer_from_str("unknown issuer"),
+            base_version: 999999999,
+            kid: "unknown kid".as_bytes().to_vec(),
+            to_upsert: None,
+        }
+    }
+
     pub fn as_issuer_level_repr(&self) -> anyhow::Result<ProviderJWKs> {
         let kid_str = String::from_utf8(self.kid.clone())
             .context("KeyLevelUpdate::as_issuer_level_repr failed on kid")?;


### PR DESCRIPTION
## Description

Refactor per-issuer implementation so some logic can later be shared with per-key logic.

### Background
Currently the jwk consensus is per-issuer: validators agree on the key set returned by provider API. This may not be enough, especially if the provider:
- rolls out a key one region by another, and
- allows concurrent rollouts of multiple keys.

In per-key JWK consensus, validators agree on key-level diffs like "provider A key 1 should be removed", "provider B key 2 should be upserted", which should ensure progress even if the provider equivocates as described above.

## How Has This Been Tested?
Existing UT

## Key Areas to Review
n/a

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Validator Node

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
