### PR TITLE
[Linter] Added support for almost swapped lint check

### DIFF
--- a/third_party/move/tools/move-linter/src/lib.rs
+++ b/third_party/move/tools/move-linter/src/lib.rs
@@ -3,6 +3,7 @@
 
 mod model_ast_lints;
 mod stackless_bytecode_lints;
+mod utils;
 
 use move_compiler_v2::external_checks::{ExpChecker, ExternalChecks, StacklessBytecodeChecker};
 use std::sync::Arc;

--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -3,6 +3,7 @@
 
 //! This module (and its submodules) contain various model-AST-based lint checks.
 
+mod almost_swapped;
 mod blocks_in_conditions;
 mod needless_bool;
 mod needless_deref_ref;
@@ -19,6 +20,7 @@ use move_compiler_v2::external_checks::ExpChecker;
 /// Returns a default pipeline of "expression linters" to run.
 pub fn get_default_linter_pipeline() -> Vec<Box<dyn ExpChecker>> {
     vec![
+        Box::<almost_swapped::AlmostSwapped>::default(),
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
         Box::<needless_bool::NeedlessBool>::default(),
         Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/almost_swapped.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/almost_swapped.rs
@@ -1,0 +1,67 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for expression patterns
+//! that look like a failed swap attempt. This currently only detects simple access
+//! patterns such as `a = b; b = a;`, and `a.b = c.d; c.d = a.b;`. Notably, this does
+//! not detect patterns involving non-builtin functions (including vector operations)
+//! nor does it detect patterns that deal with global storage. Support for these cases
+//! may be added in the future.
+use crate::utils;
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{Exp, ExpData, ExpData::Sequence, Pattern},
+    model::{GlobalEnv, Loc},
+};
+
+#[derive(Default)]
+pub struct AlmostSwapped;
+
+impl ExpChecker for AlmostSwapped {
+    fn get_name(&self) -> String {
+        "almost_swapped".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+        if let Sequence(_, exprs) = expr {
+            for pair in exprs.windows(2) {
+                let (first, second) = (&pair[0], &pair[1]);
+                let (lhs1, rhs1, lhs2, rhs2) = match (first.as_ref(), second.as_ref()) {
+                    (ExpData::Mutate(_, e1, e2), ExpData::Mutate(_, e3, e4)) => {
+                        (e1.clone(), e2.clone(), e3.clone(), e4.clone())
+                    },
+                    // The order of expressions does not matter
+                    (ExpData::Mutate(_, e1, e2), ExpData::Assign(_, Pattern::Var(_, v1), e4))
+                    | (ExpData::Assign(_, Pattern::Var(_, v1), e4), ExpData::Mutate(_, e1, e2)) => {
+                        // The node id isn't used, so any node id will work.
+                        let new_local = Exp::from(ExpData::LocalVar(e4.node_id(), *v1));
+                        (e1.clone(), e2.clone(), new_local, e4.clone())
+                    },
+                    (
+                        ExpData::Assign(_, Pattern::Var(_, v1), e2),
+                        ExpData::Assign(_, Pattern::Var(_, v2), e4),
+                    ) => {
+                        // The node id isn't used, so any node id will work.
+                        let l1 = Exp::from(ExpData::LocalVar(e2.node_id(), *v1));
+                        let l2 = Exp::from(ExpData::LocalVar(e4.node_id(), *v2));
+                        (l1, e2.clone(), l2, e4.clone())
+                    },
+                    _ => continue,
+                };
+                if utils::is_simple_access_equal(lhs1.as_ref(), rhs2.as_ref())
+                    && utils::is_simple_access_equal(rhs1.as_ref(), lhs2.as_ref())
+                {
+                    let new_loc = Loc::enclosing(&[
+                        env.get_node_loc(first.node_id()),
+                        env.get_node_loc(second.node_id()),
+                    ]);
+                    self.report(
+                        env,
+                        &new_loc,
+                        "This looks like a swap, but one assignment overwrites the other.",
+                    );
+                }
+            }
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/src/utils.rs
+++ b/third_party/move/tools/move-linter/src/utils.rs
@@ -1,0 +1,35 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module holds utility functions for the Move linter.
+
+use move_model::ast::{ExpData, Operation};
+
+/// Returns `true` if two expressions represent the same simple access pattern.
+/// This compares nested `Select`, `Borrow`, and local variable references for structural equality.
+/// `Deref` calls can occur anywhere without affecting the result.
+/// Patterns that use global storage or non-builtin function (including vector operations)
+/// are not considered simple access patterns for the purpose of this function and return `false`.
+pub(crate) fn is_simple_access_equal(expr1: &ExpData, expr2: &ExpData) -> bool {
+    match (expr1, expr2) {
+        (ExpData::Call(_, Operation::Deref, args), expr)
+        | (expr, ExpData::Call(_, Operation::Deref, args)) => {
+            is_simple_access_equal(&args[0], expr)
+        },
+        (ExpData::Call(_, op1, args1), ExpData::Call(_, op2, args2)) => {
+            op1 == op2
+                && matches!(
+                    op1,
+                    Operation::Select(_, _, _)
+                        | Operation::Borrow(_)
+                        | Operation::SelectVariants(_, _, _)
+                )
+                && args1
+                    .iter()
+                    .zip(args2.iter())
+                    .all(|(a1, a2)| is_simple_access_equal(a1, a2))
+        },
+        (ExpData::LocalVar(_, s1), ExpData::LocalVar(_, s2)) => s1 == s2,
+        _ => false,
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/almost_swapped.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/almost_swapped.exp
@@ -1,0 +1,151 @@
+
+Diagnostics:
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:11:5
+   │
+11 │ ╭     x = y;
+12 │ │     y = x;
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:19:5
+   │
+19 │ ╭     x1 = x2;
+20 │ │     x2 = x1;
+   │ ╰───────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:27:5
+   │
+27 │ ╭     x1.f = x2.f;
+28 │ │     x2.f = x1.f;
+   │ ╰───────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:34:5
+   │
+34 │ ╭     y1.x1 = y2.x1;
+35 │ │     y2.x1 = y1.x1;
+   │ ╰─────────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:36:5
+   │
+36 │ ╭     y1.x1.f = y2.x1.f;
+37 │ │     y2.x1.f = y1.x1.f;
+   │ ╰─────────────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:44:5
+   │
+44 │ ╭     y2 = *y3;
+45 │ │     *y3 = y2;
+   │ ╰────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:52:5
+   │
+52 │ ╭     *y3 = y2;
+53 │ │     y2 = *y3;
+   │ ╰────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:61:5
+   │
+61 │ ╭     (*y3).x2 = y2.x2;
+62 │ │     y2.x2 = (*y3).x2;
+   │ ╰────────────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:70:5
+   │
+70 │ ╭     (*y3).x2 = (*y4).x2;
+71 │ │     y4.x2 = y3.x2;
+   │ ╰─────────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:72:5
+   │
+72 │ ╭     (*y3) = *y4;
+73 │ │     y4 = y3;
+   │ ╰───────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:80:5
+   │
+80 │ ╭     pair1.0 = pair2.0;
+81 │ │     pair2.0 = pair1.0;
+   │ ╰─────────────────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:87:5
+   │
+87 │ ╭     x = y;
+88 │ │     y = x;
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:88:5
+   │
+88 │ ╭     y = x;
+89 │ │     x = y;
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+   ┌─ tests/model_ast_lints/almost_swapped.move:98:5
+   │
+98 │ ╭     v1 = v2;
+99 │ │     v2 = v1;
+   │ ╰───────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.
+
+warning: [lint] This looks like a swap, but one assignment overwrites the other.
+    ┌─ tests/model_ast_lints/almost_swapped.move:111:5
+    │
+111 │ ╭     f = e.x;
+112 │ │     e.x = f;
+    │ ╰───────────^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(almost_swapped)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#almost_swapped.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/almost_swapped.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/almost_swapped.move
@@ -1,0 +1,164 @@
+module 0xc0ffee::m {
+  use std::vector;
+
+  struct X has drop, copy { f: u64 }
+  struct Y has drop, copy { x1: X, x2: X }
+  struct Pair(u64, u8) has copy, drop;
+
+  public fun assign_assign_swap_var() {
+    let x : u64;
+    let y : u64 = 2;
+    x = y;
+    y = x;
+    if (y == x) ();
+  }
+
+  public fun assign_assign_swap_struct() {
+    let x1 : X;
+    let x2 = X {f : 2};
+    x1 = x2;
+    x2 = x1;
+    if (x2 == x1) ();
+  }
+
+  public fun mutate_mutate_swap_struct() {
+    let x1 = X {f : 4};
+    let x2 = X {f : 2};
+    x1.f = x2.f;
+    x2.f = x1.f;
+  }
+
+  public fun mutate_mutate_swap_struct_deep() {
+    let y1 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y2 = Y {x1 : X {f : 1}, x2 : X {f : 3}};
+    y1.x1 = y2.x1;
+    y2.x1 = y1.x1;
+    y1.x1.f = y2.x1.f;
+    y2.x1.f = y1.x1.f;
+  }
+
+  public fun assign_mutate_swap() {
+    let y1 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y2 : Y;
+    let y3 = &mut y1;
+    y2 = *y3;
+    *y3 = y2;
+  }
+
+  public fun mutate_assign_swap() {
+    let y1 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y2 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y3 = &mut y1;
+    *y3 = y2;
+    y2 = *y3;
+    if (y2 == y1) ();
+  }
+
+  public fun inner_swap() {
+    let y1 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y2 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y3 = &y1;
+    (*y3).x2 = y2.x2;
+    y2.x2 = (*y3).x2;
+  }
+
+  public fun inner_deref() {
+    let y1 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y2 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y3 = &mut y1;
+    let y4 = &mut y2;
+    (*y3).x2 = (*y4).x2;
+    y4.x2 = y3.x2;
+    (*y3) = *y4;
+    y4 = y3;
+    if (y4 == y3) ()
+  }
+
+  public fun positional_struct_swap() {
+    let pair1 = Pair(4, 2);
+    let pair2 = Pair(1, 3);
+    pair1.0 = pair2.0;
+    pair2.0 = pair1.0;
+  }
+
+  public fun double_swap() {
+    let x : u64;
+    let y : u64 = 2;
+    x = y;
+    y = x;
+    x = y;
+    if (y == x) ();
+  }
+
+  public fun entire_vector_swap() {
+    let v1 = vector::empty<u64>();
+    vector::push_back(&mut v1, 4);
+    let v2 = vector::empty<u64>();
+    vector::push_back(&mut v2, 2);
+    v1 = v2;
+    v2 = v1;
+    if (v1 == v2) ();
+  }
+
+  enum E has drop {
+    A { x: u64 },
+    B { x: u64 },
+  }
+
+  fun enum_variant_swap() {
+    let e = E::A { x: 5 };
+    let f : u64;
+    f = e.x;
+    e.x = f;
+  }
+
+  public fun no_swap_no_warn() {
+    let x : u64;
+    let y : u64 = 2;
+    x = y;
+    y = x + 1;
+    if (y == x) ();
+    let y1 = Y {x1 : X {f : 4}, x2 : X {f : 2}};
+    let y2 = Y {x1 : X {f : 1}, x2 : X {f : 3}};
+    y1.x1 = y2.x1;
+    y2.x1 = y1.x2;
+  }
+
+  public fun out_of_scope_vector_swap_no_warn() {
+    let v1 = vector::empty<u64>();
+    vector::push_back(&mut v1, 4);
+    let v2 = vector::empty<u64>();
+    vector::push_back(&mut v2, 2);
+    v1[0] = v2[0];
+    v2[0] = v1[0];
+  }
+
+  public fun out_of_scope_vector_swap_no_warn_2(): vector<u64> {
+    let v = vector[1, 2];
+    v[0] = v[1];
+    v[1] = v[0];
+    v
+  }
+
+  #[lint::skip(needless_mutable_reference)]
+  fun iden(x : &mut X): &mut X {
+    x
+  }
+
+  public fun out_of_scope_function_swap_no_warn() {
+    let x1 = X {f : 4};
+    let x2 = X {f : 2};
+    *iden(&mut x1) = x2;
+    x2 = *iden(&mut x1);
+    if (x2 == x1) ();
+  }
+
+  #[lint::skip(almost_swapped)]
+  public fun test_no_warn() {
+    let x : u64;
+    let y : u64 = 2;
+    x = y;
+    y = x;
+    if (y == x) ();
+  }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
This adds a linting rule for catching "almost swapped" sequences of assignments (such as `a = b; b = a;`). As implemented, this specifically targets simple assignments: those that involve local vars or structs, and do not contain any non-builtin functions (including vector functions)/global storage accesses.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

A testing file was added (almost_swapped.move).

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->
1) Is utils setup in a good way? I made a utils file because other lint rules (such as self assignment, `a = a;`) is likely to use this same functionality. I am new to rust though, and am not sure if this is the idiomatic way to handle such functions.
2) This lint rule will catch `a = a; a = a;`. The self-assignment rule (yet to be added) will also catch this. Is that fine? Should I disable almost_swapped from catching self-assignment swaps?
3) In line 59 of almost_swapped.rs, I opt to always remove `deref` if seen on rhs expression. This is based on my belief that `deref` never occur as the outer-most element of lhs expression in an `assign`/`mutate` command. Is this correct? Basically, is this greedy removal of `deref` fine
4) Similarly, it is my understanding that a `deref` will always have exactly a single elements in the "`args`" field. Is this also correct?
5) Is the error message too specific? It looks like a new operator, `mem::swap` is being released soon. And this should perhaps be the idiomatic way to swap certain objects.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Move Linter

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation (TODO: [Dev Docs](https://aptos.dev/en/build/smart-contracts/linter#almost_swapped)

<!-- Thank you for your contribution! -->
