### PR TITLE
Fix inline for_each* methods in OrderedMap and BigOrderedMap

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
@@ -959,7 +959,7 @@ Aborts with EKEY_ALREADY_EXISTS if key already exist, or duplicate keys are pass
 <pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_add_all">add_all</a>&lt;K: drop + <b>copy</b> + store, V: store&gt;(self: &<b>mut</b> <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;, keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;) {
     // TODO: Can be optimized, both in insertion order (largest first, then from smallest),
     // <b>as</b> well <b>as</b> on initializing inner_max_degree/leaf_max_degree better
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_zip">vector::zip</a>(keys, values, |key, value| {
+    keys.zip(values, |key, value| {
         self.<a href="big_ordered_map.md#0x1_big_ordered_map_add">add</a>(key, value);
     });
 }
@@ -1448,7 +1448,7 @@ Apply the function to each element in the vector, consuming it, and consuming th
     // TODO - this can be done more efficiently, by destroying the leaves directly
     // but that <b>requires</b> more complicated <a href="code.md#0x1_code">code</a> and testing.
     self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_and_clear">for_each_and_clear</a>(|k, v| f(k, v));
-    <a href="big_ordered_map.md#0x1_big_ordered_map_destroy_empty">destroy_empty</a>(self)
+    self.<a href="big_ordered_map.md#0x1_big_ordered_map_destroy_empty">destroy_empty</a>()
 }
 </code></pre>
 
@@ -1502,7 +1502,7 @@ Destroy a map, by destroying elements individually.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_destroy">destroy</a>&lt;K: drop + <b>copy</b> + store, V: store&gt;(self: <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;, dv: |V|) {
-    <a href="big_ordered_map.md#0x1_big_ordered_map_for_each">for_each</a>(self, |_k, v| {
+    self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each">for_each</a>(|_k, v| {
         dv(v);
     });
 }
@@ -1757,7 +1757,7 @@ Requires the map is not changed after the input iterator is generated.
         <b>return</b> <a href="big_ordered_map.md#0x1_big_ordered_map_new_iter">new_iter</a>(next_index, child_iter, iter_key);
     };
 
-    <a href="big_ordered_map.md#0x1_big_ordered_map_new_end_iter">new_end_iter</a>(map)
+    map.<a href="big_ordered_map.md#0x1_big_ordered_map_new_end_iter">new_end_iter</a>()
 }
 </code></pre>
 
@@ -2835,7 +2835,7 @@ Given a path to node (excluding the node itself), which is currently stored unde
     };
 
     <b>assert</b>!(!path_to_node.<a href="big_ordered_map.md#0x1_big_ordered_map_is_empty">is_empty</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="big_ordered_map.md#0x1_big_ordered_map_EINTERNAL_INVARIANT_BROKEN">EINTERNAL_INVARIANT_BROKEN</a>));
-    <b>let</b> slot_to_remove = <a href="big_ordered_map.md#0x1_big_ordered_map_destroy_inner_child">destroy_inner_child</a>(self.<a href="big_ordered_map.md#0x1_big_ordered_map_remove_at">remove_at</a>(path_to_node, &key_to_remove));
+    <b>let</b> slot_to_remove = self.<a href="big_ordered_map.md#0x1_big_ordered_map_remove_at">remove_at</a>(path_to_node, &key_to_remove).<a href="big_ordered_map.md#0x1_big_ordered_map_destroy_inner_child">destroy_inner_child</a>();
     self.nodes.free_reserved_slot(reserved_slot_to_remove, slot_to_remove);
 
     old_child

