### PR TITLE
[compiler-v2] Make mutable references invariant in the complier

### DIFF
--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16335.exp
@@ -2,12 +2,11 @@ processed 2 tasks
 
 task 0 'publish'. lines 1-11:
 Error: compilation errors:
- bug: bytecode verification failed with unexpected status code `CALL_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
-Error message: none
-  ┌─ TEMPFILE:8:9
+ error: cannot pass `&mut || has copy + drop` to a function which expects argument of type `&mut || has drop`
+  ┌─ TEMPFILE:8:11
   │
 8 │         f(&mut x);
-  │         ^^^^^^^^^
+  │           ^^^^^^
 
 
 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/mut_ref_downgrade.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/mut_ref_downgrade.exp
@@ -2,12 +2,11 @@ processed 2 tasks
 
 task 0 'publish'. lines 1-24:
 Error: compilation errors:
- bug: bytecode verification failed with unexpected status code `CALL_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
-Error message: none
-   ┌─ TEMPFILE:14:9
+ error: cannot pass `&mut ||u64 has copy + drop` to a function which expects argument of type `&mut ||u64 has drop`
+   ┌─ TEMPFILE:14:30
    │
 14 │         assn<||u64 has drop>(&mut b, a);
-   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │                              ^^^^^^
 
 
 

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -2538,7 +2538,14 @@ impl Substitution {
                 }
             },
             (Type::Reference(k1, ty1), Type::Reference(k2, ty2)) => {
-                // For references, allow variance to be passed down, and not use sub-variance
+                let variance = if matches!((k1, k2), (ReferenceKind::Mutable, ReferenceKind::Mutable))
+                {
+                    // For both being mutable references, use no variance.
+                    Variance::NoVariance
+                } else {
+                    // For other cases of references, allow variance to be passed down, and not use sub-variance
+                    variance
+                };
                 let ty = self
                     .unify(context, variance, order, ty1, ty2)
                     .map_err(TypeUnificationError::lift(order, t1, t2))?;


### PR DESCRIPTION
## Description

To be sound, unifying mutable references should have invariance.

In this PR, we fix the compiler's type checker accordingly. Related to another fix: #16691.

## How Has This Been Tested?
- Existing tests that already showed the bug

## Key Areas to Review

Completeness of the fix.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
