### PR TITLE
[cli] Build generic Linux binary to be compatible with non-SIMD proce…

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "Ubuntu-22.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}"
+        run: scripts/cli/build_cli_release.sh "Ubuntu-22.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
         uses: actions/upload-artifact@v4
         with:
@@ -54,7 +54,7 @@ jobs:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "Ubuntu-24.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}"
+        run: scripts/cli/build_cli_release.sh "Ubuntu-24.04" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
         uses: actions/upload-artifact@v4
         with:
@@ -62,6 +62,8 @@ jobs:
           path: aptos-cli-*.zip
 
   # Generic linux should be the older version, more likely compatible
+  # This actually builds for non-SIMD processors, and an older GLIBC
+  # TODO: Possibly find a way to support a baseline GLIBC rather than just whatever is on 22.04
   build-linux-binary:
     name: "Build Linux binary"
     runs-on: ubuntu-22.04
@@ -71,7 +73,7 @@ jobs:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}"
+        run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "true"
       - name: Upload Binary
         uses: actions/upload-artifact@v4
         with:
@@ -88,7 +90,7 @@ jobs:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: Build CLI
-        run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}"
+        run: scripts/cli/build_cli_release.sh "Linux" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
       - name: Upload Binary
         uses: actions/upload-artifact@v4
         with:
@@ -106,7 +108,7 @@ jobs:
   #       with:
   #         macos: true
   #     - name: Build CLI
-  #       run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}"
+  #       run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
   #     - name: Upload Binary
   #       uses: actions/upload-artifact@v4
   #       with:
@@ -124,7 +126,7 @@ jobs:
   #       with:
   #         macos: true
   #     - name: Build CLI
-  #       run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}"
+  #       run: scripts/cli/build_cli_release.sh "macOS" "${{inputs.release_version}}" "${{inputs.skip_checks}}" "false"
   #     - name: Upload Binary
   #       uses: actions/upload-artifact@v4
   #       with:

--- a/scripts/cli/build_cli_release.sh
+++ b/scripts/cli/build_cli_release.sh
@@ -22,6 +22,7 @@ CARGO_PATH="crates/$CRATE_NAME/Cargo.toml"
 PLATFORM_NAME="$1"
 EXPECTED_VERSION="$2"
 SKIP_CHECKS="$3"
+COMPATIBILITY_MODE="$4"
 
 # Grab system information
 ARCH=$(uname -m)
@@ -51,8 +52,11 @@ else
 fi
 
 echo "Building release $VERSION of $NAME for $OS-$PLATFORM_NAME on $ARCH"
-cargo build -p "$CRATE_NAME" --profile cli
-
+if [[ "$COMPATIBILITY_MODE" == "true" ]]; then
+  RUSTFLAGS="-C target-cpu=generic --cfg tokio_unstable -C target-feature=-sse4.2,-avx" cargo build -p "$CRATE_NAME" --profile cli
+else
+  cargo build -p "$CRATE_NAME" --profile cli
+fi
 cd target/cli/
 
 # Compress the CLI


### PR DESCRIPTION
…ssors

## Description
This usually manifests as a docker image not working with `Illegal instruction`, particularly on an x86_64 Ubuntu image on an ARM Mac.

This now changes the generic "Linux" CLI to be more compatible, and support older processors, or in this case emulation on non-x86_64 processors.

## How Has This Been Tested?
Built and tested directly on a Docker container on my Mac.  Without it, it actually creates a binary that breaks (even though it's built on the machine), when running `aptos node run-localnet`

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
