### PR TITLE
[move-package-manifest] initial implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.11.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "710e8eae58854cdc1790fcb56cca04d712a17be849eeb81da2a724bf4bae2bc4"
+dependencies = [
+ "anstyle",
+ "unicode-width 0.2.0",
+]
+
+[[package]]
 name = "ansi-escapes"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6571,7 +6581,7 @@ dependencies = [
  "bitflags 1.3.2",
  "strsim 0.8.0",
  "textwrap 0.11.0",
- "unicode-width",
+ "unicode-width 0.1.11",
  "vec_map",
 ]
 
@@ -6725,7 +6735,7 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "serde",
  "termcolor",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -6847,7 +6857,7 @@ dependencies = [
  "encode_unicode 0.3.6",
  "lazy_static",
  "libc",
- "unicode-width",
+ "unicode-width 0.1.11",
  "windows-sys 0.45.0",
 ]
 
@@ -10487,7 +10497,7 @@ dependencies = [
  "instant",
  "number_prefix 0.4.0",
  "portable-atomic",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -12248,6 +12258,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-package-manifest"
+version = "0.1.0"
+dependencies = [
+ "annotate-snippets",
+ "anyhow",
+ "datatest-stable",
+ "move-core-types",
+ "move-model",
+ "move-prover-test-utils",
+ "serde",
+ "toml 0.7.8",
+ "url",
+]
+
+[[package]]
 name = "move-prover"
 version = "0.1.0"
 dependencies = [
@@ -13379,7 +13404,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ad9b889f1b12e0b9ee24db044b5129150d5eada288edc800f789928dc8c0e3"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -14428,7 +14453,7 @@ dependencies = [
  "is-terminal",
  "lazy_static",
  "term",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -17417,7 +17442,7 @@ version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d326610f408c7a4eb6f51c37c330e496b08506c9457c9d34287ecc38809fb060"
 dependencies = [
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -17427,7 +17452,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd05616119e612a8041ef58f2b578906cc2531a6069047ae092cfb86a325d835"
 dependencies = [
  "smawk",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -17438,7 +17463,7 @@ checksum = "b7b3e525a49ec206798b40326a44121291b530c963cfb01018f63e135bac543d"
 dependencies = [
  "smawk",
  "unicode-linebreak",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -18235,7 +18260,7 @@ dependencies = [
  "cassowary",
  "crossterm 0.25.0",
  "unicode-segmentation",
- "unicode-width",
+ "unicode-width 0.1.11",
 ]
 
 [[package]]
@@ -18468,6 +18493,12 @@ name = "unicode-width"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51733f11c9c4f72aa0c160008246859e340b00807569a0da0e7a1079b27ba85"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -246,6 +246,7 @@ members = [
     "third_party/move/tools/move-disassembler",
     "third_party/move/tools/move-linter",
     "third_party/move/tools/move-package",
+    "third_party/move/tools/move-package-manifest",
     "third_party/move/tools/move-resource-viewer",
     "third_party/move/tools/move-unit-test",
     "tools/calc-dep-sizes",
@@ -479,6 +480,7 @@ nalgebra = "0.32"
 float-cmp = "0.9.0"
 again = "0.1.2"
 ambassador = "0.4.1"
+annotate-snippets = "0.11.5"
 anyhow = "1.0.98"
 anstyle = "1.0.1"
 arbitrary = { version = "1.4.1", features = ["derive"] }
@@ -851,6 +853,7 @@ move-ir-to-bytecode = { path = "third_party/move/move-ir-compiler/move-ir-to-byt
 move-linter = { path = "third_party/move/tools/move-linter" }
 move-model = { path = "third_party/move/move-model" }
 move-package = { path = "third_party/move/tools/move-package" }
+move-package-manifest = { path = "third_party/move/tools/move-package-manifest" }
 move-prover = { path = "third_party/move/move-prover" }
 move-prover-boogie-backend = { path = "third_party/move/move-prover/boogie-backend" }
 move-prover-bytecode-pipeline = { path = "third_party/move/move-prover/bytecode-pipeline" }

--- a/aptos-move/move-examples/aggregator_examples/Move.toml
+++ b/aptos-move/move-examples/aggregator_examples/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Aggregator examples"
+name = "Aggregator-examples"
 version = "0.0.0"
 
 [addresses]

--- a/aptos-move/move-examples/event/Move.toml
+++ b/aptos-move/move-examples/event/Move.toml
@@ -1,5 +1,5 @@
 [package]
-name = "Event example"
+name = "Event-example"
 version = "0.0.1"
 
 [addresses]

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -179,7 +179,7 @@ impl CompilerVersion {
 /// Typically, a major version change is given with an addition of larger new language
 /// features. There are no breaking changes expected with major version changes,
 /// however, there maybe some isolated exceptions.
-#[derive(Clone, Copy, Debug, Serialize, Deserialize, Eq, PartialEq, PartialOrd, Ord)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, PartialOrd, Ord)]
 pub enum LanguageVersion {
     /// The version of Move at around the genesis of the Aptos network end
     /// of '22. This is the original Diem Move plus the extension of inline
@@ -202,6 +202,26 @@ impl Default for LanguageVersion {
     }
 }
 
+impl Serialize for LanguageVersion {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.to_str().serialize(serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for LanguageVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+
+        Self::from_str(&s).map_err(serde::de::Error::custom)
+    }
+}
+
 impl FromStr for LanguageVersion {
     type Err = anyhow::Error;
 
@@ -217,7 +237,7 @@ impl FromStr for LanguageVersion {
             "2.2" => Ok(Self::V2_2),
             "2.3" => Ok(Self::V2_3),
             _ => bail!(
-                "unrecognized language version `{}` (supported versions: `1`, `2`, `2.0-2.3`)",
+                "unrecognized language version \"{}\" (supported versions: \"1\", \"2\", \"2.0-2.3\")",
                 s
             ),
         }

--- a/third_party/move/tools/move-package-manifest/Cargo.toml
+++ b/third_party/move/tools/move-package-manifest/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "move-package-manifest"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+annotate-snippets = { workspace = true }
+anyhow = { workspace = true }
+serde = { workspace = true }
+toml = { workspace = true }
+url = { workspace = true }
+
+move-core-types = { workspace = true }
+move-model = { workspace = true }
+
+[dev-dependencies]
+datatest-stable = { workspace = true }
+move-prover-test-utils = { workspace = true }
+
+[[test]]
+name = "expected_output"
+harness = false
+
+[[test]]
+name = "serde_round_trip"
+harness = false
+
+[[test]]
+name = "framework_manifests"
+harness = false
+
+[[test]]
+name = "move_example_manifests"
+harness = false

--- a/third_party/move/tools/move-package-manifest/src/lib.rs
+++ b/third_party/move/tools/move-package-manifest/src/lib.rs
@@ -1,0 +1,19 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod manifest;
+mod named_address;
+mod package_name;
+mod util;
+
+pub use manifest::{
+    AddressAssignment, BuildOptions, Dependency, PackageLocation, PackageManifest, PackageMetadata,
+    Version,
+};
+pub use named_address::NamedAddress;
+pub use package_name::PackageName;
+pub use util::render_error;
+
+pub fn parse_package_manifest(s: &str) -> Result<PackageManifest, toml::de::Error> {
+    toml::from_str(s)
+}

--- a/third_party/move/tools/move-package-manifest/src/manifest.rs
+++ b/third_party/move/tools/move-package-manifest/src/manifest.rs
@@ -1,0 +1,425 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{NamedAddress, PackageName};
+use move_core_types::account_address::AccountAddress;
+use move_model::metadata::LanguageVersion;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::{self, Debug, Display},
+    path::PathBuf,
+    str::FromStr,
+};
+use url::Url;
+
+/***************************************************************************************************
+ * Manifest Definition
+ *
+ **************************************************************************************************/
+/// Represents the full parsed contents of a `Move.toml` manifest file.
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageManifest {
+    /// Metadata about the package itself, such as package name etc.
+    pub package: PackageMetadata,
+
+    /// Named address mappings defined by the package.
+    #[serde(default)]
+    pub addresses: BTreeMap<NamedAddress, AddressAssignment>,
+
+    /// Dev-only named address bindings defined by the package.
+    /// Being dev-only means the bindings are only active in unit tests, not when being compiled regularly.
+    #[serde(default, rename = "dev-addresses")]
+    pub dev_addresses: BTreeMap<NamedAddress, AccountAddress>,
+
+    /// Build options.
+    pub build: Option<BuildOptions>,
+
+    /// Regular (non-dev) package dependencies.
+    #[serde(default)]
+    pub dependencies: BTreeMap<PackageName, Dependency>,
+
+    /// Dev-only package dependencies.
+    #[serde(default, rename = "dev-dependencies")]
+    pub dev_dependencies: BTreeMap<PackageName, Dependency>,
+}
+
+/// Metadata defined in the `[package]` section of `Move.toml`.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct PackageMetadata {
+    /// Name of the Move package.
+    pub name: PackageName,
+
+    /// Version of the package.
+    pub version: Version,
+
+    /// List of authors.
+    #[serde(default, deserialize_with = "deserialize_unique_vec")]
+    pub authors: Vec<String>,
+
+    /// Optional license string for the package.
+    pub license: Option<String>,
+
+    /// Optional upgrade policy for the package.
+    pub upgrade_policy: Option<UpgradePolicy>,
+}
+
+/// Upgrade policy for a Move package, controlling whether upgrades are allowed and if so, what rules to follow.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub enum UpgradePolicy {
+    /// Indicates that upgrades are allowed, but must be compatible with the current version.
+    #[serde(rename = "compatible")]
+    Compatible,
+
+    /// Indicates that the package is immutable and should not be upgraded.
+    #[serde(rename = "immutable")]
+    Immutable,
+}
+
+/// A semantic version consisting of major, minor, and patch components.
+#[derive(Clone, Eq, PartialEq)]
+pub struct Version {
+    pub major: u64,
+    pub minor: u64,
+    pub patch: u64,
+}
+
+/// Represents either an unspecified or numerical address.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum AddressAssignment {
+    /// Unspecified address (`"_"` in `Move.toml`).
+    Unspecified,
+
+    /// A specific numerical address.
+    Numerical(AccountAddress),
+}
+
+/// Build options defined in the `[build]` section of `Move.toml`.
+#[derive(Default, Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct BuildOptions {
+    /// Version of the source language used to compile the package.
+    ///
+    /// TODO: This is currently unused. The exact functionality will be determined once
+    ///       we hook it up to the compiler.
+    pub language_version: Option<LanguageVersion>,
+}
+
+/// Represents a dependency entry in `[dependencies]` or `[dev-dependencies]`.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Dependency {
+    /// Optional version requirement for the dependency.
+    /// Not in use by the package resolver, yet.
+    ///
+    /// Note: This is intended to be a build-time constraint, and it alone does not guarantee
+    ///       that your program will be linked to the specific version of the dependency
+    ///       during execution on-chain.
+    version: Option<Version>,
+
+    /// Location of the dependency: local, git, or aptos (on-chain).
+    location: PackageLocation,
+}
+
+/// Location of a package dependency.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum PackageLocation {
+    /// Refers to a package stored in the local file system.
+    Local { path: PathBuf },
+
+    /// Refers to a package stored in a git repository.
+    Git {
+        /// URL to the Git repository.
+        url: Url,
+        /// Optional Git revision to pin the dependency to.
+        /// This can be a commit hash, a branch name or a tag name.
+        rev: Option<String>,
+        /// Optional subdirectory within the Git repository.
+        subdir: Option<String>,
+    },
+
+    /// Refers to a package published on-chain.
+    ///
+    // TODO: The current design is tentative. There are issues we plan to resolve later:
+    //       - Leaky abstraction -- can we still want to maintain clear Move/Aptos separation?
+    //       - Replacing `String` w/ more specific data structures
+    //         - `node_url`: Should accept both URL and known network names (e.g. "mainnet")
+    //         - `package_addr`: May accept both numerical and named addresses
+    Aptos {
+        /// URL to the Aptos full-node connected to the network where the package is published.
+        node_url: String,
+
+        /// Address of the published package.
+        package_addr: String,
+    },
+}
+
+/***************************************************************************************************
+ * Custom Deserializer Implementations
+ *
+ **************************************************************************************************/
+pub fn deserialize_unique_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    struct UniqueVecVisitor;
+
+    impl<'de> serde::de::Visitor<'de> for UniqueVecVisitor {
+        type Value = Vec<String>;
+
+        fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
+            formatter.write_str("a list of unique strings")
+        }
+
+        fn visit_seq<A>(self, mut seq: A) -> Result<Self::Value, A::Error>
+        where
+            A: serde::de::SeqAccess<'de>,
+        {
+            let mut seen = BTreeSet::new();
+            let mut values = Vec::new();
+
+            while let Some(value) = seq.next_element::<String>()? {
+                if !seen.insert(value.clone()) {
+                    return Err(serde::de::Error::custom(format!(
+                        "duplicate entry: {}",
+                        value
+                    )));
+                }
+                values.push(value);
+            }
+
+            Ok(values)
+        }
+    }
+
+    deserializer.deserialize_seq(UniqueVecVisitor)
+}
+
+impl<'de> Deserialize<'de> for Version {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let make_err = || {
+            serde::de::Error::custom(
+                "Invalid version -- a version in the format 'x.y.z' (e.g. '1.2.3')",
+            )
+        };
+
+        let s = String::deserialize(deserializer)?;
+        let parts: Vec<&str> = s.split('.').collect();
+        if parts.len() != 3 {
+            return Err(make_err());
+        }
+        let major = parts[0].parse().map_err(|_| make_err())?;
+        let minor = parts[1].parse().map_err(|_| make_err())?;
+        let patch = parts[2].parse().map_err(|_| make_err())?;
+
+        Ok(Version {
+            major,
+            minor,
+            patch,
+        })
+    }
+}
+
+impl<'de> Deserialize<'de> for AddressAssignment {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Ok(match s.as_str() {
+            "_" => Self::Unspecified,
+            _ => Self::Numerical(
+                AccountAddress::from_str(&s)
+                    .map_err(|_| serde::de::Error::custom("Invalid account address"))?,
+            ),
+        })
+    }
+}
+
+#[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawDependency {
+    version: Option<Version>,
+
+    local: Option<PathBuf>,
+
+    git: Option<Url>,
+    rev: Option<String>,
+    subdir: Option<String>,
+
+    aptos: Option<String>,
+    address: Option<String>,
+}
+
+impl<'de> Deserialize<'de> for Dependency {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let raw = RawDependency::deserialize(deserializer)?;
+
+        macro_rules! error_on_unneeded_fields {
+            ($field_name:ident, $tag_name:ident) => {
+                if (raw.$field_name.is_some() && raw.$tag_name.is_none()) {
+                    return Err(serde::de::Error::custom(format!(
+                        "redundant field \"{}\" -- only needed for \"{}\" dependencies",
+                        stringify!($field_name),
+                        stringify!($tag_name),
+                    )));
+                }
+            };
+        }
+
+        error_on_unneeded_fields!(rev, git);
+        error_on_unneeded_fields!(subdir, git);
+
+        error_on_unneeded_fields!(address, aptos);
+
+        let location = match (raw.local, raw.git, raw.aptos) {
+            (Some(path), None, None) => PackageLocation::Local { path },
+            (None, Some(url), None) => PackageLocation::Git {
+                url,
+                rev: raw.rev,
+                subdir: raw.subdir,
+            },
+            (None, None, Some(node_url)) => match raw.address {
+                Some(package_addr) => PackageLocation::Aptos {
+                    node_url,
+                    package_addr,
+                },
+                None => {
+                    return Err(serde::de::Error::custom(
+                        "missing field \"address\" for aptos dependency",
+                    ))
+                },
+            },
+            (None, None, None) => {
+                return Err(serde::de::Error::custom(
+                    "no package location specified for dependency",
+                ));
+            },
+            _ => {
+                return Err(serde::de::Error::custom(
+                    "dependency cannot have have multiple locations",
+                ));
+            },
+        };
+
+        Ok(Dependency {
+            version: raw.version,
+            location,
+        })
+    }
+}
+
+/***************************************************************************************************
+ * Custom Serializer Implementations
+ *
+ **************************************************************************************************/
+impl Serialize for Version {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        let s = format!("{}", self);
+        s.serialize(serializer)
+    }
+}
+
+impl Serialize for AddressAssignment {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            AddressAssignment::Unspecified => "_".serialize(serializer),
+            AddressAssignment::Numerical(addr) => addr.serialize(serializer),
+        }
+    }
+}
+
+impl Dependency {
+    fn into_raw(self) -> RawDependency {
+        let mut raw = RawDependency {
+            version: self.version,
+            ..Default::default()
+        };
+
+        match self.location {
+            PackageLocation::Local { path } => raw.local = Some(path),
+            PackageLocation::Git { url, rev, subdir } => {
+                raw.git = Some(url);
+                raw.rev = rev;
+                raw.subdir = subdir;
+            },
+            PackageLocation::Aptos {
+                node_url,
+                package_addr,
+            } => {
+                raw.aptos = Some(node_url);
+                raw.address = Some(package_addr);
+            },
+        }
+
+        raw
+    }
+
+    fn to_raw(&self) -> RawDependency {
+        self.clone().into_raw()
+    }
+}
+
+impl Serialize for Dependency {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.to_raw().serialize(serializer)
+    }
+}
+
+/***************************************************************************************************
+ * Default Values
+ *
+ **************************************************************************************************/
+#[allow(clippy::derivable_impls)]
+impl Default for Version {
+    fn default() -> Self {
+        Self {
+            major: 0,
+            minor: 0,
+            patch: 0,
+        }
+    }
+}
+
+impl Default for PackageMetadata {
+    fn default() -> Self {
+        Self {
+            name: PackageName::new("some_package").unwrap(),
+            version: Default::default(),
+            authors: vec![],
+            license: None,
+            upgrade_policy: None,
+        }
+    }
+}
+/***************************************************************************************************
+ * Debug/Display
+ *
+ **************************************************************************************************/
+impl Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}.{}.{}", self.major, self.minor, self.patch)
+    }
+}
+
+impl Debug for Version {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "\"{}.{}.{}\"", self.major, self.minor, self.patch)
+    }
+}

