### PR TITLE
block prologue transaction sees latest timestamp

### DIFF
--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -19,9 +19,12 @@ use aptos_framework::natives::{
 };
 use aptos_table_natives::{NativeTableContext, TableChangeSet};
 use aptos_types::{
-    chain_id::ChainId, contract_event::ContractEvent, on_chain_config::Features,
+    chain_id::ChainId,
+    contract_event::ContractEvent,
+    on_chain_config::{CurrentTimeMicroseconds, Features, OnChainConfig},
     state_store::state_key::StateKey,
-    transaction::user_transaction_context::UserTransactionContext, write_set::WriteOp,
+    transaction::user_transaction_context::UserTransactionContext,
+    write_set::WriteOp,
 };
 use aptos_vm_types::{
     change_set::VMChangeSet, module_and_script_storage::module_storage::AptosModuleStorage,
@@ -66,6 +69,7 @@ pub struct SessionExt<'r, R> {
     data_cache: TransactionDataCache,
     extensions: NativeContextExtensions<'r>,
     pub(crate) resolver: &'r R,
+    current_time: Option<CurrentTimeMicroseconds>,
     is_storage_slot_metadata_enabled: bool,
 }
 
@@ -78,6 +82,7 @@ where
         chain_id: ChainId,
         features: &Features,
         vm_config: &VMConfig,
+        current_time_override: Option<CurrentTimeMicroseconds>,
         maybe_user_transaction_context: Option<UserTransactionContext>,
         resolver: &'r R,
     ) -> Self {
@@ -109,11 +114,15 @@ where
         extensions.add(NativeEventContext::default());
         extensions.add(NativeObjectContext::default());
 
+        let current_time =
+            current_time_override.or_else(|| CurrentTimeMicroseconds::fetch_config(resolver));
+
         let is_storage_slot_metadata_enabled = features.is_storage_slot_metadata_enabled();
         Self {
             data_cache: TransactionDataCache::empty(),
             extensions,
             resolver,
+            current_time,
             is_storage_slot_metadata_enabled,
         }
     }
@@ -236,6 +245,7 @@ where
             data_cache,
             mut extensions,
             resolver,
+            current_time,
             is_storage_slot_metadata_enabled,
         } = self;
 
@@ -260,7 +270,11 @@ where
         let event_context: NativeEventContext = extensions.remove();
         let events = event_context.into_events();
 
-        let woc = WriteOpConverter::new(resolver, is_storage_slot_metadata_enabled);
+        let woc = WriteOpConverter::new(
+            resolver,
+            current_time.as_ref(),
+            is_storage_slot_metadata_enabled,
+        );
 
         let change_set = Self::convert_change_set(
             &woc,
@@ -550,16 +564,25 @@ where
 
         Ok(change_set)
     }
+
+    pub(crate) fn current_time(&self) -> Option<&CurrentTimeMicroseconds> {
+        self.current_time.as_ref()
+    }
 }
 
 /// Converts module bytes and their compiled representation extracted from publish request into
 /// write ops. Only used by V2 loader implementation.
 pub fn convert_modules_into_write_ops(
     resolver: &impl AptosMoveResolver,
+    current_time: Option<&CurrentTimeMicroseconds>,
     features: &Features,
     module_storage: &impl AptosModuleStorage,
     verified_module_bundle: VerifiedModuleBundle<ModuleId, Bytes>,
 ) -> PartialVMResult<BTreeMap<StateKey, ModuleWrite<WriteOp>>> {
-    let woc = WriteOpConverter::new(resolver, features.is_storage_slot_metadata_enabled());
+    let woc = WriteOpConverter::new(
+        resolver,
+        current_time,
+        features.is_storage_slot_metadata_enabled(),
+    );
     woc.convert_modules_into_write_ops(module_storage, verified_module_bundle.into_iter())
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/respawned_session.rs
@@ -9,7 +9,10 @@ use crate::{
     },
     AptosVM,
 };
-use aptos_types::transaction::user_transaction_context::UserTransactionContext;
+use aptos_types::{
+    on_chain_config::CurrentTimeMicroseconds,
+    transaction::user_transaction_context::UserTransactionContext,
+};
 use aptos_vm_types::{change_set::VMChangeSet, storage::change_set_configs::ChangeSetConfigs};
 use move_core_types::vm_status::{err_msg, StatusCode, VMStatus};
 use move_vm_runtime::ModuleStorage;
@@ -65,7 +68,7 @@ impl<'r> RespawnedSession<'r> {
         self.with_session_mut(|session| {
             fun(session
                 .as_mut()
-                .expect("session is set on construction and live until destruction."))
+                .expect("session is set on construction and lives until destruction."))
         })
     }
 
@@ -106,5 +109,13 @@ impl<'r> RespawnedSession<'r> {
                 )
             })?;
         Ok(change_set)
