### PR TITLE
[compiler-v2] Provide error hints when trying to call a closure via field access

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/receiver_ambiguous.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/receiver_ambiguous.exp
@@ -1,0 +1,31 @@
+
+Diagnostics:
+error: undeclared receiver function `bar` for type `Func`
+  ┌─ tests/checking-lang-v2.2/lambda/receiver_ambiguous.move:8:9
+  │
+8 │         f.bar()
+  │         ^^^^^^^
+  │
+  = if you intend to call the closure stored in field `bar`, surround the entire field access with parenthesis `()`
+
+error: undeclared receiver function `bar` for type `Func`
+   ┌─ tests/checking-lang-v2.2/lambda/receiver_ambiguous.move:20:9
+   │
+20 │         f.bar()
+   │         ^^^^^^^
+   │
+   = if you intend to call the closure stored in field `bar`, surround the entire field access with parenthesis `()`
+
+error: undeclared receiver function `bar` for type `Func`
+   ┌─ tests/checking-lang-v2.2/lambda/receiver_ambiguous.move:32:9
+   │
+32 │         f.bar()
+   │         ^^^^^^^
+
+error: undeclared receiver function `0` for type `Func`
+   ┌─ tests/checking-lang-v2.2/lambda/receiver_ambiguous.move:41:9
+   │
+41 │         f.0(1)
+   │         ^^^^^^
+   │
+   = if you intend to call the closure stored in field `0`, surround the entire field access with parenthesis `()`

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/receiver_ambiguous.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/receiver_ambiguous.move
@@ -1,0 +1,43 @@
+module 0xc0ffee::m1 {
+    struct Func {
+        bar: ||u64
+     } has copy, drop;
+
+    fun test(): u64 {
+        let f = Func{ bar: || 42};
+        f.bar()
+    }
+}
+
+module 0xc0ffee::m2 {
+    enum Func {
+        V1 { bar: ||u64 },
+        V2 { bar: ||u64, x: u64 },
+     } has copy, drop;
+
+    fun test(): u64 {
+        let f = Func::V1{ bar: || 42};
+        f.bar()
+    }
+}
+
+module 0xc0ffee::m3 {
+    enum Func {
+        V1 { bar: ||u64 },
+        V2 { bar: u64 }
+     } has copy, drop;
+
+    fun test(): u64 {
+        let f = Func::V1{ bar: || 42};
+        f.bar()
+    }
+}
+
+module 0xc0ffee::m4 {
+    struct Func(|u64|u64) has copy, drop;
+
+    fun test(): u64 {
+        let f = Func(|x| x + 1);
+        f.0(1)
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/field_access_closure.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/field_access_closure.exp
@@ -1,0 +1,10 @@
+processed 4 tasks
+
+task 1 'run'. lines 31-31:
+return values: 42
+
+task 2 'run'. lines 33-33:
+return values: 87
+
+task 3 'run'. lines 35-35:
+return values: 42

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/field_access_closure.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/field_access_closure.move
@@ -1,0 +1,35 @@
+//# publish
+module 0xc0ffee::m {
+    struct Func1 {
+        bar: ||u64
+     } has copy, drop;
+
+    fun test1(): u64 {
+        let f = Func1{ bar: || 42};
+        (f.bar)()
+    }
+
+    enum Func2 {
+        V1 { bar: |u64|u64 },
+        V2 { bar: |u64|u64, x: u64 },
+     } has copy, drop;
+
+    fun test2(): u64 {
+        let f1 = Func2::V1{ bar: |x| x};
+        let f2 = Func2::V2{ bar: |x| x + 1, x: 44};
+        (f1.bar)(42) + (f2.bar)(f2.x)
+    }
+
+    struct Func3(||u64) has copy, drop;
+
+    fun test3(): u64 {
+        let f = Func3(|| 42);
+        (f.0)()
+    }
+}
+
+//# run 0xc0ffee::m::test1
+
+//# run 0xc0ffee::m::test2
+
+//# run 0xc0ffee::m::test3


### PR DESCRIPTION
## Description

A call of the form `f.bar()` is always interpreted as a method call, i.e., it is equivalent to `bar(f)` (or `bar(&f)` or `bar(&mut f)`, as appropriate for the context).

However, with the introduction of function values, `f` may be a struct with field `bar` that is a function value. In such a case, `f.bar()` leads to an error saying there is no receiver method `bar`. In this PR, we provide an additional hint saying, surround the field access with parenthesis if you intend to call the closure in field `bar`.

Closes #16448.

## How Has This Been Tested?

Added new tests to showcase the hints.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