--- a/third_party/move/tools/move-package-manifest/src/named_address.rs
+++ b/third_party/move/tools/move-package-manifest/src/named_address.rs
@@ -1,0 +1,94 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    fmt,
+    fmt::{Debug, Display},
+    ops::{Deref, DerefMut},
+};
+
+/// A wrapper around a `String` representing a named address.
+///
+/// A valid named address is an identifier that
+/// - Begins with an ASCII letter (`a–z`, `A–Z`) or an underscore (`_`)
+/// - Contains only ASCII letters, digits (`0–9`) or underscores (`_`)
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct NamedAddress(String);
+
+impl Deref for NamedAddress {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
+impl DerefMut for NamedAddress {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_str()
+    }
+}
+
+impl AsRef<str> for NamedAddress {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsMut<str> for NamedAddress {
+    fn as_mut(&mut self) -> &mut str {
+        self.0.as_mut_str()
+    }
+}
+
+impl Serialize for NamedAddress {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+fn is_valid_named_address(s: &str) -> bool {
+    let mut chars = s.chars();
+
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => (),
+        _ => return false,
+    }
+
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
+}
+
+impl<'de> Deserialize<'de> for NamedAddress {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let make_err = || {
+            serde::de::Error::custom("Invalid named address -- must start with a letter or _; only letters, digits, and _ allowed.")
+        };
+
+        let s = String::deserialize(deserializer).map_err(|_| make_err())?;
+
+        if !is_valid_named_address(&s) {
+            return Err(make_err());
+        }
+
+        Ok(Self(s))
+    }
+}
+
+impl Display for NamedAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "@{}", self.0)
+    }
+}
+
+impl Debug for NamedAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}

