### PR TITLE
[fix] Remove the incorrect whitespace in the example address value in api/types/src/derive.rs

### DIFF
--- a/api/doc/spec.json
+++ b/api/doc/spec.json
@@ -15380,7 +15380,7 @@
         "type": "string",
         "format": "hex",
         "description": "A hex encoded 32 byte Aptos account address.\n\nThis is represented in a string as a 64 character hex string, sometimes\nshortened by stripping leading 0s, and adding a 0x.\n\nFor example, address 0x0000000000000000000000000000000000000000000000000000000000000001 is represented as 0x1.\n",
-        "example": "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 "
+        "example": "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1"
       },
       "AptosError": {
         "type": "object",
@@ -16362,7 +16362,7 @@
         "type": "string",
         "format": "hex",
         "description": "All bytes (Vec<u8>) data is represented as hex-encoded string prefixed with `0x` and fulfilled with\ntwo hex digits per byte.\n\nUnlike the `Address` type, HexEncodedBytes will not trim any zeros.\n",
-        "example": "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 "
+        "example": "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1"
       },
       "IdentifierWrapper": {
         "type": "string"

--- a/api/doc/spec.yaml
+++ b/api/doc/spec.yaml
@@ -11493,7 +11493,7 @@ components:
         shortened by stripping leading 0s, and adding a 0x.
 
         For example, address 0x0000000000000000000000000000000000000000000000000000000000000001 is represented as 0x1.
-      example: '0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 '
+      example: 0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1
     AptosError:
       type: object
       description: |-
@@ -12218,7 +12218,7 @@ components:
         two hex digits per byte.
 
         Unlike the `Address` type, HexEncodedBytes will not trim any zeros.
-      example: '0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 '
+      example: 0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1
     IdentifierWrapper:
       type: string
     IndexResponse:

--- a/api/types/src/derives.rs
+++ b/api/types/src/derives.rs
@@ -32,7 +32,7 @@ impl_poem_type!(
     "string",
     (
         example = Some(serde_json::Value::String(
-            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 ".to_string()
+            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1".to_string()
         )),
         format = Some("hex"),
         description = Some(indoc! {"
@@ -88,7 +88,7 @@ impl_poem_type!(
     "string",
     (
         example = Some(serde_json::Value::String(
-            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1 ".to_string()
+            "0x88fbd33f54e1126269769780feb24480428179f552e2313fbe571b72e62a1ca1".to_string()
         )),
         format = Some("hex"),
         description = Some(indoc! {"


### PR DESCRIPTION
## Description

Remove the incorrect whitespace in the example address value in api/types/src/derive.rs

This causes an error in the current spec file's example because there is an extra space after the address.

<img width="711" alt="image" src="https://github.com/user-attachments/assets/121810c6-8b62-41c6-a62f-7f2f8b1b28d8" />

- https://github.com/aptos-labs/aptos-core/blob/4f09b3b797e8549329eacaa793bff1c2c2d0ae1e/api/doc/spec.json#L15383
- https://github.com/aptos-labs/aptos-core/blob/4f09b3b797e8549329eacaa793bff1c2c2d0ae1e/api/doc/spec.json#L16365
- https://github.com/aptos-labs/aptos-core/blob/4f09b3b797e8549329eacaa793bff1c2c2d0ae1e/api/doc/spec.yaml#L11496
- https://github.com/aptos-labs/aptos-core/blob/4f09b3b797e8549329eacaa793bff1c2c2d0ae1e/api/doc/spec.yaml#L12221



## How Has This Been Tested?

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