--- a/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
@@ -61,6 +61,8 @@ allowing cleaner iterator APIs.
 -  [Function `for_each_and_clear`](#0x1_big_ordered_map_for_each_and_clear)
 -  [Function `for_each`](#0x1_big_ordered_map_for_each)
 -  [Function `for_each_ref`](#0x1_big_ordered_map_for_each_ref)
+-  [Function `for_each_ref_friend`](#0x1_big_ordered_map_for_each_ref_friend)
+-  [Function `for_each_mut`](#0x1_big_ordered_map_for_each_mut)
 -  [Function `destroy`](#0x1_big_ordered_map_destroy)
 -  [Function `new_begin_iter`](#0x1_big_ordered_map_new_begin_iter)
 -  [Function `new_end_iter`](#0x1_big_ordered_map_new_end_iter)
@@ -447,7 +449,7 @@ Map key is not found
 
 <a id="0x1_big_ordered_map_EARGUMENT_BYTES_TOO_LARGE"></a>
 
-Trying to insert too large of an object into the mp.
+Trying to insert too large of an object into the map.
 
 
 <pre><code><b>const</b> <a href="big_ordered_map.md#0x1_big_ordered_map_EARGUMENT_BYTES_TOO_LARGE">EARGUMENT_BYTES_TOO_LARGE</a>: u64 = 13;
@@ -459,6 +461,7 @@ Trying to insert too large of an object into the mp.
 
 borrow_mut requires that key and value types have constant size
 (otherwise it wouldn't be able to guarantee size requirements are not violated)
+Use remove() + add() combo instead.
 
 
 <pre><code><b>const</b> <a href="big_ordered_map.md#0x1_big_ordered_map_EBORROW_MUT_REQUIRES_CONSTANT_KV_SIZE">EBORROW_MUT_REQUIRES_CONSTANT_KV_SIZE</a>: u64 = 14;
@@ -1355,7 +1358,7 @@ Disclaimer: This function may be costly as the BigOrderedMap may be huge in size
 
 <pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_to_ordered_map">to_ordered_map</a>&lt;K: drop + <b>copy</b> + store, V: <b>copy</b> + store&gt;(self: &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;): OrderedMap&lt;K, V&gt; {
     <b>let</b> result = <a href="ordered_map.md#0x1_ordered_map_new">ordered_map::new</a>();
-    self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref">for_each_ref</a>(|k, v| {
+    self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>(|k, v| {
         result.<a href="big_ordered_map.md#0x1_big_ordered_map_new_end_iter">new_end_iter</a>().iter_add(&<b>mut</b> result, *k, *v);
     });
     result
@@ -1387,7 +1390,7 @@ use iterartor or next_key/prev_key to iterate over across portion of the map.
 
 <pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_keys">keys</a>&lt;K: store + <b>copy</b> + drop, V: store + <b>copy</b>&gt;(self: &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt; {
     <b>let</b> result = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>[];
-    self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref">for_each_ref</a>(|k, _v| {
+    self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>(|k, _v| {
         result.push_back(*k);
     });
     result
@@ -1403,6 +1406,9 @@ use iterartor or next_key/prev_key to iterate over across portion of the map.
 ## Function `for_each_and_clear`
 
 Apply the function to each element in the vector, consuming it, leaving the map empty.
+
+Current implementation is O(n * log(n)). After function values will be optimized
+to O(n).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_and_clear">for_each_and_clear</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(self: &<b>mut</b> <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;K, V&gt;, f: |(K, V)|)
@@ -1434,6 +1440,9 @@ Apply the function to each element in the vector, consuming it, leaving the map 
 
 Apply the function to each element in the vector, consuming it, and consuming the map
 
+Current implementation is O(n * log(n)). After function values will be optimized
+to O(n).
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each">for_each</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(self: <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;K, V&gt;, f: |(K, V)|)
 </code></pre>
@@ -1462,6 +1471,9 @@ Apply the function to each element in the vector, consuming it, and consuming th
 
 Apply the function to a reference of each element in the vector.
 
+Current implementation is O(n * log(n)). After function values will be optimized
+to O(n).
+
 
 <pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref">for_each_ref</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(self: &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;K, V&gt;, f: |(&K, &V)|)
 </code></pre>
@@ -1473,11 +1485,107 @@ Apply the function to a reference of each element in the vector.
 
 
 <pre><code><b>public</b> inline <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref">for_each_ref</a>&lt;K: drop + <b>copy</b> + store, V: store&gt;(self: &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;, f: |&K, &V|) {
+    // This implementation is innefficient: O(log(n)) for next_key / borrow lookups every time,
+    // but is the only one available through the <b>public</b> API.
+    <b>if</b> (!self.<a href="big_ordered_map.md#0x1_big_ordered_map_is_empty">is_empty</a>()) {
+        <b>let</b> (k, v) = self.<a href="big_ordered_map.md#0x1_big_ordered_map_borrow_front">borrow_front</a>();
+        f(&k, v);
+
+        <b>let</b> cur_k = self.<a href="big_ordered_map.md#0x1_big_ordered_map_next_key">next_key</a>(&k);
+        <b>while</b> (cur_k.is_some()) {
+            <b>let</b> k = cur_k.destroy_some();
+            f(&k, self.<a href="big_ordered_map.md#0x1_big_ordered_map_borrow">borrow</a>(&k));
+
+            cur_k = self.<a href="big_ordered_map.md#0x1_big_ordered_map_next_key">next_key</a>(&k);
+        };
+    };
+
+    // TODO <b>use</b> this more efficient implementation when function values are enabled.
+    // self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_leaf_node_ref">for_each_leaf_node_ref</a>(|node| {
+    //     node.children.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref">for_each_ref</a>(|k: &K, v: &<a href="big_ordered_map.md#0x1_big_ordered_map_Child">Child</a>&lt;V&gt;| {
+    //         f(k, &v.value);
+    //     });
+    // })
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_big_ordered_map_for_each_ref_friend"></a>
+
+## Function `for_each_ref_friend`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(self: &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;K, V&gt;, f: |(&K, &V)|)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) inline <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>&lt;K: drop + <b>copy</b> + store, V: store&gt;(self: &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;, f: |&K, &V|) {
     self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_leaf_node_ref">for_each_leaf_node_ref</a>(|node| {
-        node.children.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref">for_each_ref</a>(|k: &K, v: &<a href="big_ordered_map.md#0x1_big_ordered_map_Child">Child</a>&lt;V&gt;| {
+        node.children.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>(|k: &K, v: &<a href="big_ordered_map.md#0x1_big_ordered_map_Child">Child</a>&lt;V&gt;| {
             f(k, &v.value);
         });
     })
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_big_ordered_map_for_each_mut"></a>
+
+## Function `for_each_mut`
+
+Apply the function to a mutable reference of each key-value pair in the map.
+
+Current implementation is O(n * log(n)). After function values will be optimized
+to O(n).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_mut">for_each_mut</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(self: &<b>mut</b> <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;K, V&gt;, f: |(&K, &<b>mut</b> V)|)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_mut">for_each_mut</a>&lt;K: <b>copy</b> + drop + store, V: store&gt;(self: &<b>mut</b> <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;, f: |&K, &<b>mut</b> V|) {
+    // This implementation is innefficient: O(log(n)) for next_key / borrow lookups every time,
+    // but is the only one available through the <b>public</b> API.
+    <b>if</b> (!self.<a href="big_ordered_map.md#0x1_big_ordered_map_is_empty">is_empty</a>()) {
+        <b>let</b> (k, _v) = self.<a href="big_ordered_map.md#0x1_big_ordered_map_borrow_front">borrow_front</a>();
+
+        <b>let</b> done = <b>false</b>;
+        <b>while</b> (!done) {
+            f(&k, self.<a href="big_ordered_map.md#0x1_big_ordered_map_borrow_mut">borrow_mut</a>(&k));
+
+            <b>let</b> cur_k = self.<a href="big_ordered_map.md#0x1_big_ordered_map_next_key">next_key</a>(&k);
+            <b>if</b> (cur_k.is_some()) {
+                k = cur_k.destroy_some();
+            } <b>else</b> {
+                done = <b>true</b>;
+            }
+        };
+    };
+
+    // TODO: <b>if</b> we make iterator api <b>public</b> <b>update</b> <b>to</b>:
+    // <b>let</b> iter = self.<a href="big_ordered_map.md#0x1_big_ordered_map_new_begin_iter">new_begin_iter</a>();
+    // <b>while</b> (!iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_is_end">iter_is_end</a>(self)) {
+    //     <b>let</b> key = *iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_borrow_key">iter_borrow_key</a>(self);
+    //     f(key, iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_borrow_mut">iter_borrow_mut</a>(self));
+    //     iter = iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_next">iter_next</a>(self);
+    // }
 }
 </code></pre>
 
@@ -1490,6 +1598,9 @@ Apply the function to a reference of each element in the vector.
 ## Function `destroy`
 
 Destroy a map, by destroying elements individually.
+
+Current implementation is O(n * log(n)). After function values will be optimized
+to O(n).
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_destroy">destroy</a>&lt;K: <b>copy</b>, drop, store, V: store&gt;(self: <a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;K, V&gt;, dv: |V|)

--- a/aptos-move/framework/aptos-framework/doc/ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/ordered_map.md
@@ -312,7 +312,7 @@ Aborts with EKEY_ALREADY_EXISTS if duplicate keys are passed in.
 
 <pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_new_from">new_from</a>&lt;K, V&gt;(keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;): <a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt; {
     <b>let</b> map = <a href="ordered_map.md#0x1_ordered_map_new">new</a>();
-    <a href="ordered_map.md#0x1_ordered_map_add_all">add_all</a>(&<b>mut</b> map, keys, values);
+    map.<a href="ordered_map.md#0x1_ordered_map_add_all">add_all</a>(keys, values);
     map
 }
 </code></pre>
@@ -605,7 +605,7 @@ Aborts with EKEY_ALREADY_EXISTS if key already exist, or duplicate keys are pass
 
 <pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_add_all">add_all</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;, keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;) {
     // TODO: Can be optimized, by sorting keys and values, and then creating map.
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_zip">vector::zip</a>(keys, values, |key, value| {
+    keys.zip(values, |key, value| {
         self.<a href="ordered_map.md#0x1_ordered_map_add">add</a>(key, value);
     });
 }
@@ -634,7 +634,7 @@ or if duplicate keys are passed in.
 
 <pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_upsert_all">upsert_all</a>&lt;K: drop, V: drop&gt;(self: &<b>mut</b> <a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;, keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt;, values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt;) {
     // TODO: Can be optimized, by sorting keys and values, and then creating map.
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_zip">vector::zip</a>(keys, values, |key, value| {
+    keys.zip(values, |key, value| {
         self.<a href="ordered_map.md#0x1_ordered_map_upsert">upsert</a>(key, value);
     });
 }
@@ -753,7 +753,7 @@ Takes all elements from <code>other</code> and adds them to <code>self</code>, r
                 self.entries.<a href="ordered_map.md#0x1_ordered_map_append">append</a>(other_entries);
                 <b>break</b>;
             } <b>else</b> {
-                cur_i = cur_i - 1;
+                cur_i -= 1;
             };
         } <b>else</b> {
             // is_lt or is_eq
@@ -767,7 +767,7 @@ Takes all elements from <code>other</code> and adds them to <code>self</code>, r
                 other_entries.<a href="ordered_map.md#0x1_ordered_map_destroy_empty">destroy_empty</a>();
                 <b>break</b>;
             } <b>else</b> {
-                other_i = other_i - 1;
+                other_i -= 1;
             };
         };
     };
