### PR TITLE
[compiler-v2] Fix type checking of returns within lambdas

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/returning_a_function.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/returning_a_function.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: expected function of type `|_|_` but found `u64`
+  ┌─ tests/checking-lang-v2.2/lambda/returning_a_function.move:4:20
+  │
+4 │             return (|y| x + y)
+  │                    ^^^^^^^^^^^
+
+error: expected function type has argument of type `()` but `u64` was provided
+   ┌─ tests/checking-lang-v2.2/lambda/returning_a_function.move:10:20
+   │
+10 │             return (|| x * y)
+   │                    ^^^^^^^^^^
+
+error: expected `u64` but found a value of type `(u64, u64)`
+   ┌─ tests/checking-lang-v2.2/lambda/returning_a_function.move:16:24
+   │
+16 │             return (|| (x, y))
+   │                        ^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/returning_a_function.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/returning_a_function.move
@@ -1,0 +1,19 @@
+module 0xc0ffee::m {
+    fun make_bad_func_1(): |u64|u64 has copy + drop {
+        |x: u64| {
+            return (|y| x + y)
+        }
+    }
+
+    fun make_bad_func_2(): |u64, u64|(|u64|u64) has copy + drop {
+        return (|x, y| {
+            return (|| x * y)
+        })
+    }
+
+    fun make_bad_func_3(): |u64, u64|(||u64) has copy + drop {
+        return (|x, y| {
+            return (|| (x, y))
+        })
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16408.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16408.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16408.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16408.move
@@ -1,0 +1,30 @@
+//# publish
+module 0xc0ffee::m {
+    fun make_func_1(): |u64|(|u64|u64) has copy + drop {
+        |x: u64| {
+            return (|y| x + y)
+        }
+    }
+
+    fun make_func_2(): |u64, u64|(||u64) has copy + drop {
+        return (|x, y| {
+            return (|| x * y)
+        })
+    }
+
+    fun make_func_3(): |u64, u64|(||(u64, u64)) has copy + drop {
+        return (|x, y| {
+            return (|| (x, y))
+        })
+    }
+
+    fun test() {
+        assert!(make_func_1()(10)(20) == 30);
+        assert!(make_func_2()(10, 20)() == 200);
+        let (a, b) = make_func_3()(10, 20)();
+        assert!(a == 10);
+        assert!(b == 20);
+    }
+}
+
+//# run 0xc0ffee::m::test

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -71,6 +71,9 @@ pub(crate) struct ExpTranslator<'env, 'translator, 'module_translator> {
     pub fun_is_inline: bool,
     /// The result type of the function this expression is associated with.
     pub result_type: Option<Type>,
+    /// A stack of return types for nested lambda expressions.
+    /// The top of the stack refers to the nearest enclosing lambda expression.
+    pub lambda_result_type_stack: Vec<Type>,
     /// Status for the `old(...)` expression form.
     pub old_status: OldExpStatus,
     /// The currently build type substitution.
@@ -158,6 +161,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             fun_name: None,
             fun_is_inline: false,
             result_type: None,
+            lambda_result_type_stack: vec![],
             old_status: OldExpStatus::NotSupported,
             subs: Substitution::new(),
             type_var_counter: 0,
@@ -516,6 +520,16 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
     /// Exits the most inner scope of the locals table.
     pub fn exit_scope(&mut self) {
         self.local_table.pop_front();
+    }
+
+    /// Pushes the given lambda result type onto the stack.
+    pub fn push_lambda_result_type(&mut self, result_type: &Type) {
+        self.lambda_result_type_stack.push(result_type.clone());
+    }
+
+    /// Pops the top element from the lambda result type stack.
+    pub fn pop_lambda_result_type(&mut self) {
+        self.lambda_result_type_stack.pop();
     }
 
     /// Mark the current active scope level as context, i.e. symbols which are not
@@ -1756,10 +1770,19 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             },
             EA::Exp_::Return(exp) => {
                 self.require_impl_language(&loc);
-                let return_type = if let Some(ty) = &self.result_type {
-                    ty.clone()
+                let return_type = if self.lambda_result_type_stack.is_empty() {
+                    // Use the function's result type as we are not in a lambda.
+                    if let Some(ty) = &self.result_type {
+                        ty.clone()
+                    } else {
+                        Type::unit()
+                    }
                 } else {
-                    Type::unit()
+                    // Use the nearest enclosing lambda's result type.
+                    self.lambda_result_type_stack
+                        .last()
+                        .expect("stack is not empty")
+                        .clone()
                 };
                 let exp =
                     self.translate_exp_in_context(exp, &return_type, &ErrorMessageContext::Return);
@@ -5317,7 +5340,9 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
             None,
         );
         // Translate body
+        self.push_lambda_result_type(&result_ty);
         let rbody = self.translate_exp(body, &result_ty);
+        self.pop_lambda_result_type();
         let id = self.new_node_id_with_type_loc(expected_type, loc);
         let spec_ty = self.fresh_type_var();
         if let Some(spec) = spec_opt {


### PR DESCRIPTION
## Description

Closes #16408.

When we type checked the expression `return exp`, the type of `exp` was expected to be the return type of the function containing this expression. This is not correct if we are inside a lambda expression, in which case, we should instead expect the return type of the nearest enclosing lambda expression.

Previously, we would admit:
```move
    fun make_bad_func_1(): |u64|u64 has copy + drop {
        |x: u64| {
            return (|y| x + y)
        }
    }
```
But this would fail bytecode verification.

Now we fail type check on this code.

## How Has This Been Tested?
- Added new tests.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
