### PR TITLE
[Consensus] Tolerate critical errors in buffer manager item processing.

### DIFF
--- a/config/src/config/consensus_observer_config.rs
+++ b/config/src/config/consensus_observer_config.rs
@@ -51,6 +51,8 @@ pub struct ConsensusObserverConfig {
 
     /// Duration (in milliseconds) to require state sync to synchronize when in fallback mode
     pub observer_fallback_duration_ms: u64,
+    /// Duration (in milliseconds) to require state sync to synchronize when in critical fallback mode
+    pub observer_fallback_critical_duration_ms: u64,
     /// Duration (in milliseconds) we'll wait on startup before considering fallback mode
     pub observer_fallback_startup_period_ms: u64,
     /// Duration (in milliseconds) we'll wait for syncing progress before entering fallback mode
@@ -77,9 +79,10 @@ impl Default for ConsensusObserverConfig {
             subscription_peer_change_interval_ms: 180_000,     // 3 minutes
             subscription_refresh_interval_ms: 600_000,         // 10 minutes
             observer_fallback_duration_ms: 600_000,            // 10 minutes
-            observer_fallback_startup_period_ms: 60_000,       // 60 seconds
-            observer_fallback_progress_threshold_ms: 10_000,   // 10 seconds
-            observer_fallback_sync_lag_threshold_ms: 15_000,   // 15 seconds
+            observer_fallback_critical_duration_ms: 9_999_999_000, // ~ 100 days (enough to fix the critical failure)
+            observer_fallback_startup_period_ms: 60_000,           // 60 seconds
+            observer_fallback_progress_threshold_ms: 10_000,       // 10 seconds
+            observer_fallback_sync_lag_threshold_ms: 15_000,       // 15 seconds
         }
     }
 }

--- a/consensus/src/consensus_observer/common/metrics.rs
+++ b/consensus/src/consensus_observer/common/metrics.rs
@@ -25,6 +25,7 @@ pub const PENDING_BLOCKS_LABEL: &str = "pending_blocks";
 pub const STORED_PAYLOADS_LABEL: &str = "stored_payloads";
 
 // Useful state sync metric labels
+pub const STATE_SYNCING_FOR_CRITICAL_FALLBACK: &str = "sync_for_critical_fallback";
 pub const STATE_SYNCING_FOR_FALLBACK: &str = "sync_for_fallback";
 pub const STATE_SYNCING_TO_COMMIT: &str = "sync_to_commit";
 

--- a/consensus/src/pipeline/buffer.rs
+++ b/consensus/src/pipeline/buffer.rs
@@ -4,6 +4,7 @@
 
 use crate::pipeline::hashable::Hashable;
 use aptos_crypto::HashValue;
+use aptos_logger::warn;
 use std::collections::HashMap;
 
 pub struct LinkedItem<T: Hashable> {
@@ -75,6 +76,36 @@ impl<T: Hashable> Buffer<T> {
                 self.tail = None;
             }
             elem.unwrap()
+        })
+    }
+
+    /// pop_front_safe is a safe version of pop_front (i.e., it
+    /// doesn't use unwrap and returns None if data is missing).
+    pub fn pop_front_safe(&mut self) -> Option<T> {
+        self.head.take().and_then(|head| {
+            // Get the item and remove it from the map
+            let mut item = match self.map.remove(&head) {
+                Some(item) => item,
+                None => {
+                    warn!("Failed to find buffer item with hash: {:?}", head);
+                    return None;
+                },
+            };
+
+            // Get the element and update the head
+            let elem = item.elem.take();
+            self.head = item.next;
+            if self.head.is_none() {
+                // empty
+                self.tail = None;
+            }
+
+            // If the element is None, log a warning
+            if elem.is_none() {
+                warn!("Buffer item with hash {:?} had no element", head);
+            }
+
+            elem
         })
     }
 

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -22,6 +22,7 @@ use aptos_types::{
 };
 use futures::future::BoxFuture;
 use itertools::zip_eq;
+use rand::{rngs::OsRng, Rng};
 use std::{collections::HashMap, fmt::Debug};
 use tokio::time::Instant;
 
