### PR TITLE
[CI/CD] Fix cargo sort version on install.

### DIFF
--- a/.github/actions/rust-lints/action.yaml
+++ b/.github/actions/rust-lints/action.yaml
@@ -17,5 +17,5 @@ runs:
     - name: Run cargo sort and rust lint checks
       shell: bash
       run: |
-        cargo install cargo-sort
+        cargo install cargo-sort --version 1.0.7  # Fix the version to avoid unexpected changes
         scripts/rust_lint.sh --check


### PR DESCRIPTION
## Description
This PR fixes the `cargo sort` install version to `1.0.7` inside CI/CD. The latest version appears to cause some issues with our `Cargo.toml` formatting.

## Testing Plan
Existing test infrastructure.