### PR TITLE
Adding replay protection type option in Move CLI

### DIFF
--- a/api/types/src/transaction.rs
+++ b/api/types/src/transaction.rs
@@ -516,6 +516,16 @@ pub struct UserTransactionRequest {
     pub replay_protection_nonce: Option<U64>,
 }
 
+impl UserTransactionRequest {
+    pub fn replay_protector(&self) -> aptos_types::transaction::ReplayProtector {
+        if let Some(nonce) = self.replay_protection_nonce {
+            aptos_types::transaction::ReplayProtector::Nonce(nonce.0)
+        } else {
+            aptos_types::transaction::ReplayProtector::SequenceNumber(self.sequence_number.0)
+        }
+    }
+}
+
 /// Request to create signing messages
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Object)]
 pub struct UserCreateSigningMessageRequest {

--- a/crates/aptos/src/common/transactions.rs
+++ b/crates/aptos/src/common/transactions.rs
@@ -30,7 +30,26 @@ use aptos_vm_types::output::VMOutput;
 use clap::Parser;
 use move_core_types::vm_status::VMStatus;
 pub use move_package::*;
-use std::time::{SystemTime, UNIX_EPOCH};
+use std::{
+    fmt::Display,
+    time::{SystemTime, UNIX_EPOCH},
+};
+
+#[derive(Clone, Copy, Debug, Default, Parser, PartialEq, clap::ValueEnum)]
+pub enum ReplayProtectionType {
+    Turbo,
+    #[default]
+    Seqnum,
+}
+
+impl Display for ReplayProtectionType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", match self {
+            ReplayProtectionType::Turbo => "turbo",
+            ReplayProtectionType::Seqnum => "seqnum",
+        })
+    }
+}
 
 /// Common options for simulating and running transactions
 ///
@@ -58,6 +77,13 @@ pub struct TxnOptions {
     pub(crate) gas_options: GasOptions,
     #[clap(flatten)]
     pub prompt_options: PromptOptions,
+    /// Replay protection mechanism to use when generating the transaction.
+    ///
+    /// When "turbo" is chosen, the transaction will contain a replay protection nonce.
+    ///
+    /// When "seqnum" is chosen, the transaction will contain a sequence number that matches with the sender's onchain sequence number.
+    #[clap(long, default_value_t = ReplayProtectionType::Seqnum)]
+    pub(crate) replay_protection_type: ReplayProtectionType,
 }
 
 impl TxnOptions {
@@ -171,12 +197,15 @@ impl TxnOptions {
         let transaction_factory =
             TransactionFactory::new(chain_id).with_gas_unit_price(gas_unit_price);
 
-        let unsigned_transaction = transaction_factory
+        let mut txn_builder = transaction_factory
             .payload(payload.clone())
             .sender(sender_address)
             .sequence_number(sequence_number)
-            .expiration_timestamp_secs(expiration_time_secs)
-            .build();
+            .expiration_timestamp_secs(expiration_time_secs);
+        if self.replay_protection_type == ReplayProtectionType::Turbo {
+            txn_builder = txn_builder.upgrade_payload(true, true);
+        }
+        let unsigned_transaction = txn_builder.build();
 
         // TODO: Support other transaction authenticator types, like multi-agent and fee-payer
         let signed_transaction = SignedTransaction::new_signed_transaction(
@@ -200,7 +229,7 @@ impl TxnOptions {
             gas_unit_price: Some(user_txn.gas_unit_price()),
             pending: None,
             sender: Some(user_txn.sender()),
-            sequence_number: Some(user_txn.sequence_number()),
+            replay_protector: Some(user_txn.replay_protector()),
             success: Some(simulated_txn.info.status().is_success()),
             timestamp_us: None,
             version: Some(simulated_txn.version),
@@ -276,7 +305,7 @@ impl TxnOptions {
             gas_unit_price: Some(gas_unit_price),
             pending: None,
             sender: Some(sender_address),
-            sequence_number: None, // The transaction is not committed so there is no new sequence number.
+            replay_protector: None, // The transaction is not committed so there is no new sequence number.
             success,
             timestamp_us: None,
             version: Some(version), // The transaction is not committed so there is no new version.

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -51,7 +51,9 @@ use aptos_types::{
     account_address::{create_resource_address, AccountAddress},
     object_address::create_object_code_deployment_address,
     on_chain_config::aptos_test_feature_flags_genesis,
-    transaction::{Transaction, TransactionArgument, TransactionPayload, TransactionStatus},
+    transaction::{
+        ReplayProtector, Transaction, TransactionArgument, TransactionPayload, TransactionStatus,
+    },
 };
 use aptos_vm::data_cache::AsMoveResolver;
 use async_trait::async_trait;
@@ -2397,6 +2399,10 @@ impl CliCommand<TransactionSummary> for Replay {
             gas_unit_price: Some(txn.gas_unit_price()),
             pending: None,
             sender: Some(txn.sender()),
+            sequence_number: match txn.replay_protector() {
+                ReplayProtector::SequenceNumber(sequence_number) => Some(sequence_number),
+                _ => None,
+            },
             replay_protector: Some(txn.replay_protector()),
             success,
             timestamp_us: None,

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -2397,7 +2397,7 @@ impl CliCommand<TransactionSummary> for Replay {
             gas_unit_price: Some(txn.gas_unit_price()),
             pending: None,
             sender: Some(txn.sender()),
-            sequence_number: Some(txn.sequence_number()),
+            replay_protector: Some(txn.replay_protector()),
             success,
             timestamp_us: None,
             version: Some(self.txn_id),

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -79,7 +79,6 @@ impl TransactionBuilder {
         self.payload.replay_protection_nonce().is_some()
     }
 
-    // Primarily used for running the tests with both payload v1 and v2 formats.
     pub fn upgrade_payload(
         mut self,
         use_txn_payload_v2_format: bool,


### PR DESCRIPTION
## Description
In order to create orderless transaction, add `--replay-protection-type turbo` at the end of your move command.

## How Has This Been Tested?
```
cargo run --bin aptos -- move run   --profile testnet  --replay-protection-type nonce --function-id 0x1::aptos_account::transfer --args address:0x49ffe7968750a5ffea80af6fd7657bb246ff8ce6657cbf2c8ed13d9276096b3f u64:20000
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
