### PR TITLE
[move][docs] fixed confidential_transfer

### DIFF
--- a/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
+++ b/aptos-move/framework/aptos-experimental/doc/confidential_asset.md
@@ -453,6 +453,16 @@ The provided auditors or auditor proofs are invalid.
 
 
 
+<a id="0x7_confidential_asset_EINVALID_SENDER_AMOUNT"></a>
+
+Sender and recipient amounts encrypt different transfer amounts
+
+
+<pre><code><b>const</b> <a href="confidential_asset.md#0x7_confidential_asset_EINVALID_SENDER_AMOUNT">EINVALID_SENDER_AMOUNT</a>: u64 = 17;
+</code></pre>
+
+
+
 <a id="0x7_confidential_asset_ENORMALIZATION_REQUIRED"></a>
 
 The operation requires the actual balance to be normalized.
@@ -833,7 +843,7 @@ Warning: If the auditor feature is enabled, the sender must include the auditor 
 <code>auditor_eks</code> vector.
 
 
-<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_confidential_transfer">confidential_transfer</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, <b>to</b>: <b>address</b>, new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, transfer_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, auditor_eks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, auditor_amounts: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, zkrp_transfer_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
+<pre><code><b>public</b> entry <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_confidential_transfer">confidential_transfer</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, <b>to</b>: <b>address</b>, new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, sender_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, recipient_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, auditor_eks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, auditor_amounts: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, zkrp_transfer_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;, sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;)
 </code></pre>
 
 
@@ -847,7 +857,8 @@ Warning: If the auditor feature is enabled, the sender must include the auditor 
     token: Object&lt;Metadata&gt;,
     <b>to</b>: <b>address</b>,
     new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
-    transfer_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    sender_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
+    recipient_amount: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     auditor_eks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     auditor_amounts: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     zkrp_new_balance: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
@@ -855,7 +866,8 @@ Warning: If the auditor feature is enabled, the sender must include the auditor 
     sigma_proof: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
 {
     <b>let</b> new_balance = <a href="confidential_balance.md#0x7_confidential_balance_new_actual_balance_from_bytes">confidential_balance::new_actual_balance_from_bytes</a>(new_balance).extract();
-    <b>let</b> transfer_amount = <a href="confidential_balance.md#0x7_confidential_balance_new_pending_balance_from_bytes">confidential_balance::new_pending_balance_from_bytes</a>(transfer_amount).extract();
+    <b>let</b> sender_amount = <a href="confidential_balance.md#0x7_confidential_balance_new_pending_balance_from_bytes">confidential_balance::new_pending_balance_from_bytes</a>(sender_amount).extract();
+    <b>let</b> recipient_amount = <a href="confidential_balance.md#0x7_confidential_balance_new_pending_balance_from_bytes">confidential_balance::new_pending_balance_from_bytes</a>(recipient_amount).extract();
     <b>let</b> auditor_eks = <a href="confidential_asset.md#0x7_confidential_asset_deserialize_auditor_eks">deserialize_auditor_eks</a>(auditor_eks).extract();
     <b>let</b> auditor_amounts = <a href="confidential_asset.md#0x7_confidential_asset_deserialize_auditor_amounts">deserialize_auditor_amounts</a>(auditor_amounts).extract();
     <b>let</b> proof = <a href="confidential_proof.md#0x7_confidential_proof_deserialize_transfer_proof">confidential_proof::deserialize_transfer_proof</a>(
@@ -869,7 +881,8 @@ Warning: If the auditor feature is enabled, the sender must include the auditor 
         token,
         <b>to</b>,
         new_balance,
-        transfer_amount,
+        sender_amount,
+        recipient_amount,
         auditor_eks,
         auditor_amounts,
         proof
@@ -1725,7 +1738,7 @@ Withdrawals are always allowed, regardless of the token allow status.
 Implementation of the <code>confidential_transfer</code> entry function.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_confidential_transfer_internal">confidential_transfer_internal</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, <b>to</b>: <b>address</b>, new_balance: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, transfer_amount: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof: <a href="confidential_proof.md#0x7_confidential_proof_TransferProof">confidential_proof::TransferProof</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_asset.md#0x7_confidential_asset_confidential_transfer_internal">confidential_transfer_internal</a>(sender: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, token: <a href="../../aptos-framework/doc/object.md#0x1_object_Object">object::Object</a>&lt;<a href="../../aptos-framework/doc/fungible_asset.md#0x1_fungible_asset_Metadata">fungible_asset::Metadata</a>&gt;, <b>to</b>: <b>address</b>, new_balance: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, sender_amount: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, recipient_amount: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof: <a href="confidential_proof.md#0x7_confidential_proof_TransferProof">confidential_proof::TransferProof</a>)
 </code></pre>
 
 
@@ -1739,7 +1752,8 @@ Implementation of the <code>confidential_transfer</code> entry function.
     token: Object&lt;Metadata&gt;,
     <b>to</b>: <b>address</b>,
     new_balance: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
-    transfer_amount: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    sender_amount: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    recipient_amount: <a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     auditor_eks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;twisted_elgamal::CompressedPubkey&gt;,
     auditor_amounts: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;,
     proof: TransferProof) <b>acquires</b> <a href="confidential_asset.md#0x7_confidential_asset_ConfidentialAssetStore">ConfidentialAssetStore</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAConfig">FAConfig</a>, <a href="confidential_asset.md#0x7_confidential_asset_FAController">FAController</a>
@@ -1747,8 +1761,12 @@ Implementation of the <code>confidential_transfer</code> entry function.
     <b>assert</b>!(<a href="confidential_asset.md#0x7_confidential_asset_is_token_allowed">is_token_allowed</a>(token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_ETOKEN_DISABLED">ETOKEN_DISABLED</a>));
     <b>assert</b>!(!<a href="confidential_asset.md#0x7_confidential_asset_is_frozen">is_frozen</a>(<b>to</b>, token), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="confidential_asset.md#0x7_confidential_asset_EALREADY_FROZEN">EALREADY_FROZEN</a>));
     <b>assert</b>!(
-        <a href="confidential_asset.md#0x7_confidential_asset_validate_auditors">validate_auditors</a>(token, &transfer_amount, &auditor_eks, &auditor_amounts, &proof),
+        <a href="confidential_asset.md#0x7_confidential_asset_validate_auditors">validate_auditors</a>(token, &recipient_amount, &auditor_eks, &auditor_amounts, &proof),
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EINVALID_AUDITORS">EINVALID_AUDITORS</a>)
+    );
+    <b>assert</b>!(
+        <a href="confidential_balance.md#0x7_confidential_balance_balance_c_equals">confidential_balance::balance_c_equals</a>(&sender_amount, &recipient_amount),
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="confidential_asset.md#0x7_confidential_asset_EINVALID_SENDER_AMOUNT">EINVALID_SENDER_AMOUNT</a>)
     );
 
     <b>let</b> from = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(sender);
@@ -1767,7 +1785,8 @@ Implementation of the <code>confidential_transfer</code> entry function.
         &recipient_ek,
         &sender_current_actual_balance,
         &new_balance,
-        &transfer_amount,
+        &sender_amount,
+        &recipient_amount,
         &auditor_eks,
         &auditor_amounts,
         &proof);
