### PR TITLE
[Fuzz] Revert --no-rosegment linker flag

### DIFF
--- a/testsuite/fuzzer/.cargo/config.toml
+++ b/testsuite/fuzzer/.cargo/config.toml
@@ -5,4 +5,4 @@ rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", 
 
 [host.x86_64-unknown-linux-gnu]
 linker = "clang"
-rustflags = ["--cfg", "tokio_unstable", "-C", "link-args=-fuse-ld=gold -Wl,--no-keep-files-mapped -Wl,--no-keep-memory -Wl,--no-threads, -Wl,--no-rosegment", "-C", "codegen-units=1", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]
+rustflags = ["--cfg", "tokio_unstable", "-C", "link-args=-fuse-ld=gold -Wl,--no-keep-files-mapped -Wl,--no-keep-memory -Wl,--no-threads", "-C", "codegen-units=1", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]


### PR DESCRIPTION
## Description
Revert --no-rosegment linker flag

## How Has This Been Tested?
N/A

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [X] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [X] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
