### PR TITLE
[compiler-v2] Compiler checks for various reference of a reference

### DIFF
--- a/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/instantiate_signatures.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-check/v1-typing/instantiate_signatures.exp
@@ -22,6 +22,12 @@ error: reference type `&u64` is not allowed as a type argument
    │
    = required by instantiating type parameter `T:drop` of struct `S`
 
+error: reference to a reference is not allowed
+   ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:13:13
+   │
+13 │         f3: &(&u64),
+   │             ^^^^^^^
+
 error: reference type `&&u64` is not allowed as a field type
    ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:13:13
    │
@@ -63,6 +69,12 @@ error: reference type `&u64` is not allowed as a type argument
    │
    = required by instantiating type parameter `T:drop` of struct `S`
 
+error: reference to a reference is not allowed
+   ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:20:14
+   │
+20 │         _f3: &(&u64),
+   │              ^^^^^^^
+
 error: tuple type `(u64, u64)` is not allowed as a type argument
    ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:21:16
    │
@@ -95,6 +107,12 @@ error: reference type `&u64` is not allowed as a type argument
    │           ^^^^
    │
    = required by instantiating type parameter `T:drop` of struct `S`
+
+error: reference to a reference is not allowed
+   ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:30:9
+   │
+30 │         &(&u64),
+   │         ^^^^^^^
 
 error: tuple type `(u64, u64)` is not allowed as a type argument
    ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:31:11
@@ -129,6 +147,12 @@ error: reference type `&u64` is not allowed as a type argument
    │
    = required by instantiating type parameter `T:drop` of struct `S`
 
+error: reference to a reference is not allowed
+   ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:39:17
+   │
+39 │         let f3: &(&u64) = abort 0;
+   │                 ^^^^^^^
+
 error: tuple type `(u64, u64)` is not allowed as a type argument
    ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:40:19
    │
@@ -139,6 +163,12 @@ error: tuple type `(u64, u64)` is not allowed as a type argument
    │                   ^^^^^^^^^^
    │
    = required by instantiating type parameter `T:drop` of struct `S`
+
+error: reference to a reference is not allowed
+   ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:44:12
+   │
+44 │         id<&(&u64)>(abort 0);
+   │            ^^^^^^^
 
 error: reference type `&&u64` is not allowed as a type argument
    ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:44:12
@@ -162,3 +192,9 @@ error: type `R` is missing required ability `drop`
    │
    = required by instantiating type parameter `T:drop` of struct `S`
    = required by instantiating type parameter `T:drop` of struct `S`
+
+error: reference to a reference is not allowed
+   ┌─ tests/ability-check/v1-typing/instantiate_signatures.move:49:11
+   │
+49 │         S<&(&u64)> { f: abort 0 };
+   │           ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/constraints.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/constraints.exp
@@ -18,7 +18,7 @@ error: phantom type `T` can only be used as an argument for another phantom type
 4 │     struct Func3<phantom T>(|u64|(T, T)) has copy, drop;
   │                                   ^
 
