### PR TITLE
[forge] Make duration a real timeout

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -270,7 +270,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: realistic_env_max_load
       IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_RUNNER_DURATION_SECS: 480
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-e2e
       # Use the cache ID as the Forge namespace so we can limit Forge test concurrency on k8s, since Forge
       # test lifecycle is separate from that of GHA. This protects us from the case where many Forge tests are triggered
@@ -353,7 +353,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
       IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-compat
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' }}
@@ -383,7 +383,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
       IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 3600
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-framework-upgrade
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       SKIP_JOB: ${{ !contains(github.event.pull_request.labels.*.name, 'CICD:run-framework-upgrade-test') && (needs.test-target-determinator.outputs.run_framework_upgrade_test == 'false') }}
@@ -406,7 +406,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: consensus_only_realistic_env_max_tps
       IMAGE_TAG: consensus_only_perf_test_${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: consensus-only-realistic-env-max-tps
       FORGE_NAMESPACE: forge-consensus-only-realistic-env-max-tps-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
 
@@ -428,7 +428,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: multiregion_benchmark_test
       IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-multiregion-test
       FORGE_NAMESPACE: forge-multiregion-test-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       FORGE_CLUSTER_NAME: forge-multiregion

--- a/.github/workflows/forge-continuous-land-blocking-test.yaml
+++ b/.github/workflows/forge-continuous-land-blocking-test.yaml
@@ -84,7 +84,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: realistic_env_max_load
       IMAGE_TAG: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
-      FORGE_RUNNER_DURATION_SECS: 480
+      FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_NAMESPACE: forge-e2e-${{ needs.determine-docker-build-metadata.outputs.FORGE_NAMESPACE_SUFFIX }}
       SEND_RESULTS_TO_TRUNK: true
 
@@ -143,7 +143,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
       IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.FORGE_NAMESPACE_SUFFIX }}
       SEND_RESULTS_TO_TRUNK: true
 
@@ -160,6 +160,6 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: framework_upgrade
       IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_NAMESPACE: forge-framework-upgrade-${{ needs.determine-docker-build-metadata.outputs.FORGE_NAMESPACE_SUFFIX }}
       SEND_RESULTS_TO_TRUNK: true

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -27,7 +27,7 @@ on:
       FORGE_RUNNER_DURATION_SECS:
         required: false
         type: number
-        default: 480
+        default: 1800
         description: Duration of the forge test run
       FORGE_TEST_SUITE:
         required: false

--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -24,12 +24,17 @@ use aptos_sdk::{
 use rand::{rngs::OsRng, Rng, SeedableRng};
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 
 #[async_trait::async_trait]
 pub trait AptosTest: Test {
     /// Executes the test against the given context.
     async fn run<'t>(&self, ctx: &mut AptosContext<'t>) -> Result<()>;
+
+    async fn run_with_timeout<'t>(&self, ctx: &mut AptosContext<'t>, timeout: Duration) -> Result<()> {
+        let timeout = tokio::time::timeout(timeout, self.run(ctx));
+        timeout.await.map_err(|_| anyhow!("Test timed out"))?
+    }
 }
 
 pub struct AptosContext<'t> {

--- a/testsuite/forge/src/interface/aptos.rs
+++ b/testsuite/forge/src/interface/aptos.rs
@@ -31,7 +31,11 @@ pub trait AptosTest: Test {
     /// Executes the test against the given context.
     async fn run<'t>(&self, ctx: &mut AptosContext<'t>) -> Result<()>;
 
-    async fn run_with_timeout<'t>(&self, ctx: &mut AptosContext<'t>, timeout: Duration) -> Result<()> {
+    async fn run_with_timeout<'t>(
+        &self,
+        ctx: &mut AptosContext<'t>,
+        timeout: Duration,
+    ) -> Result<()> {
         let timeout = tokio::time::timeout(timeout, self.run(ctx));
         timeout.await.map_err(|_| anyhow!("Test timed out"))?
     }

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -3,12 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Test;
-use anyhow::anyhow;
 use crate::{
     prometheus_metrics::LatencyBreakdown,
     success_criteria::{SuccessCriteria, SuccessCriteriaChecker},
     CoreContext, Result, Swarm, TestReport,
 };
+use anyhow::anyhow;
 use aptos_transaction_emitter_lib::{EmitJobRequest, TxnStats};
 use async_trait::async_trait;
 use std::{future::Future, sync::Arc, time::Duration};
@@ -22,7 +22,11 @@ pub trait NetworkTest: Test {
     /// Executes the test against the given context.
     async fn run<'t>(&self, ctx: NetworkContextSynchronizer<'t>) -> Result<()>;
 
