### PR TITLE
[API] Extend simulation filtering support.

### DIFF
--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -1666,7 +1666,7 @@ async fn test_simulation_filter_deny() {
 
     // Blocklist the balance function.
     let mut filter = node_config.api.simulation_filter.clone();
-    filter = filter.add_deny_all();
+    filter = filter.add_all_filter(false);
     node_config.api.simulation_filter = filter;
 
     let mut context = new_test_context_with_config(current_function_name!(), node_config);
@@ -1691,8 +1691,8 @@ async fn test_simulation_filter_allow_sender() {
 
     // Allow the root sender only.
     let mut filter = node_config.api.simulation_filter.clone();
-    filter = filter.add_allow_sender(aptos_test_root_address());
-    filter = filter.add_deny_all();
+    filter = filter.add_sender_filter(true, aptos_test_root_address());
+    filter = filter.add_all_filter(false);
     node_config.api.simulation_filter = filter;
 
     let mut context = new_test_context_with_config(current_function_name!(), node_config);

--- a/api/src/transactions.rs
+++ b/api/src/transactions.rs
@@ -585,6 +585,7 @@ impl TransactionsApi {
             // simulation filters. See the ConfigSanitizer for ApiConfig.
             if !context.node_config.api.simulation_filter.allows(
                 aptos_crypto::HashValue::zero(),
+                ledger_info.epoch(),
                 ledger_info.timestamp(),
                 &signed_transaction,
             ) {

--- a/config/src/config/transaction_filter_type.rs
+++ b/config/src/config/transaction_filter_type.rs
@@ -163,74 +163,74 @@ impl Filter {
         self.rules.is_empty()
     }
 
-    pub fn add_deny_all(mut self) -> Self {
-        self.rules.push(Rule::Deny(Matcher::All));
+    fn add_match_rule(mut self, allow: bool, matcher: Matcher) -> Self {
+        if allow {
+            self.rules.push(Rule::Allow(matcher));
+        } else {
+            self.rules.push(Rule::Deny(matcher));
+        }
         self
     }
 
-    pub fn add_deny_block_id(mut self, block_id: HashValue) -> Self {
-        self.rules.push(Rule::Deny(Matcher::BlockId(block_id)));
-        self
+    pub fn add_all_filter(self, allow: bool) -> Self {
+        let matcher = Matcher::All;
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_allow_block_timestamp_greater_than(mut self, timestamp: u64) -> Self {
-        self.rules
-            .push(Rule::Allow(Matcher::BlockTimeStampGreaterThan(timestamp)));
-        self
+    pub fn add_block_id_filter(self, allow: bool, block_id: HashValue) -> Self {
+        let matcher = Matcher::BlockId(block_id);
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_deny_transaction_id(mut self, txn_id: HashValue) -> Self {
-        self.rules.push(Rule::Deny(Matcher::TransactionId(txn_id)));
-        self
+    pub fn add_block_timestamp_greater_than_filter(self, allow: bool, timestamp: u64) -> Self {
+        let matcher = Matcher::BlockTimeStampGreaterThan(timestamp);
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_allow_sender(mut self, sender: AccountAddress) -> Self {
-        self.rules.push(Rule::Allow(Matcher::Sender(sender)));
-        self
+    pub fn add_block_timestamp_less_than_filter(self, allow: bool, timestamp: u64) -> Self {
+        let matcher = Matcher::BlockTimeStampLessThan(timestamp);
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_deny_sender(mut self, sender: AccountAddress) -> Self {
-        self.rules.push(Rule::Deny(Matcher::Sender(sender)));
-        self
+    pub fn add_transaction_id_filter(self, allow: bool, txn_id: HashValue) -> Self {
+        let matcher = Matcher::TransactionId(txn_id);
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_allow_module_address(mut self, address: AccountAddress) -> Self {
-        self.rules
-            .push(Rule::Allow(Matcher::ModuleAddress(address)));
-        self
+    pub fn add_sender_filter(self, allow: bool, sender: AccountAddress) -> Self {
+        let matcher = Matcher::Sender(sender);
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_deny_module_address(mut self, address: AccountAddress) -> Self {
-        self.rules.push(Rule::Deny(Matcher::ModuleAddress(address)));
-        self
+    pub fn add_module_address_filter(self, allow: bool, address: AccountAddress) -> Self {
+        let matcher = Matcher::ModuleAddress(address);
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_deny_entry_function(
-        mut self,
+    pub fn add_entry_function_filter(
+        self,
+        allow: bool,
         address: AccountAddress,
         module_name: String,
         function: String,
     ) -> Self {
-        self.rules.push(Rule::Deny(Matcher::EntryFunction(
-            address,
-            module_name,
-            function,
-        )));
-        self
+        let matcher = Matcher::EntryFunction(address, module_name, function);
+        self.add_match_rule(allow, matcher)
     }
 
-    pub fn add_allow_entry_function(
-        mut self,
-        address: AccountAddress,
-        module_name: String,
-        function: String,
-    ) -> Self {
-        self.rules.push(Rule::Allow(Matcher::EntryFunction(
-            address,
-            module_name,
-            function,
-        )));
-        self
+    pub fn add_block_epoch_greater_than_filter(self, allow: bool, epoch: u64) -> Self {
+        let matcher = Matcher::BlockEpochGreaterThan(epoch);
+        self.add_match_rule(allow, matcher)
+    }
+
+    pub fn add_block_epoch_less_than_filter(self, allow: bool, epoch: u64) -> Self {
+        let matcher = Matcher::BlockEpochLessThan(epoch);
+        self.add_match_rule(allow, matcher)
+    }
+
+    pub fn add_matches_all_of_filter(self, allow: bool, matchers: Vec<Matcher>) -> Self {
+        let matcher = Matcher::MatchesAllOf(matchers);
+        self.add_match_rule(allow, matcher)
     }
 
     pub fn rules(&self) -> &[Rule] {

--- a/consensus/src/block_preparer.rs
+++ b/consensus/src/block_preparer.rs
@@ -64,10 +64,12 @@ impl BlockPreparer {
         let txn_deduper = self.txn_deduper.clone();
         let txn_shuffler = self.txn_shuffler.clone();
         let block_id = block.id();
+        let block_epoch = block.epoch();
         let block_timestamp_usecs = block.timestamp_usecs();
         // Transaction filtering, deduplication and shuffling are CPU intensive tasks, so we run them in a blocking task.
         let result = tokio::task::spawn_blocking(move || {
-            let filtered_txns = txn_filter.filter(block_id, block_timestamp_usecs, txns);
+            let filtered_txns =
+                txn_filter.filter(block_id, block_epoch, block_timestamp_usecs, txns);
             let deduped_txns = txn_deduper.dedup(filtered_txns);
             let mut shuffled_txns = {
                 let _timer = TXN_SHUFFLE_SECONDS.start_timer();

--- a/consensus/src/transaction_filter/mod.rs
+++ b/consensus/src/transaction_filter/mod.rs
@@ -38,7 +38,7 @@ impl TransactionFilter {
 #[cfg(test)]
 mod test {
     use crate::transaction_filter::TransactionFilter;
-    use aptos_config::config::transaction_filter_type::Filter;
+    use aptos_config::config::transaction_filter_type::{Filter, Matcher};
     use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
     use aptos_types::{
         chain_id::ChainId,
@@ -79,14 +79,20 @@ mod test {
 
     fn get_transactions() -> Vec<SignedTransaction> {
         vec![
-            create_signed_transaction(str::parse("0x1::test::add").unwrap()),
-            create_signed_transaction(str::parse("0x1::test::check").unwrap()),
-            create_signed_transaction(str::parse("0x1::test::new").unwrap()),
-            create_signed_transaction(str::parse("0x1::test::sub").unwrap()),
-            create_signed_transaction(str::parse("0x2::test2::mul").unwrap()),
-            create_signed_transaction(str::parse("0x3::test2::div").unwrap()),
-            create_signed_transaction(str::parse("0x4::test2::mod").unwrap()),
+            create_signed_transaction(str::parse("0x0::test0::add").unwrap()),
+            create_signed_transaction(str::parse("0x1::test1::check").unwrap()),
+            create_signed_transaction(str::parse("0x2::test2::new").unwrap()),
+            create_signed_transaction(str::parse("0x3::test3::sub").unwrap()),
+            create_signed_transaction(str::parse("0x4::test4::mul").unwrap()),
+            create_signed_transaction(str::parse("0x5::test5::div").unwrap()),
+            create_signed_transaction(str::parse("0x6::test6::mod").unwrap()),
         ]
+    }
+
+    fn get_block_id_and_transactions() -> (HashValue, Vec<SignedTransaction>) {
+        let txns = get_transactions();
+        let block_id = HashValue::random();
+        (block_id, txns)
     }
 
     fn get_module_address(txn: &SignedTransaction) -> AccountAddress {
@@ -117,189 +123,500 @@ mod test {
     }
 
     #[test]
-    fn test_no_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let no_filter = TransactionFilter::new(Filter::empty());
-        let filtered_txns = no_filter.filter(block_id, 0, 0, txns.clone());
+    fn test_empty_filter() {
+        // Create an empty filter
+        let filter = TransactionFilter::new(Filter::empty());
+
+        // Verify that it returns all transactions
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, txns);
     }
 
     #[test]
     fn test_all_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let all_filter = TransactionFilter::new(Filter::empty().add_deny_all());
-        let filtered_txns = all_filter.filter(block_id, 0, 0, txns.clone());
+        // Create a filter that allows all transactions
+        let filter = TransactionFilter::new(Filter::empty().add_all_filter(true));
+
+        // Verify that it returns all transactions
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, txns);
+
+        // Create a filter that denies all transactions
+        let filter = TransactionFilter::new(Filter::empty().add_all_filter(false));
+
+        // Verify that it returns no transactions
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, vec![]);
     }
 
     #[test]
     fn test_block_id_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let block_id_filter = TransactionFilter::new(Filter::empty().add_deny_block_id(block_id));
-
-        let filtered_txns = block_id_filter.filter(block_id, 0, 0, txns.clone());
-        assert_eq!(filtered_txns, vec![]);
-        let block_id = HashValue::random();
-        let filtered_txns = block_id_filter.filter(block_id, 0, 0, txns.clone());
-        assert_eq!(filtered_txns, txns);
-    }
-
-    #[test]
-    fn test_block_timestamp_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        // Allows all transactions with block timestamp greater than 1000
-        let block_timestamp_filter = TransactionFilter::new(
+        // Create a filter that only allows transactions with a specific block ID
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filter = TransactionFilter::new(
             Filter::empty()
-                .add_allow_block_timestamp_greater_than(1000)
-                .add_deny_all(),
+                .add_block_id_filter(true, block_id)
+                .add_all_filter(false),
         );
 
-        let filtered_txns = block_timestamp_filter.filter(block_id, 0, 0, txns.clone());
+        // Verify that it returns all transactions with the specified block ID
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, txns);
+
+        // Verify that it returns no transactions with a different block ID
+        let different_block_id = HashValue::random();
+        let filtered_txns = filter.filter(different_block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, vec![]);
-        let filtered_txns = block_timestamp_filter.filter(block_id, 0, 1001, txns.clone());
+
+        // Create a filter that denies transactions with a specific block ID
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_block_id_filter(false, block_id)
+                .add_all_filter(true),
+        );
+
+        // Verify that it returns all transactions except those with the specified block ID
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+
+        // Verify that it returns all transactions with a different block ID
+        let different_block_id = HashValue::random();
+        let filtered_txns = filter.filter(different_block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, txns);
     }
 
     #[test]
-    fn test_transaction_hash_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let transaction_hash_filter = TransactionFilter::new(
-            Filter::empty().add_deny_transaction_id(txns[0].committed_hash()),
+    fn test_block_timestamp_greater_than_filter() {
+        // Create a filter that only allows transactions with a block timestamp greater than a specific value
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_block_timestamp_greater_than_filter(true, 1000)
+                .add_all_filter(false),
         );
-        let filtered_txns = transaction_hash_filter.filter(block_id, 0, 0, txns.clone());
+
+        // Verify that it returns no transactions with a block timestamp less than or equal to 1000
+        let (block_id, txns) = get_block_id_and_transactions();
+        for block_timestamp in [0, 999, 1000] {
+            let filtered_txns = filter.filter(block_id, 0, block_timestamp, txns.clone());
+            assert_eq!(filtered_txns, vec![]);
+        }
+
+        // Verify that it returns all transactions with a block timestamp greater than 1000
+        let filtered_txns = filter.filter(block_id, 0, 1001, txns.clone());
+        assert_eq!(filtered_txns, txns);
+
+        // Create a filter that denies transactions with a block timestamp greater than a specific value
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_block_timestamp_greater_than_filter(false, 1000)
+                .add_all_filter(true),
+        );
+
+        // Verify that it returns all transactions with a block timestamp less than or equal to 1000
+        for block_timestamp in [0, 999, 1000] {
+            let filtered_txns = filter.filter(block_id, 0, block_timestamp, txns.clone());
+            assert_eq!(filtered_txns, txns);
+        }
+
+        // Verify that it returns no transactions with a block timestamp greater than 1000
+        let filtered_txns = filter.filter(block_id, 0, 1001, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+    }
+
+    #[test]
+    fn test_block_timestamp_less_than_filter() {
+        // Create a filter that only allows transactions with a block timestamp less than a specific value
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_block_timestamp_less_than_filter(true, 1000)
+                .add_all_filter(false),
+        );
+
+        // Verify that it returns all transactions with a block timestamp less than 1000
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filtered_txns = filter.filter(block_id, 0, 999, txns.clone());
+        assert_eq!(filtered_txns, txns);
+
+        // Verify that it returns no transactions with a block timestamp greater than or equal to 1000
+        for block_timestamp in [1000, 1001] {
+            let filtered_txns = filter.filter(block_id, 0, block_timestamp, txns.clone());
+            assert_eq!(filtered_txns, vec![]);
+        }
+
+        // Create a filter that denies transactions with a block timestamp less than a specific value
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_block_timestamp_less_than_filter(false, 1000)
+                .add_all_filter(true),
+        );
+
+        // Verify that it returns no transactions with a block timestamp less than 1000
+        let filtered_txns = filter.filter(block_id, 0, 999, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+
+        // Verify that it returns all transactions with a block timestamp greater than or equal to 1000
+        for block_timestamp in [1000, 1001] {
+            let filtered_txns = filter.filter(block_id, 0, block_timestamp, txns.clone());
+            assert_eq!(filtered_txns, txns);
+        }
+    }
+
+    #[test]
+    fn test_transaction_id_filter() {
+        // Create a filter that only allows transactions with a specific transaction ID (txn 0)
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_transaction_id_filter(true, txns[0].committed_hash())
+                .add_all_filter(false),
+        );
+
+        // Verify that it returns the transaction with the specified ID
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, vec![txns[0].clone()]);
+
+        // Create a filter that denies transactions with a specific transaction ID (txn 0)
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_transaction_id_filter(false, txns[0].committed_hash())
+                .add_all_filter(true),
+        );
+
+        // Verify that it returns all transactions except the one with the specified ID
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, txns[1..].to_vec());
     }
 
     #[test]
     fn test_sender_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let block_list_sender_filter = TransactionFilter::new(
+        // Create a filter that only allows transactions from a specific sender (txn 0 and txn 1)
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filter = TransactionFilter::new(
             Filter::empty()
-                .add_deny_sender(txns[0].sender())
-                .add_deny_sender(txns[1].sender()),
+                .add_sender_filter(true, txns[0].sender())
+                .add_sender_filter(true, txns[1].sender())
+                .add_all_filter(false),
         );
-        let filtered_txns = block_list_sender_filter.filter(block_id, 0, 0, txns.clone());
-        assert_eq!(filtered_txns, txns[2..].to_vec());
+
+        // Verify that it returns transactions from the specified senders
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, txns[0..2].to_vec());
+
+        // Create a filter that denies transactions from a specific sender (txn 0, txn 1 and txn 2)
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_sender_filter(false, txns[0].sender())
+                .add_sender_filter(false, txns[1].sender())
+                .add_sender_filter(false, txns[2].sender()),
+        );
+
+        // Verify that it returns transactions from other senders
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, txns[3..].to_vec());
+    }
+
+    #[test]
+    fn test_module_address_filter() {
+        // Create a filter that only allows transactions from a specific module address (txn 0 and txn 1)
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_module_address_filter(true, get_module_address(&txns[0]))
+                .add_module_address_filter(true, get_module_address(&txns[1]))
+                .add_all_filter(false),
+        );
+
+        // Verify that it returns transactions from the specified module addresses
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, txns[0..2].to_vec());
+
+        // Create a filter that denies transactions from a specific module address (txn 0)
+        let filter = TransactionFilter::new(
+            Filter::empty().add_module_address_filter(false, get_module_address(&txns[0])),
+        );
+
+        // Verify that it returns transactions from other module addresses
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, txns[1..].to_vec());
     }
 
     #[test]
     fn test_entry_function_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let allow_list_entry_function_filter = TransactionFilter::new(
+        // Create a filter that only allows transactions with specific entry functions (txn 0 and txn 1)
+        let filter = TransactionFilter::new(
             Filter::empty()
-                .add_allow_entry_function(
-                    get_module_address(&txns[0]),
-                    get_module_name(&txns[0]),
-                    get_function_name(&txns[0]),
+                .add_entry_function_filter(
+                    true,
+                    get_module_address(&get_transactions()[0]),
+                    get_module_name(&get_transactions()[0]),
+                    get_function_name(&get_transactions()[0]),
                 )
-                .add_allow_entry_function(
-                    get_module_address(&txns[1]),
-                    get_module_name(&txns[1]),
-                    get_function_name(&txns[1]),
+                .add_entry_function_filter(
+                    true,
+                    get_module_address(&get_transactions()[1]),
+                    get_module_name(&get_transactions()[1]),
+                    get_function_name(&get_transactions()[1]),
                 )
-                .add_deny_all(),
+                .add_all_filter(false),
         );
-        let filtered_txns = allow_list_entry_function_filter.filter(block_id, 0, 0, txns.clone());
+
+        // Verify that it returns transactions with the specified entry functions
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, txns[0..2].to_vec());
 
-        let deny_list_entry_function_filter = TransactionFilter::new(
-            Filter::empty()
-                .add_deny_entry_function(
-                    get_module_address(&txns[0]),
-                    get_module_name(&txns[0]),
-                    get_function_name(&txns[0]),
-                )
-                .add_deny_entry_function(
-                    get_module_address(&txns[1]),
-                    get_module_name(&txns[1]),
-                    get_function_name(&txns[1]),
-                ),
-        );
-        let filtered_txns = deny_list_entry_function_filter.filter(block_id, 0, 0, txns.clone());
-        assert_eq!(filtered_txns, txns[2..].to_vec());
+        // Create a filter that denies transactions with specific entry functions (txn 0)
+        let filter = TransactionFilter::new(Filter::empty().add_entry_function_filter(
+            false,
+            get_module_address(&get_transactions()[0]),
+            get_module_name(&get_transactions()[0]),
+            get_function_name(&get_transactions()[0]),
+        ));
+
+        // Verify that it returns transactions with other entry functions
+        let filtered_txns = filter.filter(block_id, 0, 0, txns.clone());
+        assert_eq!(filtered_txns, txns[1..].to_vec());
     }
 
     #[test]
-    fn test_allow_list_module_address_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let allow_list_module_address_filter = TransactionFilter::new(
+    fn test_block_epoch_greater_than_filter() {
+        // Create a filter that only allows transactions with a block epoch greater than a specific value
+        let filter = TransactionFilter::new(
             Filter::empty()
-                .add_allow_module_address(get_module_address(&txns[0]))
-                .add_allow_module_address(get_module_address(&txns[1]))
-                .add_deny_all(),
+                .add_block_epoch_greater_than_filter(true, 1000)
+                .add_all_filter(false),
         );
-        let filtered_txns = allow_list_module_address_filter.filter(block_id, 0, 0, txns.clone());
-        assert_eq!(filtered_txns, txns[0..4].to_vec());
 
-        let block_list_module_address_filter = TransactionFilter::new(
+        // Verify that it returns no transactions with a block epoch less than or equal to 1000
+        let (block_id, txns) = get_block_id_and_transactions();
+        for block_epoch in [0, 999, 1000] {
+            let filtered_txns = filter.filter(block_id, block_epoch, 0, txns.clone());
+            assert_eq!(filtered_txns, vec![]);
+        }
+
+        // Verify that it returns all transactions with a block epoch greater than 1000
+        let filtered_txns = filter.filter(block_id, 1001, 0, txns.clone());
+        assert_eq!(filtered_txns, txns);
+
+        // Create a filter that denies transactions with a block epoch greater than a specific value
+        let filter = TransactionFilter::new(
             Filter::empty()
-                .add_deny_module_address(get_module_address(&txns[0]))
-                .add_deny_module_address(get_module_address(&txns[1])),
+                .add_block_epoch_greater_than_filter(false, 1000)
+                .add_all_filter(true),
         );
-        let filtered_txns = block_list_module_address_filter.filter(block_id, 0, 0, txns.clone());
-        assert_eq!(filtered_txns, txns[4..].to_vec());
+
+        // Verify that it returns all transactions with a block epoch less than or equal to 1000
+        for block_epoch in [0, 999, 1000] {
+            let filtered_txns = filter.filter(block_id, block_epoch, 0, txns.clone());
+            assert_eq!(filtered_txns, txns);
+        }
+
+        // Verify that it returns no transactions with a block epoch greater than 1000
+        let filtered_txns = filter.filter(block_id, 1001, 0, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+    }
+
+    #[test]
+    fn test_block_epoch_less_than_filter() {
+        // Create a filter that only allows transactions with a block epoch less than a specific value
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_block_epoch_less_than_filter(true, 1000)
+                .add_all_filter(false),
+        );
+
+        // Verify that it returns all transactions with a block epoch less than 1000
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filtered_txns = filter.filter(block_id, 999, 0, txns.clone());
+        assert_eq!(filtered_txns, txns);
+
+        // Verify that it returns no transactions with a block epoch greater than or equal to 1000
+        for block_epoch in [1000, 1001] {
+            let filtered_txns = filter.filter(block_id, block_epoch, 0, txns.clone());
+            assert_eq!(filtered_txns, vec![]);
+        }
+
+        // Create a filter that denies transactions with a block epoch less than a specific value
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_block_epoch_less_than_filter(false, 1000)
+                .add_all_filter(true),
+        );
+
+        // Verify that it returns no transactions with a block epoch less than 1000
+        let filtered_txns = filter.filter(block_id, 999, 0, txns.clone());
+        assert_eq!(filtered_txns, vec![]);
+
+        // Verify that it returns all transactions with a block epoch greater than or equal to 1000
+        for block_epoch in [1000, 1001] {
+            let filtered_txns = filter.filter(block_id, block_epoch, 0, txns.clone());
+            assert_eq!(filtered_txns, txns);
+        }
+    }
+
+    #[test]
+    fn test_matches_all_of_filter() {
+        // Create a filter that only matches transactions with epoch greater than 1000 and a specific sender (only txn 0)
+        let (block_id, txns) = get_block_id_and_transactions();
+        let matchers = vec![
+            Matcher::BlockEpochGreaterThan(1000),
+            Matcher::Sender(txns[0].sender()),
+        ];
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_matches_all_of_filter(true, matchers)
+                .add_all_filter(false),
+        );
+
+        // Verify that it returns no transactions with block epoch less than or equal to 1000
+        for block_epoch in [0, 999, 1000] {
+            let filtered_txns = filter.filter(block_id, block_epoch, 0, txns.clone());
+            assert_eq!(filtered_txns, vec![]);
+        }
+
+        // Verify that it returns transactions with block epoch greater than 1000 and the specified sender
+        let filtered_txns = filter.filter(block_id, 1001, 0, txns.clone());
+        assert_eq!(filtered_txns, txns[0..1].to_vec());
+
+        // Create a filter that denies transactions with timestamp greater than 1000 and a specific sender (only txn 0)
+        let matchers = vec![
+            Matcher::BlockTimeStampGreaterThan(1000),
+            Matcher::Sender(txns[0].sender()),
+        ];
+        let filter = TransactionFilter::new(
+            Filter::empty()
+                .add_matches_all_of_filter(false, matchers)
+                .add_all_filter(true),
+        );
+
+        // Verify that it returns all transactions with block timestamp less than or equal to 1000
+        for block_timestamp in [0, 999, 1000] {
+            let filtered_txns = filter.filter(block_id, 0, block_timestamp, txns.clone());
+            assert_eq!(filtered_txns, txns);
+        }
+
+        // Verify that it returns no transactions with block timestamp greater than 1000 and the specified sender
+        let filtered_txns = filter.filter(block_id, 0, 1001, txns.clone());
+        assert_eq!(filtered_txns, txns[1..].to_vec());
     }
 
     #[test]
     fn test_composite_allow_list_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let filter = serde_yaml::from_str::<Filter>(r#"
+        // Create a filter that only allows transactions based on multiple criteria
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filter_string = format!(
+            r#"
             rules:
                 - Allow:
-                    Sender: f8871acf2c827d40e23b71f6ff2b9accef8dbb17709b88bd9eb95e6bb748c25a
+                    Sender: "{}"
                 - Allow:
                     ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000001"
                 - Allow:
                     EntryFunction:
-                        - "0000000000000000000000000000000000000000000000000000000000000001"
-                        - test
-                        - check
+                        - "0000000000000000000000000000000000000000000000000000000000000002"
+                        - test2
+                        - new
                 - Allow:
                     EntryFunction:
-                        - "0000000000000000000000000000000000000000000000000000000000000001"
-                        - test
-                        - new
+                        - "0000000000000000000000000000000000000000000000000000000000000003"
+                        - test3
+                        - sub
                 - Deny: All
-              "#).unwrap();
-
+          "#,
+            txns[0].sender().to_standard_string()
+        );
+        let filter = serde_yaml::from_str::<Filter>(&filter_string).unwrap();
         let allow_list_filter = TransactionFilter::new(filter);
+
+        // Verify that only the first four transactions are allowed
         let filtered_txns = allow_list_filter.filter(block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, txns[0..4].to_vec());
     }
 
     #[test]
     fn test_composite_block_list_filter() {
-        let txns = get_transactions();
-        let block_id = HashValue::random();
-        let filter = serde_yaml::from_str::<Filter>(r#"
+        // Create a filter that denies transactions based on multiple criteria
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filter_string = format!(
+            r#"
             rules:
                 - Deny:
-                    Sender: f8871acf2c827d40e23b71f6ff2b9accef8dbb17709b88bd9eb95e6bb748c25a
+                    ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000000"
                 - Deny:
-                    ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000001"
-                - Deny:
-                    EntryFunction:
-                        - "0000000000000000000000000000000000000000000000000000000000000001"
-                        - test
-                        - check
+                    Sender: "{}"
                 - Deny:
                     EntryFunction:
-                        - "0000000000000000000000000000000000000000000000000000000000000001"
-                        - test
+                        - "0000000000000000000000000000000000000000000000000000000000000002"
+                        - test2
                         - new
-              "#).unwrap();
+                - Deny:
+                    ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000003"
+                - Allow: All
+          "#,
+            txns[1].sender().to_standard_string()
+        );
+        let filter = serde_yaml::from_str::<Filter>(&filter_string).unwrap();
+        let block_list_filter = TransactionFilter::new(filter);
 
-        let allow_list_filter = TransactionFilter::new(filter);
-        let filtered_txns = allow_list_filter.filter(block_id, 0, 0, txns.clone());
+        // Verify that the first four transactions are denied
+        let filtered_txns = block_list_filter.filter(block_id, 0, 0, txns.clone());
         assert_eq!(filtered_txns, txns[4..].to_vec());
+    }
+
+    #[test]
+    fn test_composite_matches_all_of_filter() {
+        // Create a filter that denies transactions based on the matches all of rule
+        let (block_id, txns) = get_block_id_and_transactions();
+        let filter_string = format!(
+            r#"
+            rules:
+                - Deny:
+                    MatchesAllOf:
+                        - Sender: "{}"
+                        - ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000000"
+                        - BlockEpochGreaterThan: 10
+                - Deny:
+                    MatchesAllOf:
+                        - Sender: "{}"
+                        - ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000001"
+                        - BlockEpochGreaterThan: 10
+                        - BlockTimeStampGreaterThan: 1000
+                - Deny:
+                    MatchesAllOf:
+                        - Sender: "{}"
+                        - ModuleAddress: "0000000000000000000000000000000000000000000000000000000000000002"
+                        - BlockEpochGreaterThan: 10
+                        - BlockTimeStampGreaterThan: 1000
+                        - BlockId: "{}"
+                - Allow: All
+          "#,
+            txns[0].sender().to_standard_string(),
+            txns[1].sender().to_standard_string(),
+            txns[2].sender().to_standard_string(),
+            block_id.to_hex()
+        );
+        let filter = serde_yaml::from_str::<Filter>(&filter_string).unwrap();
+        let block_list_filter = TransactionFilter::new(filter);
+
+        // Filter transactions with a block epoch of 11, timestamp of 1001, and the expected block ID
+        let filtered_txns = block_list_filter.filter(block_id, 11, 1001, txns.clone());
+
+        // Verify that only the first three transactions are denied
+        assert_eq!(filtered_txns, txns[3..].to_vec());
+
+        // Filter transactions with a block epoch of 11, timestamp of 1001, and a random block ID
+        let random_block_id = HashValue::random();
+        let filtered_txns = block_list_filter.filter(random_block_id, 11, 1001, txns.clone());
+
+        // Verify that only the first two transactions are denied
+        assert_eq!(filtered_txns, txns[2..].to_vec());
+
+        // Filter transactions with a block epoch of 11, timestamp of 999, and the expected block ID
+        let filtered_txns = block_list_filter.filter(block_id, 11, 999, txns.clone());
+
+        // Verify that only the first transaction is denied
+        assert_eq!(filtered_txns, txns[1..].to_vec());
     }
 }

--- a/consensus/src/transaction_filter/mod.rs
+++ b/consensus/src/transaction_filter/mod.rs
@@ -25,6 +25,7 @@ impl TransactionFilter {
         if self.filter.is_empty() {
             return txns;
         }
+
         txns.into_iter()
             .filter(|txn| {
                 self.filter


### PR DESCRIPTION
## Description
This PR extends the transaction filtering support offered by the `simulation` API on fullnodes. The PR offers the following commits:
1. Add support for the `BlockEpochGreaterThan` and `BlockEpochLessThan` filter. These filter transactions based on the epoch of the block containing the transactions.
2. Add support for the `MatchesAllOf` filter. This allows filter rules to be combined, e.g., filter transactions that touch specific modules in blocks with a timestamp greater than a specific value.
3. Add tests for the new filters, and extend the tests for the existing filters (e.g., negative and positive cases).

## Testing Plan
New and existing test infrastructure.
