### PR TITLE
[Indexer gRPC v2] Make data service maximum transaction filter size configurable

### DIFF
--- a/ecosystem/indexer-grpc/transaction-filter/src/boolean_transaction_filter.rs
+++ b/ecosystem/indexer-grpc/transaction-filter/src/boolean_transaction_filter.rs
@@ -98,7 +98,11 @@ impl BooleanTransactionFilter {
         if let Some(max_filter_size) = max_filter_size {
             ensure!(
                 proto_filter.encoded_len() <= max_filter_size,
-                "Filter is too complicated."
+                format!(
+                    "Filter is too complicated. Max size: {} bytes, Actual size: {} bytes",
+                    max_filter_size,
+                    proto_filter.encoded_len()
+                )
             );
         }
         Ok(


### PR DESCRIPTION
## Description
Title + include size in error message

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
Config format

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [X] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [X] Indexer gRPC v2

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [X] I tested both happy and unhappy path of the functionality
- [X] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
