### PR TITLE
Add telemetry to the Rust smoke tests job

### DIFF
--- a/.github/actions/rust-smoke-tests/action.yaml
+++ b/.github/actions/rust-smoke-tests/action.yaml
@@ -9,6 +9,9 @@ runs:
   using: composite
   steps:
     # The source code must be checkout out by the workflow that invokes this action.
+    - name: Build aptos-node
+      run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release
+      shell: bash
 
     # Run a postgres database
     - name: Run postgres database
@@ -20,9 +23,10 @@ runs:
       # Prebuild the aptos-node binary so that tests don't start before the node is built.
       # Also, prebuild the aptos-node binary as a separate step to avoid feature unification issues.
       # Note: --test-threads is intentionally set to reduce resource contention in ci jobs. Increasing this, increases job failures and retries.
-      run: cargo build --locked --package=aptos-node --features=failpoints,indexer --release && LOCAL_SWARM_NODE_RELEASE=1 cargo nextest run --release --profile smoke-test --package smoke-test
+      run: cargo nextest run --release --profile smoke-test --package smoke-test
       shell: bash
       env:
+        LOCAL_SWARM_NODE_RELEASE: "1"
         INDEXER_DATABASE_URL: postgresql://postgres@localhost/postgres
 
     # We always try to create the artifact, but it only creates on flaky or failed smoke tests -- when the directories are empty.

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -121,8 +121,17 @@ jobs:
         contains(github.event.pull_request.body, '#e2e'
       )
     runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run rust smoke tests
         uses: ./.github/actions/rust-smoke-tests
@@ -183,12 +192,21 @@ jobs:
         contains(github.event.pull_request.base.ref, '-release-')
       )
     runs-on: runs-on,cpu=64,family=c7,hdd=500,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    permissions:
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
+      - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
+        with:
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
       # Install Move Prover tools
       - name: Run dev_setup.sh
         run: |
           scripts/dev_setup.sh -b -y
+      - name: Collect Workflow Telemetry
+        uses: catchpoint/workflow-telemetry-action@v2
+        if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run rust unit tests
         uses: ./.github/actions/rust-unit-tests
         with:


### PR DESCRIPTION
## Description

Use `catchpoint/workflow-telemetry-action@v2` to determine where the test spends its time and what's the typical CPU usage.
