### PR TITLE
BlockSTMv2 PR [3/n]: executor refactors for integration preparation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -739,7 +739,6 @@ dependencies = [
  "proptest-derive",
  "rand 0.7.3",
  "rayon",
- "scopeguard",
  "test-case",
 ]
 

--- a/aptos-move/block-executor/Cargo.toml
+++ b/aptos-move/block-executor/Cargo.toml
@@ -47,7 +47,6 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 rand = { workspace = true }
 rayon = { workspace = true }
-scopeguard = { workspace = true }
 
 [dev-dependencies]
 aptos-aggregator = { workspace = true, features = ["testing"] }

--- a/aptos-move/block-executor/src/lib.rs
+++ b/aptos-move/block-executor/src/lib.rs
@@ -136,9 +136,6 @@ and threads that perform these tasks can already detect validation failures
 due to the ESTIMATE markers on memory locations, instead of waiting for a
 subsequent incarnation to finish.
 **/
-#[macro_use(defer)]
-extern crate scopeguard;
-
 mod captured_reads;
 mod code_cache;
 pub mod code_cache_global;
@@ -155,6 +152,7 @@ pub mod proptest_types;
 mod scheduler;
 mod scheduler_status;
 mod scheduler_v2;
+mod scheduler_wrapper;
 pub mod task;
 pub mod txn_commit_hook;
 pub mod txn_last_input_output;

