### PR TITLE
[Linter] Fixed a typo in nonminimal bool lint

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints/nonminimal_bool.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/nonminimal_bool.rs
@@ -100,7 +100,7 @@ impl ExpChecker for NonminimalBool {
             },
             Not => match args[0].as_ref() {
                 ExpValue(_, Bool(b)) => {
-                    Some(format!("The inner expression evaluates to `{}`. Recall that the expression `! {}` is logically equivalent to `{}`. Consider simplifying.", b, b, !b))
+                    Some(format!("This expression evaluates to `{}`. Recall that the expression `!{}` is logically equivalent to `{}`. Consider simplifying.", !b, b, !b))
                 },
                 _ => None,
             },

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.exp
@@ -144,29 +144,29 @@ warning: [lint] The left-hand side of `==>` evaluates to `false`. Recall that th
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
 
-warning: [lint] The inner expression evaluates to `true`. Recall that the expression `! true` is logically equivalent to `false`. Consider simplifying.
+warning: [lint] This expression evaluates to `false`. Recall that the expression `!true` is logically equivalent to `false`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:36:13
    │
-36 │         if (! true) ();
-   │             ^^^^^^
+36 │         if (!true) ();
+   │             ^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
 
-warning: [lint] The inner expression evaluates to `false`. Recall that the expression `! false` is logically equivalent to `true`. Consider simplifying.
+warning: [lint] This expression evaluates to `true`. Recall that the expression `!false` is logically equivalent to `true`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:37:13
    │
-37 │         if (! false) ();
-   │             ^^^^^^^
+37 │         if (!false) ();
+   │             ^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
 
-warning: [lint] The inner expression evaluates to `true`. Recall that the expression `! true` is logically equivalent to `false`. Consider simplifying.
+warning: [lint] This expression evaluates to `false`. Recall that the expression `!true` is logically equivalent to `false`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:42:13
    │
-42 │         if (! true && false || true) ();
-   │             ^^^^^^
+42 │         if (!true && false || true) ();
+   │             ^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
@@ -174,8 +174,8 @@ warning: [lint] The inner expression evaluates to `true`. Recall that the expres
 warning: [lint] The right-hand side of `&&` evaluates to `false`. Recall that the expression `bexpr && false` is logically equivalent to `false`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:42:13
    │
-42 │         if (! true && false || true) ();
-   │             ^^^^^^^^^^^^^^^
+42 │         if (!true && false || true) ();
+   │             ^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.
@@ -183,8 +183,8 @@ warning: [lint] The right-hand side of `&&` evaluates to `false`. Recall that th
 warning: [lint] The right-hand side of `||` evaluates to `true`. Recall that the expression `bexpr || true` is logically equivalent to `true`. Consider simplifying.
    ┌─ tests/model_ast_lints/nonminimal_bool.move:42:13
    │
-42 │         if (! true && false || true) ();
-   │             ^^^^^^^^^^^^^^^^^^^^^^^
+42 │         if (!true && false || true) ();
+   │             ^^^^^^^^^^^^^^^^^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(nonminimal_bool)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#nonminimal_bool.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/nonminimal_bool.move
@@ -33,17 +33,17 @@ module 0xc0ffee::m {
     }
 
     public fun test_warn_not() {
-        if (! true) ();
-        if (! false) ();
+        if (!true) ();
+        if (!false) ();
     }
 
 
     public fun combo() {
-        if (! true && false || true) ();
+        if (!true && false || true) ();
     }
 
     #[lint::skip(nonminimal_bool)]
     fun test_no_warn(): bool {
-        ! true
+        !true
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The initial version of nonminimal bool had a small typo in the `!` case (incorrectly stating that `!b` is equivalent `b`). This fixes that, slightly cleans up the message, and takes out some unnecessary whitespace in the tests.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests sufficiently cover this.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->
N/A

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Linter

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
