### PR TITLE
Expand lint checker to cover additional boolean identities

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -8,6 +8,7 @@ mod needless_bool;
 mod needless_deref_ref;
 mod needless_ref_deref;
 mod needless_ref_in_field_access;
+mod nonminimal_bool;
 mod simpler_numeric_expression;
 mod unnecessary_boolean_identity_comparison;
 mod unnecessary_numerical_extreme_comparison;
@@ -23,6 +24,7 @@ pub fn get_default_linter_pipeline() -> Vec<Box<dyn ExpChecker>> {
         Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),
         Box::<needless_deref_ref::NeedlessDerefRef>::default(),
         Box::<needless_ref_deref::NeedlessRefDeref>::default(),
+        Box::<nonminimal_bool::NonminimalBool>::default(),
         Box::<simpler_numeric_expression::SimplerNumericExpression>::default(),
         Box::<unnecessary_boolean_identity_comparison::UnnecessaryBooleanIdentityComparison>::default(),
         Box::<unnecessary_numerical_extreme_comparison::UnnecessaryNumericalExtremeComparison>::default(),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/nonminimal_bool.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/nonminimal_bool.rs
@@ -1,0 +1,114 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for boolean expressions:
+//! 1. `x && true`, which can be replaced with just `x`.
+//! 2. `x && false`, which can be replaced with just `false`.
+//! 3. `x || true`, which can be replaced with just `true`.
+//! 4. `x || false`, which can be replaced with just `x`.
+//! 5. `x <==> true`, which can be replaced with just `x`.
+//! 6. `x <==> false`, which can be replaced with just `!x`.
+//! 7. `x ==> true`, which can be replaced with just `true`.
+//! 8. `x ==> false`, which can be replaced with just `!x`.
+//! 9. `true ==> x`, which can be replaced with just `x`.
+//! 10. `false ==> x`, which can be replaced with just `true`.
+//! 11. `!true`, which can be replaced with just `false`.
+//! 12. `!false`, which can be replaced with just `true`.
+//!
+//! Note also that rules 1 through 6 have both LHS and RHS version
+
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{ExpData, Operation, Value},
+    model::GlobalEnv,
+};
+
+#[derive(Default)]
+pub struct NonminimalBool;
+
+impl NonminimalBool {
+    // Converts a binary boolean operator to its string representation
+    fn name_of_op(&self, cmp: &Operation) -> &'static str {
+        match cmp {
+            Operation::And => "&&",
+            Operation::Or => "||",
+            Operation::Implies => "==>",
+            Operation::Iff => "<==>",
+            _ => unreachable!("Unexpected operation"),
+        }
+    }
+
+    // Returns the message for a binary boolean operator with a literal
+    // cmp is the boolean operator
+    // b is the boolean literal, true or false
+    // literal_is_lhs is true if literal is on the left and false if it is on the right
+    // lhs and rhs are the literal and "bexpr" (based on the side of the literal)
+    fn get_msg(
+        &self,
+        cmp: &Operation,
+        b: bool,
+        literal_is_lhs: bool,
+        lhs: String,
+        rhs: String,
+    ) -> Option<String> {
+        use Operation::*;
+        let equiv = match (cmp, b, literal_is_lhs) {
+            (Or, true, _) | (Implies, true, false) | (Implies, false, true) => Some("`true`"),
+            (And, false, _) => Some("`false`"),
+            (And, true, _) | (Or, false, _) | (Iff, true, _) | (Implies, true, true) => {
+                Some("`bexpr`")
+            },
+            (Iff, false, _) | (Implies, false, false) => Some("the negation of `bexpr`"),
+            _ => None,
+        };
+        equiv.map(|s| {
+            format!(
+                "The {}-hand side of `{}` evaluates to `{}`. Recall that the expression `{} {} {}` is logically equivalent to {}. Consider simplifying.",
+                if literal_is_lhs { "left" } else { "right" },
+                self.name_of_op(cmp),
+                b,
+                lhs,
+                self.name_of_op(cmp),
+                rhs,
+                s
+            )
+        })
+    }
+}
+
+impl ExpChecker for NonminimalBool {
+    fn get_name(&self) -> String {
+        "nonminimal_bool".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+        use ExpData::{Call, Value as ExpValue};
+        use Operation::*;
+        use Value::Bool;
+
+        let Call(_, cmp, args) = expr else {
+            return;
+        };
+        let msg = match cmp {
+            And | Or | Implies | Iff => {
+                match (args[0].as_ref(), args[1].as_ref()) {
+                    // When one of the arguments is a boolean literal (true or false)
+                    (ExpValue(_, Bool(b)), _) => self.get_msg(cmp, *b, true, b.to_string(), "bexpr".to_string()),
+                    (_, ExpValue(_, Bool(b))) => self.get_msg(cmp, *b, false, "bexpr".to_string(), b.to_string()),
+                    _ => None,
+                }
+            },
+            Not => match args[0].as_ref() {
+                ExpValue(_, Bool(b)) => {
+                    Some(format!("The inner expression evaluates to `{}`. Recall that the expression `! {}` is logically equivalent to `{}`. Consider simplifying.", b, b, !b))
+                },
+                _ => None,
+            },
+            _ => None,
+        };
+
+        if let Some(msg) = msg {
+            self.report(env, &env.get_node_loc(expr.node_id()), &msg);
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.exp
@@ -1,0 +1,190 @@
+
+Diagnostics:
+warning: [lint] The left-hand side of `&&` evaluates to `true`. Recall that the expression `true && bexpr` is logically equivalent to `bexpr`. Consider simplifying.
+  ┌─ tests/model_ast_lints/nonminimal_bool.move:4:13
+  │
+4 │         if (true && x) ();
+  │             ^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `&&` evaluates to `true`. Recall that the expression `bexpr && true` is logically equivalent to `bexpr`. Consider simplifying.
+  ┌─ tests/model_ast_lints/nonminimal_bool.move:5:13
+  │
+5 │         if (x && true) ();
+  │             ^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The left-hand side of `&&` evaluates to `false`. Recall that the expression `false && bexpr` is logically equivalent to `false`. Consider simplifying.
+  ┌─ tests/model_ast_lints/nonminimal_bool.move:6:13
+  │
+6 │         if (false && x) ();
+  │             ^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `&&` evaluates to `false`. Recall that the expression `bexpr && false` is logically equivalent to `false`. Consider simplifying.
+  ┌─ tests/model_ast_lints/nonminimal_bool.move:7:13
+  │
+7 │         if (x && false) ();
+  │             ^^^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The left-hand side of `||` evaluates to `true`. Recall that the expression `true || bexpr` is logically equivalent to `true`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:11:13
+   │
+11 │         if (true || x) ();
+   │             ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `||` evaluates to `true`. Recall that the expression `bexpr || true` is logically equivalent to `true`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:12:13
+   │
+12 │         if (x || true) ();
+   │             ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The left-hand side of `||` evaluates to `false`. Recall that the expression `false || bexpr` is logically equivalent to `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:13:13
+   │
+13 │         if (false || x) ();
+   │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `||` evaluates to `false`. Recall that the expression `bexpr || false` is logically equivalent to `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:14:13
+   │
+14 │         if (x || false) ();
+   │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `<==>` evaluates to `true`. Recall that the expression `bexpr <==> true` is logically equivalent to `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:19:20
+   │
+19 │             assert x <==> true;
+   │                    ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The left-hand side of `<==>` evaluates to `true`. Recall that the expression `true <==> bexpr` is logically equivalent to `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:20:20
+   │
+20 │             assert true <==> x;
+   │                    ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `<==>` evaluates to `false`. Recall that the expression `bexpr <==> false` is logically equivalent to the negation of `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:21:20
+   │
+21 │             assert x <==> false;
+   │                    ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The left-hand side of `<==>` evaluates to `false`. Recall that the expression `false <==> bexpr` is logically equivalent to the negation of `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:22:20
+   │
+22 │             assert false <==> x;
+   │                    ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `==>` evaluates to `true`. Recall that the expression `bexpr ==> true` is logically equivalent to `true`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:28:20
+   │
+28 │             assert x ==> true;
+   │                    ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The left-hand side of `==>` evaluates to `true`. Recall that the expression `true ==> bexpr` is logically equivalent to `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:29:20
+   │
+29 │             assert true ==> x;
+   │                    ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `==>` evaluates to `false`. Recall that the expression `bexpr ==> false` is logically equivalent to the negation of `bexpr`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:30:20
+   │
+30 │             assert x ==> false;
+   │                    ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The left-hand side of `==>` evaluates to `false`. Recall that the expression `false ==> bexpr` is logically equivalent to `true`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:31:20
+   │
+31 │             assert false ==> x;
+   │                    ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The inner expression evaluates to `true`. Recall that the expression `! true` is logically equivalent to `false`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:36:13
+   │
+36 │         if (! true) ();
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The inner expression evaluates to `false`. Recall that the expression `! false` is logically equivalent to `true`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:37:13
+   │
+37 │         if (! false) ();
+   │             ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The inner expression evaluates to `true`. Recall that the expression `! true` is logically equivalent to `false`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:42:13
+   │
+42 │         if (! true && false || true) ();
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `&&` evaluates to `false`. Recall that the expression `bexpr && false` is logically equivalent to `false`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:42:13
+   │
+42 │         if (! true && false || true) ();
+   │             ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
+
+warning: [lint] The right-hand side of `||` evaluates to `true`. Recall that the expression `bexpr || true` is logically equivalent to `true`. Consider simplifying.
+   ┌─ tests/model_ast_lints/nonminimal_bool.move:42:13
+   │
+42 │         if (! true && false || true) ();
+   │             ^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.move
@@ -1,0 +1,49 @@
+module 0xc0ffee::m {
+
+    public fun test_warn_and(x : bool) {
+        if (true && x) ();
+        if (x && true) ();
+        if (false && x) ();
+        if (x && false) ();
+    }
+
+    public fun test_warn_or(x : bool) {
+        if (true || x) ();
+        if (x || true) ();
+        if (false || x) ();
+        if (x || false) ();
+    }
+
+    public fun test_warn_iff(x : bool) {
+        spec {
+            assert x <==> true;
+            assert true <==> x;
+            assert x <==> false;
+            assert false <==> x;
+        }
+    }
+
+    public fun test_warn_implies(x : bool) {
+        spec {
+            assert x ==> true;
+            assert true ==> x;
+            assert x ==> false;
+            assert false ==> x;
+        }
+    }
+
+    public fun test_warn_not() {
+        if (! true) ();
+        if (! false) ();
+    }
+
+
+    public fun combo() {
+        if (! true && false || true) ();
+    }
+
+    #[lint::skip(nonminimal_bool)]
+    fun test_no_warn(): bool {
+        ! true
+    }
+}


### PR DESCRIPTION
## Description
This change adds lint check for additional boolean identities - namely those that a involve boolean literal (true or false) used inside a boolean operator (and, or, not, iff, implies).

## How Has This Been Tested?
New tests were added for each additional case that linter now covers.

## Key Areas to Review
In the modified file "nonminimal_bol.move", see the test for "fun combo". This entire expression is equivalent to true, but the lint rule as it is currently implemented only looks a single operator at a time (so this conditional gets three separate warnings). Is this an issue?

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Third party tools (Move Linter)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation: TODO: Change the documentation in https://aptos.dev/en/build/smart-contracts/linter

<!-- Thank you for your contribution! -->
