### PR TITLE
[compiler-v2][trivial] Do not allow using inline functions as function value

### DIFF
--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16678.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16678.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: inline function cannot be used as a function value
+  ┌─ tests/bytecode-generator/bug_16678.move:7:10
+  │
+7 │         (function1)();
+  │          ^^^^^^^^^
+
+error: inline function cannot be used as a function value
+   ┌─ tests/bytecode-generator/bug_16678.move:19:17
+   │
+19 │         let f = foo;
+   │                 ^^^

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16678.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16678.move
@@ -1,0 +1,32 @@
+module 0xCAFE::Module0 {
+    public inline fun function1() {
+        (||{})();
+    }
+
+    public fun function2() {
+        (function1)();
+    }
+
+    public fun function3() {
+        function1();
+    }
+
+    public inline fun foo(x: u64): u64 {
+        x + 1
+    }
+
+    public fun negative(): u64 {
+        let f = foo;
+        f(42)
+    }
+
+    public fun positive_1(): u64 {
+        let f = || foo(42);
+        f()
+    }
+
+    public fun positive_2(): u64 {
+        let f = |x| foo(x);
+        f(42)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16679.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16679.exp
@@ -1,0 +1,19 @@
+
+Diagnostics:
+error: inline function cannot be used as a function value
+  ┌─ tests/bytecode-generator/bug_16679.move:5:10
+  │
+5 │         (function1)();
+  │          ^^^^^^^^^
+
+error: inline function cannot be used as a function value
+  ┌─ tests/bytecode-generator/bug_16679.move:9:12
+  │
+9 │         f3(function1);
+  │            ^^^^^^^^^
+
+error: inline function cannot be used as a function value
+   ┌─ tests/bytecode-generator/bug_16679.move:21:24
+   │
+21 │         let s = S { x: function1 };
+   │                        ^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16679.move
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16679.move
@@ -1,0 +1,25 @@
+module 0xCAFE::Module1 {
+    public inline fun function1() {}
+
+    public fun function2() {
+        (function1)();
+    }
+
+    public fun function3() {
+        f3(function1);
+    }
+
+    public fun f3(x: ||) {
+        x();
+    }
+
+    struct S {
+        x: ||,
+    }
+
+    public fun f4() {
+        let s = S { x: function1 };
+        let S { x } = s;
+        x();
+    }
+}

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -3683,6 +3683,10 @@ impl ExpTranslator<'_, '_, '_> {
         }
 
         if let Some(entry) = self.parent.parent.fun_table.get(&global_var_sym) {
+            if entry.kind == FunctionKind::Inline {
+                self.error(loc, "inline function cannot be used as a function value");
+                return self.new_error_exp();
+            }
             let module_id = entry.module_id;
             let fun_id = entry.fun_id;
             let result_type = entry.result_type.clone();


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds a check to forbid using inline functions as a function value.

close #16678  close #16679 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests and two new test cases.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
