### PR TITLE
[vm] Single signature loading

### DIFF
--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -2961,6 +2961,108 @@ impl Bytecode {
 
         v
     }
+
+    /// Returns a signature index for instruction, if it exists. Signature index is used by:
+    ///   - Vector instructions (for vector element),
+    ///   - Calling a closure (for function signature).
+    pub fn get_signature_idx(&self) -> Option<SignatureIndex> {
+        use Bytecode::*;
+        match self {
+            // Instructions with single signature index.
+            VecPack(idx, _)
+            | VecLen(idx)
+            | VecImmBorrow(idx)
+            | VecMutBorrow(idx)
+            | VecPushBack(idx)
+            | VecPopBack(idx)
+            | VecUnpack(idx, _)
+            | VecSwap(idx)
+            | CallClosure(idx) => Some(*idx),
+
+            // Instructions without single signature index.
+            Pop
+            | Ret
+            | BrTrue(_)
+            | BrFalse(_)
+            | Branch(_)
+            | LdU8(_)
+            | LdU16(_)
+            | LdU32(_)
+            | LdU64(_)
+            | LdU128(_)
+            | LdU256(_)
+            | CastU8
+            | CastU16
+            | CastU32
+            | CastU64
+            | CastU128
+            | CastU256
+            | LdConst(_)
+            | LdTrue
+            | LdFalse
+            | CopyLoc(_)
+            | MoveLoc(_)
+            | StLoc(_)
+            | MutBorrowLoc(_)
+            | ImmBorrowLoc(_)
+            | MutBorrowField(_)
+            | ImmBorrowField(_)
+            | MutBorrowFieldGeneric(_)
+            | ImmBorrowFieldGeneric(_)
+            | Call(_)
+            | CallGeneric(_)
+            | Pack(_)
+            | PackGeneric(_)
+            | Unpack(_)
+            | UnpackGeneric(_)
+            | Exists(_)
+            | ExistsGeneric(_)
+            | MutBorrowGlobal(_)
+            | ImmBorrowGlobal(_)
+            | MutBorrowGlobalGeneric(_)
+            | ImmBorrowGlobalGeneric(_)
+            | MoveFrom(_)
+            | MoveFromGeneric(_)
+            | MoveTo(_)
+            | MoveToGeneric(_)
+            | FreezeRef
+            | ReadRef
+            | WriteRef
+            | Add
+            | Sub
+            | Mul
+            | Mod
+            | Div
+            | BitOr
+            | BitAnd
+            | Xor
+            | Shl
+            | Shr
+            | Or
+            | And
+            | Not
+            | Eq
+            | Neq
+            | Lt
+            | Gt
+            | Le
+            | Ge
+            | Abort
+            | Nop
+            | ImmBorrowVariantField(_)
+            | ImmBorrowVariantFieldGeneric(_)
+            | MutBorrowVariantField(_)
+            | MutBorrowVariantFieldGeneric(_)
+            | PackVariant(_)
+            | PackVariantGeneric(_)
+            | UnpackVariant(_)
+            | UnpackVariantGeneric(_)
+            | TestVariant(_)
+            | TestVariantGeneric(_)
+            | PackClosure(_, _)
+            | PackClosureGeneric(_, _) => None,
+        }
+    }
 }
 
 /// Contains the main function to execute and its dependencies.

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/scripts.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/scripts.exp
@@ -1,0 +1,1 @@
+processed 4 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/scripts.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/scripts.move
@@ -1,0 +1,28 @@
+//# publish
+module 0xc0ffee::m {
+    public fun foo() {}
+}
+
+//# run
+script {
+    fun main() {
+        use 0xc0ffee::m;
+        let f = m::foo;
+        f();
+    }
+}
+
+//# run
+script {
+    fun main() {
+        let f = || 0xc0ffee::m::foo();
+        f();
+    }
+}
+
+//# run
+script {
+    fun main() {
+        (0xc0ffee::m::foo)();
+    }
+}

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -17,5 +17,7 @@ pub(crate) use modules::{StructVariantInfo, VariantFieldInfo};
 mod script;
 pub use script::Script;
 
+mod single_signature_loader;
+
 mod type_loader;
 use type_loader::intern_type;