--- a/third_party/move/tools/move-package-manifest/src/package_name.rs
+++ b/third_party/move/tools/move-package-manifest/src/package_name.rs
@@ -1,0 +1,110 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::bail;
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::{
+    fmt,
+    fmt::{Debug, Display},
+    ops::{Deref, DerefMut},
+};
+
+/// A wrapper around a `String` representing the name of a Move package.
+///
+/// A valid package name must:
+/// - Begin with an ASCII letter (`a–z`, `A–Z`) or an underscore (`_`)
+/// - Contain only ASCII letters, digits (`0–9`), hyphens (`-`), or underscores (`_`)
+///
+/// TODO: The rules above are tentative and are subject to change if we find incompatibility
+///       in production.
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct PackageName(String);
+
+impl Deref for PackageName {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        self.0.as_str()
+    }
+}
+
+impl DerefMut for PackageName {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        self.0.as_mut_str()
+    }
+}
+
+impl AsRef<str> for PackageName {
+    fn as_ref(&self) -> &str {
+        self.0.as_str()
+    }
+}
+
+impl AsMut<str> for PackageName {
+    fn as_mut(&mut self) -> &mut str {
+        self.0.as_mut_str()
+    }
+}
+
+impl Serialize for PackageName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        self.0.serialize(serializer)
+    }
+}
+
+fn is_valid_package_name(s: &str) -> bool {
+    let mut chars = s.chars();
+
+    match chars.next() {
+        Some(c) if c.is_ascii_alphabetic() || c == '_' => (),
+        _ => return false,
+    }
+
+    chars.all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
+}
+
+impl<'de> Deserialize<'de> for PackageName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let make_err = || {
+            serde::de::Error::custom("Invalid package name -- must start with a letter or _; only letters, digits, - and _ allowed.")
+        };
+
+        let s = String::deserialize(deserializer)?;
+
+        if !is_valid_package_name(&s) {
+            return Err(make_err());
+        }
+
+        Ok(Self(s))
+    }
+}
+
+impl Display for PackageName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl Debug for PackageName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}", self.0)
+    }
+}
+
+impl PackageName {
+    pub fn new(s: impl Into<String>) -> anyhow::Result<Self> {
+        let s: String = s.into();
+
+        if !is_valid_package_name(&s) {
+            bail!("Invalid package name {:?}", s);
+        }
+
+        Ok(Self(s))
+    }
+}

