### PR TITLE
[compiler] Fix cyclic substitution bug

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16336.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16336.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: function returns value of type `()` but `|()|` was expected
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16336.move:4:10
+  │
+4 │         *(&mut x) = x();
+  │          ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16336.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16336.move
@@ -1,0 +1,6 @@
+module 0x42::Test {
+    fun f() {
+        let x : ||(||) = || {||{}};
+        *(&mut x) = x();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_local.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_local.exp
@@ -3,5 +3,5 @@ Diagnostics:
 error: unable to infer type due to cyclic type constraints (try annotating the type)
   ┌─ tests/checking/typing/recursive_local.move:5:9
   │
-5 │         x = (x, 0);
+5 │         x = vector[x];
   │         ^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_local.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_local.move
@@ -2,7 +2,7 @@ address 0x42 {
 module M {
     fun t() {
         let x;
-        x = (x, 0);
+        x = vector[x];
     }
 }
 }

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -1846,7 +1846,7 @@ impl Substitution {
         ty: Type,
     ) -> Result<(), TypeUnificationError> {
         // Specialize the type before binding, to maximize groundness of type terms.
-        let ty = self.specialize(&ty);
+        let mut ty = self.specialize(&ty);
         if let Some(mut constrs) = self.constraints.remove(&var) {
             // Sort constraints to report primary errors first
             constrs.sort_by(|(_, _, c1), (_, _, c2)| c1.compare(c2).reverse());
@@ -1874,9 +1874,17 @@ impl Substitution {
                     },
                 }
             }
+            // New bindings could have been created, so specialize again.
+            ty = self.specialize(&ty)
         }
-        self.subs.insert(var, ty);
-        Ok(())
+
+        // Occurs check
+        if ty.get_vars().contains(&var) {
+            Err(TypeUnificationError::CyclicSubstitution(Type::Var(var), ty))
+        } else {
+            self.subs.insert(var, ty);
+            Ok(())
+        }
     }
 
     /// Evaluates whether the given type satisfies the constraint, discharging the constraint.
@@ -1906,7 +1914,7 @@ impl Substitution {
         if matches!(ty, Type::Error) {
             Ok(())
         } else if let Type::Var(other_var) = ty {
-            // Transfer constraint on to other variable, which we assert to be free
+            // Transfer constraint on to other variable which we assert to be free
             debug_assert!(!self.subs.contains_key(other_var));
             self.add_constraint(context, *other_var, loc.clone(), order, c, ctx_opt)
         } else if c.propagate_over_reference() && ty.is_reference() {
@@ -2568,38 +2576,16 @@ impl Substitution {
                     break;
                 }
             }
-            // Skip the cycle check if we are unifying the same two variables.
+            // Skip binding if we are unifying the same two variables.
             if t1 == &t2 {
-                return Ok(Some(t1.clone()));
-            }
-            // Cycle check.
-            if !self.occurs_check(&t2, *v1) {
+                Ok(Some(t1.clone()))
+            } else {
                 self.bind(context, *v1, variance, order, t2.clone())?;
                 Ok(Some(t2))
-            } else {
-                Err(TypeUnificationError::CyclicSubstitution(
-                    self.specialize(t1),
-                    self.specialize(&t2),
-                ))
             }
         } else {
             Ok(None)
         }
-    }
-
-    /// Check whether the variables occurs in the type, or in any assignment to variables in the
-    /// type.
-    fn occurs_check(&self, ty: &Type, var: u32) -> bool {
-        ty.get_vars().iter().any(|v| {
-            if v == &var {
-                return true;
-            }
-            if let Some(sty) = self.subs.get(v) {
-                self.occurs_check(sty, var)
-            } else {
-                false
-            }
-        })
     }
 }
 


### PR DESCRIPTION
## Description

The `Substitution::bind` function could create a cyclic substitution by evaluating constraints after the occurrs check and before the variable was assigned, causing stackoverflow crashes. Kind of a reentrancy problem.

This moves the occurs check after constraint evaluation. As we are specializing types before assignment since a while anyway, the occurs check logic could be simplified.

Closes #16336

## How Has This Been Tested?

New test

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

