### PR TITLE
[Fuzz] Disable gas check in fuzzer while generating coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,3 +135,6 @@ ecosystem/indexer-grpc/indexer-transaction-generator/*.yaml
 *.dot
 *.bytecode
 !third_party/move/move-prover/tests/xsources/design/*.bytecode
+
+# ignore antithesis
+genesis_antithesis_*/

--- a/testsuite/fuzzer/.cargo/config.toml
+++ b/testsuite/fuzzer/.cargo/config.toml
@@ -5,4 +5,4 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", 
 
 [host.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["--cfg", "tokio_unstable", "-C", "link-args=-fuse-ld=gold -Wl,--no-keep-files-mapped -Wl,--no-keep-memory -Wl,--no-threads", "-C", "codegen-units=1", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]
+rustflags = ["--cfg", "tokio_unstable", "-C", "link-args=-fuse-ld=gold -Wl,--no-keep-files-mapped -Wl,--no-keep-memory -Wl,--no-threads, -Wl,--no-rosegment", "-C", "codegen-units=1", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]

--- a/testsuite/fuzzer/.gitignore
+++ b/testsuite/fuzzer/.gitignore
@@ -1,0 +1,4 @@
+*.svg
+*.crash
+perf.data
+perf.data.old

--- a/testsuite/fuzzer/fuzz/Cargo.toml
+++ b/testsuite/fuzzer/fuzz/Cargo.toml
@@ -3,6 +3,7 @@ name = "fuzzer-fuzz"
 version = "0.0.0"
 publish = false
 edition = "2021"
+build = "build.rs"
 
 [package.metadata]
 cargo-fuzz = true

--- a/testsuite/fuzzer/fuzz/build.rs
+++ b/testsuite/fuzzer/fuzz/build.rs
@@ -1,0 +1,18 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::env;
+
+fn main() {
+    println!("cargo::rustc-check-cfg=cfg(coverage_enabled)");
+
+    let rustflags = env::var("RUSTFLAGS").unwrap_or_default();
+    let sanitizer = env::var("RUSTC_SANITIZER").unwrap_or_default();
+
+    let has_instr_cov = rustflags.contains("instrument-coverage");
+    let has_san_cov = rustflags.contains("sanitizer=coverage") || sanitizer.contains("coverage");
+
+    if has_instr_cov || has_san_cov {
+        println!("cargo:rustc-cfg=coverage_enabled");
+    }
+}

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -36,7 +36,7 @@ use utils::vm::{
 };
 
 // genesis write set generated once for each fuzzing session
-static VM: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
+static VM_WRITE_SET: Lazy<WriteSet> = Lazy::new(|| GENESIS_CHANGE_SET_HEAD.write_set().clone());
 
 const FUZZER_CONCURRENCY_LEVEL: usize = 1;
 static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
@@ -51,6 +51,12 @@ static TP: Lazy<Arc<rayon::ThreadPool>> = Lazy::new(|| {
 const MAX_TYPE_PARAMETER_VALUE: u16 = 64 / 4 * 16; // third_party/move/move-bytecode-verifier/src/signature_v2.rs#L1306-L1312
 
 const EXECUTION_TIME_GAS_RATIO: u8 = 50;
+
+#[inline(always)]
+fn is_coverage_enabled() -> bool {
+    cfg!(coverage_enabled) ||
+    std::env::var("LLVM_PROFILE_FILE").is_ok()
+}
 
 fn check_for_invariant_violation_vmerror(e: VMError) {
     if e.status_type() == StatusType::InvariantViolation
@@ -167,7 +173,7 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
 
     AptosVM::set_concurrency_level_once(FUZZER_CONCURRENCY_LEVEL);
     let mut vm = FakeExecutor::from_genesis_with_existing_thread_pool(
-        &VM,
+        &VM_WRITE_SET,
         ChainId::mainnet(),
         Arc::clone(&TP),
     )
@@ -376,8 +382,8 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     // EXECUTION_TIME_GAS_RATIO is a ratio between execution time and gas used. If the ratio is higher than EXECUTION_TIME_GAS_ratio, we consider the gas usage as unexpected.
     // EXPERIMENTAL: This very sensible to excution enviroment, e.g. local run, OSS-Fuzz. It may cause false positive. Real data from production does not apply to this ratio.
     // We only want to catch big unexpected gas usage.
-    if (elapsed.as_millis() / (fee.execution_gas_used() + fee.io_gas_used()) as u128)
-        > EXECUTION_TIME_GAS_RATIO as u128
+    if ((elapsed.as_millis() / (fee.execution_gas_used() + fee.io_gas_used()) as u128)
+        > EXECUTION_TIME_GAS_RATIO as u128) && !is_coverage_enabled()
     {
         if std::env::var("DEBUG").is_ok() {
             tdbg!(

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/aptosvm_publish_and_run.rs
@@ -54,8 +54,7 @@ const EXECUTION_TIME_GAS_RATIO: u8 = 50;
 
 #[inline(always)]
 fn is_coverage_enabled() -> bool {
-    cfg!(coverage_enabled) ||
-    std::env::var("LLVM_PROFILE_FILE").is_ok()
+    cfg!(coverage_enabled) || std::env::var("LLVM_PROFILE_FILE").is_ok()
 }
 
 fn check_for_invariant_violation_vmerror(e: VMError) {
@@ -383,7 +382,8 @@ fn run_case(mut input: RunnableState) -> Result<(), Corpus> {
     // EXPERIMENTAL: This very sensible to excution enviroment, e.g. local run, OSS-Fuzz. It may cause false positive. Real data from production does not apply to this ratio.
     // We only want to catch big unexpected gas usage.
     if ((elapsed.as_millis() / (fee.execution_gas_used() + fee.io_gas_used()) as u128)
-        > EXECUTION_TIME_GAS_RATIO as u128) && !is_coverage_enabled()
+        > EXECUTION_TIME_GAS_RATIO as u128)
+        && !is_coverage_enabled()
     {
         if std::env::var("DEBUG").is_ok() {
             tdbg!(


### PR DESCRIPTION
## Description
Added compile time and runtime checks to disable gas divergence checks in the move_aptosvm_publish_and_run fuzzer, which is time sensitive and triggers many false positives while generating coverage reports.

## How Has This Been Tested?
Generated a coverage report offline

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [X] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [X] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
