### PR TITLE
Git ignore rule for cursor rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,6 @@ ecosystem/indexer-grpc/indexer-transaction-generator/*.yaml
 
 # ignore antithesis
 genesis_antithesis_*/
+
+# ignore cursor rules
+.cursor/rules


### PR DESCRIPTION
## Description
Only touches the .gitignore to ignore local cursor rules directory.