### PR TITLE
[vm] Support gas meter in native functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3149,8 +3149,6 @@ dependencies = [
  "aptos-gas-algebra",
  "aptos-gas-schedule",
  "aptos-types",
- "bcs 0.1.4",
- "bytes",
  "move-binary-format",
  "move-core-types",
  "move-vm-runtime",

--- a/aptos-move/aptos-gas-profiling/src/log.rs
+++ b/aptos-move/aptos-gas-profiling/src/log.rs
@@ -58,6 +58,8 @@ pub enum FrameName {
 pub struct CallFrame {
     pub name: FrameName,
     pub events: Vec<ExecutionGasEvent>,
+    /// Accumulates gas charged by native functions. For frames of non-native functions, kept as 0.
+    pub native_gas: InternalGas,
 }
 
 /// The type of an operation performed on a storage item.
@@ -183,6 +185,7 @@ impl CallFrame {
                 ty_args,
             },
             events: vec![],
+            native_gas: 0.into(),
         }
     }
 
@@ -190,6 +193,7 @@ impl CallFrame {
         Self {
             name: FrameName::Script,
             events: vec![],
+            native_gas: 0.into(),
         }
     }
 }

--- a/aptos-move/aptos-native-interface/Cargo.toml
+++ b/aptos-move/aptos-native-interface/Cargo.toml
@@ -15,8 +15,6 @@ rust-version = { workspace = true }
 aptos-gas-algebra = { workspace = true }
 aptos-gas-schedule = { workspace = true }
 aptos-types = { workspace = true }
-bcs = { workspace = true }
-bytes = { workspace = true }
 move-binary-format = { workspace = true }
 move-core-types = { workspace = true }
 move-vm-runtime = { workspace = true }

--- a/aptos-move/aptos-native-interface/src/errors.rs
+++ b/aptos-move/aptos-native-interface/src/errors.rs
@@ -2,11 +2,50 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use move_binary_format::errors::PartialVMError;
-use move_core_types::{
-    gas_algebra::InternalGas, identifier::Identifier, language_storage::ModuleId,
-};
+use move_core_types::{identifier::Identifier, language_storage::ModuleId, vm_status::StatusCode};
 use move_vm_types::{loaded_data::runtime_types::Type, values::Value};
 use smallvec::SmallVec;
+
+/// Wraps [PartialVMError] to ensure it cannot be constructed via public constructor when we create
+/// a [LimitExceededError].
+pub struct MeteringError(PartialVMError);
+
+impl MeteringError {
+    pub fn unpack(self) -> PartialVMError {
+        self.0
+    }
+}
+
+/// Specifies different ways of exceeding the limit.
+pub enum LimitExceededError {
+    /// Represents legacy out of gas status. Mapped to [StatusCode::OUT_OF_GAS]. Does not represent
+    /// anything else, e.g., reaching memory limits, loading too many dependencies.
+    LegacyOutOfGas,
+    /// Error due to metering. The inner value contains the VM error which can be later returned to
+    /// interpreter.
+    LimitExceeded(MeteringError),
+}
+
+impl LimitExceededError {
+    pub fn from_err(err: PartialVMError) -> SafeNativeError {
+        match err.major_status() {
+            StatusCode::OUT_OF_GAS
+            | StatusCode::EXECUTION_LIMIT_REACHED
+            | StatusCode::DEPENDENCY_LIMIT_REACHED
+            | StatusCode::MEMORY_LIMIT_EXCEEDED
+            | StatusCode::TOO_MANY_TYPE_NODES
+            | StatusCode::VM_MAX_VALUE_DEPTH_REACHED => SafeNativeError::LimitExceeded(
+                LimitExceededError::LimitExceeded(MeteringError(err)),
+            ),
+            // Treat all other code as invariant violations and leave it for the VM to propagate
+            // these further. Note that we do not remap the errors. For example, if there is a
+            // speculative error returned (signaling Block-STM to stop executing this transaction),
+            // we better not remap it.
+            // TODO(Gas): Have a single method to convert partial VM error to safe native error.
+            _ => SafeNativeError::InvariantViolation(err),
+        }
+    }
+}
 
 /// Saner representation of a native function error.
 #[allow(unused)]
