### PR TITLE
[compiler] Fixing a bug in inferred type defaults

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inferred_default_with_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inferred_default_with_abilities.exp
@@ -1,0 +1,15 @@
+
+Diagnostics:
+error: function resulting from lambda lifting is missing the `store` ability
+   ┌─ tests/checking-lang-v2.2/lambda/inferred_default_with_abilities.move:10:17
+   │
+10 │           let f = || {
+   │ ╭─────────────────^
+11 │ │             let a = one();
+12 │ │             let b = one();
+13 │ │             a + b
+14 │ │         };
+   │ ╰─────────^
+   │
+   = lambda cannot be reduced to partial application of existing function
+   = expected function type: `|()|u64 with store`

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inferred_default_with_abilities.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inferred_default_with_abilities.move
@@ -1,0 +1,17 @@
+// Fixes #16405
+module 0xc0ffee::m {
+    struct S<T>(T) has key;
+
+    fun one(): u64 {
+        1
+    }
+
+    public fun test(s: &signer) {
+        let f = || {
+            let a = one();
+            let b = one();
+            a + b
+        };
+        move_to(s, S(f));
+    }
+}


### PR DESCRIPTION
## Description

Inferred type defaults where not checked for abilities. Closes #16405

## How Has This Been Tested?

New test

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

