### PR TITLE
[storage] add basic data structure to track speculative hot state

### DIFF
--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -154,3 +154,11 @@ impl StateSlot {
         }
     }
 }
+
+/// The hot-state LRU is backed by a doubly-linked list: `next` links to the slightly older entry,
+/// while `prev` links to the slightly newer one.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct HotLRUEntry {
+    pub prev: StateKey,
+    pub next: StateKey,
+}


### PR DESCRIPTION

The hot state is an LRU that is backed by a `map<StateKey, HotLRUEntry>`.
Each entry stores the previous key and the next key that are older / newer.
Newly added entries are inserted as heads and the tail points to the oldest
entries that are candidates for eviction.