@@ -1493,7 +1493,7 @@ Return all keys in the map. This requires keys to be copyable.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_keys">keys</a>&lt;K: <b>copy</b>, V&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt; {
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(&self.entries, |e| {
+    self.entries.map_ref(|e| {
         <b>let</b> e: &<a href="ordered_map.md#0x1_ordered_map_Entry">Entry</a>&lt;K, V&gt; = e;
         e.key
     })
@@ -1521,7 +1521,7 @@ Return all values in the map. This requires values to be copyable.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_values">values</a>&lt;K, V: <b>copy</b>&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;): <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt; {
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_map_ref">vector::map_ref</a>(&self.entries, |e| {
+    self.entries.map_ref(|e| {
         <b>let</b> e: &<a href="ordered_map.md#0x1_ordered_map_Entry">Entry</a>&lt;K, V&gt; = e;
         e.value
     })
@@ -1553,10 +1553,10 @@ Primarily used to destroy a map
     <b>let</b> keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt; = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
     <b>let</b> values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt; = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
     <b>let</b> OrderedMap::SortedVectorMap { entries } = self;
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each">vector::for_each</a>(entries, |e| {
+    entries.for_each(|e| {
         <b>let</b> <a href="ordered_map.md#0x1_ordered_map_Entry">Entry</a> { key, value } = e;
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> keys, key);
-        <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_push_back">vector::push_back</a>(&<b>mut</b> values, value);
+        keys.push_back(key);
+        values.push_back(value);
     });
     (keys, values)
 }
