### PR TITLE
Fix Aptos CLI Bug: move clean does not recognize --output-dir

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 - Compiler v1 is now deprecated. It is now removed from the Aptos CLI.
 - Added a new option `aptos move compile --fail-on-warning` which fails the compilation if any warnings are found.
 - We now default to running extended checks when compiling test code (this was previously only done with the option `--check-test-code`, but this is no longer available). However, these checks can be now be skipped with `--skip-checks-on-test-code`.
+- Add `--output-dir` option to `aptos move clean`.
 
 ## [6.2.0]
 - Several compiler parsing bugs fixed, including in specifications for receiver style functions

--- a/crates/aptos/e2e/main.py
+++ b/crates/aptos/e2e/main.py
@@ -48,6 +48,8 @@ from cases.move import (
     test_move_publish,
     test_move_run,
     test_move_view,
+    test_move_clean,
+    test_move_clean_with_output_dir,
 )
 from cases.node import (
     test_node_show_validator_set,
@@ -163,6 +165,8 @@ async def run_tests(run_helper):
     test_move_publish(run_helper)
     test_move_run(run_helper)
     test_move_view(run_helper)
+    test_move_clean(run_helper)
+    test_move_clean_with_output_dir(run_helper)
 
     # Run stake subcommand group tests.
     """

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -2042,7 +2042,12 @@ impl CliCommand<&'static str> for CleanPackage {
     }
 
     async fn execute(self) -> CliTypedResult<&'static str> {
-        let path = self.move_options.get_package_path()?;
+        let path = if let Some(output_dir) = self.move_options.output_dir.clone() {
+            output_dir
+        } else {
+            self.move_options.get_package_path()?
+        };
+
         let build_dir = path.join("build");
         // Only remove the build dir if it exists, allowing for users to still clean their cache
         if build_dir.exists() {


### PR DESCRIPTION
## Description

This PR adds support for `--output-dir` option in the `aptos move clean` command. 

Currently `aptos move compile` followed by `aptos move clean` creates and cleans up compiled artifacts respectively. However, `aptos move compile --output-dir` followed by `aptos move clean --output-dir` creates but does not clean up the artifacts in dir.
This PR is based on the Move Club Bounty posted [here](https://moveclub.xyz/bounty/67ebf7025dcb73104cc11d90).

## How Has This Been Tested?
Added 2 test cases to `crates/aptos/e2e/cases/move.py`.
- test_move_clean
- test_move_clean_with_output_dir

The first is successful before (and after) implementing the fix. The second is only successful after implementing the fix.

## Key Areas to Review

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [X] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [X] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
