### PR TITLE
Update REST API link in fullnode Helm chart README

### DIFF
--- a/terraform/helm/fullnode/README.md
+++ b/terraform/helm/fullnode/README.md
@@ -134,6 +134,6 @@ Deployment
 
        $ helm install fullnode --set storage.class=gp2 .
 
-[REST API]: https://github.com/aptos-labs/aptos-core/blob/main/api/doc/v0/openapi.yaml
+[REST API]: https://github.com/aptos-labs/aptos-core/blob/main/api/doc/spec.yaml
 [values.yaml]: values.yaml
 [Aptos dockerhub]: https://hub.docker.com/r/aptoslabs/validator/tags?page=1&ordering=last_updated


### PR DESCRIPTION
Replaced the outdated link to the Aptos REST API OpenAPI specification in terraform/helm/fullnode/README.md with the current and correct URL (api/doc/spec.yaml). This ensures users are directed to the latest API documentation.