### PR TITLE
initialize the DerivableDispatchableAuthenticator from within the reg…

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
+++ b/aptos-move/framework/aptos-framework/sources/account/account_abstraction.move
@@ -186,17 +186,17 @@ module aptos_framework::account_abstraction {
         assert!(features::is_derivable_account_abstraction_enabled(), error::invalid_state(EDERIVABLE_ACCOUNT_ABSTRACTION_NOT_ENABLED));
         system_addresses::assert_aptos_framework(aptos_framework);
 
+        // First initialize the DerivableDispatchableAuthenticator if not already initialized
+        if (!exists<DerivableDispatchableAuthenticator>(@aptos_framework)) {
+            move_to(
+                aptos_framework,
+                DerivableDispatchableAuthenticator::V1 { auth_functions: big_ordered_map::new_with_config(0, 0, false) }
+            );
+        };
+
         DerivableDispatchableAuthenticator[@aptos_framework].auth_functions.add(
             function_info::new_function_info_from_address(module_address, module_name, function_name),
             DerivableRegisterValue::Empty,
-        );
-    }
-
-    entry fun initialize(aptos_framework: &signer) {
-        system_addresses::assert_aptos_framework(aptos_framework);
-        move_to(
-            aptos_framework,
-            DerivableDispatchableAuthenticator::V1 { auth_functions: big_ordered_map::new_with_config(0, 0, false) }
         );
     }
 


### PR DESCRIPTION
…ister_derivable_authentication_function

## Description
The `account_abstraction::initialize` function is being called during genesis, which is what enables us to register auth functions.
Since this function is a private entry function, it can’t be called from a script directly.

So moving the check/initialize part to be part of the `register_derivable_authentication_function`

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
