### PR TITLE
Increase forge test upgrade delay to 5 mins

### DIFF
--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -29,7 +29,7 @@ use aptos_api_types::{
     UserTransaction, VersionedEvent, ViewFunction, ViewRequest,
 };
 use aptos_crypto::HashValue;
-use aptos_logger::{debug, info, sample, sample::SampleRate};
+use aptos_logger::{debug, info, sample, sample::SampleRate, warn};
 use aptos_types::{
     account_address::AccountAddress,
     account_config::{AccountResource, NewBlockEvent, CORE_CODE_ADDRESS},
@@ -785,7 +785,7 @@ impl Client {
                 Ok(WaitForTransactionResult::NotFound(error)) => {
                     sample!(
                         SampleRate::Duration(Duration::from_secs(5)),
-                        debug!(
+                        warn!(
                             "Cannot yet find transaction in mempool on {:?}, continuing to wait, error is {:?}.",
                             self.path_prefix_string(), error
                         )

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -783,6 +783,13 @@ impl Client {
                     chain_timestamp_usecs = Some(state.timestamp_usecs);
                 },
                 Ok(WaitForTransactionResult::NotFound(error)) => {
+                    sample!(
+                        SampleRate::Duration(Duration::from_secs(5)),
+                        debug!(
+                            "Cannot yet find transaction in mempool on {:?}, continuing to wait, error is {:?}.",
+                            self.path_prefix_string(), error
+                        )
+                    );
                     if let RestError::Api(aptos_error_response) = error {
                         if let Some(state) = aptos_error_response.state {
                             if expiration_timestamp_secs <= state.timestamp_usecs / 1_000_000 {

--- a/testsuite/testcases/src/compatibility_test.rs
+++ b/testsuite/testcases/src/compatibility_test.rs
@@ -26,7 +26,7 @@ impl Test for SimpleValidatorUpgrade {
 impl NetworkTest for SimpleValidatorUpgrade {
     async fn run<'a>(&self, ctxa: NetworkContextSynchronizer<'a>) -> Result<()> {
         let upgrade_wait_for_healthy = true;
-        let upgrade_node_delay = Duration::from_secs(60);
+        let upgrade_node_delay = Duration::from_secs(300);
         let upgrade_max_wait = Duration::from_secs(40);
 
         let epoch_duration = Duration::from_secs(Self::EPOCH_DURATION_SECS);


### PR DESCRIPTION
## Description

Temporarily increase the upgrade delay from 1m to 5m to observe if it stabilizes the test. 