-    async fn run_with_timeout<'t>(&self, ctx: NetworkContextSynchronizer<'t>, timeout: Duration) -> Result<()> {
+    async fn run_with_timeout<'t>(
+        &self,
+        ctx: NetworkContextSynchronizer<'t>,
+        timeout: Duration,
+    ) -> Result<()> {
         let timeout = tokio::time::timeout(timeout, self.run(ctx));
         timeout.await.map_err(|_| anyhow!("Test timed out"))?
     }

--- a/testsuite/forge/src/interface/network.rs
+++ b/testsuite/forge/src/interface/network.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Test;
+use anyhow::anyhow;
 use crate::{
     prometheus_metrics::LatencyBreakdown,
     success_criteria::{SuccessCriteria, SuccessCriteriaChecker},
@@ -20,6 +21,11 @@ use tokio::runtime::{Handle, Runtime};
 pub trait NetworkTest: Test {
     /// Executes the test against the given context.
     async fn run<'t>(&self, ctx: NetworkContextSynchronizer<'t>) -> Result<()>;
+
+    async fn run_with_timeout<'t>(&self, ctx: NetworkContextSynchronizer<'t>, timeout: Duration) -> Result<()> {
+        let timeout = tokio::time::timeout(timeout, self.run(ctx));
+        timeout.await.map_err(|_| anyhow!("Test timed out"))?
+    }
 }
 
 #[derive(Clone)]

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -305,8 +305,9 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     swarm.chain_info().into_aptos_public_info(),
                     &mut report,
                 );
-                let result = process_test_result(runtime.block_on(
-                    tokio::time::timeout(test_duration, test.run(&mut aptos_ctx))));
+                let result = process_test_result(
+                    runtime.block_on(tokio::time::timeout(test_duration, test.run(&mut aptos_ctx))).unwrap()
+                );
                 report.report_text(result.to_string());
                 summary.handle_result(test.details(), result)?;
             }
@@ -340,7 +341,9 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 let handle = network_ctx.runtime.handle().clone();
                 let _handle_context = handle.enter();
                 let network_ctx = NetworkContextSynchronizer::new(network_ctx, handle.clone());
-                let result = process_test_result(handle.block_on(tokio::time::timeout(test_duration, test.run(network_ctx.clone()))));
+                let result = process_test_result(
+                    handle.block_on(tokio::time::timeout(test_duration, test.run(network_ctx.clone()))).unwrap()
+                );
                 // explicitly keep network context in scope so that its created tokio Runtime drops after all the stuff has run.
                 let NetworkContextSynchronizer { ctx, handle } = network_ctx;
                 drop(handle);

--- a/testsuite/forge/src/runner.rs
+++ b/testsuite/forge/src/runner.rs
@@ -306,7 +306,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                     &mut report,
                 );
                 let result = process_test_result(
-                    runtime.block_on(tokio::time::timeout(test_duration, test.run(&mut aptos_ctx))).unwrap()
+                    runtime.block_on(test.run_with_timeout(&mut aptos_ctx, test_duration))
                 );
                 report.report_text(result.to_string());
                 summary.handle_result(test.details(), result)?;
@@ -342,7 +342,7 @@ impl<'cfg, F: Factory> Forge<'cfg, F> {
                 let _handle_context = handle.enter();
                 let network_ctx = NetworkContextSynchronizer::new(network_ctx, handle.clone());
                 let result = process_test_result(
-                    handle.block_on(tokio::time::timeout(test_duration, test.run(network_ctx.clone()))).unwrap()
+                    handle.block_on(test.run_with_timeout(network_ctx.clone(), test_duration))
                 );
                 // explicitly keep network context in scope so that its created tokio Runtime drops after all the stuff has run.
                 let NetworkContextSynchronizer { ctx, handle } = network_ctx;


### PR DESCRIPTION
## Description
Added timeouts to Forge test runner to prevent tests from running indefinitely. This change implements a global timeout mechanism for test execution by:

1. Tracking the start time of the test suite
2. Adding timeout wrappers around swarm launch and test execution
3. Calculating appropriate test durations based on elapsed time plus the global duration

The implementation uses `tokio::time::timeout` to enforce time limits on async operations, ensuring tests complete within reasonable timeframes.

## How Has This Been Tested?
The existing test infrastructure validates the functionality of the runner. The timeout mechanism is applied to the test execution flow without changing the underlying test behavior.

Compat test successfully times out!

https://github.com/aptos-labs/aptos-core/actions/runs/14652378928/attempts/1#summary-41121640380

## Key Areas to Review
- The timeout calculation logic in the test runner, particularly how test durations are calculated based on elapsed time
- The implementation of timeouts for different test types (Aptos tests and Network tests)
- Note that Admin tests don't have timeouts as they're not async and should be quick to execute

## Type of Change
- [x] Performance improvement
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure
- [x] Other (Test Infrastructure)

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I tested both happy and unhappy path of the functionality