### PR TITLE
[lint] Update linter API

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/model_ast_lints.rs
@@ -43,7 +43,7 @@ fn check_function(
     module_lint_skips: &BTreeSet<String>,
     known_checker_names: &BTreeSet<String>,
 ) {
-    let env = function.module_env.env;
+    let env = function.env();
     let function_lint_skips =
         lint_skips_from_attributes(env, function.get_attributes(), known_checker_names);
     let mut lint_skips = BTreeSet::from_iter(function_lint_skips);
@@ -53,11 +53,11 @@ fn check_function(
         let mut visitor = |post: bool, e: &ExpData| {
             if !post {
                 for exp_lint in expression_linters.iter_mut() {
-                    exp_lint.visit_expr_pre(env, e);
+                    exp_lint.visit_expr_pre(function, e);
                 }
             } else {
                 for exp_lint in expression_linters.iter_mut() {
-                    exp_lint.visit_expr_post(env, e);
+                    exp_lint.visit_expr_post(function, e);
                 }
             }
             true

--- a/third_party/move/move-compiler-v2/src/external_checks.rs
+++ b/third_party/move/move-compiler-v2/src/external_checks.rs
@@ -7,7 +7,7 @@
 use legacy_move_compiler::shared::known_attributes::LintAttribute;
 use move_model::{
     ast::ExpData,
-    model::{GlobalEnv, Loc},
+    model::{FunctionEnv, GlobalEnv, Loc},
 };
 use move_stackless_bytecode::function_target::FunctionTarget;
 use std::{collections::BTreeSet, fmt, sync::Arc};
@@ -55,11 +55,11 @@ pub trait ExpChecker {
 
     /// Examine `expr` before any of its children have been visited.
     /// Potentially emit reports using `self.report()`.
-    fn visit_expr_pre(&mut self, _env: &GlobalEnv, _expr: &ExpData) {}
+    fn visit_expr_pre(&mut self, _function: &FunctionEnv, _expr: &ExpData) {}
 
     /// Examine `expr` after all its children have been visited.
     /// Potentially emit reports using `self.report()`.
-    fn visit_expr_post(&mut self, _env: &GlobalEnv, _expr: &ExpData) {}
+    fn visit_expr_post(&mut self, _function: &FunctionEnv, _expr: &ExpData) {}
 
     /// Report the `msg` highlighting the `loc`.
     fn report(&self, env: &GlobalEnv, loc: &Loc, msg: &str) {

--- a/third_party/move/tools/move-linter/src/model_ast_lints/almost_swapped.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/almost_swapped.rs
@@ -11,7 +11,7 @@ use crate::utils;
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{Exp, ExpData, ExpData::Sequence, Pattern},
-    model::{GlobalEnv, Loc},
+    model::{FunctionEnv, Loc},
 };
 
 #[derive(Default)]
@@ -22,7 +22,7 @@ impl ExpChecker for AlmostSwapped {
         "almost_swapped".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         if let Sequence(_, exprs) = expr {
             for pair in exprs.windows(2) {
                 let (first, second) = (&pair[0], &pair[1]);
@@ -51,6 +51,7 @@ impl ExpChecker for AlmostSwapped {
                 if utils::is_simple_access_equal(lhs1.as_ref(), rhs2.as_ref())
                     && utils::is_simple_access_equal(rhs1.as_ref(), lhs2.as_ref())
                 {
+                    let env = function.env();
                     let new_loc = Loc::enclosing(&[
                         env.get_node_loc(first.node_id()),
                         env.get_node_loc(second.node_id()),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/blocks_in_conditions.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/blocks_in_conditions.rs
@@ -12,7 +12,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::ExpData,
-    model::{GlobalEnv, NodeId},
+    model::{FunctionEnv, NodeId},
 };
 
 /// Expression linter keeping track of traversal state.
@@ -42,7 +42,7 @@ impl ExpChecker for BlocksInConditions {
         "blocks_in_conditions".to_string()
     }
 
-    fn visit_expr_pre(&mut self, _env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, _function: &FunctionEnv, expr: &ExpData) {
         use CondExprState::*;
         use ExpData::{Block, IfElse, Match, Sequence, SpecBlock};
         match self.state {
@@ -77,7 +77,7 @@ impl ExpChecker for BlocksInConditions {
         }
     }
 
-    fn visit_expr_post(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_post(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use CondExprState::*;
         match self.state {
             Some(Traversing {
@@ -88,6 +88,7 @@ impl ExpChecker for BlocksInConditions {
                 // We are done with traversing the condition of interest.
                 self.state = None;
                 if has_any_block && !has_spec_block {
+                    let env = function.env();
                     self.report(
                         env,
                         &env.get_node_loc(id),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/needless_bool.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/needless_bool.rs
@@ -13,7 +13,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Value},
-    model::GlobalEnv,
+    model::FunctionEnv,
 };
 
 #[derive(Default)]
@@ -24,8 +24,9 @@ impl ExpChecker for NeedlessBool {
         "needless_bool".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use ExpData::IfElse;
+        let env = function.env();
         if let IfElse(id, _, then, else_) = expr {
             match Self::fixed_bool_values(then, else_) {
                 None => {},

--- a/third_party/move/tools/move-linter/src/model_ast_lints/needless_deref_ref.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/needless_deref_ref.rs
@@ -10,7 +10,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Operation},
-    model::{GlobalEnv, NodeId},
+    model::{FunctionEnv, NodeId},
     ty::ReferenceKind,
 };
 
@@ -22,8 +22,9 @@ impl ExpChecker for NeedlessDerefRef {
         "needless_deref_ref".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         if let Some((id, kind)) = Self::needless_deref_ref_pair(expr) {
+            let env = function.env();
             self.report(
                 env,
                 &env.get_node_loc(id),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/needless_ref_deref.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/needless_ref_deref.rs
@@ -8,7 +8,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Operation},
-    model::GlobalEnv,
+    model::FunctionEnv,
     ty::ReferenceKind,
 };
 
@@ -20,7 +20,7 @@ impl ExpChecker for NeedlessRefDeref {
         "needless_ref_deref".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use ExpData::Call;
         use Operation::{Borrow, Deref};
         use ReferenceKind::Immutable;
@@ -34,6 +34,7 @@ impl ExpChecker for NeedlessRefDeref {
         let Call(_, Deref, _) = args[0].as_ref() else {
             return;
         };
+        let env = function.env();
         self.report(
             env,
             &env.get_node_loc(*id),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/needless_ref_in_field_access.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/needless_ref_in_field_access.rs
@@ -10,7 +10,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Operation},
-    model::GlobalEnv,
+    model::FunctionEnv,
 };
 
 #[derive(Default)]
@@ -21,7 +21,7 @@ impl ExpChecker for NeedlessRefInFieldAccess {
         "needless_ref_in_field_access".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use ExpData::Call;
         use Operation::{Borrow, Select, SelectVariants};
         let Call(_, select @ (Select(..) | SelectVariants(..)), args) = expr else {
@@ -43,6 +43,7 @@ impl ExpChecker for NeedlessRefInFieldAccess {
             ),
             _ => unreachable!("select is limited to the two variants above"),
         };
+        let env = function.env();
         let field_name = env
             .get_module(*module_id)
             .into_struct(*struct_id)

--- a/third_party/move/tools/move-linter/src/model_ast_lints/nonminimal_bool.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/nonminimal_bool.rs
@@ -20,7 +20,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Operation, Value},
-    model::GlobalEnv,
+    model::FunctionEnv,
 };
 
 #[derive(Default)]
@@ -81,7 +81,7 @@ impl ExpChecker for NonminimalBool {
         "nonminimal_bool".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use ExpData::{Call, Value as ExpValue};
         use Operation::*;
         use Value::Bool;
@@ -108,6 +108,7 @@ impl ExpChecker for NonminimalBool {
         };
 
         if let Some(msg) = msg {
+            let env = function.env();
             self.report(env, &env.get_node_loc(expr.node_id()), &msg);
         }
     }

--- a/third_party/move/tools/move-linter/src/model_ast_lints/self_assignment.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/self_assignment.rs
@@ -11,7 +11,7 @@ use crate::utils;
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Pattern},
-    model::{GlobalEnv, Loc},
+    model::{FunctionEnv, Loc},
 };
 
 #[derive(Default)]
@@ -22,7 +22,8 @@ impl ExpChecker for SelfAssignment {
         "self_assignment".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
+        let env = function.env();
         let mut report_loc: Loc = env.get_node_loc(expr.node_id());
         let mut error = false;
         match expr {

--- a/third_party/move/tools/move-linter/src/model_ast_lints/simpler_numeric_expression.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/simpler_numeric_expression.rs
@@ -13,7 +13,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Operation, Value},
-    model::GlobalEnv,
+    model::FunctionEnv,
 };
 use num::BigInt;
 
@@ -25,7 +25,7 @@ impl ExpChecker for SimplerNumericExpression {
         "simpler_numeric_expression".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use ExpData::{Call, Value as ExpVal};
         use Operation::*;
         use Value::Number as N;
@@ -66,6 +66,7 @@ impl ExpChecker for SimplerNumericExpression {
             },
             _ => None,
         } {
+            let env = function.env();
             self.report(env, &env.get_node_loc(*id), msg);
         }
     }

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_boolean_identity_comparison.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_boolean_identity_comparison.rs
@@ -12,7 +12,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Operation, Value},
-    model::GlobalEnv,
+    model::FunctionEnv,
 };
 
 #[derive(Default)]
@@ -23,7 +23,7 @@ impl ExpChecker for UnnecessaryBooleanIdentityComparison {
         "unnecessary_boolean_identity_comparison".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use ExpData::{Call, Value as ExpValue};
         use Operation::*;
         use Value::Bool;
@@ -45,6 +45,7 @@ impl ExpChecker for UnnecessaryBooleanIdentityComparison {
                         },
                         if *b { "true" } else { "false" }
                     );
+                    let env = function.env();
                     self.report(env, &env.get_node_loc(e.node_id()), &msg);
                 },
                 _ => {},

--- a/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_numerical_extreme_comparison.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_numerical_extreme_comparison.rs
@@ -15,7 +15,7 @@
 use move_compiler_v2::external_checks::ExpChecker;
 use move_model::{
     ast::{ExpData, Operation, Value},
-    model::GlobalEnv,
+    model::FunctionEnv,
     ty::Type,
 };
 use num::BigInt;
@@ -29,7 +29,7 @@ impl ExpChecker for UnnecessaryNumericalExtremeComparison {
         "unnecessary_numerical_extreme_comparison".to_string()
     }
 
-    fn visit_expr_pre(&mut self, env: &GlobalEnv, expr: &ExpData) {
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
         use ExpData::Call;
         use Operation::*;
         // Let's narrow down to the comparison operators we are interested in.
@@ -39,6 +39,7 @@ impl ExpChecker for UnnecessaryNumericalExtremeComparison {
                 "there should be exactly two arguments for comparison operators"
             );
             let (lhs, rhs) = (args[0].as_ref(), args[1].as_ref());
+            let env = function.env();
             // Types on both sides of the comparison must be the same, so let's just
             // get the type of the left-hand side.
             let ty = env.get_node_type(lhs.node_id());


### PR DESCRIPTION
## Description

We update the model AST linter trait to take `FunctionEnv` as an argument instead of `GlobalEnv`. This allows the lint checks to access information about the function easily, as well as get to the `GlobalEnv` easily (thus, it is strictly more powerful).

## How Has This Been Tested?

Existing tests.

## Type of Change
- [x] Refactoring

## Which Components or Systems Does This Change Impact?
- [x] Move Linter