### PR TITLE
[refactoring] Remove display for tags

### DIFF
--- a/api/src/accounts.rs
+++ b/api/src/accounts.rs
@@ -664,7 +664,8 @@ impl Account {
             .find_resource(&state_view, self.address, resource_type)
             .context(format!(
                 "Failed to query DB to check for {} at {}",
-                resource_type, self.address
+                resource_type.to_canonical_string(),
+                self.address
             ))
             .map_err(|err| {
                 BasicErrorWith404::internal_with_code(

--- a/api/src/response.rs
+++ b/api/src/response.rs
@@ -663,7 +663,9 @@ pub fn resource_not_found<E: NotFoundError>(
         "Resource",
         format!(
             "Address({}), Struct tag({}) and Ledger version({})",
-            address, struct_tag, ledger_version
+            address,
+            struct_tag.to_canonical_string(),
+            ledger_version
         ),
         AptosErrorCode::ResourceNotFound,
         ledger_info,
@@ -698,7 +700,10 @@ pub fn struct_field_not_found<E: NotFoundError>(
         "Struct Field",
         format!(
             "Address({}), Struct tag({}), Field name({}) and Ledger version({})",
-            address, struct_tag, field_name, ledger_version
+            address,
+            struct_tag.to_canonical_string(),
+            field_name,
+            ledger_version
         ),
         AptosErrorCode::StructFieldNotFound,
         ledger_info,

--- a/api/src/state.rs
+++ b/api/src/state.rs
@@ -291,7 +291,8 @@ impl StateApi {
             .find_resource(&state_view, address, &tag)
             .context(format!(
                 "Failed to query DB to check for {} at {}",
-                tag, address
+                tag.to_canonical_string(),
+                address
             ))
             .map_err(|err| {
                 BasicErrorWith404::internal_with_code(

--- a/api/types/src/convert.rs
+++ b/api/types/src/convert.rs
@@ -573,9 +573,9 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
 
         Ok(Some(DecodedTableData {
             key: key.json().unwrap(),
-            key_type: table_info.key_type.to_string(),
+            key_type: table_info.key_type.to_canonical_string(),
             value: value.json().unwrap(),
-            value_type: table_info.value_type.to_string(),
+            value_type: table_info.value_type.to_canonical_string(),
         }))
     }
 
@@ -596,7 +596,7 @@ impl<'a, S: StateView> MoveConverter<'a, S> {
 
         Ok(Some(DeletedTableData {
             key: key.json().unwrap(),
-            key_type: table_info.key_type.to_string(),
+            key_type: table_info.key_type.to_canonical_string(),
         }))
     }
 

--- a/aptos-move/aptos-gas-profiling/src/aggregate.rs
+++ b/aptos-move/aptos-gas-profiling/src/aggregate.rs
@@ -99,7 +99,7 @@ impl ExecutionAndIOCosts {
                     addr: _addr,
                     ty,
                     cost,
-                } => insert_or_add(&mut storage_reads, format!("{}", ty), *cost),
+                } => insert_or_add(&mut storage_reads, ty.to_canonical_string(), *cost),
                 CreateTy { cost } => insert_or_add(&mut ops, "create_ty".to_string(), *cost),
             }
         }

--- a/aptos-move/aptos-gas-profiling/src/erased.rs
+++ b/aptos-move/aptos-gas-profiling/src/erased.rs
@@ -148,9 +148,10 @@ impl ExecutionGasEvent {
                 ),
                 *cost,
             ),
-            LoadResource { addr, ty, cost } => {
-                Node::new(format!("load<{}::{}>", Render(addr), ty), *cost)
-            },
+            LoadResource { addr, ty, cost } => Node::new(
+                format!("load<{}::{}>", Render(addr), ty.to_canonical_string()),
+                *cost,
+            ),
             CreateTy { cost } => Node::new("create_ty", *cost),
         }
     }
@@ -272,7 +273,7 @@ impl WriteStorage {
 
 impl EventStorage {
     fn to_erased(&self) -> Node<StoragePair> {
-        Node::new(format!("{}", self.ty), (self.cost, Fee::zero()))
+        Node::new(self.ty.to_canonical_string(), (self.cost, Fee::zero()))
     }
 }
 

--- a/aptos-move/aptos-gas-profiling/src/flamegraph.rs
+++ b/aptos-move/aptos-gas-profiling/src/flamegraph.rs
@@ -47,7 +47,10 @@ impl StorageFees {
 
         for event in &self.events {
             // TODO: Handle discounts.
-            lines.push(format!("events;{}", event.ty), event.cost)
+            lines.push(
+                format!("events;{}", event.ty.to_canonical_string()),
+                event.cost,
+            )
         }
 
         lines.into_inner()
@@ -148,7 +151,12 @@ impl ExecutionAndIOCosts {
                             *cost,
                         ),
                         LoadResource { addr, ty, cost } => self.lines.push(
-                            format!("{};load<{}::{}>", self.path(), Render(addr), ty),
+                            format!(
+                                "{};load<{}::{}>",
+                                self.path(),
+                                Render(addr),
+                                ty.to_canonical_string()
+                            ),
                             *cost,
                         ),
                     }

--- a/aptos-move/aptos-gas-profiling/src/render.rs
+++ b/aptos-move/aptos-gas-profiling/src/render.rs
@@ -45,9 +45,9 @@ impl<'a> Display for Render<'a, (&'a ModuleId, &'a IdentStr, &'a [TypeTag])> {
                 self.0
                      .2
                     .iter()
-                    .map(|ty| format!("{}", ty))
+                    .map(|ty| ty.to_canonical_string())
                     .collect::<Vec<_>>()
-                    .join(",")
+                    .join(", ")
             )?;
         }
         Ok(())
@@ -75,8 +75,8 @@ impl Display for Render<'_, Path> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self.0 {
             Path::Code(module_id) => write!(f, "{}", Render(module_id)),
-            Path::Resource(struct_ty) => write!(f, "{}", struct_ty),
-            Path::ResourceGroup(struct_ty) => write!(f, "{}", struct_ty),
+            Path::Resource(struct_ty) => write!(f, "{}", struct_ty.to_canonical_string()),
+            Path::ResourceGroup(struct_ty) => write!(f, "{}", struct_ty.to_canonical_string()),
         }
     }
 }