--- a/aptos-move/block-executor/src/scheduler.rs
+++ b/aptos-move/block-executor/src/scheduler.rs
@@ -297,10 +297,6 @@ pub struct Scheduler {
 
     has_halted: CachePadded<AtomicBool>,
 
-    /// Set to true if we do not need to validate module reads. Most of the time this is the case,
-    /// unless modules are published.
-    skip_module_reads_validation: CachePadded<AtomicBool>,
-
     queueing_commits_lock: CachePadded<ArmedLock>,
 
     commit_queue: ConcurrentQueue<u32>,
@@ -330,14 +326,9 @@ impl Scheduler {
             validation_idx: AtomicU64::new(0),
             done_marker: CachePadded::new(AtomicBool::new(false)),
             has_halted: CachePadded::new(AtomicBool::new(false)),
-            skip_module_reads_validation: CachePadded::new(AtomicBool::new(true)),
             queueing_commits_lock: CachePadded::new(ArmedLock::new()),
             commit_queue: ConcurrentQueue::<u32>::bounded(num_txns as usize),
         }
-    }
-
-    pub fn num_txns(&self) -> TxnIndex {
-        self.num_txns
     }
 
     pub fn add_to_commit_queue(&self, txn_idx: u32) {
@@ -1025,17 +1016,6 @@ impl Scheduler {
     /// Checks whether the done marker is set. The marker can only be set by 'try_commit'.
     fn done(&self) -> bool {
         self.done_marker.load(Ordering::Acquire)
-    }
-
-    /// Sets the flag to validate module reads.
-    pub(crate) fn validate_module_reads(&self) {
-        self.skip_module_reads_validation
-            .store(false, Ordering::Release);
-    }
-
-    /// Returns true if module validation can be skipped.
-    pub(crate) fn skip_module_reads_validation(&self) -> bool {
-        self.skip_module_reads_validation.load(Ordering::Acquire)
     }
 }
 

--- a/aptos-move/block-executor/src/scheduler_wrapper.rs
+++ b/aptos-move/block-executor/src/scheduler_wrapper.rs
@@ -1,0 +1,85 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::scheduler::{DependencyResult, Scheduler, TWaitForDependency};
+use aptos_mvhashmap::types::TxnIndex;
+use aptos_types::error::PanicError;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+#[derive(Copy, Clone)]
+pub(crate) enum SchedulerWrapper<'a> {
+    V1(&'a Scheduler, &'a AtomicBool),
+    // TODO(BlockSTMv2): connect v2.
+    #[allow(dead_code)]
+    V2,
+}
+
+impl SchedulerWrapper<'_> {
+    pub(crate) fn is_v2(&self) -> bool {
+        matches!(self, SchedulerWrapper::V2)
+    }
+
+    pub(crate) fn wake_dependencies_and_decrease_validation_idx(
+        &self,
+        txn_idx: TxnIndex,
+    ) -> Result<(), PanicError> {
+        match self {
+            SchedulerWrapper::V1(scheduler, _) => {
+                scheduler.wake_dependencies_and_decrease_validation_idx(txn_idx)
+            },
+            SchedulerWrapper::V2 => unimplemented!("V2 scheduler not connected in wrapper"),
+        }
+    }
+
+    pub(crate) fn halt(&self) -> bool {
+        match self {
+            SchedulerWrapper::V1(scheduler, _) => scheduler.halt(),
+            SchedulerWrapper::V2 => unimplemented!("V2 scheduler not connected in wrapper"),
+        }
+    }
+
+    pub(crate) fn add_to_post_commit(&self, txn_idx: TxnIndex) -> Result<(), PanicError> {
+        match self {
+            SchedulerWrapper::V1(scheduler, _) => {
+                scheduler.add_to_commit_queue(txn_idx);
+                Ok(())
+            },
+            SchedulerWrapper::V2 => unimplemented!("V2 scheduler not connected in wrapper"),
+        }
+    }
+
+    pub(crate) fn set_module_read_validation(&self) {
+        match self {
+            SchedulerWrapper::V1(_, skip_module_reads_validation) => {
+                // Relaxed suffices as syncronization (reducing validation index) occurs after
+                // setting the module read validation flag.
+                skip_module_reads_validation.store(false, Ordering::Relaxed);
+            },
+            SchedulerWrapper::V2 => unimplemented!("V2 scheduler not connected in wrapper"),
+        }
+    }
+
+    pub(crate) fn has_halted(&self) -> bool {
+        match self {
+            SchedulerWrapper::V1(scheduler, _) => scheduler.has_halted(),
+            SchedulerWrapper::V2 => unimplemented!("V2 scheduler not connected in wrapper"),
+        }
+    }
+}
+
+impl TWaitForDependency for SchedulerWrapper<'_> {
+    fn wait_for_dependency(
+        &self,
+        txn_idx: TxnIndex,
+        dep_txn_idx: TxnIndex,
+    ) -> Result<DependencyResult, PanicError> {
+        match self {
+            SchedulerWrapper::V1(scheduler, _) => {
+                scheduler.wait_for_dependency(txn_idx, dep_txn_idx)
+            },
+            SchedulerWrapper::V2 => {
+                unreachable!("SchedulerV2 handles waiting w.o. TWaitForDependency")
+            },
+        }
+    }
+}

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -52,6 +52,7 @@ pub(crate) enum KeyKind<T> {
     Resource,
     // Contains the set of tags for the given group key.
     Group(HashSet<T>),
+    AggregatorV1,
 }
 
 pub struct TxnLastInputOutput<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug> {
@@ -234,15 +235,17 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
                 ExecutionStatus::Success(t) | ExecutionStatus::SkipRest(t) => Some(
                     t.resource_write_set()
                         .into_iter()
-                        .map(|(k, _, _)| k)
-                        .chain(t.aggregator_v1_write_set().into_keys())
+                        .map(|(k, _, _)| (k, KeyKind::Resource))
+                        .chain(
+                            t.aggregator_v1_write_set()
+                                .into_keys()
+                                .map(|k| (k, KeyKind::AggregatorV1)),
+                        )
                         .chain(
                             t.aggregator_v1_delta_set()
                                 .into_iter()
-                                .map(|(k, _)| k)
-                                .collect::<Vec<_>>(),
+                                .map(|(k, _)| (k, KeyKind::AggregatorV1)),
                         )
-                        .map(|k| (k, KeyKind::Resource))
                         .chain(
                             group_keys_and_tags
                                 .into_iter()


### PR DESCRIPTION
Introduce SchedulerWrapper by wrapping the dispatching logic (currently V2 branches marked unimplemented!). Refactor executor.rs to:
- decouple parameters (module read validation), 
- isolate functionality (process execution results), 
- clean up and streamline the prepare and commit ready txns method
- introduce AggregatorV1 KeyKind
- add additional validation to confirm safaty in post commit parallel hook
All facilitating later re-use and integration of features with Scheduler/BlockSTMv2 alongside V1. 

- other minor / convenience clean-ups from the prototype branch, such as extracting parameters from a result before calling finalize groups (https://github.com/aptos-labs/aptos-core/compare/main...gelash/v2scheduler#diff-9ef162a216d74568caa85b78dfaf100e0c8b3eb1e66536451492392d8c00d2b0) to not distract from later (larger) PRs.

Must review extra carefully, as this is the first PR in the sequence that affects in-prod enabled code flows. However, it is intended to maintain the current functionality and passes existing tests. 

Can be landed directly to main, does not require 2/n to land beforehand.