### PR TITLE
config_buffer fix

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/config_buffer.md
+++ b/aptos-move/framework/aptos-framework/doc/config_buffer.md
@@ -22,13 +22,15 @@ NOTE: on-chain config <code>0x1::state::ValidatorSet</code> implemented its own 
 -  [Function `does_exist`](#0x1_config_buffer_does_exist)
 -  [Function `upsert`](#0x1_config_buffer_upsert)
 -  [Function `extract`](#0x1_config_buffer_extract)
+-  [Function `extract_v2`](#0x1_config_buffer_extract_v2)
 -  [Specification](#@Specification_1)
     -  [Function `does_exist`](#@Specification_1_does_exist)
     -  [Function `upsert`](#@Specification_1_upsert)
-    -  [Function `extract`](#@Specification_1_extract)
+    -  [Function `extract_v2`](#@Specification_1_extract_v2)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/doc/any.md#0x1_any">0x1::any</a>;
+<b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
 <b>use</b> <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map">0x1::simple_map</a>;
 <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">0x1::string</a>;
@@ -68,6 +70,16 @@ NOTE: on-chain config <code>0x1::state::ValidatorSet</code> implemented its own 
 <a id="@Constants_0"></a>
 
 ## Constants
+
+
+<a id="0x1_config_buffer_EDEPRECATED"></a>
+
+Function is deprecated.
+
+
+<pre><code><b>const</b> <a href="config_buffer.md#0x1_config_buffer_EDEPRECATED">EDEPRECATED</a>: u64 = 2;
+</code></pre>
+
 
 
 <a id="0x1_config_buffer_ESTD_SIGNER_NEEDED"></a>
@@ -173,13 +185,11 @@ Typically used in <code>X::set_for_next_epoch()</code> where X is an on-chain co
 
 ## Function `extract`
 
-Take the buffered config <code>T</code> out (buffer cleared). Abort if the buffer is empty.
-Should only be used at the end of a reconfiguration.
-
-Typically used in <code>X::on_new_epoch()</code> where X is an on-chaon config.
+Use <code>extract_v2</code> instead.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract">extract</a>&lt;T: store&gt;(): T
+<pre><code>#[deprecated]
+<b>public</b> <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract">extract</a>&lt;T: store&gt;(): T
 </code></pre>
 
 
@@ -188,7 +198,35 @@ Typically used in <code>X::on_new_epoch()</code> where X is an on-chaon config.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract">extract</a>&lt;T: store&gt;(): T <b>acquires</b> <a href="config_buffer.md#0x1_config_buffer_PendingConfigs">PendingConfigs</a> {
+<pre><code><b>public</b> <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract">extract</a>&lt;T: store&gt;(): T {
+    <b>abort</b>(<a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_unavailable">error::unavailable</a>(<a href="config_buffer.md#0x1_config_buffer_EDEPRECATED">EDEPRECATED</a>))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_config_buffer_extract_v2"></a>
+
+## Function `extract_v2`
+
+Take the buffered config <code>T</code> out (buffer cleared). Abort if the buffer is empty.
+Should only be used at the end of a reconfiguration.
+
+Typically used in <code>X::on_new_epoch()</code> where X is an on-chaon config.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract_v2">extract_v2</a>&lt;T: store&gt;(): T
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract_v2">extract_v2</a>&lt;T: store&gt;(): T <b>acquires</b> <a href="config_buffer.md#0x1_config_buffer_PendingConfigs">PendingConfigs</a> {
     <b>let</b> configs = <b>borrow_global_mut</b>&lt;<a href="config_buffer.md#0x1_config_buffer_PendingConfigs">PendingConfigs</a>&gt;(@aptos_framework);
     <b>let</b> key = <a href="../../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;T&gt;();
     <b>let</b> (_, value_packed) = <a href="../../aptos-stdlib/doc/simple_map.md#0x1_simple_map_remove">simple_map::remove</a>(&<b>mut</b> configs.configs, &key);
@@ -261,12 +299,12 @@ Typically used in <code>X::on_new_epoch()</code> where X is an on-chaon config.
 
 
 
-<a id="@Specification_1_extract"></a>
+<a id="@Specification_1_extract_v2"></a>
 
-### Function `extract`
+### Function `extract_v2`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract">extract</a>&lt;T: store&gt;(): T
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="config_buffer.md#0x1_config_buffer_extract_v2">extract_v2</a>&lt;T: store&gt;(): T
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/consensus_config.md
@@ -192,7 +192,7 @@ Only used in reconfigurations to apply the pending <code><a href="consensus_conf
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="consensus_config.md#0x1_consensus_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;()) {
-        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;();
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="consensus_config.md#0x1_consensus_config_ConsensusConfig">ConsensusConfig</a>&gt;(@aptos_framework) = new_config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/execution_config.md
+++ b/aptos-move/framework/aptos-framework/doc/execution_config.md
@@ -161,7 +161,7 @@ Only used in reconfigurations to apply the pending <code><a href="execution_conf
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="execution_config.md#0x1_execution_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a>&gt;()) {
-        <b>let</b> config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a>&gt;();
+        <b>let</b> config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="execution_config.md#0x1_execution_config_ExecutionConfig">ExecutionConfig</a>&gt;(@aptos_framework) = config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/gas_schedule.md
+++ b/aptos-move/framework/aptos-framework/doc/gas_schedule.md
@@ -362,7 +362,7 @@ Only used in reconfigurations to apply the pending <code><a href="gas_schedule.m
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="gas_schedule.md#0x1_gas_schedule_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;()) {
-        <b>let</b> new_gas_schedule = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;();
+        <b>let</b> new_gas_schedule = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="gas_schedule.md#0x1_gas_schedule_GasScheduleV2">GasScheduleV2</a>&gt;(@aptos_framework) = new_gas_schedule;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/jwk_consensus_config.md
+++ b/aptos-move/framework/aptos-framework/doc/jwk_consensus_config.md
@@ -249,7 +249,7 @@ Only used in reconfigurations to apply the pending <code><a href="jwk_consensus_
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="jwk_consensus_config.md#0x1_jwk_consensus_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="jwk_consensus_config.md#0x1_jwk_consensus_config_JWKConsensusConfig">JWKConsensusConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="jwk_consensus_config.md#0x1_jwk_consensus_config_JWKConsensusConfig">JWKConsensusConfig</a>&gt;()) {
-        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="jwk_consensus_config.md#0x1_jwk_consensus_config_JWKConsensusConfig">JWKConsensusConfig</a>&gt;();
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="jwk_consensus_config.md#0x1_jwk_consensus_config_JWKConsensusConfig">JWKConsensusConfig</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="jwk_consensus_config.md#0x1_jwk_consensus_config_JWKConsensusConfig">JWKConsensusConfig</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="jwk_consensus_config.md#0x1_jwk_consensus_config_JWKConsensusConfig">JWKConsensusConfig</a>&gt;(@aptos_framework) = new_config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/jwks.md
+++ b/aptos-move/framework/aptos-framework/doc/jwks.md
@@ -1036,7 +1036,7 @@ aptos_framework::aptos_governance::reconfigure(&framework_signer);
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>let</b> provider_set = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;()) {
-        <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;()
+        <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;()
     } <b>else</b> {
         *<b>borrow_global</b>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;(@aptos_framework)
     };
@@ -1111,7 +1111,7 @@ aptos_framework::aptos_governance::reconfigure(&framework_signer);
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>let</b> provider_set = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;()) {
-        <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;()
+        <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;()
     } <b>else</b> {
         *<b>borrow_global</b>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;(@aptos_framework)
     };
@@ -1144,7 +1144,7 @@ Only used in reconfigurations to apply the pending <code><a href="jwks.md#0x1_jw
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="jwks.md#0x1_jwks_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;()) {
-        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;();
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="jwks.md#0x1_jwks_SupportedOIDCProviders">SupportedOIDCProviders</a>&gt;(@aptos_framework) = new_config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/keyless_account.md
+++ b/aptos-move/framework/aptos-framework/doc/keyless_account.md
@@ -616,7 +616,7 @@ WARNING: If a malicious key is set, this *could* lead to stolen funds.
     };
 
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
-        <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
+        <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
         *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
     };
@@ -652,7 +652,7 @@ reconfiguration. Only callable via governance proposal.
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
-        <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
+        <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
         *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
     };
@@ -691,7 +691,7 @@ is no longer possible.
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
-        <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
+        <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
         *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
     };
@@ -729,7 +729,7 @@ WARNING: If a malicious override <code>aud</code> is set, this *could* lead to s
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>let</b> config = <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
-        <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
+        <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()
     } <b>else</b> {
         *<b>borrow_global</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(fx))
     };
@@ -764,7 +764,7 @@ Only used in reconfigurations to apply the queued up configuration changes, if t
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(fx);
 
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">Groth16VerificationKey</a>&gt;()) {
-        <b>let</b> vk = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>();
+        <b>let</b> vk = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>();
         <b>if</b> (<b>exists</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">Groth16VerificationKey</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Groth16VerificationKey">Groth16VerificationKey</a>&gt;(@aptos_framework) = vk;
         } <b>else</b> {
@@ -773,7 +773,7 @@ Only used in reconfigurations to apply the queued up configuration changes, if t
     };
 
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;()) {
-        <b>let</b> config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>();
+        <b>let</b> config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>();
         <b>if</b> (<b>exists</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="keyless_account.md#0x1_keyless_account_Configuration">Configuration</a>&gt;(@aptos_framework) = config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/randomness_api_v0_config.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness_api_v0_config.md
@@ -176,7 +176,7 @@ Only used in reconfigurations to apply the pending <code><a href="randomness_api
 <pre><code><b>public</b> <b>fun</b> <a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_RequiredGasDeposit">RequiredGasDeposit</a>, <a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_AllowCustomMaxGasFlag">AllowCustomMaxGasFlag</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_RequiredGasDeposit">RequiredGasDeposit</a>&gt;()) {
-        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_RequiredGasDeposit">RequiredGasDeposit</a>&gt;();
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_RequiredGasDeposit">RequiredGasDeposit</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_RequiredGasDeposit">RequiredGasDeposit</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_RequiredGasDeposit">RequiredGasDeposit</a>&gt;(@aptos_framework) = new_config;
         } <b>else</b> {
@@ -184,7 +184,7 @@ Only used in reconfigurations to apply the pending <code><a href="randomness_api
         }
     };
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_AllowCustomMaxGasFlag">AllowCustomMaxGasFlag</a>&gt;()) {
-        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_AllowCustomMaxGasFlag">AllowCustomMaxGasFlag</a>&gt;();
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_AllowCustomMaxGasFlag">AllowCustomMaxGasFlag</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_AllowCustomMaxGasFlag">AllowCustomMaxGasFlag</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="randomness_api_v0_config.md#0x1_randomness_api_v0_config_AllowCustomMaxGasFlag">AllowCustomMaxGasFlag</a>&gt;(@aptos_framework) = new_config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/randomness_config.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness_config.md
@@ -253,7 +253,7 @@ Only used in reconfigurations to apply the pending <code><a href="randomness_con
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="randomness_config.md#0x1_randomness_config_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a>&gt;()) {
-        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a>&gt;();
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="randomness_config.md#0x1_randomness_config_RandomnessConfig">RandomnessConfig</a>&gt;(@aptos_framework) = new_config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/randomness_config_seqnum.md
+++ b/aptos-move/framework/aptos-framework/doc/randomness_config_seqnum.md
@@ -131,7 +131,7 @@ Only used in reconfigurations to apply the pending <code>RandomnessConfig</code>
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;()) {
-        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;();
+        <b>let</b> new_config = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="randomness_config_seqnum.md#0x1_randomness_config_seqnum_RandomnessConfigSeqNum">RandomnessConfigSeqNum</a>&gt;(@aptos_framework) = new_config;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/version.md
+++ b/aptos-move/framework/aptos-framework/doc/version.md
@@ -233,7 +233,7 @@ Only used in reconfigurations to apply the pending <code><a href="version.md#0x1
 <pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="version.md#0x1_version_on_new_epoch">on_new_epoch</a>(framework: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>) <b>acquires</b> <a href="version.md#0x1_version_Version">Version</a> {
     <a href="system_addresses.md#0x1_system_addresses_assert_aptos_framework">system_addresses::assert_aptos_framework</a>(framework);
     <b>if</b> (<a href="config_buffer.md#0x1_config_buffer_does_exist">config_buffer::does_exist</a>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;()) {
-        <b>let</b> new_value = <a href="config_buffer.md#0x1_config_buffer_extract">config_buffer::extract</a>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;();
+        <b>let</b> new_value = <a href="config_buffer.md#0x1_config_buffer_extract_v2">config_buffer::extract_v2</a>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;();
         <b>if</b> (<b>exists</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework)) {
             *<b>borrow_global_mut</b>&lt;<a href="version.md#0x1_version_Version">Version</a>&gt;(@aptos_framework) = new_value;
         } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/sources/configs/config_buffer.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/config_buffer.spec.move
@@ -22,7 +22,7 @@ spec aptos_framework::config_buffer {
         aborts_if !exists<PendingConfigs>(@aptos_framework);
     }
 
-    spec extract<T: store>(): T {
+    spec extract_v2<T: store>(): T {
         aborts_if !exists<PendingConfigs>(@aptos_framework);
         include ExtractAbortsIf<T>;
     }

--- a/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/consensus_config.move
@@ -59,7 +59,7 @@ module aptos_framework::consensus_config {
     public(friend) fun on_new_epoch(framework: &signer) acquires ConsensusConfig {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<ConsensusConfig>()) {
-            let new_config = config_buffer::extract<ConsensusConfig>();
+            let new_config = config_buffer::extract_v2<ConsensusConfig>();
             if (exists<ConsensusConfig>(@aptos_framework)) {
                 *borrow_global_mut<ConsensusConfig>(@aptos_framework) = new_config;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/execution_config.move
@@ -55,7 +55,7 @@ module aptos_framework::execution_config {
     public(friend) fun on_new_epoch(framework: &signer) acquires ExecutionConfig {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<ExecutionConfig>()) {
-            let config = config_buffer::extract<ExecutionConfig>();
+            let config = config_buffer::extract_v2<ExecutionConfig>();
             if (exists<ExecutionConfig>(@aptos_framework)) {
                 *borrow_global_mut<ExecutionConfig>(@aptos_framework) = config;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/gas_schedule.move
@@ -135,7 +135,7 @@ module aptos_framework::gas_schedule {
     public(friend) fun on_new_epoch(framework: &signer) acquires GasScheduleV2 {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<GasScheduleV2>()) {
-            let new_gas_schedule = config_buffer::extract<GasScheduleV2>();
+            let new_gas_schedule = config_buffer::extract_v2<GasScheduleV2>();
             if (exists<GasScheduleV2>(@aptos_framework)) {
                 *borrow_global_mut<GasScheduleV2>(@aptos_framework) = new_gas_schedule;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/jwk_consensus_config.move
@@ -68,7 +68,7 @@ module aptos_framework::jwk_consensus_config {
     public(friend) fun on_new_epoch(framework: &signer) acquires JWKConsensusConfig {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<JWKConsensusConfig>()) {
-            let new_config = config_buffer::extract<JWKConsensusConfig>();
+            let new_config = config_buffer::extract_v2<JWKConsensusConfig>();
             if (exists<JWKConsensusConfig>(@aptos_framework)) {
                 *borrow_global_mut<JWKConsensusConfig>(@aptos_framework) = new_config;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_api_v0_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_api_v0_config.move
@@ -38,7 +38,7 @@ module aptos_framework::randomness_api_v0_config {
     public fun on_new_epoch(framework: &signer) acquires RequiredGasDeposit, AllowCustomMaxGasFlag {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<RequiredGasDeposit>()) {
-            let new_config = config_buffer::extract<RequiredGasDeposit>();
+            let new_config = config_buffer::extract_v2<RequiredGasDeposit>();
             if (exists<RequiredGasDeposit>(@aptos_framework)) {
                 *borrow_global_mut<RequiredGasDeposit>(@aptos_framework) = new_config;
             } else {
@@ -46,7 +46,7 @@ module aptos_framework::randomness_api_v0_config {
             }
         };
         if (config_buffer::does_exist<AllowCustomMaxGasFlag>()) {
-            let new_config = config_buffer::extract<AllowCustomMaxGasFlag>();
+            let new_config = config_buffer::extract_v2<AllowCustomMaxGasFlag>();
             if (exists<AllowCustomMaxGasFlag>(@aptos_framework)) {
                 *borrow_global_mut<AllowCustomMaxGasFlag>(@aptos_framework) = new_config;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config.move
@@ -59,7 +59,7 @@ module aptos_framework::randomness_config {
     public(friend) fun on_new_epoch(framework: &signer) acquires RandomnessConfig {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<RandomnessConfig>()) {
-            let new_config = config_buffer::extract<RandomnessConfig>();
+            let new_config = config_buffer::extract_v2<RandomnessConfig>();
             if (exists<RandomnessConfig>(@aptos_framework)) {
                 *borrow_global_mut<RandomnessConfig>(@aptos_framework) = new_config;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/configs/randomness_config_seqnum.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/randomness_config_seqnum.move
@@ -38,7 +38,7 @@ module aptos_framework::randomness_config_seqnum {
     public(friend) fun on_new_epoch(framework: &signer) acquires RandomnessConfigSeqNum {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<RandomnessConfigSeqNum>()) {
-            let new_config = config_buffer::extract<RandomnessConfigSeqNum>();
+            let new_config = config_buffer::extract_v2<RandomnessConfigSeqNum>();
             if (exists<RandomnessConfigSeqNum>(@aptos_framework)) {
                 *borrow_global_mut<RandomnessConfigSeqNum>(@aptos_framework) = new_config;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/configs/version.move
+++ b/aptos-move/framework/aptos-framework/sources/configs/version.move
@@ -67,7 +67,7 @@ module aptos_framework::version {
     public(friend) fun on_new_epoch(framework: &signer) acquires Version {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<Version>()) {
-            let new_value = config_buffer::extract<Version>();
+            let new_value = config_buffer::extract_v2<Version>();
             if (exists<Version>(@aptos_framework)) {
                 *borrow_global_mut<Version>(@aptos_framework) = new_value;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/jwks.move
+++ b/aptos-move/framework/aptos-framework/sources/jwks.move
@@ -315,7 +315,7 @@ module aptos_framework::jwks {
         system_addresses::assert_aptos_framework(fx);
 
         let provider_set = if (config_buffer::does_exist<SupportedOIDCProviders>()) {
-            config_buffer::extract<SupportedOIDCProviders>()
+            config_buffer::extract_v2<SupportedOIDCProviders>()
         } else {
             *borrow_global<SupportedOIDCProviders>(@aptos_framework)
         };
@@ -350,7 +350,7 @@ module aptos_framework::jwks {
         system_addresses::assert_aptos_framework(fx);
 
         let provider_set = if (config_buffer::does_exist<SupportedOIDCProviders>()) {
-            config_buffer::extract<SupportedOIDCProviders>()
+            config_buffer::extract_v2<SupportedOIDCProviders>()
         } else {
             *borrow_global<SupportedOIDCProviders>(@aptos_framework)
         };
@@ -363,7 +363,7 @@ module aptos_framework::jwks {
     public(friend) fun on_new_epoch(framework: &signer) acquires SupportedOIDCProviders {
         system_addresses::assert_aptos_framework(framework);
         if (config_buffer::does_exist<SupportedOIDCProviders>()) {
-            let new_config = config_buffer::extract<SupportedOIDCProviders>();
+            let new_config = config_buffer::extract_v2<SupportedOIDCProviders>();
             if (exists<SupportedOIDCProviders>(@aptos_framework)) {
                 *borrow_global_mut<SupportedOIDCProviders>(@aptos_framework) = new_config;
             } else {

--- a/aptos-move/framework/aptos-framework/sources/keyless_account.move
+++ b/aptos-move/framework/aptos-framework/sources/keyless_account.move
@@ -224,7 +224,7 @@ module aptos_framework::keyless_account {
         };
 
         let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
+            config_buffer::extract_v2<Configuration>()
         } else {
             *borrow_global<Configuration>(signer::address_of(fx))
         };
@@ -240,7 +240,7 @@ module aptos_framework::keyless_account {
         system_addresses::assert_aptos_framework(fx);
 
         let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
+            config_buffer::extract_v2<Configuration>()
         } else {
             *borrow_global<Configuration>(signer::address_of(fx))
         };
@@ -259,7 +259,7 @@ module aptos_framework::keyless_account {
         system_addresses::assert_aptos_framework(fx);
 
         let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
+            config_buffer::extract_v2<Configuration>()
         } else {
             *borrow_global<Configuration>(signer::address_of(fx))
         };
@@ -277,7 +277,7 @@ module aptos_framework::keyless_account {
         system_addresses::assert_aptos_framework(fx);
 
         let config = if (config_buffer::does_exist<Configuration>()) {
-            config_buffer::extract<Configuration>()
+            config_buffer::extract_v2<Configuration>()
         } else {
             *borrow_global<Configuration>(signer::address_of(fx))
         };
@@ -292,7 +292,7 @@ module aptos_framework::keyless_account {
         system_addresses::assert_aptos_framework(fx);
 
         if (config_buffer::does_exist<Groth16VerificationKey>()) {
-            let vk = config_buffer::extract();
+            let vk = config_buffer::extract_v2();
             if (exists<Groth16VerificationKey>(@aptos_framework)) {
                 *borrow_global_mut<Groth16VerificationKey>(@aptos_framework) = vk;
             } else {
@@ -301,7 +301,7 @@ module aptos_framework::keyless_account {
         };
 
         if (config_buffer::does_exist<Configuration>()) {
-            let config = config_buffer::extract();
+            let config = config_buffer::extract_v2();
             if (exists<Configuration>(@aptos_framework)) {
                 *borrow_global_mut<Configuration>(@aptos_framework) = config;
             } else {


### PR DESCRIPTION
## Description

Add `config_buffer::extract_v2()` and deprecate `config_buffer::extract()` which has incorrect visibility.

## How Has This Been Tested?
Existing UT

## Key Areas to Review
n/a

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
