### PR TITLE
[vm] Make mutable references invariant

### DIFF
--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -1152,7 +1152,8 @@ impl SignatureToken {
     /// Returns true if this type can have assigned a value of the source type.
     /// For function types, this is true if the argument and result types
     /// are equal, and if this function type's ability set is a subset of the other
-    /// one. For all other types, they must be equal
+    /// one. For immutable references, this is true if the inner types are assignable.
+    /// For all other types, this is true if the two types are equal.
     pub fn is_assignable_from(&self, source: &SignatureToken) -> bool {
         match (self, source) {
             (
@@ -1160,9 +1161,6 @@ impl SignatureToken {
                 SignatureToken::Function(args2, results2, abs2),
             ) => args1 == args2 && results1 == results2 && abs1.is_subset(*abs2),
             (SignatureToken::Reference(ty1), SignatureToken::Reference(ty2)) => {
-                ty1.is_assignable_from(ty2)
-            },
-            (SignatureToken::MutableReference(ty1), SignatureToken::MutableReference(ty2)) => {
                 ty1.is_assignable_from(ty2)
             },
             _ => self == source,

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335.move
@@ -8,19 +8,6 @@ module 0x42::Test {
         let x: || has copy+drop = ||{};
         f(&mut x);
     }
-
-    fun f3() {
-        let ff: || has drop = || {};
-
-        // let ff: || has copy+drop = || {}; // This runs fine
-
-        (|| {
-            *(&mut {ff}) = || {};
-        })();
-    }
-
 }
 
 //# run --verbose 0x42::Test::f2
-
-//# run --verbose 0x42::Test::f3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335_split.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335_split.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335_split.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335_split.move
@@ -1,0 +1,16 @@
+//# publish
+module 0x42::Test {
+    fun f3() {
+        let ff: || has drop = || {};
+
+        (|| {
+            *(&mut {ff}) = || {};
+        })();
+
+        let ff2: || has copy+drop = || {};
+        ff2();
+    }
+
+}
+
+//# run --verbose 0x42::Test::f3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/mut_ref_downgrade.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/mut_ref_downgrade.exp
@@ -1,23 +1,21 @@
 processed 2 tasks
 
-task 0 'publish'. lines 1-11:
+task 0 'publish'. lines 1-24:
 Error: compilation errors:
  bug: bytecode verification failed with unexpected status code `CALL_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
 Error message: none
-  ┌─ TEMPFILE:8:9
-  │
-8 │         f(&mut x);
-  │         ^^^^^^^^^
+   ┌─ TEMPFILE:14:9
+   │
+14 │         assn<||u64 has drop>(&mut b, a);
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
 
-task 1 'run'. lines 13-13:
+task 1 'run'. lines 26-26:
 Error: Function execution failed with VMError: {
-    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::Test doesn't exist,
     major_status: LINKER_ERROR,
     sub_status: None,
     location: undefined,
     indices: [],
     offsets: [],
-    exec_state: None,
 }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/mut_ref_downgrade.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/mut_ref_downgrade.move
@@ -1,0 +1,26 @@
+//# publish
+module 0xc0ffee::m {
+    struct NoCopy has drop;
+
+    public fun assn<T: drop>(ref: &mut T, x: T){
+        *ref = x;
+    }
+
+    public fun foo() {
+        let x = NoCopy;
+
+        let a: ||u64 has drop = ||{
+            let NoCopy = x;
+            1
+        };
+
+        let b: ||u64 has drop + copy = ||1;
+
+        assn<||u64 has drop>(&mut b, a);
+
+        b();
+        b();
+    }
+}
+
+//# run 0xc0ffee::m::foo

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -517,10 +517,6 @@ impl Type {
                 given.paranoid_check_assignable(ty)?;
                 true
             },
-            (Type::MutableReference(ty), Type::MutableReference(given)) => {
-                given.paranoid_check_assignable(ty)?;
-                true
-            },
             _ => expected_ty == self,
         };
         if !ok {


### PR DESCRIPTION
## Description

To be sound, assignments of mutable references should have invariance.

This PR fixes the static bytecode verifier and the paranoid mode accordingly.

The follow up compiler fix is here: https://github.com/aptos-labs/aptos-core/pull/16692

## How Has This Been Tested?
- Added a test showcasing the issue. Checked manually that if I disable the static bytecode verifier fix, then the paranoid mode fix is triggered. This test is a good candidate for adding assembler-based tests, because the compiler will start rejecting this code after #16692 lands.
- Split an existing test to separate out the valid and invalid code.

## Key Areas to Review
- Completeness of the fix, if there are other areas we should consider

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move VM
