### PR TITLE
[tests] Add tests for any and function values

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/any.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/any.data/pack/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "any_tests"
+version = "0.0.0"
+
+[dependencies]
+AptosStdlib = { local = "../../../../../framework/aptos-stdlib" }

--- a/aptos-move/e2e-move-tests/src/tests/any.data/pack/sources/any_with_function_values.move
+++ b/aptos-move/e2e-move-tests/src/tests/any.data/pack/sources/any_with_function_values.move
@@ -1,0 +1,65 @@
+module 0x123::any_with_function_values {
+    use 0x1::any::pack;
+
+    // Should fail: we cannot gain abilities.
+    public entry fun roundtrip_fails_1() {
+        let f: || has drop + store = || dummy();
+        let _g = pack(f).unpack<|| has drop + store + copy>();
+        // g();
+    }
+
+    // Should fail: we cannot drop abilities.
+    public entry fun roundtrip_fails_2() {
+        let f: || has drop + store + copy = || dummy();
+        let g = pack(f).unpack<|| has drop + store>();
+        g();
+    }
+
+    public fun dummy() {}
+
+    public fun dummy_with_args(x: u64): u64 {
+        x
+    }
+
+    public fun returns_dummy(): || {
+        || dummy()
+    }
+
+    // Should fail: cannot confuse between abilities.
+    public entry fun roundtrip_fails_3() {
+        let f: || (||) has drop + store = returns_dummy;
+        let g = pack(f).unpack<|| (|| has drop + store)>();
+        g();
+    }
+
+    struct X { x: u64 }
+    struct Xu64 { x: u64 }
+    struct S<T, phantom U, phantom V> has key { x: T }
+
+    public fun create(): S<X, u64, Xu64> {
+        S { x: X { x: 100 } }
+    }
+
+    // Should fail: cannot confuse between different generic parameters - they are comma-separated.
+    public entry fun roundtrip_fails_4() {
+        let f: || S<X, u64, Xu64> has drop + store = || create();
+        let g = pack(f).unpack<||S<Xu64, X, u64> has drop + store>();
+
+        let S { x } = g();
+        let Xu64 { x } = x;
+        assert!(x == 100);
+    }
+
+    public entry fun roundtrip_success_1() {
+        let x: u64 = 1;
+        let f: ||u64 has drop + store = || dummy_with_args(x);
+        let g = pack(f).unpack<||u64 has drop + store>();
+        assert!(g() == 1, 404);
+    }
+
+    public entry fun roundtrip_success_2() {
+        let f: || has drop + store = || dummy();
+        let g = pack(f).unpack<|| has drop + store>();
+        g();
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/any.rs
+++ b/aptos-move/e2e-move-tests/src/tests/any.rs
@@ -1,0 +1,44 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{assert_abort, assert_success, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use move_core_types::account_address::AccountAddress;
+
+#[test]
+fn test_any_with_function_values() {
+    let mut h = MoveHarness::new();
+
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x123").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        &common::test_dir_path("any.data/pack"),
+        BuildOptions::move_2().set_latest_language(),
+    ));
+
+    for idx in [1, 2, 3, 4] {
+        let result = h.run_entry_function(
+            &acc,
+            str::parse(&format!(
+                "0x123::any_with_function_values::roundtrip_fails_{idx}"
+            ))
+            .unwrap(),
+            vec![],
+            vec![],
+        );
+        assert_abort!(result, 65537);
+    }
+
+    for idx in [1, 2] {
+        let result = h.run_entry_function(
+            &acc,
+            str::parse(&format!(
+                "0x123::any_with_function_values::roundtrip_success_{idx}"
+            ))
+            .unwrap(),
+            vec![],
+            vec![],
+        );
+        assert_success!(result);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -9,6 +9,7 @@ mod aggregator_v2_enums;
 mod aggregator_v2_events;
 mod aggregator_v2_function_values;
 mod aggregator_v2_runtime_checks;
+mod any;
 mod attributes;
 mod chain_id;
 mod code_publishing;

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -18,7 +18,7 @@ use move_binary_format::{
     },
 };
 use move_core_types::{
-    ability::{Ability, AbilitySet},
+    ability::AbilitySet,
     function::ClosureMask,
     identifier::{IdentStr, Identifier},
     language_storage,
@@ -346,10 +346,6 @@ impl LoadedFunction {
         &self.ty_args
     }
 
-    pub fn abilities(&self) -> AbilitySet {
-        self.function.abilities()
-    }
-
     /// Returns the corresponding module id of this function, i.e., its address and module name.
     pub fn module_id(&self) -> Option<&ModuleId> {
         match &self.owner {
@@ -574,28 +570,6 @@ impl Function {
 
     pub fn has_module_lock(&self) -> bool {
         self.has_module_reentrancy_lock
-    }
-
-    /// Creates the function type instance for this function. This requires cloning
-    /// the parameter and result types.
-    pub fn create_function_type(&self) -> Type {
-        Type::Function {
-            args: self.param_tys.clone(),
-            results: self.return_tys.clone(),
-            abilities: self.abilities(),
-        }
-    }
-
-    /// Returns the abilities associated with this function, without consideration of any captured
-    /// closure arguments. By default, this is copy and drop, and if the function signature cannot
-    /// be changed (i.e., the function has `#[persistent]` attribute or is public), also store.
-    pub fn abilities(&self) -> AbilitySet {
-        let result = AbilitySet::singleton(Ability::Copy).add(Ability::Drop);
-        if self.is_persistent() {
-            result.add(Ability::Store)
-        } else {
-            result
-        }
     }
 
     pub fn is_native(&self) -> bool {


### PR DESCRIPTION
## Description

1. Removing `abilities()` on function. This is not used and is error-prone as captured arguments need to be taken into account.
2. More tests for `Any` and function values.

## How Has This Been Tested?

Move end-to-end tests.

## Key Areas to Review

N/A

## Type of Change

- [x] Refactoring
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine
- [x] Aptos Framework

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