@@ -1788,7 +1807,7 @@ Implementation of the <code>confidential_transfer</code> entry function.
     <b>let</b> recipient_pending_balance = <a href="confidential_balance.md#0x7_confidential_balance_decompress_balance">confidential_balance::decompress_balance</a>(
         &recipient_ca_store.pending_balance
     );
-    <a href="confidential_balance.md#0x7_confidential_balance_add_balances_mut">confidential_balance::add_balances_mut</a>(&<b>mut</b> recipient_pending_balance, &transfer_amount);
+    <a href="confidential_balance.md#0x7_confidential_balance_add_balances_mut">confidential_balance::add_balances_mut</a>(&<b>mut</b> recipient_pending_balance, &recipient_amount);
 
     recipient_ca_store.pending_counter += 1;
     recipient_ca_store.pending_balance = <a href="confidential_balance.md#0x7_confidential_balance_compress_balance">confidential_balance::compress_balance</a>(&recipient_pending_balance);

--- a/aptos-move/framework/aptos-experimental/doc/confidential_proof.md
+++ b/aptos-move/framework/aptos-experimental/doc/confidential_proof.md
@@ -447,6 +447,12 @@ Represents the proof structure for validating a key rotation operation.
 <dd>
 
 </dd>
+<dt>
+<code>x8s: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_CompressedRistretto">ristretto255::CompressedRistretto</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
 </dl>
 
 
@@ -494,6 +500,12 @@ Represents the proof structure for validating a key rotation operation.
 </dd>
 <dt>
 <code>a5: <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_Scalar">ristretto255::Scalar</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>a6s: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_Scalar">ristretto255::Scalar</a>&gt;</code>
 </dt>
 <dd>
 
@@ -557,6 +569,12 @@ Represents the proof structure for validating a key rotation operation.
 </dd>
 <dt>
 <code>g7s: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_Scalar">ristretto255::Scalar</a>&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>g8s: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_Scalar">ristretto255::Scalar</a>&gt;</code>
 </dt>
 <dd>
 
@@ -1077,20 +1095,19 @@ If all conditions are satisfied, the proof validates the withdrawal; otherwise, 
 Verifies the validity of the <code>confidential_transfer</code> operation.
 
 This function ensures that the provided proof (<code><a href="confidential_proof.md#0x7_confidential_proof_TransferProof">TransferProof</a></code>) meets the following conditions:
-1. The transferred amount (<code>transfer_amount</code>) and the auditor's balances (<code>auditor_amounts</code>), if provided,
-encrypt the same transfer value under the recipient's encryption key (<code>recipient_ek</code>) and the auditor's
-encryption keys (<code>auditor_eks</code>), respectively.
+1. The transferred amount (<code>recipient_amount</code> and <code>sender_amount</code>) and the auditors' amounts
+(<code>auditor_amounts</code>), if provided, encrypt the transfer value using the recipient's, sender's,
+and auditors' encryption keys, repectively.
 2. The sender's current balance (<code>current_balance</code>) and new balance (<code>new_balance</code>) encrypt the corresponding values
 under the sender's encryption key (<code>sender_ek</code>) before and after the transfer, respectively.
 3. The relationship <code>new_balance = current_balance - transfer_amount</code> is maintained, ensuring balance integrity.
