### PR TITLE
[CLI Movefmt] Fix bug where movefmt runs over curr directory if package path given does not exist

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,8 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+- Add flag `--file-path <FILE_PATH>...` to `aptos move fmt`, which allows to specify individual files to format.
+- Fixed bug where `aptos move fmt` would format current directory if invalid `--package-path` was provided
 
 ## [7.3.0]
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This is a bug fix. Currently, if `aptos move fmt --package-path /path/typo` is called such that `/path/typo` does not exist, then this command is treated as though no package path was provided and the current directory is instead reformatted. The pr here fixes that. This pr also reformats the cli error message outputs to convey the actual path to the user instead of the debug-mode path with escape characters.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
 
Manual testing

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

For cli error messages: I assume that displaying actual file error paths like

`  "Error": "Unexpected error: Unable to find package manifest in /Users/jake/Desktop or in its parents"
`

is better than displaying with escaped chars like 

`  "Error": "Unexpected error: Unable to find package manifest in \"/Users/jake/Desktop\" or in its parents"
`

Let me know if this is incorrect. If so, I will undo these changes so this PR only adddresses the `/path/typo` issue.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
