### PR TITLE
[vm] Event validation with closures

### DIFF
--- a/aptos-move/aptos-vm/src/verifier/event_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/event_validation.rs
@@ -6,10 +6,11 @@ use aptos_types::{
     vm::module_metadata::{get_metadata_from_compiled_code, RuntimeModuleMetadataV1},
 };
 use move_binary_format::{
-    access::{ModuleAccess, ScriptAccess},
+    access::ModuleAccess,
+    binary_views::BinaryIndexedView,
     errors::{Location, PartialVMError, VMError, VMResult},
     file_format::{
-        Bytecode, CompiledScript,
+        Bytecode, CompiledScript, FunctionHandle,
         SignatureToken::{Struct, StructInstantiation},
     },
     CompiledModule,
@@ -71,7 +72,23 @@ pub(crate) fn validate_module_events(
 }
 
 /// Validate all the `0x1::event::emit` calls have the struct defined in the same module with event
-/// attribute.
+/// attribute. Note that this function checks regular calls, e.g.
+///
+/// ```move
+/// // Here, `Event` must be defined in the same module.
+/// 0x1::event::emit<Event>();
+/// ```
+///
+/// as well as calls via closures:
+///
+/// ```move
+/// // Both are allowed only if `Event` is defined in the same module.
+/// let f = || 0x1::event::emit<Event>();
+/// let g = {
+///    // ... some Move code ...
+///    0x1::event::emit<Event>();
+/// }
+/// ```
 pub(crate) fn validate_emit_calls(
     event_structs: &HashSet<String>,
     module: &CompiledModule,
@@ -79,44 +96,135 @@ pub(crate) fn validate_emit_calls(
     for fun in module.function_defs() {
         if let Some(code_unit) = &fun.code {
             for bc in &code_unit.code {
-                if let Bytecode::CallGeneric(index) = bc {
-                    let func_instantiation = &module.function_instantiation_at(*index);
-                    let func_handle = module.function_handle_at(func_instantiation.handle);
-                    let module_handle = module.module_handle_at(func_handle.module);
-                    let module_addr = module.address_identifier_at(module_handle.address);
-                    let module_name = module.identifier_at(module_handle.name);
-                    let func_name = module.identifier_at(func_handle.name);
-                    if module_addr != &AccountAddress::ONE
-                        || module_name.as_str() != EVENT_MODULE_NAME
-                        || func_name.as_str() != EVENT_EMIT_FUNCTION_NAME
-                    {
-                        continue;
-                    }
-                    let param = module
-                        .signature_at(func_instantiation.type_parameters)
-                        .0
-                        .first()
-                        .ok_or_else(|| {
-                            metadata_validation_error(
-                                "Missing parameter for 0x1::event::emit function",
-                            )
-                        })?;
-                    match param {
-                        StructInstantiation(index, _) | Struct(index) => {
-                            let struct_handle = &module.struct_handle_at(*index);
-                            let struct_name = module.identifier_at(struct_handle.name);
-                            if struct_handle.module != module.self_handle_idx() {
-                                metadata_validation_err(format!("{} passed to 0x1::event::emit function is not defined in the same module", struct_name).as_str())
-                            } else if !event_structs.contains(struct_name.as_str()) {
-                                metadata_validation_err(format!("Missing #[event] attribute on {}. The #[event] attribute is required for all structs passed into 0x1::event::emit.", struct_name).as_str())
-                            } else {
-                                Ok(())
-                            }
-                        },
-                        _ => metadata_validation_err(
-                            "Passed in a non-struct parameter into 0x1::event::emit.",
-                        ),
-                    }?;
+                use Bytecode::*;
+                match bc {
+                    CallGeneric(index) | PackClosureGeneric(index, ..) => {
+                        let func_instantiation = &module.function_instantiation_at(*index);
+                        let func_handle = module.function_handle_at(func_instantiation.handle);
+
+                        if !is_event_emit_call(BinaryIndexedView::Module(module), func_handle) {
+                            continue;
+                        }
+
+                        let param = module
+                            .signature_at(func_instantiation.type_parameters)
+                            .0
+                            .first()
+                            .ok_or_else(|| {
+                                metadata_validation_error(
+                                    "Missing parameter for 0x1::event::emit function",
+                                )
+                            })?;
+                        match param {
+                            StructInstantiation(index, _) | Struct(index) => {
+                                let struct_handle = &module.struct_handle_at(*index);
+                                let struct_name = module.identifier_at(struct_handle.name);
+                                if struct_handle.module != module.self_handle_idx() {
+                                    metadata_validation_err(format!("{} passed to 0x1::event::emit function is not defined in the same module", struct_name).as_str())
+                                } else if !event_structs.contains(struct_name.as_str()) {
+                                    metadata_validation_err(format!("Missing #[event] attribute on {}. The #[event] attribute is required for all structs passed into 0x1::event::emit.", struct_name).as_str())
+                                } else {
+                                    Ok(())
+                                }
+                            },
+                            _ => metadata_validation_err(
+                                "Passed in a non-struct parameter into 0x1::event::emit.",
+                            ),
+                        }?;
+                    },
+                    // Note: If a closure is packed, it cannot be 0x1::event::emit, but the lifted
+                    // lambda body may contain the emit function, and so will match the case above.
+                    // For all other instructions, no validation. We specifically do a full match
+                    // here to ensure that when a new bytecode gets added, compiler complains and
+                    // the validation pass is revisited.
+                    PackClosure(_, _)
+                    | VecPack(_, _)
+                    | VecLen(_)
+                    | VecImmBorrow(_)
+                    | VecMutBorrow(_)
+                    | VecPushBack(_)
+                    | VecPopBack(_)
+                    | VecUnpack(_, _)
+                    | VecSwap(_)
+                    | CallClosure(_)
+                    | Pop
+                    | Ret
+                    | BrTrue(_)
+                    | BrFalse(_)
+                    | Branch(_)
+                    | LdU8(_)
+                    | LdU16(_)
+                    | LdU32(_)
+                    | LdU64(_)
+                    | LdU128(_)
+                    | LdU256(_)
+                    | CastU8
+                    | CastU16
+                    | CastU32
+                    | CastU64
+                    | CastU128
+                    | CastU256
+                    | LdConst(_)
+                    | LdTrue
+                    | LdFalse
+                    | CopyLoc(_)
+                    | MoveLoc(_)
+                    | StLoc(_)
+                    | MutBorrowLoc(_)
+                    | ImmBorrowLoc(_)
+                    | MutBorrowField(_)
+                    | ImmBorrowField(_)
+                    | MutBorrowFieldGeneric(_)
+                    | ImmBorrowFieldGeneric(_)
+                    | Call(_)
+                    | Pack(_)
+                    | PackGeneric(_)
+                    | Unpack(_)
+                    | UnpackGeneric(_)
+                    | Exists(_)
+                    | ExistsGeneric(_)
+                    | MutBorrowGlobal(_)
+                    | ImmBorrowGlobal(_)
+                    | MutBorrowGlobalGeneric(_)
+                    | ImmBorrowGlobalGeneric(_)
+                    | MoveFrom(_)
+                    | MoveFromGeneric(_)
+                    | MoveTo(_)
+                    | MoveToGeneric(_)
+                    | FreezeRef
+                    | ReadRef
+                    | WriteRef
+                    | Add
+                    | Sub
+                    | Mul
+                    | Mod
+                    | Div
+                    | BitOr
+                    | BitAnd
+                    | Xor
+                    | Shl
+                    | Shr
+                    | Or
+                    | And
+                    | Not
+                    | Eq
+                    | Neq
+                    | Lt
+                    | Gt
+                    | Le
+                    | Ge
+                    | Abort
+                    | Nop
+                    | ImmBorrowVariantField(_)
+                    | ImmBorrowVariantFieldGeneric(_)
+                    | MutBorrowVariantField(_)
+                    | MutBorrowVariantFieldGeneric(_)
+                    | PackVariant(_)
+                    | PackVariantGeneric(_)
+                    | UnpackVariant(_)
+                    | UnpackVariantGeneric(_)
+                    | TestVariant(_)
+                    | TestVariantGeneric(_) => (),
                 }
             }
         }
@@ -139,23 +247,44 @@ pub(crate) fn extract_event_metadata(
     Ok(event_structs)
 }
 
+/// Returns an error if the script uses 0x1::event::emit function (whether as a direct call, or as
+/// a closure). Note that this is not overly restrictive: even a callback to emit an event cannot
+/// be passed, i.e. the following script should fail:
+///
+/// ```move
+/// script {
+///   fun main() {
+///     let f = |e| {
+///       // ... do something here ...
+///       0x1::event::emit(e);
+///     }
+///
+///     // This call creates an event and calls `f` on it.
+///     0x123::some_module::some_function(f);
+///   }
+/// }
+/// ```
+///
+/// This is ok to fail here, as event emission should be done by the module where event is defined.
 pub(crate) fn verify_no_event_emission_in_compiled_script(script: &CompiledScript) -> VMResult<()> {
-    for bc in &script.code().code {
-        if let Bytecode::CallGeneric(index) = bc {
-            let func_instantiation = &script.function_instantiation_at(*index);
-            let func_handle = script.function_handle_at(func_instantiation.handle);
-            let module_handle = script.module_handle_at(func_handle.module);
-            let module_addr = script.address_identifier_at(module_handle.address);
-            let module_name = script.identifier_at(module_handle.name);
-            let func_name = script.identifier_at(func_handle.name);
-            if module_addr == &AccountAddress::ONE
-                && module_name.as_str() == EVENT_MODULE_NAME
-                && func_name.as_str() == EVENT_EMIT_FUNCTION_NAME
-            {
-                return Err(PartialVMError::new(StatusCode::INVALID_OPERATION_IN_SCRIPT)
-                    .finish(Location::Script));
-            }
+    for func_handle in &script.function_handles {
+        if is_event_emit_call(BinaryIndexedView::Script(script), func_handle) {
+            debug_assert!(func_handle.type_parameters.len() == 1);
+            return Err(PartialVMError::new(StatusCode::INVALID_OPERATION_IN_SCRIPT)
+                .finish(Location::Script));
         }
     }
     Ok(())
+}
+
+/// Returns true if the handle corresponds to `0x1::event::emit` function call.
+fn is_event_emit_call(view: BinaryIndexedView, func_handle: &FunctionHandle) -> bool {
+    let module_handle = view.module_handle_at(func_handle.module);
+    let module_addr = view.address_identifier_at(module_handle.address);
+    let module_name = view.identifier_at(module_handle.name);
+    let func_name = view.identifier_at(func_handle.name);
+
+    module_addr == &AccountAddress::ONE
+        && module_name.as_str() == EVENT_MODULE_NAME
+        && func_name.as_str() == EVENT_EMIT_FUNCTION_NAME
 }

--- a/aptos-move/e2e-move-tests/src/tests/module_event.rs
+++ b/aptos-move/e2e-move-tests/src/tests/module_event.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
+use aptos_framework::{BuildOptions, BuiltPackage};
 use aptos_package_builder::PackageBuilder;
-use aptos_types::{account_address::AccountAddress, on_chain_config::FeatureFlag};
+use aptos_types::{
+    account_address::AccountAddress, on_chain_config::FeatureFlag, transaction::ExecutionStatus,
+};
+use claims::assert_ok;
 use move_core_types::{language_storage::TypeTag, vm_status::StatusCode};
 use serde::{Deserialize, Serialize};
 use std::str::FromStr;
@@ -115,4 +119,196 @@ fn verify_module_event_upgrades() {
     let path = builder.write_to_temp().unwrap();
     let result = h.publish_package(&account, path.path());
     assert_vm_status!(result, StatusCode::EVENT_METADATA_VALIDATION_ERROR);
+}
+
+#[test]
+fn test_event_emission_not_allowed_in_scripts() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x123").unwrap());
+    let mut build_options = BuildOptions::move_2().set_latest_language();
+    build_options
+        .experiments
+        .push("skip-bailout-on-extended-checks".to_string());
+
+    let mut builder = PackageBuilder::new("P1");
+    let source = r#"
+    module 0x123::test {
+        #[event]
+        struct Event has copy, drop, store;
+
+        public fun new_event(): Event {
+            Event
+        }
+
+        public fun with_callback(callback: |Event|) {
+            let event = new_event();
+            callback(event);
+        }
+
+        public fun emit_from_callback(callback: ||Event) {
+            let event = callback();
+            0x1::event::emit(event);
+        }
+    }
+    "#;
+    builder.add_source("test.move", source);
+    builder.add_local_dep(
+        "AptosFramework",
+        &common::framework_dir_path("aptos-framework").to_string_lossy(),
+    );
+
+    let p1_path = builder.write_to_temp().unwrap();
+    assert_success!(h.publish_package_with_options(&acc, p1_path.path(), build_options.clone()));
+
+    let mut builder = PackageBuilder::new("P2");
+    let sources = [
+        r#"
+        script {
+            fun main_0() {
+                let event = 0x123::test::new_event();
+                0x1::event::emit<0x123::test::Event>(event);
+            }
+        }
+        "#,
+        r#"
+        script {
+            fun main_1() {
+                let event = 0x123::test::new_event();
+                let f = || 0x1::event::emit<0x123::test::Event>(event);
+                f();
+            }
+        }
+        "#,
+        r#"
+        script {
+            fun main_2() {
+                let f = |e| 0x1::event::emit<0x123::test::Event>(e);
+                0x123::test::with_callback(f);
+            }
+        }
+        "#,
+    ];
+    for (idx, source) in sources.iter().enumerate() {
+        builder.add_source(&format!("main_{idx}.move"), source);
+    }
+    builder.add_local_dep("P1", p1_path.path().to_str().unwrap());
+    builder.add_local_dep(
+        "AptosFramework",
+        &common::framework_dir_path("aptos-framework").to_string_lossy(),
+    );
+
+    let p2_path = builder.write_to_temp().unwrap();
+    let p2_package = BuiltPackage::build(p2_path.path().to_path_buf(), build_options.clone())
+        .expect("Should be able to build a package");
+
+    let scripts = p2_package.extract_script_code();
+    assert_eq!(scripts.len(), 3);
+
+    for script in scripts {
+        let txn = h.create_script(&acc, script, vec![], vec![]);
+        let execution_status = assert_ok!(h.run_raw(txn).status().as_kept_status());
+        assert!(matches!(
+            execution_status,
+            ExecutionStatus::MiscellaneousError(Some(StatusCode::INVALID_OPERATION_IN_SCRIPT))
+        ));
+    }
+
+    let mut builder = PackageBuilder::new("P3");
+    let source = r#"
+        script {
+            fun main() {
+                let f = || 0x123::test::new_event();
+                0x123::test::emit_from_callback(f);
+            }
+        }
+        "#;
+    builder.add_source("main.move", source);
+    builder.add_local_dep("P1", p1_path.path().to_str().unwrap());
+
+    let p3_path = builder.write_to_temp().unwrap();
+    let p3_package = BuiltPackage::build(p3_path.path().to_path_buf(), build_options)
+        .expect("Should be able to build a package");
+
+    let mut scripts = p3_package.extract_script_code();
+    assert_eq!(scripts.len(), 1);
+
+    let txn = h.create_script(&acc, scripts.pop().unwrap(), vec![], vec![]);
+    assert_success!(h.run_raw(txn).status().clone());
+}
+
+#[test]
+fn test_event_emission_in_modules() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x123").unwrap());
+    let mut build_options = BuildOptions::move_2().set_latest_language();
+    build_options
+        .experiments
+        .push("skip-bailout-on-extended-checks".to_string());
+
+    let mut builder = PackageBuilder::new("P1");
+    let source = r#"
+    module 0x123::event {
+        #[event]
+        struct Event has copy, drop, store;
+
+        public fun new_event(): Event {
+            Event
+        }
+    }
+    "#;
+    builder.add_source("event.move", source);
+    let p1_path = builder.write_to_temp().unwrap();
+    assert_success!(h.publish_package_with_options(&acc, p1_path.path(), build_options.clone()));
+
+    let sources = [
+        r#"
+        module 0x123::test2 {
+            public fun emit() {
+                let event = 0x123::event::new_event();
+                0x1::event::emit<0x123::event::Event>(event);
+            }
+        }
+        "#,
+        r#"
+        module 0x123::test3 {
+            public fun emit() {
+                let event = 0x123::event::new_event();
+                let f = || 0x1::event::emit<0x123::event::Event>(event);
+                f();
+            }
+        }
+        "#,
+        r#"
+        module 0x123::test4 {
+            public fun emit() {
+                let event = 0x123::event::new_event();
+                let f = || {
+                  if (true) {
+                    0x1::event::emit<0x123::event::Event>(event);
+                  };
+                };
+                f();
+            }
+        }
+        "#,
+    ];
+    for (idx, source) in sources.into_iter().enumerate() {
+        // To make sure files and packages named consistently.
+        let idx = idx + 2;
+
+        let mut builder = PackageBuilder::new(&format!("P{idx}"));
+        builder.add_source(&format!("test{idx}.move"), source);
+        builder.add_local_dep("P1", p1_path.path().to_str().unwrap());
+        builder.add_local_dep(
+            "AptosFramework",
+            &common::framework_dir_path("aptos-framework").to_string_lossy(),
+        );
+        let path = builder.write_to_temp().unwrap();
+        let status = h.publish_package_with_options(&acc, path.path(), build_options.clone());
+        let execution_status = assert_ok!(status.as_kept_status());
+        assert!(matches!(
+            execution_status,
+            ExecutionStatus::MiscellaneousError(Some(StatusCode::EVENT_METADATA_VALIDATION_ERROR))
+        ));
+    }
 }

--- a/aptos-move/framework/aptos-framework/doc/event.md
+++ b/aptos-move/framework/aptos-framework/doc/event.md
@@ -81,7 +81,7 @@ A handle for an event such that:
 
 <a id="0x1_event_ECANNOT_CREATE_EVENT"></a>
 
-An event cannot be created. This error is returned by native implementations when.
+An event cannot be created. This error is returned by native implementations when
 - The type tag for event is too deeply nested.
 
 

--- a/aptos-move/framework/aptos-framework/sources/event.move
+++ b/aptos-move/framework/aptos-framework/sources/event.move
@@ -9,7 +9,7 @@ module aptos_framework::event {
     friend aptos_framework::account;
     friend aptos_framework::object;
 
-    /// An event cannot be created. This error is returned by native implementations when.
+    /// An event cannot be created. This error is returned by native implementations when
     ///   - The type tag for event is too deeply nested.
     const ECANNOT_CREATE_EVENT: u64 = 1;
 


### PR DESCRIPTION
## Description

With closures, event validation needs to be adjusted to account for `0x1::event::emit` captured in a closure. This PR improves event validation and event natives to account for that:

1. For scripts, any event emission is disallowed (i.e., for any function handle, it should not be `0x1::event::emit`). As scripts have no struct definitions, there is nothing to emit.
2. Native `emit` implementation ensure the caller is known. When the caller is `None` (i.e., the call comes from script), an error is also returned.
3. For modules, in addition to direct static calls to `0x1::event::emit`, we also check any closure that is packed from `0x1::event::emit`. This is sufficient to enforce that all event structs come from the same module at publish time.

## How Has This Been Tested?

- New tests for scripts
- New tests for modules

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] New feature
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
