### PR TITLE
[compiler-v2] Implement a warning for inline functions that cannot be called in all contexts they could be called in

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/function_checker.rs
@@ -185,7 +185,7 @@ pub fn check_for_function_typed_parameters(env: &mut GlobalEnv) {
 
 fn access_error(
     env: &GlobalEnv,
-    fun_loc: &Loc,
+    fun_env: &FunctionEnv,
     id: &NodeId,
     oper: &str,
     msg: String,
@@ -200,14 +200,56 @@ fn access_error(
         msg,
         module_env.get_full_name_str()
     );
-    env.diag_with_labels(Severity::Error, fun_loc, &msg, call_details);
+    env.diag_with_labels(Severity::Error, &fun_env.get_id_loc(), &msg, call_details);
 }
 
-/// check privileged operations on a struct such as storage operation, pack/unpack and field accesses
-/// can only be performed within the module that defines it.
+fn access_warning(
+    env: &GlobalEnv,
+    fun_env: &FunctionEnv,
+    id: &NodeId,
+    oper: &str,
+    msg: String,
+    module_env: &ModuleEnv,
+) {
+    let call_details: Vec<_> = [*id]
+        .iter()
+        .map(|node_id| (env.get_node_loc(*node_id), format!("{} here", oper)))
+        .collect();
+    let msg = format!(
+        "{} can only be done within the defining module `{}`, but `{}` could be called (and expanded) outside the module",
+        msg,
+        module_env.get_full_name_str(),
+        fun_env.get_full_name_str()
+    );
+    env.diag_with_labels(Severity::Warning, &fun_env.get_id_loc(), &msg, call_details);
+}
+
+fn check_for_access_error_or_warning<F>(
+    env: &GlobalEnv,
+    fun_env: &FunctionEnv,
+    id: &NodeId,
+    oper: &str,
+    msg_maker: F,
+    module_env: &ModuleEnv,
+    cross_module: bool,
+    caller_is_inline_non_private: bool,
+) where
+    F: Fn() -> String,
+{
+    if cross_module {
+        access_error(env, fun_env, id, oper, msg_maker(), module_env);
+    } else if caller_is_inline_non_private {
+        access_warning(env, fun_env, id, oper, msg_maker(), module_env);
+    }
+}
+
+/// Check for privileged operations on a struct/enum that can only be performed
+/// within the module that defines it.
 fn check_privileged_operations_on_structs(env: &GlobalEnv, fun_env: &FunctionEnv) {
     if let Some(fun_body) = fun_env.get_def() {
         let caller_module_id = fun_env.module_env.get_id();
+        let caller_is_inline_non_private =
+            fun_env.is_inline() && fun_env.visibility() != Visibility::Private;
         fun_body.visit_pre_order(&mut |exp: &ExpData| {
             match exp {
                 ExpData::Call(id, oper, _) => match oper {
@@ -220,91 +262,104 @@ fn check_privileged_operations_on_structs(env: &GlobalEnv, fun_env: &FunctionEnv
                         if let Some((struct_env, _)) = inst[0].get_struct(env) {
                             let mid = struct_env.module_env.get_id();
                             let sid = struct_env.get_id();
-                            if mid != caller_module_id {
-                                let qualified_struct_id = mid.qualified(sid);
-                                let struct_env = env.get_struct(qualified_struct_id);
-                                access_error(
-                                    env,
-                                    &fun_env.get_id_loc(),
-                                    id,
-                                    "called",
-                                    format!(
-                                        "storage operation on type `{}`",
-                                        struct_env.get_full_name_str(),
-                                    ),
-                                    &struct_env.module_env,
-                                );
-                            }
+                            let qualified_struct_id = mid.qualified(sid);
+                            let struct_env = env.get_struct(qualified_struct_id);
+                            let msg_maker = || {
+                                format!(
+                                    "storage operation on type `{}`",
+                                    struct_env.get_full_name_str(),
+                                )
+                            };
+                            check_for_access_error_or_warning(
+                                env,
+                                fun_env,
+                                id,
+                                "called",
+                                msg_maker,
+                                &struct_env.module_env,
+                                mid != caller_module_id,
+                                caller_is_inline_non_private,
+                            );
                         }
                     },
                     Operation::Select(mid, sid, fid) => {
-                        if *mid != caller_module_id {
-                            let qualified_struct_id = mid.qualified(*sid);
-                            let struct_env = env.get_struct(qualified_struct_id);
-                            access_error(
-                                env,
-                                &fun_env.get_id_loc(),
-                                id,
-                                "accessed",
-                                format!(
-                                    "access of the field `{}` on type `{}`",
-                                    fid.symbol().display(struct_env.symbol_pool()),
-                                    struct_env.get_full_name_str(),
-                                ),
-                                &struct_env.module_env,
-                            );
-                        }
+                        let qualified_struct_id = mid.qualified(*sid);
+                        let struct_env = env.get_struct(qualified_struct_id);
+                        let msg_maker = || {
+                            format!(
+                                "access of the field `{}` on type `{}`",
+                                fid.symbol().display(struct_env.symbol_pool()),
+                                struct_env.get_full_name_str(),
+                            )
+                        };
+                        check_for_access_error_or_warning(
+                            env,
+                            fun_env,
+                            id,
+                            "accessed",
+                            msg_maker,
+                            &struct_env.module_env,
+                            *mid != caller_module_id,
+                            caller_is_inline_non_private,
+                        );
                     },
                     Operation::SelectVariants(mid, sid, fids) => {
-                        if *mid != caller_module_id {
-                            let qualified_struct_id = mid.qualified(*sid);
-                            let struct_env = env.get_struct(qualified_struct_id);
-                            // All field names are the same, so take one representative field id to report.
-                            let field_env = struct_env.get_field(fids[0]);
-                            access_error(
-                                env,
-                                &fun_env.get_id_loc(),
-                                id,
-                                "accessed",
-                                format!(
-                                    "access of the field `{}` on enum type `{}`",
-                                    field_env.get_name().display(struct_env.symbol_pool()),
-                                    struct_env.get_full_name_str(),
-                                ),
-                                &struct_env.module_env,
-                            );
-                        }
+                        let qualified_struct_id = mid.qualified(*sid);
+                        let struct_env = env.get_struct(qualified_struct_id);
+                        // All field names are the same, so take one representative field id to report.
+                        let field_env = struct_env.get_field(fids[0]);
+                        let msg_maker = || {
+                            format!(
+                                "access of the field `{}` on enum type `{}`",
+                                field_env.get_name().display(struct_env.symbol_pool()),
+                                struct_env.get_full_name_str(),
+                            )
+                        };
+                        check_for_access_error_or_warning(
+                            env,
+                            fun_env,
+                            id,
+                            "accessed",
+                            msg_maker,
+                            &struct_env.module_env,
+                            *mid != caller_module_id,
+                            caller_is_inline_non_private,
+                        );
                     },
                     Operation::TestVariants(mid, sid, _) => {
-                        if *mid != caller_module_id {
-                            let qualified_struct_id = mid.qualified(*sid);
-                            let struct_env = env.get_struct(qualified_struct_id);
-                            access_error(
-                                env,
-                                &fun_env.get_id_loc(),
-                                id,
-                                "tested",
-                                format!(
-                                    "variant test on enum type `{}`",
-                                    struct_env.get_full_name_str(),
-                                ),
-                                &struct_env.module_env,
-                            );
-                        }
+                        let qualified_struct_id = mid.qualified(*sid);
+                        let struct_env = env.get_struct(qualified_struct_id);
+                        let msg_maker = || {
+                            format!(
+                                "variant test on enum type `{}`",
+                                struct_env.get_full_name_str(),
+                            )
+                        };
+                        check_for_access_error_or_warning(
+                            env,
+                            fun_env,
+                            id,
+                            "tested",
+                            msg_maker,
+                            &struct_env.module_env,
+                            *mid != caller_module_id,
+                            caller_is_inline_non_private,
+                        );
                     },
                     Operation::Pack(mid, sid, _) => {
-                        if *mid != caller_module_id {
-                            let qualified_struct_id = mid.qualified(*sid);
-                            let struct_env = env.get_struct(qualified_struct_id);
-                            access_error(
-                                env,
-                                &fun_env.get_id_loc(),
-                                id,
-                                "packed",
-                                format!("pack of `{}`", struct_env.get_full_name_str(),),
-                                &struct_env.module_env,
-                            );
-                        }
+                        let qualified_struct_id = mid.qualified(*sid);
+                        let struct_env = env.get_struct(qualified_struct_id);
+                        let msg_maker = || format!("pack of `{}`", struct_env.get_full_name_str());
+                        check_for_access_error_or_warning(
+                            env,
+                            fun_env,
+                            id,
+                            "packed",
+                            msg_maker,
+                            &struct_env.module_env,
+                            *mid != caller_module_id,
+                            caller_is_inline_non_private,
+                        );
                     },
                     _ => {
                         // all the other operations are either:
@@ -318,17 +373,19 @@ fn check_privileged_operations_on_structs(env: &GlobalEnv, fun_env: &FunctionEnv
                     pat.visit_pre_post(&mut |_, pat| {
                         if let Pattern::Struct(id, str, _, _) = pat {
                             let module_id = str.module_id;
-                            if module_id != caller_module_id {
-                                let struct_env = env.get_struct(str.to_qualified_id());
-                                access_error(
-                                    env,
-                                    &fun_env.get_id_loc(),
-                                    id,
-                                    "unpacked",
-                                    format!("unpack of `{}`", struct_env.get_full_name_str(),),
-                                    &struct_env.module_env,
-                                );
-                            }
+                            let struct_env = env.get_struct(str.to_qualified_id());
+                            let msg_maker =
+                                || format!("unpack of `{}`", struct_env.get_full_name_str(),);
+                            check_for_access_error_or_warning(
+                                env,
+                                fun_env,
+                                id,
+                                "unpacked",
+                                msg_maker,
+                                &struct_env.module_env,
+                                module_id != caller_module_id,
+                                caller_is_inline_non_private,
+                            );
                         }
                     });
                 },
@@ -337,18 +394,20 @@ fn check_privileged_operations_on_structs(env: &GlobalEnv, fun_env: &FunctionEnv
                     if let Type::Struct(mid, sid, _) =
                         env.get_node_type(discriminator_node_id).drop_reference()
                     {
-                        if mid != caller_module_id {
-                            let qualified_struct_id = mid.qualified(sid);
-                            let struct_env = env.get_struct(qualified_struct_id);
-                            access_error(
-                                env,
-                                &fun_env.get_id_loc(),
-                                &discriminator_node_id,
-                                "matched",
-                                format!("match on enum type `{}`", struct_env.get_full_name_str()),
-                                &struct_env.module_env,
-                            );
-                        }
+                        let qualified_struct_id = mid.qualified(sid);
+                        let struct_env = env.get_struct(qualified_struct_id);
+                        let msg_maker =
+                            || format!("match on enum type `{}`", struct_env.get_full_name_str(),);
+                        check_for_access_error_or_warning(
+                            env,
+                            fun_env,
+                            &discriminator_node_id,
+                            "matched",
+                            msg_maker,
+                            &struct_env.module_env,
+                            mid != caller_module_id,
+                            caller_is_inline_non_private,
+                        );
                     }
                 },
                 ExpData::Invalid(_)
@@ -398,6 +457,7 @@ pub fn check_access_and_use(env: &mut GlobalEnv, before_inlining: bool) {
             for caller_func in caller_module.get_functions() {
                 if !before_inlining {
                     check_privileged_operations_on_structs(env, &caller_func);
+                    check_inline_function_bodies_for_calls(env, &caller_func);
                 }
                 let caller_qfid = caller_func.get_qualified_id();
 
@@ -549,6 +609,135 @@ pub fn check_access_and_use(env: &mut GlobalEnv, before_inlining: bool) {
                 }
             }
         }
+    }
+}
+
+/// Check the body of inline functions (after inlining) to ensure they do not call
+/// inaccessible functions.
+fn check_inline_function_bodies_for_calls(env: &GlobalEnv, caller_func: &FunctionEnv) {
+    if !caller_func.is_inline() {
+        return;
+    }
+    let Some(def) = caller_func.get_def() else {
+        return;
+    };
+    let caller_visibility = caller_func.visibility();
+    if caller_visibility == Visibility::Private {
+        // if caller is private inline function, it can only be called from the same module
+        return;
+    }
+    let callees_with_sites = def.used_funs_with_uses();
+    for (callee, sites) in &callees_with_sites {
+        let callee_func = env.get_function(*callee);
+        let callee_visibility = callee_func.visibility();
+        let warn_info = match (caller_visibility, callee_visibility) {
+            (_, Visibility::Public) => {
+                // callee can be called from anywhere, so nothing to warn about
+                None
+            },
+            (Visibility::Public, _) => Some("".to_string()),
+            (Visibility::Friend, Visibility::Private) => {
+                let caller_module = &caller_func.module_env;
+                Some(format!(
+                    ", such as in a {}friend module of `{}`",
+                    if caller_module.has_no_friends() {
+                        "(future) "
+                    } else {
+                        ""
+                    },
+                    caller_module.get_full_name_str()
+                ))
+            },
+            (Visibility::Friend, Visibility::Friend) => {
+                match (
+                    caller_func.has_package_visibility(),
+                    callee_func.has_package_visibility(),
+                ) {
+                    (_, true) => {
+                        // TODO(#13745): fix when we can explicitly say if two modules are in the same package.
+                        let same_package = callee_func.module_env.is_primary_target()
+                            && callee_func.module_env.self_address()
+                                == caller_func.module_env.self_address();
+                        if !same_package {
+                            Some("".to_string())
+                        } else {
+                            // caller and callee are in the same package, caller can only be called from
+                            // friend contexts, so callee (package function) can also be called there.
+                            None
+                        }
+                    },
+                    (true, false) => Some(format!(
+                        ", such as from a module in this package that is not a friend of `{}`",
+                        callee_func.module_env.get_full_name_str()
+                    )),
+                    (false, false) => {
+                        let caller_friends = caller_func.module_env.get_friend_modules();
+                        let callee_friends = callee_func.module_env.get_friend_modules();
+                        let covered = caller_friends.difference(&callee_friends).next().is_none();
+                        if !covered {
+                            Some(format!(
+                                ", such as from a module that is a friend of `{}` but not a friend of `{}`",
+                                caller_func.module_env.get_full_name_str(),
+                                callee_func.module_env.get_full_name_str()
+                            ))
+                        } else {
+                            // all of caller's friends are also callee's friends, so no warning
+                            None
+                        }
+                    },
+                }
+            },
+            (Visibility::Private, _) => {
+                unreachable!("we return early")
+            },
+        };
+        if let Some(additional_context) = warn_info {
+            // We use just one call site as the warning label.
+            let label: Vec<_> = sites
+                    .first()
+                    .map(|node_id| {
+                        (
+                            env.get_node_loc(*node_id),
+                            format!(
+                                "inline expansion calls {} function that may not be accessible in all locations that `{}` can be called",
+                                function_visibility_description(&callee_func),
+                                caller_func.get_full_name_str()
+                            ),
+                        )
+                    })
+                    .iter()
+                    .cloned()
+                    .collect::<Vec<(Loc, String)>>();
+            env.diag_with_primary_and_labels(
+                Severity::Warning,
+                &caller_func.get_id_loc(),
+                &format!(
+                    "{} inline function `{}` cannot be called from all locations it is accessible",
+                    function_visibility_description(caller_func),
+                    caller_func.get_name_str()
+                ),
+                &format!(
+                    "if called from a location where `{}` is not accessible{}",
+                    callee_func.get_full_name_str(),
+                    additional_context
+                ),
+                label,
+            );
+        }
+    }
+}
+
+fn function_visibility_description(func: &FunctionEnv) -> String {
+    match func.visibility() {
+        Visibility::Public => "public".to_string(),
+        Visibility::Friend => {
+            if func.has_package_visibility() {
+                "package".to_string()
+            } else {
+                "friend".to_string()
+            }
+        },
+        Visibility::Private => "private".to_string(),
     }
 }
 

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
@@ -38,9 +38,13 @@
 //!   `Lambda`.
 
 use super::lambda_lifter::{LambdaLifter, LambdaLiftingOptions};
-use crate::env_pipeline::{
-    rewrite_target::{RewriteState, RewriteTarget, RewriteTargets, RewritingScope},
-    spec_rewriter::run_spec_rewriter_inline,
+use crate::{
+    env_pipeline::{
+        rewrite_target::{RewriteState, RewriteTarget, RewriteTargets, RewritingScope},
+        spec_rewriter::run_spec_rewriter_inline,
+    },
+    experiments::Experiment,
+    options::Options,
 };
 use codespan_reporting::diagnostic::Severity;
 use itertools::Itertools;
@@ -77,10 +81,10 @@ pub fn run_inlining(
     keep_inline_functions: bool,
     lift_inline_funs: bool,
 ) {
-    // Get non-inline function roots for running inlining.
-    // Also generate an error for any target inline functions lacking a body to inline.
+    // Get function roots for running inlining.
+    // Also generate errors for any invalid target inline functions.
     let mut targets = RewriteTargets::create(env, scope);
-    filter_targets(env, &mut targets);
+    check_and_maybe_filter_targets(env, &mut targets);
     let mut todo: BTreeSet<_> = targets.keys().collect();
 
     // Only look for inlining sites if we have targets to inline into.
@@ -151,10 +155,13 @@ pub fn run_inlining(
     }
 }
 
-/// Filter out inline functions from targets since we only process them when they are
-/// called from other functions. While we're iterating, produce an error
-/// on every inline function lacking a body to inline.
-fn filter_targets(env: &GlobalEnv, targets: &mut RewriteTargets) {
+/// Check that inline functions are (1) not native, (2) have a body (3) are not in a script.
+/// Filter out inline functions from the targets if `Experiment::SKIP_INLINING_INLINE_FUNS` is on.
+fn check_and_maybe_filter_targets(env: &GlobalEnv, targets: &mut RewriteTargets) {
+    let keep_inline_functions = !env
+        .get_extension::<Options>()
+        .unwrap_or_default()
+        .experiment_on(Experiment::SKIP_INLINING_INLINE_FUNS);
     targets.filter(|target: &RewriteTarget, _| {
         if let RewriteTarget::MoveFun(fnid) = target {
             let func = env.get_function(*fnid);
@@ -173,11 +180,19 @@ fn filter_targets(env: &GlobalEnv, targets: &mut RewriteTargets) {
                         env.diag(Severity::Bug, &func_loc, &msg);
                     }
                 }
-                false
+                if func.module_env.is_script_module() {
+                    env.error(
+                        &func.get_id_loc(),
+                        "inline function cannot be defined in a script",
+                    );
+                }
+                keep_inline_functions
             } else {
+                // not an inline function
                 true
             }
         } else {
+            // not a move function
             true
         }
     });

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -193,6 +193,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(false),
         },
         Experiment {
+            name: Experiment::SKIP_INLINING_INLINE_FUNS.to_string(),
+            description: "Whether to skip inlining the (standalone) inline functions".to_string(),
+            default: Given(false),
+        },
+        Experiment {
             name: Experiment::AST_SIMPLIFY.to_string(),
             description: "Whether to run the ast simplifier".to_string(),
             default: Inherited(Experiment::OPTIMIZE.to_string()),
@@ -298,6 +303,7 @@ impl Experiment {
     pub const REFERENCE_SAFETY_V3: &'static str = "reference-safety-v3";
     pub const SEQS_IN_BINOPS_CHECK: &'static str = "seqs-in-binops-check";
     pub const SKIP_BAILOUT_ON_EXTENDED_CHECKS: &'static str = "skip-bailout-on-extended-checks";
+    pub const SKIP_INLINING_INLINE_FUNS: &'static str = "skip-inlining-inline-funs";
     pub const SPEC_CHECK: &'static str = "spec-check";
     pub const SPEC_REWRITE: &'static str = "spec-rewrite";
     pub const SPLIT_CRITICAL_EDGES: &'static str = "split-critical-edges";

--- a/third_party/move/move-compiler-v2/tests/ability-check/resources.move
+++ b/third_party/move/move-compiler-v2/tests/ability-check/resources.move
@@ -2,7 +2,7 @@ module 0x42::M {
 
     struct R has key { f: u64 }
 
-    public inline fun my_borrow(): &R {
+    inline fun my_borrow(): &R {
         borrow_global<R>(@0x42)
     }
 

--- a/third_party/move/move-compiler-v2/tests/acquires-checker/resources_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/acquires-checker/resources_invalid.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+warning: access of the field `addr` on type `objects::ReaderRef` can only be done within the defining module `0x42::objects`, but `objects::reader` could be called (and expanded) outside the module
+  ┌─ tests/acquires-checker/resources_invalid.move:7:23
+  │
+7 │     public inline fun reader<T: key>(ref: &ReaderRef<T>): &T {
+  │                       ^^^^^^
+8 │         borrow_global<T>(ref.addr)
+  │                          -------- accessed here
+
 error: Invalid operation: access of the field `addr` on type `objects::ReaderRef` can only be done within the defining module `0x42::objects`
    ┌─ tests/acquires-checker/resources_invalid.move:17:16
    │

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/unused_inline_fun.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/unused_inline_fun.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: Currently, a function-typed parameter to an inline function must be a literal lambda expression
+  ┌─ tests/checking-lang-v1/unused_inline_fun.move:7:17
+  │
+7 │         another(f)
+  │                 ^

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v1/unused_inline_fun.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v1/unused_inline_fun.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    inline fun another(f: ||u64): u64 {
+        f()
+    }
+
+    public inline fun apply(f: ||u64): u64 {
+        another(f)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/lambda_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/lambda_typed.exp
@@ -57,8 +57,35 @@ module 0x42::LambdaTest2 {
           }
         }, 2)
     }
-    public inline fun inline_apply3(g: |u64|u64,c: u64): u64 {
-        Add<u64>(LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64| LambdaTest1::inline_apply(|y: u64| y, x), 3))), 4)
+    public inline fun inline_apply3(c: u64): u64 {
+        Add<u64>({
+          let (b: u64): (u64) = Tuple({
+            let (a: u64, b: u64): (u64, u64) = Tuple(c, {
+              let (b: u64): (u64) = Tuple(3);
+              {
+                let (x: u64): (u64) = Tuple(b);
+                {
+                  let (b: u64): (u64) = Tuple(x);
+                  {
+                    let (y: u64): (u64) = Tuple(b);
+                    y
+                  }
+                }
+              }
+            });
+            Mul<u64>(a, b)
+          });
+          {
+            let (a: u64, b: u64): (u64, u64) = Tuple(Add<u64>({
+              let (x: u64): (u64) = Tuple(b);
+              Add<u64>(x, 1)
+            }, 1), {
+              let (a: u64, b: u64): (u64, u64) = Tuple(3, 4);
+              Mul<u64>(a, b)
+            });
+            Mul<u64>(a, b)
+          }
+        }, 4)
     }
     public fun test_inline_lambda() {
         {
@@ -280,8 +307,27 @@ module 0x42::LambdaTest2 {
             a * b
         } + 2
     }
-    public inline fun inline_apply3(g: |u64|u64, c: u64): u64 {
-        LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x| LambdaTest1::inline_apply(|y| y, x), 3))) + 4
+    public inline fun inline_apply3(c: u64): u64 {
+        {
+            let (b) = ({
+                let (a,b) = (c, {
+                    let (b) = (3);
+                    let (x) = (b);
+                    let (b) = (x);
+                    let (y) = (b);
+                    y
+                });
+                a * b
+            });
+            let (a,b) = ({
+                let (x) = (b);
+                x + 1
+            } + 1, {
+                let (a,b) = (3, 4);
+                a * b
+            });
+            a * b
+        } + 4
     }
     public fun test_inline_lambda() {
         let v = vector[1, 2, 3];

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/lambda_typed.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/lambda_typed.move
@@ -34,8 +34,8 @@ module 0x42::LambdaTest2 {
 	LambdaTest1::inline_apply1(|z: u64|z, g(LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64|x, 3)))) + 2
     }
 
-    public inline fun inline_apply3(g: |u64|u64, c: u64) : u64 {
-	LambdaTest1::inline_apply1(g,
+    public inline fun inline_apply3(c: u64) : u64 {
+	LambdaTest1::inline_apply1(|x| x+1,
 	    LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x:u64| {
 		LambdaTest1::inline_apply(|y: u64|y, x)
 	    },

--- a/third_party/move/move-compiler-v2/tests/checking/friends/bug_16668.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/friends/bug_16668.exp
@@ -1,3 +1,24 @@
+
+Diagnostics:
+warning: public inline function `outer` cannot be called from all locations it is accessible
+  ┌─ tests/checking/friends/bug_16668.move:6:23
+  │
+6 │     public inline fun outer(): u64 {
+  │                       ^^^^^ if called from a location where `m::package_inner` is not accessible
+7 │         package_inner() + package_inner()
+  │         --------------- inline expansion calls package function that may not be accessible in all locations that `m::outer` can be called
+
+warning: public inline function `outer_2` cannot be called from all locations it is accessible
+   ┌─ tests/checking/friends/bug_16668.move:10:23
+   │
+ 7 │         package_inner() + package_inner()
+   │         --------------- inline expansion calls package function that may not be accessible in all locations that `m::outer_2` can be called
+   ·
+10 │     public inline fun outer_2(): u64 {
+   │                       ^^^^^^^ if called from a location where `m::package_inner` is not accessible
+11 │         outer() + outer()
+   │         ------- from a call inlined at this callsite
+
 // -- Model dump before first bytecode pipeline
 module 0xc0ffee::m {
     public inline fun outer(): u64 {

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg_inline.exp
@@ -10,3 +10,19 @@ error: missing acquires annotation for `Test`
    ·
 11 │         borrow_global_mut<Test>(@0xcafe).value = 2;
    │         -------------------------------- acquired here
+
+warning: storage operation on type `test::Test` can only be done within the defining module `0x42::test`, but `test::modify` could be called (and expanded) outside the module
+   ┌─ tests/checking/inlining/acquires_error_msg_inline.move:10:23
+   │
+10 │     public inline fun modify() acquires Test {
+   │                       ^^^^^^
+11 │         borrow_global_mut<Test>(@0xcafe).value = 2;
+   │         -------------------------------- called here
+
+warning: access of the field `value` on type `test::Test` can only be done within the defining module `0x42::test`, but `test::modify` could be called (and expanded) outside the module
+   ┌─ tests/checking/inlining/acquires_error_msg_inline.move:10:23
+   │
+10 │     public inline fun modify() acquires Test {
+   │                       ^^^^^^
+11 │         borrow_global_mut<Test>(@0xcafe).value = 2;
+   │         -------------------------------------- accessed here

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.exp
@@ -57,8 +57,35 @@ module 0x42::LambdaTest2 {
           }
         }, 2)
     }
-    public inline fun inline_apply3(g: |u64|u64,c: u64): u64 {
-        Add<u64>(LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64| LambdaTest1::inline_apply(|y: u64| y, x), 3))), 4)
+    public inline fun inline_apply3(c: u64): u64 {
+        Add<u64>({
+          let (b: u64): (u64) = Tuple({
+            let (a: u64, b: u64): (u64, u64) = Tuple(c, {
+              let (b: u64): (u64) = Tuple(3);
+              {
+                let (x: u64): (u64) = Tuple(b);
+                {
+                  let (b: u64): (u64) = Tuple(x);
+                  {
+                    let (y: u64): (u64) = Tuple(b);
+                    y
+                  }
+                }
+              }
+            });
+            Mul<u64>(a, b)
+          });
+          {
+            let (a: u64, b: u64): (u64, u64) = Tuple(Add<u64>({
+              let (x: u64): (u64) = Tuple(b);
+              Add<u64>(x, 1)
+            }, 1), {
+              let (a: u64, b: u64): (u64, u64) = Tuple(3, 4);
+              Mul<u64>(a, b)
+            });
+            Mul<u64>(a, b)
+          }
+        }, 4)
     }
     public fun test_inline_lambda() {
         {
@@ -280,8 +307,27 @@ module 0x42::LambdaTest2 {
             a * b
         } + 2
     }
-    public inline fun inline_apply3(g: |u64|u64, c: u64): u64 {
-        LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x| LambdaTest1::inline_apply(|y| y, x), 3))) + 4
+    public inline fun inline_apply3(c: u64): u64 {
+        {
+            let (b) = ({
+                let (a,b) = (c, {
+                    let (b) = (3);
+                    let (x) = (b);
+                    let (b) = (x);
+                    let (y) = (b);
+                    y
+                });
+                a * b
+            });
+            let (a,b) = ({
+                let (x) = (b);
+                x + 1
+            } + 1, {
+                let (a,b) = (3, 4);
+                a * b
+            });
+            a * b
+        } + 4
     }
     public fun test_inline_lambda() {
         let v = vector[1, 2, 3];
@@ -466,8 +512,20 @@ module 0x42::LambdaTest2 {
           }
         }, 2)
     }
-    public inline fun inline_apply3(g: |u64|u64,c: u64): u64 {
-        Add<u64>(LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64| LambdaTest1::inline_apply(|y: u64| y, x), 3))), 4)
+    public inline fun inline_apply3(c: u64): u64 {
+        Add<u64>({
+          let (b: u64): (u64) = Tuple({
+            let (a: u64, b: u64): (u64, u64) = Tuple(c, 3);
+            Mul<u64>(a, 3)
+          });
+          {
+            let (a: u64, b: u64): (u64, u64) = Tuple(Add<u64>({
+              let (x: u64): (u64) = Tuple(b);
+              Add<u64>(x, 1)
+            }, 1), 12);
+            Mul<u64>(a, 12)
+          }
+        }, 4)
     }
     public fun test_inline_lambda() {
         {

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda.move
@@ -34,8 +34,8 @@ module 0x42::LambdaTest2 {
 	LambdaTest1::inline_apply1(|z|z, g(LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x|x, 3)))) + 2
     }
 
-    public inline fun inline_apply3(g: |u64|u64, c: u64) : u64 {
-	LambdaTest1::inline_apply1(g,
+    public inline fun inline_apply3(c: u64) : u64 {
+	LambdaTest1::inline_apply1(|x| x+1,
 	    LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x| {
 		LambdaTest1::inline_apply(|y|y, x)
 	    },

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_typed.exp
@@ -57,8 +57,35 @@ module 0x42::LambdaTest2 {
           }
         }, 2)
     }
-    public inline fun inline_apply3(g: |u64|u64,c: u64): u64 {
-        Add<u64>(LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64| LambdaTest1::inline_apply(|y: u64| y, x), 3))), 4)
+    public inline fun inline_apply3(c: u64): u64 {
+        Add<u64>({
+          let (b: u64): (u64) = Tuple({
+            let (a: u64, b: u64): (u64, u64) = Tuple(c, {
+              let (b: u64): (u64) = Tuple(3);
+              {
+                let (x: u64): (u64) = Tuple(b);
+                {
+                  let (b: u64): (u64) = Tuple(x);
+                  {
+                    let (y: u64): (u64) = Tuple(b);
+                    y
+                  }
+                }
+              }
+            });
+            Mul<u64>(a, b)
+          });
+          {
+            let (a: u64, b: u64): (u64, u64) = Tuple(Add<u64>({
+              let (x: u64): (u64) = Tuple(b);
+              Add<u64>(x, 1)
+            }, 1), {
+              let (a: u64, b: u64): (u64, u64) = Tuple(3, 4);
+              Mul<u64>(a, b)
+            });
+            Mul<u64>(a, b)
+          }
+        }, 4)
     }
     public fun test_inline_lambda() {
         {
@@ -280,8 +307,27 @@ module 0x42::LambdaTest2 {
             a * b
         } + 2
     }
-    public inline fun inline_apply3(g: |u64|u64, c: u64): u64 {
-        LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x| LambdaTest1::inline_apply(|y| y, x), 3))) + 4
+    public inline fun inline_apply3(c: u64): u64 {
+        {
+            let (b) = ({
+                let (a,b) = (c, {
+                    let (b) = (3);
+                    let (x) = (b);
+                    let (b) = (x);
+                    let (y) = (b);
+                    y
+                });
+                a * b
+            });
+            let (a,b) = ({
+                let (x) = (b);
+                x + 1
+            } + 1, {
+                let (a,b) = (3, 4);
+                a * b
+            });
+            a * b
+        } + 4
     }
     public fun test_inline_lambda() {
         let v = vector[1, 2, 3];
@@ -466,8 +512,20 @@ module 0x42::LambdaTest2 {
           }
         }, 2)
     }
-    public inline fun inline_apply3(g: |u64|u64,c: u64): u64 {
-        Add<u64>(LambdaTest1::inline_apply1(g, LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64| LambdaTest1::inline_apply(|y: u64| y, x), 3))), 4)
+    public inline fun inline_apply3(c: u64): u64 {
+        Add<u64>({
+          let (b: u64): (u64) = Tuple({
+            let (a: u64, b: u64): (u64, u64) = Tuple(c, 3);
+            Mul<u64>(a, 3)
+          });
+          {
+            let (a: u64, b: u64): (u64, u64) = Tuple(Add<u64>({
+              let (x: u64): (u64) = Tuple(b);
+              Add<u64>(x, 1)
+            }, 1), 12);
+            Mul<u64>(a, 12)
+          }
+        }, 4)
     }
     public fun test_inline_lambda() {
         {

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_typed.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/lambda_typed.move
@@ -34,8 +34,8 @@ module 0x42::LambdaTest2 {
 	LambdaTest1::inline_apply1(|z: u64|z, g(LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x: u64|x, 3)))) + 2
     }
 