--- a/third_party/move/tools/move-package-manifest/src/util.rs
+++ b/third_party/move/tools/move-package-manifest/src/util.rs
@@ -1,0 +1,53 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use annotate_snippets::{Level, Renderer, Snippet};
+use std::fmt::Write;
+
+/// Renders a formatted error message for a toml deserialization failure, optionally with
+/// source span annotations.
+///
+/// If the error contains span information, this function highlights the relevant portion
+/// of the original text using a diagnostic-style output. Otherwise, it falls back to a
+/// plain error message.
+///
+/// # Example Output
+///
+/// ```text
+/// error: failed to parse manifest
+///   |
+/// 1 | [package]
+/// 2 | name = "some_package_name"
+/// 3 | version = "0.1.2"
+/// 4 | upgrade_policy = "invalid-policy"
+///   |                  ^^^^^^^^^^^^^^^^ unknown variant `invalid-policy`, expected `compatible` or `immutable`
+///   |
+/// ```
+pub fn render_error(
+    output: &mut impl Write,
+    manifest_text: &str,
+    err: &toml::de::Error,
+) -> anyhow::Result<()> {
+    match err.span() {
+        Some(span) => {
+            let snippet = Snippet::source(manifest_text)
+                .annotation(Level::Error.span(span).label(err.message()));
+
+            writeln!(
+                output,
+                "{}",
+                Renderer::plain().render(
+                    Level::Error
+                        .title("failed to parse manifest")
+                        .snippet(snippet)
+                )
+            )?;
+        },
+        None => {
+            writeln!(output, "{}", err.message())?;
+            writeln!(output, "(no span info)")?;
+        },
+    }
+
+    Ok(())
+}

--- a/third_party/move/tools/move-package-manifest/tests/addresses/duplicate-addresses.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/duplicate-addresses.exp
@@ -1,0 +1,12 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [addresses]
+6 | addr1 = "0x1"
+7 | addr1 = "0x1"
+  | ^ duplicate key `addr1` in table `addresses`
+8 | addr2 = "0x2"
+  |

--- a/third_party/move/tools/move-package-manifest/tests/addresses/duplicate-addresses.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/duplicate-addresses.toml
@@ -1,0 +1,8 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+    
+[addresses]
+addr1 = "0x1"
+addr1 = "0x1"
+addr2 = "0x2"

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-empty.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-empty.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [addresses]
+6 | addr1 = ""
+  |         ^^ Invalid account address
+  |

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-empty.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-empty.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+    
+[addresses]
+addr1 = ""

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-empty.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-empty.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [addresses]
+6 | "" = ""
+  | ^^ Invalid named address -- must start with a letter or _; only letters, digits, and _ allowed.
+  |

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-empty.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-empty.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+    
+[addresses]
+"" = ""

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-hyphen.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-hyphen.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [addresses]
+6 | foo-bar = ""
+  | ^^^^^^^ Invalid named address -- must start with a letter or _; only letters, digits, and _ allowed.
+  |

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-hyphen.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-hyphen.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+    
+[addresses]
+foo-bar = ""

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-numerical-prefix.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-numerical-prefix.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [addresses]
+6 | "0foo" = ""
+  | ^^^^^^ Invalid named address -- must start with a letter or _; only letters, digits, and _ allowed.
+  |

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-numerical-prefix.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-name-numerical-prefix.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+    
+[addresses]
+"0foo" = ""

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-too-long.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-too-long.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [addresses]
+6 | addr1 = "0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00"
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid account address
+  |