-4. The transferred value is properly normalized, with each chunk in both <code>transfer_amount</code> and the <code>auditor_amounts</code>
-balance adhering to the range [0, 2^16).
+4. The transferred value (<code>recipient_amount</code>) is properly normalized, with each chunk adhering to the range [0, 2^16).
 5. The sender's new balance is normalized, with each chunk in <code>new_balance</code> also adhering to the range [0, 2^16).
 
 If all conditions are satisfied, the proof validates the transfer; otherwise, the function causes an error.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="confidential_proof.md#0x7_confidential_proof_verify_transfer_proof">verify_transfer_proof</a>(sender_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, recipient_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof: &<a href="confidential_proof.md#0x7_confidential_proof_TransferProof">confidential_proof::TransferProof</a>)
+<pre><code><b>public</b> <b>fun</b> <a href="confidential_proof.md#0x7_confidential_proof_verify_transfer_proof">verify_transfer_proof</a>(sender_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, recipient_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, sender_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, recipient_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof: &<a href="confidential_proof.md#0x7_confidential_proof_TransferProof">confidential_proof::TransferProof</a>)
 </code></pre>
 
 
@@ -1104,7 +1121,8 @@ If all conditions are satisfied, the proof validates the transfer; otherwise, th
     recipient_ek: &twisted_elgamal::CompressedPubkey,
     current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
-    transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    sender_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    recipient_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;twisted_elgamal::CompressedPubkey&gt;,
     auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;,
     proof: &<a href="confidential_proof.md#0x7_confidential_proof_TransferProof">TransferProof</a>)
@@ -1114,13 +1132,14 @@ If all conditions are satisfied, the proof validates the transfer; otherwise, th
         recipient_ek,
         current_balance,
         new_balance,
-        transfer_amount,
+        sender_amount,
+        recipient_amount,
         auditor_eks,
         auditor_amounts,
         &proof.sigma_proof
     );
     <a href="confidential_proof.md#0x7_confidential_proof_verify_new_balance_range_proof">verify_new_balance_range_proof</a>(new_balance, &proof.zkrp_new_balance);
-    <a href="confidential_proof.md#0x7_confidential_proof_verify_transfer_amount_range_proof">verify_transfer_amount_range_proof</a>(transfer_amount, &proof.zkrp_transfer_amount);
+    <a href="confidential_proof.md#0x7_confidential_proof_verify_transfer_amount_range_proof">verify_transfer_amount_range_proof</a>(recipient_amount, &proof.zkrp_transfer_amount);
 }
 </code></pre>
 
@@ -1325,7 +1344,7 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
 Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProof">TransferSigmaProof</a></code>.
 
 
-<pre><code><b>fun</b> <a href="confidential_proof.md#0x7_confidential_proof_verify_transfer_sigma_proof">verify_transfer_sigma_proof</a>(sender_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, recipient_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof: &<a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProof">confidential_proof::TransferSigmaProof</a>)
+<pre><code><b>fun</b> <a href="confidential_proof.md#0x7_confidential_proof_verify_transfer_sigma_proof">verify_transfer_sigma_proof</a>(sender_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, recipient_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, sender_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, recipient_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof: &<a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProof">confidential_proof::TransferSigmaProof</a>)
 </code></pre>
 
 
@@ -1339,7 +1358,8 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
     recipient_ek: &twisted_elgamal::CompressedPubkey,
     current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
-    transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    sender_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    recipient_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;twisted_elgamal::CompressedPubkey&gt;,
     auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;,
     proof: &<a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProof">TransferSigmaProof</a>)
@@ -1349,7 +1369,8 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
         recipient_ek,
         current_balance,
         new_balance,
-        transfer_amount,
+        sender_amount,
+        recipient_amount,
         auditor_eks,
         auditor_amounts,
         &proof.xs
@@ -1364,6 +1385,7 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
     scalars_lhs.push_back(gammas.g5);
     scalars_lhs.append(gammas.g6s);
     gammas.g7s.for_each(|gamma| scalars_lhs.append(gamma));
+    scalars_lhs.append(gammas.g8s);
 
     <b>let</b> points_lhs = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[
         <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_decompress">ristretto255::point_decompress</a>(&proof.xs.x1),
@@ -1376,6 +1398,7 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
     proof.xs.x7s.for_each_ref(|xs| {
         points_lhs.append(xs.map_ref(|x| <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_decompress">ristretto255::point_decompress</a>(x)));
     });
+    points_lhs.append(proof.xs.x8s.map_ref(|x| <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_decompress">ristretto255::point_decompress</a>(x)));
 
     <b>let</b> scalar_g = <a href="confidential_proof.md#0x7_confidential_proof_scalar_linear_combination">scalar_linear_combination</a>(
         &proof.alphas.a1s,
@@ -1394,25 +1417,33 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
     );
 
     <b>let</b> scalar_h = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_mul">ristretto255::scalar_mul</a>(&gammas.g5, &proof.alphas.a5);
-    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).for_each(|i| {
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 8).for_each(|i| {
         <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_add_assign">ristretto255::scalar_add_assign</a>(
             &<b>mut</b> scalar_h,
-            &<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_mul">ristretto255::scalar_mul</a>(&gammas.g4s[i], &proof.alphas.a3s[i])
+            &<a href="confidential_proof.md#0x7_confidential_proof_scalar_mul_3">scalar_mul_3</a>(&gammas.g1, &proof.alphas.a6s[i], &<a href="confidential_proof.md#0x7_confidential_proof_new_scalar_from_pow2">new_scalar_from_pow2</a>(i * 16))
         );
     });
-    <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_add_assign">ristretto255::scalar_add_assign</a>(
-        &<b>mut</b> scalar_h,
-        &<a href="confidential_proof.md#0x7_confidential_proof_scalar_linear_combination">scalar_linear_combination</a>(&gammas.g6s, &proof.alphas.a3s)
-    );
-    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(4, 8).for_each(|i| {
-        <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_add_assign">ristretto255::scalar_add_assign</a>(
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).for_each(|i| {
+        <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_sub_assign">ristretto255::scalar_sub_assign</a>(
             &<b>mut</b> scalar_h,
             &<a href="confidential_proof.md#0x7_confidential_proof_scalar_mul_3">scalar_mul_3</a>(&gammas.g1, &proof.alphas.a3s[i], &<a href="confidential_proof.md#0x7_confidential_proof_new_scalar_from_pow2">new_scalar_from_pow2</a>(i * 16))
         );
     });
+    <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_add_assign">ristretto255::scalar_add_assign</a>(
+        &<b>mut</b> scalar_h,
+        &<a href="confidential_proof.md#0x7_confidential_proof_scalar_linear_combination">scalar_linear_combination</a>(&gammas.g4s, &proof.alphas.a3s)
+    );
+    <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_add_assign">ristretto255::scalar_add_assign</a>(
+        &<b>mut</b> scalar_h,
+        &<a href="confidential_proof.md#0x7_confidential_proof_scalar_linear_combination">scalar_linear_combination</a>(&gammas.g6s, &proof.alphas.a6s)
+    );
 
-    <b>let</b> scalar_sender_ek = <a href="confidential_proof.md#0x7_confidential_proof_scalar_linear_combination">scalar_linear_combination</a>(&gammas.g2s, &proof.alphas.a3s);
+    <b>let</b> scalar_sender_ek = <a href="confidential_proof.md#0x7_confidential_proof_scalar_linear_combination">scalar_linear_combination</a>(&gammas.g2s, &proof.alphas.a6s);
     <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_add_assign">ristretto255::scalar_add_assign</a>(&<b>mut</b> scalar_sender_ek, &<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_mul">ristretto255::scalar_mul</a>(&gammas.g5, &rho));
+    <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_add_assign">ristretto255::scalar_add_assign</a>(
+        &<b>mut</b> scalar_sender_ek,
+        &<a href="confidential_proof.md#0x7_confidential_proof_scalar_linear_combination">scalar_linear_combination</a>(&gammas.g8s, &proof.alphas.a3s)
+    );
 
     <b>let</b> scalar_recipient_ek = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_zero">ristretto255::scalar_zero</a>();
     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).for_each(|i| {
@@ -1442,7 +1473,7 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
         scalar
     });
 
