### PR TITLE
[Compiler] Fix bug relating to inferring enum variant during is check

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_err.exp
@@ -1,0 +1,51 @@
+
+Diagnostics:
+error: expected `S1<u8>` but found a value of type `S1<u16>`
+  ┌─ tests/checking/variants/variants_test_infer_err.move:7:14
+  │
+7 │         s is S1<u16>;
+  │              ^^^^^^^
+
+error: expected variant of enum type but found type `0x815::m::S1<u16>`
+  ┌─ tests/checking/variants/variants_test_infer_err.move:7:14
+  │
+7 │         s is S1<u16>;
+  │              ^^^^^^^
+
+error: expected `S1<u8>` but found a value of type `S2`
+   ┌─ tests/checking/variants/variants_test_infer_err.move:11:14
+   │
+11 │         s is S2;
+   │              ^^
+
+error: expected variant of enum type but found type `0x815::m::S2`
+   ┌─ tests/checking/variants/variants_test_infer_err.move:11:14
+   │
+11 │         s is S2;
+   │              ^^
+
+error: expected 0 type arguments but 1 were provided
+   ┌─ tests/checking/variants/variants_test_infer_err.move:15:14
+   │
+15 │         s is S2<u8>;
+   │              ^^
+
+error: cannot select field `inner` since it has different types in variants of enum `S3<G>`
+   ┌─ tests/checking/variants/variants_test_infer_err.move:21:9
+   │
+21 │         first.inner is One<G>|One<u8>;
+   │         ^^^^^
+   │
+   = field `inner` has type `S1<u8>` in variant `Four` and type `S1<G>` in variant `Three`
+
+error: undeclared struct `m::One`
+   ┌─ tests/checking/variants/variants_test_infer_err.move:21:24
+   │
+21 │         first.inner is One<G>|One<u8>;
+   │                        ^^^
+
+error: undeclared struct `m::One`
+   ┌─ tests/checking/variants/variants_test_infer_err.move:21:31
+   │
+21 │         first.inner is One<G>|One<u8>;
+   │                               ^^^

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_err.move
@@ -1,0 +1,23 @@
+module 0x815::m {
+
+    enum S1<phantom T> { One }
+    enum S2 { One }
+
+    fun incorrect_generic(s: S1<u8>) {
+        s is S1<u16>;
+    }
+
+    fun incorrect_enum(s : S1<u8>) {
+        s is S2;
+    }
+
+    fun non_empty_arguments_for_empty_expected(s : S2) {
+        s is S2<u8>;
+    }
+
+    enum S3<T> {Three{ inner : S1<T>}, Four{ inner : S1<u8>}}
+
+    fun infer_nested_choice<G>(first: S3<G>,) {
+        first.inner is One<G>|One<u8>;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_ok.exp
@@ -1,0 +1,98 @@
+// -- Model dump before first bytecode pipeline
+module 0x815::m {
+    enum S1<T> {
+        One,
+    }
+    enum S2<T> {
+        Two {
+            inner: S1<T>,
+        }
+    }
+    enum S3<T> {
+        Three {
+            inner: S1<T>,
+        }
+        Four {
+            inner: S1<u8>,
+        }
+    }
+    enum S4<T> {
+        Five {
+            inner: S1<T>,
+        }
+    }
+    enum Unused<T> {
+        Two,
+    }
+    private fun infer_nested<G>(first: S2<u8>,second: S2<G>) {
+        test_variants m::S2::Two<u8>(first);
+        test_variants m::S2::Two<G>(second);
+        test_variants m::S2::Two<u8>(first);
+        test_variants m::S2::Two<G>(second);
+        test_variants m::S1::One<u8>(select_variants m::S2.Two.inner<S2<u8>>(first));
+        test_variants m::S1::One<G>(select_variants m::S2.Two.inner<S2<G>>(second));
+        test_variants m::S1::One<u8>(select_variants m::S2.Two.inner<S2<u8>>(first));
+        test_variants m::S1::One<G>(select_variants m::S2.Two.inner<S2<G>>(second));
+        Tuple()
+    }
+    private fun infer_nested_choice<G>(first: S3<G>,second: S4<G>) {
+        test_variants m::S3::Three|Four<G>(first);
+        test_variants m::S1::One<G>(select_variants m::S4.Five.inner<S4<G>>(second));
+        Tuple()
+    }
+    private fun infer_phantom(first: S1<u8>) {
+        test_variants m::S1::One<u8>(first);
+        test_variants m::S1::One<u8>(first);
+        test_variants m::S1::One<u8>(first);
+        test_variants m::S1::One<u8>(first);
+        Tuple()
+    }
+} // end 0x815::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x815::m {
+    enum S1<phantom T> {
+        One,
+    }
+    enum S2<T> {
+        Two {
+            inner: S1<T>,
+        }
+    }
+    enum S3<T> {
+        Three {
+            inner: S1<T>,
+        }
+        Four {
+            inner: S1<u8>,
+        }
+    }
+    enum S4<T> {
+        Five {
+            inner: S1<T>,
+        }
+    }
+    enum Unused<phantom T> {
+        Two,
+    }
+    fun infer_nested<G>(first: S2<u8>, second: S2<G>) {
+        first is Two;
+        second is Two;
+        first is Two;
+        second is Two;
+        first.inner is One;
+        second.inner is One;
+        first.inner is One;
+        second.inner is One;
+    }
+    fun infer_nested_choice<G>(first: S3<G>, second: S4<G>) {
+        first is Three | Four;
+        second.inner is One;
+    }
+    fun infer_phantom(first: S1<u8>) {
+        first is One;
+        first is One;
+        first is One;
+        first is One;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_ok.move
+++ b/third_party/move/move-compiler-v2/tests/checking/variants/variants_test_infer_ok.move
@@ -1,0 +1,33 @@
+module 0x815::m {
+
+    enum S1<phantom T> { One }
+
+    fun infer_phantom(first: S1<u8>) {
+        first is One;
+        first is S1::One;
+        first is One<u8>;
+        first is S1::One<u8>;
+    }
+
+    enum S2<T> {Two{inner: S1<T>}}
+    enum Unused<phantom T> { Two }
+
+    fun infer_nested<G>(first: S2<u8>, second : S2<G>) {
+        first is Two;
+        second is Two;
+        first is S2::Two;
+        second is S2::Two<G>;
+        first.inner is One;
+        second.inner is One;
+        first.inner is One<u8>;
+        second.inner is One<G>;
+    }
+
+    enum S3<T> {Three{ inner : S1<T>}, Four{ inner : S1<u8>}}
+    enum S4<T> {Five{ inner : S1<T>}}
+
+    fun infer_nested_choice<G>(first: S3<G>, second: S4<G>) {
+        first is Three|Four;
+        second.inner is One<G>;
+    }
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -4257,6 +4257,9 @@ impl ExpTranslator<'_, '_, '_> {
         for ty in tys {
             let ty_loc = self.to_loc(&ty.loc);
             if let EA::Type_::Apply(maccess, generics) = &ty.value {
+                // If no type params were given, pass `None` to `translate_constructor_name` to trigger inference;
+                // an empty vec means "explicitly no type params".
+                // If any were given, pass them through to avoid inferring.
                 let generics = (!generics.is_empty()).then_some(generics.clone());
                 if let Some((inferred_struct_id, variant)) = self.translate_constructor_name(
                     &exp_ty,

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -4257,19 +4257,7 @@ impl ExpTranslator<'_, '_, '_> {
         for ty in tys {
             let ty_loc = self.to_loc(&ty.loc);
             if let EA::Type_::Apply(maccess, generics) = &ty.value {
-                let expected_type = self.subs.specialize(&exp_ty).drop_reference();
-
-                let (_, _, struct_entry) =
-                    match self.resolve_struct_access(&expected_type, maccess, true) {
-                        Some(x) => x,
-                        None => continue,
-                    };
-                let generics = if generics.is_empty() && !&struct_entry.type_params.is_empty() {
-                    None
-                } else {
-                    Some(generics.clone())
-                };
-
+                let generics = (!generics.is_empty()).then_some(generics.clone());
                 if let Some((inferred_struct_id, variant)) = self.translate_constructor_name(
                     &exp_ty,
                     WideningOrder::LeftToRight,

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -4257,13 +4257,26 @@ impl ExpTranslator<'_, '_, '_> {
         for ty in tys {
             let ty_loc = self.to_loc(&ty.loc);
             if let EA::Type_::Apply(maccess, generics) = &ty.value {
+                let expected_type = self.subs.specialize(&exp_ty).drop_reference();
+
+                let (_, _, struct_entry) =
+                    match self.resolve_struct_access(&expected_type, maccess, true) {
+                        Some(x) => x,
+                        None => continue,
+                    };
+                let generics = if generics.is_empty() && !&struct_entry.type_params.is_empty() {
+                    None
+                } else {
+                    Some(generics.clone())
+                };
+
                 if let Some((inferred_struct_id, variant)) = self.translate_constructor_name(
                     &exp_ty,
                     WideningOrder::LeftToRight,
                     context,
                     &ty_loc,
                     maccess,
-                    &Some(generics.clone()),
+                    &generics,
                 ) {
                     if let Some(variant) = variant {
                         // Any time in the loop is the same if type unification succeeds, so


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fix for compiler warning no type argument during enum variant test when type argument can be inferred from context.

Close: https://github.com/aptos-labs/aptos-core/issues/16014, https://github.com/aptos-labs/aptos-core/issues/16360

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

New test cases added

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

I want to confirm that on `line 4265` of `exp_builder.rs`, the behavior should be to continue incase of `self.resolve_struct_access` failing. It is my understanding that `self.resolve_struct_access` will handle the error reporting.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