--- a/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-too-long.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/invalid-address-too-long.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+    
+[addresses]
+addr1 = "0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF00"

--- a/third_party/move/tools/move-package-manifest/tests/addresses/no-addresses.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/no-addresses.exp
@@ -1,0 +1,16 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/addresses/no-addresses.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/no-addresses.toml
@@ -1,0 +1,5 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[addresses]

--- a/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address-full-length.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address-full-length.exp
@@ -1,0 +1,20 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {
+        "addr1": Numerical(
+            00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff,
+        ),
+    },
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address-full-length.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address-full-length.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[addresses]
+addr1 = "0x00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF"

--- a/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address.exp
@@ -1,0 +1,20 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {
+        "addr1": Numerical(
+            0000000000000000000000000000000000000000000000000000000000000001,
+        ),
+    },
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-numerical-address.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[addresses]
+addr1 = "0x1"

--- a/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-wildcard-address.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-wildcard-address.exp
@@ -1,0 +1,18 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {
+        "addr1": Unspecified,
+    },
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-wildcard-address.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/one-valid-wildcard-address.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[addresses]
+addr1 = "_"

--- a/third_party/move/tools/move-package-manifest/tests/addresses/two-valid-addresses.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/two-valid-addresses.exp
@@ -1,0 +1,21 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {
+        "addr1": Numerical(
+            0000000000000000000000000000000000000000000000000000000000000001,
+        ),
+        "addr2": Unspecified,
+    },
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/addresses/two-valid-addresses.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/two-valid-addresses.toml
@@ -1,0 +1,7 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[addresses]
+addr1 = "0x1"
+addr2 = "_"

--- a/third_party/move/tools/move-package-manifest/tests/addresses/valid-address-no-0x-prefix.exp
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/valid-address-no-0x-prefix.exp
@@ -1,0 +1,20 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {
+        "addr1": Numerical(
+            0000000000000000000000000000000000000000000000000000000000001234,
+        ),
+    },
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/addresses/valid-address-no-0x-prefix.toml
+++ b/third_party/move/tools/move-package-manifest/tests/addresses/valid-address-no-0x-prefix.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+    
+[addresses]
+addr1 = "1234"

--- a/third_party/move/tools/move-package-manifest/tests/basic/duplicate-authors.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/duplicate-authors.exp
@@ -1,0 +1,8 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 | authors = ["alice", "bob", "alice"]
+  |           ^^^^^^^^^^^^^^^^^^^^^^^^^ duplicate entry: alice
+  |

--- a/third_party/move/tools/move-package-manifest/tests/basic/duplicate-authors.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/duplicate-authors.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+authors = ["alice", "bob", "alice"]

--- a/third_party/move/tools/move-package-manifest/tests/basic/empty-authors.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/empty-authors.exp
@@ -1,0 +1,16 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/empty-authors.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/empty-authors.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+authors = []

--- a/third_party/move/tools/move-package-manifest/tests/basic/empty-manifest.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/empty-manifest.exp
@@ -1,0 +1,3 @@
+error: failed to parse manifest
+ |
+ |

--- a/third_party/move/tools/move-package-manifest/tests/basic/everything.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/everything.exp
@@ -1,0 +1,86 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [
+            "alice",
+            "bob",
+            "carol",
+        ],
+        license: Some(
+            "MIT",
+        ),
+        upgrade_policy: Some(
+            Compatible,
+        ),
+    },
+    addresses: {
+        "alice": Unspecified,
+        "bob": Numerical(
+            0000000000000000000000000000000000000000000000000000000000001234,
+        ),
+    },
+    dev_addresses: {
+        "alice": 0000000000000000000000000000000000000000000000000000000000005678,
+    },
+    build: Some(
+        BuildOptions {
+            language_version: Some(
+                V2_3,
+            ),
+        },
+    ),
+    dependencies: {
+        "bar": Dependency {
+            version: Some(
+                "0.1.2",
+            ),
+            location: Aptos {
+                node_url: "mainnet",
+                package_addr: "0x1",
+            },
+        },
+        "baz": Dependency {
+            version: None,
+            location: Local {
+                path: "../baz",
+            },
+        },
+        "foo": Dependency {
+            version: None,
+            location: Git {
+                url: Url {
+                    scheme: "https",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "github.com",
+                        ),
+                    ),
+                    port: None,
+                    path: "/some-org/some-project",
+                    query: None,
+                    fragment: None,
+                },
+                rev: Some(
+                    "main",
+                ),
+                subdir: Some(
+                    "foo",
+                ),
+            },
+        },
+    },
+    dev_dependencies: {
+        "dd": Dependency {
+            version: None,
+            location: Local {
+                path: "../dd",
+            },
+        },
+    },
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/everything.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/everything.toml
@@ -1,0 +1,24 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+authors = ["alice", "bob", "carol"]
+license = "MIT"
+upgrade_policy = "compatible"
+
+[addresses]
+alice = "_"
+bob = "0x1234"
+
+[dev-addresses]
+alice = "0x5678"
+
+[build]
+language_version = "2.3"
+
+[dependencies]
+foo = { git = "https://github.com/some-org/some-project", rev = "main", subdir = "foo" }
+bar = { aptos = "mainnet", address = "0x1", version = "0.1.2" }
+baz = { local = "../baz" }
+
+[dev-dependencies]
+dd = { local = "../dd" }

--- a/third_party/move/tools/move-package-manifest/tests/basic/minimal-manifest.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/minimal-manifest.exp
@@ -1,0 +1,16 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/minimal-manifest.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/minimal-manifest.toml
@@ -1,0 +1,3 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"

--- a/third_party/move/tools/move-package-manifest/tests/basic/missing-package-name.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/missing-package-name.exp
@@ -1,0 +1,6 @@
+error: failed to parse manifest
+  |
+1 | / [package]
+2 | | version = "0.1.2"
+  | |_________________^ missing field `name`
+  |