@@ -17,13 +56,16 @@ pub enum SafeNativeError {
     /// be followed.
     Abort { abort_code: u64 },
 
-    /// Indicating that the native function has run out of gas during execution.
+    /// Indicating that the native function has exceeded execution limits.
     ///
-    /// This will cause the VM to deduct all the remaining balance and abort the transaction,
-    /// so use it carefully!
-    /// Normally this should only be triggered by `SafeNativeContext::charge()` and you should
-    /// not return this manually without a good reason.
-    OutOfGas,
+    /// If metering in native context is not enabled, this will cause the VM to deduct all the
+    /// remaining balance and abort the transaction, so use it carefully! Normally this should only
+    /// be triggered by `SafeNativeContext::charge()` and one should not return this variant
+    /// manually without a good reason.
+    ///
+    /// If metering in native context is enabled, then simply returns the error code that specifies
+    /// the limit that was exceeded.
+    LimitExceeded(LimitExceededError),
 
     /// Indicating that the native function ran into some internal errors that shall not normally
     /// be triggerable by user inputs.
@@ -37,7 +79,6 @@ pub enum SafeNativeError {
     /// It is important to make sure the args are in the exact same order as passed in from the native argument input
     /// as the MoveVM relies on this ordering to perform paranoid mode stack transition.
     FunctionDispatch {
-        cost: InternalGas,
         module_name: ModuleId,
         func_name: Identifier,
         ty_args: Vec<Type>,
@@ -46,8 +87,10 @@ pub enum SafeNativeError {
 
     /// Load up a module and charge the module accordingly.
     ///
-    /// It is critical to invoke this function before calling FunctionDispatch to make sure the module loading
-    /// is charged properly, otherwise it would be a potential gas issue.
+    /// It is critical to invoke this function before calling FunctionDispatch to make sure the
+    /// module loading is charged properly, otherwise it would be a potential gas issue.
+    ///
+    /// Note: not used once metering in native context is enabled.
     LoadModule { module_name: ModuleId },
 }
 

--- a/aptos-move/framework/src/natives/account_abstraction.rs
+++ b/aptos-move/framework/src/natives/account_abstraction.rs
@@ -32,9 +32,10 @@ pub(crate) fn native_dispatch(
         .check_is_special_or_visited(module_name.address(), module_name.name())
         .map_err(|_| SafeNativeError::Abort { abort_code: 4 })?;
 
+    context.charge(DISPATCHABLE_AUTHENTICATE_DISPATCH_BASE)?;
+
     // Use Error to instruct the VM to perform a function call dispatch.
     Err(SafeNativeError::FunctionDispatch {
-        cost: context.eval_gas(DISPATCHABLE_AUTHENTICATE_DISPATCH_BASE),
         module_name,
         func_name,
         ty_args,

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -97,7 +97,7 @@ fn create_string_value(value: Vec<u8>) -> Value {
 }
 
 fn get_context_data<'t, 'b>(
-    context: &'t mut SafeNativeContext<'_, 'b, '_>,
+    context: &'t mut SafeNativeContext<'_, 'b, '_, '_>,
 ) -> Option<(&'b dyn DelayedFieldResolver, RefMut<'t, DelayedFieldData>)> {
     let aggregator_context = context.extensions().get::<NativeAggregatorContext>();
     if aggregator_context.delayed_field_optimization_enabled {

--- a/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
+++ b/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
@@ -44,9 +44,10 @@ pub(crate) fn native_dispatch(
     check_visited(module_name.address(), module_name.name())
         .map_err(|_| SafeNativeError::Abort { abort_code: 4 })?;
 
+    context.charge(DISPATCHABLE_FUNGIBLE_ASSET_DISPATCH_BASE)?;
+
     // Use Error to instruct the VM to perform a function call dispatch.
     Err(SafeNativeError::FunctionDispatch {
-        cost: context.eval_gas(DISPATCHABLE_FUNGIBLE_ASSET_DISPATCH_BASE),
         module_name,
         func_name,
         ty_args,

--- a/aptos-move/framework/src/natives/function_info.rs
+++ b/aptos-move/framework/src/natives/function_info.rs
@@ -182,7 +182,13 @@ fn native_load_function_impl(
     context.charge(FUNCTION_INFO_LOAD_FUNCTION_BASE)?;
     let (module_name, _) = extract_function_info(&mut arguments)?;
 
-    Err(SafeNativeError::LoadModule { module_name })
+    if context.has_direct_gas_meter_access_in_native_context() {
+        context.charge_gas_for_dependencies(module_name)?;
+        Ok(smallvec![])
+    } else {
+        // Legacy flow, VM will charge gas for module loading.
+        Err(SafeNativeError::LoadModule { module_name })
+    }
 }
 
 /***************************************************************************************************

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -29,8 +29,8 @@ const EARGS_MISMATCH: u64 = 1;
 const EINVALID_FORMAT: u64 = 2;
 const EUNABLE_TO_FORMAT_DELAYED_FIELD: u64 = 3;
 
-struct FormatContext<'a, 'b, 'c, 'd> {
-    context: &'d mut SafeNativeContext<'a, 'b, 'c>,
+struct FormatContext<'a, 'b, 'c, 'd, 'e> {
+    context: &'e mut SafeNativeContext<'a, 'b, 'c, 'd>,
     should_charge_gas: bool,
     max_depth: usize,
     max_len: usize,

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -400,7 +400,7 @@ fn native_add_box(
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
     if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount);
+        context.use_heap_memory(amount)?;
     }
     charge_load_cost(context, loaded)?;
 
@@ -451,7 +451,7 @@ fn native_borrow_box(
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
     if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount);
+        context.use_heap_memory(amount)?;
     }
     charge_load_cost(context, loaded)?;
 
@@ -496,7 +496,7 @@ fn native_contains_box(
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
     if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount);
+        context.use_heap_memory(amount)?;
     }
     charge_load_cost(context, loaded)?;
 
@@ -547,7 +547,7 @@ fn native_remove_box(
     // TODO(Gas): Figure out a way to charge this earlier.
     context.charge(key_cost)?;
     if let Some(amount) = mem_usage {
-        context.use_heap_memory(amount);
+        context.use_heap_memory(amount)?;
     }
     charge_load_cost(context, loaded)?;
 

--- a/aptos-move/replay-benchmark/src/overrides.rs
+++ b/aptos-move/replay-benchmark/src/overrides.rs
@@ -12,7 +12,7 @@
 use anyhow::bail;
 use aptos_framework::{natives::code::PackageRegistry, BuildOptions, BuiltPackage};
 use aptos_gas_schedule::LATEST_GAS_FEATURE_VERSION;
-use aptos_logger::error;
+use aptos_logger::{error, warn};
 use aptos_types::{
     on_chain_config::{FeatureFlag, Features, GasScheduleV2, OnChainConfig},
     state_store::{state_key::StateKey, state_value::StateValue, StateView},
@@ -74,8 +74,8 @@ impl OverrideConfig {
             bail!("Enabled and disabled feature flags cannot overlap")
         }
         if matches!(gas_feature_version, Some(v) if v > LATEST_GAS_FEATURE_VERSION) {
-            bail!(
-                "Gas feature version must be at most the latest one: {}",
+            warn!(
+                "Gas feature version is greater than the latest one: {}",
                 LATEST_GAS_FEATURE_VERSION
             );
         }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -863,15 +863,6 @@ impl InterpreterImpl<'_> {
             }
         }
 
-        let mut native_context = NativeContext::new(
-            self,
-            data_cache,
-            resource_resolver,
-            module_storage,
-            extensions,
-            gas_meter.balance_internal(),
-            traversal_context,
-        );
         let native_function = function.get_native()?;
 
         gas_meter.charge_native_function_before_execution(
@@ -882,9 +873,16 @@ impl InterpreterImpl<'_> {
             args.iter(),
         )?;
 
+        let mut native_context = NativeContext::new(
+            self,
+            data_cache,
+            resource_resolver,
+            module_storage,
+            extensions,
+            gas_meter,
+            traversal_context,
+        );
         let result = native_function(&mut native_context, ty_args.to_vec(), args)?;
-
-        gas_meter.charge_heap_memory(native_context.heap_memory_usage())?;
 
         // Note(Gas): The order by which gas is charged / error gets returned MUST NOT be modified
         //            here or otherwise it becomes an incompatible change!!!

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
+    check_dependencies_and_charge_gas,
     data_cache::TransactionDataCache,
     interpreter::InterpreterDebugInterface,
     module_traversal::TraversalContext,
@@ -13,18 +14,18 @@ use crate::{
     },
     ModuleStorage,
 };
-use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult};
+use move_binary_format::errors::{ExecutionState, PartialVMError, PartialVMResult, VMResult};
 use move_core_types::{
     account_address::AccountAddress,
     gas_algebra::{InternalGas, NumBytes},
     identifier::Identifier,
-    language_storage::TypeTag,
+    language_storage::{ModuleId, TypeTag},
     value::MoveTypeLayout,
     vm_status::StatusCode,
 };
 use move_vm_types::{
-    loaded_data::runtime_types::Type, natives::function::NativeResult, resolver::ResourceResolver,
-    values::Value,
+    gas::NativeGasMeter, loaded_data::runtime_types::Type, natives::function::NativeResult,
+    resolver::ResourceResolver, values::Value,
 };
 use std::{
     collections::{HashMap, VecDeque},
@@ -98,32 +99,25 @@ impl NativeFunctions {
     }
 }
 
-pub struct NativeContext<'a, 'b> {
+pub struct NativeContext<'a, 'b, 'c> {
     interpreter: &'a dyn InterpreterDebugInterface,
     data_store: &'a mut TransactionDataCache,
     resource_resolver: &'a dyn ResourceResolver,
     module_storage: &'a dyn ModuleStorage,
     extensions: &'a mut NativeContextExtensions<'b>,
-    gas_balance: InternalGas,
-    traversal_context: &'a TraversalContext<'a>,
-
-    /// Counter used to record the (conceptual) heap memory usage by a native functions,
-    /// measured in abstract memory unit.
-    ///
-    /// This is a hack to emulate memory usage tracking, before we could refactor native functions
-    /// and allow them to access the gas meter directly.
-    heap_memory_usage: u64,
+    gas_meter: &'a mut dyn NativeGasMeter,
+    traversal_context: &'a mut TraversalContext<'c>,
 }
 
-impl<'a, 'b> NativeContext<'a, 'b> {
+impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     pub(crate) fn new(
         interpreter: &'a dyn InterpreterDebugInterface,
         data_store: &'a mut TransactionDataCache,
         resource_resolver: &'a dyn ResourceResolver,
         module_storage: &'a dyn ModuleStorage,
         extensions: &'a mut NativeContextExtensions<'b>,
-        gas_balance: InternalGas,
-        traversal_context: &'a TraversalContext<'a>,
+        gas_meter: &'a mut dyn NativeGasMeter,
+        traversal_context: &'a mut TraversalContext<'c>,
     ) -> Self {
         Self {
             interpreter,
@@ -131,15 +125,13 @@ impl<'a, 'b> NativeContext<'a, 'b> {
             resource_resolver,
             module_storage,
             extensions,
-            gas_balance,
+            gas_meter,
             traversal_context,
-
-            heap_memory_usage: 0,
         }
     }
 }
 
-impl<'b> NativeContext<'_, 'b> {
+impl<'b, 'c> NativeContext<'_, 'b, 'c> {
     pub fn print_stack_trace(&self, buf: &mut String) -> PartialVMResult<()> {
         self.interpreter
             .debug_print_stack_trace(buf, self.module_storage.runtime_environment())
@@ -209,19 +201,30 @@ impl<'b> NativeContext<'_, 'b> {
         self.interpreter.get_stack_frames(count)
     }
 
-    pub fn gas_balance(&self) -> InternalGas {
-        self.gas_balance
+    pub fn legacy_gas_budget(&self) -> InternalGas {
+        self.gas_meter.legacy_gas_budget_in_native_context()
     }
 
-    pub fn use_heap_memory(&mut self, amount: u64) {
-        self.heap_memory_usage = self.heap_memory_usage.saturating_add(amount);
+    /// Returns the gas meter used for execution. Even if native functions cannot use it to
+    /// charge gas (feature-gating), gas meter can be used to query gas meter's balance.
+    pub fn gas_meter(&mut self) -> &mut dyn NativeGasMeter {
+        self.gas_meter
     }
 
-    pub fn heap_memory_usage(&self) -> u64 {
-        self.heap_memory_usage
+    pub fn charge_gas_for_dependencies(&mut self, module_id: ModuleId) -> VMResult<()> {
+        let arena_id = self
+            .traversal_context
+            .referenced_module_ids
+            .alloc(module_id);
+        check_dependencies_and_charge_gas(
+            self.module_storage,
+            self.gas_meter,
+            self.traversal_context,
+            [(arena_id.address(), arena_id.name())],
+        )
     }
 
-    pub fn traversal_context(&self) -> &TraversalContext {
+    pub fn traversal_context(&self) -> &TraversalContext<'c> {
         self.traversal_context
     }
 

--- a/third_party/move/move-vm/runtime/src/storage/dependencies_gas_charging.rs
+++ b/third_party/move/move-vm/runtime/src/storage/dependencies_gas_charging.rs
@@ -13,7 +13,10 @@ use move_core_types::{
     language_storage::{ModuleId, TypeTag},
 };
 use move_vm_metrics::{Timer, VM_TIMER};
-use move_vm_types::{gas::GasMeter, module_linker_error};
+use move_vm_types::{
+    gas::{DependencyGasMeter, GasMeter},
+    module_linker_error,
+};
 use std::collections::BTreeSet;
 
 pub fn check_script_dependencies_and_check_gas(
@@ -80,8 +83,8 @@ pub fn check_type_tag_dependencies_and_charge_gas(
 /// `ModuleId`, a.k.a. heap allocations, as much as possible, which is critical for
 /// performance.
 pub fn check_dependencies_and_charge_gas<'a, I>(
-    module_storage: &impl ModuleStorage,
-    gas_meter: &mut impl GasMeter,
+    module_storage: &dyn ModuleStorage,
+    gas_meter: &mut dyn DependencyGasMeter,
     traversal_context: &mut TraversalContext<'a>,
     ids: I,
 ) -> VMResult<()>

--- a/third_party/move/move-vm/test-utils/src/gas_schedule.rs
+++ b/third_party/move/move-vm/test-utils/src/gas_schedule.rs
@@ -30,7 +30,7 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_types::{
-    gas::{GasMeter, SimpleInstruction},
+    gas::{DependencyGasMeter, GasMeter, NativeGasMeter, SimpleInstruction},
     views::{TypeView, ValueView},
 };
 use once_cell::sync::Lazy;
@@ -192,6 +192,32 @@ impl GasStatus {
 
     pub fn set_metering(&mut self, enabled: bool) {
         self.charge = enabled
+    }
+}
+
+impl DependencyGasMeter for GasStatus {
+    fn charge_dependency(
+        &mut self,
+        _is_new: bool,
+        _addr: &AccountAddress,
+        _name: &IdentStr,
+        _size: NumBytes,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+}
+
+impl NativeGasMeter for GasStatus {
+    fn legacy_gas_budget_in_native_context(&self) -> InternalGas {
+        self.gas_left
+    }
+
+    fn charge_native_execution(&mut self, _amount: InternalGas) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn use_heap_memory_in_native_context(&mut self, _amount: u64) -> PartialVMResult<()> {
+        Ok(())
     }
 }
 
@@ -507,20 +533,6 @@ impl GasMeter for GasStatus {
     }
 
     fn charge_create_ty(&mut self, _num_nodes: NumTypeNodes) -> PartialVMResult<()> {
-        Ok(())
-    }
-
-    fn charge_dependency(
-        &mut self,
-        _is_new: bool,
-        _addr: &AccountAddress,
-        _name: &IdentStr,
-        _size: NumBytes,
-    ) -> PartialVMResult<()> {
-        Ok(())
-    }
-
-    fn charge_heap_memory(&mut self, _amount: u64) -> PartialVMResult<()> {
         Ok(())
     }
 }

--- a/third_party/move/move-vm/types/src/gas.rs
+++ b/third_party/move/move-vm/types/src/gas.rs
@@ -138,9 +138,37 @@ impl SimpleInstruction {
     }
 }
 
+/// Metering API for module or script dependencies. Defined as a stand-alone trait so it can be
+/// used in native context.
+///
+/// Note: because native functions are trait objects, it is not possible to make [GasMeter] a trait
+/// object as well as it has APIs that are generic.
+pub trait DependencyGasMeter {
+    fn charge_dependency(
+        &mut self,
+        is_new: bool,
+        addr: &AccountAddress,
+        name: &IdentStr,
+        size: NumBytes,
+    ) -> PartialVMResult<()>;
+}
+
+/// Gas meter to use to meter native function.
+pub trait NativeGasMeter: DependencyGasMeter {
+    /// Returns the remaining gas budget of the meter. Same as [GasMeter::balance_internal] and
+    /// will be removed in the future.
+    fn legacy_gas_budget_in_native_context(&self) -> InternalGas;
+
+    /// Charges the given gas amount. Only used if metering in native context is enabled.
+    fn charge_native_execution(&mut self, amount: InternalGas) -> PartialVMResult<()>;
+
+    /// Tracks heap memory usage.
+    fn use_heap_memory_in_native_context(&mut self, amount: u64) -> PartialVMResult<()>;
+}
+
 /// Trait that defines a generic gas meter interface, allowing clients of the Move VM to implement
 /// their own metering scheme.
-pub trait GasMeter {
+pub trait GasMeter: NativeGasMeter {
     fn balance_internal(&self) -> InternalGas;
 
     /// Charge an instruction and fail if not enough gas units are left.
@@ -330,23 +358,37 @@ pub trait GasMeter {
     ) -> PartialVMResult<()>;
 
     fn charge_create_ty(&mut self, num_nodes: NumTypeNodes) -> PartialVMResult<()>;
-
-    fn charge_dependency(
-        &mut self,
-        is_new: bool,
-        addr: &AccountAddress,
-        name: &IdentStr,
-        size: NumBytes,
-    ) -> PartialVMResult<()>;
-
-    /// A special interface for the VM to signal to the gas meter that certain internal ops or
-    /// native functions have used additional heap memory that needs to be metered.
-    fn charge_heap_memory(&mut self, amount: u64) -> PartialVMResult<()>;
 }
 
 /// A dummy gas meter that does not meter anything.
 /// Charge operations will always succeed.
 pub struct UnmeteredGasMeter;
+
+impl DependencyGasMeter for UnmeteredGasMeter {
+    fn charge_dependency(
+        &mut self,
+        _is_new: bool,
+        _addr: &AccountAddress,
+        _name: &IdentStr,
+        _size: NumBytes,
+    ) -> PartialVMResult<()> {
+        Ok(())
+    }
+}
+
+impl NativeGasMeter for UnmeteredGasMeter {
+    fn legacy_gas_budget_in_native_context(&self) -> InternalGas {
+        u64::MAX.into()
+    }
+
+    fn charge_native_execution(&mut self, _amount: InternalGas) -> PartialVMResult<()> {
+        Ok(())
+    }
+
+    fn use_heap_memory_in_native_context(&mut self, _amount: u64) -> PartialVMResult<()> {
+        Ok(())
+    }
+}
 
 impl GasMeter for UnmeteredGasMeter {
     fn balance_internal(&self) -> InternalGas {
@@ -575,20 +617,6 @@ impl GasMeter for UnmeteredGasMeter {
     }
 
     fn charge_create_ty(&mut self, _num_nodes: NumTypeNodes) -> PartialVMResult<()> {
-        Ok(())
-    }
-
-    fn charge_dependency(
-        &mut self,
-        _is_new: bool,
-        _addr: &AccountAddress,
-        _name: &IdentStr,
-        _size: NumBytes,
-    ) -> PartialVMResult<()> {
-        Ok(())
-    }
-
-    fn charge_heap_memory(&mut self, _amount: u64) -> PartialVMResult<()> {
         Ok(())
     }
 }


### PR DESCRIPTION
## Description

This refactors native context to be able to use `GasMeter` directly. Note that using the trait as is is not possible, because it cannot be maid a trait object (which is a requirement for native functions). Hence, I added 2 more traits:

```rust
// moved from GasMeter
pub trait DependencyGasMeter {
    fn charge_dependency(
        &mut self,
        is_new: bool,
        addr: &AccountAddress,
        name: &IdentStr,
        size: NumBytes,
    ) -> PartialVMResult<()>;
}
```

```rust
// charge_heap_memory is moved from GasMeter, legacy_gas_budget_in_native_context == balance_internal
pub trait NativeGasMeter: DependencyGasMeter {
    fn legacy_gas_budget_in_native_context(&self) -> InternalGas;
    fn is_metering_in_native_context_enabled(&self) -> bool;
    fn charge_native_execution(&mut self, amount: InternalGas) -> PartialVMResult<()>;
    fn charge_heap_memory(&mut self, amount: u64) -> PartialVMResult<()>;
}
```

that `GasMeter` extends. This way storing `NativeGasMeter` in native context is possible, and gas can be charged incrementally in a nice fashion updating the gas meter's counter. I had to refactor error/results to make things work correctly.

Importantly, it unblock lazy loading because it is possible to charge dependencies in native context. Also it allows to get rid of ugly `LoadModule` native result: native context now nows how to handle dependencies.

## How Has This Been Tested?

- Existing tests
- Replay verify: 
- Manual replay (`replay-benchmark`)

## Key Areas to Review

Ensure semantics is correct, and invariants are preserved.

## Type of Change

- [x] New feature
- [x] Refactoring

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
