### PR TITLE
[compiler-v2] Fix bytecode generator's generation of args

### DIFF
--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -418,10 +418,7 @@ impl Generator<'_> {
                 self.scopes.pop();
             },
             ExpData::Mutate(id, lhs, rhs) => {
-                // Notice that we cannot be in reference mode here for reasons
-                // of typing: the result of the Mutate operator is `()` and cannot
-                // appear where references are processed.
-                let rhs_temp = self.gen_arg(rhs, false);
+                let rhs_temp = self.gen_escape_auto_ref_arg(rhs, false);
                 let lhs_temp = self.gen_auto_ref_arg(lhs, ReferenceKind::Mutable);
                 let lhs_type = self.get_node_type(lhs.node_id());
 
@@ -643,7 +640,7 @@ impl Generator<'_> {
         // Arguments are first computed, finally the function. (On a stack machine, the
         // function is on the top).
         let mut arg_temps = self.gen_arg_list(args);
-        let fun_temp = self.gen_arg(fun, false);
+        let fun_temp = self.gen_escape_auto_ref_arg(fun, false);
 
         // The function can be a wrapper `struct W(|T|S|)` which we need to unpack first.
         let fun_ty = self.get_node_type(fun.node_id());
@@ -1244,7 +1241,9 @@ impl Generator<'_> {
     // nested.
     fn gen_tuple(&mut self, exp: &Exp, with_forced_temp: bool) -> Vec<TempIndex> {
         if let ExpData::Call(_, Operation::Tuple, args) = exp.as_ref() {
-            args.iter().map(|arg| self.gen_arg(arg, false)).collect()
+            args.iter()
+                .map(|arg| self.gen_escape_auto_ref_arg(arg, false))
+                .collect()
         } else {
             let exp_ty = self.env().get_node_type(exp.node_id());
             if exp_ty.is_tuple() {
@@ -1257,7 +1256,7 @@ impl Generator<'_> {
                 self.gen(temps.clone(), exp);
                 temps
             } else {
-                vec![self.gen_arg(exp, with_forced_temp)]
+                vec![self.gen_escape_auto_ref_arg(exp, with_forced_temp)]
             }
         }
     }
@@ -1342,7 +1341,7 @@ impl Generator<'_> {
         // Borrow the temporary, allowing to do e.g. `&(1+2)`. Note to match
         // this capability in the stack machine, we need to keep those temps in locals
         // and can't manage them on the stack during stackification.
-        let temp = self.gen_arg(arg, false);
+        let temp = self.gen_escape_auto_ref_arg(arg, false);
         self.gen_borrow_temp(target, id, temp)
     }
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14817.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14817.exp
@@ -14,21 +14,14 @@ B0:
 	1: Pack[0](S)
 	2: StLoc[0](s: S)
 	3: LdTrue
-	4: MutBorrowLoc[0](s: S)
+	4: ImmBorrowLoc[0](s: S)
 	5: ImmBorrowField[0](S.x: bool)
-	6: StLoc[1]($t5: bool)
-	7: MutBorrowLoc[1]($t5: bool)
-	8: WriteRef
-	9: MoveLoc[0](s: S)
-	10: Ret
+	6: ReadRef
+	7: StLoc[1]($t5: bool)
+	8: MutBorrowLoc[1]($t5: bool)
+	9: WriteRef
+	10: MoveLoc[0](s: S)
+	11: Ret
 }
 }
