### PR TITLE
fix issue #16195

### DIFF
--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs
@@ -2604,7 +2604,7 @@ fn parse_type(context: &mut Context) -> Result<Type, Box<Diagnostic>> {
 fn is_start_of_type(context: &mut Context) -> bool {
     matches!(
         context.tokens.peek(),
-        Tok::LParen | Tok::Amp | Tok::AmpMut | Tok::Pipe | Tok::Identifier
+        Tok::LParen | Tok::Amp | Tok::AmpMut | Tok::Pipe | Tok::PipePipe | Tok::Identifier
     )
 }
 

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195.exp
@@ -1,0 +1,387 @@
+// -- Model dump before bytecode pipeline
+module 0xc0ffee::m {
+    struct Bug16195 {
+        0: |()||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant1 {
+        0: |()||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant2 {
+        0: |()||()||()||()||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant3 {
+        0: ||()|||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant4 {
+        0: ||()|||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant5 {
+        0: |()||()|bool with copy + drop,
+    }
+    struct Bug16195_variant6 {
+        0: |()||()||()||()||()|bool with copy + drop,
+    }
+    struct Bug16195_variant7 {
+        0: |()||bool|bool with copy + drop,
+    }
+    struct Bug16195_variant8 {
+        0: |bool||()|bool with copy + drop,
+    }
+    public fun test_bug16195(): u64 {
+        {
+          let f: Bug16195 = pack m::Bug16195(closure#0m::__lambda__2__test_bug16195());
+          ((f)())()
+        }
+    }
+    public fun test_bug16195_OR_mix1(a: bool): bool {
+        {
+          let f: Bug16195_variant5 = pack m::Bug16195_variant5(closure#0m::__lambda__2__test_bug16195_OR_mix1());
+          Or(((f)())(), a)
+        }
+    }
+    public fun test_bug16195_OR_mix2(a: bool,b: bool): bool {
+        {
+          let f: Bug16195_variant5 = pack m::Bug16195_variant5(closure#0m::__lambda__2__test_bug16195_OR_mix2());
+          Or(Or(((f)())(), a), b)
+        }
+    }
+    public fun test_bug16195_OR_mix3(a: bool): bool {
+        {
+          let f: Bug16195_variant6 = pack m::Bug16195_variant6(closure#0m::__lambda__5__test_bug16195_OR_mix3());
+          Or((((((f)())())())())(), a)
+        }
+    }
+    public fun test_bug16195_OR_mix4(a: bool,b: bool): bool {
+        {
+          let f: Bug16195_variant6 = pack m::Bug16195_variant6(closure#0m::__lambda__5__test_bug16195_OR_mix4());
+          Or(Or((((((f)())())())())(), a), b)
+        }
+    }
+    public fun test_bug16195_OR_mix5(a: bool): bool {
+        {
+          let f: Bug16195_variant7 = pack m::Bug16195_variant7(closure#1m::__lambda__2__test_bug16195_OR_mix5(a));
+          Or(((f)())(true), a)
+        }
+    }
+    public fun test_bug16195_OR_mix6(a: bool): bool {
+        {
+          let f: Bug16195_variant8 = pack m::Bug16195_variant8(closure#0m::__lambda__2__test_bug16195_OR_mix6());
+          Or(((f)(true))(), a)
+        }
+    }
+    public fun test_bug16195_variant1(): u64 {
+        {
+          let f: Bug16195_variant1 = pack m::Bug16195_variant1(closure#0m::__lambda__2__test_bug16195_variant1());
+          ((f)())()
+        }
+    }
+    public fun test_bug16195_variant2(): u64 {
+        {
+          let f: Bug16195_variant2 = pack m::Bug16195_variant2(closure#0m::__lambda__5__test_bug16195_variant2());
+          (((((f)())())())())()
+        }
+    }
+    public fun test_bug16195_variant3(): u64 {
+        {
+          let _arg: |()| = closure#0m::__lambda__1__test_bug16195_variant3();
+          {
+            let f: Bug16195_variant3 = pack m::Bug16195_variant3(closure#0m::__lambda__3__test_bug16195_variant3());
+            ((f)(_arg))()
+          }
+        }
+    }
+    public fun test_bug16195_variant4(): u64 {
+        {
+          let _arg: |()| = closure#0m::__lambda__1__test_bug16195_variant4();
+          {
+            let f: Bug16195_variant4 = pack m::Bug16195_variant4(closure#0m::__lambda__3__test_bug16195_variant4());
+            ((f)(_arg))()
+          }
+        }
+    }
+    public fun test_regular_OR_case1(a: u64,b: u64): bool {
+        Or(Gt<u64>(a, 10), Gt<u64>(b, 20))
+    }
+    public fun test_regular_OR_case2(a: u64,b: u64,c: u64): bool {
+        Or(Or(Gt<u64>(a, 10), Gt<u64>(b, 20)), Gt<u64>(c, 20))
+    }
+    private fun __lambda__1__test_bug16195(): u64 {
+        42
+    }
+    private fun __lambda__2__test_bug16195(): |()|u64 {
+        closure#0m::__lambda__1__test_bug16195()
+    }
+    private fun __lambda__1__test_bug16195_OR_mix1(): bool {
+        true
+    }
+    private fun __lambda__2__test_bug16195_OR_mix1(): |()|bool {
+        closure#0m::__lambda__1__test_bug16195_OR_mix1()
+    }
+    private fun __lambda__1__test_bug16195_OR_mix2(): bool {
+        true
+    }
+    private fun __lambda__2__test_bug16195_OR_mix2(): |()|bool {
+        closure#0m::__lambda__1__test_bug16195_OR_mix2()
+    }
+    private fun __lambda__1__test_bug16195_OR_mix3(): bool {
+        true
+    }
+    private fun __lambda__2__test_bug16195_OR_mix3(): |()|bool {
+        closure#0m::__lambda__1__test_bug16195_OR_mix3()
+    }
+    private fun __lambda__3__test_bug16195_OR_mix3(): |()||()|bool {
+        closure#0m::__lambda__2__test_bug16195_OR_mix3()
+    }
+    private fun __lambda__4__test_bug16195_OR_mix3(): |()||()||()|bool {
+        closure#0m::__lambda__3__test_bug16195_OR_mix3()
+    }
+    private fun __lambda__5__test_bug16195_OR_mix3(): |()||()||()||()|bool {
+        closure#0m::__lambda__4__test_bug16195_OR_mix3()
+    }
+    private fun __lambda__1__test_bug16195_OR_mix4(): bool {
+        true
+    }
+    private fun __lambda__2__test_bug16195_OR_mix4(): |()|bool {
+        closure#0m::__lambda__1__test_bug16195_OR_mix4()
+    }
+    private fun __lambda__3__test_bug16195_OR_mix4(): |()||()|bool {
+        closure#0m::__lambda__2__test_bug16195_OR_mix4()
+    }
+    private fun __lambda__4__test_bug16195_OR_mix4(): |()||()||()|bool {
+        closure#0m::__lambda__3__test_bug16195_OR_mix4()
+    }
+    private fun __lambda__5__test_bug16195_OR_mix4(): |()||()||()||()|bool {
+        closure#0m::__lambda__4__test_bug16195_OR_mix4()
+    }
+    private fun __lambda__1__test_bug16195_OR_mix5(a: bool,x: bool): bool {
+        Or(x, a)
+    }
+    private fun __lambda__2__test_bug16195_OR_mix5(a: bool): |bool|bool {
+        closure#1m::__lambda__1__test_bug16195_OR_mix5(a)
+    }
+    private fun __lambda__1__test_bug16195_OR_mix6(x: bool): bool {
+        Or(x, true)
+    }
+    private fun __lambda__2__test_bug16195_OR_mix6(x: bool): |()|bool {
+        closure#1m::__lambda__1__test_bug16195_OR_mix6(x)
+    }
+    private fun __lambda__1__test_bug16195_variant1(): u64 {
+        42
+    }
+    private fun __lambda__2__test_bug16195_variant1(): |()|u64 {
+        closure#0m::__lambda__1__test_bug16195_variant1()
+    }
+    private fun __lambda__1__test_bug16195_variant2(): u64 {
+        42
+    }
+    private fun __lambda__2__test_bug16195_variant2(): |()|u64 {
+        closure#0m::__lambda__1__test_bug16195_variant2()
+    }
+    private fun __lambda__3__test_bug16195_variant2(): |()||()|u64 {
+        closure#0m::__lambda__2__test_bug16195_variant2()
+    }
+    private fun __lambda__4__test_bug16195_variant2(): |()||()||()|u64 {
+        closure#0m::__lambda__3__test_bug16195_variant2()
+    }
+    private fun __lambda__5__test_bug16195_variant2(): |()||()||()||()|u64 {
+        closure#0m::__lambda__4__test_bug16195_variant2()
+    }
+    private fun __lambda__1__test_bug16195_variant3() {
+        Tuple()
+    }
+    private fun __lambda__2__test_bug16195_variant3(): u64 {
+        42
+    }
+    private fun __lambda__3__test_bug16195_variant3(_arg: |()|): |()|u64 {
+        closure#0m::__lambda__2__test_bug16195_variant3()
+    }
+    private fun __lambda__1__test_bug16195_variant4() {
+        Tuple()
+    }
+    private fun __lambda__2__test_bug16195_variant4(): u64 {
+        42
+    }
+    private fun __lambda__3__test_bug16195_variant4(_arg: |()|): |()|u64 {
+        closure#0m::__lambda__2__test_bug16195_variant4()
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before bytecode pipeline
+module 0xc0ffee::m {
+    struct Bug16195 has copy, drop {
+        0: |()||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant1 has copy, drop {
+        0: |()||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant2 has copy, drop {
+        0: |()||()||()||()||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant3 has copy, drop {
+        0: ||()|||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant4 has copy, drop {
+        0: ||()|||()|u64 with copy + drop,
+    }
+    struct Bug16195_variant5 has copy, drop {
+        0: |()||()|bool with copy + drop,
+    }
+    struct Bug16195_variant6 has copy, drop {
+        0: |()||()||()||()||()|bool with copy + drop,
+    }
+    struct Bug16195_variant7 has copy, drop {
+        0: |()||bool|bool with copy + drop,
+    }
+    struct Bug16195_variant8 has copy, drop {
+        0: |bool||()|bool with copy + drop,
+    }
+    public fun test_bug16195(): u64 {
+        let f = Bug16195(|()| __lambda__2__test_bug16195());
+        f()()
+    }
+    public fun test_bug16195_OR_mix1(a: bool): bool {
+        let f = Bug16195_variant5(|()| __lambda__2__test_bug16195_OR_mix1());
+        f()() || a
+    }
+    public fun test_bug16195_OR_mix2(a: bool, b: bool): bool {
+        let f = Bug16195_variant5(|()| __lambda__2__test_bug16195_OR_mix2());
+        f()() || a || b
+    }
+    public fun test_bug16195_OR_mix3(a: bool): bool {
+        let f = Bug16195_variant6(|()| __lambda__5__test_bug16195_OR_mix3());
+        f()()()()() || a
+    }
+    public fun test_bug16195_OR_mix4(a: bool, b: bool): bool {
+        let f = Bug16195_variant6(|()| __lambda__5__test_bug16195_OR_mix4());
+        f()()()()() || a || b
+    }
+    public fun test_bug16195_OR_mix5(a: bool): bool {
+        let f = Bug16195_variant7(|()| __lambda__2__test_bug16195_OR_mix5(a));
+        f()(true) || a
+    }
+    public fun test_bug16195_OR_mix6(a: bool): bool {
+        let f = Bug16195_variant8(|arg0| __lambda__2__test_bug16195_OR_mix6(arg0));
+        f(true)() || a
+    }
+    public fun test_bug16195_variant1(): u64 {
+        let f = Bug16195_variant1(|()| __lambda__2__test_bug16195_variant1());
+        f()()
+    }
+    public fun test_bug16195_variant2(): u64 {
+        let f = Bug16195_variant2(|()| __lambda__5__test_bug16195_variant2());
+        f()()()()()
+    }
+    public fun test_bug16195_variant3(): u64 {
+        let _arg = |()| __lambda__1__test_bug16195_variant3();
+        let f = Bug16195_variant3(|arg0| __lambda__3__test_bug16195_variant3(arg0));
+        f(_arg)()
+    }
+    public fun test_bug16195_variant4(): u64 {
+        let _arg = |()| __lambda__1__test_bug16195_variant4();
+        let f = Bug16195_variant4(|arg0| __lambda__3__test_bug16195_variant4(arg0));
+        f(_arg)()
+    }
+    public fun test_regular_OR_case1(a: u64, b: u64): bool {
+        a > 10 || b > 20
+    }
+    public fun test_regular_OR_case2(a: u64, b: u64, c: u64): bool {
+        a > 10 || b > 20 || c > 20
+    }
+    fun __lambda__1__test_bug16195(): u64 {
+        42
+    }
+    fun __lambda__2__test_bug16195(): |()|u64 {
+        |()| __lambda__1__test_bug16195()
+    }
+    fun __lambda__1__test_bug16195_OR_mix1(): bool {
+        true
+    }
+    fun __lambda__2__test_bug16195_OR_mix1(): |()|bool {
+        |()| __lambda__1__test_bug16195_OR_mix1()
+    }
+    fun __lambda__1__test_bug16195_OR_mix2(): bool {
+        true
+    }
+    fun __lambda__2__test_bug16195_OR_mix2(): |()|bool {
+        |()| __lambda__1__test_bug16195_OR_mix2()
+    }
+    fun __lambda__1__test_bug16195_OR_mix3(): bool {
+        true
+    }
+    fun __lambda__2__test_bug16195_OR_mix3(): |()|bool {
+        |()| __lambda__1__test_bug16195_OR_mix3()
+    }
+    fun __lambda__3__test_bug16195_OR_mix3(): |()||()|bool {
+        |()| __lambda__2__test_bug16195_OR_mix3()
+    }
+    fun __lambda__4__test_bug16195_OR_mix3(): |()||()||()|bool {
+        |()| __lambda__3__test_bug16195_OR_mix3()
+    }
+    fun __lambda__5__test_bug16195_OR_mix3(): |()||()||()||()|bool {
+        |()| __lambda__4__test_bug16195_OR_mix3()
+    }
+    fun __lambda__1__test_bug16195_OR_mix4(): bool {
+        true
+    }
+    fun __lambda__2__test_bug16195_OR_mix4(): |()|bool {
+        |()| __lambda__1__test_bug16195_OR_mix4()
+    }
+    fun __lambda__3__test_bug16195_OR_mix4(): |()||()|bool {
+        |()| __lambda__2__test_bug16195_OR_mix4()
+    }
+    fun __lambda__4__test_bug16195_OR_mix4(): |()||()||()|bool {
+        |()| __lambda__3__test_bug16195_OR_mix4()
+    }
+    fun __lambda__5__test_bug16195_OR_mix4(): |()||()||()||()|bool {
+        |()| __lambda__4__test_bug16195_OR_mix4()
+    }
+    fun __lambda__1__test_bug16195_OR_mix5(a: bool, x: bool): bool {
+        x || a
+    }
+    fun __lambda__2__test_bug16195_OR_mix5(a: bool): |bool|bool {
+        |arg0| __lambda__1__test_bug16195_OR_mix5(a, arg0)
+    }
+    fun __lambda__1__test_bug16195_OR_mix6(x: bool): bool {
+        x || true
+    }
+    fun __lambda__2__test_bug16195_OR_mix6(x: bool): |()|bool {
+        |()| __lambda__1__test_bug16195_OR_mix6(x)
+    }
+    fun __lambda__1__test_bug16195_variant1(): u64 {
+        42
+    }
+    fun __lambda__2__test_bug16195_variant1(): |()|u64 {
+        |()| __lambda__1__test_bug16195_variant1()
+    }
+    fun __lambda__1__test_bug16195_variant2(): u64 {
+        42
+    }
+    fun __lambda__2__test_bug16195_variant2(): |()|u64 {
+        |()| __lambda__1__test_bug16195_variant2()
+    }
+    fun __lambda__3__test_bug16195_variant2(): |()||()|u64 {
+        |()| __lambda__2__test_bug16195_variant2()
+    }
+    fun __lambda__4__test_bug16195_variant2(): |()||()||()|u64 {
+        |()| __lambda__3__test_bug16195_variant2()
+    }
+    fun __lambda__5__test_bug16195_variant2(): |()||()||()||()|u64 {
+        |()| __lambda__4__test_bug16195_variant2()
+    }
+    fun __lambda__1__test_bug16195_variant3() {
+    }
+    fun __lambda__2__test_bug16195_variant3(): u64 {
+        42
+    }
+    fun __lambda__3__test_bug16195_variant3(_arg: |()|): |()|u64 {
+        |()| __lambda__2__test_bug16195_variant3()
+    }
+    fun __lambda__1__test_bug16195_variant4() {
+    }
+    fun __lambda__2__test_bug16195_variant4(): u64 {
+        42
+    }
+    fun __lambda__3__test_bug16195_variant4(_arg: |()|): |()|u64 {
+        |()| __lambda__2__test_bug16195_variant4()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195.move
@@ -1,0 +1,97 @@
+module 0xc0ffee::m {
+    struct Bug16195(|| ||u64) has copy, drop;
+
+    struct Bug16195_variant1(||||u64) has copy, drop;
+
+    struct Bug16195_variant2(||||||||||u64) has copy, drop;
+
+    struct Bug16195_variant3(|(||)| ||u64) has copy, drop;
+
+    struct Bug16195_variant4(|(||)|(||u64)) has copy, drop;
+
+    struct Bug16195_variant5(|| ||bool) has copy, drop;
+
+    struct Bug16195_variant6(||||||||||bool) has copy, drop;
+
+    struct Bug16195_variant7(|| |bool|bool) has copy, drop;
+
+    struct Bug16195_variant8(|bool| ||bool) has copy, drop;
+
+    /// function that returns a function value
+    public fun test_bug16195(): u64 {
+        let f = Bug16195(|| ||42);
+        f()()
+    }
+
+    /// function that returns a function value
+    public fun test_bug16195_variant1(): u64 {
+        let f = Bug16195_variant1(||||42);
+        f()()
+    }
+
+    /// five-layers of nested function values
+    public fun test_bug16195_variant2(): u64 {
+        let f = Bug16195_variant2(||||||||||42);
+        f()()()()()
+    }
+
+    /// function that returns a function value
+    public fun test_bug16195_variant3(): u64 {
+        let _arg = || {};
+        let f = Bug16195_variant3(|_arg| ||42);
+        f(_arg)()
+    }
+
+    /// function that returns a function value
+    public fun test_bug16195_variant4(): u64 {
+        let _arg = || {};
+        let f = Bug16195_variant4(|_arg|(||42));
+        f(_arg)()
+    }
+
+    /// regular OR between two operands
+    public fun test_regular_OR_case1(a: u64, b: u64): bool {
+        (a > 10) || (b > 20)
+    }
+
+    /// regular OR among three operands
+    public fun test_regular_OR_case2(a: u64, b: u64, c: u64): bool {
+        (a > 10) || (b > 20) || (c > 20)
+    }
+
+    /// mix of OR and a function that returns a function value.
+    public fun test_bug16195_OR_mix1(a: bool): bool {
+        let f = Bug16195_variant5(|| ||true);
+        f ()() || a
+    }
+
+    /// mix of OR and a function that returns a function value.
+    public fun test_bug16195_OR_mix2(a: bool, b: bool): bool {
+        let f = Bug16195_variant5(|| ||true);
+        f ()() || a || b
+    }
+
+    /// mix of OR and a five-layter nested function value
+    public fun test_bug16195_OR_mix3(a: bool): bool {
+        let f = Bug16195_variant6(||||||||||true);
+        f ()()()()() || a
+    }
+
+     /// mix of OR and a five-layter nested function value
+    public fun test_bug16195_OR_mix4(a: bool, b: bool): bool {
+        let f = Bug16195_variant6(||||||||||true);
+        f ()()()()() || a || b
+    }
+
+    /// mix of OR and a function that returns a function value. The second-layer function takes an argument
+    public fun test_bug16195_OR_mix5(a: bool): bool {
+        let f = Bug16195_variant7(|| |x| x || a);
+        f ()(true) || a
+    }
+
+    /// mix of OR and a function that returns a function value. The first-layer function takes an argument
+    public fun test_bug16195_OR_mix6(a: bool): bool {
+        let f = Bug16195_variant8(|x| || x || true);
+        f (true)() || a
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195_variant1.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195_variant1.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: unexpected token
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16195_variant1.move:2:22
+  │
+2 │     struct Func(|(||)|||u64) has copy, drop;
+  │                 -    ^ Expected '|'
+  │                 │
+  │                 To match this '|'

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195_variant1.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195_variant1.move
@@ -1,0 +1,6 @@
+module 0xc0ffee::m {
+    struct Func(|(||)|||u64) has copy, drop;
+    let _arg = || {};
+    let f = Func(|_arg|||42);
+    f()()
+}


### PR DESCRIPTION
## Description
#16195 is a trivial bug. The function [`is_start_of_type`](https://github.com/aptos-labs/aptos-core/blob/fa9adf8fc987993e25f38f1ec76bf861d36d800a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/syntax.rs#L2604-L2609) does not consider `||` (the so-called `Tok::PipePipe`) as a start of a type. The PR fixes it by adding support for `Tok::PipePipe` in  `is_start_of_type`.

## How Has This Been Tested?
- Add the test case reported by #16195 to move-compiler-v2/tests; See [bug_16195.move](https://github.com/aptos-labs/aptos-core/blob/3ac112ec51f8176d3fce764d812a920eca784ecd/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16195.move) and other variants to test trickier cases and the impacts on `OR` operations.
- Re-run all `tests` and `transactional-tests` under `move-compiler-v2`

## Key Areas to Review
- Potential effects of the fix to other compiler parsing operations.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
