### PR TITLE
Correct constant in table item StableKeyRegistry

### DIFF
--- a/types/src/state_store/state_key/registry.rs
+++ b/types/src/state_store/state_key/registry.rs
@@ -253,7 +253,7 @@ impl StateKeyRegistry {
         handle: &TableHandle,
         key: &[u8],
     ) -> &TwoKeyRegistry<TableHandle, Vec<u8>> {
-        &self.table_item_shards[Self::hash_address_and_name(&handle.0, key) % NUM_MODULE_SHARDS]
+        &self.table_item_shards[Self::hash_address_and_name(&handle.0, key) % NUM_TABLE_ITEM_SHARDS]
     }
 
     pub(crate) fn raw(&self, bytes: &[u8]) -> &TwoKeyRegistry<Vec<u8>, ()> {


### PR DESCRIPTION
## Description

This PR updates StableKeyRegistry to use correct constant value for table item shards.

## How Has This Been Tested?

Successfully built.

## Key Areas to Review

`NUM_MODULE_SHARDS` is incorrectly used where `NUM_TABLE_ITEM_SHARDS` should be used. It has worked correctly, because both constant values are same.

```rs
const NUM_MODULE_SHARDS: usize = 8;
const NUM_TABLE_ITEM_SHARDS: usize = 8;
```

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation