### PR TITLE
[metrics] count debug logs

### DIFF
--- a/crates/aptos-logger/src/aptos_logger.rs
+++ b/crates/aptos-logger/src/aptos_logger.rs
@@ -13,8 +13,8 @@ use crate::{
     sample,
     sample::SampleRate,
     telemetry_log_writer::{TelemetryLog, TelemetryLogWriter},
-    Event, Filter, Key, Level, LevelFilter, Metadata, ERROR_LOG_COUNT, INFO_LOG_COUNT,
-    WARN_LOG_COUNT,
+    Event, Filter, Key, Level, LevelFilter, Metadata, DEBUG_LOG_COUNT, ERROR_LOG_COUNT,
+    INFO_LOG_COUNT, WARN_LOG_COUNT,
 };
 use aptos_infallible::RwLock;
 use backtrace::Backtrace;
@@ -622,6 +622,7 @@ impl LoggerService {
                         Level::Error => ERROR_LOG_COUNT.inc(),
                         Level::Warn => WARN_LOG_COUNT.inc(),
                         Level::Info => INFO_LOG_COUNT.inc(),
+                        Level::Debug => DEBUG_LOG_COUNT.inc(),
                         _ => {},
                     }
 

--- a/crates/aptos-logger/src/counters.rs
+++ b/crates/aptos-logger/src/counters.rs
@@ -27,6 +27,8 @@ pub static WARN_LOG_COUNT: Lazy<IntCounter> =
     Lazy::new(|| register_int_counter!("aptos_warn_log_count", "Count of warn!() logs").unwrap());
 pub static INFO_LOG_COUNT: Lazy<IntCounter> =
     Lazy::new(|| register_int_counter!("aptos_info_log_count", "Count of info!() logs").unwrap());
+pub static DEBUG_LOG_COUNT: Lazy<IntCounter> =
+    Lazy::new(|| register_int_counter!("aptos_debug_log_count", "Count of debug!() logs").unwrap());
 
 /// Metric for when we fail to log during sending to the queue
 pub static STRUCT_LOG_QUEUE_ERROR_COUNT: Lazy<IntCounter> = Lazy::new(|| {

--- a/crates/aptos-logger/src/lib.rs
+++ b/crates/aptos-logger/src/lib.rs
@@ -169,4 +169,4 @@ pub use metadata::{Level, Metadata};
 pub use security::SecurityEvent;
 
 mod counters;
-pub use counters::{ERROR_LOG_COUNT, INFO_LOG_COUNT, WARN_LOG_COUNT};
+pub use counters::{DEBUG_LOG_COUNT, ERROR_LOG_COUNT, INFO_LOG_COUNT, WARN_LOG_COUNT};


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Add a counter for debug logs. This way we can get a handle of increasing log volume from the node.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Test on PR. Also canary via https://github.com/aptos-labs/aptos-core/pull/16374 with debug logs enabled. Check for possible performance regressions that come from spammy logs

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [x] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
