### PR TITLE
[lazy-loading] Module metadata integration (6/n)

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -86,7 +86,10 @@ use aptos_types::{
     vm_status::{AbortLocation, StatusCode, VMStatus},
 };
 use aptos_vm_environment::environment::AptosEnvironment;
-use aptos_vm_logging::{log_schema::AdapterLogSchema, speculative_error, speculative_log};
+use aptos_vm_logging::{
+    alert, log_schema::AdapterLogSchema, prelude::CRITICAL_ERRORS, speculative_error,
+    speculative_log,
+};
 use aptos_vm_types::{
     abstract_write_op::AbstractResourceWriteOp,
     change_set::{
@@ -536,6 +539,8 @@ impl AptosVM {
     fn inject_abort_info_if_available(
         &self,
         module_storage: &impl AptosModuleStorage,
+        traversal_context: &TraversalContext,
+        log_context: &AdapterLogSchema,
         status: ExecutionStatus,
     ) -> ExecutionStatus {
         if let ExecutionStatus::MoveAbort {
@@ -544,12 +549,30 @@ impl AptosVM {
             ..
         } = status
         {
+            // Note: in general, this module should have been charged for (because the location is
+            // set). This cannot be enforced though, so the best option is to perform unmetered
+            // access in any case to get a consistent error message. In case it was not metered,
+            // log an error.
+            if self.features().is_lazy_loading_enabled()
+                && traversal_context
+                    .check_is_special_or_visited(module_id.address(), module_id.name())
+                    .is_err()
+            {
+                alert!(
+                    *log_context,
+                    "Unmetered metadata access for {}::{} when injecting abort info",
+                    module_id.address(),
+                    module_id.name()
+                );
+            }
+
             let info = module_storage
-                .fetch_module_metadata(module_id.address(), module_id.name())
+                .unmetered_get_module_metadata(module_id.address(), module_id.name())
                 .ok()
                 .flatten()
                 .and_then(|metadata| get_metadata(&metadata))
                 .and_then(|m| m.extract_abort_info(code));
+
             ExecutionStatus::MoveAbort {
                 location: AbortLocation::Module(module_id),
                 code,
@@ -672,14 +695,12 @@ impl AptosVM {
         );
 
         // Abort information is injected using the user defined error in the Move contract.
-        //
-        // DO NOT move abort info injection before we create an epilogue session, because if
-        // there is a code publishing transaction that fails, it will invalidate VM loader
-        // cache which is flushed ONLY WHEN THE NEXT SESSION IS CREATED!
-        // Also, do not move this after we run failure epilogue below, because this will load
-        // module, which alters abort info. We have a transaction at version 596888095 which
-        // relies on this specific behavior...
-        let status = self.inject_abort_info_if_available(module_storage, status);
+        let status = self.inject_abort_info_if_available(
+            module_storage,
+            traversal_context,
+            log_context,
+            status,
+        );
         epilogue_session.execute(|session| {
             transaction_validation::run_failure_epilogue(
                 session,
@@ -2423,6 +2444,9 @@ impl AptosVM {
         let module_storage = state_view.as_aptos_code_storage(&env);
 
         let mut session = vm.new_session(&resolver, SessionId::Void, None);
+
+        let traversal_storage = TraversalStorage::new();
+        let mut traversal_context = TraversalContext::new(&traversal_storage);
         let execution_result = Self::execute_view_function_in_vm(
             &mut session,
             &vm,
@@ -2431,6 +2455,7 @@ impl AptosVM {
             type_args,
             arguments,
             &mut gas_meter,
+            &mut traversal_context,
             &module_storage,
         );
         let gas_used = Self::gas_used(max_gas_amount.into(), &gas_meter);
@@ -2458,8 +2483,12 @@ impl AptosVM {
                     TransactionStatus::Keep(status) => status,
                     _ => ExecutionStatus::MiscellaneousError(Some(vm_status.status_code())),
                 };
-                let status_with_abort_info =
-                    vm.inject_abort_info_if_available(&module_storage, execution_status);
+                let status_with_abort_info = vm.inject_abort_info_if_available(
+                    &module_storage,
+                    &traversal_context,
+                    &log_context,
+                    execution_status,
+                );
                 ViewFunctionOutput::new_move_abort_error(
                     status_with_abort_info,
                     Some(vm_status.status_code()),
@@ -2484,11 +2513,9 @@ impl AptosVM {
         ty_args: Vec<TypeTag>,
         arguments: Vec<Vec<u8>>,
         gas_meter: &mut impl AptosGasMeter,
+        traversal_context: &mut TraversalContext,
         module_storage: &impl AptosModuleStorage,
     ) -> Result<Vec<Vec<u8>>, VMError> {
-        let traversal_storage = TraversalStorage::new();
-        let mut traversal_context = TraversalContext::new(&traversal_storage);
-
         let func = module_storage.load_function(&module_id, &func_name, &ty_args)?;
         let metadata = get_metadata(&func.owner_as_module()?.metadata);
 
@@ -2507,7 +2534,7 @@ impl AptosVM {
             func,
             arguments,
             gas_meter,
-            &mut traversal_context,
+            traversal_context,
             module_storage,
         )?;
 
@@ -3106,8 +3133,14 @@ pub(crate) fn should_create_account_resource(
         && txn_data.replay_protector == ReplayProtector::SequenceNumber(0)
     {
         let account_tag = AccountResource::struct_tag();
+
+        // INVARIANT:
+        //   Account lives at a special address, so we should not be charging for it and unmetered
+        //   access is safe. There are tests that ensure that address is always special.
+        assert!(account_tag.address.is_special());
         let metadata = module_storage
-            .fetch_existing_module_metadata(&account_tag.address, &account_tag.module)?;
+            .unmetered_get_existing_module_metadata(&account_tag.address, &account_tag.module)?;
+
         let (maybe_bytes, _) = resolver
             .get_resource_bytes_with_metadata_and_layout(
                 &txn_data.sender(),

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -361,9 +361,16 @@ where
 
             for (struct_tag, blob_op) in resources {
                 let resource_group_tag = {
+                    // INVARIANT:
+                    //   We do not need to meter metadata access here. If this resource is in data
+                    //   cache, we must have already fetched metadata for its tag.
                     let metadata = module_storage
-                        .fetch_existing_module_metadata(&struct_tag.address, &struct_tag.module)
+                        .unmetered_get_existing_module_metadata(
+                            &struct_tag.address,
+                            &struct_tag.module,
+                        )
                         .map_err(|e| e.to_partial())?;
+
                     get_resource_group_member_from_metadata(&struct_tag, &metadata)
                 };
 

--- a/third_party/move/move-vm/integration-tests/src/tests/module_storage_tests.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/module_storage_tests.rs
@@ -59,7 +59,8 @@ fn test_module_does_not_exist() {
     let result = module_storage.unmetered_get_module_size(&AccountAddress::ZERO, ident_str!("a"));
     assert_none!(assert_ok!(result));
 
-    let result = module_storage.fetch_module_metadata(&AccountAddress::ZERO, ident_str!("a"));
+    let result =
+        module_storage.unmetered_get_module_metadata(&AccountAddress::ZERO, ident_str!("a"));
     assert_none!(assert_ok!(result));
 
     let result = module_storage.fetch_deserialized_module(&AccountAddress::ZERO, ident_str!("a"));
@@ -98,7 +99,7 @@ fn test_deserialized_caching() {
 
     let module_storage = module_bytes_storage.into_unsync_module_storage();
 
-    let result = module_storage.fetch_module_metadata(a_id.address(), a_id.name());
+    let result = module_storage.unmetered_get_module_metadata(a_id.address(), a_id.name());
     let expected = make_module("a", vec!["b", "c"], vec![]).0.metadata;
     assert_eq!(assert_some!(assert_ok!(result)), expected);
     module_storage.assert_cached_state(vec![&a_id], vec![]);

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1135,6 +1135,7 @@ where
         ty: &Type,
     ) -> PartialVMResult<DataCacheEntry> {
         let (entry, bytes_loaded) = TransactionDataCache::create_data_cache_entry(
+            self.loader,
             self.layout_converter,
             gas_meter,
             traversal_context,

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -391,6 +391,7 @@ impl<'a, 'b> LoaderContext<'a, 'b> {
     ) -> PartialVMResult<(DataCacheEntry, NumBytes)> {
         dispatch_loader!(&self.module_storage, loader, {
             TransactionDataCache::create_data_cache_entry(
+                &loader,
                 &LayoutConverter::new(&loader),
                 &mut self.gas_meter,
                 self.traversal_context,

--- a/third_party/move/move-vm/runtime/src/storage/loader/traits.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader/traits.rs
@@ -3,7 +3,7 @@
 
 use crate::{module_traversal::TraversalContext, WithRuntimeEnvironment};
 use move_binary_format::errors::PartialVMResult;
-use move_core_types::language_storage::ModuleId;
+use move_core_types::{language_storage::ModuleId, metadata::Metadata};
 use move_vm_types::{
     gas::DependencyGasMeter,
     loaded_data::{runtime_types::StructType, struct_name_indexing::StructNameIndex},
@@ -38,7 +38,19 @@ pub trait NativeModuleLoader {
     ) -> PartialVMResult<()>;
 }
 
+/// Provides access to module metadata.
+pub trait ModuleMetadataLoader {
+    /// Loads the module metadata, ensuring the module access gets charged. Returns an error if
+    /// out-of-gas, module does not exist, or if there is some miscellaneous storage error.
+    fn load_module_metadata(
+        &self,
+        gas_meter: &mut impl DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        module_id: &ModuleId,
+    ) -> PartialVMResult<Vec<Metadata>>;
+}
+
 /// Encapsulates all possible module accesses in a safe, gas-metered way. This trait (and more
 /// fine-grained) traits should be used when working with modules, functions, structs, and other
 /// module information.
-pub trait Loader: StructDefinitionLoader + NativeModuleLoader {}
+pub trait Loader: StructDefinitionLoader + NativeModuleLoader + ModuleMetadataLoader {}

--- a/third_party/move/move-vm/runtime/src/storage/module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/module_storage.rs
@@ -66,7 +66,9 @@ pub trait ModuleStorage: WithRuntimeEnvironment {
 
     /// Returns the metadata in the module, or [None] otherwise. An error is returned if there is
     /// a storage error or the module fails deserialization.
-    fn fetch_module_metadata(
+    ///
+    /// Note: this API is not metered!
+    fn unmetered_get_module_metadata(
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,
@@ -74,12 +76,14 @@ pub trait ModuleStorage: WithRuntimeEnvironment {
 
     /// Returns the metadata in the module. An error is returned if there is a storage error,
     /// module fails deserialization, or does not exist.
-    fn fetch_existing_module_metadata(
+    ///
+    /// Note: this API is not metered!
+    fn unmetered_get_existing_module_metadata(
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,
     ) -> VMResult<Vec<Metadata>> {
-        self.fetch_module_metadata(address, module_name)?
+        self.unmetered_get_module_metadata(address, module_name)?
             .ok_or_else(|| module_linker_error!(address, module_name))
     }
 
@@ -274,7 +278,7 @@ where
             .map(|(module, _)| module.extension().bytes().len()))
     }
 
-    fn fetch_module_metadata(
+    fn unmetered_get_module_metadata(
         &self,
         address: &AccountAddress,
         module_name: &IdentStr,

--- a/types/src/account_config/resources/core_account.rs
+++ b/types/src/account_config/resources/core_account.rs
@@ -97,3 +97,15 @@ impl MoveStructType for AccountResource {
 }
 
 impl MoveResource for AccountResource {}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_account_resource_has_special_address() {
+        // Note: module loading gas charging logic depends on this assumption. This should never
+        // change, but a test should catch if address changes at any point.
+        assert!(AccountResource::struct_tag().address.is_special());
+    }
+}


### PR DESCRIPTION
## Description

This PR adds support for metered metadata accesses:

```rust
pub trait ModuleMetadataLoader {
    fn load_module_metadata(
        &self,
        gas_meter: &mut impl GasMeter,
        traversal_context: &mut impl ModuleTraversalContext,
        module_id: &ModuleId,
    ) -> PartialVMResult<Vec<Metadata>>;
}
```

Lazy loader charges gas for metadata if module is not visited. Eager loader is unmetered.

On Aptos VM layer, metadata is accessed without loader. There, we expect all metadata accesses be metered or not requiring metering:

1. Getting an error information in Aptos VM: module must be visited if it error's location is set to its ID.
2. Checking if account needs creation: `Account` is defined at `0x1`, no metering needed.
3. Fetching keyless resources: those are defined at special addresses, no metering needed.
4. When splitting change set: all metadata accesses must be accounted for when an entry into data cache has been created.

## How Has This Been Tested?

Exiting tests for now. Invariant checks for lazy loading to detect if things go wrong. Asserts + debug asserts.

## Key Areas to Review

N/A

## Type of Change

- [x] New feature

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
