### PR TITLE
Reapply "replay-on-archive: remove hack to ignore failure on first tx…

### DIFF
--- a/storage/db-tool/src/replay_on_archive.rs
+++ b/storage/db-tool/src/replay_on_archive.rs
@@ -325,23 +325,12 @@ impl Verifier {
                 Some(&expected_writesets[idx]),
                 Some(&expected_events[idx]),
             ) {
-                let err_opt = if idx == 0 {
-                    // FIXME(aldenhu): remove this hack
-                    warn!(
-                        version = version,
-                        "Probably known failure due to StateStorageUsage missing from a restored DB."
-                    );
-                    Ok(None)
-                } else {
-                    Ok(Some(err))
-                };
-
                 cur_txns.drain(0..idx + 1);
                 expected_txn_infos.drain(0..idx + 1);
                 expected_events.drain(0..idx + 1);
                 expected_writesets.drain(0..idx + 1);
 
-                return err_opt;
+                return Ok(Some(err));
             }
         }
 


### PR DESCRIPTION
revert the revert

gonna test run before landing
https://github.com/aptos-labs/aptos-core/actions/runs/15351711548

a few pods timed out, which I think we should tackle otherwise, but I don't see the StateStorageUsage related failures we used to see on the restored dbs, gonna land this. 
