### PR TITLE
[vm] Refactor function type layout

### DIFF
--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -927,7 +927,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
             MoveTypeLayout::Struct(struct_layout) => {
                 self.try_into_vm_value_struct(struct_layout, val)?
             },
-            MoveTypeLayout::Function(..) => {
+            MoveTypeLayout::Function => {
                 // TODO(#15664): do we actually need this? It appears the code here is dead and
                 //   nowhere used
                 bail!("unexpected move type {:?} for value {:?}", layout, val)

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2.data/function_values/sources/function_store.move
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2.data/function_values/sources/function_store.move
@@ -1,5 +1,5 @@
 module 0x1::function_store {
-    use aptos_framework::aggregator_v2::{Aggregator, create_unbounded_aggregator};
+    use aptos_framework::aggregator_v2::{Aggregator, create_unbounded_aggregator, try_add};
 
     struct FunctionStore has key, store {
         // Capturing aggregators, snapshots or anything that contains delayed fields is not
@@ -34,5 +34,28 @@ module 0x1::function_store {
     #[view]
     public fun view_function_store_exists(addr: address): bool {
         exists<FunctionStore>(addr)
+    }
+
+    struct FunctionStoreV2 has key, store {
+        value: u64,
+        add: |&mut Aggregator<u64>|bool has copy + store,
+    }
+
+    public entry fun try_initialize_should_succeed(account: &signer, value: u64) {
+        let add = |a| try_add(a, value);
+        move_to(account, FunctionStoreV2 { value, add });
+    }
+
+    public entry fun run_stored_add(account: &signer, value: u64) acquires FunctionStoreV2 {
+        let aggregator = create_unbounded_aggregator<u64>();
+        aggregator.add(value);
+
+        let addr = std::signer::address_of(account);
+        let store = borrow_global<FunctionStoreV2>(addr);
+
+        let stored_add = store.add;
+        let success = stored_add(&mut aggregator);
+        assert!(success, 123);
+        assert!(aggregator.read() == value + store.value, 234);
     }
 }

--- a/aptos-move/e2e-move-tests/src/tests/aggregator_v2_function_values.rs
+++ b/aptos-move/e2e-move-tests/src/tests/aggregator_v2_function_values.rs
@@ -113,6 +113,29 @@ fn test_function_value_captures_aggregator_is_not_storable() {
 }
 
 #[test]
+fn test_function_value_uses_aggregator_is_storable() {
+    let mut h = MoveHarness::new_with_executor(FakeExecutor::from_head_genesis().set_parallel());
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x123").unwrap());
+    initialize(&mut h);
+
+    let status = h.run_entry_function(
+        &acc,
+        MemberId::from_str("0x1::function_store::try_initialize_should_succeed").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&100_u64).unwrap()],
+    );
+    assert_success!(status);
+
+    let status = h.run_entry_function(
+        &acc,
+        MemberId::from_str("0x1::function_store::run_stored_add").unwrap(),
+        vec![],
+        vec![bcs::to_bytes(&200_u64).unwrap()],
+    );
+    assert_success!(status);
+}
+
+#[test]
 fn test_function_value_captures_aggregator() {
     let mut h = MoveHarness::new_with_executor(FakeExecutor::from_head_genesis().set_parallel());
     let acc = h.new_account_at(AccountAddress::from_hex_literal("0x123").unwrap());

--- a/aptos-move/framework/move-stdlib/src/natives/bcs.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/bcs.rs
@@ -199,7 +199,7 @@ fn constant_serialized_size(ty_layout: &MoveTypeLayout) -> (u64, PartialVMResult
         MoveTypeLayout::Struct(
             MoveStructLayout::RuntimeVariants(_) | MoveStructLayout::WithVariants(_),
         )
-        | MoveTypeLayout::Function(..) => Ok(None),
+        | MoveTypeLayout::Function => Ok(None),
         MoveTypeLayout::Struct(MoveStructLayout::Runtime(fields)) => {
             let mut total = Some(0);
             for field in fields {

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -358,7 +358,7 @@ fn native_format_impl(
             )?;
             out.push('}');
         },
-        MoveTypeLayout::Function(_) => {
+        MoveTypeLayout::Function => {
             // Notice that we print the undecorated value representation,
             // avoiding potential loading of the function to get full
             // decorated type information.

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/helpers.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/utils/helpers.rs
@@ -6,10 +6,7 @@
 use aptos_language_e2e_tests::{account::Account, executor::FakeExecutor};
 use arbitrary::Arbitrary;
 use move_binary_format::file_format::CompiledModule;
-use move_core_types::{
-    function::MoveFunctionLayout,
-    value::{MoveStructLayout, MoveTypeLayout},
-};
+use move_core_types::value::{MoveStructLayout, MoveTypeLayout};
 
 #[macro_export]
 macro_rules! tdbg {
@@ -71,9 +68,16 @@ pub(crate) fn is_valid_layout(layout: &MoveTypeLayout) -> bool {
     use MoveTypeLayout as L;
 
     match layout {
-        L::Bool | L::U8 | L::U16 | L::U32 | L::U64 | L::U128 | L::U256 | L::Address | L::Signer => {
-            true
-        },
+        L::Bool
+        | L::U8
+        | L::U16
+        | L::U32
+        | L::U64
+        | L::U128
+        | L::U256
+        | L::Address
+        | L::Signer
+        | L::Function => true,
 
         L::Vector(layout) | L::Native(_, layout) => is_valid_layout(layout),
         L::Struct(MoveStructLayout::RuntimeVariants(variants)) => {
@@ -84,9 +88,6 @@ pub(crate) fn is_valid_layout(layout: &MoveTypeLayout) -> bool {
                 return false;
             }
             fields.iter().all(is_valid_layout)
-        },
-        L::Function(MoveFunctionLayout(args, results, _)) => {
-            args.iter().chain(results).all(is_valid_layout)
         },
         L::Struct(_) => {
             // decorated layouts not supported

--- a/third_party/move/move-binary-format/src/constant.rs
+++ b/third_party/move/move-binary-format/src/constant.rs
@@ -40,7 +40,7 @@ fn construct_ty_for_constant(layout: &MoveTypeLayout) -> Option<SignatureToken> 
             construct_ty_for_constant(l.as_ref())?,
         ))),
         MoveTypeLayout::Struct(_) => None,
-        MoveTypeLayout::Function(_) => None,
+        MoveTypeLayout::Function => None,
         MoveTypeLayout::Bool => Some(SignatureToken::Bool),
 
         // It is not possible to have native layout for constant values.

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/storage_examples.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/storage_examples.exp
@@ -1,0 +1,4 @@
+processed 3 tasks
+
+task 2 'run'. lines 23-23:
+return values: 7

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/storage_examples.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/storage_examples.move
@@ -1,0 +1,23 @@
+//# publish
+module 0xc0ffee::m {
+    struct Wrapper(|&signer|u64) has copy, drop, store, key;
+
+    #[persistent]
+    fun foo(_s: &signer): u64 {
+        7
+    }
+
+    public fun init(s: &signer) {
+        let w = Wrapper(foo);
+        move_to(s, w)
+    }
+
+    public fun fetch_and_run(s: &signer): u64{
+        let w = borrow_global<Wrapper>(std::signer::address_of(s));
+        (w.0)(s)
+    }
+}
+
+//# run 0xc0ffee::m::init --signers 0xc0ffee
+
+//# run 0xc0ffee::m::fetch_and_run --signers 0xc0ffee

--- a/third_party/move/move-core/types/src/function.rs
+++ b/third_party/move/move-core/types/src/function.rs
@@ -4,7 +4,7 @@
 use crate::{
     ability::AbilitySet,
     identifier::Identifier,
-    language_storage::{FunctionTag, ModuleId, TypeTag},
+    language_storage::{ModuleId, TypeTag},
     value::{MoveTypeLayout, MoveValue},
 };
 use serde::{de::Error, ser::SerializeSeq, Deserialize, Serialize};
@@ -253,10 +253,9 @@ pub struct MoveClosure {
     pub captured: Vec<(MoveTypeLayout, MoveValue)>,
 }
 
-#[allow(unused)] // Currently, we do not use the expected function layout
-pub(crate) struct ClosureVisitor<'a>(pub(crate) &'a MoveFunctionLayout);
+pub(crate) struct ClosureVisitor;
 
-impl<'d> serde::de::Visitor<'d> for ClosureVisitor<'_> {
+impl<'d> serde::de::Visitor<'d> for ClosureVisitor {
     type Value = MoveClosure;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -377,55 +376,14 @@ mod serialization_tests {
         eprintln!("{:?}", blob);
         assert_eq!(
             value,
-            MoveValue::simple_deserialize(
-                &blob,
-                // The type layout is currently ignored by the serializer, so pass in some
-                // arbitrary one
-                &MoveTypeLayout::Function(MoveFunctionLayout(vec![], vec![], AbilitySet::EMPTY))
-            )
-            .expect("deserialization must succeed"),
+            MoveValue::simple_deserialize(&blob, &MoveTypeLayout::Function)
+                .expect("deserialization must succeed"),
             "deserialized value not equal to original one"
         );
     }
 }
 
 //===========================================================================================
-
-impl fmt::Display for MoveFunctionLayout {
-    fn fmt(&self, f: &mut fmt::Formatter) -> std::fmt::Result {
-        let fmt_list = |l: &[MoveTypeLayout]| {
-            l.iter()
-                .map(|t| t.to_string())
-                .collect::<Vec<_>>()
-                .join(", ")
-        };
-        let MoveFunctionLayout(args, results, abilities) = self;
-        write!(
-            f,
-            "|{}|{}{}",
-            fmt_list(args),
-            fmt_list(results),
-            abilities.display_postfix()
-        )
-    }
-}
-
-impl TryInto<FunctionTag> for &MoveFunctionLayout {
-    type Error = anyhow::Error;
-
-    fn try_into(self) -> Result<FunctionTag, Self::Error> {
-        let into_list = |ts: &[MoveTypeLayout]| {
-            ts.iter()
-                .map(|t| t.try_into())
-                .collect::<Result<Vec<TypeTag>, _>>()
-        };
-        Ok(FunctionTag {
-            args: into_list(&self.0)?,
-            results: into_list(&self.1)?,
-            abilities: self.2,
-        })
-    }
-}
 
 impl fmt::Display for MoveClosure {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/third_party/move/move-core/types/src/value.rs
+++ b/third_party/move/move-core/types/src/value.rs
@@ -9,7 +9,7 @@
 
 use crate::{
     account_address::AccountAddress,
-    function::{ClosureVisitor, MoveClosure, MoveFunctionLayout},
+    function::{ClosureVisitor, MoveClosure},
     ident_str,
     identifier::Identifier,
     language_storage::{ModuleId, StructTag, TypeTag},
@@ -267,7 +267,7 @@ pub enum MoveTypeLayout {
 
     // Added in bytecode version v8
     #[serde(rename(serialize = "fun", deserialize = "fun"))]
-    Function(MoveFunctionLayout),
+    Function,
 }
 
 impl MoveTypeLayout {
@@ -276,17 +276,6 @@ impl MoveTypeLayout {
     pub fn is_compatible_with(&self, other: &Self) -> bool {
         use MoveTypeLayout::*;
         match (self, other) {
-            (
-                Function(MoveFunctionLayout(args1, res1, ab1)),
-                Function(MoveFunctionLayout(args2, res2, ab2)),
-            ) => {
-                // Notice that (currently) the function layout is not influencing
-                // serialization, but we anyway don't want it to diverge.
-                // Notice contra-variance for arguments.
-                Self::is_compatible_with_slice(args2, args1)
-                    && Self::is_compatible_with_slice(res1, res2)
-                    && ab1.is_subset(*ab2)
-            },
             (Vector(t1), Vector(t2)) => t1.is_compatible_with(t2),
             (Struct(s1), Struct(s2)) => s1.is_compatible_with(s2),
             // For all other cases, equality is used
@@ -623,8 +612,8 @@ impl<'d> serde::de::DeserializeSeed<'d> for &MoveTypeLayout {
             },
             MoveTypeLayout::Signer => Err(D::Error::custom("cannot deserialize signer")),
             MoveTypeLayout::Struct(ty) => Ok(MoveValue::Struct(ty.deserialize(deserializer)?)),
-            MoveTypeLayout::Function(fun) => Ok(MoveValue::Closure(Box::new(
-                deserializer.deserialize_seq(ClosureVisitor(fun))?,
+            MoveTypeLayout::Function => Ok(MoveValue::Closure(Box::new(
+                deserializer.deserialize_seq(ClosureVisitor)?,
             ))),
             MoveTypeLayout::Vector(layout) => Ok(MoveValue::Vector(
                 deserializer.deserialize_seq(VectorElementVisitor(layout))?,
@@ -952,7 +941,7 @@ impl fmt::Display for MoveTypeLayout {
             Address => write!(f, "address"),
             Vector(typ) => write!(f, "vector<{}>", typ),
             Struct(s) => fmt::Display::fmt(s, f),
-            Function(fun) => fmt::Display::fmt(fun, f),
+            Function => write!(f, "function"),
             Signer => write!(f, "signer"),
             // TODO[agg_v2](cleanup): consider printing the tag as well.
             Native(_, typ) => write!(f, "native<{}>", typ),
@@ -1020,7 +1009,12 @@ impl TryInto<TypeTag> for &MoveTypeLayout {
             MoveTypeLayout::Signer => TypeTag::Signer,
             MoveTypeLayout::Vector(v) => TypeTag::Vector(Box::new(v.as_ref().try_into()?)),
             MoveTypeLayout::Struct(v) => TypeTag::Struct(Box::new(v.try_into()?)),
-            MoveTypeLayout::Function(f) => TypeTag::Function(Box::new(f.try_into()?)),
+
+            // For function values, we cannot reconstruct the tag because we do not know the
+            // argument and return types.
+            MoveTypeLayout::Function => {
+                bail!("Function layout cannot be constructed from type tag")
+            },
 
             // Native layout variant is only used by MoveVM, and is irrelevant
             // for type tags which are used to key resources in the global state.

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -5,7 +5,7 @@ use crate::values::{DeserializationSeed, SerializationReadyValue, VMValueCast, V
 use better_any::Tid;
 use move_binary_format::errors::{PartialVMError, PartialVMResult};
 use move_core_types::{
-    function::{ClosureMask, MoveFunctionLayout, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
+    function::{ClosureMask, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
     identifier::Identifier,
     language_storage::{ModuleId, TypeTag},
     value::MoveTypeLayout,
@@ -108,7 +108,7 @@ impl VMValueCast<Closure> for Value {
     }
 }
 
-impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveFunctionLayout, Closure> {
+impl serde::Serialize for SerializationReadyValue<'_, '_, '_, (), Closure> {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         let Closure(fun, captured) = self.value;
         let fun_ext = self
@@ -136,11 +136,9 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveFunctionLayout
     }
 }
 
-pub(crate) struct ClosureVisitor<'c, 'l>(
-    pub(crate) DeserializationSeed<'c, &'l MoveFunctionLayout>,
-);
+pub(crate) struct ClosureVisitor<'c>(pub(crate) DeserializationSeed<'c, ()>);
 
-impl<'d, 'c, 'l> serde::de::Visitor<'d> for ClosureVisitor<'c, 'l> {
+impl<'d, 'c> serde::de::Visitor<'d> for ClosureVisitor<'c> {
     type Value = Closure;
 
     fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -16,9 +16,7 @@ mod tests {
     use move_core_types::{
         ability::AbilitySet,
         account_address::AccountAddress,
-        function::{
-            ClosureMask, MoveClosure, MoveFunctionLayout, FUNCTION_DATA_SERIALIZATION_FORMAT_V1,
-        },
+        function::{ClosureMask, MoveClosure, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
         identifier::Identifier,
         language_storage::{FunctionTag, ModuleId, StructTag, TypeTag},
         u256,
@@ -208,12 +206,7 @@ mod tests {
     // Closures
 
     fn make_fun_layout() -> MoveTypeLayout {
-        // Currently, content of layout doesn't influence parsing, so can set anything here
-        MoveTypeLayout::Function(MoveFunctionLayout(
-            vec![],
-            vec![],
-            AbilitySet::PUBLIC_FUNCTIONS,
-        ))
+        MoveTypeLayout::Function
     }
 
     fn make_type_args() -> Vec<TypeTag> {

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -3770,9 +3770,9 @@ impl serde::Serialize for SerializationReadyValue<'_, '_, '_, MoveTypeLayout, Va
             },
 
             // Functions.
-            (L::Function(fun_layout), ValueImpl::ClosureValue(clos)) => SerializationReadyValue {
+            (L::Function, ValueImpl::ClosureValue(clos)) => SerializationReadyValue {
                 ctx: self.ctx,
-                layout: fun_layout,
+                layout: &(),
                 value: clos,
             }
             .serialize(serializer),
@@ -4042,10 +4042,10 @@ impl<'d> serde::de::DeserializeSeed<'d> for DeserializationSeed<'_, &MoveTypeLay
             }),
 
             // Functions
-            L::Function(fun_layout) => {
+            L::Function => {
                 let seed = DeserializationSeed {
                     ctx: self.ctx,
-                    layout: fun_layout,
+                    layout: (),
                 };
                 let closure = deserializer.deserialize_seq(ClosureVisitor(seed))?;
                 Ok(Value(ValueImpl::ClosureValue(closure)))
@@ -4710,7 +4710,7 @@ pub mod prop {
                 .prop_map(move |vals| Value::struct_(Struct::pack(vals)))
                 .boxed(),
 
-            L::Function(_function_layout) => {
+            L::Function => {
                 // TODO(#15664): not clear how to generate closure values, we'd need
                 //   some test functions for this, and generate `AbstractFunction` impls.
                 //   As we do not generate function layouts in the first place, we can bail

--- a/third_party/move/tools/move-bytecode-utils/src/layout.rs
+++ b/third_party/move/tools/move-bytecode-utils/src/layout.rs
@@ -14,7 +14,6 @@ use move_binary_format::{
 };
 use move_core_types::{
     account_address::AccountAddress,
-    function::MoveFunctionLayout,
     identifier::{IdentStr, Identifier},
     language_storage::{ModuleId, StructTag, TypeTag},
     value::{MoveFieldLayout, MoveStructLayout, MoveTypeLayout},
@@ -375,18 +374,7 @@ impl TypeLayoutBuilder {
                 compiled_module_view,
                 layout_type,
             )?),
-            Function(f) => {
-                let build_list = |ts: &[TypeTag]| {
-                    ts.iter()
-                        .map(|t| Self::build(t, compiled_module_view, layout_type))
-                        .collect::<anyhow::Result<Vec<_>>>()
-                };
-                MoveTypeLayout::Function(MoveFunctionLayout(
-                    build_list(&f.args)?,
-                    build_list(&f.results)?,
-                    f.abilities,
-                ))
-            },
+            Function(_) => MoveTypeLayout::Function,
         })
     }
 


### PR DESCRIPTION
## Description

Before, we defined function value layout as a triple of argument layouts, return value layouts and abilities. This design does not make sense because then it is not possible to store functions which operate on references (#16664):

```move
// Invariant violation returned at runtime, because reference layout is not possible.
struct Wrapper(|&signer|) has copy, drop, store, key;
```

In general, layout of function value is well defined as the function identifier, type arguments, and captured argument-layout pairs, so argument layouts and return value layouts are really not needed. In the end, here we talk about *layout*, not a *type*. Note that adding a "reference" variant to layout is not correct.

This PR changes function layout to a primitive `MoveTypeLayout::Function`. This works perfectly fine in the VM, as we do not care about argument or return types of a stored function (these are checked by paranoid mode at call site).

## How Has This Been Tested?

- Transactional test
- e2e Move test for aggregators

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] New feature
- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
