### PR TITLE
Update Swatinem/rust-cache to 2.7.8

### DIFF
--- a/.github/actions/move-prover-setup/action.yaml
+++ b/.github/actions/move-prover-setup/action.yaml
@@ -14,7 +14,7 @@ runs:
     # rust-cache action will cache ~/.cargo and ./target
     # https://github.com/Swatinem/rust-cache#cache-details
     - name: Run cargo cache
-      uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2.7.3
+      uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # pin@v2.7.8
 
     - name: install related tools and prover dependencies
       shell: bash

--- a/.github/actions/rust-setup/action.yaml
+++ b/.github/actions/rust-setup/action.yaml
@@ -26,7 +26,7 @@ runs:
     # rust-cache action will cache ~/.cargo and ./target
     # https://github.com/Swatinem/rust-cache#cache-details
     - name: Run cargo cache
-      uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2.7.3
+      uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # pin@v2.7.8
       with:
         key: ${{ inputs.ADDITIONAL_KEY }}
 

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -41,7 +41,7 @@ jobs:
       # this case). See more here:
       # https://github.com/Swatinem/rust-cache#cache-details
       - name: Run cargo cache
-        uses: Swatinem/rust-cache@23bce251a8cd2ffc3c1075eaa2367cf899916d84 # pin@v2.7.3
+        uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6 # pin@v2.7.8
 
       - name: Install the Developer Tools
         run: Set-Variable ProgressPreference SilentlyContinue ; PowerShell -ExecutionPolicy Bypass -File scripts/windows_dev_setup.ps1 -t


### PR DESCRIPTION
## Description

The new version switches to v4 of the `checkout` and `upload-artifact` actions, adds support for Cargo.lock v4, as well as improving cacheing.