-============ bytecode verification failed ========
-
-Diagnostics:
-bug: bytecode verification failed with unexpected status code `STLOC_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
-Error message: none
-  ┌─ tests/file-format-generator/bug_14817.move:7:16
-  │
-7 │         *&mut {s.x} = true;
-  │                ^^^
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14817.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14817.opt.exp
@@ -14,21 +14,14 @@ B0:
 	1: Pack[0](S)
 	2: StLoc[0](s: S)
 	3: LdTrue
-	4: MutBorrowLoc[0](s: S)
+	4: ImmBorrowLoc[0](s: S)
 	5: ImmBorrowField[0](S.x: bool)
-	6: StLoc[1]($t5: bool)
-	7: MutBorrowLoc[1]($t5: bool)
-	8: WriteRef
-	9: MoveLoc[0](s: S)
-	10: Ret
+	6: ReadRef
+	7: StLoc[1]($t5: bool)
+	8: MutBorrowLoc[1]($t5: bool)
+	9: WriteRef
+	10: MoveLoc[0](s: S)
+	11: Ret
 }
 }
-============ bytecode verification failed ========
-
-Diagnostics:
-bug: bytecode verification failed with unexpected status code `STLOC_TYPE_MISMATCH_ERROR`. This is a compiler bug, consider reporting it.
-Error message: none
-  ┌─ tests/file-format-generator/bug_14817.move:7:16
-  │
-7 │         *&mut {s.x} = true;
-  │                ^^^
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.exp
@@ -1,0 +1,1 @@
+processed 8 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.move
@@ -1,0 +1,203 @@
+//# publish
+module 0xc0ffee::m {
+    struct P has copy, drop {
+        q: Q,
+    }
+
+    struct Q has copy, drop {
+        r: u64,
+    }
+
+    fun new_p(): P {
+        P { q: Q { r: 0 } }
+    }
+
+    fun test_01(p: P): P {
+        p.q.r = 1;
+        p
+    }
+
+    fun test_02(p: P): u64 {
+        p.q.r + 10
+    }
+
+    fun test_03(p: &mut P) {
+        p.q.r = 12;
+    }
+
+    fun test_04(p: P): P {
+        *&mut p.q.r = 14;
+        p
+    }
+
+    fun test_05(p: P): P {
+        *&mut (p.q.r) = 15;
+        p
+    }
+
+    fun test_06(p: P): P {
+        let pq = &mut p.q;
+        pq.r = 16;
+        p
+    }
+
+    fun test_07(p: P): P {
+        // The code below modifies a temporary value.
+        *&mut {p.q.r} = 17;
+        p
+    }
+
+
+    fun test_08(v: u64): u64 {
+        *&mut {v} = 18;
+        v
+    }
+
+    fun test_09(p: u64): bool {
+        &mut p == &mut (1+2)
+    }
+
+    inline fun derive_01(p: &mut P): &mut u64 {
+        &mut p.q.r
+    }
+
+    fun test_10(p: P): P {
+        *derive_01(&mut p) = 20;
+        p
+    }
+
+    inline fun derive_02(p: P): &mut u64 {
+        &mut p.q.r
+    }
+
+    fun test_11(p: P): P {
+        *derive_02(p) = 21;
+        p
+    }
+
+    fun test_12(p: P): P {
+        *&mut {*&mut p.q.r = 5; p.q.r} = 22;
+        p
+    }
+
+    fun test_13(p: P): P {
+        *(&mut (*(&p.q.r))) = 23;
+        p
+    }
+
+    fun test_14(p: P): P {
+        *&mut {p.q = Q { r: 24 }; p.q.r} = 12;
+        p
+    }
+
+    public fun main() {
+        let p01 = new_p();
+        let p01_result = test_01(p01);
+        assert!(p01_result.q.r == 1, 0);
+
+        let p02 = new_p();
+        let p02_result = test_02(p02);
+        assert!(p02_result == 10, 0);
+
+        let p03 = new_p();
+        test_03(&mut p03);
+        assert!(p03.q.r == 12, 0);
+
+        let p04 = new_p();
+        let p04_result = test_04(p04);
+        assert!(p04_result.q.r == 14, 0);
+
+        let p05 = new_p();
+        let p05_result = test_05(p05);
+        assert!(p05_result.q.r == 15, 0);
+
+        let p06 = new_p();
+        let p06_result = test_06(p06);
+        assert!(p06_result.q.r == 16, 0);
+
+        let p07 = new_p();
+        let p07_result = test_07(p07);
+        assert!(p07_result.q.r == 0, 0);
+
+        assert!(test_08(1) == 1, 0);
+
+        assert!(test_09(3), 0);
+
+        assert!(test_10(new_p()).q.r == 20, 0);
+
+        let p11 = new_p();
+        let p11_result = test_11(p11);
+        assert!(p11_result.q.r == 0, 0);
+
+        let p12 = new_p();
+        let p12_result = test_12(p12);
+        assert!(p12_result.q.r == 5, 0);
+
+        let p13 = new_p();
+        let p13_result = test_13(p13);
+        assert!(p13_result.q.r == 0, 0);
+
+        let p14 = new_p();
+        let p14_result = test_14(p14);
+        assert!(p14_result.q.r == 24, 0);
+    }
+}
+
+//# run 0xc0ffee::m::main
+
+//# publish
+module 0xCAFE::m1 {
+    struct Struct0 has copy, drop {
+        x: bool,
+    }
+
+    fun f(s: Struct0) {
+        *(&mut (*(&s.x))) = true;
+    }
+
+    public fun main() {
+        let s = Struct0 { x: true };
+        f(s);
+    }
+}
+
+//# run 0xCAFE::m1::main
+
+//# publish
+module 0xCAFE::m2 {
+    struct S has copy, drop {
+        x: bool,
+    }
+
+    fun f(s: S) {
+        *({
+            *(&mut (true)) = s.x;
+            &mut (0u8)
+        }) = 123u8;
+    }
+
+    public fun main() {
+        let s = S { x: true };
+        f(s);
+    }
+}
+
+//# run 0xCAFE::m2::main
+
+//# publish
+module 0xc0ffee::m3 {
+    struct S has copy, drop {
+        f: ||u8
+    }
+
+    fun test(s: S) {
+        *&mut {(s.f)()} = 1;
+    }
+
+    public fun main() {
+        let s = S { f: || 42 };
+        test(s);
+    }
+}
+
+//# run 0xc0ffee::m3::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16599.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16599.exp
@@ -1,0 +1,1 @@
+processed 4 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16599.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16599.move
@@ -1,0 +1,55 @@
+//# publish
+module 0xCAFE::m0 {
+    struct S has copy, drop {
+        x: bool,
+    }
+
+    enum E has copy, drop {
+        E1,
+    }
+
+    fun f(s: S) {
+        *(match (E::E1) {
+            E::E1 => {
+                *(&mut (true)) = s.x;
+                &mut ( 0u8)
+            }
+        }) = 123u8;
+    }
+
+    fun test() {
+        let s = S { x: true };
+        f(s);
+    }
+}
+
+//# run 0xCAFE::m0::test
+
+//# publish
+module 0xCAFE::m1 {
+    struct S has copy, drop {
+        x: bool,
+    }
+
+    enum E has copy, drop {
+        E1,
+    }
+
+    fun f(s: S, y: u64) {
+        *({
+            if (y == 10) {
+                abort 0;
+            };
+            *(&mut s.x) = s.x;
+            let z = 3;
+            &mut z
+        }) = 123u8;
+    }
+
+    fun test() {
+        let s = S { x: true };
+        f(s, 20);
+    }
+}
+
+//# run 0xCAFE::m1::test

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16607.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16607.exp
@@ -1,0 +1,1 @@
+processed 1 task

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16607.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16607.move
@@ -1,0 +1,17 @@
+//# publish
+module 0xCAFE::Module0 {
+    enum Enum0 has copy, drop {
+        E1(bool),
+    }
+
+    struct S has copy, drop {
+        x: Enum0,
+    }
+
+    fun f(s: S) {
+        let a: || has copy+drop = || {};
+        *(match (s.x) {
+            Enum0::E1(_) => &mut a,
+        }) = || {};
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16622.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16622.exp
@@ -1,0 +1,1 @@
+processed 9 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16622.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16622.move
@@ -1,0 +1,142 @@
+//# publish
+module 0xCAFE::m0 {
+    enum Enum0 has copy, drop {
+        Variant0,
+        Variant1 {
+            field1: bool,
+        },
+    }
+
+    struct S has copy, drop {
+        field2: Enum0,
+    }
+
+    public fun f0( ) {
+        let x = S { field2: Enum0::Variant1 { field1: false} };
+        *(match (x.field2) {
+            Enum0::Variant0 => {
+                &mut ( true)
+            },
+            _ => {
+                &mut (x.field2.field1)
+            }
+        }) = true;
+    }
+}
+
+//# run 0xCAFE::m0::f0
+
+//# publish
+module 0xCAFE::m1 {
+    enum Enum0 has copy, drop {
+        Variant0,
+        Variant1,
+    }
+
+    struct S has copy, drop {
+        field: Enum0,
+    }
+
+    public fun f0() {
+        let x = S { field: Enum0::Variant1 };
+        *(
+            match (x.field) {
+                Enum0::Variant1 {..} => {&mut (true)},
+                _ => {
+                        let y = x;
+                        let _z = y.field;
+                        &mut (true)
+                }
+            }
+        ) = true;
+    }
+
+    public fun f1() {
+        let x = S { field: Enum0::Variant1 };
+        *(
+            match ((x.field, x.field)) {
+                (Enum0::Variant1 {..}, Enum0::Variant1 {..}) => {&mut (true)},
+                (_, _) => {
+                        let y = x;
+                        let _z = y.field;
+                        &mut (true)
+                }
+            }
+        ) = true;
+    }
+}
+
+//# run 0xCAFE::m1::f0
+
+//# run 0xCAFE::m1::f1
+
+//# publish
+module 0xCAFE::m2 {
+    struct Struct1(bool) has copy, drop;
+
+    enum Enum0 has copy, drop {
+        Variant0,
+        Variant1 {
+            field1: bool,
+        },
+    }
+
+    enum Enum1 has copy, drop {
+        Variant2 {
+            field2: Enum0,
+        },
+    }
+
+    public fun f0() {
+        let x = Enum1::Variant2 { field2: Enum0::Variant1 { field1: false}};
+        *(
+            {
+                *( &mut ( Struct1 (x.field2.field1,))) =
+                match (x.field2) {
+                    Enum0::Variant1 {..} => {
+                        *( &( Struct1 (true)))
+                    },
+                    _ => {
+                        let y = x;
+                        let _z = y.field2;
+                        *( &( Struct1 (true)))
+                    }
+                };
+                &mut (true)
+            }
+        ) = *( &(true));
+    }
+}
+
+//# run 0xCAFE::m2::f0
+
+//# publish
+module 0xCAFE::m3 {
+    enum Enum0 has copy, drop {
+        Variant0,
+        Variant1,
+    }
+
+    struct S has copy, drop {
+        field: Enum0,
+    }
+
+    fun f0(x: S) {
+        *(
+            match (x.field) {
+                Enum0::Variant0 => &mut (1),
+                _ => {
+                    let _a = x.field;
+                    &mut (1)
+                }
+            }
+        ) = 1u8;
+    }
+
+    public fun test() {
+        let x = S { field: Enum0::Variant1 };
+        f0(x);
+    }
+}
+
+//# run 0xCAFE::m3::test

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16625.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16625.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16625.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_16625.move
@@ -1,0 +1,19 @@
+//# publish
+module 0xCAFE::m {
+    struct S has copy, drop {
+        f: || (u8),
+    }
+
+    fun foo(x: S) {
+        *(&mut (
+            (x.f)()
+        )) = 1;
+    }
+
+    public fun main() {
+        let s = S { f: || 42 };
+        foo(s);
+    }
+}
+
+//# run 0xCAFE::m::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/mutate_if.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/mutate_if.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/mutate_if.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/mutate_if.move
@@ -1,0 +1,31 @@
+//# publish
+module 0xc0ffee::m {
+    struct S has copy, drop {
+        x: bool,
+        y: u64,
+        z: u64,
+    }
+
+    fun foo1(s: S): S {
+        let r = &mut (if (s.x) { s.y } else { s.z });
+        *r = 2;
+        s
+    }
+
+    fun foo2(s: S): S {
+        *&mut (if (s.x) s.y else s.z) = 2;
+        s
+    }
+
+    fun test() {
+        let s1 = S { x: true, y: 1, z: 3 };
+        let result1 = foo1(s1);
+        assert!(s1 == result1, 0);
+
+        let s2 = S { x: false, y: 4, z: 5 };
+        let result2 = foo2(s2);
+        assert!(s2 == result2, 1);
+    }
+}
+
+//# run 0xc0ffee::m::test

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/nested_mutate.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/nested_mutate.exp
@@ -1,0 +1,1 @@
+processed 2 tasks

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/nested_mutate.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/nested_mutate.move
@@ -1,0 +1,24 @@
+//# publish
+module 0xc0ffee::m {
+    struct S has copy, drop {
+        x: T,
+    }
+
+    struct T has copy, drop {
+        y: u64,
+    }
+
+    fun foo(s: S, p: S): S {
+        *&mut {s.x.y = p.x.y; s.x.y} = 1;
+        s
+    }
+
+    public fun test() {
+        let s = S { x: T { y: 42 } };
+        let p = S { x: T { y: 43 } };
+        let result = foo(s, p);
+        assert!(result.x.y == 43, 0);
+    }
+}
+
+//# run 0xc0ffee::m::test


### PR DESCRIPTION
## Description

In this PR, we fix a few cases in the bytecode generator where we need to escape from "reference mode".

When we have an expression like `a.b.c` (which could appear in various contexts, like `*&mut a.b.c = 1;`, or `a.b.c = 1;`, or `let x = a.b.c + 1`):
- we need to generate the appropriate kind of intermediate references to `a`, and then derive the field reference `.b` from it
- finally, we either need to either just derive the field reference `.c`, or also do a readref on this final field reference.

What we do depends on the context in which `a.b.c` appears. All of this is tracked using whether you are in reference mode or not, and we were missing some cases where we escaped reference mode.

fixes #14817, fixes #16599, fixes #16607, fixes #16622, fixes #16625

## How Has This Been Tested?

- several new tests have been added from the various bugs (as well as some variations)

## Key Areas to Review

In general, I have converted all calls to `gen_arg` into `gen_escape_auto_ref_arg` (except of course the two calls to `gen_arg` from `gen_auto_ref_arg` and `gen_escape_auto_ref_arg`). I originally had a more complex fix, but I believe this simpler fix is sufficient, as demonstrated by the various tests.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