-    <b>let</b> scalars_transfer_amount_d = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).map(|i| {
+    <b>let</b> scalars_recipient_amount_d = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).map(|i| {
         <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_mul">ristretto255::scalar_mul</a>(&gammas.g3s[i], &rho)
     });
 
@@ -1452,6 +1483,10 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
 
     <b>let</b> scalars_auditor_amount_d = gammas.g7s.map_ref(|gamma| {
         gamma.map_ref(|gamma| <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_mul">ristretto255::scalar_mul</a>(gamma, &rho))
+    });
+
+    <b>let</b> scalars_sender_amount_d = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).map(|i| {
+        <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_mul">ristretto255::scalar_mul</a>(&gammas.g8s[i], &rho)
     });
 
     <b>let</b> scalars_current_balance_c = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 8).map(|i| {
@@ -1474,9 +1509,10 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
     <b>let</b> scalars_rhs = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[scalar_g, scalar_h, scalar_sender_ek, scalar_recipient_ek];
     scalars_rhs.append(scalar_ek_auditors);
     scalars_rhs.append(scalars_new_balance_d);
-    scalars_rhs.append(scalars_transfer_amount_d);
+    scalars_rhs.append(scalars_recipient_amount_d);
     scalars_rhs.append(scalars_current_balance_d);
     scalars_auditor_amount_d.for_each(|scalars| scalars_rhs.append(scalars));
+    scalars_rhs.append(scalars_sender_amount_d);
     scalars_rhs.append(scalars_current_balance_c);
     scalars_rhs.append(scalars_transfer_amount_c);
     scalars_rhs.append(scalars_new_balance_c);
@@ -1489,13 +1525,14 @@ Verifies the validity of the <code><a href="confidential_proof.md#0x7_confidenti
     ];
     points_rhs.append(auditor_eks.map_ref(|ek| twisted_elgamal::pubkey_to_point(ek)));
     points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(new_balance));
-    points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(transfer_amount));
+    points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(recipient_amount));
     points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(current_balance));
     auditor_amounts.for_each_ref(|balance| {
         points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(balance));
     });
+    points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(sender_amount));
     points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_c">confidential_balance::balance_to_points_c</a>(current_balance));
-    points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_c">confidential_balance::balance_to_points_c</a>(transfer_amount));
+    points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_c">confidential_balance::balance_to_points_c</a>(recipient_amount));
     points_rhs.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_c">confidential_balance::balance_to_points_c</a>(new_balance));
 
     <b>let</b> lhs = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_multi_scalar_mul">ristretto255::multi_scalar_mul</a>(&points_lhs, &scalars_lhs);
