### PR TITLE
chore: Correct the debug log when aptos_vm::process_jwk_update_inner returns ExpectedFailure

### DIFF
--- a/aptos-move/aptos-vm/src/validator_txns/jwk.rs
+++ b/aptos-move/aptos-vm/src/validator_txns/jwk.rs
@@ -77,7 +77,7 @@ impl AptosVM {
             },
             Err(Expected(failure)) => {
                 // Pretend we are inside Move, and expected failures are like Move aborts.
-                debug!("Processing dkg transaction expected failure: {:?}", failure);
+                debug!("Processing jwk transaction expected failure: {:?}", failure);
                 Ok((
                     VMStatus::MoveAbort(AbortLocation::Script, failure as u64),
                     VMOutput::empty_with_status(TransactionStatus::Discard(StatusCode::ABORTED)),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

When reading the code for jwk processing logic of aptos_vm, i found out the the debug log is not correct. 

https://github.com/aptos-labs/aptos-core/blob/dde3795685455ee06fc5fb0cfdec767276d1aef7/aptos-move/aptos-vm/src/validator_txns/jwk.rs#L80

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
