### PR TITLE
[Compiler] Catch borrow of tuple at expression builder time

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_local.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_local.exp
@@ -8,6 +8,7 @@ module 0x8675309::M {
     }
     private fun t0(b: bool,u: u64,s: S,r: R): R {
         Borrow(Immutable)(b);
+        Borrow(Immutable)(b);
         Borrow(Mutable)(b);
         Borrow(Immutable)(u);
         Borrow(Mutable)(u);
@@ -49,6 +50,7 @@ module 0x8675309::M {
     struct S has drop {
     }
     fun t0(b: bool, u: u64, s: S, r: R): R {
+        &b;
         &b;
         &mut b;
         &u;

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_local.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_local.move
@@ -4,6 +4,7 @@ module 0x8675309::M {
 
     fun t0(b: bool, u: u64, s: S, r: R): R {
         (&b : &bool);
+        (&(b) : &bool);
         (&mut b : &mut bool);
         (&u : &u64);
         (&mut u : &mut u64);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_local_temp_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_local_temp_invalid.exp
@@ -1,5 +1,23 @@
 
 Diagnostics:
+error: cannot borrow a tuple
+  ┌─ tests/checking/typing/borrow_local_temp_invalid.move:3:9
+  │
+3 │         &();
+  │         ^^^
+
+error: cannot borrow a tuple
+  ┌─ tests/checking/typing/borrow_local_temp_invalid.move:4:9
+  │
+4 │         &(0, 1);
+  │         ^^^^^^^
+
+error: cannot borrow a tuple
+  ┌─ tests/checking/typing/borrow_local_temp_invalid.move:5:9
+  │
+5 │         &(0, 1, true, @0x0);
+  │         ^^^^^^^^^^^^^^^^^^^
+
 error: cannot borrow from a reference
   ┌─ tests/checking/typing/borrow_local_temp_invalid.move:9:9
   │

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.exp
@@ -1,0 +1,119 @@
+
+Diagnostics:
+error: cannot borrow a tuple
+  ┌─ tests/checking/typing/borrow_tuple_invalid.move:4:9
+  │
+4 │         &();
+  │         ^^^
+
+error: cannot borrow a tuple
+  ┌─ tests/checking/typing/borrow_tuple_invalid.move:5:9
+  │
+5 │         &(1, 2);
+  │         ^^^^^^^
+
+error: cannot borrow a tuple
+  ┌─ tests/checking/typing/borrow_tuple_invalid.move:6:17
+  │
+6 │         let x = &();
+  │                 ^^^
+
+error: cannot borrow a tuple
+  ┌─ tests/checking/typing/borrow_tuple_invalid.move:7:17
+  │
+7 │         let y = &(1, 2);
+  │                 ^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:11:10
+   │
+11 │         *&();
+   │          ^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:12:10
+   │
+12 │         *&(1, 2);
+   │          ^^^^^^^
+
+error: tuple type `()` is not allowed as a local variable type
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:13:13
+   │
+13 │         let x = *&();
+   │             ^
+   │
+   = required by declaration of local `x`
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:13:18
+   │
+13 │         let x = *&();
+   │                  ^^^
+
+error: tuple type `(integer, integer)` is not allowed as a local variable type
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:14:13
+   │
+14 │         let y = *&(1, 2);
+   │             ^
+   │
+   = required by declaration of local `y`
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:14:18
+   │
+14 │         let y = *&(1, 2);
+   │                  ^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:26:9
+   │
+26 │         &return_tuple();
+   │         ^^^^^^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:27:9
+   │
+27 │         &return_unit();
+   │         ^^^^^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:34:9
+   │
+34 │         &in_unit();
+   │         ^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:35:9
+   │
+35 │         &in_tuple();
+   │         ^^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:39:9
+   │
+39 │         &(if (true) (1, 2) else (2, 1));
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:40:9
+   │
+40 │         &(if (false) ());
+   │         ^^^^^^^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:44:9
+   │
+44 │         &(assert!(true, 0));
+   │         ^^^^^^^^^^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:45:9
+   │
+45 │         &mut spec {};
+   │         ^^^^^^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:49:16
+   │
+49 │         return &(1, 2)
+   │                ^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.move
@@ -1,0 +1,51 @@
+module 0x8675309::M {
+
+    fun borrow_local() {
+        &();
+        &(1, 2);
+        let x = &();
+        let y = &(1, 2);
+    }
+
+    fun deref_borrow() {
+        *&();
+        *&(1, 2);
+        let x = *&();
+        let y = *&(1, 2);
+    }
+
+    fun return_tuple() : (u64, u64) {
+        return (1, 2)
+    }
+
+    fun return_unit() : () {
+        return ()
+    }
+
+    fun borrow_func() {
+        &return_tuple();
+        &return_unit();
+    }
+
+    inline fun in_unit(): () { () }
+    inline fun in_tuple(): (u64, u64) { (1, 2) }
+
+    fun borrow_inline() {
+        &in_unit();
+        &in_tuple();
+    }
+
+    fun borrow_conditional() {
+        &(if (true) (1, 2) else (2, 1));
+        &(if (false) ());
+    }
+
+    fun borrow_special() {
+        &(assert!(true, 0));
+        &mut spec {};
+    }
+
+    fun return_borrow_tuple() : &(u64, u64) {
+        return &(1, 2)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/typing/derefrence_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/derefrence_invalid.exp
@@ -60,6 +60,12 @@ error: expected `(bool, u64)` but found a value of type `u64`
 16 │         (*&mut s_mut.f: (bool, u64));
    │                ^^^^^^^
 
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/derefrence_invalid.move:16:11
+   │
+16 │         (*&mut s_mut.f: (bool, u64));
+   │           ^^^^^^^^^^^^
+
 error: expected `&u64` but found a value of type `u64`
    ┌─ tests/checking/typing/derefrence_invalid.move:17:10
    │
@@ -72,8 +78,20 @@ error: expected `(X, S)` but found a value of type `X`
 18 │         (*&s_mut.x: (X, S));
    │            ^^^^^^^
 
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/derefrence_invalid.move:18:11
+   │
+18 │         (*&s_mut.x: (X, S));
+   │           ^^^^^^^^
+
 error: expected expression with no value but found `X`
    ┌─ tests/checking/typing/derefrence_invalid.move:19:16
    │
 19 │         (*&mut s_mut.x: ());
    │                ^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/derefrence_invalid.move:19:11
+   │
+19 │         (*&mut s_mut.x: ());
+   │           ^^^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/spec_parsing_inside_fun.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/spec_parsing_inside_fun.exp
@@ -11,3 +11,9 @@ error: cannot use `()` with an operator which expects a value of type `bool`
    │
 33 │         spec {} && spec {};
    │         ^^^^^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/more-v1/parser/spec_parsing_inside_fun.move:34:9
+   │
+34 │         &mut spec {};
+   │         ^^^^^^^^^^^^

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1901,8 +1901,12 @@ impl ExpTranslator<'_, '_, '_> {
                 } else {
                     self.translate_exp(exp, &target_ty)
                 };
-                if self.subs.specialize(&target_ty).is_reference() {
+                let specialized_target_ty = self.subs.specialize(&target_ty);
+                if specialized_target_ty.is_reference() {
                     self.error(&loc, "cannot borrow from a reference")
+                }
+                if specialized_target_ty.is_tuple() {
+                    self.error(&loc, "cannot borrow a tuple")
                 }
                 let id = self.new_node_id_with_type_loc(&result_ty, &loc);
                 let target_exp =


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Resolves #16583

Disallow borrowing tuples.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Existing text coverage

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

1) Look at error message added to `third_party/move/move-compiler-v2/tests/more-v1/parser/spec_parsing_inside_fun.exp`. This is potentially a bit confusing if the user doesn't know that `spec` has type `unit`. Are we fine with this error message?

2) I don't love that my solution spaghettifies the code. Curious if a better way to do this. 

3) Perhaps worth looking into: there were existing move language tests that clearly intended to capture this bug (which is why I didn't need to write new tests), but the`.exp` files were incomplete (for example, `spec_parsing_inside_fun.move` noted that the expression `&mut spec {};` is a typing error but the corresponding `.exp` file did not capture this). Are there other instances of move tests where the `.exp` file may be incomplete?

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