@@ -2082,8 +2119,8 @@ Returns <code>Some(<a href="confidential_proof.md#0x7_confidential_proof_Transfe
 
 
 <pre><code><b>fun</b> <a href="confidential_proof.md#0x7_confidential_proof_deserialize_transfer_sigma_proof">deserialize_transfer_sigma_proof</a>(proof_bytes: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): Option&lt;<a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProof">TransferSigmaProof</a>&gt; {
-    <b>let</b> alphas_count = 22;
-    <b>let</b> xs_count = 26;
+    <b>let</b> alphas_count = 26;
+    <b>let</b> xs_count = 30;
 
     <b>if</b> (proof_bytes.length() &lt; 32 * xs_count + 32 * alphas_count) {
         <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
@@ -2114,9 +2151,10 @@ Returns <code>Some(<a href="confidential_proof.md#0x7_confidential_proof_Transfe
             alphas: <a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProofAlphas">TransferSigmaProofAlphas</a> {
                 a1s: alphas.slice(0, 8).map(|alpha| alpha.extract()),
                 a2: alphas[8].extract(),
-                a3s: alphas.slice(9, 17).map(|alpha| alpha.extract()),
-                a4s: alphas.slice(17, 21).map(|alpha| alpha.extract()),
-                a5: alphas[21].extract(),
+                a3s: alphas.slice(9, 13).map(|alpha| alpha.extract()),
+                a4s: alphas.slice(13, 17).map(|alpha| alpha.extract()),
+                a5: alphas[17].extract(),
+                a6s: alphas.slice(18, 26).map(|alpha| alpha.extract()),
             },
             xs: <a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProofXs">TransferSigmaProofXs</a> {
                 x1: xs[0].extract(),
@@ -2125,9 +2163,10 @@ Returns <code>Some(<a href="confidential_proof.md#0x7_confidential_proof_Transfe
                 x4s: xs.slice(13, 17).map(|x| x.extract()),
                 x5: xs[17].extract(),
                 x6s: xs.slice(18, 26).map(|x| x.extract()),
-                x7s: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range_with_step">vector::range_with_step</a>(26, xs_count, 4).map(|i| {
+                x7s: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range_with_step">vector::range_with_step</a>(26, xs_count - 4, 4).map(|i| {
                     <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(i, i + 4).map(|j| xs[j].extract())
                 }),
+                x8s: xs.slice(xs_count - 4, xs_count).map(|x| x.extract()),
             },
         }
     )
@@ -2436,18 +2475,18 @@ Derives the Fiat-Shamir challenge for the <code><a href="confidential_proof.md#0
     current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     proof_xs: &<a href="confidential_proof.md#0x7_confidential_proof_WithdrawalSigmaProofXs">WithdrawalSigmaProofXs</a>): Scalar
 {
-    // rho = H(DST, v_{1..4}, P, (C_cur, D_cur)_{1..8}, G, H, X_{1..18})
+    // rho = H(DST, G, H, P, v_{1..4}, (C_cur, D_cur)_{1..8}, X_{1..18})
     <b>let</b> bytes = <a href="confidential_proof.md#0x7_confidential_proof_FIAT_SHAMIR_WITHDRAWAL_SIGMA_DST">FIAT_SHAMIR_WITHDRAWAL_SIGMA_DST</a>;
 
-    amount_chunks.for_each_ref(|chunk| {
-        bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_to_bytes">ristretto255::scalar_to_bytes</a>(chunk));
-    });
-    bytes.append(twisted_elgamal::pubkey_to_bytes(ek));
-    bytes.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_bytes">confidential_balance::balance_to_bytes</a>(current_balance));
     bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_compressed_point_to_bytes">ristretto255::compressed_point_to_bytes</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_basepoint_compressed">ristretto255::basepoint_compressed</a>()));
     bytes.append(
         <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_compressed_point_to_bytes">ristretto255::compressed_point_to_bytes</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_hash_to_point_base">ristretto255::hash_to_point_base</a>()))
     );