--- a/third_party/move/tools/move-package-manifest/tests/basic/missing-package-name.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/missing-package-name.toml
@@ -1,0 +1,2 @@
+[package]
+version = "0.1.2"

--- a/third_party/move/tools/move-package-manifest/tests/basic/missing-package-version.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/missing-package-version.exp
@@ -1,0 +1,6 @@
+error: failed to parse manifest
+  |
+1 | / [package]
+2 | | name = "some_package_name"
+  | |__________________________^ missing field `version`
+  |

--- a/third_party/move/tools/move-package-manifest/tests/basic/missing-package-version.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/missing-package-version.toml
@@ -1,0 +1,2 @@
+[package]
+name = "some_package_name"

--- a/third_party/move/tools/move-package-manifest/tests/basic/one-author.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/one-author.exp
@@ -1,0 +1,18 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [
+            "alice",
+        ],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/one-author.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/one-author.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+authors = ["alice"]

--- a/third_party/move/tools/move-package-manifest/tests/basic/two-authors.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/two-authors.exp
@@ -1,0 +1,19 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [
+            "alice",
+            "bob",
+        ],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/two-authors.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/two-authors.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+authors = ["alice", "bob"]

--- a/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-compatible.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-compatible.exp
@@ -1,0 +1,18 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: Some(
+            Compatible,
+        ),
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-compatible.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-compatible.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+upgrade_policy = "compatible"

--- a/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-immutable.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-immutable.exp
@@ -1,0 +1,18 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: Some(
+            Immutable,
+        ),
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-immutable.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-immutable.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+upgrade_policy = "immutable"

--- a/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-invalid.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-invalid.exp
@@ -1,0 +1,8 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 | upgrade_policy = "invalid-policy"
+  |                  ^^^^^^^^^^^^^^^^ unknown variant `invalid-policy`, expected `compatible` or `immutable`
+  |

--- a/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-invalid.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/upgrade-policy-invalid.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+upgrade_policy = "invalid-policy"

--- a/third_party/move/tools/move-package-manifest/tests/basic/with-license.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/with-license.exp
@@ -1,0 +1,18 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: Some(
+            "MIT",
+        ),
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/basic/with-license.toml
+++ b/third_party/move/tools/move-package-manifest/tests/basic/with-license.toml
@@ -1,0 +1,4 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+license = "MIT"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/empty-build-section.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/empty-build-section.exp
@@ -1,0 +1,20 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: Some(
+        BuildOptions {
+            language_version: None,
+        },
+    ),
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/build-options/empty-build-section.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/empty-build-section.toml
@@ -1,0 +1,5 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-1.1.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-1.1.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [build]
+6 | language_version = "1.1"
+  |                    ^^^^^ unrecognized language version "1.1" (supported versions: "1", "2", "2.0-2.3")
+  |

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-1.1.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-1.1.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "1.1"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-2.4.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-2.4.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [build]
+6 | language_version = "2.4"
+  |                    ^^^^^ unrecognized language version "2.4" (supported versions: "1", "2", "2.0-2.3")
+  |

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-2.4.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-2.4.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "2.4"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-a.b.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-a.b.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [build]
+6 | language_version = "a.b"
+  |                    ^^^^^ unrecognized language version "a.b" (supported versions: "1", "2", "2.0-2.3")
+  |

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-a.b.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-a.b.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "a.b"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-empty.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-empty.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [build]
+6 | language_version = ""
+  |                    ^^ unrecognized language version "" (supported versions: "1", "2", "2.0-2.3")
+  |

