### PR TITLE
[compiler-v2] Check privileged enum operations outside the defining module

### DIFF
--- a/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_01.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_01.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: Invalid operation: access of the field `0` on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/cross_module_enum_access_01.move:15:9
+   │
+15 │     fun test() {
+   │         ^^^^
+16 │         let x = m::make(22);
+17 │         assert!(x.0 == 22, 1);
+   │                 --- accessed here

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_01.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_01.move
@@ -1,0 +1,19 @@
+module 0xc0ffee::m {
+    enum Wrapper has drop {
+        V1(u64),
+        V2(u64),
+    }
+
+    public fun make(x: u64): Wrapper {
+        Wrapper::V1(x)
+    }
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m;
+
+    fun test() {
+        let x = m::make(22);
+        assert!(x.0 == 22, 1);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_02.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_02.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: Invalid operation: variant test on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/cross_module_enum_access_02.move:15:9
+   │
+15 │     fun test() {
+   │         ^^^^
+16 │         let x = m::make(22);
+17 │         assert!(x is m::Wrapper::V1, 1);
+   │                 ------------------- tested here

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_02.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_02.move
@@ -1,0 +1,19 @@
+module 0xc0ffee::m {
+    enum Wrapper has drop {
+        V1(u64),
+        V2(u64),
+    }
+
+    public fun make(x: u64): Wrapper {
+        Wrapper::V1(x)
+    }
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m;
+
+    fun test() {
+        let x = m::make(22);
+        assert!(x is m::Wrapper::V1, 1);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_03.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_03.exp
@@ -1,0 +1,28 @@
+
+Diagnostics:
+error: Invalid operation: match on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/cross_module_enum_access_03.move:15:9
+   │
+15 │     fun test1() {
+   │         ^^^^^
+16 │         let x = m::make(22);
+17 │         match (x) {
+   │                - matched here
+
+error: Invalid operation: match on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/cross_module_enum_access_03.move:23:9
+   │
+23 │     fun test2() {
+   │         ^^^^^
+24 │         let x = m::make(22);
+25 │         match (&x) {
+   │                -- matched here
+
+error: Invalid operation: match on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/cross_module_enum_access_03.move:31:9
+   │
+31 │     fun test3() {
+   │         ^^^^^
+32 │         let x = m::make(22);
+33 │         match (&mut x) {
+   │                ------ matched here

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_03.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/cross_module_enum_access_03.move
@@ -1,0 +1,40 @@
+module 0xc0ffee::m {
+    enum Wrapper has drop {
+        V1(u64),
+        V2(u64),
+    }
+
+    public fun make(x: u64): Wrapper {
+        Wrapper::V1(x)
+    }
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m;
+
+    fun test1() {
+        let x = m::make(22);
+        match (x) {
+            m::Wrapper::V1(v) => assert!(v == 22, 1),
+            _ => abort(0),
+        };
+    }
+
+    fun test2() {
+        let x = m::make(22);
+        match (&x) {
+            m::Wrapper::V2(v) => assert!(*v == 22, 1),
+            _ => abort(0),
+        };
+    }
+
+    fun test3() {
+        let x = m::make(22);
+        match (&mut x) {
+            m::Wrapper::V1(v) => assert!(*v == 22, 1),
+            m::Wrapper::V2(v) => {
+                *v = 0;
+            }
+        };
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_01.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_01.exp
@@ -1,0 +1,23 @@
+
+Diagnostics:
+error: Invalid operation: pack of `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/inline_with_enums_01.move:15:9
+   │
+ 7 │         let x = Wrapper::V1(22);
+   │                 --------------- packed here
+   ·
+15 │     fun test(): u64 {
+   │         ^^^^
+16 │         m::use_me_not()
+   │         --------------- from a call inlined at this callsite
+
+error: Invalid operation: access of the field `0` on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/inline_with_enums_01.move:15:9
+   │
+ 8 │         x.0
+   │         --- accessed here
+   ·
+15 │     fun test(): u64 {
+   │         ^^^^
+16 │         m::use_me_not()
+   │         --------------- from a call inlined at this callsite

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_01.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_01.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    enum Wrapper {
+        V1(u64),
+    }
+
+    public inline fun use_me_not(): u64 {
+        let x = Wrapper::V1(22);
+        x.0
+    }
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m;
+
+    fun test(): u64 {
+        m::use_me_not()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_02.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_02.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: Invalid operation: access of the field `0` on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/inline_with_enums_02.move:19:9
+   │
+12 │         x.0
+   │         --- accessed here
+   ·
+19 │     fun test(): u64 {
+   │         ^^^^
+20 │         m::use_me_not()
+   │         --------------- from a call inlined at this callsite

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_02.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_02.move
@@ -1,0 +1,22 @@
+module 0xc0ffee::m {
+    enum Wrapper has drop {
+        V1(u64),
+    }
+
+    public fun make(x: u64): Wrapper {
+        Wrapper::V1(x)
+    }
+
+    public inline fun use_me_not(): u64 {
+        let x = make(22);
+        x.0
+    }
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m;
+
+    fun test(): u64 {
+        m::use_me_not()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_03.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_03.exp
@@ -1,0 +1,12 @@
+
+Diagnostics:
+error: Invalid operation: match on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/visibility-checker/inline_with_enums_03.move:21:9
+   │
+12 │         match (x) {
+   │                - matched here
+   ·
+21 │     fun test(): u64 {
+   │         ^^^^
+22 │         m::use_me_not()
+   │         --------------- from a call inlined at this callsite

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_03.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_03.move
@@ -1,0 +1,24 @@
+module 0xc0ffee::m {
+    enum Wrapper has drop {
+        V1(u64),
+    }
+
+    public fun make(x: u64): Wrapper {
+        Wrapper::V1(x)
+    }
+
+    public inline fun use_me_not(): u64 {
+        let x = make(22);
+        match (x) {
+            V1(x) => x
+        }
+    }
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m;
+
+    fun test(): u64 {
+        m::use_me_not()
+    }
+}


### PR DESCRIPTION
## Description

In this PR, the compiler disallows performing certain privileged operations on enums defined in a different modules. Previously, the compiler would emit an internal compiler error (ICE) in these cases.

For example, the compiler would ICE on the code below before, but we now instead give a compiler error:
```move
module 0xc0ffee::m {
    enum Wrapper has drop {
        V1(u64),
        V2(u64),
    }

    public fun make(x: u64): Wrapper {
        Wrapper::V1(x)
    }
}

module 0xc0ffee::n {
    use 0xc0ffee::m;

    fun test1() {
        let x = m::make(22);
        match (x) { // !! match on enum defined in a different module
            m::Wrapper::V1(v) => assert!(v == 22, 1),
            _ => abort(0),
        };
    }
}
```

## How Has This Been Tested?

Added several new tests.

## Key Areas to Review

Completeness of the fix.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