+    bytes.append(twisted_elgamal::pubkey_to_bytes(ek));
+    amount_chunks.for_each_ref(|chunk| {
+        bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_to_bytes">ristretto255::scalar_to_bytes</a>(chunk));
+    });
+    bytes.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_bytes">confidential_balance::balance_to_bytes</a>(current_balance));
     bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&proof_xs.x1));
     bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&proof_xs.x2));
     proof_xs.x3s.for_each_ref(|x| {
@@ -2472,7 +2511,7 @@ Derives the Fiat-Shamir challenge for the <code><a href="confidential_proof.md#0
 Derives the Fiat-Shamir challenge for the <code><a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProof">TransferSigmaProof</a></code>.
 
 
-<pre><code><b>fun</b> <a href="confidential_proof.md#0x7_confidential_proof_fiat_shamir_transfer_sigma_proof_challenge">fiat_shamir_transfer_sigma_proof_challenge</a>(sender_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, recipient_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof_xs: &<a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProofXs">confidential_proof::TransferSigmaProofXs</a>): <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_Scalar">ristretto255::Scalar</a>
+<pre><code><b>fun</b> <a href="confidential_proof.md#0x7_confidential_proof_fiat_shamir_transfer_sigma_proof_challenge">fiat_shamir_transfer_sigma_proof_challenge</a>(sender_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, recipient_ek: &<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>, current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, sender_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, recipient_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>, auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="ristretto255_twisted_elgamal.md#0x7_ristretto255_twisted_elgamal_CompressedPubkey">ristretto255_twisted_elgamal::CompressedPubkey</a>&gt;, auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;, proof_xs: &<a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProofXs">confidential_proof::TransferSigmaProofXs</a>): <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_Scalar">ristretto255::Scalar</a>
 </code></pre>
 
 
@@ -2486,12 +2525,13 @@ Derives the Fiat-Shamir challenge for the <code><a href="confidential_proof.md#0
     recipient_ek: &twisted_elgamal::CompressedPubkey,
     current_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     new_balance: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
-    transfer_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    sender_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
+    recipient_amount: &<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>,
     auditor_eks: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;twisted_elgamal::CompressedPubkey&gt;,
     auditor_amounts: &<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="confidential_balance.md#0x7_confidential_balance_ConfidentialBalance">confidential_balance::ConfidentialBalance</a>&gt;,
     proof_xs: &<a href="confidential_proof.md#0x7_confidential_proof_TransferSigmaProofXs">TransferSigmaProofXs</a>): Scalar
 {
-    // rho = H(DST, G, H, P_s, P_r, P_a_{1..n}, (C_cur, D_cur)_{1..8}, (C_new, D_new)_{1..8}, (C_v, D_v)_{1..8}, D_a_{1..n}, X_{1..26 + 4n})
+    // rho = H(DST, G, H, P_s, P_r, P_a_{1..n}, (C_cur, D_cur)_{1..8}, (C_v, D_v)_{1..4}, D_a_{1..4n}, D_s_{1..4}, (C_new, D_new)_{1..8}, X_{1..30 + 4n})
     <b>let</b> bytes = <a href="confidential_proof.md#0x7_confidential_proof_FIAT_SHAMIR_TRANSFER_SIGMA_DST">FIAT_SHAMIR_TRANSFER_SIGMA_DST</a>;
 
     bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_compressed_point_to_bytes">ristretto255::compressed_point_to_bytes</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_basepoint_compressed">ristretto255::basepoint_compressed</a>()));
@@ -2504,13 +2544,16 @@ Derives the Fiat-Shamir challenge for the <code><a href="confidential_proof.md#0
         bytes.append(twisted_elgamal::pubkey_to_bytes(ek));
     });
     bytes.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_bytes">confidential_balance::balance_to_bytes</a>(current_balance));
-    bytes.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_bytes">confidential_balance::balance_to_bytes</a>(new_balance));
-    bytes.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_bytes">confidential_balance::balance_to_bytes</a>(transfer_amount));
+    bytes.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_bytes">confidential_balance::balance_to_bytes</a>(recipient_amount));
     auditor_amounts.for_each_ref(|balance| {
         <a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(balance).for_each_ref(|d| {
             bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_compressed_point_to_bytes">ristretto255::compressed_point_to_bytes</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(d)));
         });
     });
+    <a href="confidential_balance.md#0x7_confidential_balance_balance_to_points_d">confidential_balance::balance_to_points_d</a>(sender_amount).for_each_ref(|d| {
+        bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_compressed_point_to_bytes">ristretto255::compressed_point_to_bytes</a>(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(d)));
+    });
+    bytes.append(<a href="confidential_balance.md#0x7_confidential_balance_balance_to_bytes">confidential_balance::balance_to_bytes</a>(new_balance));
     bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&proof_xs.x1));
     proof_xs.x2s.for_each_ref(|x| {
         bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(x));
@@ -2529,6 +2572,9 @@ Derives the Fiat-Shamir challenge for the <code><a href="confidential_proof.md#0
         xs.for_each_ref(|x| {
             bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(x));
         });
+    });
+    proof_xs.x8s.for_each_ref(|x| {
+        bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(x));
     });
 
     <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_scalar_from_sha2_512">ristretto255::new_scalar_from_sha2_512</a>(bytes)
@@ -2710,6 +2756,9 @@ Returns the scalar multipliers for the <code><a href="confidential_proof.md#0x7_
             <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).map(|j| {
                 <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_scalar_from_sha2_512">ristretto255::new_scalar_from_sha2_512</a>(<a href="confidential_proof.md#0x7_confidential_proof_msm_gamma_2">msm_gamma_2</a>(rho, (i + 7 <b>as</b> u8), (j <b>as</b> u8)))
             })
+        }),
+        g8s: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_range">vector::range</a>(0, 4).map(|i| {
+            <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_scalar_from_sha2_512">ristretto255::new_scalar_from_sha2_512</a>(<a href="confidential_proof.md#0x7_confidential_proof_msm_gamma_2">msm_gamma_2</a>(rho, 8, (i <b>as</b> u8)))
         }),
     }
 }