--- a/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-empty.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/invalid-langauge-version-empty.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = ""

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-1.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-1.exp
@@ -1,0 +1,22 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: Some(
+        BuildOptions {
+            language_version: Some(
+                V1,
+            ),
+        },
+    ),
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-1.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-1.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "1"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.0.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.0.exp
@@ -1,0 +1,22 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: Some(
+        BuildOptions {
+            language_version: Some(
+                V2_0,
+            ),
+        },
+    ),
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.0.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.0.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "2.0"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.1.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.1.exp
@@ -1,0 +1,22 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: Some(
+        BuildOptions {
+            language_version: Some(
+                V2_1,
+            ),
+        },
+    ),
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.1.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.1.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "2.1"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.2.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.2.exp
@@ -1,0 +1,22 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: Some(
+        BuildOptions {
+            language_version: Some(
+                V2_2,
+            ),
+        },
+    ),
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.2.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.2.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "2.2"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.3.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.3.exp
@@ -1,0 +1,22 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: Some(
+        BuildOptions {
+            language_version: Some(
+                V2_3,
+            ),
+        },
+    ),
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.3.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.3.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "2.3"

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.exp
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.exp
@@ -1,0 +1,22 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: Some(
+        BuildOptions {
+            language_version: Some(
+                V2_1,
+            ),
+        },
+    ),
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.toml
+++ b/third_party/move/tools/move-package-manifest/tests/build-options/valid-language-version-2.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[build]
+language_version = "2"

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/aptos-missing-address.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/aptos-missing-address.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { aptos = "mainnet" }
+  |     ^^^^^^^^^^^^^^^^^^^^^ missing field "address" for aptos dependency
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/aptos-missing-address.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/aptos-missing-address.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { aptos = "mainnet" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/aptos.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/aptos.exp
@@ -1,0 +1,24 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {
+        "a": Dependency {
+            version: None,
+            location: Aptos {
+                node_url: "mainnet",
+                package_addr: "0x1",
+            },
+        },
+    },
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/aptos.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/aptos.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { aptos = "mainnet", address = "0x1" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/git-bad-url.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/git-bad-url.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { git = "bad" }
+  |             ^^^^^ invalid value: string "bad", expected relative URL without a base
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/git-bad-url.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/git-bad-url.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { git = "bad" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/git.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/git.exp
@@ -1,0 +1,113 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {
+        "a": Dependency {
+            version: None,
+            location: Git {
+                url: Url {
+                    scheme: "https",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "github.com",
+                        ),
+                    ),
+                    port: None,
+                    path: "/a/b",
+                    query: None,
+                    fragment: None,
+                },
+                rev: None,
+                subdir: None,
+            },
+        },
+        "b": Dependency {
+            version: None,
+            location: Git {
+                url: Url {
+                    scheme: "https",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "github.com",
+                        ),
+                    ),
+                    port: None,
+                    path: "/a/b",
+                    query: None,
+                    fragment: None,
+                },
+                rev: None,
+                subdir: Some(
+                    "b",
+                ),
+            },
+        },
+        "c": Dependency {
+            version: None,
+            location: Git {
+                url: Url {
+                    scheme: "https",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "github.com",
+                        ),
+                    ),
+                    port: None,
+                    path: "/a/b",
+                    query: None,
+                    fragment: None,
+                },
+                rev: Some(
+                    "main",
+                ),
+                subdir: None,
+            },
+        },
+        "d": Dependency {
+            version: None,
+            location: Git {
+                url: Url {
+                    scheme: "https",
+                    cannot_be_a_base: false,
+                    username: "",
+                    password: None,
+                    host: Some(
+                        Domain(
+                            "github.com",
+                        ),
+                    ),
+                    port: None,
+                    path: "/a/b",
+                    query: None,
+                    fragment: None,
+                },
+                rev: Some(
+                    "main",
+                ),
+                subdir: Some(
+                    "b",
+                ),
+            },
+        },
+    },
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/git.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/git.toml
@@ -1,0 +1,9 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { git = "https://github.com/a/b" }
+b = { git = "https://github.com/a/b", subdir = "b" }
+c = { git = "https://github.com/a/b", rev = "main" }
+d = { git = "https://github.com/a/b", subdir = "b", rev = "main" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/local.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/local.exp
@@ -1,0 +1,23 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {
+        "a": Dependency {
+            version: None,
+            location: Local {
+                path: "../a",
+            },
+        },
+    },
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/local.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/local.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { local = "../a" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-1.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-1.exp
@@ -1,0 +1,11 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { git = "https://github.com/a/b", local = "../a" }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency cannot have have multiple locations
+7 |
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-1.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-1.toml
@@ -1,0 +1,7 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { git = "https://github.com/a/b", local = "../a" }
+

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-2.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-2.exp
@@ -1,0 +1,11 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { git = "https://github.com/a/b", aptos = "mainnet" }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency cannot have have multiple locations
+7 |
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-2.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-2.toml
@@ -1,0 +1,7 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { git = "https://github.com/a/b", aptos = "mainnet" }
+

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-3.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-3.exp
@@ -1,0 +1,11 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { local = "../a", aptos = "mainnet" }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency cannot have have multiple locations
+7 |
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-3.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-3.toml
@@ -1,0 +1,7 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { local = "../a", aptos = "mainnet" }
+

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-4.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-4.exp
@@ -1,0 +1,11 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { git = "https://github.com/a/b", local = "../a", aptos = "mainnet" }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ dependency cannot have have multiple locations
+7 |
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-4.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/multiple-locations-4.toml
@@ -1,0 +1,7 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { git = "https://github.com/a/b", local = "../a", aptos = "mainnet" }
+

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/no-location.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/no-location.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = {}
+  |     ^^ no package location specified for dependency
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/no-location.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/no-location.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = {}

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-address.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-address.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { local = "../a", address = "0x123" }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ redundant field "address" -- only needed for "aptos" dependencies
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-address.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-address.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { local = "../a", address = "0x123" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-rev.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-rev.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { local = "../a", rev = "0x1234" }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ redundant field "rev" -- only needed for "git" dependencies
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-rev.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-rev.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { local = "../a", rev = "0x1234" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-subdir.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-subdir.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dependencies]
+6 | a = { local = "../a", subdir = "a/b" }
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ redundant field "subdir" -- only needed for "git" dependencies
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-subdir.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/redundant-fields-subdir.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { local = "../a", subdir = "a/b" }

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/with-version.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/with-version.exp
@@ -1,0 +1,25 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {
+        "a": Dependency {
+            version: Some(
+                "1.2.3",
+            ),
+            location: Local {
+                path: "../a",
+            },
+        },
+    },
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/with-version.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/with-version.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dependencies]
+a = { local = "../a", version = "1.2.3" }

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/duplicate-dev-addresses.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/duplicate-dev-addresses.exp
@@ -1,0 +1,11 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dev-addresses]
+6 | addr1 = "0x1"
+7 | addr1 = "0x2"
+  | ^ duplicate key `addr1` in table `dev-addresses`
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/duplicate-dev-addresses.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/duplicate-dev-addresses.toml
@@ -1,0 +1,7 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dev-addresses]
+addr1 = "0x1"
+addr1 = "0x2"

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-empty.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-empty.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dev-addresses]
+6 | addr1 = ""
+  |         ^^ Hex string is too short, must be 1 to 64 chars long, excluding the leading 0x
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-empty.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-empty.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dev-addresses]
+addr1 = ""

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-wildcard.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-wildcard.exp
@@ -1,0 +1,10 @@
+error: failed to parse manifest
+  |
+1 | [package]
+2 | name = "some_package_name"
+3 | version = "0.1.2"
+4 |
+5 | [dev-addresses]
+6 | addr1 = "_"
+  |         ^^^ Hex characters are invalid: Invalid character '_' at position 63
+  |

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-wildcard.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/invalid-dev-address-wildcard.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dev-addresses]
+addr1 = "_"

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/one-valid-dev-address.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/one-valid-dev-address.exp
@@ -1,0 +1,18 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {
+        "addr1": 0000000000000000000000000000000000000000000000000000000000000001,
+    },
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/one-valid-dev-address.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/one-valid-dev-address.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dev-addresses]
+addr1 = "0x1"

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/two-valid-dev-addresses.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/two-valid-dev-addresses.exp
@@ -1,0 +1,19 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {
+        "addr1": 0000000000000000000000000000000000000000000000000000000000000001,
+        "addr2": 0000000000000000000000000000000000000000000000000000000000000002,
+    },
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/two-valid-dev-addresses.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/two-valid-dev-addresses.toml
@@ -1,0 +1,7 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dev-addresses]
+addr1 = "0x1"
+addr2 = "0x2"

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/valid-dev-address-leading-zeros.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/valid-dev-address-leading-zeros.exp
@@ -1,0 +1,18 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {
+        "addr1": 0000000000000000000000000000000000000000000000000000000000001234,
+    },
+    build: None,
+    dependencies: {},
+    dev_dependencies: {},
+}

