### PR TITLE
[faucet] Allow setting API key / headers

### DIFF
--- a/crates/aptos-faucet/cli/src/main.rs
+++ b/crates/aptos-faucet/cli/src/main.rs
@@ -82,6 +82,8 @@ impl FaucetCliArgs {
         // Build the MintFunder service.
         let mut mint_funder = MintFunder::new(
             self.api_connection_args.node_url.clone(),
+            self.api_connection_args.api_key.clone(),
+            self.api_connection_args.additional_headers.clone(),
             self.api_connection_args.chain_id,
             transaction_submission_config,
             faucet_account,

--- a/crates/aptos-faucet/core/src/endpoints/errors.rs
+++ b/crates/aptos-faucet/core/src/endpoints/errors.rs
@@ -161,6 +161,9 @@ pub enum AptosTapErrorCode {
     /// The server has hit its max concurrent requests limit.
     ServerOverloaded = 57,
 
+    /// Unexpected internal problem.
+    InternalError = 58,
+
     /// Error from the web framework.
     WebFrameworkError = 60,
 }
@@ -180,7 +183,8 @@ impl AptosTapErrorCode {
             | AptosTapErrorCode::SerializationError
             | AptosTapErrorCode::BypasserError
             | AptosTapErrorCode::CheckerError
-            | AptosTapErrorCode::StorageError => StatusCode::INTERNAL_SERVER_ERROR,
+            | AptosTapErrorCode::StorageError
+            | AptosTapErrorCode::InternalError => StatusCode::INTERNAL_SERVER_ERROR,
             AptosTapErrorCode::ServerOverloaded | AptosTapErrorCode::FunderAccountProblem => {
                 StatusCode::SERVICE_UNAVAILABLE
             },

--- a/crates/aptos-faucet/core/src/funder/common.rs
+++ b/crates/aptos-faucet/core/src/funder/common.rs
@@ -25,6 +25,7 @@ use clap::Parser;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::{
+    collections::HashMap,
     path::PathBuf,
     str::FromStr,
     sync::{
@@ -52,6 +53,15 @@ pub struct ApiConnectionConfig {
     #[clap(long, default_value = "https://fullnode.testnet.aptoslabs.com/")]
     pub node_url: Url,
 
+    /// API key for talking to the node API.
+    #[clap(long)]
+    pub api_key: Option<String>,
+
+    /// Any additional headers to send with the request. We don't accept this on the
+    /// CLI.
+    #[clap(skip)]
+    pub additional_headers: Option<HashMap<String, String>>,
+
     /// Path to the private key for creating test account and minting coins in
     /// the MintFunder case, or for transferring coins in the TransferFunder case.
     /// To keep Testnet simple, we used one private key for aptos root account
@@ -76,12 +86,16 @@ pub struct ApiConnectionConfig {
 impl ApiConnectionConfig {
     pub fn new(
         node_url: Url,
+        api_key: Option<String>,
+        additional_headers: Option<HashMap<String, String>>,
         key_file_path: PathBuf,
         key: Option<ConfigKey<Ed25519PrivateKey>>,
         chain_id: ChainId,
     ) -> Self {
         Self {
             node_url,
+            api_key,
+            additional_headers,
             key_file_path,
             key,
             chain_id,

--- a/crates/aptos-faucet/core/src/funder/mint.rs
+++ b/crates/aptos-faucet/core/src/funder/mint.rs
@@ -8,7 +8,7 @@ use anyhow::{Context, Result};
 use aptos_logger::info;
 use aptos_sdk::{
     crypto::ed25519::Ed25519PublicKey,
-    rest_client::Client,
+    rest_client::{AptosBaseUrl, Client},
     transaction_builder::{aptos_stdlib, TransactionFactory},
     types::{
         account_address::AccountAddress,
@@ -22,6 +22,7 @@ use aptos_sdk::{
 use async_trait::async_trait;
 use reqwest::Url;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tokio::sync::RwLock;
 
 static MINTER_SCRIPT: &[u8] = include_bytes!(
@@ -66,6 +67,8 @@ impl MintFunderConfig {
 
         let mut minter = MintFunder::new(
             self.api_connection_config.node_url.clone(),
+            self.api_connection_config.api_key.clone(),
+            self.api_connection_config.additional_headers.clone(),
             self.api_connection_config.chain_id,
             self.transaction_submission_config,
             faucet_account,
@@ -85,6 +88,8 @@ impl MintFunderConfig {
 pub struct MintFunder {
     /// URL of an Aptos node API.
     node_url: Url,
+    node_api_key: Option<String>,
+    node_additional_headers: Option<HashMap<String, String>>,
 
     txn_config: TransactionSubmissionConfig,
 
@@ -102,6 +107,8 @@ pub struct MintFunder {
 impl MintFunder {
     pub fn new(
         node_url: Url,
+        node_api_key: Option<String>,
+        node_additional_headers: Option<HashMap<String, String>>,
         chain_id: ChainId,
         txn_config: TransactionSubmissionConfig,
         faucet_account: LocalAccount,
@@ -113,6 +120,8 @@ impl MintFunder {
             .with_transaction_expiration_time(txn_config.transaction_expiration_secs);
         Self {
             node_url,
+            node_api_key,
+            node_additional_headers,
             txn_config,
             faucet_account: RwLock::new(faucet_account),
             transaction_factory,
@@ -203,7 +212,19 @@ impl MintFunder {
     /// the entire time because it uses cookies, ensuring we're talking to the same
     /// node behind the LB every time.
     pub fn get_api_client(&self) -> Client {
-        Client::new(self.node_url.clone())
+        let mut builder = Client::builder(AptosBaseUrl::Custom(self.node_url.clone()));
+
+        if let Some(api_key) = self.node_api_key.clone() {
+            builder = builder.api_key(&api_key).expect("Failed to set API key");
+        }
+
+        if let Some(additional_headers) = &self.node_additional_headers {
+            for (key, value) in additional_headers {
+                builder = builder.header(key, value).expect("Failed to set header");
+            }
+        }
+
+        builder.build()
     }
 
     pub async fn process(
@@ -299,11 +320,8 @@ impl FunderTrait for MintFunder {
     /// Assert the funder account actually exists.
     async fn is_healthy(&self) -> FunderHealthMessage {
         let account_address = self.faucet_account.read().await.address();
-        match self
-            .get_api_client()
-            .get_account_bcs(account_address)
-            .await
-        {
+        let client = self.get_api_client();
+        match client.get_account_bcs(account_address).await {
             Ok(_) => FunderHealthMessage {
                 can_process_requests: true,
                 message: None,

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -271,6 +271,8 @@ impl RunConfig {
             funder_config: FunderConfig::MintFunder(MintFunderConfig {
                 api_connection_config: ApiConnectionConfig::new(
                     api_url,
+                    None,
+                    None,
                     key_file_path,
                     key,
                     chain_id.unwrap_or_else(ChainId::test),


### PR DESCRIPTION
## Description
If you want to make the faucet use a node API, often you'll need to be able to set some kind of auth, e.g. an API key or some other kind of header.

## How Has This Been Tested?
Using this config:
```
server_config:
  api_path_base: ""
  listen_port: 8010
metrics_server_config: {}
bypasser_configs: []
checker_configs: []
funder_config:
  type: "MintFunder"
  node_url: "https://api.testnet.aptoslabs.com"
  api_key: <key>
  chain_id: 2
  key:
    key: <key>
  maximum_amount: 100000000
  maximum_amount_with_bypass: 10000000000
  do_not_delegate: true
  transaction_expiration_secs: 15
  wait_for_outstanding_txns_secs: 20
handler_config:
  use_helpful_errors: true
  return_rejections_early: true
```

Run this:
```
cargo run -p aptos-faucet-service -- run --config-path ~/faucet-config.yaml
```

Then mint:
```
curl -H 'Content-Type: application/json' http://127.0.0.1:8010/fund -d '{"address": "0x2", "amount": 1000000000000000000}'
```
```
{"txn_hashes":["813fa133249d13364807a6492612812880c3cb5a125b5829a693545f2af06ef1"]}
```

If you use an invalid API key you get this instead:
```
{"message":"funder account 0x2ca3df28743a5cf69baa78f501716bd264a5e7128cecc8eb7aaa6cb375a56378 not found: Unknown error Unauthorized: API key not found","error_code":"AccountDoesNotExist","rejection_reasons":[],"txn_hashes":[]}
```

## Key Areas to Review
Make sure I'm not missing anything.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