+    }
+
+    pub fn current_time(&self) -> Option<&CurrentTimeMicroseconds> {
+        self.with_session(|s| {
+            s.as_ref()
+                .expect("session is set on construction and lives until destruction.")
+                .current_time()
+        })
     }
 }

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
@@ -130,6 +130,7 @@ impl<'r> UserSession<'r> {
         // Get the changes from running module initialization. Note that here we use the staged
         // module storage to ensure resource group metadata from new modules is visible.
         let Self { session } = self;
+        let current_time = session.current_time().cloned();
         let change_set = session.finish_with_squashed_change_set(
             change_set_configs,
             &staging_module_storage,
@@ -138,6 +139,7 @@ impl<'r> UserSession<'r> {
 
         let write_ops = convert_modules_into_write_ops(
             resolver,
+            current_time.as_ref(),
             features,
             module_storage,
             staging_module_storage.release_verified_module_bundle(),

--- a/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/vm.rs
@@ -7,7 +7,7 @@ use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEAT
 use aptos_native_interface::SafeNativeBuilder;
 use aptos_types::{
     chain_id::ChainId,
-    on_chain_config::{Features, TimedFeaturesBuilder},
+    on_chain_config::{CurrentTimeMicroseconds, Features, TimedFeaturesBuilder},
     transaction::user_transaction_context::UserTransactionContext,
 };
 use aptos_vm_environment::{
@@ -95,6 +95,7 @@ impl GenesisMoveVm {
             self.chain_id,
             &self.features,
             &self.vm_config,
+            None, // current_time_override
             None,
             resolver,
         )
@@ -123,6 +124,7 @@ impl MoveVmExt {
 
     pub fn new_session<'r, R: AptosMoveResolver>(
         &self,
+        current_time_override: Option<CurrentTimeMicroseconds>,
         resolver: &'r R,
         session_id: SessionId,
         maybe_user_transaction_context: Option<UserTransactionContext>,
@@ -132,6 +134,7 @@ impl MoveVmExt {
             self.env.chain_id(),
             self.env.features(),
             self.env.vm_config(),
+            current_time_override,
             maybe_user_transaction_context,
             resolver,
         )

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -1103,7 +1103,7 @@ impl FakeExecutor {
         let mut i = 0;
         let mut measurements = Vec::new();
         while i < iterations {
-            let mut session = vm.new_session(&resolver, SessionId::void(), None);
+            let mut session = vm.new_session(None, &resolver, SessionId::void(), None);
 
             // load function name into cache to ensure cache is hot
             let _ = module_storage.load_function(
@@ -1240,7 +1240,7 @@ impl FakeExecutor {
             let vm = MoveVmExt::new(&env);
 
             let module_storage = self.state_store.as_aptos_code_storage(&env);
-            let mut session = vm.new_session(&resolver, SessionId::void(), None);
+            let mut session = vm.new_session(None, &resolver, SessionId::void(), None);
 
             let fun_name = Self::name(function_name);
             let should_error = fun_name.clone().into_string().ends_with(POSTFIX);
@@ -1301,7 +1301,7 @@ impl FakeExecutor {
             let vm = MoveVmExt::new(&env);
 
             let module_storage = self.state_store.as_aptos_code_storage(&env);
-            let mut session = vm.new_session(&resolver, SessionId::void(), None);
+            let mut session = vm.new_session(None, &resolver, SessionId::void(), None);
             let storage = TraversalStorage::new();
             session
                 .execute_function_bypass_visibility(
@@ -1345,7 +1345,7 @@ impl FakeExecutor {
 
         let module_storage = self.state_store.as_aptos_code_storage(&env);
 
-        let mut session = vm.new_session(&resolver, SessionId::void(), None);
+        let mut session = vm.new_session(None, &resolver, SessionId::void(), None);
         let traversal_storage = TraversalStorage::new();
         session
             .execute_function_bypass_visibility(

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -948,6 +948,7 @@ fn code_to_writes_for_publishing(
 
     convert_modules_into_write_ops(
         &resolver,
+        None,
         genesis_features,
         &module_storage,
         verified_module_bundle,

--- a/consensus/src/block_storage/execution_pool/common_test.rs
+++ b/consensus/src/block_storage/execution_pool/common_test.rs
@@ -25,6 +25,7 @@ pub const DEFAULT_MAX_PRUNED_BLOCKS_IN_MEM: usize = 10;
 
 /// Helper function to create a `QuorumCert` which can provide a `highest_commit_cert` via
 /// `highest_quorum_cert.into_wrapped_ledger_info()`
+#[allow(dead_code)]
 pub fn generate_qc(round: Round, parent_round: Round) -> QuorumCert {
     let num_nodes = 4;
     let (signers, validators) = random_validator_verifier(num_nodes, None, false);

--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -325,23 +325,12 @@ impl Verifier {
                 Some(&expected_writesets[idx]),
                 Some(&expected_events[idx]),
             ) {
-                let err_opt = if idx == 0 {
-                    // FIXME(aldenhu): remove this hack
-                    warn!(
-                        version = version,
-                        "Probably known failure due to StateStorageUsage missing from a restored DB."
-                    );
-                    Ok(None)
-                } else {
-                    Ok(Some(err))
-                };
-
                 cur_txns.drain(0..idx + 1);
                 expected_txn_infos.drain(0..idx + 1);
                 expected_events.drain(0..idx + 1);
                 expected_writesets.drain(0..idx + 1);
 
-                return err_opt;
+                return Ok(Some(err));
             }
         }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

The WriteOpConverter was seeing the timestmap of the previous block. It used not to be a problem because the timestmap is only used when a new slot is created, which doesn't happen for the block metadata transaction.
Now that we intend to use (and later write down) the access timestmap in addition to the creation timestmap, it should be fixed.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

replay-verify
https://github.com/aptos-labs/aptos-core/actions/runs/14870093379

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature


## Which Components or Systems Does This Change Impact?
- [x] Validator Node