--- a/third_party/move/move-vm/runtime/src/loader/single_signature_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/single_signature_loader.rs
@@ -1,0 +1,106 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+use super::type_loader::intern_type;
+use move_binary_format::{
+    access::ModuleAccess,
+    binary_views::BinaryIndexedView,
+    errors::{PartialVMError, PartialVMResult},
+    file_format::{Bytecode, CodeUnit, CompiledModule, CompiledScript, SignatureIndex},
+};
+use move_core_types::vm_status::StatusCode;
+use move_vm_types::loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndex};
+use std::collections::BTreeMap;
+
+/// Maps indices of single signatures to their types. For example, vector bytecode instruction
+/// carries an index of a signature of vector element. This loader ensures that all these indices
+/// map to their runtime types.
+struct SingleSignatureMap<'a> {
+    /// Script or a module.
+    view: BinaryIndexedView<'a>,
+    /// The map from single signature index to its runtime type.
+    index_to_type: BTreeMap<SignatureIndex, Type>,
+    /// Interned struct names as indices. The caller is responsible for ensuring that all names
+    /// are interned and included here.
+    struct_idxs: &'a [StructNameIndex],
+}
+
+/// Creates a map of all single signature indices to their types for a script.
+///
+/// The caller is responsible for ensuring that all struct indices (interned names) are included
+/// here.
+
+pub(crate) fn load_single_signatures_for_script(
+    script: &CompiledScript,
+    struct_idxs: &[StructNameIndex],
+) -> PartialVMResult<BTreeMap<SignatureIndex, Type>> {
+    let mut map = SingleSignatureMap {
+        view: BinaryIndexedView::Script(script),
+        index_to_type: BTreeMap::new(),
+        struct_idxs,
+    };
+
+    map.load_single_signatures_for_code_unit(&script.code)?;
+
+    Ok(map.index_to_type)
+}
+
+/// Creates a map of all single signature indices to their types for a module.
+///
+/// The caller is responsible for ensuring that all struct indices (interned names) are included
+/// here.
+pub(crate) fn load_single_signatures_for_module(
+    module: &CompiledModule,
+    struct_idxs: &[StructNameIndex],
+) -> PartialVMResult<BTreeMap<SignatureIndex, Type>> {
+    let mut map = SingleSignatureMap {
+        view: BinaryIndexedView::Module(module),
+        index_to_type: BTreeMap::new(),
+        struct_idxs,
+    };
+
+    for function_def in module.function_defs() {
+        if let Some(code_unit) = &function_def.code {
+            map.load_single_signatures_for_code_unit(code_unit)?;
+        }
+    }
+
+    Ok(map.index_to_type)
+}
+
+impl<'a> SingleSignatureMap<'a> {
+    /// Goes over all bytecode instructions, adding mappings from signature index to runtime type
+    /// if needed.
+    fn load_single_signatures_for_code_unit(&mut self, code: &CodeUnit) -> PartialVMResult<()> {
+        for instr in &code.code {
+            if let Some(idx) = instr.get_signature_idx() {
+                self.load_single_signature_idx(idx, instr)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// If signature index is not in the map, converts the signature to runtime type and adds it.
+    fn load_single_signature_idx(
+        &mut self,
+        idx: SignatureIndex,
+        instruction: &Bytecode,
+    ) -> PartialVMResult<()> {
+        if self.index_to_type.contains_key(&idx) {
+            return Ok(());
+        }
+
+        let sig_toks = &self.view.signature_at(idx).0;
+        if sig_toks.len() != 1 {
+            return Err(
+                PartialVMError::new(StatusCode::VERIFIER_INVARIANT_VIOLATION).with_message(
+                    format!("A single token signature is expected for {:?}", instruction),
+                ),
+            );
+        }
+
+        let ty = intern_type(self.view, &sig_toks[0], self.struct_idxs)?;
+        self.index_to_type.insert(idx, ty);
+        Ok(())
+    }
+}


### PR DESCRIPTION
## Description

Refactors loading single signatures (for instructions like `VecPack`, etc.) so that it is reused when loading scripts and modules. The match is now exhaustive so that if new instructions are added there is a compile-time error. This also fixes an issue when calling closures from scripts (added a test which was failing before).

## How Has This Been Tested?

New transactional test + existing tests.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