@@ -1588,9 +1588,9 @@ using lambdas to destroy the individual keys and values.
     dk: |K|,
     dv: |V|
 ) {
-    <b>let</b> (keys, values) = <a href="ordered_map.md#0x1_ordered_map_to_vec_pair">to_vec_pair</a>(self);
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_destroy">vector::destroy</a>(keys, |_k| dk(_k));
-    <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_destroy">vector::destroy</a>(values, |_v| dv(_v));
+    <b>let</b> (keys, values) = self.<a href="ordered_map.md#0x1_ordered_map_to_vec_pair">to_vec_pair</a>();
+    keys.<a href="ordered_map.md#0x1_ordered_map_destroy">destroy</a>(|_k| dk(_k));
+    values.<a href="ordered_map.md#0x1_ordered_map_destroy">destroy</a>(|_v| dv(_v));
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/ordered_map.md
@@ -75,7 +75,9 @@ allowing cleaner iterator APIs.
 -  [Function `values`](#0x1_ordered_map_values)
 -  [Function `to_vec_pair`](#0x1_ordered_map_to_vec_pair)
 -  [Function `destroy`](#0x1_ordered_map_destroy)
+-  [Function `for_each`](#0x1_ordered_map_for_each)
 -  [Function `for_each_ref`](#0x1_ordered_map_for_each_ref)
+-  [Function `for_each_ref_friend`](#0x1_ordered_map_for_each_ref_friend)
 -  [Function `for_each_mut`](#0x1_ordered_map_for_each_mut)
 -  [Function `new_iter`](#0x1_ordered_map_new_iter)
 -  [Function `binary_search`](#0x1_ordered_map_binary_search)
@@ -1553,7 +1555,7 @@ Primarily used to destroy a map
     <b>let</b> keys: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;K&gt; = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
     <b>let</b> values: <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;V&gt; = <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
     <b>let</b> OrderedMap::SortedVectorMap { entries } = self;
-    entries.for_each(|e| {
+    entries.<a href="ordered_map.md#0x1_ordered_map_for_each">for_each</a>(|e| {
         <b>let</b> <a href="ordered_map.md#0x1_ordered_map_Entry">Entry</a> { key, value } = e;
         keys.push_back(key);
         values.push_back(value);
@@ -1598,14 +1600,14 @@ using lambdas to destroy the individual keys and values.
 
 </details>
 
-<a id="0x1_ordered_map_for_each_ref"></a>
+<a id="0x1_ordered_map_for_each"></a>
 
-## Function `for_each_ref`
+## Function `for_each`
 
-Apply the function to a reference of each key-value pair in the table.
+Apply the function to each key-value pair in the map, consuming it.
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_ref">for_each_ref</a>&lt;K, V&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">ordered_map::OrderedMap</a>&lt;K, V&gt;, f: |(&K, &V)|)
+<pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each">for_each</a>&lt;K, V&gt;(self: <a href="ordered_map.md#0x1_ordered_map_OrderedMap">ordered_map::OrderedMap</a>&lt;K, V&gt;, f: |(K, V)|)
 </code></pre>
 
 
@@ -1614,12 +1616,61 @@ Apply the function to a reference of each key-value pair in the table.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_ref">for_each_ref</a>&lt;K, V&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;, f: |&K, &V|) {
-    <b>let</b> iter = self.<a href="ordered_map.md#0x1_ordered_map_new_begin_iter">new_begin_iter</a>();
-    <b>while</b> (!iter.<a href="ordered_map.md#0x1_ordered_map_iter_is_end">iter_is_end</a>(self)) {
-        f(iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow_key">iter_borrow_key</a>(self), iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow">iter_borrow</a>(self));
-        iter = iter.<a href="ordered_map.md#0x1_ordered_map_iter_next">iter_next</a>(self);
-    }
+<pre><code><b>public</b> inline <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each">for_each</a>&lt;K, V&gt;(
+    self: <a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;,
+    f: |K, V|
+) {
+    <b>let</b> (keys, values) = self.<a href="ordered_map.md#0x1_ordered_map_to_vec_pair">to_vec_pair</a>();
+    keys.zip(values, |k, v| f(k, v));
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_ordered_map_for_each_ref"></a>
+
+## Function `for_each_ref`
+
+Apply the function to a reference of each key-value pair in the map.
+
+Current implementation is O(n * log(n)). After function values will be optimized
+to O(n).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_ref">for_each_ref</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">ordered_map::OrderedMap</a>&lt;K, V&gt;, f: |(&K, &V)|)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_ref">for_each_ref</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;, f: |&K, &V|) {
+    // This implementation is innefficient: O(log(n)) for next_key / borrow lookups every time,
+    // but is the only one available through the <b>public</b> API.
+    <b>if</b> (!self.<a href="ordered_map.md#0x1_ordered_map_is_empty">is_empty</a>()) {
+        <b>let</b> (k, v) = self.<a href="ordered_map.md#0x1_ordered_map_borrow_front">borrow_front</a>();
+        f(k, v);
+
+        <b>let</b> cur_k = self.<a href="ordered_map.md#0x1_ordered_map_next_key">next_key</a>(k);
+        <b>while</b> (cur_k.is_some()) {
+            <b>let</b> k = cur_k.destroy_some();
+            f(&k, self.<a href="ordered_map.md#0x1_ordered_map_borrow">borrow</a>(&k));
+
+            cur_k = self.<a href="ordered_map.md#0x1_ordered_map_next_key">next_key</a>(&k);
+        };
+    };
+
+    // TODO: <b>if</b> we make iterator api <b>public</b> <b>update</b> <b>to</b>:
+    // <b>let</b> iter = self.<a href="ordered_map.md#0x1_ordered_map_new_begin_iter">new_begin_iter</a>();
+    // <b>while</b> (!iter.<a href="ordered_map.md#0x1_ordered_map_iter_is_end">iter_is_end</a>(self)) {
+    //     f(iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow_key">iter_borrow_key</a>(self), iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow">iter_borrow</a>(self));
+    //     iter = iter.<a href="ordered_map.md#0x1_ordered_map_iter_next">iter_next</a>(self);
+    // }
+
     // TODO: once <b>move</b> supports private functions udpate <b>to</b>:
     // <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_ref">vector::for_each_ref</a>(
     //     &self.entries,
@@ -1634,14 +1685,13 @@ Apply the function to a reference of each key-value pair in the table.
 
 </details>
 
-<a id="0x1_ordered_map_for_each_mut"></a>
+<a id="0x1_ordered_map_for_each_ref_friend"></a>
 
-## Function `for_each_mut`
-
-Apply the function to a mutable reference of each key-value pair in the table.
+## Function `for_each_ref_friend`
 
 
-<pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_mut">for_each_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="ordered_map.md#0x1_ordered_map_OrderedMap">ordered_map::OrderedMap</a>&lt;K, V&gt;, f: |(K, &<b>mut</b> V)|)
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_ref_friend">for_each_ref_friend</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">ordered_map::OrderedMap</a>&lt;K, V&gt;, f: |(&K, &V)|)
 </code></pre>
 
 
@@ -1650,13 +1700,66 @@ Apply the function to a mutable reference of each key-value pair in the table.
 <summary>Implementation</summary>
 
 
-<pre><code><b>public</b> inline <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_mut">for_each_mut</a>&lt;K, V&gt;(self: &<b>mut</b> <a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;, f: |K, &<b>mut</b> V|) {
+<pre><code><b>public</b>(<b>friend</b>) inline <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_ref_friend">for_each_ref_friend</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;, f: |&K, &V|) {
     <b>let</b> iter = self.<a href="ordered_map.md#0x1_ordered_map_new_begin_iter">new_begin_iter</a>();
     <b>while</b> (!iter.<a href="ordered_map.md#0x1_ordered_map_iter_is_end">iter_is_end</a>(self)) {
-        <b>let</b> key = *iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow_key">iter_borrow_key</a>(self);
-        f(key, iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow_mut">iter_borrow_mut</a>(self));
+        f(iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow_key">iter_borrow_key</a>(self), iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow">iter_borrow</a>(self));
         iter = iter.<a href="ordered_map.md#0x1_ordered_map_iter_next">iter_next</a>(self);
     }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_ordered_map_for_each_mut"></a>
+
+## Function `for_each_mut`
+
+Apply the function to a mutable reference of each key-value pair in the map.
+
+Current implementation is O(n * log(n)). After function values will be optimized
+to O(n).
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_mut">for_each_mut</a>&lt;K: <b>copy</b>, drop, V&gt;(self: &<b>mut</b> <a href="ordered_map.md#0x1_ordered_map_OrderedMap">ordered_map::OrderedMap</a>&lt;K, V&gt;, f: |(&K, &<b>mut</b> V)|)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> inline <b>fun</b> <a href="ordered_map.md#0x1_ordered_map_for_each_mut">for_each_mut</a>&lt;K: <b>copy</b> + drop, V&gt;(self: &<b>mut</b> <a href="ordered_map.md#0x1_ordered_map_OrderedMap">OrderedMap</a>&lt;K, V&gt;, f: |&K, &<b>mut</b> V|) {
+    // This implementation is innefficient: O(log(n)) for next_key / borrow lookups every time,
+    // but is the only one available through the <b>public</b> API.
+    <b>if</b> (!self.<a href="ordered_map.md#0x1_ordered_map_is_empty">is_empty</a>()) {
+        <b>let</b> (k, _v) = self.<a href="ordered_map.md#0x1_ordered_map_borrow_front">borrow_front</a>();
+
+        <b>let</b> k = *k;
+        <b>let</b> done = <b>false</b>;
+        <b>while</b> (!done) {
+            f(&k, self.<a href="ordered_map.md#0x1_ordered_map_borrow_mut">borrow_mut</a>(&k));
+
+            <b>let</b> cur_k = self.<a href="ordered_map.md#0x1_ordered_map_next_key">next_key</a>(&k);
+            <b>if</b> (cur_k.is_some()) {
+                k = cur_k.destroy_some();
+            } <b>else</b> {
+                done = <b>true</b>;
+            }
+        };
+    };
+
+    // TODO: <b>if</b> we make iterator api <b>public</b> <b>update</b> <b>to</b>:
+    // <b>let</b> iter = self.<a href="ordered_map.md#0x1_ordered_map_new_begin_iter">new_begin_iter</a>();
+    // <b>while</b> (!iter.<a href="ordered_map.md#0x1_ordered_map_iter_is_end">iter_is_end</a>(self)) {
+    //     <b>let</b> key = *iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow_key">iter_borrow_key</a>(self);
+    //     f(key, iter.<a href="ordered_map.md#0x1_ordered_map_iter_borrow_mut">iter_borrow_mut</a>(self));
+    //     iter = iter.<a href="ordered_map.md#0x1_ordered_map_iter_next">iter_next</a>(self);
+    // }
+
     // TODO: once <b>move</b> supports private functions udpate <b>to</b>:
     // <a href="../../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_for_each_mut">vector::for_each_mut</a>(
     //     &<b>mut</b> self.entries,

--- a/aptos-move/move-examples/data_structures/Move.toml
+++ b/aptos-move/move-examples/data_structures/Move.toml
@@ -4,6 +4,7 @@ version = "0.0.1"
 
 [dependencies]
 AptosStdlib = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-stdlib", rev = "mainnet" }
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework.git", subdir = "aptos-framework", rev = "mainnet" }
 
 
 [addresses]

--- a/aptos-move/move-examples/data_structures/sources/big_ordered_map_usage_examples.move
+++ b/aptos-move/move-examples/data_structures/sources/big_ordered_map_usage_examples.move
@@ -1,0 +1,26 @@
+module aptos_std::big_ordered_map_usage_examples {
+    use aptos_framework::big_ordered_map;
+
+    #[test]
+    fun example_with_primitive_types() {
+        let map = big_ordered_map::new<u64, u64>();
+
+        map.add(2, 2);
+        map.add(3, 3);
+
+        assert!(map.contains(&2));
+
+        let sum = 0;
+        map.for_each_ref(|k, v| sum += *k + *v);
+        assert!(sum == 10);
+
+        *map.borrow_mut(&2) = 5;
+        assert!(map.get(&2).destroy_some() == 5);
+
+        map.for_each_mut(|_k, v| *v += 1);
+
+        let sum = 0;
+        map.for_each(|k, v| sum += k + v);
+        assert!(sum == 15);
+    }
+}


### PR DESCRIPTION
## Description
for_each methods are using ability for inline functions to receive function as an argument.
For that - they require whole body of the inline function to be public. 

With that, we need to fallback to this less efficient way to handle it.

After function values are enabled, we can implement them as a non-inline functions, which will then be able to use internal methods. 

Also went through and applied move2 syntax throughout (separate commit for easy review)

## How Has This Been Tested?
added example test

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