-    public inline fun inline_apply3(g: |u64|u64, c: u64) : u64 {
-	LambdaTest1::inline_apply1(g,
+    public inline fun inline_apply3(c: u64) : u64 {
+	LambdaTest1::inline_apply1(|x|x+1,
 	    LambdaTest1::inline_mul(c, LambdaTest1::inline_apply(|x:u64| {
 		LambdaTest1::inline_apply(|y: u64|y, x)
 	    },

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/private_call.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/private_call.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+warning: public inline function `foo` cannot be called from all locations it is accessible
+  ┌─ tests/checking/inlining/private_call.move:3:23
+  │
+3 │     public inline fun foo(): u64 {
+  │                       ^^^ if called from a location where `m::bar` is not accessible
+4 │         bar()
+  │         ----- inline expansion calls private function that may not be accessible in all locations that `m::foo` can be called
+
 error: function `0x42::m::bar` cannot be called from function `0x42::n::test` because it is private to module `0x42::m`
    ┌─ tests/checking/inlining/private_call.move:7:9
    │

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/private_call_2.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+warning: public inline function `foo` cannot be called from all locations it is accessible
+  ┌─ tests/checking/inlining/private_call_2.move:3:23
+  │
+3 │     public inline fun foo(): u64 {
+  │                       ^^^ if called from a location where `m::bar` is not accessible
+4 │         bar()
+  │         ----- inline expansion calls friend function that may not be accessible in all locations that `m::foo` can be called
+
 error: function `0x42::m::bar` cannot be called from function `0x42::n::test` because module `0x42::n` is not a `friend` of `0x42::m`
    ┌─ tests/checking/inlining/private_call_2.move:7:24
    │
@@ -14,6 +22,26 @@ error: function `0x42::m::bar` cannot be called from function `0x42::n::test` be
    ·
 25 │         assert!(o::foo() == 42, 1);
    │                 -------- from a call inlined at this callsite
+
+warning: public inline function `foo` cannot be called from all locations it is accessible
+   ┌─ tests/checking/inlining/private_call_2.move:13:23
+   │
+ 4 │         bar()
+   │         ----- inline expansion calls friend function that may not be accessible in all locations that `o::foo` can be called
+   ·
+13 │     public inline fun foo(): u64 {
+   │                       ^^^ if called from a location where `m::bar` is not accessible
+14 │         m::foo();
+   │         -------- from a call inlined at this callsite
+
+warning: public inline function `foo` cannot be called from all locations it is accessible
+   ┌─ tests/checking/inlining/private_call_2.move:13:23
+   │
+13 │     public inline fun foo(): u64 {
+   │                       ^^^ if called from a location where `o::bar` is not accessible
+14 │         m::foo();
+15 │     bar()
+   │     ----- inline expansion calls private function that may not be accessible in all locations that `o::foo` can be called
 
 error: function `0x42::o::bar` cannot be called from function `0x42::n::test` because it is private to module `0x42::o`
    ┌─ tests/checking/inlining/private_call_2.move:18:9

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/resources_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/resources_invalid.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+warning: access of the field `addr` on type `objects::ReaderRef` can only be done within the defining module `0x42::objects`, but `objects::reader` could be called (and expanded) outside the module
+  ┌─ tests/checking/inlining/resources_invalid.move:7:23
+  │
+7 │     public inline fun reader<T: key>(ref: &ReaderRef<T>): &T {
+  │                       ^^^^^^
+8 │         borrow_global<T>(ref.addr)
+  │                          -------- accessed here
+
 error: Invalid operation: access of the field `addr` on type `objects::ReaderRef` can only be done within the defining module `0x42::objects`
    ┌─ tests/checking/inlining/resources_invalid.move:17:16
    │

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/script_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/script_inline.exp
@@ -1,0 +1,7 @@
+
+Diagnostics:
+error: inline function cannot be defined in a script
+  ┌─ tests/checking/inlining/script_inline.move:2:16
+  │
+2 │     inline fun outer() {
+  │                ^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/script_inline.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/script_inline.move
@@ -1,0 +1,5 @@
+script {
+    inline fun outer() {
+        42;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking/unused/private_call_2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/unused/private_call_2.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+warning: public inline function `foo` cannot be called from all locations it is accessible
+  ┌─ tests/checking/unused/private_call_2.move:3:23
+  │
+3 │     public inline fun foo(): u64 {
+  │                       ^^^ if called from a location where `m::bar` is not accessible
+4 │         bar()
+  │         ----- inline expansion calls friend function that may not be accessible in all locations that `m::foo` can be called
+
 error: function `0x42::m::bar` cannot be called from function `0x42::n::test` because module `0x42::n` is not a `friend` of `0x42::m`
    ┌─ tests/checking/unused/private_call_2.move:7:24
    │
@@ -14,6 +22,26 @@ error: function `0x42::m::bar` cannot be called from function `0x42::n::test` be
    ·
 25 │         assert!(o::foo() == 42, 1);
    │                 -------- from a call inlined at this callsite
+
+warning: public inline function `foo` cannot be called from all locations it is accessible
+   ┌─ tests/checking/unused/private_call_2.move:13:23
+   │
+ 4 │         bar()
+   │         ----- inline expansion calls friend function that may not be accessible in all locations that `o::foo` can be called
+   ·
+13 │     public inline fun foo(): u64 {
+   │                       ^^^ if called from a location where `m::bar` is not accessible
+14 │         m::foo();
+   │         -------- from a call inlined at this callsite
+
+warning: public inline function `foo` cannot be called from all locations it is accessible
+   ┌─ tests/checking/unused/private_call_2.move:13:23
+   │
+13 │     public inline fun foo(): u64 {
+   │                       ^^^ if called from a location where `o::bar` is not accessible
+14 │         m::foo();
+15 │     bar()
+   │     ----- inline expansion calls private function that may not be accessible in all locations that `o::foo` can be called
 
 error: function `0x42::o::bar` cannot be called from function `0x42::n::test` because it is private to module `0x42::o`
    ┌─ tests/checking/unused/private_call_2.move:18:9

--- a/third_party/move/move-compiler-v2/tests/checking/visibility-checker/ok_until_inlining.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/visibility-checker/ok_until_inlining.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+warning: public inline function `foo` cannot be called from all locations it is accessible
+  ┌─ tests/checking/visibility-checker/ok_until_inlining.move:2:23
+  │
+2 │     public inline fun foo() {
+  │                       ^^^ if called from a location where `m::priv` is not accessible
+3 │         priv();
+  │         ------ inline expansion calls private function that may not be accessible in all locations that `m::foo` can be called
+
 error: function `0xc0ffee::m::priv` cannot be called from function `0xc0ffee::n::test` because it is private to module `0xc0ffee::m`
    ┌─ tests/checking/visibility-checker/ok_until_inlining.move:6:9
    │

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct.move
@@ -19,7 +19,7 @@ module 0x42::m {
         key: Key,
     }
 
-    public inline fun h<Key: store + drop>(x: E<Key>, v: |Key| E<Key>): E<Key> {
+    inline fun h<Key: store + drop>(x: E<Key>, v: |Key| E<Key>): E<Key> {
         let E { key } = x;
         v(key)
     }

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/unpack_generic_struct_typed.move
@@ -19,7 +19,7 @@ module 0x42::m {
         key: Key,
     }
 
-    public inline fun h<Key: store + drop>(x: E<Key>, v: |Key| E<Key>): E<Key> {
+    inline fun h<Key: store + drop>(x: E<Key>, v: |Key| E<Key>): E<Key> {
         let E { key } = x;
         v(key)
     }

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_01.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_01.exp
@@ -1,5 +1,22 @@
 
 Diagnostics:
+warning: pack of `m::Wrapper` can only be done within the defining module `0xc0ffee::m`, but `m::use_me_not` could be called (and expanded) outside the module
+  ┌─ tests/visibility-checker/inline_with_enums_01.move:6:23
+  │
+6 │     public inline fun use_me_not(): u64 {
+  │                       ^^^^^^^^^^
+7 │         let x = Wrapper::V1(22);
+  │                 --------------- packed here
+
+warning: access of the field `0` on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`, but `m::use_me_not` could be called (and expanded) outside the module
+  ┌─ tests/visibility-checker/inline_with_enums_01.move:6:23
+  │
+6 │     public inline fun use_me_not(): u64 {
+  │                       ^^^^^^^^^^
+7 │         let x = Wrapper::V1(22);
+8 │         x.0
+  │         --- accessed here
+
 error: Invalid operation: pack of `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
    ┌─ tests/visibility-checker/inline_with_enums_01.move:15:9
    │

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_02.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_02.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: access of the field `0` on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`, but `m::use_me_not` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/inline_with_enums_02.move:10:23
+   │
+10 │     public inline fun use_me_not(): u64 {
+   │                       ^^^^^^^^^^
+11 │         let x = make(22);
+12 │         x.0
+   │         --- accessed here
+
 error: Invalid operation: access of the field `0` on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
    ┌─ tests/visibility-checker/inline_with_enums_02.move:19:9
    │

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_03.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_enums_03.exp
@@ -1,5 +1,14 @@
 
 Diagnostics:
+warning: match on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`, but `m::use_me_not` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/inline_with_enums_03.move:10:23
+   │
+10 │     public inline fun use_me_not(): u64 {
+   │                       ^^^^^^^^^^
+11 │         let x = make(22);
+12 │         match (x) {
+   │                - matched here
+
 error: Invalid operation: match on enum type `m::Wrapper` can only be done within the defining module `0xc0ffee::m`
    ┌─ tests/visibility-checker/inline_with_enums_03.move:21:9
    │

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_01.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_01.exp
@@ -1,0 +1,93 @@
+
+Diagnostics:
+warning: public inline function `outer` cannot be called from all locations it is accessible
+   ┌─ tests/visibility-checker/inline_with_warning_01.move:14:23
+   │
+ 7 │         secret() + secret()
+   │         -------- inline expansion calls private function that may not be accessible in all locations that `m::outer` can be called
+   ·
+14 │     public inline fun outer(): u64 {
+   │                       ^^^^^ if called from a location where `m::secret` is not accessible
+15 │         inner() + inner() + some_what_inner()
+   │         ------- from a call inlined at this callsite
+
+warning: public inline function `outer` cannot be called from all locations it is accessible
+   ┌─ tests/visibility-checker/inline_with_warning_01.move:14:23
+   │
+14 │     public inline fun outer(): u64 {
+   │                       ^^^^^ if called from a location where `m::some_what_inner` is not accessible
+15 │         inner() + inner() + some_what_inner()
+   │                             ----------------- inline expansion calls friend function that may not be accessible in all locations that `m::outer` can be called
+
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    private inline fun inner(): u64 {
+        Add<u64>(m::secret(), m::secret())
+    }
+    public inline fun outer(): u64 {
+        Add<u64>(Add<u64>({
+          let (): ();
+          Add<u64>(m::secret(), m::secret())
+        }, {
+          let (): ();
+          Add<u64>(m::secret(), m::secret())
+        }), m::some_what_inner())
+    }
+    private fun secret(): u64 {
+        42
+    }
+    friend fun some_what_inner(): u64 {
+        Add<u64>(m::secret(), m::secret())
+    }
+    private fun test() {
+        if Eq<u64>({
+          let (): ();
+          Add<u64>(Add<u64>({
+            let (): ();
+            Add<u64>(m::secret(), m::secret())
+          }, {
+            let (): ();
+            Add<u64>(m::secret(), m::secret())
+          }), m::some_what_inner())
+        }, 168) {
+          Tuple()
+        } else {
+          Abort(14566554180833181696)
+        };
+        Tuple()
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    inline fun inner(): u64 {
+        secret() + secret()
+    }
+    public inline fun outer(): u64 {
+        {
+            let ();
+            secret() + secret()
+        } + {
+            let ();
+            secret() + secret()
+        } + some_what_inner()
+    }
+    fun secret(): u64 {
+        42
+    }
+    friend fun some_what_inner(): u64 {
+        secret() + secret()
+    }
+    fun test() {
+        if ({
+            let ();
+            {
+                let ();
+                secret() + secret()
+            } + {
+                let ();
+                secret() + secret()
+            } + some_what_inner()
+        } == 168) () else abort 14566554180833181696;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_01.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_01.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    fun secret(): u64 {
+        42
+    }
+
+    inline fun inner(): u64 {
+        secret() + secret()
+    }
+
+    friend fun some_what_inner(): u64 {
+        secret() + secret()
+    }
+
+    public inline fun outer(): u64 {
+        inner() + inner() + some_what_inner()
+    }
+
+    fun test() {
+        assert!(outer() == 168);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_02.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_02.exp
@@ -1,0 +1,192 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    private inline fun inner(): u64 {
+        Add<u64>(m::secret(), m::secret())
+    }
+    private inline fun outer(): u64 {
+        Add<u64>({
+          let (): ();
+          Add<u64>(m::secret(), m::secret())
+        }, {
+          let (): ();
+          Add<u64>(m::secret(), m::secret())
+        })
+    }
+    private fun secret(): u64 {
+        42
+    }
+    private fun test() {
+        if Eq<u64>({
+          let (): ();
+          Add<u64>({
+            let (): ();
+            Add<u64>(m::secret(), m::secret())
+          }, {
+            let (): ();
+            Add<u64>(m::secret(), m::secret())
+          })
+        }, 168) {
+          Tuple()
+        } else {
+          Abort(14566554180833181696)
+        };
+        Tuple()
+    }
+} // end 0xc0ffee::m
+module 0xc0ffee::n {
+    private inline fun inner(): u64 {
+        Add<u64>(n::non_secret(), n::non_secret())
+    }
+    private fun test() {
+        if Eq<u64>({
+          let (): ();
+          Add<u64>({
+            let (): ();
+            Add<u64>(n::non_secret(), n::non_secret())
+          }, {
+            let (): ();
+            Add<u64>(n::non_secret(), n::non_secret())
+          })
+        }, 168) {
+          Tuple()
+        } else {
+          Abort(14566554180833181696)
+        };
+        Tuple()
+    }
+    public fun non_secret(): u64 {
+        42
+    }
+    friend inline fun outer_friend(): u64 {
+        Add<u64>({
+          let (): ();
+          Add<u64>(n::non_secret(), n::non_secret())
+        }, {
+          let (): ();
+          Add<u64>(n::non_secret(), n::non_secret())
+        })
+    }
+} // end 0xc0ffee::n
+module 0xc0ffee::o {
+    private inline fun inner(): u64 {
+        Add<u64>(o::non_secret(), o::non_secret())
+    }
+    private fun test() {
+        if Eq<u64>({
+          let (): ();
+          Add<u64>({
+            let (): ();
+            Add<u64>(o::non_secret(), o::non_secret())
+          }, {
+            let (): ();
+            Add<u64>(o::non_secret(), o::non_secret())
+          })
+        }, 168) {
+          Tuple()
+        } else {
+          Abort(14566554180833181696)
+        };
+        Tuple()
+    }
+    public fun non_secret(): u64 {
+        42
+    }
+    friend inline fun outer_package(): u64 {
+        Add<u64>({
+          let (): ();
+          Add<u64>(o::non_secret(), o::non_secret())
+        }, {
+          let (): ();
+          Add<u64>(o::non_secret(), o::non_secret())
+        })
+    }
+} // end 0xc0ffee::o
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    inline fun inner(): u64 {
+        secret() + secret()
+    }
+    inline fun outer(): u64 {
+        {
+            let ();
+            secret() + secret()
+        } + {
+            let ();
+            secret() + secret()
+        }
+    }
+    fun secret(): u64 {
+        42
+    }
+    fun test() {
+        if ({
+            let ();
+            {
+                let ();
+                secret() + secret()
+            } + {
+                let ();
+                secret() + secret()
+            }
+        } == 168) () else abort 14566554180833181696;
+    }
+}
+module 0xc0ffee::n {
+    inline fun inner(): u64 {
+        non_secret() + non_secret()
+    }
+    fun test() {
+        if ({
+            let ();
+            {
+                let ();
+                non_secret() + non_secret()
+            } + {
+                let ();
+                non_secret() + non_secret()
+            }
+        } == 168) () else abort 14566554180833181696;
+    }
+    public fun non_secret(): u64 {
+        42
+    }
+    friend inline fun outer_friend(): u64 {
+        {
+            let ();
+            non_secret() + non_secret()
+        } + {
+            let ();
+            non_secret() + non_secret()
+        }
+    }
+}
+module 0xc0ffee::o {
+    inline fun inner(): u64 {
+        non_secret() + non_secret()
+    }
+    fun test() {
+        if ({
+            let ();
+            {
+                let ();
+                non_secret() + non_secret()
+            } + {
+                let ();
+                non_secret() + non_secret()
+            }
+        } == 168) () else abort 14566554180833181696;
+    }
+    public fun non_secret(): u64 {
+        42
+    }
+    friend inline fun outer_package(): u64 {
+        {
+            let ();
+            non_secret() + non_secret()
+        } + {
+            let ();
+            non_secret() + non_secret()
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_02.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_02.move
@@ -1,0 +1,59 @@
+module 0xc0ffee::m {
+    fun secret(): u64 {
+        42
+    }
+
+    inline fun inner(): u64 {
+        secret() + secret()
+    }
+
+    inline fun outer(): u64 {
+        // private inline function calling private function
+        // should be okay
+        inner() + inner()
+    }
+
+    fun test() {
+        assert!(outer() == 168);
+    }
+}
+
+module 0xc0ffee::n {
+    public fun non_secret(): u64 {
+        42
+    }
+
+    inline fun inner(): u64 {
+        non_secret() + non_secret()
+    }
+
+    public(friend) inline fun outer_friend(): u64 {
+        // public(friend) inline function eventually calling public function
+        // should be okay
+        inner() + inner()
+    }
+
+    fun test() {
+        assert!(outer_friend() == 168);
+    }
+}
+
+module 0xc0ffee::o {
+    public fun non_secret(): u64 {
+        42
+    }
+
+    inline fun inner(): u64 {
+        non_secret() + non_secret()
+    }
+
+    package inline fun outer_package(): u64 {
+        // package inline function eventually calling public function
+        // should be okay
+        inner() + inner()
+    }
+
+    fun test() {
+        assert!(outer_package() == 168);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_03.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_03.exp
@@ -1,0 +1,158 @@
+
+Diagnostics:
+warning: friend inline function `foo` cannot be called from all locations it is accessible
+   ┌─ tests/visibility-checker/inline_with_warning_03.move:12:31
+   │
+ 9 │         secret() + secret()
+   │         -------- inline expansion calls private function that may not be accessible in all locations that `m::foo` can be called
+   ·
+12 │     public(friend) inline fun foo(): u64 {
+   │                               ^^^ if called from a location where `m::secret` is not accessible, such as in a friend module of `0xc0ffee::m`
+13 │         blah() + blah()
+   │         ------ from a call inlined at this callsite
+
+warning: friend inline function `foo` cannot be called from all locations it is accessible
+   ┌─ tests/visibility-checker/inline_with_warning_03.move:32:31
+   │
+29 │         secret() + secret()
+   │         -------- inline expansion calls private function that may not be accessible in all locations that `o::foo` can be called
+   ·
+32 │     public(friend) inline fun foo(): u64 {
+   │                               ^^^ if called from a location where `o::secret` is not accessible, such as in a (future) friend module of `0xc0ffee::o`
+33 │         blah() + blah()
+   │         ------ from a call inlined at this callsite
+
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    private inline fun blah(): u64 {
+        Add<u64>(m::secret(), m::secret())
+    }
+    friend inline fun foo(): u64 {
+        Add<u64>({
+          let (): ();
+          Add<u64>(m::secret(), m::secret())
+        }, {
+          let (): ();
+          Add<u64>(m::secret(), m::secret())
+        })
+    }
+    private fun secret(): u64 {
+        42
+    }
+    private fun test() {
+        if Eq<u64>({
+          let (): ();
+          Add<u64>({
+            let (): ();
+            Add<u64>(m::secret(), m::secret())
+          }, {
+            let (): ();
+            Add<u64>(m::secret(), m::secret())
+          })
+        }, 168) {
+          Tuple()
+        } else {
+          Abort(14566554180833181696)
+        };
+        Tuple()
+    }
+} // end 0xc0ffee::m
+module 0xc0ffee::n {
+} // end 0xc0ffee::n
+module 0xc0ffee::o {
+    private inline fun blah(): u64 {
+        Add<u64>(o::secret(), o::secret())
+    }
+    friend inline fun foo(): u64 {
+        Add<u64>({
+          let (): ();
+          Add<u64>(o::secret(), o::secret())
+        }, {
+          let (): ();
+          Add<u64>(o::secret(), o::secret())
+        })
+    }
+    private fun secret(): u64 {
+        42
+    }
+    private fun test() {
+        if Eq<u64>({
+          let (): ();
+          Add<u64>({
+            let (): ();
+            Add<u64>(o::secret(), o::secret())
+          }, {
+            let (): ();
+            Add<u64>(o::secret(), o::secret())
+          })
+        }, 168) {
+          Tuple()
+        } else {
+          Abort(14566554180833181696)
+        };
+        Tuple()
+    }
+} // end 0xc0ffee::o
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    friend 0xc0ffee::n;
+    inline fun blah(): u64 {
+        secret() + secret()
+    }
+    friend inline fun foo(): u64 {
+        {
+            let ();
+            secret() + secret()
+        } + {
+            let ();
+            secret() + secret()
+        }
+    }
+    fun secret(): u64 {
+        42
+    }
+    fun test() {
+        if ({
+            let ();
+            {
+                let ();
+                secret() + secret()
+            } + {
+                let ();
+                secret() + secret()
+            }
+        } == 168) () else abort 14566554180833181696;
+    }
+}
+module 0xc0ffee::n {
+}
+module 0xc0ffee::o {
+    inline fun blah(): u64 {
+        secret() + secret()
+    }
+    friend inline fun foo(): u64 {
+        {
+            let ();
+            secret() + secret()
+        } + {
+            let ();
+            secret() + secret()
+        }
+    }
+    fun secret(): u64 {
+        42
+    }
+    fun test() {
+        if ({
+            let ();
+            {
+                let ();
+                secret() + secret()
+            } + {
+                let ();
+                secret() + secret()
+            }
+        } == 168) () else abort 14566554180833181696;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_03.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_03.move
@@ -1,0 +1,39 @@
+module 0xc0ffee::m {
+    friend 0xc0ffee::n;
+
+    fun secret(): u64 {
+        42
+    }
+
+    inline fun blah(): u64 {
+        secret() + secret()
+    }
+
+    public(friend) inline fun foo(): u64 {
+        blah() + blah()
+    }
+
+    fun test() {
+        assert!(foo() == 168);
+    }
+}
+
+module 0xc0ffee::n {}
+
+module 0xc0ffee::o {
+    fun secret(): u64 {
+        42
+    }
+
+    inline fun blah(): u64 {
+        secret() + secret()
+    }
+
+    public(friend) inline fun foo(): u64 {
+        blah() + blah()
+    }
+
+    fun test() {
+        assert!(foo() == 168);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_04.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_04.exp
@@ -1,0 +1,34 @@
+
+Diagnostics:
+warning: package inline function `blah` cannot be called from all locations it is accessible
+  ┌─ tests/visibility-checker/inline_with_warning_04.move:2:24
+  │
+2 │     package inline fun blah(): u64 {
+  │                        ^^^^ if called from a location where `n::foo` is not accessible, such as from a module in this package that is not a friend of `0xdeadbeef::n`
+3 │         0xdeadbeef::n::foo()
+  │         -------------------- inline expansion calls friend function that may not be accessible in all locations that `m::blah` can be called
+
+// -- Model dump before first bytecode pipeline
+module 0xdeadbeef::n {
+    friend fun foo(): u64 {
+        42
+    }
+} // end 0xdeadbeef::n
+module 0xdeadbeef::m {
+    friend inline fun blah(): u64 {
+        n::foo()
+    }
+} // end 0xdeadbeef::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xdeadbeef::n {
+    friend 0xdeadbeef::m;
+    friend fun foo(): u64 {
+        42
+    }
+}
+module 0xdeadbeef::m {
+    friend inline fun blah(): u64 {
+        0xdeadbeef::n::foo()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_04.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_04.move
@@ -1,0 +1,13 @@
+module 0xdeadbeef::m {
+    package inline fun blah(): u64 {
+        0xdeadbeef::n::foo()
+    }
+}
+
+module 0xdeadbeef::n {
+    friend 0xdeadbeef::m;
+
+    public(friend) fun foo(): u64 {
+        42
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_05.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_05.exp
@@ -1,0 +1,45 @@
+
+Diagnostics:
+warning: friend inline function `bar` cannot be called from all locations it is accessible
+   ┌─ tests/visibility-checker/inline_with_warning_05.move:12:31
+   │
+12 │     public(friend) inline fun bar(): u64 {
+   │                               ^^^ if called from a location where `m::foo` is not accessible, such as from a module that is a friend of `0xc0ffee::n` but not a friend of `0xc0ffee::m`
+13 │         0xc0ffee::m::foo() + 0xc0ffee::m::foo()
+   │         ------------------ inline expansion calls friend function that may not be accessible in all locations that `n::bar` can be called
+
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    friend fun foo(): u64 {
+        42
+    }
+} // end 0xc0ffee::m
+module 0xc0ffee::n {
+    friend inline fun bar(): u64 {
+        Add<u64>(m::foo(), m::foo())
+    }
+} // end 0xc0ffee::n
+module 0xc0ffee::o {
+    private fun test(): u64 {
+        42
+    }
+} // end 0xc0ffee::o
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    friend 0xc0ffee::n;
+    friend fun foo(): u64 {
+        42
+    }
+}
+module 0xc0ffee::n {
+    friend 0xc0ffee::o;
+    friend inline fun bar(): u64 {
+        0xc0ffee::m::foo() + 0xc0ffee::m::foo()
+    }
+}
+module 0xc0ffee::o {
+    fun test(): u64 {
+        42
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_05.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_05.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    friend 0xc0ffee::n;
+
+    public(friend) fun foo(): u64 {
+        42
+    }
+}
+
+module 0xc0ffee::n {
+    friend 0xc0ffee::o;
+
+    public(friend) inline fun bar(): u64 {
+        0xc0ffee::m::foo() + 0xc0ffee::m::foo()
+    }
+}
+
+module 0xc0ffee::o {
+    fun test(): u64 {
+        42
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_06.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_06.exp
@@ -1,0 +1,36 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    friend fun foo(): u64 {
+        42
+    }
+} // end 0xc0ffee::m
+module 0xc0ffee::n {
+    friend inline fun bar(): u64 {
+        Add<u64>(m::foo(), m::foo())
+    }
+} // end 0xc0ffee::n
+module 0xc0ffee::o {
+    private fun test(): u64 {
+        42
+    }
+} // end 0xc0ffee::o
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    friend 0xc0ffee::n;
+    friend 0xc0ffee::o;
+    friend fun foo(): u64 {
+        42
+    }
+}
+module 0xc0ffee::n {
+    friend 0xc0ffee::o;
+    friend inline fun bar(): u64 {
+        0xc0ffee::m::foo() + 0xc0ffee::m::foo()
+    }
+}
+module 0xc0ffee::o {
+    fun test(): u64 {
+        42
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_06.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_06.move
@@ -1,0 +1,24 @@
+module 0xc0ffee::m {
+    friend 0xc0ffee::n;
+    friend 0xc0ffee::o;
+
+    public(friend) fun foo(): u64 {
+        42
+    }
+}
+
+module 0xc0ffee::n {
+    friend 0xc0ffee::o;
+
+    // no warning: all locations where this can be called (module `o`)
+    // can also call `m::foo`
+    public(friend) inline fun bar(): u64 {
+        0xc0ffee::m::foo() + 0xc0ffee::m::foo()
+    }
+}
+
+module 0xc0ffee::o {
+    fun test(): u64 {
+        42
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_07.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_07.exp
@@ -1,0 +1,138 @@
+
+Diagnostics:
+warning: unpack of `m::W` can only be done within the defining module `0xc0ffee::m`, but `m::destroy1` could be called (and expanded) outside the module
+  ┌─ tests/visibility-checker/inline_with_warning_07.move:4:23
+  │
+4 │     public inline fun destroy1(w: W) {
+  │                       ^^^^^^^^
+5 │         let W(_) = w;
+  │             ---- unpacked here
+
+warning: unpack of `m::W` can only be done within the defining module `0xc0ffee::m`, but `m::destroy2` could be called (and expanded) outside the module
+  ┌─ tests/visibility-checker/inline_with_warning_07.move:8:24
+  │
+8 │     package inline fun destroy2(w: W) {
+  │                        ^^^^^^^^
+9 │         let W(_) = w;
+  │             ---- unpacked here
+
+warning: access of the field `0` on type `m::W` can only be done within the defining module `0xc0ffee::m`, but `m::get_field` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/inline_with_warning_07.move:12:23
+   │
+12 │     public inline fun get_field(w: W): u64 {
+   │                       ^^^^^^^^^
+13 │         w.0
+   │         --- accessed here
+
+warning: match on enum type `n::E` can only be done within the defining module `0xc0ffee::n`, but `n::fetch` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/inline_with_warning_07.move:23:31
+   │
+23 │     public(friend) inline fun fetch(e: E): u64 {
+   │                               ^^^^^
+24 │         match (e) {
+   │                - matched here
+
+warning: storage operation on type `o::R` can only be done within the defining module `0xc0ffee::o`, but `o::my_borrow` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/inline_with_warning_07.move:38:23
+   │
+38 │     public inline fun my_borrow(): &R {
+   │                       ^^^^^^^^^
+39 │         borrow_global<R>(@0xc0ffee)
+   │         --------------------------- called here
+
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    struct W {
+        0: u64,
+    }
+    public inline fun destroy1(w: W) {
+        {
+          let m::W{ 0: _ } = w;
+          Tuple()
+        }
+    }
+    friend inline fun destroy2(w: W) {
+        {
+          let m::W{ 0: _ } = w;
+          Tuple()
+        }
+    }
+    public inline fun get_field(w: W): u64 {
+        select m::W.0<W>(w)
+    }
+} // end 0xc0ffee::m
+module 0xc0ffee::n {
+    enum E {
+        A {
+            0: u64,
+        }
+        B {
+            0: u64,
+        }
+    }
+    friend inline fun fetch(e: E): u64 {
+        match (e) {
+          n::E::A{ 0: x } => {
+            x
+          }
+          n::E::B{ 0: x } => {
+            x
+          }
+        }
+
+    }
+    private inline fun no_warn(): E {
+        pack n::E::A(0)
+    }
+} // end 0xc0ffee::n
+module 0xc0ffee::o {
+    struct R {
+        f: u64,
+    }
+    public inline fun my_borrow(): &R {
+        BorrowGlobal(Immutable)<R>(0xc0ffee)
+    }
+} // end 0xc0ffee::o
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    struct W {
+        0: u64,
+    }
+    public inline fun destroy1(w: W) {
+        let W(_) = w;
+    }
+    friend inline fun destroy2(w: W) {
+        let W(_) = w;
+    }
+    public inline fun get_field(w: W): u64 {
+        w.0
+    }
+}
+module 0xc0ffee::n {
+    enum E {
+        A {
+            0: u64,
+        }
+        B {
+            0: u64,
+        }
+    }
+    friend inline fun fetch(e: E): u64 {
+        match (e) {
+            E::A(x) => x,
+            E::B(x) => x,
+        }
+    }
+    inline fun no_warn(): E {
+        E::A(0)
+    }
+}
+module 0xc0ffee::o {
+    struct R has key {
+        f: u64,
+    }
+    public inline fun my_borrow(): &R {
+        borrow_global<R>(0xc0ffee)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_07.move
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/inline_with_warning_07.move
@@ -1,0 +1,41 @@
+module 0xc0ffee::m {
+    struct W(u64);
+
+    public inline fun destroy1(w: W) {
+        let W(_) = w;
+    }
+
+    package inline fun destroy2(w: W) {
+        let W(_) = w;
+    }
+
+    public inline fun get_field(w: W): u64 {
+        w.0
+    }
+}
+
+module 0xc0ffee::n {
+    enum E {
+        A(u64),
+        B(u64),
+    }
+
+    public(friend) inline fun fetch(e: E): u64 {
+        match (e) {
+            E::A(x) => x,
+            E::B(x) => x,
+        }
+    }
+
+    inline fun no_warn(): E {
+        E::A(0)
+    }
+}
+
+module 0xc0ffee::o {
+    struct R has key { f: u64 }
+
+    public inline fun my_borrow(): &R {
+        borrow_global<R>(@0xc0ffee)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/resource_operator_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/resource_operator_inline.exp
@@ -1,5 +1,61 @@
 
 Diagnostics:
+warning: storage operation on type `M::R` can only be done within the defining module `0x42::M`, but `M::inline_borrow` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/resource_operator_inline.move:13:23
+   │
+13 │     public inline fun inline_borrow(addr: address): &R {
+   │                       ^^^^^^^^^^^^^
+14 │         borrow_global<R>(addr)
+   │         ---------------------- called here
+
+warning: storage operation on type `M::R` can only be done within the defining module `0x42::M`, but `M::inline_borrow_mut` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/resource_operator_inline.move:17:23
+   │
+17 │     public inline fun inline_borrow_mut(addr: address): &R {
+   │                       ^^^^^^^^^^^^^^^^^
+18 │         borrow_global_mut<R>(addr)
+   │         -------------------------- called here
+
+warning: storage operation on type `M::R` can only be done within the defining module `0x42::M`, but `M::inline_move_to` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/resource_operator_inline.move:21:23
+   │
+21 │     public inline fun inline_move_to(account: &signer, r: R) {
+   │                       ^^^^^^^^^^^^^^
+22 │         move_to<R>(account, r)
+   │         ---------------------- called here
+
+warning: storage operation on type `M::R` can only be done within the defining module `0x42::M`, but `M::inline_move_from` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/resource_operator_inline.move:25:23
+   │
+25 │     public inline fun inline_move_from(addr: address): R {
+   │                       ^^^^^^^^^^^^^^^^
+26 │         move_from<R>(addr)
+   │         ------------------ called here
+
+warning: pack of `M::R` can only be done within the defining module `0x42::M`, but `M::inline_pack` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/resource_operator_inline.move:29:23
+   │
+29 │     public inline fun inline_pack(): R {
+   │                       ^^^^^^^^^^^
+30 │         R {}
+   │         ---- packed here
+
+warning: unpack of `M::R` can only be done within the defining module `0x42::M`, but `M::inline_unpack` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/resource_operator_inline.move:33:23
+   │
+33 │     public inline fun inline_unpack(r: R) {
+   │                       ^^^^^^^^^^^^^
+34 │         let R{} = r;
+   │             --- unpacked here
+
+warning: access of the field `r` on type `M::T` can only be done within the defining module `0x42::M`, but `M::inline_access` could be called (and expanded) outside the module
+   ┌─ tests/visibility-checker/resource_operator_inline.move:37:23
+   │
+37 │     public inline fun inline_access(t: T): R {
+   │                       ^^^^^^^^^^^^^
+38 │         t.r
+   │         --- accessed here
+
 error: Invalid operation: storage operation on type `M::R` can only be done within the defining module `0x42::M`
    ┌─ tests/visibility-checker/resource_operator_inline.move:45:9
    │

--- a/third_party/move/move-compiler-v2/tests/visibility-checker/resources_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/visibility-checker/resources_invalid.exp
@@ -1,5 +1,13 @@
 
 Diagnostics:
+warning: access of the field `addr` on type `objects::ReaderRef` can only be done within the defining module `0x42::objects`, but `objects::reader` could be called (and expanded) outside the module
+  ┌─ tests/visibility-checker/resources_invalid.move:7:23
+  │
+7 │     public inline fun reader<T: key>(ref: &ReaderRef<T>): &T {
+  │                       ^^^^^^
+8 │         borrow_global<T>(ref.addr)
+  │                          -------- accessed here
+
 error: Invalid operation: access of the field `addr` on type `objects::ReaderRef` can only be done within the defining module `0x42::objects`
    ┌─ tests/visibility-checker/resources_invalid.move:17:16
    │

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/multi_param.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/multi_param.move
@@ -14,7 +14,7 @@ module 0x42::Test {
     struct Elem<K, V> has drop { k: K, v: V }
 
     // Checks a multi-mutality scenario.
-    public inline fun elem_for_each_ref<K,V>(v: &mut vector<Elem<K,V>>, f: |&K, &mut V|u64): u64 {
+    inline fun elem_for_each_ref<K,V>(v: &mut vector<Elem<K,V>>, f: |&K, &mut V|u64): u64 {
         let result = 0;
         for_each_ref_mut(v, |elem| {
             let elem: &mut Elem<K, V> = elem; // Checks whether scoping is fine

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/resources.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/resources.move
@@ -3,7 +3,7 @@ module 0x42::M {
 
     struct R has key { f: u64 }
 
-    public inline fun my_borrow(): &R {
+    inline fun my_borrow(): &R {
         borrow_global<R>(@0x42)
     }
 

--- a/third_party/move/move-prover/tests/testsuite.rs
+++ b/third_party/move/move-prover/tests/testsuite.rs
@@ -154,8 +154,11 @@ fn test_runner_for_feature(path: &Path, feature: &Feature) -> anyhow::Result<()>
 
     let mut error_writer = Buffer::no_color();
     options.language_version = Some(LanguageVersion::latest());
-    let function_value_experiments =
-        vec![Experiment::KEEP_INLINE_FUNS, Experiment::LIFT_INLINE_FUNS];
+    let function_value_experiments = vec![
+        Experiment::KEEP_INLINE_FUNS,
+        Experiment::LIFT_INLINE_FUNS,
+        Experiment::SKIP_INLINING_INLINE_FUNS,
+    ];
     let result = run_move_prover_v2(
         &mut error_writer,
         options,


### PR DESCRIPTION
## Description

In this PR, we fix three things.

1.
Previously, if a public inline function `foo` calls a private function, but `foo` was never called outside of the module, the compiler would be silent about it:
```move
module 0xc0ffee::m {
  fun bar() {}

  public inline fun foo() {
    bar();
  }
}
```
However, this meant when eventually someone outside of the module `m` calls `foo`, they would get a compile time error.

Instead, we now warn the developer about this. Specifically, we warn the developer when an inline can be called in some context where the inline expansion might have inaccessible functions or operations on structs/enums. This would prevent the developer from releasing code with inline functions that cannot be called in all contexts it can legally be called in.

To do this, we inline expand all functions, including inline functions that may not have been called anywhere. We then check for function visibility and privileged operation on struct/enum in inline functions and produce appropriate warnings.

Note that this produces some (correct) warnings on the aptos-framework.

2.
An inline function within a script would create a compiler ICE:
```move
script {
    inline fun outer() {
        42;
    }
}
```
We now instead produce a compiler error.

3.
Inline functions that were never called could have some checks on them skipped (such as non-literal lambdas passed as arguments to inline functions). These checks are now applied on inline functions, regardless of whether they are called or not.


## How Has This Been Tested?
- Added several new tests to showcase and test the new functionality
- Fixed some existing tests, correcting the visibility or undetected bug.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
