### PR TITLE
[ScriptComposer] Remove the usage of Fetch and rely on an externally passed-in Module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1409,13 +1409,11 @@ dependencies = [
  "bcs 0.1.4",
  "e2e-move-tests",
  "getrandom 0.2.11",
- "hex",
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
  "serde",
  "serde_bytes",
- "serde_json",
  "wasm-bindgen",
  "wasm-bindgen-futures",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1402,7 +1402,7 @@ dependencies = [
 
 [[package]]
 name = "aptos-dynamic-transaction-composer"
-version = "0.1.1"
+version = "0.1.4"
 dependencies = [
  "anyhow",
  "aptos-types",
@@ -1413,7 +1413,6 @@ dependencies = [
  "move-binary-format",
  "move-bytecode-verifier",
  "move-core-types",
- "reqwest 0.11.23",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/aptos-move/script-composer/Cargo.toml
+++ b/aptos-move/script-composer/Cargo.toml
@@ -19,13 +19,11 @@ crate-type = ["cdylib", "rlib"]
 anyhow = { workspace = true }
 bcs = { workspace = true }
 getrandom = { workspace = true, features = ["js"] }
-hex = { workspace = true }
 move-binary-format = { workspace = true }
 move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
-serde_json = { workspace = true }
 wasm-bindgen = { workspace = true }
 wasm-bindgen-futures = { workspace = true }
 

--- a/aptos-move/script-composer/Cargo.toml
+++ b/aptos-move/script-composer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos-dynamic-transaction-composer"
 description = "Generating Move Script from a batched Move calls"
-version = "0.1.1"
+version = "0.1.4"
 
 # Workspace inherited keys
 authors = { workspace = true }
@@ -23,7 +23,6 @@ hex = { workspace = true }
 move-binary-format = { workspace = true }
 move-bytecode-verifier = { workspace = true }
 move-core-types = { workspace = true }
-reqwest = { workspace = true, features = ["blocking"] }
 serde = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }

--- a/aptos-move/script-composer/src/builder.rs
+++ b/aptos-move/script-composer/src/builder.rs
@@ -134,7 +134,7 @@ impl TransactionComposer {
     // stored modules
     pub fn store_module(&mut self, module_bytes: Vec<u8>) -> Result<String, String> {
         let module =
-            CompiledModule::deserialize(module_bytes_hex.as_slice()).map_err(|e| e.to_string())?;
+            CompiledModule::deserialize(module_bytes.as_slice()).map_err(|e| e.to_string())?;
         let module_id = module.self_id();
         self.insert_module(module);
         Ok(module_id.to_string())

--- a/aptos-move/script-composer/src/builder.rs
+++ b/aptos-move/script-composer/src/builder.rs
@@ -132,13 +132,9 @@ impl TransactionComposer {
     }
 
     // stored modules
-    pub fn store_module(
-        &mut self,
-        module_bytes: Vec<u8>,
-    ) -> Result<String, String> {
-        let module = CompiledModule::deserialize(
-            module_bytes_hex.as_slice(),
-        ).map_err(|e| e.to_string())?;
+    pub fn store_module(&mut self, module_bytes: Vec<u8>) -> Result<String, String> {
+        let module =
+            CompiledModule::deserialize(module_bytes_hex.as_slice()).map_err(|e| e.to_string())?;
         let module_id = module.self_id();
         self.insert_module(module);
         Ok(module_id.to_string())
@@ -467,11 +463,14 @@ impl TransactionComposer {
                 operation_type,
             }) => {
                 let local_idx = self.calls[*call_idx as usize].returns[*return_idx as usize];
-                assert_eq!(lhs, &AllocatedLocal {
-                    local_idx,
-                    op_type: operation_type.clone(),
-                    is_parameter: false,
-                });
+                assert_eq!(
+                    lhs,
+                    &AllocatedLocal {
+                        local_idx,
+                        op_type: operation_type.clone(),
+                        is_parameter: false,
+                    }
+                );
             },
             CallArgument::Raw(input) => {
                 assert!(lhs.is_parameter);
@@ -482,11 +481,14 @@ impl TransactionComposer {
                 );
             },
             CallArgument::Signer(idx) => {
-                assert_eq!(lhs, &AllocatedLocal {
-                    op_type: ArgumentOperation::Copy,
-                    is_parameter: true,
-                    local_idx: *idx
-                })
+                assert_eq!(
+                    lhs,
+                    &AllocatedLocal {
+                        op_type: ArgumentOperation::Copy,
+                        is_parameter: true,
+                        local_idx: *idx
+                    }
+                )
             },
         }
     }

--- a/aptos-move/script-composer/src/builder.rs
+++ b/aptos-move/script-composer/src/builder.rs
@@ -463,14 +463,11 @@ impl TransactionComposer {
                 operation_type,
             }) => {
                 let local_idx = self.calls[*call_idx as usize].returns[*return_idx as usize];
-                assert_eq!(
-                    lhs,
-                    &AllocatedLocal {
-                        local_idx,
-                        op_type: operation_type.clone(),
-                        is_parameter: false,
-                    }
-                );
+                assert_eq!(lhs, &AllocatedLocal {
+                    local_idx,
+                    op_type: operation_type.clone(),
+                    is_parameter: false,
+                });
             },
             CallArgument::Raw(input) => {
                 assert!(lhs.is_parameter);
@@ -481,14 +478,11 @@ impl TransactionComposer {
                 );
             },
             CallArgument::Signer(idx) => {
-                assert_eq!(
-                    lhs,
-                    &AllocatedLocal {
-                        op_type: ArgumentOperation::Copy,
-                        is_parameter: true,
-                        local_idx: *idx
-                    }
-                )
+                assert_eq!(lhs, &AllocatedLocal {
+                    op_type: ArgumentOperation::Copy,
+                    is_parameter: true,
+                    local_idx: *idx
+                })
             },
         }
     }

--- a/aptos-move/script-composer/src/builder.rs
+++ b/aptos-move/script-composer/src/builder.rs
@@ -33,7 +33,6 @@ use move_core_types::{
     transaction_argument::TransactionArgument,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::Value;
 use std::{
     cell::RefCell,
     collections::{BTreeMap, HashMap},
@@ -132,31 +131,17 @@ impl TransactionComposer {
             .map_err(|e| e.to_string())
     }
 
-    /// Load up a module from a remote endpoint. Will need to invoke this function prior to the
-    /// call.
-    pub async fn load_module(
+    // stored modules
+    pub fn store_module(
         &mut self,
-        api_url: String,
-        module_name: String,
-    ) -> Result<(), JsValue> {
-        let module_id = ModuleId::from_str(&module_name)
-            .map_err(|err| JsValue::from(format!("Invalid module name: {:?}", err)))?;
-        self.load_module_impl(api_url.as_str(), module_id)
-            .await
-            .map_err(|err| JsValue::from(format!("{:?}", err)))
-    }
-
-    /// Load up the dependency modules of a TypeTag from a remote endpoint.
-    pub async fn load_type_tag(
-        &mut self,
-        api_url: String,
-        type_tag: String,
-    ) -> Result<(), JsValue> {
-        let type_tag = TypeTag::from_str(&type_tag)
-            .map_err(|err| JsValue::from(format!("Invalid type name: {:?}", err)))?;
-        self.load_type_tag_impl(api_url.as_str(), &type_tag)
-            .await
-            .map_err(|err| JsValue::from(format!("{:?}", err)))
+        module_bytes: Vec<u8>,
+    ) -> Result<String, String> {
+        let module = CompiledModule::deserialize(
+            module_bytes_hex.as_slice(),
+        ).map_err(|e| e.to_string())?;
+        let module_id = module.self_id();
+        self.insert_module(module);
+        Ok(module_id.to_string())
     }
 
     /// This would be the core api for the `TransactionComposer`. The function would:
@@ -446,58 +431,6 @@ impl TransactionComposer {
                 .collect(),
         })
         .unwrap())
-    }
-
-    async fn load_module_impl(&mut self, api_url: &str, module_id: ModuleId) -> anyhow::Result<()> {
-        let url = format!(
-            "{}/{}/{}/{}/{}",
-            api_url, "accounts", &module_id.address, "module", &module_id.name
-        );
-        let response = reqwest::get(url).await?;
-        let result = if response.status().is_success() {
-            Ok(response.text().await?)
-        } else {
-            Err(response.text().await?)
-        };
-
-        let bytes_result = match result {
-            Ok(json_string) => {
-                let v: Value = serde_json::from_str(&json_string)?;
-                Ok(v["bytecode"].to_string())
-            },
-            Err(json_string) => {
-                let v: Value = serde_json::from_str(&json_string)?;
-                Err(v["message"].to_string())
-            },
-        };
-
-        match bytes_result {
-            Ok(bytes_hex) => {
-                self.insert_module(CompiledModule::deserialize(
-                    hex::decode(bytes_hex.replace("0x", "").replace('\"', ""))?.as_slice(),
-                )?);
-                Ok(())
-            },
-            Err(_message) => Ok(()),
-        }
-    }
-
-    async fn load_type_tag_impl(
-        &mut self,
-        api_url: &str,
-        type_tag: &TypeTag,
-    ) -> anyhow::Result<()> {
-        match type_tag {
-            TypeTag::Struct(s) => {
-                self.load_module_impl(api_url, s.module_id()).await?;
-                for ty in s.type_args.iter() {
-                    Box::pin(self.load_type_tag_impl(api_url, ty)).await?;
-                }
-                Ok(())
-            },
-            TypeTag::Vector(v) => Box::pin(self.load_type_tag_impl(api_url, v)).await,
-            _ => Ok(()),
-        }
     }
 
     #[cfg(test)]


### PR DESCRIPTION
## Description

We've received a lot of complaints about the Script Composer:

It requires multiple fetch calls, which makes composing transactions too slow, and there's no way to cache the results.

The package size is too large due to the heavy Wasm dependency.

We plan to address the fetch issue here by relying on externally passed-in modules. This change will allow Script Composer to focus solely on its core functionality—composing scripts. It will also result in a cleaner architecture and make it easier for other developers to build their own versions of the Script Composer.

## How Has This Been Tested?

Unfortunately, we don't seem to have any other testing methods at the moment. Our current testing relies on manual verification. I've already released a follow-up support package for the TS SDK to demonstrate its effectiveness.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
