### PR TITLE
[release] Bump Version Workflow

### DIFF
--- a/.github/workflows/bump-release-version.yaml
+++ b/.github/workflows/bump-release-version.yaml
@@ -1,0 +1,105 @@
+name: Bump Release Version
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: "Release branch to run the workflow against"
+        required: true
+        default: "aptos-release-v1."
+      override-version:
+        description: "Optional version to override the calculated version"
+        required: false
+        default: ""
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update-version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Determine next version and update aptos-node/Cargo.toml
+        uses: actions/github-script@v6
+        id: determine-version
+        with:
+          script: |
+            const branch = "${{ github.event.inputs.branch }}".trim();
+            const overrideVersion = "${{ github.event.inputs.override-version }}".trim();
+
+            // Read Cargo.toml
+            const fs = require("fs");
+            const cargoFilePath = "aptos-node/Cargo.toml";
+            const cargoContent = fs.readFileSync(cargoFilePath, "utf8");
+
+            // Extract and update the version
+            const versionMatch = cargoContent.match(/version\s*=\s*"(.*?)"/);
+            if (!versionMatch) {
+              throw new Error("Could not find version in Cargo.toml");
+            }
+            const currentVersion = versionMatch[1];
+            console.log(`Current version found in Cargo.toml: ${currentVersion}`);
+
+            let newVersion;
+
+            // If override version is provided, check if it's valid and use it directly
+            if (overrideVersion) {
+              const overrideVersionMatch = overrideVersion.match(/^\d+\.\d+\.\d+$/);
+              if (!overrideVersionMatch) {
+                throw new Error(`Invalid override version format: ${overrideVersion}. Expected format: x.y.z`);
+              }
+              console.log(`Using overridden version: ${overrideVersion}`);
+              newVersion = overrideVersion;
+            } else {
+              // Match everything after 'v' in the branch name
+              const match = branch.match(/aptos-release-v(.*)/);
+              if (!match) {
+                throw new Error(`Branch name does not match expected pattern 'aptos-release-v*'. Got: ${branch}`);
+              }
+              const versionSuffix = match[1]; // Extract everything after 'v'
+              console.log(`Version suffix extracted from branch: ${versionSuffix}`);           
+
+              if (currentVersion === "0.0.0-main") {
+                newVersion = `${versionSuffix}.0`; // Use the branch suffix for the new version
+              } else {
+                const [major, minor, patch] = currentVersion.split(".").map(Number);
+                newVersion = `${major}.${minor}.${patch + 1}`;
+              }
+            }
+
+            const updatedCargoContent = cargoContent.replace(
+              /version\s*=\s*"(.*?)"/,
+              `version = "${newVersion}"`
+            );
+
+            // Write the updated content back to Cargo.toml
+            fs.writeFileSync(cargoFilePath, updatedCargoContent);
+
+            console.log(`Updated version to ${newVersion}`);
+            core.setOutput("newVersion", newVersion);
+            core.setOutput("releaseBranch", branch);
+            core.setOutput("currentVersion", currentVersion);
+      - name: Create Pull Request
+        id: create-pr
+        uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: update-version-${{ github.run_id }}
+          base: ${{ github.event.inputs.branch }}
+          title: "[${{ steps.determine-version.outputs.releaseBranch }}] Bump version to ${{ steps.determine-version.outputs.newVersion }}"
+          body: "This PR bumps the aptos-node version to ${{ steps.determine-version.outputs.newVersion }} in ${{ steps.determine-version.outputs.releaseBranch }}."
+          commit-message: "[${{ steps.determine-version.outputs.releaseBranch }}] Bump version to ${{ steps.determine-version.outputs.newVersion }}"
+          add-paths: "aptos-node/Cargo.toml"
+      - name: Log PR URL
+        if: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: |
+          echo "### Pull Request Created" >> $GITHUB_STEP_SUMMARY
+          echo "- [View Pull Request](${{ steps.create-pr.outputs.pull-request-url }})" >> $GITHUB_STEP_SUMMARY
+
+            

--- a/aptos-move/aptos-transaction-benchmarks/src/main.rs
+++ b/aptos-move/aptos-transaction-benchmarks/src/main.rs
@@ -203,7 +203,7 @@ fn main() {
             .unwrap()
             .as_millis() as i64,
     );
