### PR TITLE
replay-verify: print mismatches as found.

### DIFF
--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -109,7 +109,7 @@ jobs:
           fi
 
           eval $CMD
-        timeout-minutes: 120 
+        timeout-minutes: 240
       # This is in case user manually cancel the step above, we still want to cleanup the resources
       - name: Post-run cleanup
         env:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -109,7 +109,7 @@ jobs:
           fi
 
           eval $CMD
-        timeout-minutes: 240
+        timeout-minutes: 300
       # This is in case user manually cancel the step above, we still want to cleanup the resources
       - name: Post-run cleanup
         env:

--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -219,7 +219,7 @@ impl Verifier {
             // timeout check
             if let Some(duration) = self.timeout_secs {
                 if self.replay_stat.get_elapsed_secs() >= duration {
-                    info!(
+                    error!(
                         "Verify timeout: {}s elapsed. Deadline: {}s",
                         self.replay_stat.get_elapsed_secs(),
                         duration

--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -79,9 +79,11 @@ impl Opt {
         let all_errors = verifier.run()?;
         if !all_errors.is_empty() {
             error!("{} failed transactions", all_errors.len());
+            /* errors were printed as found.
             for e in all_errors {
                 error!("Failed: {}", e);
             }
+             */
             process::exit(2);
         }
         Ok(())

--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -219,6 +219,11 @@ impl Verifier {
             // timeout check
             if let Some(duration) = self.timeout_secs {
                 if self.replay_stat.get_elapsed_secs() >= duration {
+                    info!(
+                        "Verify timeout: {}s elapsed. Deadline: {}s",
+                        self.replay_stat.get_elapsed_secs(),
+                        duration
+                    );
                     return Ok(total_failed_txns);
                 }
             }

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -96,7 +96,7 @@ class ReplayConfig:
             self.concurrent_replayer = 20
             self.pvc_number = 5
             self.min_range_size = 10_000
-            self.range_size = 5_000_000
+            self.range_size = 2_000_000
             self.timeout_secs = 2000
         else:
             self.concurrent_replayer = 18

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -96,7 +96,7 @@ class ReplayConfig:
             self.concurrent_replayer = 20
             self.pvc_number = 5
             self.min_range_size = 10_000
-            self.range_size = 2_000_000
+            self.range_size = 5_000_000
             self.timeout_secs = 2000
         else:
             self.concurrent_replayer = 18
@@ -416,6 +416,9 @@ class ReplayScheduler:
 
         skips = self.sorted_ranges_to_skip()
 
+        range_size = self.range_size
+        heavy_range_size = int(range_size / 5)
+
         while current <= self.end_version:
             (skip_start, skip_end) = (
                 (INT64_MAX, INT64_MAX) if len(skips) == 0 else skips[0]
@@ -425,9 +428,19 @@ class ReplayScheduler:
                 current = skip_end + 1
                 continue
 
-            next_current = min(
-                current + self.range_size, self.end_version + 1, skip_start
-            )
+            # TODO(ibalajiarun): temporary hack to handle heavy ranges
+            if (
+                self.network == Network.TESTNET
+                and current >= 6700000000
+                and current < 6800000000
+            ):
+                next_current = min(
+                    current + heavy_range_size, self.end_version + 1, skip_start
+                )
+            else:
+                next_current = min(
+                    current + range_size, self.end_version + 1, skip_start
+                )
 
             # avoid having too many small tasks, simply skip the task
             range = (current, next_current - 1)
@@ -449,7 +462,7 @@ class ReplayScheduler:
         # Because PVCs can be shared among multiple replay-verify runs, a more correct TTL
         # would be computed from the number of shards and the expected run time of the replay-verify
         # run. However, for simplicity, we set the TTL to 3 hours.
-        pvc_ttl = 3 * 60 * 60  # 3 hours
+        pvc_ttl = 5 * 60 * 60  # 3 hours
         pvcs = create_replay_verify_pvcs_from_snapshot(
             self.id,
             snapshot_name,

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -97,13 +97,13 @@ class ReplayConfig:
             self.pvc_number = 5
             self.min_range_size = 10_000
             self.range_size = 5_000_000
-            self.timeout_secs = 900
+            self.timeout_secs = 2000
         else:
             self.concurrent_replayer = 18
             self.pvc_number = 8
             self.min_range_size = 10_000
             self.range_size = 2_000_000
-            self.timeout_secs = 400
+            self.timeout_secs = 1000
 
 
 class WorkerPod:

--- a/testsuite/replay-verify/replay-verify-worker-template.yaml
+++ b/testsuite/replay-verify/replay-verify-worker-template.yaml
@@ -1,34 +1,43 @@
-apiVersion: v1  
-kind: Pod  
-metadata:  
+apiVersion: v1
+kind: Pod
+metadata:
   name: worker-pod-9
   labels:
     run: some-label
   annotations: {}
-spec:  
-  serviceAccountName: default  
-  restartPolicy: Never  # Pod restarts only if it fails  
-  containers:  
-    - name: replay-verify-worker  
-      image: us-docker.pkg.dev/aptos-registry/docker/tools:nightly  
-      volumeMounts:  
-        - mountPath: /mnt/archive  
-          name: archive  
-          readOnly: true  # Mount the volume as read-only  
+spec:
+  serviceAccountName: default
+  restartPolicy: Never # Pod restarts only if it fails
+  containers:
+    - name: replay-verify-worker
+      image: us-docker.pkg.dev/aptos-registry/docker/tools:nightly
+      volumeMounts:
+        - mountPath: /mnt/archive
+          name: archive
+          readOnly: true # Mount the volume as read-only
       command: ["/bin/sh", "-c", "ls -al /mnt/archive && sleep 3600"]
-      env:  
-        #- name: PUSH_METRICS_ENDPOINT  
+      env:
+        #- name: PUSH_METRICS_ENDPOINT
         #  value: "http://localhost:9091"
-        - name: RUST_LOG  
+        - name: RUST_LOG
           value: "info"
-      resources:  
-        requests:  
-          memory: "90Gi"  
-          cpu: "30"  
-        limits:  
-          memory: "90Gi"  
-          cpu: "30"  
-  volumes:  
+      resources:
+        requests:
+          memory: "180Gi"
+          cpu: "30"
+        limits:
+          memory: "180Gi"
+          cpu: "30"
+  volumes:
     - name: archive
-      persistentVolumeClaim:  
+      persistentVolumeClaim:
         claimName: testnet-archive-9
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+          - matchExpressions:
+              - key: cloud.google.com/machine-family
+                operator: In
+                values:
+                  - t2d


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Temporary hack to split heavy ranges and verify.

also enlarge timeout to allow pods finish on mismatch

This test almost went thorough except one range, which I have addressed: https://github.com/aptos-labs/aptos-core/actions/runs/15496818186/job/43636449393