--- a/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
+++ b/aptos-move/framework/aptos-experimental/sources/confidential_asset/confidential_asset.move
@@ -79,6 +79,9 @@ module aptos_experimental::confidential_asset {
     /// An internal error occurred, indicating unexpected behavior.
     const EINTERNAL_ERROR: u64 = 16;
 
+    /// Sender and recipient amounts encrypt different transfer amounts
+    const EINVALID_SENDER_AMOUNT: u64 = 17;
+
     //
     // Constants
     //
@@ -318,7 +321,8 @@ module aptos_experimental::confidential_asset {
         token: Object<Metadata>,
         to: address,
         new_balance: vector<u8>,
-        transfer_amount: vector<u8>,
+        sender_amount: vector<u8>,
+        recipient_amount: vector<u8>,
         auditor_eks: vector<u8>,
         auditor_amounts: vector<u8>,
         zkrp_new_balance: vector<u8>,
@@ -326,7 +330,8 @@ module aptos_experimental::confidential_asset {
         sigma_proof: vector<u8>) acquires ConfidentialAssetStore, FAConfig, FAController
     {
         let new_balance = confidential_balance::new_actual_balance_from_bytes(new_balance).extract();
-        let transfer_amount = confidential_balance::new_pending_balance_from_bytes(transfer_amount).extract();
+        let sender_amount = confidential_balance::new_pending_balance_from_bytes(sender_amount).extract();
+        let recipient_amount = confidential_balance::new_pending_balance_from_bytes(recipient_amount).extract();
         let auditor_eks = deserialize_auditor_eks(auditor_eks).extract();
         let auditor_amounts = deserialize_auditor_amounts(auditor_amounts).extract();
         let proof = confidential_proof::deserialize_transfer_proof(
@@ -340,7 +345,8 @@ module aptos_experimental::confidential_asset {
             token,
             to,
             new_balance,
-            transfer_amount,
+            sender_amount,
+            recipient_amount,
             auditor_eks,
             auditor_amounts,
             proof
@@ -703,7 +709,8 @@ module aptos_experimental::confidential_asset {
         token: Object<Metadata>,
         to: address,
         new_balance: confidential_balance::ConfidentialBalance,
-        transfer_amount: confidential_balance::ConfidentialBalance,
+        sender_amount: confidential_balance::ConfidentialBalance,
+        recipient_amount: confidential_balance::ConfidentialBalance,
         auditor_eks: vector<twisted_elgamal::CompressedPubkey>,
         auditor_amounts: vector<confidential_balance::ConfidentialBalance>,
         proof: TransferProof) acquires ConfidentialAssetStore, FAConfig, FAController
@@ -711,8 +718,12 @@ module aptos_experimental::confidential_asset {
         assert!(is_token_allowed(token), error::invalid_argument(ETOKEN_DISABLED));
         assert!(!is_frozen(to, token), error::invalid_state(EALREADY_FROZEN));
         assert!(
-            validate_auditors(token, &transfer_amount, &auditor_eks, &auditor_amounts, &proof),
+            validate_auditors(token, &recipient_amount, &auditor_eks, &auditor_amounts, &proof),
             error::invalid_argument(EINVALID_AUDITORS)
+        );
+        assert!(
+            confidential_balance::balance_c_equals(&sender_amount, &recipient_amount),
+            error::invalid_argument(EINVALID_SENDER_AMOUNT)
         );
 
         let from = signer::address_of(sender);
@@ -731,7 +742,8 @@ module aptos_experimental::confidential_asset {
             &recipient_ek,
             &sender_current_actual_balance,
             &new_balance,
-            &transfer_amount,
+            &sender_amount,
+            &recipient_amount,
             &auditor_eks,
             &auditor_amounts,
             &proof);
@@ -752,7 +764,7 @@ module aptos_experimental::confidential_asset {
         let recipient_pending_balance = confidential_balance::decompress_balance(
             &recipient_ca_store.pending_balance
         );
-        confidential_balance::add_balances_mut(&mut recipient_pending_balance, &transfer_amount);
+        confidential_balance::add_balances_mut(&mut recipient_pending_balance, &recipient_amount);
 
         recipient_ca_store.pending_counter += 1;
         recipient_ca_store.pending_balance = confidential_balance::compress_balance(&recipient_pending_balance);

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_asset_tests.move
@@ -69,7 +69,8 @@ module aptos_experimental::confidential_asset_tests {
         let (
             proof,
             new_balance,
-            transfer_amount,
+            sender_amount,
+            recipient_amount,
             _
         ) = confidential_proof::prove_transfer(
             sender_dk,
@@ -90,7 +91,8 @@ module aptos_experimental::confidential_asset_tests {
             token,
             to,
             confidential_balance::balance_to_bytes(&new_balance),
-            confidential_balance::balance_to_bytes(&transfer_amount),
+            confidential_balance::balance_to_bytes(&sender_amount),
+            confidential_balance::balance_to_bytes(&recipient_amount),
             b"",
             b"",
             zkrp_new_balance,
@@ -118,7 +120,8 @@ module aptos_experimental::confidential_asset_tests {
         let (
             proof,
             new_balance,
-            transfer_amount,
+            sender_amount,
+            recipient_amount,
             auditor_amounts
         ) = confidential_proof::prove_transfer(
             sender_dk,
@@ -139,7 +142,8 @@ module aptos_experimental::confidential_asset_tests {
             token,
             to,
             confidential_balance::balance_to_bytes(&new_balance),
-            confidential_balance::balance_to_bytes(&transfer_amount),
+            confidential_balance::balance_to_bytes(&sender_amount),
+            confidential_balance::balance_to_bytes(&recipient_amount),
             confidential_asset::serialize_auditor_eks(auditor_eks),
             confidential_asset::serialize_auditor_amounts(&auditor_amounts),
             zkrp_new_balance,

--- a/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_proof_tests.move
+++ b/aptos-move/framework/aptos-experimental/tests/confidential_asset/confidential_proof_tests.move
@@ -19,7 +19,8 @@ module aptos_experimental::confidential_proof_tests {
         new_amount: u128,
         current_balance: confidential_balance::ConfidentialBalance,
         new_balance: confidential_balance::ConfidentialBalance,
-        transfer_amount: confidential_balance::ConfidentialBalance,
+        sender_amount: confidential_balance::ConfidentialBalance,
+        recipient_amount: confidential_balance::ConfidentialBalance,
         auditor_eks: vector<twisted_elgamal::CompressedPubkey>,
         auditor_amounts: vector<confidential_balance::ConfidentialBalance>,
         proof: confidential_proof::TransferProof,
@@ -99,7 +100,8 @@ module aptos_experimental::confidential_proof_tests {
         let (
             proof,
             new_balance,
-            transfer_amount,
+            sender_amount,
+            recipient_amount,
             auditor_amounts,
         ) = confidential_proof::prove_transfer(
             &sender_dk,
@@ -118,7 +120,8 @@ module aptos_experimental::confidential_proof_tests {
             new_amount,
             current_balance,
             new_balance,
-            transfer_amount,
+            sender_amount,
+            recipient_amount,
             auditor_eks,
             auditor_amounts,
             proof,
@@ -273,7 +276,8 @@ module aptos_experimental::confidential_proof_tests {
             &params.recipient_ek,
             &params.current_balance,
             &params.new_balance,
-            &params.transfer_amount,
+            &params.sender_amount,
+            &params.recipient_amount,
             &params.auditor_eks,
             &params.auditor_amounts,
             &params.proof);
@@ -289,7 +293,8 @@ module aptos_experimental::confidential_proof_tests {
             &params.recipient_ek,
             &params.current_balance,
             &params.new_balance,
-            &params.transfer_amount,
+            &params.sender_amount,
+            &params.recipient_amount,
             &params.auditor_eks,
             &params.auditor_amounts,
             &params.proof);
@@ -305,7 +310,8 @@ module aptos_experimental::confidential_proof_tests {
             &params.sender_ek,
             &params.current_balance,
             &params.new_balance,
-            &params.transfer_amount,
+            &params.sender_amount,
+            &params.recipient_amount,
             &params.auditor_eks,
             &params.auditor_amounts,
             &params.proof);
@@ -325,7 +331,8 @@ module aptos_experimental::confidential_proof_tests {
                 &params.sender_ek
             ),
             &params.new_balance,
-            &params.transfer_amount,
+            &params.sender_amount,
+            &params.recipient_amount,
             &params.auditor_eks,
             &params.auditor_amounts,
             &params.proof);
@@ -343,7 +350,8 @@ module aptos_experimental::confidential_proof_tests {
             &params.recipient_ek,
             &params.current_balance,
             &params.new_balance,
-            &params.transfer_amount,
+            &params.sender_amount,
+            &params.recipient_amount,
             &params.auditor_eks,
             &params.auditor_amounts,
             &params.proof);
@@ -351,7 +359,7 @@ module aptos_experimental::confidential_proof_tests {
 
     #[test]
     #[expected_failure(abort_code = 0x010001, location = confidential_proof)]
-    fun fail_transfer_if_wrong_transfer_amount() {
+    fun fail_transfer_if_wrong_sender_amount() {
         let params = transfer();
 
         confidential_proof::verify_transfer_proof(
@@ -359,6 +367,25 @@ module aptos_experimental::confidential_proof_tests {
             &params.recipient_ek,
             &params.current_balance,
             &params.new_balance,
+            &confidential_balance::new_pending_balance_from_u64(
+                1000, &confidential_balance::generate_balance_randomness(), &params.recipient_ek),
+            &params.recipient_amount,
+            &params.auditor_eks,
+            &params.auditor_amounts,
+            &params.proof);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = 0x010001, location = confidential_proof)]
+    fun fail_transfer_if_wrong_recipient_amount() {
+        let params = transfer();
+
+        confidential_proof::verify_transfer_proof(
+            &params.sender_ek,
+            &params.recipient_ek,
+            &params.current_balance,
+            &params.new_balance,
+            &params.sender_amount,
             &confidential_balance::new_pending_balance_from_u64(
                 1000, &confidential_balance::generate_balance_randomness(), &params.recipient_ek),
             &params.auditor_eks,
@@ -379,7 +406,8 @@ module aptos_experimental::confidential_proof_tests {
             &params.recipient_ek,
             &params.current_balance,
             &params.new_balance,
-            &params.transfer_amount,
+            &params.sender_amount,
+            &params.recipient_amount,
             &auditor_eks,
             &params.auditor_amounts,
             &params.proof);
@@ -403,7 +431,8 @@ module aptos_experimental::confidential_proof_tests {
             &params.recipient_ek,
             &params.current_balance,
             &params.new_balance,
-            &params.transfer_amount,
+            &params.sender_amount,
+            &params.recipient_amount,
             &params.auditor_eks,
             &auditor_amounts,
             &params.proof);


### PR DESCRIPTION
## Description
- Split `transfer_amount` into `sender_amount` and `recipient_amount`: contracts check that C_s == C_r and D_s is encrypted under the sender's EK. `sender_amount` is needed for indexing purposes, so that if the user loses their tx history, they can easily restore the balance.
- Fixed the bug in `confidential_transfer`. Currently, we use different randomness for the `new_sender_balance` and `recipient_amount`. `sender_amount`, `recipient_amount` and `auditor_amounts` are still encrypted with the same randomness.
- Adjusted Fiat Shamir functions so they correspond to the docs. 

## How Has This Been Tested?
UT

## Key Areas to Review
- confidential_asset.move
- confidential_proof.move

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
