### PR TITLE
[Compiler] Fix issue of return signature of borrow of tuple not caught during type checking

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.exp
@@ -112,8 +112,26 @@ error: cannot borrow a tuple
 45 │         &mut spec {};
    │         ^^^^^^^^^^^^
 
+error: reference to a tuple is not allowed
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:48:33
+   │
+48 │     fun return_borrow_tuple() : &(u64, u64) {
+   │                                 ^^^^^^^^^^^
+
 error: cannot borrow a tuple
    ┌─ tests/checking/typing/borrow_tuple_invalid.move:49:16
    │
 49 │         return &(1, 2)
    │                ^^^^^^^
+
+error: reference to a tuple is not allowed
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:52:32
+   │
+52 │     fun return_borrow_unit() : &() {
+   │                                ^^^
+
+error: cannot borrow a tuple
+   ┌─ tests/checking/typing/borrow_tuple_invalid.move:53:16
+   │
+53 │         return &()
+   │                ^^^

--- a/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.move
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/borrow_tuple_invalid.move
@@ -48,4 +48,8 @@ module 0x8675309::M {
     fun return_borrow_tuple() : &(u64, u64) {
         return &(1, 2)
     }
+
+    fun return_borrow_unit() : &() {
+        return &()
+    }
 }

--- a/third_party/move/move-model/src/builder/exp_builder.rs
+++ b/third_party/move/move-model/src/builder/exp_builder.rs
@@ -1049,6 +1049,9 @@ impl ExpTranslator<'_, '_, '_> {
                 if inner.is_reference() {
                     self.error(loc, "reference to a reference is not allowed");
                 }
+                if inner.is_tuple() {
+                    self.error(loc, "reference to a tuple is not allowed");
+                }
                 Type::Reference(ReferenceKind::from_is_mut(*is_mut), Box::new(inner))
             },
             Fun(args, result, abilities) => {


### PR DESCRIPTION
## Description
Close #16666.

Resolves issue of borrow of tuple as return signature going unresolved.



## How Has This Been Tested?
Some testing added; mostly just current coverage.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