@@ -528,6 +529,14 @@ fn assert_eq_or_error<T: PartialEq + Debug>(
     error_message: &str,
 ) -> anyhow::Result<()> {
     if tolerate_assertion_failure {
+        // HACK!
+        // Generate a random number and fail the assertion with some chance.
+        // This is to simulate a failure in the assertion.
+        let random_number = create_random_u64();
+        if random_number % 1000 == 0 {
+            return Err(anyhow!("Random failure in assert_eq_or_error!"));
+        }
+
         if item_1 != item_2 {
             let error_message = format!(
                 "Equality check failed! Error: {}. Item 1: {:?}, Item 2: {:?}",
@@ -540,6 +549,12 @@ fn assert_eq_or_error<T: PartialEq + Debug>(
     }
 
     Ok(())
+}
+
+/// Returns a random u64
+fn create_random_u64() -> u64 {
+    let mut rng = OsRng;
+    rng.gen()
 }
 
 #[cfg(test)]

--- a/consensus/src/pipeline/buffer_item.rs
+++ b/consensus/src/pipeline/buffer_item.rs
@@ -22,7 +22,7 @@ use aptos_types::{
 };
 use futures::future::BoxFuture;
 use itertools::zip_eq;
-use std::collections::HashMap;
+use std::{collections::HashMap, fmt::Debug};
 use tokio::time::Instant;
 
 fn generate_commit_ledger_info(
@@ -126,8 +126,9 @@ impl BufferItem {
         validator: &ValidatorVerifier,
         epoch_end_timestamp: Option<u64>,
         order_vote_enabled: bool,
-    ) -> Self {
-        match self {
+        tolerate_assertion_failures: bool,
+    ) -> anyhow::Result<Self> {
+        let buffer_item = match self {
             Self::Ordered(ordered_item) => {
                 let OrderedItem {
                     ordered_blocks,
@@ -137,7 +138,12 @@ impl BufferItem {
                     ordered_proof,
                 } = *ordered_item;
                 for (b1, b2) in zip_eq(ordered_blocks.iter(), executed_blocks.iter()) {
-                    assert_eq!(b1.id(), b2.id());
+                    assert_eq_or_error(
+                        b1.id(),
+                        b2.id(),
+                        tolerate_assertion_failures,
+                        "Ordered block and executed block don't match!",
+                    )?;
                 }
                 let mut commit_info = executed_blocks
                     .last()
@@ -145,10 +151,15 @@ impl BufferItem {
                     .block_info();
                 match epoch_end_timestamp {
                     Some(timestamp) if commit_info.timestamp_usecs() != timestamp => {
-                        assert!(executed_blocks
+                        let is_reconfiguration_suffix = executed_blocks
                             .last()
                             .expect("")
-                            .is_reconfiguration_suffix());
+                            .is_reconfiguration_suffix();
+                        assert_or_error(
+                            is_reconfiguration_suffix,
+                            tolerate_assertion_failures,
+                            "Last executed block is not a reconfiguration suffix!",
+                        )?;
                         commit_info.change_timestamp(timestamp);
                     },
                     _ => (),
@@ -156,7 +167,12 @@ impl BufferItem {
                 if let Some(commit_proof) = commit_proof {
                     // We have already received the commit proof in fast forward sync path,
                     // we can just use that proof and proceed to aggregated
-                    assert_eq!(commit_proof.commit_info().clone(), commit_info);
+                    assert_eq_or_error(
+                        commit_proof.commit_info().clone(),
+                        commit_info,
+                        tolerate_assertion_failures,
+                        "Commit proof and executed blocks commit info don't match!",
+                    )?;
                     debug!(
                         "{} advance to aggregated from ordered",
                         commit_proof.commit_info()
@@ -204,7 +220,9 @@ impl BufferItem {
             _ => {
                 panic!("Only ordered blocks can advance to executed blocks.")
             },
-        }
+        };
+
+        Ok(buffer_item)
     }
 
     pub fn advance_to_signed(self, author: Author, signature: bls12381::Signature) -> Self {
@@ -247,8 +265,9 @@ impl BufferItem {
     pub fn try_advance_to_aggregated_with_ledger_info(
         self,
         commit_proof: LedgerInfoWithSignatures,
-    ) -> Self {
-        match self {
+        tolerate_assertion_failures: bool,
+    ) -> anyhow::Result<Self> {
+        let buffer_item = match self {
             Self::Signed(signed_item) => {
                 let SignedItem {
                     executed_blocks,
@@ -256,10 +275,12 @@ impl BufferItem {
                     partial_commit_proof: local_commit_proof,
                     ..
                 } = *signed_item;
-                assert_eq!(
+                assert_eq_or_error(
                     local_commit_proof.data().commit_info(),
-                    commit_proof.commit_info()
-                );
+                    commit_proof.commit_info(),
+                    tolerate_assertion_failures,
+                    "Local commit proof and given commit proof don't match!",
+                )?;
                 debug!(
                     "{} advance to aggregated with commit decision",
                     commit_proof.commit_info()
@@ -277,7 +298,12 @@ impl BufferItem {
                     commit_info,
                     ..
                 } = *executed_item;
-                assert_eq!(commit_info, *commit_proof.commit_info());
+                assert_eq_or_error(
+                    &commit_info,
+                    commit_proof.commit_info(),
+                    tolerate_assertion_failures,
+                    "Executed item commit info and given commit proof don't match!",
+                )?;
                 debug!(
                     "{} advance to aggregated with commit decision",
                     commit_proof.commit_info()
@@ -290,10 +316,15 @@ impl BufferItem {
             },
             Self::Ordered(ordered_item) => {
                 let ordered = *ordered_item;
-                assert!(ordered
+                let match_ordered_commit_info = ordered
                     .ordered_proof
                     .commit_info()
-                    .match_ordered_only(commit_proof.commit_info()));
+                    .match_ordered_only(commit_proof.commit_info());
+                assert_or_error(
+                    match_ordered_commit_info,
+                    tolerate_assertion_failures,
+                    "Ordered item commit info and given commit proof don't match!",
+                )?;
                 // can't aggregate it without execution, only store the signatures
                 debug!(
                     "{} received commit decision in ordered stage",
@@ -307,7 +338,9 @@ impl BufferItem {
             Self::Aggregated(_) => {
                 unreachable!("Found aggregated buffer item but any aggregated buffer item should get dequeued right away.");
             },
-        }
+        };
+
+        Ok(buffer_item)
     }
 
     pub fn try_advance_to_aggregated(self, validator: &ValidatorVerifier) -> Self {
@@ -474,6 +507,41 @@ impl BufferItem {
     }
 }
 
+/// Checks that the given result is true. If `tolerate_assertion_failure`
+/// is true, this will return an error if the result is false. Otherwise,
+/// this will panic.
+fn assert_or_error(
+    result: bool,
+    tolerate_assertion_failure: bool,
+    error_message: &str,
+) -> anyhow::Result<()> {
+    assert_eq_or_error(result, true, tolerate_assertion_failure, error_message)
+}
+
+/// Compares two items for equality. If `tolerate_assertion_failure`
+/// is true, this will return an error if the items are not equal.
+/// Otherwise, this will panic.
+fn assert_eq_or_error<T: PartialEq + Debug>(
+    item_1: T,
+    item_2: T,
+    tolerate_assertion_failure: bool,
+    error_message: &str,
+) -> anyhow::Result<()> {
+    if tolerate_assertion_failure {
+        if item_1 != item_2 {
+            let error_message = format!(
+                "Equality check failed! Error: {}. Item 1: {:?}, Item 2: {:?}",
+                error_message, item_1, item_2
+            );
+            return Err(anyhow!(error_message));
+        }
+    } else {
+        assert_eq!(item_1, item_2);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -588,12 +656,15 @@ mod test {
             .add_signature_if_matched(commit_votes[3].clone())
             .unwrap();
 
-        let mut executed_item = ordered_item.advance_to_executed_or_aggregated(
-            vec![pipelined_block.clone()],
-            &validator_verifier,
-            None,
-            true,
-        );
+        let mut executed_item = ordered_item
+            .advance_to_executed_or_aggregated(
+                vec![pipelined_block.clone()],
+                &validator_verifier,
+                None,
+                true,
+                false,
+            )
+            .unwrap();
 
         match executed_item {
             BufferItem::Executed(ref executed_item_inner) => {
@@ -694,12 +765,15 @@ mod test {
             .unwrap();
 
         assert_eq!(validator_verifier.pessimistic_verify_set().len(), 0);
-        let mut executed_item = ordered_item.advance_to_executed_or_aggregated(
-            vec![pipelined_block.clone()],
-            &validator_verifier,
-            None,
-            true,
-        );
+        let mut executed_item = ordered_item
+            .advance_to_executed_or_aggregated(
+                vec![pipelined_block.clone()],
+                &validator_verifier,
+                None,
+                true,
+                false,
+            )
+            .unwrap();
 
         match executed_item {
             BufferItem::Executed(ref executed_item_inner) => {

--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -65,10 +65,27 @@ pub const COMMIT_VOTE_BROADCAST_INTERVAL_MS: u64 = 1500;
 pub const COMMIT_VOTE_REBROADCAST_INTERVAL_MS: u64 = 30000;
 pub const LOOP_INTERVAL_MS: u64 = 1500;
 
+#[derive(Debug)]
+
+pub struct CriticalErrorNotification {
+    error: String,
+}
+
+impl CriticalErrorNotification {
+    pub fn new(error: String) -> Self {
+        Self { error }
+    }
+
+    pub fn error(&self) -> &str {
+        &self.error
+    }
+}
+
 #[derive(Debug, Default)]
 pub struct ResetAck {}
 
 pub enum ResetSignal {
+    CriticalError,
     Stop,
     TargetRound(u64),
 }
@@ -178,6 +195,10 @@ pub struct BufferManager {
     // but we need to keep the pending blocks for reset.
     pending_commit_blocks: BTreeMap<Round, Arc<PipelinedBlock>>,
     new_pipeline_enabled: bool,
+
+    // A channel to notify any listeners that the buffer manager has
+    // hit a critical error. This is currently only used by fullnodes.
+    critical_error_notifier: UnboundedSender<CriticalErrorNotification>,
 }
 
 impl BufferManager {
@@ -210,7 +231,7 @@ impl BufferManager {
         consensus_publisher: Option<Arc<ConsensusPublisher>>,
         max_pending_rounds_in_commit_vote_cache: u64,
         new_pipeline_enabled: bool,
-    ) -> Self {
+    ) -> (Self, UnboundedReceiver<CriticalErrorNotification>) {
         let buffer = Buffer::<BufferItem>::new();
 
         let rb_backoff_policy = ExponentialBackoff::from_millis(2)
@@ -218,7 +239,9 @@ impl BufferManager {
             .max_delay(Duration::from_secs(5));
 
         let (tx, rx) = unbounded();
-        Self {
+        let (critical_error_notifier, critical_error_listener) = unbounded();
+
+        let buffer_manager = Self {
             author,
 
             buffer,
@@ -276,12 +299,21 @@ impl BufferManager {
             pending_commit_votes: BTreeMap::new(),
             pending_commit_blocks: BTreeMap::new(),
             new_pipeline_enabled,
-        }
+            critical_error_notifier,
+        };
+
+        (buffer_manager, critical_error_listener)
+    }
+
+    /// Returns true iff consensus observer is enabled. If so, this must be
+    /// a fullnode (as consensus observer is not supported on validators).
+    fn is_consensus_observer_enabled(&self) -> bool {
+        self.consensus_observer_config.observer_enabled
     }
 
     fn do_reliable_broadcast(&self, message: CommitMessage) -> Option<DropGuard> {
         // If consensus observer is enabled, we don't need to broadcast
-        if self.consensus_observer_config.observer_enabled {
+        if self.is_consensus_observer_enabled() {
             return None;
         }
 
@@ -530,7 +562,7 @@ impl BufferManager {
                 if commit_proof.ledger_info().ends_epoch() {
                     // the epoch ends, reset to avoid executing more blocks, execute after
                     // this persisting request will result in BlockNotFound
-                    self.reset().await;
+                    self.reset(false).await;
                 }
                 if let Some(consensus_publisher) = &self.consensus_publisher {
                     let message =
@@ -563,16 +595,28 @@ impl BufferManager {
         unreachable!("Aggregated item not found in the list");
     }
 
+    /// Pops the front of the buffer and returns the item. Note:
+    /// if critical_error is true, the buffer manager has failed and
+    /// a safe pop is needed.
+    fn pop_buffer_front(&mut self, critical_error: bool) -> Option<BufferItem> {
+        if critical_error {
+            self.buffer.pop_front_safe()
+        } else {
+            self.buffer.pop_front()
+        }
+    }
+
     /// Reset any request in buffer manager, this is important to avoid race condition with state sync.
     /// Internal requests are managed with ongoing_tasks.
     /// Incoming ordered blocks are pulled, it should only have existing blocks but no new blocks until reset finishes.
-    async fn reset(&mut self) {
+    /// If critical_error is true, the buffer manager has failed and state sync will be needed!
+    async fn reset(&mut self, critical_error: bool) {
         while let Some((_, block)) = self.pending_commit_blocks.pop_first() {
             // Those blocks don't have any dependencies, should be able to finish commit_ledger.
             // Abort them can cause error on epoch boundary.
             block.wait_for_commit_ledger().await;
         }
-        while let Some(item) = self.buffer.pop_front() {
+        while let Some(item) = self.pop_buffer_front(critical_error) {
             for b in item.get_blocks() {
                 if let Some(futs) = b.abort_pipeline() {
                     futs.wait_until_finishes().await;
@@ -608,9 +652,12 @@ impl BufferManager {
 
                 let _ = self.drain_pending_commit_proof_till(round);
             },
+            _ => {},
         }
 
-        self.reset().await;
+        let critical_error = matches!(signal, ResetSignal::CriticalError);
+        self.reset(critical_error).await;
+
         let _ = tx.send(ResetAck::default());
         if !self.new_pipeline_enabled {
             self.reset_flag.store(false, Ordering::SeqCst);
@@ -651,12 +698,15 @@ impl BufferManager {
 
     /// If the response is successful, advance the item to Executed, otherwise panic (TODO fix).
     #[allow(clippy::unwrap_used)]
-    async fn process_execution_response(&mut self, response: ExecutionResponse) {
+    async fn process_execution_response(
+        &mut self,
+        response: ExecutionResponse,
+    ) -> anyhow::Result<()> {
         let ExecutionResponse { block_id, inner } = response;
         // find the corresponding item, may not exist if a reset or aggregated happened
         let current_cursor = self.buffer.find_elem_by_key(self.execution_root, block_id);
         if current_cursor.is_none() {
-            return;
+            return Ok(());
         }
 
         let executed_blocks = match inner {
@@ -668,7 +718,7 @@ impl BufferManager {
                     block_id,
                     self.new_pipeline_enabled,
                 );
-                return;
+                return Ok(());
             },
         };
         info!(
@@ -683,7 +733,7 @@ impl BufferManager {
                 expected_block_id = current_item.block_id(),
                 "Received result for unexpected block id. Ignoring."
             );
-            return;
+            return Ok(());
         }
 
         // Handle reconfiguration timestamp reconciliation.
@@ -709,12 +759,16 @@ impl BufferManager {
             &self.epoch_state.verifier,
             self.end_epoch_timestamp.get().cloned(),
             self.order_vote_enabled,
-        );
+            self.is_consensus_observer_enabled(),
+        )?;
         if let Some(commit_proof) = self.drain_pending_commit_proof_till(round) {
             if !new_item.is_aggregated()
                 && commit_proof.ledger_info().commit_info().id() == block_id
             {
-                new_item = new_item.try_advance_to_aggregated_with_ledger_info(commit_proof)
+                new_item = new_item.try_advance_to_aggregated_with_ledger_info(
+                    commit_proof,
+                    self.is_consensus_observer_enabled(),
+                )?;
             }
         }
 
@@ -723,6 +777,8 @@ impl BufferManager {
         if aggregated {
             self.advance_head(block_id).await;
         }
+
+        Ok(())
     }
 
     fn generate_commit_message(commit_vote: CommitVote) -> CommitMessage {
@@ -779,7 +835,10 @@ impl BufferManager {
     /// process the commit vote messages
     /// it scans the whole buffer for a matching blockinfo
     /// if found, try advancing the item to be aggregated
-    fn process_commit_message(&mut self, commit_msg: IncomingCommitRequest) -> Option<HashValue> {
+    fn process_commit_message(
+        &mut self,
+        commit_msg: IncomingCommitRequest,
+    ) -> anyhow::Result<Option<HashValue>> {
         let IncomingCommitRequest {
             req,
             protocol,
@@ -819,9 +878,9 @@ impl BufferManager {
                     };
                     self.buffer.set(&current_cursor, new_item);
                     if self.buffer.get(&current_cursor).is_aggregated() {
-                        return Some(target_block_id);
+                        return Ok(Some(target_block_id));
                     } else {
-                        return None;
+                        return Ok(None);
                     }
                 } else if self.try_add_pending_commit_vote(vote) {
                     reply_ack(protocol, response_sender);
@@ -842,13 +901,14 @@ impl BufferManager {
                     let item = self.buffer.take(&cursor);
                     let new_item = item.try_advance_to_aggregated_with_ledger_info(
                         commit_proof.ledger_info().clone(),
-                    );
+                        self.is_consensus_observer_enabled(),
+                    )?;
                     let aggregated = new_item.is_aggregated();
                     self.buffer.set(&cursor, new_item);
 
                     reply_ack(protocol, response_sender);
                     if aggregated {
-                        return Some(target_block_id);
+                        return Ok(Some(target_block_id));
                     }
                 } else if self.try_add_pending_commit_proof(commit_proof.into_inner()) {
                     reply_ack(protocol, response_sender);
@@ -864,7 +924,8 @@ impl BufferManager {
                 error!("Unexpected NACK message");
             },
         }
-        None
+
+        Ok(None)
     }
 
     /// this function retries all the items until the signing root
@@ -955,6 +1016,32 @@ impl BufferManager {
         self.back_pressure_enabled && self.highest_committed_round + MAX_BACKLOG < self.latest_round
     }
 
+    async fn handle_critical_error(&mut self, error: anyhow::Error, error_context: &str) {
+        // Log the error message
+        let error_message = format!(
+            "Critical error encountered! Stopping the buffer manager. Error context: {}! Error: {}",
+            error_context, error
+        );
+        error!("{}", error_message);
+
+        // Reset the buffer manager
+        let (reset_signal_tx, _reset_signal_rx) = oneshot::channel();
+        let reset_request = ResetRequest {
+            tx: reset_signal_tx,
+            signal: ResetSignal::CriticalError,
+        };
+        self.process_reset_request(reset_request).await;
+
+        // Send the critical error notification to the listener
+        let error_notification = CriticalErrorNotification::new(error_message);
+        if let Err(error) = self.critical_error_notifier.send(error_notification).await {
+            error!(
+                error = ?error,
+                "Failed to send critical error notification to listener!"
+            );
+        }
+    }
+
     pub async fn start(mut self) {
         info!("Buffer manager starts.");
         let (verified_commit_msg_tx, mut verified_commit_msg_rx) = create_channel();
@@ -1000,7 +1087,11 @@ impl BufferManager {
                 Some(response) = self.execution_wait_phase_rx.next() => {
                     monitor!("buffer_manager_process_execution_wait_response", {
                     let response_block_id = response.block_id;
-                    self.process_execution_response(response).await;
+                    if let Err(error) = self.process_execution_response(response).await {
+                        // We hit a critical error (something has gone wrong)
+                        self.handle_critical_error(error, "process_execution_response").await;
+                        break;
+                    }
                     if let Some(block_id) = self.advance_execution_root() {
                         // if the response is for the current execution root, retry the schedule phase
                         if response_block_id == block_id {
@@ -1036,13 +1127,22 @@ impl BufferManager {
                 },
                 Some(rpc_request) = verified_commit_msg_rx.next() => {
                     monitor!("buffer_manager_process_commit_message",
-                    if let Some(aggregated_block_id) = self.process_commit_message(rpc_request) {
-                        self.advance_head(aggregated_block_id).await;
-                        if self.execution_root.is_none() {
-                            self.advance_execution_root();
+                    match self.process_commit_message(rpc_request) {
+                        Ok(maybe_aggregated_block_id) => {
+                            if let Some(aggregated_block_id) = maybe_aggregated_block_id {
+                                self.advance_head(aggregated_block_id).await;
+                                if self.execution_root.is_none() {
+                                    self.advance_execution_root();
+                                }
+                                if self.signing_root.is_none() {
+                                    self.advance_signing_root().await;
+                                }
+                            };
                         }
-                        if self.signing_root.is_none() {
-                            self.advance_signing_root().await;
+                        Err(error) => {
+                            // We hit a critical error (something has gone wrong)
+                            self.handle_critical_error(error, "process_commit_message").await;
+                            break;
                         }
                     });
                 }

--- a/consensus/src/pipeline/tests/buffer_manager_tests.rs
+++ b/consensus/src/pipeline/tests/buffer_manager_tests.rs
@@ -141,7 +141,7 @@ pub fn prepare_buffer_manager(
         execution_wait_phase_pipeline,
         signing_phase_pipeline,
         persisting_phase_pipeline,
-        buffer_manager,
+        (buffer_manager, _),
     ) = prepare_phases_and_buffer_manager(
         author,
         mocked_execution_proxy,

--- a/consensus/src/rand/rand_gen/rand_manager.rs
+++ b/consensus/src/rand/rand_gen/rand_manager.rs
@@ -184,6 +184,7 @@ impl<S: TShare, D: TAugmentedData> RandManager<S, D> {
     fn process_reset(&mut self, request: ResetRequest) {
         let ResetRequest { tx, signal } = request;
         let target_round = match signal {
+            ResetSignal::CriticalError => 0,
             ResetSignal::Stop => 0,
             ResetSignal::TargetRound(round) => round,
         };

--- a/consensus/src/test_utils/mock_execution_client.rs
+++ b/consensus/src/test_utils/mock_execution_client.rs
@@ -7,8 +7,10 @@ use crate::{
     network::{IncomingCommitRequest, IncomingRandGenRequest},
     payload_manager::{DirectMempoolPayloadManager, TPayloadManager},
     pipeline::{
-        buffer_manager::OrderedBlocks, execution_client::TExecutionClient,
-        pipeline_builder::PipelineBuilder, signing_phase::CommitSignerProvider,
+        buffer_manager::{CriticalErrorNotification, OrderedBlocks},
+        execution_client::TExecutionClient,
+        pipeline_builder::PipelineBuilder,
+        signing_phase::CommitSignerProvider,
     },
     rand::rand_gen::types::RandConfig,
     state_replication::StateComputerCommitCallBackType,
@@ -110,7 +112,8 @@ impl TExecutionClient for MockExecutionClient {
         _rand_msg_rx: aptos_channel::Receiver<AccountAddress, IncomingRandGenRequest>,
         _highest_committed_round: Round,
         _new_pipeline_enabled: bool,
-    ) {
+    ) -> Option<futures_channel::mpsc::UnboundedReceiver<CriticalErrorNotification>> {
+        None
     }
 
     fn get_execution_channel(&self) -> Option<UnboundedSender<OrderedBlocks>> {


### PR DESCRIPTION
## Description
This PR updates consensus observer (CO) to tolerate buffer manager failures. Instead of panicking on assertion failures (e.g., due to execution divergence), the buffer manager now notifies CO of a critical error. CO then logs the error, and falls back to state sync (indefinitely). The failure can then be addressed asynchronously (e.g., on error alerts). 

Note: this only happens for fullnodes. Validator nodes will still continue to panic on buffer manager failures.

## Testing Plan
Existing test infrastructure (and failure emulation)