### PR TITLE
Add the URI scheme field to the evm daa abstract signature + add MessageV2

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/ethereum_derivable_account.md
+++ b/aptos-move/framework/aptos-framework/doc/ethereum_derivable_account.md
@@ -81,6 +81,34 @@ Issued At: <issued_at>
 
 <dl>
 <dt>
+<code>issued_at: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+</dt>
+<dd>
+ The date and time when the signature was issued
+</dd>
+<dt>
+<code>signature: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
+</dt>
+<dd>
+ The signature of the message
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+<details>
+<summary>MessageV2</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
 <code>scheme: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
@@ -245,10 +273,14 @@ We include the issued_at in the signature as it is a required field in the SIWE 
     <b>let</b> stream = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_new">bcs_stream::new</a>(*abstract_signature);
     <b>let</b> signature_type = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_u8">bcs_stream::deserialize_u8</a>(&<b>mut</b> stream);
     <b>if</b> (signature_type == 0x00) {
+        <b>let</b> issued_at = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
+        <b>let</b> signature = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
+        SIWEAbstractSignature::MessageV1 { issued_at: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(issued_at), signature }
+    } <b>else</b> <b>if</b> (signature_type == 0x01) {
         <b>let</b> scheme = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
         <b>let</b> issued_at = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
         <b>let</b> signature = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
-        SIWEAbstractSignature::MessageV1 { scheme: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(scheme), issued_at: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(issued_at), signature }
+        SIWEAbstractSignature::MessageV2 { scheme: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(scheme), issued_at: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(issued_at), signature }
     } <b>else</b> {
         <b>abort</b>(<a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_EINVALID_SIGNATURE_TYPE">EINVALID_SIGNATURE_TYPE</a>)
     }

--- a/aptos-move/framework/aptos-framework/doc/ethereum_derivable_account.md
+++ b/aptos-move/framework/aptos-framework/doc/ethereum_derivable_account.md
@@ -12,7 +12,7 @@ SIWE.
 
 Please confirm you explicitly initiated this request from <domain>. You are approving to execute transaction <entry_function_name> on Aptos blockchain (<network_name>).
 
-URI: <domain>
+URI: <scheme>://<domain>
 Version: 1
 Chain ID: <chain_id>
 Nonce: <digest>
@@ -81,16 +81,22 @@ Issued At: <issued_at>
 
 <dl>
 <dt>
+<code>scheme: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
+</dt>
+<dd>
+ The scheme in the URI of the message, e.g. the scheme of the website that requested the signature (http, https, etc.)
+</dd>
+<dt>
 <code>issued_at: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_String">string::String</a></code>
 </dt>
 <dd>
-
+ The date and time when the signature was issued
 </dd>
 <dt>
 <code>signature: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;</code>
 </dt>
 <dd>
-
+ The signature of the message
 </dd>
 </dl>
 
@@ -239,9 +245,10 @@ We include the issued_at in the signature as it is a required field in the SIWE 
     <b>let</b> stream = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_new">bcs_stream::new</a>(*abstract_signature);
     <b>let</b> signature_type = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_u8">bcs_stream::deserialize_u8</a>(&<b>mut</b> stream);
     <b>if</b> (signature_type == 0x00) {
+        <b>let</b> scheme = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
         <b>let</b> issued_at = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
         <b>let</b> signature = <a href="../../aptos-stdlib/doc/bcs_stream.md#0x1_bcs_stream_deserialize_vector">bcs_stream::deserialize_vector</a>&lt;u8&gt;(&<b>mut</b> stream, |x| deserialize_u8(x));
-        SIWEAbstractSignature::MessageV1 { issued_at: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(issued_at), signature }
+        SIWEAbstractSignature::MessageV1 { scheme: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(scheme), issued_at: <a href="../../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string_utf8">string::utf8</a>(issued_at), signature }
     } <b>else</b> {
         <b>abort</b>(<a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_EINVALID_SIGNATURE_TYPE">EINVALID_SIGNATURE_TYPE</a>)
     }
@@ -258,7 +265,7 @@ We include the issued_at in the signature as it is a required field in the SIWE 
 
 
 
-<pre><code><b>fun</b> <a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_construct_message">construct_message</a>(ethereum_address: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, domain: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, entry_function_name: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, digest_utf8: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, issued_at: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
+<pre><code><b>fun</b> <a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_construct_message">construct_message</a>(ethereum_address: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, domain: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, entry_function_name: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, digest_utf8: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, issued_at: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, scheme: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;
 </code></pre>
 
 
@@ -273,6 +280,7 @@ We include the issued_at in the signature as it is a required field in the SIWE 
     entry_function_name: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     digest_utf8: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     issued_at: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    scheme: &<a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
 ): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     <b>let</b> message = &<b>mut</b> <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
     message.append(*domain);
@@ -290,6 +298,8 @@ We include the issued_at in the signature as it is a required field in the SIWE 
     message.append(b")");
     message.append(b".");
     message.append(b"\n\nURI: ");
+    message.append(*scheme);
+    message.append(b"://");
     message.append(*domain);
     message.append(b"\nVersion: 1");
     message.append(b"\nChain ID: ");
@@ -388,7 +398,8 @@ We include the issued_at in the signature as it is a required field in the SIWE 
     <b>let</b> digest_utf8 = <a href="../../aptos-stdlib/doc/string_utils.md#0x1_string_utils_to_string">string_utils::to_string</a>(aa_auth_data.digest()).bytes();
     <b>let</b> abstract_signature = <a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_deserialize_abstract_signature">deserialize_abstract_signature</a>(aa_auth_data.derivable_abstract_signature());
     <b>let</b> issued_at = abstract_signature.issued_at.bytes();
-    <b>let</b> message = <a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_construct_message">construct_message</a>(&abstract_public_key.ethereum_address, &abstract_public_key.domain, entry_function_name, digest_utf8, issued_at);
+    <b>let</b> scheme = abstract_signature.scheme.bytes();
+    <b>let</b> message = <a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_construct_message">construct_message</a>(&abstract_public_key.ethereum_address, &abstract_public_key.domain, entry_function_name, digest_utf8, issued_at, scheme);
     <b>let</b> hashed_message = <a href="../../aptos-stdlib/../move-stdlib/doc/hash.md#0x1_aptos_hash_keccak256">aptos_hash::keccak256</a>(message);
     <b>let</b> public_key_bytes = <a href="ethereum_derivable_account.md#0x1_ethereum_derivable_account_recover_public_key">recover_public_key</a>(&abstract_signature.signature, &hashed_message);
 

--- a/aptos-move/framework/aptos-framework/sources/account/common_account_abstractions/ethereum_derivable_account.move
+++ b/aptos-move/framework/aptos-framework/sources/account/common_account_abstractions/ethereum_derivable_account.move
@@ -7,7 +7,7 @@
 ///
 /// Please confirm you explicitly initiated this request from <domain>. You are approving to execute transaction <entry_function_name> on Aptos blockchain (<network_name>).
 ///
-/// URI: <domain>
+/// URI: <scheme>://<domain>
 /// Version: 1
 /// Chain ID: <chain_id>
 /// Nonce: <digest>
@@ -50,7 +50,11 @@ module aptos_framework::ethereum_derivable_account {
 
     enum SIWEAbstractSignature has drop {
         MessageV1 {
+            /// The scheme in the URI of the message, e.g. the scheme of the website that requested the signature (http, https, etc.)
+            scheme: String,
+            /// The date and time when the signature was issued
             issued_at: String,
+            /// The signature of the message
             signature: vector<u8>,
         },
     }
@@ -77,9 +81,10 @@ module aptos_framework::ethereum_derivable_account {
         let stream = bcs_stream::new(*abstract_signature);
         let signature_type = bcs_stream::deserialize_u8(&mut stream);
         if (signature_type == 0x00) {
+            let scheme = bcs_stream::deserialize_vector<u8>(&mut stream, |x| deserialize_u8(x));
             let issued_at = bcs_stream::deserialize_vector<u8>(&mut stream, |x| deserialize_u8(x));
             let signature = bcs_stream::deserialize_vector<u8>(&mut stream, |x| deserialize_u8(x));
-            SIWEAbstractSignature::MessageV1 { issued_at: string::utf8(issued_at), signature }
+            SIWEAbstractSignature::MessageV1 { scheme: string::utf8(scheme), issued_at: string::utf8(issued_at), signature }
         } else {
             abort(EINVALID_SIGNATURE_TYPE)
         }
@@ -93,6 +98,7 @@ module aptos_framework::ethereum_derivable_account {
         entry_function_name: &vector<u8>,
         digest_utf8: &vector<u8>,
         issued_at: &vector<u8>,
+        scheme: &vector<u8>,
     ): vector<u8> {
         let message = &mut vector[];
         message.append(*domain);
@@ -110,6 +116,8 @@ module aptos_framework::ethereum_derivable_account {
         message.append(b")");
         message.append(b".");
         message.append(b"\n\nURI: ");
+        message.append(*scheme);
+        message.append(b"://");
         message.append(*domain);
         message.append(b"\nVersion: 1");
         message.append(b"\nChain ID: ");
@@ -169,7 +177,8 @@ module aptos_framework::ethereum_derivable_account {
         let digest_utf8 = string_utils::to_string(aa_auth_data.digest()).bytes();
         let abstract_signature = deserialize_abstract_signature(aa_auth_data.derivable_abstract_signature());
         let issued_at = abstract_signature.issued_at.bytes();
-        let message = construct_message(&abstract_public_key.ethereum_address, &abstract_public_key.domain, entry_function_name, digest_utf8, issued_at);
+        let scheme = abstract_signature.scheme.bytes();
+        let message = construct_message(&abstract_public_key.ethereum_address, &abstract_public_key.domain, entry_function_name, digest_utf8, issued_at, scheme);
         let hashed_message = aptos_hash::keccak256(message);
         let public_key_bytes = recover_public_key(&abstract_signature.signature, &hashed_message);
 
@@ -216,8 +225,8 @@ module aptos_framework::ethereum_derivable_account {
     }
 
     #[test_only]
-    fun create_raw_signature(issued_at: String, signature: vector<u8>): vector<u8> {
-        let abstract_signature = SIWEAbstractSignature::MessageV1 { issued_at, signature };
+    fun create_raw_signature(scheme: String, issued_at: String, signature: vector<u8>): vector<u8> {
+        let abstract_signature = SIWEAbstractSignature::MessageV1 { scheme, issued_at, signature };
         bcs::to_bytes(&abstract_signature)
     }
 
@@ -240,11 +249,12 @@ module aptos_framework::ethereum_derivable_account {
             58, 209, 105, 56, 204, 253, 73, 82, 201, 197, 201, 139, 201, 19, 65, 215,
             28
         ];
-        let abstract_signature = create_raw_signature(utf8(b"2025-01-01T00:00:00.000Z"), signature_bytes);
+        let abstract_signature = create_raw_signature(utf8(b"https"), utf8(b"2025-01-01T00:00:00.000Z"), signature_bytes);
         let siwe_abstract_signature = deserialize_abstract_signature(&abstract_signature);
         assert!(siwe_abstract_signature is SIWEAbstractSignature::MessageV1);
         match (siwe_abstract_signature) {
-            SIWEAbstractSignature::MessageV1 { signature, issued_at } => {
+            SIWEAbstractSignature::MessageV1 { signature, issued_at, scheme } => {
+                assert!(scheme == utf8(b"https"));
                 assert!(issued_at == utf8(b"2025-01-01T00:00:00.000Z"));
                 assert!(signature == signature_bytes);
             },
@@ -260,8 +270,9 @@ module aptos_framework::ethereum_derivable_account {
         let entry_function_name = b"0x1::aptos_account::transfer";
         let digest_utf8 = b"0x2a2f07c32382a94aa90ddfdb97076b77d779656bb9730c4f3e4d22a30df298dd";
         let issued_at = b"2025-01-01T00:00:00.000Z";
-        let message = construct_message(&ethereum_address, &domain, &entry_function_name, &digest_utf8, &issued_at);
-        let expected_message = b"\x19Ethereum Signed Message:\n434localhost:3001 wants you to sign in with your Ethereum account:\n0xC7B576Ead6aFb962E2DEcB35814FB29723AEC98a\n\nPlease confirm you explicitly initiated this request from localhost:3001. You are approving to execute transaction 0x1::aptos_account::transfer on Aptos blockchain (local).\n\nURI: localhost:3001\nVersion: 1\nChain ID: 4\nNonce: 0x2a2f07c32382a94aa90ddfdb97076b77d779656bb9730c4f3e4d22a30df298dd\nIssued At: 2025-01-01T00:00:00.000Z";
+        let scheme = b"https";
+        let message = construct_message(&ethereum_address, &domain, &entry_function_name, &digest_utf8, &issued_at, &scheme);
+        let expected_message = b"\x19Ethereum Signed Message:\n442localhost:3001 wants you to sign in with your Ethereum account:\n0xC7B576Ead6aFb962E2DEcB35814FB29723AEC98a\n\nPlease confirm you explicitly initiated this request from localhost:3001. You are approving to execute transaction 0x1::aptos_account::transfer on Aptos blockchain (local).\n\nURI: https://localhost:3001\nVersion: 1\nChain ID: 4\nNonce: 0x2a2f07c32382a94aa90ddfdb97076b77d779656bb9730c4f3e4d22a30df298dd\nIssued At: 2025-01-01T00:00:00.000Z";
         assert!(message == expected_message);
     }
 
@@ -271,15 +282,16 @@ module aptos_framework::ethereum_derivable_account {
         let ethereum_address = b"0xC7B576Ead6aFb962E2DEcB35814FB29723AEC98a";
         let domain = b"localhost:3001";
         let entry_function_name = b"0x1::aptos_account::transfer";
-        let digest = b"0x56b82ccf6bdb7569c5520483071e85195b16f7aaf68fd4439b4f3875544b2d4c";
-        let issued_at = b"2025-04-24T15:23:16.375Z";
-        let message = construct_message(&ethereum_address, &domain, &entry_function_name, &digest, &issued_at);
+        let digest = b"0x705f1f57dd8399bf134e649981af43b5c42e59f985c4e4335ab70ce3f96bcd27";
+        let issued_at = b"2025-05-02T16:17:10.714Z";
+        let scheme = b"https";
+        let message = construct_message(&ethereum_address, &domain, &entry_function_name, &digest, &issued_at, &scheme);
         let hashed_message = aptos_hash::keccak256(message);
         let signature_bytes = vector[
-            25, 245, 252, 11, 228, 158, 16, 231, 84, 246, 13, 201, 92, 85, 40, 8,
-            229, 109, 228, 110, 65, 89, 180, 143, 74, 213, 232, 180, 228, 182, 50, 15,
-            112, 247, 211, 216, 72, 236, 196, 230, 14, 130, 70, 190, 188, 81, 42, 111,
-            195, 78, 248, 162, 4, 58, 93, 144, 34, 85, 60, 118, 14, 177, 10, 141, 28
+            162, 57, 230, 98, 9, 139, 202, 15, 110, 61, 237, 54, 252, 234, 202, 13,
+            181, 196, 174, 19, 226, 50, 151, 63, 137, 229, 144, 15, 4, 56, 1, 122,
+            42, 51, 191, 43, 162, 155, 55, 227, 62, 164, 247, 18, 154, 68, 59, 82,
+            108, 124, 83, 72, 224, 158, 79, 20, 123, 172, 105, 71, 12, 114, 208, 246, 27
         ];
         let base64_public_key = recover_public_key(&signature_bytes, &hashed_message);
         assert!(base64_public_key == vector[
@@ -295,14 +307,14 @@ module aptos_framework::ethereum_derivable_account {
     fun test_authenticate_auth_data(framework: &signer) {
         chain_id::initialize_for_test(framework, 4);
 
-        let digest = x"56b82ccf6bdb7569c5520483071e85195b16f7aaf68fd4439b4f3875544b2d4c";
+        let digest = x"705f1f57dd8399bf134e649981af43b5c42e59f985c4e4335ab70ce3f96bcd27";
         let signature = vector[
-            25, 245, 252, 11, 228, 158, 16, 231, 84, 246, 13, 201, 92, 85, 40, 8,
-            229, 109, 228, 110, 65, 89, 180, 143, 74, 213, 232, 180, 228, 182, 50, 15,
-            112, 247, 211, 216, 72, 236, 196, 230, 14, 130, 70, 190, 188, 81, 42, 111,
-            195, 78, 248, 162, 4, 58, 93, 144, 34, 85, 60, 118, 14, 177, 10, 141, 28
+            162, 57, 230, 98, 9, 139, 202, 15, 110, 61, 237, 54, 252, 234, 202, 13,
+            181, 196, 174, 19, 226, 50, 151, 63, 137, 229, 144, 15, 4, 56, 1, 122,
+            42, 51, 191, 43, 162, 155, 55, 227, 62, 164, 247, 18, 154, 68, 59, 82,
+            108, 124, 83, 72, 224, 158, 79, 20, 123, 172, 105, 71, 12, 114, 208, 246, 27
         ];
-        let abstract_signature = create_raw_signature(utf8(b"2025-04-24T15:23:16.375Z"), signature);
+        let abstract_signature = create_raw_signature(utf8(b"https"), utf8(b"2025-05-02T16:17:10.714Z"), signature);
         let ethereum_address = b"0xC7B576Ead6aFb962E2DEcB35814FB29723AEC98a";
         let domain = b"localhost:3001";
         let abstract_public_key = create_abstract_public_key(ethereum_address, domain);
@@ -324,7 +336,7 @@ module aptos_framework::ethereum_derivable_account {
             58, 209, 105, 56, 204, 253, 73, 82, 201, 197, 201, 139, 201, 19, 65, 215,
             28
         ];
-        let abstract_signature = create_raw_signature(utf8(b"2025-01-01T00:00:00.000Z"), signature);
+        let abstract_signature = create_raw_signature(utf8(b"https"), utf8(b"2025-01-01T00:00:00.000Z"), signature);
         let ethereum_address = b"0xC7B576Ead6aFb962E2DEcB35814FB29723AEC98a";
         let domain = b"localhost:3001";
         let abstract_public_key = create_abstract_public_key(ethereum_address, domain);

--- a/aptos-move/framework/aptos-framework/sources/account/common_account_abstractions/ethereum_derivable_account.move
+++ b/aptos-move/framework/aptos-framework/sources/account/common_account_abstractions/ethereum_derivable_account.move
@@ -252,7 +252,7 @@ module aptos_framework::ethereum_derivable_account {
     }
 
     #[test]
-    fun test_deserialize_abstract_signature() {
+    fun test_deserialize_abstract_signature_with_https() {
         let signature_bytes = vector[
             249, 247, 194, 250, 31, 233, 100, 234, 109, 142, 6, 193, 203, 33, 147, 199,
             236, 117, 69, 119, 252, 219, 150, 143, 28, 112, 33, 9, 95, 53, 0, 69,
@@ -271,6 +271,31 @@ module aptos_framework::ethereum_derivable_account {
             SIWEAbstractSignature::MessageV2 { signature, issued_at, scheme } => {
                 assert!(scheme == utf8(b"https"));
                 assert!(issued_at == utf8(b"2025-01-01T00:00:00.000Z"));
+                assert!(signature == signature_bytes);
+            },
+        };
+    }
+
+    #[test]
+    fun test_deserialize_abstract_signature_with_http() {
+        let signature_bytes = vector[
+            1, 252, 18, 58, 243, 10, 152, 94, 33, 5, 76, 133, 39, 188, 25, 92,
+            242, 39, 32, 84, 181, 94, 231, 9, 49, 141, 131, 20, 108, 93, 76, 144,
+            47, 20, 83, 177, 107, 22, 148, 93, 191, 165, 86, 42, 181, 226, 116, 136,
+            133, 84, 35, 222, 24, 36, 176, 143, 15, 14, 182, 135, 153, 141, 238, 238,
+            28
+            ];
+        let abstract_signature = create_raw_signature(utf8(b"http"), utf8(b"2025-05-08T23:39:00.000Z"), signature_bytes);
+        let siwe_abstract_signature = deserialize_abstract_signature(&abstract_signature);
+        assert!(siwe_abstract_signature is SIWEAbstractSignature::MessageV2);
+        match (siwe_abstract_signature) {
+            SIWEAbstractSignature::MessageV1 { signature, issued_at } => {
+                assert!(issued_at == utf8(b"2025-05-08T23:39:00.000Z"));
+                assert!(signature == signature_bytes);
+            },
+            SIWEAbstractSignature::MessageV2 { signature, issued_at, scheme } => {
+                assert!(scheme == utf8(b"http"));
+                assert!(issued_at == utf8(b"2025-05-08T23:39:00.000Z"));
                 assert!(signature == signature_bytes);
             },
         };

--- a/testsuite/smoke-test/src/account_abstraction.rs
+++ b/testsuite/smoke-test/src/account_abstraction.rs
@@ -37,6 +37,7 @@ struct SIWEAbstractPublicKey {
 
 #[derive(Serialize)]
 enum SIWEAbstractSignature {
+    #[allow(dead_code)]
     MessageV1 {
         issued_at: String,
         signature: Vec<u8>,

--- a/testsuite/smoke-test/src/account_abstraction.rs
+++ b/testsuite/smoke-test/src/account_abstraction.rs
@@ -38,6 +38,10 @@ struct SIWEAbstractPublicKey {
 #[derive(Serialize)]
 enum SIWEAbstractSignature {
     MessageV1 {
+        issued_at: String,
+        signature: Vec<u8>,
+    },
+    MessageV2 {
         scheme: String,
         issued_at: String,
         signature: Vec<u8>,
@@ -201,7 +205,7 @@ async fn test_ethereum_derivable_account() {
                 let signature = wallet.sign_hash(H256::from(hash)).unwrap();
                 let sig_bytes = signature.to_vec();
 
-                let signature = SIWEAbstractSignature::MessageV1 {
+                let signature = SIWEAbstractSignature::MessageV2 {
                     scheme: scheme.to_string(),
                     issued_at: "2025-01-01T00:00:00.000Z".to_string(),
                     signature: sig_bytes,

--- a/testsuite/smoke-test/src/account_abstraction.rs
+++ b/testsuite/smoke-test/src/account_abstraction.rs
@@ -38,6 +38,7 @@ struct SIWEAbstractPublicKey {
 #[derive(Serialize)]
 enum SIWEAbstractSignature {
     MessageV1 {
+        scheme: String,
         issued_at: String,
         signature: Vec<u8>,
     },
@@ -169,6 +170,8 @@ async fn test_ethereum_derivable_account() {
     })
     .unwrap();
 
+    let scheme = "https";
+
     let account = LocalAccount::new_domain_aa(
         function_info,
         account_identity,
@@ -177,11 +180,12 @@ async fn test_ethereum_derivable_account() {
                 let function_name = "0x1::aptos_account::create_account";
                 let digest = format!("0x{}", hex::encode(x));
                 let message_body = format!(
-                    "{} wants you to sign in with your Ethereum account:\n{}\n\nPlease confirm you explicitly initiated this request from {}. You are approving to execute transaction {} on Aptos blockchain (local).\n\nURI: {}\nVersion: 1\nChain ID: {}\nNonce: {}\nIssued At: {}",
+                    "{} wants you to sign in with your Ethereum account:\n{}\n\nPlease confirm you explicitly initiated this request from {}. You are approving to execute transaction {} on Aptos blockchain (local).\n\nURI: {}://{}\nVersion: 1\nChain ID: {}\nNonce: {}\nIssued At: {}",
                     domain,
                     address_str,
                     domain,
                     function_name,
+                    scheme,
                     domain,
                     4,
                     digest,
@@ -198,6 +202,7 @@ async fn test_ethereum_derivable_account() {
                 let sig_bytes = signature.to_vec();
 
                 let signature = SIWEAbstractSignature::MessageV1 {
+                    scheme: scheme.to_string(),
                     issued_at: "2025-01-01T00:00:00.000Z".to_string(),
                     signature: sig_bytes,
                 };


### PR DESCRIPTION
## Description
We use the `domain` as the `uri` in the message for the EVM dAA, but while it works locally (i.e `localhost:3001`) it is misleading since in production (i.e `aptos-labs.github.io`) it fails on the client (wallet) verification because it does not follow the `uri` format which is `<scheme>:<path>`.

Since we need to construct the message the user signed on on-chain, and need to include the `scheme`, we add it to the abstract signature so we can extract it from there and use it in the message we build on chain.

<img width="403" alt="image" src="https://github.com/user-attachments/assets/d9f8e28d-f95f-4ed2-adc4-40d9c696e091" />


## How Has This Been Tested?
unit tests + locally

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