--- a/third_party/move/tools/move-package-manifest/tests/dev-addresses/valid-dev-address-leading-zeros.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dev-addresses/valid-dev-address-leading-zeros.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dev-addresses]
+addr1 = "0x0000000000000000000000000000000000000000000000000000000000001234"

--- a/third_party/move/tools/move-package-manifest/tests/dev-dependencies/simple.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dev-dependencies/simple.exp
@@ -1,0 +1,25 @@
+success
+
+PackageManifest {
+    package: PackageMetadata {
+        name: "some_package_name",
+        version: "0.1.2",
+        authors: [],
+        license: None,
+        upgrade_policy: None,
+    },
+    addresses: {},
+    dev_addresses: {},
+    build: None,
+    dependencies: {},
+    dev_dependencies: {
+        "a": Dependency {
+            version: Some(
+                "1.2.3",
+            ),
+            location: Local {
+                path: "../a",
+            },
+        },
+    },
+}

--- a/third_party/move/tools/move-package-manifest/tests/dev-dependencies/simple.toml
+++ b/third_party/move/tools/move-package-manifest/tests/dev-dependencies/simple.toml
@@ -1,0 +1,6 @@
+[package]
+name = "some_package_name"
+version = "0.1.2"
+
+[dev-dependencies]
+a = { local = "../a", version = "1.2.3" }

--- a/third_party/move/tools/move-package-manifest/tests/expected_output.rs
+++ b/third_party/move/tools/move-package-manifest/tests/expected_output.rs
@@ -1,0 +1,31 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::{fmt::Write, path::Path};
+
+datatest_stable::harness!(expected_output_tests, "tests", r".*\.toml$");
+
+fn expected_output_tests(path: &Path) -> datatest_stable::Result<()> {
+    let content = std::fs::read_to_string(path)?;
+
+    let parse_result = move_package_manifest::parse_package_manifest(&content);
+
+    let mut output = String::new();
+    match parse_result {
+        Ok(parsed_manifest) => {
+            writeln!(output, "success")?;
+            writeln!(output)?;
+            writeln!(output, "{:#?}", parsed_manifest)?;
+        },
+        Err(err) => {
+            move_package_manifest::render_error(&mut output, &content, &err)?;
+        },
+    }
+
+    move_prover_test_utils::baseline_test::verify_or_update_baseline(
+        &path.with_extension("exp"),
+        &output,
+    )?;
+
+    Ok(())
+}

--- a/third_party/move/tools/move-package-manifest/tests/framework_manifests.rs
+++ b/third_party/move/tools/move-package-manifest/tests/framework_manifests.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use std::{env, fs, path::Path};
+
+datatest_stable::harness!(
+    parse_framework_manifests,
+    {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../../aptos-move/framework")
+            .display()
+    },
+    r"\bMove\.toml$"
+);
+
+fn parse_framework_manifests(path: &Path) -> datatest_stable::Result<()> {
+    let path = fs::canonicalize(path)?;
+    let content = std::fs::read_to_string(&path)?;
+
+    let parse_result = move_package_manifest::parse_package_manifest(&content);
+
+    match parse_result {
+        Ok(_parsed_manifest) => (),
+        Err(err) => {
+            let mut output = String::new();
+            move_package_manifest::render_error(&mut output, &content, &err)?;
+
+            return Err(anyhow!("Failed to parse {}\n\n{}", path.display(), output).into());
+        },
+    }
+
+    Ok(())
+}

--- a/third_party/move/tools/move-package-manifest/tests/move_example_manifests.rs
+++ b/third_party/move/tools/move-package-manifest/tests/move_example_manifests.rs
@@ -1,0 +1,34 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::anyhow;
+use std::{env, fs, path::Path};
+
+datatest_stable::harness!(
+    parse_move_example_manifests,
+    {
+        Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../../../../aptos-move/move-examples")
+            .display()
+    },
+    r"\bMove\.toml$"
+);
+
+fn parse_move_example_manifests(path: &Path) -> datatest_stable::Result<()> {
+    let path = fs::canonicalize(path)?;
+    let content = std::fs::read_to_string(&path)?;
+
+    let parse_result = move_package_manifest::parse_package_manifest(&content);
+
+    match parse_result {
+        Ok(_parsed_manifest) => (),
+        Err(err) => {
+            let mut output = String::new();
+            move_package_manifest::render_error(&mut output, &content, &err)?;
+
+            return Err(anyhow!("Failed to parse {}\n\n{}", path.display(), output).into());
+        },
+    }
+
+    Ok(())
+}

--- a/third_party/move/tools/move-package-manifest/tests/serde_round_trip.rs
+++ b/third_party/move/tools/move-package-manifest/tests/serde_round_trip.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+datatest_stable::harness!(serde_round_trip, "tests", r".*\.toml$");
+
+fn serde_round_trip(path: &Path) -> datatest_stable::Result<()> {
+    let content = std::fs::read_to_string(path)?;
+
+    if let Ok(parsed_manifest) = move_package_manifest::parse_package_manifest(&content) {
+        let re_serialized =
+            toml::to_string_pretty(&parsed_manifest).expect("failed to re-serialize-manifest");
+
+        let re_parsed_manifest = move_package_manifest::parse_package_manifest(&re_serialized)
+            .expect("failed to deserialize manifest again");
+
+        assert_eq!(parsed_manifest, re_parsed_manifest)
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This PR introduces the first component of the next-generation package system: a new manifest parser.

## High level designs
- **Modular architecture**: The new package system is being developed as a collection of self-contained components, each intended to be reusable as a standalone library.
- **Single-responsibility**: Each component focuses on doing one thing well, with a clearly defined and narrow scope.
  - For this crate, that means defining the manifest AST and parsing logic only.
  - Package resolution is explicitly out of scope and will be handled separately.
- **Serde-based parsing**: Replaces the custom TOML parser with `serde`, making the codebase easier to maintain and less error-prone.

## Test coverage
The parser comes with a comprehensive test suite:
- **`expected_output_tests`**: Validates that the parser produces exactly the expected outputs using synthetic inputs.
- **`serde_round_trip`**: Verifies that manifests remain unchanged after a `serialize -> deserialize` round-trip using the same synthetic inputs.
- **`parse_framework_manifests`**: Ensures all manifests in `aptos-move/framework` can be successfully parsed.
- **`parse_move_example_manifests`**: Ensures all manifests in `aptos-move/move-examples` can be successfully parsed.