### PR TITLE
Update confidential asset transfer to use dispatchable_fungible_asset

### DIFF
--- a/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
+++ b/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
@@ -72,6 +72,7 @@ It enables private transfers by obfuscating token amounts while keeping sender a
 <pre><code><b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/bcs.md#0x1_bcs">0x1::bcs</a>;
 <b>use</b> <a href="../../aptos-framework/doc/chain_id.md#0x1_chain_id">0x1::chain_id</a>;
 <b>use</b> <a href="../../aptos-framework/doc/coin.md#0x1_coin">0x1::coin</a>;
+<b>use</b> <a href="../../aptos-framework/doc/dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset">0x1::dispatchable_fungible_asset</a>;
 <b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
 <b>use</b> <a href="../../aptos-framework/doc/event.md#0x1_event">0x1::event</a>;
 <b>use</b> <a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset">0x1::fungible_asset</a>;
@@ -1645,7 +1646,7 @@ Implementation of the <code>deposit_to</code> entry function.
     <b>let</b> sender_fa_store = <a href="../../aptos-framework/doc/primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">primary_fungible_store::ensure_primary_store_exists</a>(from, token);
     <b>let</b> ca_fa_store = <a href="../../aptos-framework/doc/primary_fungible_store.md#0x1_primary_fungible_store_ensure_primary_store_exists">primary_fungible_store::ensure_primary_store_exists</a>(<a href="confidential_asset.md#0x7_confidential_asset_get_fa_store_address">get_fa_store_address</a>(), token);
 
-    <a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_transfer">fungible_asset::transfer</a>(sender, sender_fa_store, ca_fa_store, amount);
+    <a href="../../aptos-framework/doc/dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_transfer">dispatchable_fungible_asset::transfer</a>(sender, sender_fa_store, ca_fa_store, amount);
 
     <b>let</b> ca_store = <b>borrow_global_mut</b>&lt;<a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>&gt;(<a href="confidential_asset.md#0x7_confidential_asset_get_user_address">get_user_address</a>(<b>to</b>, token));
     <b>let</b> pending_balance = <a href="confidential_balance.md#0x7_confidential_balance_decompress_balance">confidential_balance::decompress_balance</a>(&ca_store.pending_balance);

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -12,7 +12,8 @@ module aptos_experimental::confidential_asset {
     use aptos_framework::chain_id;
     use aptos_framework::coin;
     use aptos_framework::event;
-    use aptos_framework::fungible_asset::{Self, Metadata};
+    use aptos_framework::dispatchable_fungible_asset;
+    use aptos_framework::fungible_asset::{Metadata};
     use aptos_framework::object::{Self, ExtendRef, Object};
     use aptos_framework::primary_fungible_store;
     use aptos_framework::system_addresses;
@@ -649,7 +650,7 @@ module aptos_experimental::confidential_asset {
         let sender_fa_store = primary_fungible_store::ensure_primary_store_exists(from, token);
         let ca_fa_store = primary_fungible_store::ensure_primary_store_exists(get_fa_store_address(), token);
 
-        fungible_asset::transfer(sender, sender_fa_store, ca_fa_store, amount);
+        dispatchable_fungible_asset::transfer(sender, sender_fa_store, ca_fa_store, amount);
 
         let ca_store = borrow_global_mut<ConfidentialAssetStore>(get_user_address(to, token));
         let pending_balance = confidential_balance::decompress_balance(&ca_store.pending_balance);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
This updates the confidential_asset module to use dispatchable_fungible_asset::transfer instead of fungible_asset::transfer.  This is needed to cover both dispatchable and non-dispatchable cases.

Deposit and withdraw use primary_fungible_store which utilizes   dispatchable_fungible_asset.


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Todo

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
