### PR TITLE
[debugger] release sender lock early

### DIFF
--- a/aptos-move/aptos-validator-interface/src/lib.rs
+++ b/aptos-move/aptos-validator-interface/src/lib.rs
@@ -149,8 +149,9 @@ impl DebuggerStateView {
         version: Version,
     ) -> Result<Option<StateValue>> {
         let (tx, rx) = std::sync::mpsc::channel();
-        let query_handler_locked = self.query_sender.lock().unwrap();
-        query_handler_locked
+        self.query_sender
+            .lock()
+            .unwrap()
             .send((state_key.clone(), version, tx))
             .unwrap();
         rx.recv()?


### PR DESCRIPTION


## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Remote state value fetches were not in parallel as expected.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

```
RUST_LOG=error cargo run --release -p aptos-debugger move execute-past-transactions --begin-version 2664750000 --limit 100 --rest-endpoint http://localhost:8080 --skip-result --concurrency-level 8
```

result:

```
[100 txns from 2664750000] Finished execution round 1/1 with concurrency_level=8 in 30990ms
```

vs (without the fix):

```
[100 txns from 2664750000] Finished execution round 1/1 with concurrency_level=8 in 52732ms
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] Bug fix


## Which Components or Systems Does This Change Impact?
- [x] Other (specify) -- tooling
