### PR TITLE
Fix issue #16155

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_function_types.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_function_types.exp
@@ -1,0 +1,199 @@
+
+Diagnostics:
+error: cyclic data
+  ┌─ tests/checking/typing/recursive_function_types.move:2:5
+  │
+2 │     struct S(|S|) has copy, drop;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │              │
+  │              invalid field `0` of `S` containing `S` itself
+
+error: cyclic data
+  ┌─ tests/checking/typing/recursive_function_types.move:6:5
+  │
+6 │     struct S1(|S2|) has copy, drop;
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = field `0` of `S1` contains `S2`
+  = field `0` of `S2` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:11:5
+   │
+11 │     struct S1(|S2|) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `0` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:17:5
+   │
+17 │     struct S1(|S2|) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `0` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S4`
+   = field `0` of `S4` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:24:5
+   │
+24 │     struct S1(||S1) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │               │
+   │               invalid field `0` of `S1` containing `S1` itself
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:28:5
+   │
+28 │     struct S(||S) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │              │
+   │              invalid field `0` of `S` containing `S` itself
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:32:5
+   │
+32 │     struct S1(|S2|) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `0` of `S1` contains `S2`
+   = field `0` of `S2` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:37:5
+   │
+37 │     struct S1(|S2|) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `0` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:43:5
+   │
+43 │     struct S1(|S2|) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `0` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S4`
+   = field `0` of `S4` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:51:5
+   │
+51 │     struct S1(|S2|) has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `0` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S4`
+   = field `0` of `S4` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:58:5
+   │
+58 │     struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `f` of `S1` contains `S2`
+   = field `0` of `S2` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:63:5
+   │
+63 │     struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `f` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:69:5
+   │
+69 │     struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `f` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S4`
+   = field `0` of `S4` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:76:5
+   │
+76 │     struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `f` of `S1` contains `S2`
+   = field `0` of `S2` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:81:5
+   │
+81 │     struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `f` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:87:5
+   │
+87 │     struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `f` of `S1` contains `S2`
+   = field `0` of `S2` contains `S3`
+   = field `0` of `S3` contains `S4`
+   = field `0` of `S4` contains `S1`, which forms a cycle.
+
+error: cyclic data
+   ┌─ tests/checking/typing/recursive_function_types.move:94:5
+   │
+94 │     struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+   │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = field `f` of `S1` contains `S2`
+   = field `0` of `S2` contains `E`
+   = field `s` of `E` contains `S1`, which forms a cycle.
+
+error: cyclic data
+    ┌─ tests/checking/typing/recursive_function_types.move:103:5
+    │
+103 │     struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = field `f` of `S1` contains `S2`
+    = field `0` of `S2` contains `E`
+    = field `s` of `E` contains `S1`, which forms a cycle.
+
+error: cyclic data
+    ┌─ tests/checking/typing/recursive_function_types.move:112:5
+    │
+112 │     struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = field `f` of `S1` contains `S2`
+    = field `0` of `S2` contains `S3`
+    = field `0` of `S3` contains `E`
+    = field `s` of `E` contains `S1`, which forms a cycle.
+
+error: cyclic data
+    ┌─ tests/checking/typing/recursive_function_types.move:122:5
+    │
+122 │     struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+    │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = field `f` of `S1` contains `S2`
+    = field `0` of `S2` contains `S3`
+    = field `0` of `S3` contains `S4`
+    = field `0` of `S4` contains `E`
+    = field `s` of `E` contains `S1`, which forms a cycle.

--- a/third_party/move/move-compiler-v2/tests/checking/typing/recursive_function_types.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/recursive_function_types.move
@@ -1,0 +1,130 @@
+module 0xc0ffed::m {
+    struct S(|S|) has copy, drop;
+}
+
+module 0xc0ffee::m1 {
+    struct S1(|S2|) has copy, drop;
+    struct S2(|S1|) has copy, drop;
+}
+
+module 0xc0ffef::m2 {
+    struct S1(|S2|) has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S1|) has copy, drop;
+}
+
+module 0xc0fff0::m3 {
+    struct S1(|S2|) has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S4|) has copy, drop;
+    struct S4(|S1|) has copy, drop;
+}
+
+module 0xc0fff1::m4 {
+    struct S1(||S1) has copy, drop;
+}
+
+module 0xc0fff2::m5 {
+    struct S(||S) has copy, drop;
+}
+
+module 0xc0fff3::m6 {
+    struct S1(|S2|) has copy, drop;
+    struct S2(||S1) has copy, drop;
+}
+
+module 0xc0fff4::m7 {
+    struct S1(|S2|) has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(||S1) has copy, drop;
+}
+
+module 0xc0fff5::m8 {
+    struct S1(|S2|) has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S4|) has copy, drop;
+    struct S4(||S1) has copy, drop;
+}
+
+
+module 0xc0fff6::m9 {
+    struct S1(|S2|) has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S4|) has copy, drop;
+    struct S4(||S1) has copy, drop;
+}
+
+module 0xc0fff7::m10 {
+    struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+    struct S2(|S1|) has copy, drop;
+}
+
+module 0xc0fff8::m11 {
+    struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S1|) has copy, drop;
+}
+
+module 0xc0fff9::m12 {
+    struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S4|) has copy, drop;
+    struct S4(|S1|) has copy, drop;
+}
+
+module 0xc0fff10::m13 {
+    struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+    struct S2(|&S1|) has copy, drop;
+}
+
+module 0xc0fff11::m14 {
+    struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|&S1|) has copy, drop;
+}
+
+module 0xc0fff12::m15 {
+    struct S1  { x: u64, y: u64, f : S2 } has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S4|) has copy, drop;
+    struct S4(|&S1|) has copy, drop;
+}
+
+module 0xc0fff13::m16 {
+    struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+    enum E {
+        A{s: S1},
+        B{a: u64}
+    } has copy, drop;
+    struct S2(|E|) has copy, drop;
+}
+
+module 0xc0fff14::m17 {
+    struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+    enum E {
+        A{s: S1},
+        B{a: u64}
+    } has copy, drop;
+    struct S2(|&E|) has copy, drop;
+}
+
+module 0xc0fff15::m18 {
+    struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+    enum E {
+        A{s: S1},
+        B{a: u64}
+    } has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|&E|) has copy, drop;
+}
+
+module 0xc0fff16::m19 {
+    struct S1 { x: u64, y: u64, f : S2 } has copy, drop;
+    enum E {
+        A{s: S1},
+        B{a: u64}
+    } has copy, drop;
+    struct S2(|S3|) has copy, drop;
+    struct S3(|S4|) has copy, drop;
+    struct S4(|&E|) has copy, drop;
+}


### PR DESCRIPTION
## Description

#16155 reports a recursive structure definition that involves function types and bypasses compiler checks. This is because the existing [recursive struct checker](https://github.com/aptos-labs/aptos-core/blob/jun/bug_16155/third_party/move/move-compiler-v2/src/env_pipeline/recursive_struct_checker.rs#L60) does not check function types nested inside structure definitions.

The fix adds support for function types, as well as other missing types (tuple and reference).

Close #16155

## How Has This Been Tested?
- New [compiler test cases](https://github.com/aptos-labs/aptos-core/blob/jun/bug_16155/third_party/move/move-compiler-v2/tests/checking/typing/recursive_function_types.move) added
- Existing compile tests and transactional_tests

## Key Areas to Review
- Potential side effects of new supports of other types in [recursive struct checker](https://github.com/aptos-labs/aptos-core/blob/jun/bug_16155/third_party/move/move-compiler-v2/src/env_pipeline/recursive_struct_checker.rs#L60) 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
