### PR TITLE
[OSS-Fuzz] Tentative: limit memory while linking in oss-fuzz

### DIFF
--- a/testsuite/fuzzer/fuzz.sh
+++ b/testsuite/fuzzer/fuzz.sh
@@ -212,7 +212,7 @@ function build-oss-fuzz() {
     clang --version
 
     # Limit the number of parallel jobs to avoid OOM
-    # export CARGO_BUILD_JOBS = 3
+    export CARGO_BUILD_JOBS=4
 
     # Build the fuzz targets
     # Doing one target at the time should prevent OOM, but use all thread while bulding dependecies


### PR DESCRIPTION
## Description
OSS-Fuzz builds are [failing](https://oss-fuzz-build-logs.storage.googleapis.com/index.html#aptos-core) for a couple of days. This might be due to changes on their side, but since KILL-9 in the linking phase previously meant OOM on their machines, it limits the built threat to 4.

## How Has This Been Tested?
Only available on Google systems.

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [X] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
