### PR TITLE
[Move prover] Rewrite invoke closure into move function call during spec rewriting

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
@@ -28,6 +28,7 @@ use log::info;
 use move_model::{
     ast::{ConditionKind, Exp, ExpData, GlobalInvariant, Operation, SpecBlockTarget, SpecFunDecl},
     exp_rewriter::ExpRewriterFunctions,
+    metadata::LanguageVersion,
     model::{
         FunId, FunctionData, GlobalEnv, ModuleId, NodeId, Parameter, QualifiedId, SpecFunId,
         StructEnv,
@@ -414,7 +415,34 @@ impl ExpRewriterFunctions for SpecConverter<'_> {
                 self.in_spec = false;
                 result
             } else {
-                self.rewrite_exp_descent(exp)
+                let exp = self.rewrite_exp_descent(exp);
+                if self
+                    .env
+                    .language_version()
+                    .is_at_least(LanguageVersion::V2_2)
+                    && !self.for_inline
+                {
+                    if let ExpData::Invoke(id, call, args) = exp.as_ref() {
+                        if let ExpData::Call(_, Closure(mid, fid, mask), captured) = call.as_ref() {
+                            let mut new_args = vec![];
+                            let mut captured_num = 0;
+                            let mut free_num = 0;
+                            let fun = self.env.get_function(mid.qualified(*fid));
+                            for i in 0..fun.get_parameter_count() {
+                                if mask.is_captured(i) {
+                                    new_args.push(captured[captured_num].clone());
+                                    captured_num += 1;
+                                } else {
+                                    new_args.push(args[free_num].clone());
+                                    free_num += 1;
+                                }
+                            }
+                            return Call(*id, MoveFunction(*mid, *fid), new_args.clone())
+                                .into_exp();
+                        }
+                    }
+                }
+                exp
             }
         } else {
             // Simplification which need to be done before descent

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/inline_fun_in_spec.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/inline_fun_in_spec.exp
@@ -35,7 +35,8 @@ module 0x42::m {
         Add<u64>(x, 1)
     }
     spec {
-      ensures Eq<u64>(result0(), m::$exec<num, num>(|x: num| Add(x, 1), $t0));
+      ensures Eq<u64>(result0(), m::$exec<num, num>(closure#0m::__lambda__1__function_spec_block(), $t0));
+      ensures Eq<u64>(result0(), m::$exec<num, num>(closure#0m::__lambda__2__function_spec_block(), $t0));
     }
 
     private inline fun get<R>(a: address): &R {
@@ -43,6 +44,12 @@ module 0x42::m {
     }
     private fun __lambda__1__function_code_spec_block(y: num): bool {
         Gt(y, 0)
+    }
+    private fun __lambda__1__function_spec_block(x: num): num {
+        Add(x, 1)
+    }
+    private fun __lambda__2__function_spec_block(x: num): num {
+        Add(x, 1)
     }
     spec fun $exec<T,R>(f: |#0|#1 has copy + drop,x: #0): #1 {
         {
@@ -52,6 +59,12 @@ module 0x42::m {
     }
     spec fun $__lambda__1__function_code_spec_block(y: num): bool {
         Gt(y, 0)
+    }
+    spec fun $__lambda__1__function_spec_block(x: num): num {
+        Add(x, 1)
+    }
+    spec fun $__lambda__2__function_spec_block(x: num): num {
+        Add(x, 1)
     }
 } // end 0x42::m
 
@@ -93,5 +106,11 @@ module 0x42::m {
     }
     fun __lambda__1__function_code_spec_block(y: num): bool {
         y > 0u256
+    }
+    fun __lambda__1__function_spec_block(x: num): num {
+        x + 1u256
+    }
+    fun __lambda__2__function_spec_block(x: num): num {
+        x + 1u256
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/inline_fun_in_spec.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/inline-parity/inline_fun_in_spec.move
@@ -12,6 +12,7 @@ module 0x42::m {
     }
     spec function_spec_block {
         ensures result == exec(|x| x + 1, x);
+        ensures result == exec(|x| x + 1, x);
     }
 
     // Function code spec block

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -287,6 +287,11 @@ impl Condition {
     pub fn all_exps(&self) -> impl Iterator<Item = &Exp> {
         std::iter::once(&self.exp).chain(self.additional_exps.iter())
     }
+
+    /// Return all expressions in the condition, the primary one and the additional ones.
+    pub fn all_exps_mut(&mut self) -> impl Iterator<Item = &mut Exp> {
+        std::iter::once(&mut self.exp).chain(self.additional_exps.iter_mut())
+    }
 }
 
 // =================================================================================================

--- a/third_party/move/move-prover/tests/sources/functional/closure.exp
+++ b/third_party/move/move-prover/tests/sources/functional/closure.exp
@@ -1,0 +1,17 @@
+Move prover returns: exiting with verification errors
+error: post-condition does not hold
+   ┌─ tests/sources/functional/closure.move:17:9
+   │
+17 │         ensures result == x + 2; // This does not verify
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   =     at tests/sources/functional/closure.move:13: test_closure_2
+   =         x = <redacted>
+   =     at tests/sources/functional/closure.move:14: test_closure_2
+   =         x = <redacted>
+   =         y = <redacted>
+   =         result = <redacted>
+   =     at tests/sources/functional/closure.move:14: test_closure_2
+   =         result = <redacted>
+   =     at tests/sources/functional/closure.move:15: test_closure_2
+   =     at tests/sources/functional/closure.move:17: test_closure_2 (spec)

--- a/third_party/move/move-prover/tests/sources/functional/closure.move
+++ b/third_party/move/move-prover/tests/sources/functional/closure.move
@@ -1,0 +1,49 @@
+module 0x42::Test {
+
+    fun add(x: u64, y: u64): u64 {
+        x + y
+    }
+    fun test_closure_1(x: u64): u64 {
+        (add)(x, 1)
+    }
+    spec test_closure_1 {
+        ensures result == x + 1;
+    }
+
+    fun test_closure_2(x: u64): u64 {
+        (|y| y + x)(1)
+    }
+    spec test_closure_2 {
+        ensures result == x + 2; // This does not verify
+    }
+
+    fun test_closure_3(x: u64): u64 {
+        (|y| y + x)(1)
+    }
+    spec test_closure_3 {
+        ensures result == (add)(1 as u64, x);
+    }
+
+    fun and(a: bool, b: bool): bool {
+        a && b
+    }
+
+    fun test_closure_4(x: bool): bool {
+        and(x, false)
+    }
+    spec test_closure_4 {
+        ensures and(x, false) == (|y| y && x)(false);
+    }
+
+    struct S<T: copy + drop> has copy, drop {
+        f: T
+    }
+
+    fun test_closure_5(x: S<bool>): bool {
+        and(x.f, false)
+    }
+    spec test_closure_5 {
+        ensures and(x.f, false) == (|s: S<bool>| s.f && x.f )(S { f: false });
+    }
+
+}

--- a/third_party/move/move-prover/tests/sources/functional/restrictions.exp
+++ b/third_party/move/move-prover/tests/sources/functional/restrictions.exp
@@ -23,13 +23,13 @@ error: [boogie translator] `|x|e` (lambda) currently only supported as argument 
 21 │             let f = |x| x + 1;
    │                     ^^^^^^^^^
 
-error: [boogie translator] `|x|e` (lambda) currently only supported as argument for `all` or `any`
+error: bug: operation closure#0M::__lambda__1__use_them is not supported in the current context
    ┌─ tests/sources/functional/restrictions.move:50:20
    │
 50 │         ensures f3(|x|x) == f3(|x|x);
    │                    ^^^^
 
-error: [boogie translator] `|x|e` (lambda) currently only supported as argument for `all` or `any`
+error: bug: operation closure#0M::__lambda__2__use_them is not supported in the current context
    ┌─ tests/sources/functional/restrictions.move:50:32
    │
 50 │         ensures f3(|x|x) == f3(|x|x);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

As the first step to support function value in Move prover, this PR adds the logic to rewrite invoke(closure) operation into call to the corresponding lifted move/spec function. Note that rewrite only happens when `rewrite_spec` flag is turned on, which means no code will be rewritten for execution.


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests and a new test case.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Check whether this change only applies code generation for formal verification.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Move prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