-error: tuple type `(u64, u64)` is not allowed as a type argument
+error: tuple type `(u64, u64)` is not allowed
   ┌─ tests/checking-lang-v2.2/lambda/constraints.move:5:24
   │
 5 │     struct Func4(|u64|((u64, u64), u64)) has copy, drop;

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_ref.exp
@@ -1,0 +1,61 @@
+
+Diagnostics:
+error: reference to a reference is not allowed
+  ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:3:19
+  │
+3 │     struct Func1(|&mut &mut u64|);
+  │                   ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:5:19
+  │
+5 │     struct Func2(|& &u64|);
+  │                   ^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:7:20
+  │
+7 │     struct Func3(||(&mut &mut u64));
+  │                    ^^^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:9:21
+  │
+9 │     struct Func4(|(|&mut &mut u64|)|);
+  │                     ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:11:19
+   │
+11 │     fun test1(f: |&mut &mut u64|) {}
+   │                   ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:13:19
+   │
+13 │     fun test2(): |&(&u64)|u64 {
+   │                   ^^^^^^^
+
+error: lambda expression has invalid type `|&&u64|u64` (reference to a reference is disallowed)
+   ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:14:9
+   │
+14 │         |x| **x + 1
+   │         ^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:18:17
+   │
+18 │         let f: |& &u64|u64 = |x| {**x + 1};
+   │                 ^^^^^^
+
+error: lambda expression has invalid type `|&&u64|u64` (reference to a reference is disallowed)
+   ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:18:30
+   │
+18 │         let f: |& &u64|u64 = |x| {**x + 1};
+   │                              ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking-lang-v2.2/lambda/ref_ref.move:21:18
+   │
+21 │     fun test4(f: & &|(&u64)|) {}
+   │                  ^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_ref.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_ref.move
@@ -1,0 +1,22 @@
+module 0xc0ffee::m {
+    // Test case from bug 16491.
+    struct Func1(|&mut &mut u64|);
+
+    struct Func2(|& &u64|);
+
+    struct Func3(||(&mut &mut u64));
+
+    struct Func4(|(|&mut &mut u64|)|);
+
+    fun test1(f: |&mut &mut u64|) {}
+
+    fun test2(): |&(&u64)|u64 {
+        |x| **x + 1
+    }
+
+    fun test3() {
+        let f: |& &u64|u64 = |x| {**x + 1};
+    }
+
+    fun test4(f: & &|(&u64)|) {}
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_to_ref_inferred.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_to_ref_inferred.exp
@@ -1,0 +1,31 @@
+
+Diagnostics:
+error: lambda expression has invalid type `|&&u64|(&&u64, &&u64)` (reference to a reference is disallowed)
+  ┌─ tests/checking-lang-v2.2/lambda/ref_to_ref_inferred.move:3:17
+  │
+3 │           let f = |x| {
+  │ ╭─────────────────^
+4 │ │             **x + 1;
+5 │ │             (x, x)
+6 │ │         };
+  │ ╰─────────^
+
+error: lambda expression has invalid type `|(&&u64, u64)|&&u64` (reference to a reference is disallowed)
+   ┌─ tests/checking-lang-v2.2/lambda/ref_to_ref_inferred.move:10:17
+   │
+10 │           let f = |x, y| {
+   │ ╭─────────────────^
+11 │ │             let p = *x;
+12 │ │             let q = *p + y;
+13 │ │             x
+14 │ │         };
+   │ ╰─────────^
+
+error: lambda expression has invalid type `|(&&&&&&u64, &&&u64)|u64` (reference to a reference is disallowed)
+   ┌─ tests/checking-lang-v2.2/lambda/ref_to_ref_inferred.move:18:17
+   │
+18 │           let f = |x, y| {
+   │ ╭─────────────────^
+19 │ │             ******x + ***y
+20 │ │         };
+   │ ╰─────────^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_to_ref_inferred.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/ref_to_ref_inferred.move
@@ -1,0 +1,23 @@
+module 0xc0ffee::m {
+    fun test1() {
+        let f = |x| {
+            **x + 1;
+            (x, x)
+        };
+    }
+
+    fun test2() {
+        let f = |x, y| {
+            let p = *x;
+            let q = *p + y;
+            x
+        };
+    }
+
+    fun test3() {
+        let f = |x, y| {
+            ******x + ***y
+        };
+        let g = f;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/abilities/instantiate_signatures.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/abilities/instantiate_signatures.exp
@@ -22,6 +22,12 @@ error: reference type `&u64` is not allowed as a type argument
    │
    = required by instantiating type parameter `T:drop` of struct `S`
 
+error: reference to a reference is not allowed
+   ┌─ tests/checking/abilities/instantiate_signatures.move:13:13
+   │
+13 │         f3: &(&u64),
+   │             ^^^^^^^
+
 error: reference type `&&u64` is not allowed as a field type
    ┌─ tests/checking/abilities/instantiate_signatures.move:13:13
    │
@@ -63,6 +69,12 @@ error: reference type `&u64` is not allowed as a type argument
    │
    = required by instantiating type parameter `T:drop` of struct `S`
 
+error: reference to a reference is not allowed
+   ┌─ tests/checking/abilities/instantiate_signatures.move:20:14
+   │
+20 │         _f3: &(&u64),
+   │              ^^^^^^^
+
 error: tuple type `(u64, u64)` is not allowed as a type argument
    ┌─ tests/checking/abilities/instantiate_signatures.move:21:16
    │
@@ -73,6 +85,12 @@ error: tuple type `(u64, u64)` is not allowed as a type argument
    │                ^^^^^^^^^^
    │
    = required by instantiating type parameter `T:drop` of struct `S`
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking/abilities/instantiate_signatures.move:25:9
+   │
+25 │         &(&u64),
+   │         ^^^^^^^
 
 error: type `R` is missing required ability `drop`
    ┌─ tests/checking/abilities/instantiate_signatures.move:32:19
@@ -96,6 +114,12 @@ error: reference type `&u64` is not allowed as a type argument
    │
    = required by instantiating type parameter `T:drop` of struct `S`
 
+error: reference to a reference is not allowed
+   ┌─ tests/checking/abilities/instantiate_signatures.move:34:17
+   │
+34 │         let f3: &(&u64) = abort 0;
+   │                 ^^^^^^^
+
 error: tuple type `(u64, u64)` is not allowed as a type argument
    ┌─ tests/checking/abilities/instantiate_signatures.move:35:19
    │
@@ -106,6 +130,12 @@ error: tuple type `(u64, u64)` is not allowed as a type argument
    │                   ^^^^^^^^^^
    │
    = required by instantiating type parameter `T:drop` of struct `S`
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking/abilities/instantiate_signatures.move:39:12
+   │
+39 │         id<&(&u64)>(abort 0);
+   │            ^^^^^^^
 
 error: reference type `&&u64` is not allowed as a type argument
    ┌─ tests/checking/abilities/instantiate_signatures.move:39:12
@@ -129,3 +159,9 @@ error: type `R` is missing required ability `drop`
    │
    = required by instantiating type parameter `T:drop` of struct `S`
    = required by instantiating type parameter `T:drop` of struct `S`
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking/abilities/instantiate_signatures.move:44:11
+   │
+44 │         S<&(&u64)> { f: abort 0 };
+   │           ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/ref_to_a_ref.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/ref_to_a_ref.exp
@@ -1,0 +1,49 @@
+
+Diagnostics:
+error: reference to a reference is not allowed
+  ┌─ tests/checking/typing/ref_to_a_ref.move:2:18
+  │
+2 │     fun test1(): & &u64 {
+  │                  ^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking/typing/ref_to_a_ref.move:3:16
+  │
+3 │         let x: & &u64;
+  │                ^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking/typing/ref_to_a_ref.move:7:18
+  │
+7 │     fun test2(x: &mut &mut u64): (&mut &mut u64, &mut &mut u64) {(x, x)}
+  │                  ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking/typing/ref_to_a_ref.move:7:35
+  │
+7 │     fun test2(x: &mut &mut u64): (&mut &mut u64, &mut &mut u64) {(x, x)}
+  │                                   ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking/typing/ref_to_a_ref.move:7:50
+  │
+7 │     fun test2(x: &mut &mut u64): (&mut &mut u64, &mut &mut u64) {(x, x)}
+  │                                                  ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking/typing/ref_to_a_ref.move:9:18
+  │
+9 │     fun test3(x: &mut &mut u64): &mut &mut u64 {x}
+  │                  ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+  ┌─ tests/checking/typing/ref_to_a_ref.move:9:34
+  │
+9 │     fun test3(x: &mut &mut u64): &mut &mut u64 {x}
+  │                                  ^^^^^^^^^^^^^
+
+error: reference to a reference is not allowed
+   ┌─ tests/checking/typing/ref_to_a_ref.move:12:16
+   │
+12 │         let x: &mut &mut u64;
+   │                ^^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/ref_to_a_ref.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/ref_to_a_ref.move
@@ -1,0 +1,14 @@
+module 0xc0ffee::m {
+    fun test1(): & &u64 {
+        let x: & &u64;
+        return x
+    }
+
+    fun test2(x: &mut &mut u64): (&mut &mut u64, &mut &mut u64) {(x, x)}
+
+    fun test3(x: &mut &mut u64): &mut &mut u64 {x}
+
+    fun test4() {
+        let x: &mut &mut u64;
+    }
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1048,23 +1048,26 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                     rty
                 }
             },
-            Ref(is_mut, ty) => Type::Reference(
-                ReferenceKind::from_is_mut(*is_mut),
-                Box::new(self.translate_type(ty)),
-            ),
+            Ref(is_mut, ty) => {
+                let inner = self.translate_type(ty);
+                if inner.is_reference() {
+                    self.error(loc, "reference to a reference is not allowed");
+                }
+                Type::Reference(ReferenceKind::from_is_mut(*is_mut), Box::new(inner))
+            },
             Fun(args, result, abilities) => {
                 let arg_tys = args
                     .iter()
-                    .map(|ty| self.translate_function_param_type(ty))
+                    .map(|ty| self.translate_function_param_or_return_type(ty))
                     .collect_vec();
                 let result_tys = match &result.value {
                     Multiple(tys) => tys
                         .iter()
-                        .map(|ty| self.translate_function_param_type(ty))
+                        .map(|ty| self.translate_function_param_or_return_type(ty))
                         .collect_vec(),
                     Unit => vec![],
                     _ => {
-                        vec![self.translate_function_param_type(result)]
+                        vec![self.translate_function_param_or_return_type(result)]
                     },
                 };
                 Type::function(
@@ -1079,8 +1082,8 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
         }
     }
 
-    /// Translates a type and impose constraints for function parameters.
-    fn translate_function_param_type(&mut self, ty: &EA::Type) -> Type {
+    /// Translates a type and impose constraints for function parameters or return.
+    fn translate_function_param_or_return_type(&mut self, ty: &EA::Type) -> Type {
         let loc = self.to_loc(&ty.loc);
         let ty = self.translate_type(ty);
         for ctr in Constraint::for_fun_parameter() {
@@ -1090,7 +1093,7 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 ty.skip_reference(),
                 Variance::NoVariance,
                 ctr,
-                None,
+                Some(ConstraintContext::default()),
             )
         }
         ty
@@ -2308,6 +2311,40 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                             "cannot mutably borrow from an immutable ref",
                         );
                         return false;
+                    }
+                }
+            }
+            true
+        });
+    }
+
+    /// Check whether types of lambda expressions are valid.
+    pub fn check_lambda_types(&self, exp: &ExpData) {
+        exp.visit_pre_order(&mut |e| {
+            if let ExpData::Lambda(id, ..) = e {
+                let lambda_type = self.env().get_node_type(*id);
+                if let Type::Fun(args, result, _) = lambda_type.clone() {
+                    let mut has_error = false;
+                    for arg_type in args.flatten() {
+                        if arg_type.is_reference_to_a_reference() {
+                            has_error = true;
+                            break;
+                        }
+                    }
+                    for result_type in result.flatten() {
+                        if result_type.is_reference_to_a_reference() {
+                            has_error = true;
+                            break;
+                        }
+                    }
+                    if has_error {
+                        self.error(
+                            &self.get_node_loc(*id),
+                            &format!(
+                                "lambda expression has invalid type `{}` (reference to a reference is disallowed)",
+                                lambda_type.display(&self.env().get_type_display_ctx())
+                            ),
+                        );
                     }
                 }
             }

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -1463,6 +1463,7 @@ impl<'env, 'translator> ModuleBuilder<'env, 'translator> {
             // Run finalization again, this time with reporting errors.
             et.finalize_types(true);
             et.check_mutable_borrow_field(&translated);
+            et.check_lambda_types(&translated);
             assert!(self.fun_defs.insert(full_name.symbol, translated).is_none());
             if let Some(specifiers) = access_specifiers {
                 assert!(self

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -4518,7 +4518,7 @@ impl<'env> FunctionEnv<'env> {
         self.data.loc.id_loc.clone()
     }
 
-    /// Returns the location of the function identifier.
+    /// Returns the location of the function's return type.
     pub fn get_result_type_loc(&self) -> Loc {
         self.data.loc.result_type_loc.clone()
     }

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -1631,6 +1631,15 @@ impl Type {
     pub fn is_tuple(&self) -> bool {
         matches!(self, Type::Tuple(_))
     }
+
+    /// Returns true if this type is a reference to a reference.
+    pub fn is_reference_to_a_reference(&self) -> bool {
+        if let Type::Reference(_, bt) = self {
+            bt.is_reference()
+        } else {
+            false
+        }
+    }
 }
 
 /// A parameter for type unification that specifies the type compatibility rules to follow.


### PR DESCRIPTION
## Description

With this PR, the compiler checks various places where you can create reference of a reference. Overall, this fixes three different bugs.

1. This closes #16491.

2. Also found that even before function values, we could cause bytecode verification failure:
```move
    fun test3(x: &mut &mut u64): &mut &mut u64 {x}
```
would result in:
```
 bug: bytecode verification failed with unexpected status code `INVALID_SIGNATURE_TOKEN`. This is a compiler bug, consider reporting it.
Error message: reference not allowed at type 0
  ┌─ TEMPFILE:2:1
  │  
2 │ ╭ module 0xc0ffee::m {
3 │ │     fun test3(x: &mut &mut u64): &mut &mut u64 {x}
4 │ │ }
  │ ╰─^
```

This is also fixed.

3. Finally, we can cause reference to a reference without providing any explicit types anywhere, just through type inference:
```move
    fun test1() {
        let f = |x| **x + 1;
    }
```
This was previously crashing the compiler.

This is also fixed. I attempted to fix this via constraint solving in the type checker, but that was getting too complicated, so I decided to fix this by checking at stackless bytecode generation time.

There are also minor improvements to documentation and error messages.

## How Has This Been Tested?
- Added 3 categories of tests, corresponding to the categories above.
- Existing tests' baselines were updated after review

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
