### PR TITLE
[forge] Bump timeout for compat

### DIFF
--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -353,7 +353,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
       IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 1800
       COMMENT_HEADER: forge-compat
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.targetCacheId }}
       SKIP_JOB: ${{ needs.file_change_determinator.outputs.only_docs_changed == 'true' }}

--- a/.github/workflows/forge-continuous-land-blocking-test.yaml
+++ b/.github/workflows/forge-continuous-land-blocking-test.yaml
@@ -143,7 +143,7 @@ jobs:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
       FORGE_TEST_SUITE: compat
       IMAGE_TAG: ${{ needs.fetch-last-released-docker-image-tag.outputs.IMAGE_TAG }}
-      FORGE_RUNNER_DURATION_SECS: 300
+      FORGE_RUNNER_DURATION_SECS: 1800
       FORGE_NAMESPACE: forge-compat-${{ needs.determine-docker-build-metadata.outputs.FORGE_NAMESPACE_SUFFIX }}
       SEND_RESULTS_TO_TRUNK: true
 


### PR DESCRIPTION
## Description
Increased the `FORGE_RUNNER_DURATION_SECS` for compatibility tests from 300 seconds (5 minutes) to 1800 seconds (30 minutes) in both the Docker build test workflow and the continuous land-blocking test workflow. This change allows compatibility tests to run for a longer duration, providing more thorough testing.

Previously in https://github.com/aptos-labs/aptos-core/pull/16387 the upgrade time was increased for debugging and that has caused all compat tests to timeout

## How Has This Been Tested?
The change modifies CI workflow parameters and will be tested in the CI pipeline itself when compatibility tests run with the new duration setting.

## Key Areas to Review
- Verify that the increased test duration is appropriate for compatibility testing needs
- Confirm that CI resources can accommodate the longer test runs

## Type of Change
- [x] Performance improvement
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Developer Infrastructure

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation