### PR TITLE
[compiler] Handling function wrapper types in closure checker

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: captured value is missing abilities `copy`
+   ┌─ tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.move:22:40
+   │
+22 │         let f: Func<S> = |x| { x.merge(s) };
+   │                                        ^
+   │
+   = expected function type: `|S|S with copy` (wrapped type of `Func<S>`)

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.exp
@@ -1,9 +1,9 @@
 
 Diagnostics:
 error: captured value is missing abilities `copy`
-   ┌─ tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.move:22:40
+   ┌─ tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.move:26:40
    │
-22 │         let f: Func<S> = |x| { x.merge(s) };
+26 │         let f: Func<S> = |x| { x.merge(s) };
    │                                        ^
    │
    = expected function type: `|S|S with copy` (wrapped type of `Func<S>`)

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.move
@@ -1,0 +1,29 @@
+// Fixes ##16158
+module 0xc0ffee::m {
+    struct Func<T>(|T|T) has copy;
+
+    fun apply<T>(f: Func<T>, v: T): T {
+        let Func(f) = f;
+        f(v)
+    }
+
+    struct S {
+        x: u64,
+    }
+
+    fun merge(self: S, other: S): S {
+        let S { x: self_x } = self;
+        let S { x: other_x } = other;
+        S { x: self_x + other_x }
+    }
+
+    fun test(): S {
+        let s = S { x: 42 };
+        // We expect an error here since the function type in `Func<S>` continues
+        // to have the `copy` requirement even though `S` is not. This is related
+        // to the current general mismatch of abilities and function types in
+        // generic structs.
+        let f: Func<S> = |x| { x.merge(s) };
+        apply(f, S {x: 0})
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/generic_wrapper_abilities.move
@@ -1,4 +1,4 @@
-// Fixes ##16158
+// Fixes #16158
 module 0xc0ffee::m {
     struct Func<T>(|T|T) has copy;
 


### PR DESCRIPTION
## Description

They were ignored since during the run of the closure checker, implicit constructors have not yet been inserted, which happens at bytecode gen time.

Closes #16158

## How Has This Been Tested?

test case

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)
