### PR TITLE
Fix CLI e2e test case `test_account_fund_with_faucet`

### DIFF
--- a/crates/aptos/e2e/cases/account.py
+++ b/crates/aptos/e2e/cases/account.py
@@ -33,7 +33,7 @@ async def test_account_fund_with_faucet(run_helper: RunHelper, test_name=None):
             run_helper.get_account_info().account_address
         )
     )
-    if balance == amount_in_octa:
+    if balance != amount_in_octa:
         raise TestError(
             f"Account {run_helper.get_account_info().account_address} has balance {balance}, expected {amount_in_octa}"
         )


### PR DESCRIPTION
## Description

If I understand the test correctly, it initializes an account (with 0 octas), then funds it with the faucet and is supposed to test that the balance afterwards is equal to the amount transferred. Therefore the error test should be `!=` instead of `==`.
