### PR TITLE
[lint] Implemented assert_const linter

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -4,6 +4,7 @@
 //! This module (and its submodules) contain various model-AST-based lint checks.
 
 mod almost_swapped;
+mod assert_const;
 mod blocks_in_conditions;
 mod needless_bool;
 mod needless_deref_ref;
@@ -22,6 +23,7 @@ use move_compiler_v2::external_checks::ExpChecker;
 pub fn get_default_linter_pipeline() -> Vec<Box<dyn ExpChecker>> {
     vec![
         Box::<almost_swapped::AlmostSwapped>::default(),
+        Box::<assert_const::AssertConst>::default(),
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
         Box::<needless_bool::NeedlessBool>::default(),
         Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/assert_const.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/assert_const.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for assert!()s
+//! where the condition is either `true` or `false`.
+//! Note: As a side-effect, the linter also checks if blocks that are
+//! equivalent to asserts. For example,
+//!
+//!   if (true){
+//!   }else{
+//!       abort(0)
+//!   };
+//!
+//! The linter will flag the the entire if statement as if it were an assert!().
+
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{ExpData, Operation, Value},
+    model::FunctionEnv,
+};
+
+#[derive(Default)]
+pub struct AssertConst;
+
+impl ExpChecker for AssertConst {
+    fn get_name(&self) -> String {
+        "assert_const".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
+        let env = function.env();
+        if let ExpData::IfElse(id, condition, then, else_) = expr {
+            if !Self::is_assert(then, else_) {
+                return;
+            }
+
+            let condition = Self::get_constant_bool_expression_value(condition);
+            if let Some(condition) = condition {
+                let string = if condition {
+                    "This `assert!` can be removed"
+                } else {
+                    "This `assert!` can replaced with an `abort`"
+                };
+                self.report(env, &env.get_node_loc(*id), string);
+            }
+        }
+    }
+}
+
+impl AssertConst {
+    fn empty_block(block: &ExpData) -> bool {
+        if let ExpData::Call(_, Operation::Tuple, exprs) = block {
+            exprs.is_empty()
+        } else {
+            false
+        }
+    }
+
+    fn abort_block(block: &ExpData) -> bool {
+        matches!(block, ExpData::Call(_, Operation::Abort, _))
+    }
+
+    /// Returns true if the then and else blocks of an if statements might have
+    /// been expanded from an assert! macro. Note that is_assert() may return
+    /// true even if the if statement is literal at the source code instead of
+    /// being the result of a macro expansion.
+    fn is_assert(then: &ExpData, else_: &ExpData) -> bool {
+        Self::empty_block(then) && Self::abort_block(else_)
+    }
+
+    fn get_constant_bool_expression_value(expr: &ExpData) -> Option<bool> {
+        match expr {
+            ExpData::Value(_, Value::Bool(x)) => Some(*x),
+            _ => None,
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/assert_const.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/assert_const.exp
@@ -1,0 +1,121 @@
+
+Diagnostics:
+warning: [lint] This `assert!` can be removed
+  ┌─ tests/model_ast_lints/assert_const.move:6:9
+  │
+6 │         assert!(true);
+  │         ^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can replaced with an `abort`
+   ┌─ tests/model_ast_lints/assert_const.move:10:9
+   │
+10 │         assert!(false);
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can be removed
+   ┌─ tests/model_ast_lints/assert_const.move:14:9
+   │
+14 │         assert!(CONSTANT_TRUE);
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can replaced with an `abort`
+   ┌─ tests/model_ast_lints/assert_const.move:18:9
+   │
+18 │         assert!(CONSTANT_FALSE);
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can be removed
+   ┌─ tests/model_ast_lints/assert_const.move:22:9
+   │
+22 │         assert!(true, 42);
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can replaced with an `abort`
+   ┌─ tests/model_ast_lints/assert_const.move:26:9
+   │
+26 │         assert!(false, 42);
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can be removed
+   ┌─ tests/model_ast_lints/assert_const.move:30:9
+   │
+30 │         assert!(CONSTANT_TRUE, 42);
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can replaced with an `abort`
+   ┌─ tests/model_ast_lints/assert_const.move:34:9
+   │
+34 │         assert!(CONSTANT_FALSE, 42);
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can be removed
+   ┌─ tests/model_ast_lints/assert_const.move:38:9
+   │
+38 │ ╭         if (true){
+39 │ │         }else{
+40 │ │             abort(0)
+41 │ │         };
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can replaced with an `abort`
+   ┌─ tests/model_ast_lints/assert_const.move:45:9
+   │
+45 │ ╭         if (false){
+46 │ │         }else{
+47 │ │             abort(0)
+48 │ │         };
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can be removed
+   ┌─ tests/model_ast_lints/assert_const.move:52:9
+   │
+52 │ ╭         if (CONSTANT_TRUE){
+53 │ │         }else{
+54 │ │             abort(0)
+55 │ │         };
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.
+
+warning: [lint] This `assert!` can replaced with an `abort`
+   ┌─ tests/model_ast_lints/assert_const.move:59:9
+   │
+59 │ ╭         if (CONSTANT_FALSE){
+60 │ │         }else{
+61 │ │             abort(0)
+62 │ │         };
+   │ ╰─────────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/assert_const.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/assert_const.move
@@ -1,0 +1,136 @@
+module 0xc0ffee::m {
+    const CONSTANT_TRUE: bool = true;
+    const CONSTANT_FALSE: bool = false;
+
+    public fun test1_warn() {
+        assert!(true);
+    }
+
+    public fun test2_warn() {
+        assert!(false);
+    }
+
+    public fun test3_warn() {
+        assert!(CONSTANT_TRUE);
+    }
+
+    public fun test4_warn() {
+        assert!(CONSTANT_FALSE);
+    }
+
+    public fun test5_warn() {
+        assert!(true, 42);
+    }
+
+    public fun test6_warn() {
+        assert!(false, 42);
+    }
+
+    public fun test7_warn() {
+        assert!(CONSTANT_TRUE, 42);
+    }
+
+    public fun test8_warn() {
+        assert!(CONSTANT_FALSE, 42);
+    }
+
+    public fun test9_warn() {
+        if (true){
+        }else{
+            abort(0)
+        };
+    }
+
+    public fun test10_warn() {
+        if (false){
+        }else{
+            abort(0)
+        };
+    }
+
+    public fun test11_warn() {
+        if (CONSTANT_TRUE){
+        }else{
+            abort(0)
+        };
+    }
+
+    public fun test12_warn() {
+        if (CONSTANT_FALSE){
+        }else{
+            abort(0)
+        };
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test1_no_warn() {
+        assert!(true);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test2_no_warn() {
+        assert!(false);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test3_no_warn() {
+        assert!(CONSTANT_TRUE);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test4_no_warn() {
+        assert!(CONSTANT_FALSE);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test5_no_warn() {
+        assert!(true, 42);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test6_no_warn() {
+        assert!(false, 42);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test7_no_warn() {
+        assert!(CONSTANT_TRUE, 42);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test8_no_warn() {
+        assert!(CONSTANT_FALSE, 42);
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test9_no_warn() {
+        if (true){
+        }else{
+            abort(0)
+        };
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test10_no_warn() {
+        if (false){
+        }else{
+            abort(0)
+        };
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test11_no_warn() {
+        if (CONSTANT_TRUE){
+        }else{
+            abort(0)
+        };
+    }
+
+    #[lint::skip(assert_const)]
+    public fun test12_no_warn() {
+        if (CONSTANT_FALSE){
+        }else{
+            abort(0)
+        };
+    }
+}


### PR DESCRIPTION
assert_const flags assert!(true) and assert!(false) and suggests replacements.

## Description
This PR implements bullet point
> Find cases of assert!(true) or assert!(false), and suggest they can either be removed or replaced with an explicit abort.

from https://github.com/aptos-labs/aptos-core/issues/15221

## How Has This Been Tested?
Positive and negative test cases have been added to the move lint unit tests.
Additionally, the linter has been run on the crates in the `aptos-move/framework` subdirectory, with the following results:

Crate | Result | Notes
-|-|-
aptos-experimental | Language errors | Move 2.2 language construct is not enabled
aptos-framework | 1 warning | See below
aptos-stdlib | No warnings |  
aptos-token | No warnings |  
aptos-token-objects | No warnings |  
move-stdlib | No warnings |  
table-natives | No warnings |  

aptos-framework warning:
```
warning: [lint] This assert can replaced with abort()
     ┌─ /home/victor/aptos/assert-const/aptos-move/framework/aptos-framework/sources/fungible_asset.move:1307:13
     │
1307 │             assert!(false, error::not_found(ESUPPLY_NOT_FOUND));
     │             ^^^^^^
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(assert_const)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#assert_const.

```

## Key Areas to Review
The key change is to third_party/move/tools/move-linter/src/model_ast_lints/assert_const.rs

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Move Linter