### PR TITLE
per-key jwk consensus 6: extra

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/jwks.md
+++ b/aptos-move/framework/aptos-framework/doc/jwks.md
@@ -1466,9 +1466,9 @@ and its <code><a href="version.md#0x1_version">version</a></code> equals to the 
             <b>assert</b>!(cur_issuer_jwks.<a href="version.md#0x1_version">version</a> + 1 == proposed_provider_jwks.<a href="version.md#0x1_version">version</a>, <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="jwks.md#0x1_jwks_EUNEXPECTED_VERSION">EUNEXPECTED_VERSION</a>));
             <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(proposed_provider_jwks.<a href="jwks.md#0x1_jwks">jwks</a>, |jwk|{
                 <b>let</b> variant_type_name = *<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(<a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_type_name">copyable_any::type_name</a>(&jwk.variant));
-                <b>let</b> is_delete = <b>if</b> (variant_type_name == b"<a href="jwks.md#0x1_jwks_RSA_JWK">0x1::jwks::RSA_JWK</a>") {
-                    <b>let</b> rsa_jwk = <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_unpack">copyable_any::unpack</a>&lt;<a href="jwks.md#0x1_jwks_RSA_JWK">RSA_JWK</a>&gt;(jwk.variant);
-                    *<a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_bytes">string::bytes</a>(&rsa_jwk.n) == <a href="jwks.md#0x1_jwks_DELETE_COMMAND_INDICATOR">DELETE_COMMAND_INDICATOR</a>
+                <b>let</b> is_delete = <b>if</b> (variant_type_name == b"<a href="jwks.md#0x1_jwks_UnsupportedJWK">0x1::jwks::UnsupportedJWK</a>") {
+                    <b>let</b> repr = <a href="../../aptos-stdlib/doc/copyable_any.md#0x1_copyable_any_unpack">copyable_any::unpack</a>&lt;<a href="jwks.md#0x1_jwks_UnsupportedJWK">UnsupportedJWK</a>&gt;(jwk.variant);
+                    &repr.payload == &<a href="jwks.md#0x1_jwks_DELETE_COMMAND_INDICATOR">DELETE_COMMAND_INDICATOR</a>
                 } <b>else</b> {
                     <b>false</b>
                 };

--- a/aptos-move/framework/aptos-framework/sources/jwks.move
+++ b/aptos-move/framework/aptos-framework/sources/jwks.move
@@ -478,9 +478,9 @@ module aptos_framework::jwks {
                 assert!(cur_issuer_jwks.version + 1 == proposed_provider_jwks.version, error::invalid_argument(EUNEXPECTED_VERSION));
                 vector::for_each(proposed_provider_jwks.jwks, |jwk|{
                     let variant_type_name = *string::bytes(copyable_any::type_name(&jwk.variant));
-                    let is_delete = if (variant_type_name == b"0x1::jwks::RSA_JWK") {
-                        let rsa_jwk = copyable_any::unpack<RSA_JWK>(jwk.variant);
-                        *string::bytes(&rsa_jwk.n) == DELETE_COMMAND_INDICATOR
+                    let is_delete = if (variant_type_name == b"0x1::jwks::UnsupportedJWK") {
+                        let repr = copyable_any::unpack<UnsupportedJWK>(jwk.variant);
+                        &repr.payload == &DELETE_COMMAND_INDICATOR
                     } else {
                         false
                     };
@@ -831,11 +831,9 @@ module aptos_framework::jwks {
         assert!(expected == borrow_global<PatchedJWKs>(@aptos_framework).jwks, 999);
 
         // Delete a key.
-        let delete_command = new_rsa_jwk(
-            utf8(b"kid123"),
-            utf8(b"RS256"),
-            utf8(b"AQAB"),
-            utf8(DELETE_COMMAND_INDICATOR),
+        let delete_command = new_unsupported_jwk(
+            b"kid123",
+            DELETE_COMMAND_INDICATOR,
         );
         let key_level_update_1 = ProviderJWKs {
             issuer: b"alice",
@@ -965,13 +963,20 @@ module aptos_framework::jwks {
     #[test(aptos_framework = @aptos_framework)]
     fun test_patched_jwks(aptos_framework: signer) acquires ObservedJWKs, PatchedJWKs, Patches {
         initialize_for_test(&aptos_framework);
+
+        features::change_feature_flags_for_testing(
+            &aptos_framework,
+            vector[],
+            vector[features::get_jwk_consensus_per_key_mode_feature()]
+        );
+
         let jwk_0 = new_unsupported_jwk(b"key_id_0", b"key_payload_0");
         let jwk_1 = new_unsupported_jwk(b"key_id_1", b"key_payload_1");
         let jwk_2 = new_unsupported_jwk(b"key_id_2", b"key_payload_2");
         let jwk_3 = new_unsupported_jwk(b"key_id_3", b"key_payload_3");
         let jwk_3b = new_unsupported_jwk(b"key_id_3", b"key_payload_3b");
 
-        // Fake observation from validators.
+        // Insert fake observation in per-issuer mode.
         upsert_into_observed_jwks(&aptos_framework, vector [
             ProviderJWKs {
                 issuer: b"alice",

--- a/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
@@ -194,7 +194,7 @@ impl KeyLevelConsensusManager {
         }
 
         let issuer_level_repr = update
-            .as_issuer_level_repr()
+            .try_as_issuer_level_repr()
             .context("initiate_key_level_consensus failed at repr conversion")?;
         let signature = self
             .consensus_key
@@ -202,7 +202,7 @@ impl KeyLevelConsensusManager {
             .context("crypto material error occurred during signing")?;
 
         let update_translated = update
-            .as_issuer_level_repr()
+            .try_as_issuer_level_repr()
             .context("maybe_start_consensus failed at update translation")?;
         let abort_handle = self
             .update_certifier
@@ -292,7 +292,7 @@ impl KeyLevelConsensusManager {
                                 author: self.my_addr,
                                 observed: my_proposal
                                     .observed
-                                    .as_issuer_level_repr()
+                                    .try_as_issuer_level_repr()
                                     .context("process_peer_request failed with repr conversion")?,
                                 signature: my_proposal.signature.clone(),
                             },
@@ -435,7 +435,7 @@ impl TConsensusManager for KeyLevelConsensusManager {
             if let Err(e) = handle_result {
                 error!(
                     epoch = this.epoch_state.epoch,
-                    "KeyLevelJWKManager error from handling: {}", e
+                    "KeyLevelJWKManager error from handling: {e:#}"
                 );
             }
         }

--- a/testsuite/smoke-test/src/jwks/jwk_consensus_basic.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_basic.rs
@@ -111,8 +111,8 @@ async fn jwk_consensus_basic() {
     let txn_summary = update_jwk_consensus_config(cli, root_idx, &config).await;
     debug!("txn_summary={:?}", txn_summary);
 
-    info!("Waiting for an on-chain update. 10 sec should be enough.");
-    sleep(Duration::from_secs(10)).await;
+    info!("Waiting for an on-chain update. 30 sec should be enough.");
+    sleep(Duration::from_secs(30)).await;
     let patched_jwks = get_patched_jwks(&client).await;
     debug!("patched_jwks={:?}", patched_jwks);
     assert_eq!(
@@ -120,7 +120,7 @@ async fn jwk_consensus_basic() {
             entries: vec![
                 ProviderJWKs {
                     issuer: alice_issuer_id.as_bytes().to_vec(),
-                    version: 1,
+                    version: 2, // in per-key mode, kid0 and kid1 each needs a txn.
                     jwks: vec![
                         JWK::RSA(RSA_JWK::new_256_aqab("kid0", "n0")).into(),
                         JWK::RSA(RSA_JWK::new_from_strs("kid1", "RSA", "RS384", "AQAB", "n1"))
@@ -161,7 +161,7 @@ async fn jwk_consensus_basic() {
             entries: vec![
                 ProviderJWKs {
                     issuer: alice_issuer_id.as_bytes().to_vec(),
-                    version: 2,
+                    version: 5, // in per-key mode, deleting kid0, deleting kid1, adding ALICE_JWK_V1B each takes 1 txn.
                     jwks: vec![JWK::Unsupported(UnsupportedJWK::new_with_payload(
                         "\"ALICE_JWK_V1B\""
                     ))

--- a/testsuite/smoke-test/src/jwks/mod.rs
+++ b/testsuite/smoke-test/src/jwks/mod.rs
@@ -8,7 +8,10 @@ mod jwk_consensus_per_key;
 mod jwk_consensus_provider_change_mind;
 
 use crate::smoke_test_environment::SwarmBuilder;
-use aptos::{common::types::TransactionSummary, test::CliTestFramework};
+use aptos::{
+    common::types::{GasOptions, TransactionSummary},
+    test::CliTestFramework,
+};
 use aptos_forge::{NodeExt, Swarm, SwarmExt};
 use aptos_logger::{debug, info};
 use aptos_rest_client::Client;
@@ -76,7 +79,14 @@ script {{
     };
     println!("script={script}");
 
-    cli.run_script(account_idx, script.as_str()).await.unwrap()
+    let gas_options = GasOptions {
+        gas_unit_price: Some(100),
+        max_gas: Some(20000),
+        expiration_secs: 60,
+    };
+    cli.run_script_with_gas_options(account_idx, script.as_str(), Some(gas_options))
+        .await
+        .unwrap()
 }
 
 async fn get_patched_jwks(rest_client: &Client) -> PatchedJWKs {

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -233,6 +233,7 @@ impl FeatureFlag {
             FeatureFlag::ENABLE_FUNCTION_VALUES,
             FeatureFlag::NEW_ACCOUNTS_DEFAULT_TO_FA_STORE,
             FeatureFlag::DEFAULT_ACCOUNT_RESOURCE,
+            FeatureFlag::JWK_CONSENSUS_PER_KEY_MODE,
             FeatureFlag::TRANSACTION_PAYLOAD_V2,
             FeatureFlag::ORDERLESS_TRANSACTIONS,
         ]


### PR DESCRIPTION
## Description

- Use `UnsupportedJWK` as the issuer-level representation of a DELETE command (instead of `RSA_JWK`)
  - Why not `RSA_JWK`: its KID type is `string` (and `UnsupportedJWK`'s KID type is `Vec<u8>`).
    As a result, a DELETE of an unsupported JWK with kID `x` can not be represented (and therefore cannot be agreed on) this way.
  - Side effect of using `UnsupportedJWK`: now the following 2 commands have the same issuer-level representation:
    - (a) "DELETE the unsupported JWK with KID `x`
    - (b) "UPSERT an unsupported JWK with KID `x` and payload `b'THIS_IS_A_DELETE_COMMAND'`
    When translating it back to `KeyLevelUpdate`, the implementation always takes it as (a) and effectively disallows (b) from happening. In practice this should be fine?
- Enable the feature by default in genesis, update smoke tests accordingly.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
