### PR TITLE
[compiler-v2] Handle function values that are referring to functions like `vector::empty`

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -19,10 +19,7 @@ use move_core_types::{
 };
 use move_ir_types::ast as IR_AST;
 use move_model::{
-    ast::{
-        AccessSpecifier, AccessSpecifierKind, Address, AddressSpecifier, Attribute,
-        ResourceSpecifier,
-    },
+    ast::{AccessSpecifier, AccessSpecifierKind, AddressSpecifier, Attribute, ResourceSpecifier},
     metadata::{CompilationMetadata, CompilerVersion, LanguageVersion, COMPILATION_METADATA_KEY},
     model::{
         FieldEnv, FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, ModuleId, Parameter, QualifiedId,
@@ -1030,29 +1027,37 @@ impl ModuleContext<'_> {
         inst_sign: Option<FF::SignatureIndex>,
     ) -> Option<FF::Bytecode> {
         let fun = self.env.get_function(qid);
-        let mod_name = fun.module_env.get_name();
-        if mod_name.addr() != &Address::Numerical(AccountAddress::ONE) {
+        if !fun.module_env.is_std_vector() {
             return None;
         }
         let pool = self.env.symbol_pool();
-        if pool.string(mod_name.name()).as_str() == "vector" {
-            if let Some(inst) = inst_sign {
-                match pool.string(fun.get_name()).as_str() {
-                    "empty" => Some(FF::Bytecode::VecPack(inst, 0)),
-                    "length" => Some(FF::Bytecode::VecLen(inst)),
-                    "borrow" => Some(FF::Bytecode::VecImmBorrow(inst)),
-                    "borrow_mut" => Some(FF::Bytecode::VecMutBorrow(inst)),
-                    "push_back" => Some(FF::Bytecode::VecPushBack(inst)),
-                    "pop_back" => Some(FF::Bytecode::VecPopBack(inst)),
-                    "destroy_empty" => Some(FF::Bytecode::VecUnpack(inst, 0)),
-                    "swap" => Some(FF::Bytecode::VecSwap(inst)),
-                    _ => None,
-                }
-            } else {
-                self.internal_error(loc, "expected type instantiation for vector operation");
-                None
+        let function_name = pool.string(fun.get_name());
+        if !well_known::VECTOR_FUNCS_WITH_BYTECODE_INSTRS.contains(&function_name.as_str()) {
+            // early return if vector function does not have a bytecode instruction
+            return None;
+        }
+
+        if let Some(inst) = inst_sign {
+            match function_name.as_str() {
+                // note: the following matched strings should all be present in `well_known::VECTOR_FUNCS_WITH_BYTECODE_INSTRS`
+                "empty" => Some(FF::Bytecode::VecPack(inst, 0)),
+                "length" => Some(FF::Bytecode::VecLen(inst)),
+                "borrow" => Some(FF::Bytecode::VecImmBorrow(inst)),
+                "borrow_mut" => Some(FF::Bytecode::VecMutBorrow(inst)),
+                "push_back" => Some(FF::Bytecode::VecPushBack(inst)),
+                "pop_back" => Some(FF::Bytecode::VecPopBack(inst)),
+                "destroy_empty" => Some(FF::Bytecode::VecUnpack(inst, 0)),
+                "swap" => Some(FF::Bytecode::VecSwap(inst)),
+                _ => {
+                    self.internal_error(
+                        loc,
+                        format!("unexpected vector function `{}`", function_name),
+                    );
+                    None
+                },
             }
         } else {
+            self.internal_error(loc, "expected type instantiation for vector operation");
             None
         }
     }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16363.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16363.move
@@ -1,11 +1,11 @@
 //# publish
 module 0x42::foo {
     struct Foo<T: store> has key, drop {
-        f: ||vector<T>,
+        f: |T|vector<T>,
     }
 
     public fun make_foo<T: store>(account: &signer) {
-        let f = || std::vector::empty<T>();
+        let f = |e| std::vector::singleton<T>(e);
         move_to(account, Foo { f })
     }
 

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16684.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16684.exp
@@ -1,0 +1,43 @@
+processed 16 tasks
+
+task 1 'run'. lines 92-92:
+return values: []
+
+task 2 'run'. lines 94-94:
+return values: []
+
+task 3 'run'. lines 96-96:
+return values: []
+
+task 4 'run'. lines 98-98:
+return values: []
+
+task 5 'run'. lines 100-100:
+return values: []
+
+task 6 'run'. lines 102-102:
+return values: []
+
+task 7 'run'. lines 104-104:
+return values: []
+
+task 8 'run'. lines 106-106:
+return values: []
+
+task 9 'run'. lines 108-108:
+return values: []
+
+task 10 'run'. lines 110-110:
+return values: [42]
+
+task 12 'run'. lines 114-114:
+return values: 3
+
+task 13 'run'. lines 116-116:
+return values: [3, 2, 1]
+
+task 14 'run'. lines 118-118:
+return values: [3, 2, 1]
+
+task 15 'run'. lines 120-120:
+return values: [1, 2, 3, 4]

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16684.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/bug_16684.move
@@ -1,0 +1,120 @@
+//# publish
+module 0xc0ffee::m {
+    public fun test1a(): vector<u64> {
+        let f = || std::vector::empty();
+        f()
+    }
+
+    public fun test1b(): vector<u64> {
+        let f = std::vector::empty;
+        f()
+    }
+
+    public fun test2a(): vector<u64> {
+        let f = || std::vector::empty<u64>();
+        f()
+    }
+
+    public fun test2b(): vector<u64> {
+        let f = std::vector::empty<u64>;
+        f()
+    }
+
+    public fun test3a<T>(): vector<T> {
+        let f = || std::vector::empty();
+        f()
+    }
+
+    public fun test3b<T>(): vector<T> {
+        let f = std::vector::empty;
+        f()
+    }
+
+    public fun test4a<T>(): vector<T> {
+        let f = || std::vector::empty<T>();
+        f()
+    }
+
+    public fun test4b<T>(): vector<T> {
+        let f = std::vector::empty<T>;
+        f()
+    }
+
+    fun apply<T>(f: || vector<T>): vector<T> {
+        f()
+    }
+
+    public fun test5(): vector<u64> {
+        let f = || apply(std::vector::empty);
+        f()
+    }
+
+    public fun test6(): vector<u64> {
+        let f = std::vector::singleton;
+        f(42)
+    }
+
+    struct Resource(u64);
+
+    public fun test7() {
+        let f = std::vector::destroy_empty<Resource>;
+        f(vector[]);
+    }
+
+    public fun test8(): u64 {
+        let f = std::vector::length;
+        f(&vector[1, 2, 3])
+    }
+
+    public fun test9a(): vector<u64> {
+        let v = vector[1, 2, 3];
+        let f = |v, i, j| std::vector::swap(v, i, j);
+        f(&mut v, 0, 2);
+        v
+    }
+
+    public fun test9b(): vector<u64> {
+        let v = vector[1, 2, 3];
+        let f = std::vector::swap;
+        f(&mut v, 0, 2);
+        v
+    }
+
+    public fun test10(): vector<u64> {
+        let e = 4;
+        let v = vector[1, 2, 3];
+        let f = |v| std::vector::push_back(v, e);
+        f(&mut v);
+        v
+    }
+}
+
+//# run 0xc0ffee::m::test1a
+
+//# run 0xc0ffee::m::test1b
+
+//# run 0xc0ffee::m::test2a
+
+//# run 0xc0ffee::m::test2b
+
+//# run 0xc0ffee::m::test3a --type-args u64
+
+//# run 0xc0ffee::m::test3b --type-args u16
+
+//# run 0xc0ffee::m::test4a --type-args u32
+
+//# run 0xc0ffee::m::test4b --type-args u128
+
+//# run 0xc0ffee::m::test5
+
+//# run 0xc0ffee::m::test6
+
+//# run 0xc0ffee::m::test7
+
+//# run 0xc0ffee::m::test8
+
+//# run 0xc0ffee::m::test9a
+
+//# run 0xc0ffee::m::test9b
+
+//# run 0xc0ffee::m::test10

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -25,7 +25,7 @@ use crate::{
         ReceiverFunctionInstance, ReferenceKind, Substitution, Type, TypeDisplayContext,
         TypeUnificationError, UnificationContext, Variance, WideningOrder, BOOL_TYPE,
     },
-    well_known::{BORROW_MUT_NAME, BORROW_NAME},
+    well_known::{BORROW_MUT_NAME, BORROW_NAME, VECTOR_FUNCS_WITH_BYTECODE_INSTRS, VECTOR_MODULE},
     FunId,
 };
 use codespan_reporting::diagnostic::Severity;
@@ -3705,23 +3705,45 @@ impl ExpTranslator<'_, '_, '_> {
             ) else {
                 return self.new_error_exp();
             };
+            let instantiated_param_types = param_types
+                .iter()
+                .map(|t| t.instantiate(&instantiation))
+                .collect::<Vec<_>>();
+            let instantiated_result_type = result_type.instantiate(&instantiation);
             let fun_type = self.fresh_type_var_constr(
                 loc.clone(),
                 WideningOrder::LeftToRight,
                 Constraint::SomeFunctionValue(
-                    Type::tuple(
-                        param_types
-                            .iter()
-                            .map(|t| t.instantiate(&instantiation))
-                            .collect(),
-                    ),
-                    result_type.instantiate(&instantiation),
+                    Type::tuple(instantiated_param_types.clone()),
+                    instantiated_result_type.clone(),
                 ),
             );
             let fun_type = self.check_type(loc, &fun_type, expected_type, context);
 
-            let id = self.env().new_node(loc.clone(), fun_type);
-            self.env().set_node_instantiation(id, instantiation);
+            let id = self.env().new_node(loc.clone(), fun_type.clone());
+            self.env().set_node_instantiation(id, instantiation.clone());
+
+            // Special-case handling for functions that are bytecode instructions in the `std::vector` module.
+            if global_var_sym.module_name.addr() == &self.env().get_stdlib_address()
+                && global_var_sym.module_name.name() == self.symbol_pool().make(VECTOR_MODULE)
+            {
+                let function_name = global_var_sym
+                    .symbol
+                    .display(self.symbol_pool())
+                    .to_string();
+                if VECTOR_FUNCS_WITH_BYTECODE_INSTRS.contains(&function_name.as_str()) {
+                    return self.translate_special_function_name(
+                        module_id,
+                        fun_id,
+                        loc,
+                        id,
+                        instantiated_param_types,
+                        instantiated_result_type,
+                        instantiation,
+                    );
+                }
+            }
+
             return ExpData::Call(
                 id,
                 Operation::Closure(module_id, fun_id, ClosureMask::new_for_leading(0)),
@@ -3738,6 +3760,49 @@ impl ExpTranslator<'_, '_, '_> {
         self.error(loc, &format!("undeclared `{}`", qualified_display));
 
         self.new_error_exp()
+    }
+
+    /// Translates a special function name, such as `std::vector::empty`, for which
+    /// there is no corresponding function definition in the module, and so a closure
+    /// cannot directly refer to it.
+    /// Instead, we wrap such names in a lambda. Eg., say there is a special function
+    /// `fun foo(x: T1, y: T2)`, then then expression `foo` --> `|p__0, p__1| foo(p__0, p__1)`.
+    fn translate_special_function_name(
+        &mut self,
+        module_id: ModuleId,
+        fun_id: FunId,
+        loc: &Loc,
+        id: NodeId,
+        instantiated_param_types: Vec<Type>,
+        instantiated_result_type: Type,
+        instantiation: Vec<Type>,
+    ) -> ExpData {
+        let (params, args): (Vec<_>, Vec<_>) = instantiated_param_types
+            .iter()
+            .enumerate()
+            .map(|(i, param_ty)| {
+                let symbol = self.symbol_pool().make(format!("p__{}", i).as_str());
+                let param_id = self.new_node_id_with_type_loc(param_ty, loc);
+                let arg_id = self.new_node_id_with_type_loc(param_ty, loc);
+                (
+                    Pattern::Var(param_id, symbol),
+                    ExpData::LocalVar(arg_id, symbol).into_exp(),
+                )
+            })
+            .unzip();
+        let pattern = if params.len() == 1 {
+            // to mimic what happens when translating a lambda
+            params[0].clone()
+        } else {
+            let pattern_id =
+                self.new_node_id_with_type_loc(&Type::Tuple(instantiated_param_types), loc);
+            Pattern::Tuple(pattern_id, params)
+        };
+        let body_id = self.new_node_id_with_type_loc(&instantiated_result_type, loc);
+        self.set_node_instantiation(body_id, instantiation);
+        let body =
+            ExpData::Call(body_id, Operation::MoveFunction(module_id, fun_id), args).into_exp();
+        ExpData::Lambda(id, pattern, body, LambdaCaptureKind::Default, None)
     }
 
     /// Creates an expression for a constant, checking the expected type.

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -30,6 +30,17 @@ pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
 pub const BORROW_NAME: &str = "borrow";
 pub const BORROW_MUT_NAME: &str = "borrow_mut";
+/// Functions in the std::vector module that are implemented as bytecode instructions.
+pub const VECTOR_FUNCS_WITH_BYTECODE_INSTRS: &[&str] = &[
+    "empty",
+    "length",
+    "borrow",
+    "borrow_mut",
+    "push_back",
+    "pop_back",
+    "destroy_empty",
+    "swap",
+];
 
 pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
 pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";


### PR DESCRIPTION
## Description

There are bunch of functions in `std::vector` that are implemented as bytecode instructions. Closures cannot directly reference such functions, they need to be lambda-lifted (instead of currying).

In cases where we refer to such functions by just the name, we explicitly build a wrapper lambda around it. E.g.,
`std::vector::destroy_empty` -> `|p__0| std::vector::destroy_empty(p__0)`.

Note: we could use the same technique for inline functions (i.e., instead of disallowing inline functions as function values, as done in https://github.com/aptos-labs/aptos-core/pull/16681).

Closes #16684.

## How Has This Been Tested?
- Added a number of tests
- Fixed an existing test

## Key Areas to Review

Creation of the wrapper lambda.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