@@ -130,6 +130,6 @@ impl Display for Render<'_, WriteOpType> {
 
 impl Display for Render<'_, TypeTag> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0.to_canonical_string())
     }
 }

--- a/aptos-move/aptos-gas-profiling/src/report.rs
+++ b/aptos-move/aptos-gas-profiling/src/report.rs
@@ -285,7 +285,7 @@ impl TransactionGasLog {
                     .iter()
                     .map(|event| {
                         json!({
-                            "name":  format!("{}", event.ty),
+                            "name":  format!("{}", event.ty.to_canonical_string()),
                             "cost": fmt_storage_fee(event.cost),
                             "cost-percentage": fmt_storage_fee_percentage(event.cost),
                         })

--- a/aptos-move/aptos-sdk-builder/src/common.rs
+++ b/aptos-move/aptos-sdk-builder/src/common.rs
@@ -18,11 +18,11 @@ use std::{
 pub(crate) fn type_not_allowed(type_tag: &TypeTag) -> ! {
     panic!(
         "Transaction scripts cannot take arguments of type {}.",
-        type_tag
+        type_tag.to_canonical_string()
     );
 }
 
-/// Clean up doc comments extracter by the Move prover.
+/// Clean up doc comments extracted by the Move prover.
 pub(crate) fn prepare_doc_string(doc: &str) -> String {
     doc.replace("\n ", "\n").trim().to_string()
 }

--- a/aptos-move/aptos-sdk-builder/src/golang.rs
+++ b/aptos-move/aptos-sdk-builder/src/golang.rs
@@ -19,6 +19,7 @@ use serde_generate::{
 };
 use std::{
     collections::BTreeMap,
+    io,
     io::{Result, Write},
     path::PathBuf,
     str::FromStr,
@@ -40,7 +41,7 @@ pub fn output(
     };
 
     // Some functions have complex types which are not currently supported in bcs or in this
-    // generator. Disable those functiosn for now.
+    // generator. Disable those functions for now.
     let abis_vec = abis
         .iter()
         .filter(|abi| {
@@ -468,8 +469,17 @@ func DecodeEntryFunctionPayload(script aptostypes.TransactionPayload) (EntryFunc
         for (index, arg) in abi.args().iter().enumerate() {
             let decoding = match Self::bcs_primitive_type_name(arg.type_tag()) {
                 None => {
-                    let type_tag_str = format!("{}", (arg.type_tag()));
-                    if "vector<0x1::string::String>".eq(&type_tag_str) {
+                    let vec_string_tag =
+                        TypeTag::from_str("vector<0x1::string::String>").map_err(|err| {
+                            io::Error::new(
+                                io::ErrorKind::Other,
+                                format!(
+                                    "Failed to construct a type tag for vector of strings: {:?}",
+                                    err
+                                ),
+                            )
+                        })?;
+                    if arg.type_tag() == &vec_string_tag {
                         format!(
                             "bcs.NewDeserializer(script.Value.Args[{}]).DeserializeVecBytes()",
                             index,

--- a/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
+++ b/aptos-move/aptos-transactional-test-harness/src/aptos_test_harness.rs
@@ -1053,7 +1053,11 @@ impl fmt::Display for PrettyEvent<'_> {
             },
             ContractEvent::V2(_v2) => (),
         }
-        writeln!(f, "    type:    {}", self.0.type_tag())?;
+        writeln!(
+            f,
+            "    type:    {}",
+            self.0.type_tag().to_canonical_string()
+        )?;
         writeln!(f, "    data:    {:?}", hex::encode(self.0.event_data()))?;
         write!(f, "}}")
     }

--- a/aptos-move/e2e-move-tests/src/tests/token_event_store.rs
+++ b/aptos-move/e2e-move-tests/src/tests/token_event_store.rs
@@ -53,6 +53,6 @@ fn test_token_creation_with_token_events_store() {
     let event = events.pop().unwrap();
     assert_eq!(
         "0x3::token_event_store::OptInTransfer".to_string(),
-        event.type_tag().to_string()
+        event.type_tag().to_canonical_string()
     );
 }

--- a/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/mod.rs
@@ -70,7 +70,7 @@ impl TryFrom<TypeTag> for Structure {
     type Error = ();
 
     fn try_from(value: TypeTag) -> Result<Self, Self::Error> {
-        match value.to_string().as_str() {
+        match value.to_canonical_string().as_str() {
             "0x1::bls12381_algebra::Fr" => Ok(Structure::BLS12381Fr),
             "0x1::bls12381_algebra::Fq12" => Ok(Structure::BLS12381Fq12),
             "0x1::bls12381_algebra::G1" => Ok(Structure::BLS12381G1),
@@ -124,7 +124,7 @@ impl TryFrom<TypeTag> for SerializationFormat {
     type Error = ();
 
     fn try_from(value: TypeTag) -> Result<Self, Self::Error> {
-        match value.to_string().as_str() {
+        match value.to_canonical_string().as_str() {
             "0x1::bls12381_algebra::FormatFq12LscLsb" => {
                 Ok(SerializationFormat::BLS12381Fq12LscLsb)
             },
@@ -166,7 +166,7 @@ impl TryFrom<TypeTag> for HashToStructureSuite {
     type Error = ();
 
     fn try_from(value: TypeTag) -> Result<Self, Self::Error> {
-        match value.to_string().as_str() {
+        match value.to_canonical_string().as_str() {
             "0x1::bls12381_algebra::HashG1XmdSha256SswuRo" => {
                 Ok(HashToStructureSuite::Bls12381g1XmdSha256SswuRo)
             },

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -279,7 +279,7 @@ fn native_format_impl(
                 return Ok(());
             }
             if context.type_tag {
-                write!(out, "{} {{", TypeTag::from(type_.clone())).unwrap();
+                write!(out, "{} {{", type_.to_canonical_string()).unwrap();
             } else {
                 write!(out, "{} {{", type_.name.as_str()).unwrap();
             };
@@ -367,7 +367,7 @@ fn native_format_impl(
                 .context
                 .function_value_extension()
                 .get_serialization_data(fun.as_ref())?;
-            out.push_str(&fun.to_stable_string());
+            out.push_str(&fun.to_canonical_string());
             format_vector(
                 context,
                 data.captured_layouts.iter(),

--- a/aptos-move/framework/src/natives/type_info.rs
+++ b/aptos-move/framework/src/natives/type_info.rs
@@ -21,9 +21,9 @@ fn type_of_internal(struct_tag: &StructTag) -> Result<SmallVec<[Value; 1]>, std:
     let mut name = struct_tag.name.to_string();
     if let Some(first_ty) = struct_tag.type_args.first() {
         write!(name, "<")?;
-        write!(name, "{}", first_ty)?;
+        write!(name, "{}", first_ty.to_canonical_string())?;
         for ty in struct_tag.type_args.iter().skip(1) {
-            write!(name, ", {}", ty)?;
+            write!(name, ", {}", ty.to_canonical_string())?;
         }
         write!(name, ">")?;
     }
@@ -57,7 +57,7 @@ fn native_type_of(
     let type_tag = context.type_to_type_tag(&ty_args[0])?;
 
     if context.eval_gas(TYPE_INFO_TYPE_OF_PER_BYTE_IN_STR) > 0.into() {
-        let type_tag_str = type_tag.to_string();
+        let type_tag_str = type_tag.to_canonical_string();
         // Ideally, we would charge *before* the `type_to_type_tag()` and `type_tag.to_string()` calls above.
         // But there are other limits in place that prevent this native from being called with too much work.
         context
@@ -92,7 +92,7 @@ fn native_type_name(
     context.charge(TYPE_INFO_TYPE_NAME_BASE)?;
 
     let type_tag = context.type_to_type_tag(&ty_args[0])?;
-    let type_name = type_tag.to_string();
+    let type_name = type_tag.to_canonical_string();
 
     // TODO: Ideally, we would charge *before* the `type_to_type_tag()` and `type_tag.to_string()` calls above.
     context.charge(TYPE_INFO_TYPE_NAME_PER_BYTE_IN_STR * NumBytes::new(type_name.len() as u64))?;
@@ -159,7 +159,7 @@ mod tests {
             type_args: vec![TypeTag::Vector(Box::new(TypeTag::U8))],
         };
 
-        let dummy_as_strings = dummy_st.to_string();
+        let dummy_as_strings = dummy_st.to_canonical_string();
         let mut dummy_as_strings = dummy_as_strings.split("::");
         let dummy_as_type_of = type_of_internal(&dummy_st).unwrap().pop().unwrap();
         let dummy_as_type_of: Struct = dummy_as_type_of.cast().unwrap();

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -156,7 +156,7 @@ pub fn native_coin() -> Currency {
         symbol: APT_SYMBOL.to_string(),
         decimals: APT_DECIMALS,
         metadata: Some(CurrencyMetadata {
-            move_type: Some(native_coin_tag().to_string()),
+            move_type: Some(native_coin_tag().to_canonical_string()),
             fa_address: None,
         }),
     }
@@ -213,7 +213,7 @@ pub fn find_coin_currency(currencies: &HashSet<Currency>, type_tag: &TypeTag) ->
                 fa_address: _,
             }) = currency.metadata
             {
-                move_type == &type_tag.to_string()
+                move_type == &type_tag.to_canonical_string()
             } else {
                 false
             }
@@ -394,7 +394,7 @@ pub fn parse_coin_currency(
             .as_ref()
             .and_then(|inner| inner.move_type.as_ref())
         {
-            struct_tag.to_string() == *move_type
+            struct_tag.to_canonical_string() == *move_type
         } else {
             false
         }
@@ -403,7 +403,7 @@ pub fn parse_coin_currency(
     } else {
         Err(ApiError::TransactionParseError(Some(format!(
             "Invalid coin for transfer {}",
-            struct_tag
+            struct_tag.to_canonical_string()
         ))))
     }
 }

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -1385,7 +1385,7 @@ async fn parse_operations_from_write_set(
                 if let Some(currency) = maybe_currency {
                     parse_coinstore_changes(
                         currency.clone(),
-                        type_tag.to_string(),
+                        type_tag.to_canonical_string(),
                         version,
                         address,
                         data,
@@ -1398,7 +1398,8 @@ async fn parse_operations_from_write_set(
             } else {
                 warn!(
                     "Failed to parse coinstore {} at version {}",
-                    struct_tag, version
+                    struct_tag.to_canonical_string(),
+                    version
                 );
                 Ok(vec![])
             }

--- a/crates/aptos/src/account/balance.rs
+++ b/crates/aptos/src/account/balance.rs
@@ -107,7 +107,7 @@ impl Balance {
 
         Ok(vec![AccountBalance {
             asset_type: "coin".to_string(),
-            coin_type: Some(coin_type.to_string()),
+            coin_type: Some(coin_type.to_canonical_string()),
             balance,
         }])
     }

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -107,7 +107,7 @@ impl CliCommand<Vec<serde_json::Value>> for ListAccount {
                 .into_iter()
                 .map(|resource| {
                     let mut map = serde_json::Map::new();
-                    map.insert(resource.resource_type.to_string(), resource.data);
+                    map.insert(resource.resource_type.to_canonical_string(), resource.data);
                     serde_json::Value::Object(map)
                 })
                 .collect::<Vec<serde_json::Value>>(),

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -267,7 +267,7 @@ impl CoinActivity {
             event_creation_number: BURN_GAS_EVENT_CREATION_NUM,
             event_sequence_number: user_transaction_request.sequence_number.0 as i64,
             owner_address: standardize_address(&user_transaction_request.sender.to_string()),
-            coin_type: AptosCoinType::type_tag().to_string(),
+            coin_type: AptosCoinType::type_tag().to_canonical_string(),
             amount: aptos_coin_burned,
             activity_type: GAS_FEE_EVENT.to_string(),
             is_gas_fee: true,

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -279,9 +279,11 @@ impl TransactionProcessor for CoinTransactionProcessor {
         let mut conn = self.get_conn();
         // get aptos_coin info for supply tracking
         // TODO: This only needs to be fetched once. Need to persist somehow
-        let maybe_aptos_coin_info =
-            &CoinInfoQuery::get_by_coin_type(AptosCoinType::type_tag().to_string(), &mut conn)
-                .unwrap();
+        let maybe_aptos_coin_info = &CoinInfoQuery::get_by_coin_type(
+            AptosCoinType::type_tag().to_canonical_string(),
+            &mut conn,
+        )
+        .unwrap();
 
         let mut all_coin_activities = vec![];
         let mut all_coin_balances = vec![];

--- a/execution/executor-benchmark/src/db_access.rs
+++ b/execution/executor-benchmark/src/db_access.rs
@@ -200,7 +200,7 @@ impl DbAccessUtil {
                         struct_tag
                             .type_args
                             .iter()
-                            .map(|v| v.to_string())
+                            .map(|v| v.to_canonical_string())
                             .join(", ")
                     )
                     .to_string()

--- a/experimental/bulk-txn-submit/src/event_lookup.rs
+++ b/experimental/bulk-txn-submit/src/event_lookup.rs
@@ -2,8 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{bail, Result};
-use aptos_sdk::types::{account_address::AccountAddress, contract_event::ContractEvent};
+use aptos_sdk::{
+    move_types::language_storage::TypeTag,
+    types::{account_address::AccountAddress, contract_event::ContractEvent},
+};
 use serde::{Deserialize, Serialize};
+use std::str::FromStr;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DepositMoveStruct {
@@ -32,30 +36,26 @@ pub struct BurnMoveStruct {
 }
 
 pub fn get_mint_token_addr(events: &[ContractEvent]) -> Result<AccountAddress> {
-    let mint_event: MintMoveStruct = search_single_event_data(
-        events,
-        "0000000000000000000000000000000000000000000000000000000000000004::collection::Mint",
-    )?;
+    let mint_event: MintMoveStruct =
+        search_single_event_data(events, &TypeTag::from_str("0x4::collection::Mint")?)?;
     Ok(mint_event.token)
 }
 
 pub fn get_burn_token_addr(events: &[ContractEvent]) -> Result<AccountAddress> {
-    let burn_event: BurnMoveStruct = search_single_event_data(
-        events,
-        "0000000000000000000000000000000000000000000000000000000000000004::collection::Burn",
-    )?;
+    let burn_event: BurnMoveStruct =
+        search_single_event_data(events, &TypeTag::from_str("0x4::collection::Burn")?)?;
     Ok(burn_event.token)
 }
 
-pub fn search_event(events: &[ContractEvent], type_tag: &str) -> Vec<ContractEvent> {
+fn search_event(events: &[ContractEvent], type_tag: &TypeTag) -> Vec<ContractEvent> {
     events
         .iter()
-        .filter(|event| event.type_tag().to_canonical_string() == type_tag)
+        .filter(|event| event.type_tag() == type_tag)
         .cloned()
         .collect::<Vec<_>>()
 }
 
-pub fn search_single_event_data<T>(events: &[ContractEvent], type_tag: &str) -> Result<T>
+fn search_single_event_data<T>(events: &[ContractEvent], type_tag: &TypeTag) -> Result<T>
 where
     T: serde::de::DeserializeOwned,
 {
@@ -77,6 +77,9 @@ where
 }
 
 pub fn get_deposit_dst(events: &[ContractEvent]) -> Result<AccountAddress> {
-    let deposit_event: DepositMoveStruct = search_single_event_data(events, "0000000000000000000000000000000000000000000000000000000000000001::coin::Deposit<0000000000000000000000000000000000000000000000000000000000000001::aptos_coin::AptosCoin>")?;
+    let deposit_event: DepositMoveStruct = search_single_event_data(
+        events,
+        &TypeTag::from_str("0x1::coin::Deposit<0x1::aptos_coin::AptosCoin>")?,
+    )?;
     Ok(deposit_event.account)
 }

--- a/state-sync/inter-component/event-notifications/src/lib.rs
+++ b/state-sync/inter-component/event-notifications/src/lib.rs
@@ -218,7 +218,7 @@ impl EventSubscriptionService {
             let maybe_subscription_ids = match event {
                 ContractEvent::V1(evt) => self.event_key_subscriptions.get(evt.key()),
                 ContractEvent::V2(evt) => {
-                    let tag = evt.type_tag().to_string();
+                    let tag = evt.type_tag().to_canonical_string();
                     self.event_v2_tag_subscriptions.get(&tag)
                 },
             };

--- a/state-sync/inter-component/event-notifications/src/tests.rs
+++ b/state-sync/inter-component/event-notifications/src/tests.rs
@@ -122,7 +122,7 @@ fn test_dynamic_subscribers() {
     // Add another subscriber for event_key_1 and the reconfig_event_key
     let mut event_listener_2 = event_service
         .subscribe_to_events(vec![event_key_1], vec![
-            NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG.to_string()
+            NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG.to_canonical_string()
         ])
         .unwrap();
 
@@ -170,7 +170,9 @@ fn test_event_and_reconfig_subscribers() {
         .subscribe_to_events(vec![event_key_1, event_key_2], vec![])
         .unwrap();
     let mut event_listener_3 = event_service
-        .subscribe_to_events(vec![], vec![NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG.to_string()])
+        .subscribe_to_events(vec![], vec![
+            NEW_EPOCH_EVENT_V2_MOVE_TYPE_TAG.to_canonical_string()
+        ])
         .unwrap();
 
     // Create reconfiguration subscribers

--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/type_tag_to_string.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/type_tag_to_string.rs
@@ -60,16 +60,15 @@ fuzz_target!(|data: FuzzData| -> Corpus {
         tdbg!(
             "a_type:{:?}\na_string:{}\nserialized:{:?}",
             data.a.clone(),
-            data.a.to_string(),
+            data.a.to_canonical_string(),
             bcs::to_bytes(&data.a).unwrap()
         );
         tdbg!(
             "b_type:{:?}\nb_string:{}\nserialized:{:?}",
             data.b.clone(),
-            data.b.to_string(),
+            data.b.to_canonical_string(),
             bcs::to_bytes(&data.b).unwrap()
         );
-        assert!(data.a.to_string() != data.b.to_string());
         assert!(data.a.to_canonical_string() != data.b.to_canonical_string());
     }
 

--- a/testsuite/smoke-test/src/randomness/mod.rs
+++ b/testsuite/smoke-test/src/randomness/mod.rs
@@ -51,7 +51,7 @@ async fn get_on_chain_resource_at_version<T: OnChainConfig>(
     let maybe_response = rest_client
         .get_account_resource_at_version_bcs::<T>(
             CORE_CODE_ADDRESS,
-            T::struct_tag().to_string().as_str(),
+            T::struct_tag().to_canonical_string().as_str(),
             version,
         )
         .await;

--- a/testsuite/smoke-test/src/utils.rs
+++ b/testsuite/smoke-test/src/utils.rs
@@ -279,7 +279,10 @@ pub async fn get_current_version(rest_client: &RestClient) -> u64 {
 
 pub async fn get_on_chain_resource<T: OnChainConfig>(rest_client: &Client) -> T {
     let maybe_response = rest_client
-        .get_account_resource_bcs::<T>(CORE_CODE_ADDRESS, T::struct_tag().to_string().as_str())
+        .get_account_resource_bcs::<T>(
+            CORE_CODE_ADDRESS,
+            T::struct_tag().to_canonical_string().as_str(),
+        )
         .await;
     let response = maybe_response.unwrap();
     response.into_inner()

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -70,7 +70,12 @@ impl TableInfo {
 
 impl Display for TableInfo {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        writeln!(f, "Table<{}, {}>", self.key_type, self.value_type)
+        writeln!(
+            f,
+            "Table<{}, {}>",
+            self.key_type.to_canonical_string(),
+            self.value_type.to_canonical_string()
+        )
     }
 }
 

--- a/third_party/move/move-core/types/src/effects.rs
+++ b/third_party/move/move-core/types/src/effects.rs
@@ -138,7 +138,10 @@ impl<Resource> AccountChanges<Resource> {
         use btree_map::Entry::*;
 
         match self.resources.entry(struct_tag) {
-            Occupied(entry) => bail!("Resource {} already exists", entry.key()),
+            Occupied(entry) => bail!(
+                "Resource {} already exists",
+                entry.key().to_canonical_string()
+            ),
             Vacant(entry) => {
                 entry.insert(op);
             },

--- a/third_party/move/move-core/types/src/function.rs
+++ b/third_party/move/move-core/types/src/function.rs
@@ -382,38 +382,3 @@ mod serialization_tests {
         );
     }
 }
-
-//===========================================================================================
-
-impl fmt::Display for MoveClosure {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let MoveClosure {
-            module_id,
-            fun_id,
-            ty_args,
-            mask,
-            captured,
-        } = self;
-        let captured_str = mask
-            .format_arguments(captured.iter().map(|v| v.1.to_string()).collect())
-            .join(", ");
-        let inst_str = if ty_args.is_empty() {
-            "".to_string()
-        } else {
-            format!(
-                "<{}>",
-                ty_args
-                    .iter()
-                    .map(|t| t.to_string())
-                    .collect::<Vec<_>>()
-                    .join(",")
-            )
-        };
-        write!(
-            f,
-            // this will print `a::m::f<T>(a1,_,a2,_)`
-            "{}::{}{}({})",
-            module_id, fun_id, inst_str, captured_str
-        )
-    }
-}

--- a/third_party/move/move-core/types/src/parser.rs
+++ b/third_party/move/move-core/types/src/parser.rs
@@ -639,7 +639,7 @@ mod tests {
         for text in valid {
             let st = parse_struct_tag(text).expect("valid StructTag");
             assert_eq!(
-                st.to_string().replace(' ', ""),
+                st.to_canonical_string().replace(' ', ""),
                 text.replace(' ', ""),
                 "text: {:?}, StructTag: {:?}",
                 text,

--- a/third_party/move/move-stdlib/src/natives/debug.rs
+++ b/third_party/move/move-stdlib/src/natives/debug.rs
@@ -460,8 +460,11 @@ mod testing {
                     )?;
                 }
             },
-            MoveValue::Closure(clos) => {
-                write!(out, "{}", clos).map_err(fmt_error_to_partial_vm_error)?;
+            MoveValue::Closure(_) => {
+                // Using non-Aptos Move stdlib with function values is not supported. In general,
+                // this debug implementation should be removed and replaced by the new one from
+                // Aptos Move.
+                return Err(PartialVMError::new(StatusCode::FEATURE_NOT_ENABLED));
             },
             MoveValue::Struct(move_struct) => match move_struct {
                 MoveStruct::WithTypes {
@@ -512,7 +515,8 @@ mod testing {
                         let str = move_value_as_escaped_string(val)?;
                         write!(out, "\"{}\"", str).map_err(fmt_error_to_partial_vm_error)?
                     } else {
-                        write!(out, "{} ", type_tag).map_err(fmt_error_to_partial_vm_error)?;
+                        write!(out, "{} ", type_tag.to_canonical_string())
+                            .map_err(fmt_error_to_partial_vm_error)?;
                         write!(out, "{}", STRUCT_BEGIN).map_err(fmt_error_to_partial_vm_error)?;
 
                         // For each field, print its name and value (and type)

--- a/third_party/move/move-stdlib/tests/type_name_tests.move
+++ b/third_party/move/move-stdlib/tests/type_name_tests.move
@@ -19,20 +19,18 @@ module 0xA::type_name_tests {
         assert!(into_string(get<vector<u8>>()) == string(b"vector<u8>"), 0)
     }
 
-    // Note: these tests assume a 16 byte address length, and will fail on platforms where addresses are 20 or 32 bytes
     #[test]
     fun test_structs() {
-        assert!(into_string(get<TestStruct>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestStruct"), 0);
-        assert!(into_string(get<std::ascii::String>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::ascii::String"), 0);
-        assert!(into_string(get<std::option::Option<u64>>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::option::Option<u64>"), 0);
-        assert!(into_string(get<std::string::String>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::string::String"), 0);
+        assert!(into_string(get<TestStruct>()) == string(b"0xa::type_name_tests::TestStruct"), 0);
+        assert!(into_string(get<std::ascii::String>()) == string(b"0x1::ascii::String"), 0);
+        assert!(into_string(get<std::option::Option<u64>>()) == string(b"0x1::option::Option<u64>"), 0);
+        assert!(into_string(get<std::string::String>()) == string(b"0x1::string::String"), 0);
     }
 
-    // Note: these tests assume a 16 byte address length, and will fail on platforms where addresses are 20 or 32 bytes
     #[test]
     fun test_generics() {
-        assert!(into_string(get<TestGenerics<std::string::String>>()) == string(b"000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<0000000000000000000000000000000000000000000000000000000000000001::string::String>"), 0);
-        assert!(into_string(get<vector<TestGenerics<u64>>>()) == string(b"vector<000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u64>>"), 0);
-        assert!(into_string(get<std::option::Option<TestGenerics<u8>>>()) == string(b"0000000000000000000000000000000000000000000000000000000000000001::option::Option<000000000000000000000000000000000000000000000000000000000000000a::type_name_tests::TestGenerics<u8>>"), 0);
+        assert!(into_string(get<TestGenerics<std::string::String>>()) == string(b"0xa::type_name_tests::TestGenerics<0x1::string::String>"), 0);
+        assert!(into_string(get<vector<TestGenerics<u64>>>()) == string(b"vector<0xa::type_name_tests::TestGenerics<u64>>"), 0);
+        assert!(into_string(get<std::option::Option<TestGenerics<u8>>>()) == string(b"0x1::option::Option<0xa::type_name_tests::TestGenerics<u8>>"), 0);
     }
 }

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -175,8 +175,11 @@ impl TransactionDataCache {
                     .with_delayed_fields_serde()
                     .deserialize(&blob, &layout)
                     .ok_or_else(|| {
-                        let msg =
-                            format!("Failed to deserialize resource {} at {}!", struct_tag, addr);
+                        let msg = format!(
+                            "Failed to deserialize resource {} at {}!",
+                            struct_tag.to_canonical_string(),
+                            addr
+                        );
                         PartialVMError::new(StatusCode::FAILED_TO_DESERIALIZE_RESOURCE)
                             .with_message(msg)
                     })?;

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -573,7 +573,7 @@ impl InterpreterImpl<'_> {
                                 //   to be able to let scripts use closures.
                                 let err = PartialVMError::new_invariant_violation(format!(
                                     "module id required to charge gas for function `{}`",
-                                    lazy_function.to_stable_string()
+                                    lazy_function.to_canonical_string()
                                 ));
                                 return Err(set_err_info!(current_frame, err));
                             };
@@ -1432,10 +1432,10 @@ impl InterpreterImpl<'_> {
             debug_write!(buf, "<")?;
             let mut it = ty_tags.iter();
             if let Some(tag) = it.next() {
-                debug_write!(buf, "{}", tag)?;
+                debug_write!(buf, "{}", tag.to_canonical_string())?;
                 for tag in it {
                     debug_write!(buf, ", ")?;
-                    debug_write!(buf, "{}", tag)?;
+                    debug_write!(buf, "{}", tag.to_canonical_string())?;
                 }
             }
             debug_write!(buf, ">")?;

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -316,7 +316,7 @@ impl AbstractFunction for LazyLoadedFunction {
         Ok(Box::new(self.clone()))
     }
 
-    fn to_stable_string(&self) -> String {
+    fn to_canonical_string(&self) -> String {
         self.with_name_and_ty_args(|module_id, fun_id, ty_args| {
             let prefix = if let Some(m) = module_id {
                 format!("0x{}::{}::", m.address(), m.name())
@@ -332,7 +332,7 @@ impl AbstractFunction for LazyLoadedFunction {
                         .iter()
                         .map(|t| t.to_canonical_string())
                         .collect::<Vec<_>>()
-                        .join(",")
+                        .join(", ")
                 )
             };
             format!("{}::{}{}", prefix, fun_id, ty_args_str)

--- a/third_party/move/move-vm/types/src/values/function_values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/function_values_impl.rs
@@ -31,7 +31,7 @@ pub trait AbstractFunction: for<'a> Tid<'a> {
     fn closure_mask(&self) -> ClosureMask;
     fn cmp_dyn(&self, other: &dyn AbstractFunction) -> PartialVMResult<Ordering>;
     fn clone_dyn(&self) -> PartialVMResult<Box<dyn AbstractFunction>>;
-    fn to_stable_string(&self) -> String;
+    fn to_canonical_string(&self) -> String;
 }
 
 /// A closure, consisting of an abstract function descriptor and the captured arguments.
@@ -84,7 +84,7 @@ impl Closure {
 impl Debug for Closure {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         let Self(fun, captured) = self;
-        write!(f, "Closure({}, {:?})", fun.to_stable_string(), captured)
+        write!(f, "Closure({}, {:?})", fun.to_canonical_string(), captured)
     }
 }
 
@@ -94,7 +94,7 @@ impl Display for Closure {
         let captured = fun
             .closure_mask()
             .format_arguments(captured.iter().map(|v| v.to_string()).collect());
-        write!(f, "{}({})", fun.to_stable_string(), captured.join(", "))
+        write!(f, "{}({})", fun.to_canonical_string(), captured.join(", "))
     }
 }
 

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -382,7 +382,7 @@ mod tests {
             unimplemented!()
         }
 
-        fn to_stable_string(&self) -> String {
+        fn to_canonical_string(&self) -> String {
             // Needed for assertion failure printing
             "<some function>".to_string()
         }

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -756,7 +756,7 @@ fn pretty_print_struct(
     indent: u64,
 ) -> std::fmt::Result {
     pretty_print_ability_modifiers(f, value.abilities)?;
-    write!(f, "{}", value.ty_tag)?;
+    write!(f, "{}", value.ty_tag.to_canonical_string())?;
     if let Some((_, name)) = &value.variant_info {
         write!(f, "::{}", name)?;
     }
@@ -817,7 +817,7 @@ fn pretty_print_closure(
         for ty in ty_args {
             f.write_str(last_sep)?;
             last_sep = ", ";
-            write!(f, "{}", ty)?
+            write!(f, "{}", ty.to_canonical_string())?
         }
         write!(f, ">")?
     }

--- a/third_party/move/tools/move-unit-test/src/extensions.rs
+++ b/third_party/move/tools/move-unit-test/src/extensions.rs
@@ -84,7 +84,7 @@ fn print_table_extension<W: Write>(
                 "new tables {}",
                 cs.new_tables
                     .iter()
-                    .map(|(k, v)| format!("{}<{},{}>", k, v.key_type, v.value_type))
+                    .map(|(handle, table)| format!("({handle}: {table})"))
                     .join(", ")
             )
             .unwrap();

--- a/types/src/access_path.rs
+++ b/types/src/access_path.rs
@@ -89,10 +89,10 @@ impl fmt::Display for Path {
                 write!(f, "Code({})", module_id)
             },
             Path::Resource(struct_tag) => {
-                write!(f, "Resource({})", struct_tag)
+                write!(f, "Resource({})", struct_tag.to_canonical_string())
             },
             Path::ResourceGroup(struct_tag) => {
-                write!(f, "ResourceGroup({})", struct_tag)
+                write!(f, "ResourceGroup({})", struct_tag.to_canonical_string())
             },
         }
     }

--- a/types/src/transaction/script.rs
+++ b/types/src/transaction/script.rs
@@ -155,7 +155,10 @@ impl EntryFunction {
             self.module.address,
             self.module.name().to_string(),
             self.function.to_string(),
-            self.ty_args.iter().map(|ty| ty.to_string()).collect(),
+            self.ty_args
+                .iter()
+                .map(|ty| ty.to_canonical_string())
+                .collect(),
             self.args.clone(),
         )
     }


### PR DESCRIPTION
## Description

This PR fixes function value ambiguous conversion to string. Before, it was possible to have `||||` which can either be interpreted as `||(||)` or `|(||)|`. The fix is to add parentheses to the returns. 

Also, this PR removes `Display` implementation for `TypeTag` (and `StructTag` /  `FunctionTag`) and replaces it with `to_canonical_string()` which is intended to be stable. In turn, implementation of `to_canonical_string()` is changed to be equivalent to `Display`:

1. Address has trimmed 0 at front, and
2. Commas are added between type arguments of a struct (bug in `to_canonical_string()` that has not been fixed before).

Note that (1) is needed because `type_info.move` from Aptos stdlib relies on `Display` implementation, and so, it is not easy to change this without feature gating. As a result, in all places where `to_canonical_string()` is used instead of `Display`, there is no change in behaviour.

There are places where `to_canonical_string()` is used already:

- API uses to display function `MoveType`: https://github.com/aptos-labs/aptos-core/blob/ec604d0b74f6860c21252cc4c3cf66df7425eadc/api/types/src/move_types.rs#L291, function values are not yet out so change is safe.
- Replay benchmark uses to display events in diffs: https://github.com/aptos-labs/aptos-core/blob/ec604d0b74f6860c21252cc4c3cf66df7425eadc/aptos-move/replay-benchmark/src/diff.rs#L83 (3 instances): safe to change.
- Fuzzer now has tag to string support and was using it: https://github.com/aptos-labs/aptos-core/blob/ec604d0b74f6860c21252cc4c3cf66df7425eadc/testsuite/fuzzer/fuzz/fuzz_targets/move/type_tag_to_string.rs#L73. Now it uses `to_canonical_string()` only (essentially renamed `Display`).
- `Display` for function value tags was using `to_canonical_string()`. Implementation is removed so this usage is irrelevant.
- `move-stdlib` in `third_party` uses it https://github.com/aptos-labs/aptos-core/blob/ec604d0b74f6860c21252cc4c3cf66df7425eadc/third_party/move/move-stdlib/src/natives/type_name.rs#L31. This is safe to change because this is not used anyway (one under `aptos-move/framework`) is actually used in production.
- In `bulk-txn-submit`: https://github.com/aptos-labs/aptos-core/blob/ec604d0b74f6860c21252cc4c3cf66df7425eadc/experimental/bulk-txn-submit/src/event_lookup.rs#L53 to search for events (2 instances). Adjusted code to work with trimmed addresses.

Other changes: 
- `to_stable_string()` for lazy loaded function is renamed to `to_canonical_string()`.
- Removed `Display` for `MoveValue` because it is error-prone and unstable, using `Debug` should suffice and `Display` was actually used in legacy `0x1::debug::print` in `move-stdlib` in `third_party` for closures. They do not need to be supported there.

## How Has This Been Tested?

New unit tests.
Also tested with new fuzzer (left to run for few hours)

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Bug fix

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
