### PR TITLE
[compiler-v2] Disallow lambda lifting in functions

### DIFF
--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -426,7 +426,7 @@ pub fn env_check_and_transform_pipeline<'a, 'b>(options: &'a Options) -> EnvProc
         .unwrap_or_default()
         .is_at_least(LanguageVersion::V2_2)
     {
-        env_pipeline.add("closure-ability-checker", |env: &mut GlobalEnv| {
+        env_pipeline.add("closure-checker", |env: &mut GlobalEnv| {
             closure_checker::check_closures(env)
         });
     }

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16592.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16592.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16592.move:3:17
+  │
+3 │         let f = |x| x + 1;
+  │                 ^^^^^^^^^
+  │
+  = lambda cannot be reduced to partial application of an existing function

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16592.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16592.move
@@ -1,0 +1,6 @@
+script {
+    fun main() {
+        let f = |x| x + 1;
+        assert!(f(1) == 2);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16593.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16593.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16593.move:3:21
+  │
+3 │         let f = |x| |y| x + y;
+  │                     ^^^^^^^^^
+  │
+  = lambda cannot be reduced to partial application of an existing function
+
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16593.move:3:17
+  │
+3 │         let f = |x| |y| x + y;
+  │                 ^^^^^^^^^^^^^
+  │
+  = lambda cannot be reduced to partial application of an existing function

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16593.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16593.move
@@ -1,0 +1,6 @@
+script {
+    fun main() {
+        let f = |x| |y| x + y;
+        assert!(f(1)(2) == 3);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16594.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16594.exp
@@ -1,0 +1,17 @@
+
+Diagnostics:
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16594.move:3:17
+  │
+3 │         let f = || {};
+  │                 ^^^^^
+  │
+  = lambda cannot be reduced to partial application of an existing function
+
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16594.move:4:17
+  │
+4 │         let g = |func| func();
+  │                 ^^^^^^^^^^^^^
+  │
+  = lambda cannot be reduced to partial application of an existing function

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16594.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16594.move
@@ -1,0 +1,7 @@
+script {
+    fun main() {
+        let f = || {};
+        let g = |func| func();
+        g(f);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16609.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16609.exp
@@ -1,0 +1,9 @@
+
+Diagnostics:
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16609.move:3:30
+  │
+3 │         let f: || has drop = || {};
+  │                              ^^^^^
+  │
+  = lambda cannot be reduced to partial application of an existing function

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16609.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16609.move
@@ -1,0 +1,5 @@
+script {
+    fun function103() {
+        let f: || has drop = || {};
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16616.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16616.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16616.move:3:9
+  │
+3 │ ╭         (
+4 │ │             | x: |u8| has drop | { 1u16 } // Lambda
+5 │ │         )(
+  │ ╰─────────^
+  │
+  = lambda cannot be reduced to partial application of an existing function
+
+error: lambda lifting is not allowed in scripts
+  ┌─ tests/checking-lang-v2.2/lambda/bug_16616.move:6:13
+  │
+6 │             | y: u8 | { 1u8 & y; } // Argument
+  │             ^^^^^^^^^^^^^^^^^^^^^^
+  │
+  = lambda cannot be reduced to partial application of an existing function

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16616.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16616.move
@@ -1,0 +1,9 @@
+script {
+    fun f( ) {
+        (
+            | x: |u8| has drop | { 1u16 } // Lambda
+        )(
+            | y: u8 | { 1u8 & y; } // Argument
+        ) >= 1u16;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_a.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_a.exp
@@ -1,0 +1,35 @@
+
+Diagnostics:
+error: lambda lifting is not allowed in scripts
+   ┌─ tests/checking-lang-v2.2/lambda/bug_16623_a.move:10:13
+   │
+10 │ ╭             |
+11 │ │                 v2: || has copy+drop,
+12 │ │             |
+13 │ │             { }
+   │ ╰───────────────^
+   │
+   = lambda cannot be reduced to partial application of an existing function
+
+error: lambda lifting is not allowed in scripts
+   ┌─ tests/checking-lang-v2.2/lambda/bug_16623_a.move:9:9
+   │
+ 9 │ ╭         || {
+10 │ │             |
+11 │ │                 v2: || has copy+drop,
+12 │ │             |
+13 │ │             { }
+14 │ │         };
+   │ ╰─────────^
+   │
+   = lambda cannot be reduced to partial application of an existing function
+
+error: lambda lifting is not allowed in scripts
+   ┌─ tests/checking-lang-v2.2/lambda/bug_16623_a.move:16:13
+   │
+16 │ ╭             |v4: bool| {
+17 │ │                     *(&mut (true)) = v4;
+18 │ │             };
+   │ ╰─────────────^
+   │
+   = lambda cannot be reduced to partial application of an existing function

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_a.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_a.move
@@ -1,0 +1,20 @@
+script {
+    fun f( ) {
+        let v1: || (
+            |
+                || has copy+drop,
+            | has copy+drop
+        ) has copy+drop
+        =
+        || {
+            |
+                v2: || has copy+drop,
+            |
+            { }
+        };
+        let v3: |bool| has copy+drop =
+            |v4: bool| {
+                    *(&mut (true)) = v4;
+            };
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_b.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_b.exp
@@ -1,0 +1,37 @@
+
+Diagnostics:
+error: lambda lifting is not allowed in scripts
+   ┌─ tests/checking-lang-v2.2/lambda/bug_16623_b.move:11:13
+   │
+11 │ ╭             |
+12 │ │                 v2: || has copy+drop,
+13 │ │                 v3: || has copy+drop,
+14 │ │             |
+15 │ │             { }
+   │ ╰───────────────^
+   │
+   = lambda cannot be reduced to partial application of an existing function
+
+error: lambda lifting is not allowed in scripts
+   ┌─ tests/checking-lang-v2.2/lambda/bug_16623_b.move:10:9
+   │
+10 │ ╭         || {
+11 │ │             |
+12 │ │                 v2: || has copy+drop,
+13 │ │                 v3: || has copy+drop,
+14 │ │             |
+15 │ │             { }
+16 │ │         };
+   │ ╰─────────^
+   │
+   = lambda cannot be reduced to partial application of an existing function
+
+error: lambda lifting is not allowed in scripts
+   ┌─ tests/checking-lang-v2.2/lambda/bug_16623_b.move:18:13
+   │
+18 │ ╭             |v5: bool| {
+19 │ │                     *(&mut (true)) = v5;
+20 │ │             };
+   │ ╰─────────────^
+   │
+   = lambda cannot be reduced to partial application of an existing function

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_b.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/bug_16623_b.move
@@ -1,0 +1,22 @@
+script {
+    fun f( ) {
+        let v1: || (
+            |
+                || has copy+drop,
+                || has copy+drop,
+            | has copy+drop
+        ) has copy+drop
+        =
+        || {
+            |
+                v2: || has copy+drop,
+                v3: || has copy+drop,
+            |
+            { }
+        };
+        let v4: |bool| has copy+drop =
+            |v5: bool| {
+                    *(&mut (true)) = v5;
+            };
+    }
+}


### PR DESCRIPTION
## Description

Allowing lambda lifting in functions causes a variety of bugs (with different observed errors). This PR disallows it.

Closes #16592, closes #16593, closes #16594, closes #16609, closes #16616, closes #16623.

## How Has This Been Tested?

Added a number of tests.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
