### PR TITLE
[compiler-v2] Error on returning nested tuples

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/nested_tuple_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/nested_tuple_err.exp
@@ -1,5 +1,17 @@
 
 Diagnostics:
+error: tuples cannot be nested
+  ┌─ tests/checking/typing/nested_tuple_err.move:2:25
+  │
+2 │     public fun test(): ((u64, u64), (u64, u64)) {
+  │                         ^^^^^^^^^^
+
+error: tuples cannot be nested
+  ┌─ tests/checking/typing/nested_tuple_err.move:2:37
+  │
+2 │     public fun test(): ((u64, u64), (u64, u64)) {
+  │                                     ^^^^^^^^^^
+
 error: Expected a single type, but found a tuple type
   ┌─ tests/checking/typing/nested_tuple_err.move:3:10
   │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/return_nested_tuple.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/return_nested_tuple.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: tuples cannot be nested
+  ┌─ tests/checking/typing/return_nested_tuple.move:3:25
+  │
+3 │     public fun test(): ((u64, u64), (u64, u64)) {
+  │                         ^^^^^^^^^^
+
+error: tuples cannot be nested
+  ┌─ tests/checking/typing/return_nested_tuple.move:3:37
+  │
+3 │     public fun test(): ((u64, u64), (u64, u64)) {
+  │                                     ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/return_nested_tuple.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/return_nested_tuple.move
@@ -1,0 +1,6 @@
+module 0xc0ffee::m {
+
+    public fun test(): ((u64, u64), (u64, u64)) {
+        abort 0
+    }
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1077,7 +1077,15 @@ impl<'env, 'translator, 'module_translator> ExpTranslator<'env, 'translator, 'mo
                 )
             },
             Unit => Type::Tuple(vec![]),
-            Multiple(vst) => Type::Tuple(self.translate_types(vst.as_ref())),
+            Multiple(vst) => {
+                let (inner_locs, inner_types) = self.translate_types_with_loc(vst.as_ref());
+                for (inner_ty, inner_loc) in inner_types.iter().zip(inner_locs.iter()) {
+                    if inner_ty.is_tuple() {
+                        self.error(inner_loc, "tuples cannot be nested");
+                    }
+                }
+                Type::Tuple(inner_types)
+            },
             UnresolvedError => Type::Error,
         }
     }


### PR DESCRIPTION
## Description

Closes #16539.

Return types of functions could have nested tuples, but unless an expression of that type was created, we could end up with a compiler ICE, which we fix with this PR.

## How Has This Been Tested?
- Existing tests
- A new test has been added which used to ICE before, but gives a compiler error now.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