-    aptos_node_resource_metrics::register_node_metrics_collector();
+    aptos_node_resource_metrics::register_node_metrics_collector(None);
     let _mp = MetricsPusher::start_for_local_run("block-stm-benchmark");
     let args = Args::parse();
 

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -105,7 +105,7 @@ pub fn start_telemetry_service(
     logger_filter_update_job: Option<LoggerFilterUpdater>,
 ) -> Option<Runtime> {
     if enable_prometheus_node_metrics() {
-        aptos_node_resource_metrics::register_node_metrics_collector();
+        aptos_node_resource_metrics::register_node_metrics_collector(Some(&build_info));
     }
 
     // Don't start the service if telemetry has been disabled

--- a/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
@@ -9,75 +9,100 @@ use prometheus::{
     proto::MetricFamily,
     Opts,
 };
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 use sysinfo::{RefreshKind, System, SystemExt};
 
 const BASIC_NODE_INFO_METRICS_COUNT: usize = 2;
 const RELEASE_GIT_HASH_LABEL: &str = "release_git_hash";
+const RELEASE_VERSION_LABEL: &str = "release_version";
 const NODE_HOSTNAME_LABEL: &str = "hostname";
 
 const GIT_HASH_LABEL: &str = "git_hash";
+const VERSION_LABEL: &str = "version";
 const HOSTNAME_LABEL: &str = "name";
 
 const UNKNOW_LABEL: &str = "unknown";
 
 pub(crate) struct BasicNodeInfoCollector {
-    system: Arc<Mutex<System>>,
-    release: Desc,
-    hostname: Desc,
+    release_metric: ConstMetric,
+    hostname_metric: ConstMetric,
+    version_metric: ConstMetric,
 }
 
 impl BasicNodeInfoCollector {
-    fn new() -> Self {
+    pub fn new(maybe_build_info: Option<&BTreeMap<String, String>>) -> Self {
         let system = Arc::new(Mutex::new(System::new_with_specifics(RefreshKind::new())));
+        let mut fallback_build_info = BTreeMap::new();
 
-        let release = Opts::new(RELEASE_GIT_HASH_LABEL, "Release git hash.")
+        let build_info = if let Some(build_info) = maybe_build_info {
+            build_info
+        } else {
+            let git_hash = aptos_build_info::get_git_hash();
+            fallback_build_info.insert(aptos_build_info::BUILD_COMMIT_HASH.into(), git_hash);
+            &fallback_build_info
+        };
+
+        let release_hash_desc = Opts::new(RELEASE_GIT_HASH_LABEL, "Release git hash.")
             .namespace(NAMESPACE)
             .variable_label(GIT_HASH_LABEL)
             .describe()
             .unwrap();
-        let hostname = Opts::new(NODE_HOSTNAME_LABEL, "Hostname.")
+        let release_version_desc = Opts::new(RELEASE_VERSION_LABEL, "Release version")
+            .namespace(NAMESPACE)
+            .variable_label(VERSION_LABEL)
+            .describe()
+            .unwrap();
+        let hostname_desc = Opts::new(NODE_HOSTNAME_LABEL, "Hostname.")
             .namespace(NAMESPACE)
             .variable_label(HOSTNAME_LABEL)
             .describe()
             .unwrap();
 
-        Self {
-            system,
-            release,
-            hostname,
-        }
-    }
-}
+        let git_hash = build_info
+            .get(aptos_build_info::BUILD_COMMIT_HASH)
+            .cloned()
+            .unwrap_or_else(|| String::from(UNKNOW_LABEL));
+        let release_metric =
+            ConstMetric::new_gauge(release_hash_desc, 1.0, Some(&[git_hash])).unwrap();
 
-impl Default for BasicNodeInfoCollector {
-    fn default() -> Self {
-        Self::new()
+        let node_version = build_info
+            .get(aptos_build_info::BUILD_PKG_VERSION)
+            .cloned()
+            .unwrap_or_else(|| String::from(UNKNOW_LABEL));
+        let version_metric =
+            ConstMetric::new_gauge(release_version_desc, 1.0, Some(&[node_version])).unwrap();
+
+        let hostname = system
+            .lock()
+            .host_name()
+            .unwrap_or_else(|| String::from(UNKNOW_LABEL));
+
+        let hostname_metric =
+            ConstMetric::new_gauge(hostname_desc, 1.0, Some(&[hostname])).unwrap();
+
+        Self {
+            release_metric,
+            version_metric,
+            hostname_metric,
+        }
     }
 }
 
 impl Collector for BasicNodeInfoCollector {
     fn desc(&self) -> Vec<&Desc> {
-        vec![&self.hostname, &self.release]
+        self.hostname_metric
+            .desc()
+            .into_iter()
+            .chain(self.release_metric.desc())
+            .chain(self.version_metric.desc())
+            .collect()
     }
 
     fn collect(&self) -> Vec<MetricFamily> {
-        let hostname = self
-            .system
-            .lock()
-            .host_name()
-            .unwrap_or_else(|| String::from(UNKNOW_LABEL));
-
-        let host_name_metrics =
-            ConstMetric::new_gauge(self.hostname.clone(), 1.0, Some(&[hostname])).unwrap();
-
-        let git_hash = aptos_build_info::get_git_hash();
-        let release_metrics =
-            ConstMetric::new_gauge(self.release.clone(), 1.0, Some(&[git_hash])).unwrap();
-
         let mut mfs = Vec::with_capacity(BASIC_NODE_INFO_METRICS_COUNT);
-        mfs.extend(host_name_metrics.collect());
-        mfs.extend(release_metrics.collect());
+        mfs.extend(self.hostname_metric.collect());
+        mfs.extend(self.release_metric.collect());
+        mfs.extend(self.version_metric.collect());
         mfs
     }
 }

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -11,13 +11,14 @@ use collectors::{
 };
 use once_cell::sync::Lazy;
 use prometheus::core::Collector;
+use std::collections::BTreeMap;
 
 mod collectors;
 
 static IS_REGISTERED: Lazy<Mutex<bool>> = Lazy::new(|| Mutex::new(false));
 
 /// Registers the node metrics collector with the default registry.
-pub fn register_node_metrics_collector() {
+pub fn register_node_metrics_collector(maybe_build_info: Option<&BTreeMap<String, String>>) {
     let mut registered = IS_REGISTERED.lock();
     if *registered {
         return;
@@ -31,7 +32,7 @@ pub fn register_node_metrics_collector() {
     register_collector(Box::<NetworkMetricsCollector>::default());
     register_collector(Box::<LoadAvgCollector>::default());
     register_collector(Box::<ProcessMetricsCollector>::default());
-    register_collector(Box::<BasicNodeInfoCollector>::default());
+    register_collector(Box::new(BasicNodeInfoCollector::new(maybe_build_info)));
     cfg_if! {
         if #[cfg(all(target_os="linux"))] {
             register_collector(Box::<collectors::LinuxCpuMetricsCollector>::default());

--- a/execution/executor-benchmark/src/main.rs
+++ b/execution/executor-benchmark/src/main.rs
@@ -577,7 +577,7 @@ fn main() {
         .build_global()
         .expect("Failed to build rayon global thread pool.");
 
-    aptos_node_resource_metrics::register_node_metrics_collector();
+    aptos_node_resource_metrics::register_node_metrics_collector(None);
     let _mp = MetricsPusher::start_for_local_run("executor-benchmark");
 
     let execution_threads = opt.execution_threads();

--- a/execution/executor-service/src/process_executor_service.rs
+++ b/execution/executor-service/src/process_executor_service.rs
@@ -26,7 +26,7 @@ impl ProcessExecutorService {
             "Starting process remote executor service on {}; coordinator address: {}, other shard addresses: {:?}; num threads: {}",
             self_address, coordinator_address, remote_shard_addresses, num_threads
         );
-        aptos_node_resource_metrics::register_node_metrics_collector();
+        aptos_node_resource_metrics::register_node_metrics_collector(None);
         let _mp = MetricsPusher::start_for_local_run(
             &("remote-executor-service-".to_owned() + &shard_id.to_string()),
         );


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds a new release versioning workflow to bump the version number in `aptos-node/Cargo.toml` for each release. It's a dispatch based workflow that creates a PR against the target release branch to set the proper version. It also increments the patch version when multiple patch releases need to be made. Since the PR is created by the bot, the release manager can stamp it, so only requires one additional reviewer.

Also, updates telemetry service to export the package version as a metric.