### PR TITLE
[linter] Added aborting_overflow_checks lint

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -3,15 +3,11 @@
 
 //! This module (and its submodules) contain various model-AST-based lint checks.
 
+mod aborting_overflow_checks;
 mod almost_swapped;
 mod assert_const;
 mod blocks_in_conditions;
-<<<<<<< HEAD
 mod equal_operands_in_bin_op;
-||||||| parent of b8abccb6b6 ([linter] Added aborting_overflow_checks lint)
-=======
-mod aborting_overflow_checks;
->>>>>>> b8abccb6b6 ([linter] Added aborting_overflow_checks lint)
 mod needless_bool;
 mod needless_deref_ref;
 mod needless_ref_deref;
@@ -45,7 +41,6 @@ pub fn get_default_linter_pipeline(config: &BTreeMap<String, String>) -> Vec<Box
         Box::<unnecessary_boolean_identity_comparison::UnnecessaryBooleanIdentityComparison>::default(),
         Box::<unnecessary_numerical_extreme_comparison::UnnecessaryNumericalExtremeComparison>::default(),
         Box::<while_true::WhileTrue>::default(),
-        
     ];
     let checks_category = config.get("checks").map_or("default", |s| s.as_str());
     if checks_category == "strict" || checks_category == "experimental" {

--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -6,7 +6,12 @@
 mod almost_swapped;
 mod assert_const;
 mod blocks_in_conditions;
+<<<<<<< HEAD
 mod equal_operands_in_bin_op;
+||||||| parent of b8abccb6b6 ([linter] Added aborting_overflow_checks lint)
+=======
+mod aborting_overflow_checks;
+>>>>>>> b8abccb6b6 ([linter] Added aborting_overflow_checks lint)
 mod needless_bool;
 mod needless_deref_ref;
 mod needless_ref_deref;
@@ -25,6 +30,7 @@ use std::collections::BTreeMap;
 pub fn get_default_linter_pipeline(config: &BTreeMap<String, String>) -> Vec<Box<dyn ExpChecker>> {
     // Start with the default set of checks.
     let checks: Vec<Box<dyn ExpChecker>> = vec![
+        Box::<aborting_overflow_checks::AbortingOverflowChecks>::default(),
         Box::<almost_swapped::AlmostSwapped>::default(),
         Box::<assert_const::AssertConst>::default(),
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
@@ -39,6 +45,7 @@ pub fn get_default_linter_pipeline(config: &BTreeMap<String, String>) -> Vec<Box
         Box::<unnecessary_boolean_identity_comparison::UnnecessaryBooleanIdentityComparison>::default(),
         Box::<unnecessary_numerical_extreme_comparison::UnnecessaryNumericalExtremeComparison>::default(),
         Box::<while_true::WhileTrue>::default(),
+        
     ];
     let checks_category = config.get("checks").map_or("default", |s| s.as_str());
     if checks_category == "strict" || checks_category == "experimental" {

--- a/third_party/move/tools/move-linter/src/model_ast_lints/aborting_overflow_checks.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/aborting_overflow_checks.rs
@@ -1,0 +1,141 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for expressions that look
+//! like overflow checks done in a C style. This pattern in move does not make sense,
+//! as it either aborts immediately or is always `true` or `false`.
+//! E.g.
+//!      `a > a + b`  => Always false if (a + b) does not overflow, else abort.
+//!      `a < a + b`  => Always true if (a + b) does not overflow, else abort.
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{Exp, ExpData, Operation},
+    model::FunctionEnv,
+};
+
+const MSG: &str =
+    "This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.";
+
+#[derive(Default)]
+
+pub struct AbortingOverflowChecks;
+
+impl ExpChecker for AbortingOverflowChecks {
+    fn get_name(&self) -> String {
+        "aborting_overflow_checks".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, env: &FunctionEnv, expr: &ExpData) {
+        let g_env = env.env();
+        if is_c_like_check_cmp(expr) {
+            self.report(g_env, &g_env.get_node_loc(expr.node_id()), MSG);
+        }
+    }
+}
+
+/// Checks if an Exp is a binary comparison and looks if the operands
+/// of the comparison are formatted like a C overflow check:
+/// ```C
+///     if (a > a + b) {
+///         //...
+///     }
+/// ```
+/// It checks for (Gt | Lt) operands, with one side matching (Add | Sub) operations.
+/// Excludes patterns like `a > a - b` and `a - b < a` as they can be true, false, or abort.
+fn is_c_like_check_cmp(exp: &ExpData) -> bool {
+    let ExpData::Call(_, operation, operands_vec) = exp else {
+        return false;
+    };
+
+    // Only look for strict comparisons.
+    if !matches!(operation, Operation::Gt | Operation::Lt) || operands_vec.len() != 2 {
+        return false;
+    }
+
+    let [lhs_exp, rhs_exp] = &operands_vec[..] else {
+        return false;
+    };
+
+    let lhs_add_sub_operands = get_add_or_sub_operands(lhs_exp);
+    let rhs_add_sub_operands = get_add_or_sub_operands(rhs_exp);
+
+    // Check if one side of the expression contains one expression "equal" to the other side
+    let lhs_matches_rhs = has_matching_operand(lhs_add_sub_operands, rhs_exp);
+    let rhs_matches_lhs = has_matching_operand(rhs_add_sub_operands, lhs_exp);
+    let has_matches = lhs_matches_rhs || rhs_matches_lhs;
+
+    has_matches
+        && !expression_has_different_results(
+            operation,
+            lhs_exp,
+            rhs_exp,
+            lhs_matches_rhs,
+            rhs_matches_lhs,
+        )
+}
+
+/// Checks if the boolean expression could result in any of (true, false, abort).
+/// We do not warn in such cases.
+fn expression_has_different_results(
+    operation: &Operation,
+    lhs_exp: &ExpData,
+    rhs_exp: &ExpData,
+    lhs_matches_rhs: bool,
+    rhs_matches_lhs: bool,
+) -> bool {
+    match (
+        operation,
+        is_subtraction_operation(lhs_exp),
+        is_subtraction_operation(rhs_exp),
+    ) {
+        (Operation::Gt, _, true) if rhs_matches_lhs => true,
+        (Operation::Lt, true, _) if lhs_matches_rhs => true,
+        _ => false,
+    }
+}
+
+fn is_subtraction_operation(exp_data: &ExpData) -> bool {
+    matches!(exp_data, ExpData::Call(_, Operation::Sub, _))
+}
+
+fn has_matching_operand(add_sub_operands: Option<[&Exp; 2]>, target_exp: &ExpData) -> bool {
+    add_sub_operands.is_some_and(|ops| ops.iter().any(|op| expr_are_equal(op, target_exp)))
+}
+
+fn get_add_or_sub_operands(exp_data: &ExpData) -> Option<[&Exp; 2]> {
+    match exp_data {
+        ExpData::Call(_, op, operands)
+            if matches!(op, Operation::Add | Operation::Sub) && operands.len() == 2 =>
+        {
+            Some([&operands[0], &operands[1]])
+        },
+        _ => None,
+    }
+}
+
+/// This function performs a structural comparison of two expressions. It handles the following expression types:
+/// - Local variables: compared by symbol equality
+/// - Values: compared by value equality
+/// - Temporaries: compared by temporary ID equality
+/// - Function calls: compared by operation type and recursive argument comparison
+///     - In this case, also checks that the operation is NOT a MoveFunction,
+///       as they could be side-effecting.
+fn expr_are_equal(exp_a: &ExpData, exp_b: &ExpData) -> bool {
+    use ExpData::*;
+
+    match (exp_a, exp_b) {
+        (LocalVar(_, s1), LocalVar(_, s2)) => s1 == s2,
+        (Value(_, v1), Value(_, v2)) => v1 == v2,
+        (Temporary(_, t1), Temporary(_, t2)) => t1 == t2,
+        (Call(_, op1, args1), Call(_, op2, args2)) => {
+            (!matches!(op1, Operation::MoveFunction(..)))
+                && op1 == op2
+                && args1.len() == args2.len()
+                && args1
+                    .iter()
+                    .zip(args2.iter())
+                    .all(|(a1, a2)| expr_are_equal(a1, a2))
+        },
+        _ => false,
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.exp
@@ -1,0 +1,109 @@
+
+Diagnostics:
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:23:9
+   │
+23 │     if (a + b < a) {
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:29:9
+   │
+29 │     if (a + b > a) {
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:35:9
+   │
+35 │     if (a < a + b) {
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:41:9
+   │
+41 │     if (a > a + b) {
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:48:9
+   │
+48 │     if (a - b > a) {
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:68:9
+   │
+68 │     if (a < a - b) {
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:87:9
+   │
+87 │     if (c > c + b) {
+   │         ^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+   ┌─ tests/model_ast_lints/aborting_overflow_checks.move:94:9
+   │
+94 │     if (nc.n.i > nc.n.i + b) {
+   │         ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:101:9
+    │
+101 │     if (hnc.n.n.i > hnc.n.n.i + b) {
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:108:12
+    │
+108 │     while (a + b > a) {
+    │            ^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:112:9
+    │
+112 │     if ((a + 1) + (b + 1) < (a + 1)) {
+    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
+
+warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:122:5
+    │
+122 │     a + b < a
+    │     ^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:23:9
    │
 23 │     if (a + b < a) {
@@ -9,7 +9,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:29:9
    │
 29 │     if (a + b > a) {
@@ -18,7 +18,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:35:9
    │
 35 │     if (a < a + b) {
@@ -27,7 +27,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:41:9
    │
 41 │     if (a > a + b) {
@@ -36,7 +36,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:48:9
    │
 48 │     if (a - b > a) {
@@ -45,7 +45,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:68:9
    │
 68 │     if (a < a - b) {
@@ -54,7 +54,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:87:9
    │
 87 │     if (c > c + b) {
@@ -63,7 +63,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
    ┌─ tests/model_ast_lints/aborting_overflow_checks.move:94:9
    │
 94 │     if (nc.n.i > nc.n.i + b) {
@@ -72,7 +72,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
     ┌─ tests/model_ast_lints/aborting_overflow_checks.move:101:9
     │
 101 │     if (hnc.n.n.i > hnc.n.n.i + b) {
@@ -81,7 +81,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
     ┌─ tests/model_ast_lints/aborting_overflow_checks.move:108:12
     │
 108 │     while (a + b > a) {
@@ -90,7 +90,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
     ┌─ tests/model_ast_lints/aborting_overflow_checks.move:112:9
     │
 112 │     if ((a + 1) + (b + 1) < (a + 1)) {
@@ -99,7 +99,7 @@ warning: [lint] This looks like a C-style overflow check. In Move, overflows aut
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(aborting_overflow_checks)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#aborting_overflow_checks.
 
-warning: [lint] This looks like a C-style overflow check. In Move, overflows automatically abort.
+warning: [lint] This looks like a C-style overflow check. In Move, overflows abort, and such checks are unnecessary.
     ┌─ tests/model_ast_lints/aborting_overflow_checks.move:122:5
     │
 122 │     a + b < a

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/aborting_overflow_checks.move
@@ -1,0 +1,128 @@
+module 0xc0ffee::m {
+
+  struct Counter has key, store { i: u64 }
+
+  struct NestedCounter has key, store {
+    n: Counter
+  }
+
+  struct HyperNestedCounter has key, store {
+    n: NestedCounter
+  }
+
+  #[lint::skip(aborting_overflow_checks)]
+  public fun ignore(a: u64, b: u64) : u64 {
+    if (a + b < a) {
+      a + b
+    } else {
+      abort 1
+    }
+  }
+
+  public fun arg_cmp(a: u64, b: u64, addr: address) : u64 acquires Counter, NestedCounter, HyperNestedCounter {
+    if (a + b < a) {
+      a + b
+    } else {
+      abort 1
+    };
+
+    if (a + b > a) {
+      a + b
+    } else {
+      abort 1
+    };
+
+    if (a < a + b) {
+      a + b
+    } else {
+      abort 1
+    };
+
+    if (a > a + b) {
+      a + b
+    } else {
+      abort 1
+    };
+
+
+    if (a - b > a) {
+      a + b
+    } else {
+      abort 1
+    };
+
+
+    if (a - b < a) { // This should not be warned.
+      a + b
+    } else {
+      abort 1
+    };
+
+    if (a > a - b) { // This should not be warned.
+      a + b
+    } else {
+      abort 1
+    };
+
+
+    if (a < a - b) {
+      a + b
+    } else {
+      abort 1
+    };
+
+    if (a_fn(a) + b < a_fn(a)) {     // This should not be warned.
+      a + b
+    } else {
+      abort 1
+    };
+
+    if (a_fn(a) > a_fn(a) + b ) {    // This should not be warned.
+      a + b
+    } else {
+      abort 1
+    };
+
+    let c = borrow_global<Counter>(addr).i;
+    if (c > c + b) {
+      c + b
+    } else {
+      abort 1
+    };
+
+    let nc = borrow_global<NestedCounter>(addr);
+    if (nc.n.i > nc.n.i + b) {
+      nc.n.i + b
+    } else {
+      abort 1
+    };
+
+    let hnc = borrow_global<HyperNestedCounter>(addr);
+    if (hnc.n.n.i > hnc.n.n.i + b) {
+      hnc.n.n.i + b
+    } else {
+      abort 1
+    };
+
+    let i = 0;
+    while (a + b > a) {
+      i = i + 1;
+    };
+
+    if ((a + 1) + (b + 1) < (a + 1)) {
+      (a + 1) + (b + 1)
+    } else {
+      abort 1
+    };
+
+    a + b
+  }
+
+  public fun overflows(a: u64, b: u64) : bool {
+    a + b < a
+  }
+
+  public fun a_fn(a: u64) : u64 {
+    a
+  }
+}


### PR DESCRIPTION
## Description
This PR adds a new lint to `aptos move lint`: Checking for C-like overflow checks, as requested in #15221
> Find code patterns that resemble C-style underflow/overflow checks: `if (a + b < a) { ... }`.


## How Has This Been Tested?
Added test in `move_linter/tests` folder

This lint do not triggers in any file in `aptos-move/framework/*`.

## Key Areas to Review
- Recognized patterns are enough?
- Lint message.
## Type of Change
New feature
## Which Components or Systems Does This Change Impact?
Other (move_linter)
## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation