### PR TITLE
Enable comparison operations, Lt/Le/Gt/Ge, on non-integer types

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/pack/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "generic_cmp"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/pack/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/pack/sources/test.move
@@ -1,0 +1,783 @@
+ /// Module for testing non-integer primitive types
+ module 0x99::primitive_cmp {
+    //* bool group
+    fun test_left_lt_right_bool(x: bool, y: bool): bool {
+        // a and b are created to test our optimization
+        let a = &x;
+        let b = &y;
+
+        *a < *b &&
+        x < y
+    }
+    fun test_left_le_right_bool(x: bool, y: bool): bool {
+        x <= y
+    }
+    fun test_left_gt_right_bool(x: bool, y: bool): bool {
+        x > y
+    }
+    fun test_left_ge_right_bool(x: bool, y: bool): bool {
+        x >= y
+    }
+
+    //* address group
+    fun test_left_lt_right_address(x: address, y: address): bool {
+        // a and b are created to test our optimization
+        let a = &x;
+        let b = &y;
+
+        *a < *b &&
+        x < y
+    }
+    fun test_left_le_right_address(x: address, y: address): bool {
+        x <= y
+    }
+    fun test_left_gt_right_address(x: address, y: address): bool {
+        x > y
+    }
+    fun test_left_ge_right_address(x: address, y: address): bool {
+        x >= y
+    }
+
+    //* vector group
+    fun test_left_lt_right_vector(x: vector<u8>, y: vector<u8>): bool {
+        // a and b are created to test our optimization
+        let a = &x;
+        let b = &y;
+
+        *a < *b &&
+        x < y
+    }
+    fun test_left_le_right_vector(x: vector<u8>, y: vector<u8>): bool {
+        x <= y
+    }
+    fun test_left_gt_right_vector(x: vector<u8>, y: vector<u8>): bool {
+        x > y
+    }
+    fun test_left_ge_right_vector(x: vector<u8>, y: vector<u8>): bool {
+        x >= y
+    }
+
+    //* nested vector group
+    fun test_left_lt_right_nested_vector(x: vector<vector<u8>>, y: vector<vector<u8>>): bool {
+        // a and b are created to test our optimization
+        let a = &x;
+        let b = &y;
+
+        *a < *b &&
+        x < y
+    }
+    fun test_left_le_right_nested_vector(x: vector<vector<u8>>, y: vector<vector<u8>>): bool {
+        x <= y
+    }
+    fun test_left_gt_right_nested_vector(x: vector<vector<u8>>, y: vector<vector<u8>>): bool {
+        x > y
+    }
+    fun test_left_ge_right_nested_vector(x: vector<vector<u8>>, y: vector<vector<u8>>): bool {
+        x >= y
+    }
+
+    //* entry functions for testing non-integer primitive types
+    entry fun test_bool(){
+        let x = false;
+        let y = true;
+        assert!(test_left_lt_right_bool(x, y), 0);
+        assert!(test_left_le_right_bool(x, y), 0);
+        assert!(test_left_le_right_bool(x, x), 0);
+        assert!(test_left_le_right_bool(y, y), 0);
+
+        assert!(test_left_gt_right_bool(y, x), 0);
+        assert!(test_left_ge_right_bool(y, x), 0);
+        assert!(test_left_ge_right_bool(x, x), 0);
+        assert!(test_left_ge_right_bool(y, y), 0);
+    }
+
+    entry fun test_address(){
+        let x = @0x1;
+        let y = @0x2;
+        assert!(test_left_lt_right_address(x, y), 0);
+        assert!(test_left_le_right_address(x, y), 0);
+        assert!(test_left_le_right_address(x, x), 0);
+        assert!(test_left_le_right_address(y, y), 0);
+
+        assert!(test_left_gt_right_address(y, x), 0);
+        assert!(test_left_ge_right_address(y, x), 0);
+        assert!(test_left_ge_right_address(x, x), 0);
+        assert!(test_left_ge_right_address(y, y), 0);
+    }
+
+    entry fun test_vector(){
+        let x = vector[0u8, 1u8, 2u8, 3u8, 4u8, 5u8];
+        let y = vector[0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8];
+        let z = vector[1u8, 2u8, 3u8, 4u8, 5u8, 6u8];
+
+        assert!(test_left_lt_right_vector(x, y), 0);
+        assert!(test_left_lt_right_vector(y, z), 0);
+        assert!(test_left_lt_right_vector(x, z), 0);
+
+        assert!(test_left_le_right_vector(x, y), 0);
+        assert!(test_left_le_right_vector(y, z), 0);
+        assert!(test_left_le_right_vector(x, z), 0);
+        assert!(test_left_le_right_vector(x, x), 0);
+        assert!(test_left_le_right_vector(y, y), 0);
+        assert!(test_left_le_right_vector(z, z), 0);
+
+        assert!(test_left_gt_right_vector(y, x), 0);
+        assert!(test_left_gt_right_vector(z, y), 0);
+        assert!(test_left_gt_right_vector(z, x), 0);
+
+        assert!(test_left_ge_right_vector(y, x), 0);
+        assert!(test_left_ge_right_vector(z, y), 0);
+        assert!(test_left_ge_right_vector(z, x), 0);
+        assert!(test_left_ge_right_vector(x, x), 0);
+        assert!(test_left_ge_right_vector(y, y), 0);
+        assert!(test_left_ge_right_vector(z, z), 0);
+    }
+
+    entry fun test_nested_vector(){
+        let x = vector[0u8, 1u8, 2u8, 3u8, 4u8, 5u8];
+        let y = vector[0u8, 1u8, 2u8, 3u8, 4u8, 5u8, 6u8];
+        let z = vector[1u8, 2u8, 3u8, 4u8, 5u8, 6u8];
+
+        let nested_1 = vector[x];
+        let nested_2 = vector[x, x];
+        let nested_3 = vector[x, y];
+        let nested_4 = vector[x, y, z];
+        let nested_5 = vector[x, z];
+        let nested_6 = vector[y];
+        let nested_7 = vector[y, y];
+        let nested_8 = vector[y, z];
+        let nested_9 = vector[z];
+        let nested_10 = vector[z, z];
+
+        assert!(test_left_lt_right_nested_vector(nested_1, nested_2), 0);
+        assert!(test_left_lt_right_nested_vector(nested_2, nested_3), 0);
+        assert!(test_left_lt_right_nested_vector(nested_3, nested_4), 0);
+        assert!(test_left_lt_right_nested_vector(nested_4, nested_5), 0);
+        assert!(test_left_lt_right_nested_vector(nested_5, nested_6), 0);
+        assert!(test_left_lt_right_nested_vector(nested_6, nested_7), 0);
+        assert!(test_left_lt_right_nested_vector(nested_7, nested_8), 0);
+        assert!(test_left_lt_right_nested_vector(nested_8, nested_9), 0);
+        assert!(test_left_lt_right_nested_vector(nested_9, nested_10), 0);
+
+        assert!(test_left_le_right_nested_vector(nested_1, nested_2), 0);
+        assert!(test_left_le_right_nested_vector(nested_2, nested_3), 0);
+        assert!(test_left_le_right_nested_vector(nested_3, nested_4), 0);
+        assert!(test_left_le_right_nested_vector(nested_4, nested_5), 0);
+        assert!(test_left_le_right_nested_vector(nested_5, nested_6), 0);
+        assert!(test_left_le_right_nested_vector(nested_6, nested_7), 0);
+        assert!(test_left_le_right_nested_vector(nested_7, nested_8), 0);
+        assert!(test_left_le_right_nested_vector(nested_8, nested_9), 0);
+        assert!(test_left_le_right_nested_vector(nested_9, nested_10), 0);
+
+        assert!(test_left_gt_right_nested_vector(nested_2, nested_1), 0);
+        assert!(test_left_gt_right_nested_vector(nested_3, nested_2), 0);
+        assert!(test_left_gt_right_nested_vector(nested_4, nested_3), 0);
+        assert!(test_left_gt_right_nested_vector(nested_5, nested_4), 0);
+        assert!(test_left_gt_right_nested_vector(nested_6, nested_5), 0);
+        assert!(test_left_gt_right_nested_vector(nested_7, nested_6), 0);
+        assert!(test_left_gt_right_nested_vector(nested_8, nested_7), 0);
+        assert!(test_left_gt_right_nested_vector(nested_9, nested_8), 0);
+        assert!(test_left_gt_right_nested_vector(nested_10, nested_9), 0);
+
+        assert!(test_left_ge_right_nested_vector(nested_2, nested_1), 0);
+        assert!(test_left_ge_right_nested_vector(nested_3, nested_2), 0);
+        assert!(test_left_ge_right_nested_vector(nested_4, nested_3), 0);
+        assert!(test_left_ge_right_nested_vector(nested_5, nested_4), 0);
+        assert!(test_left_ge_right_nested_vector(nested_6, nested_5), 0);
+        assert!(test_left_ge_right_nested_vector(nested_7, nested_6), 0);
+        assert!(test_left_ge_right_nested_vector(nested_8, nested_7), 0);
+        assert!(test_left_ge_right_nested_vector(nested_9, nested_8), 0);
+        assert!(test_left_ge_right_nested_vector(nested_10, nested_9), 0);
+    }
+}
+
+/// Module for struct types
+ module 0x99::struct_cmp {
+    use std::cmp;
+    /// A simple struct
+    struct Int has drop, copy {
+        a: u8,
+        b: u16,
+        c: u32,
+        d: u64,
+        e: u128,
+        f: u256
+    }
+
+    /// A more complex struct
+    struct Complex has drop, copy {
+        a: u8,
+        b: Int,
+    }
+
+    /// A more complex struct with vectors
+    struct ComplexWithVec has drop, copy {
+        a: u8,
+        b: Int,
+        c: vector<Int>,
+        d: vector<vector<Complex>>
+    }
+
+    //* Simple struct group
+    fun test_simple_struct_lt(x: Int, y: Int): bool {
+        // a and b are created to test our optimization
+        let a = &x;
+        let b = &y;
+
+        *a < *b &&
+        x < y
+    }
+    fun test_simple_struct_le(x: Int, y: Int): bool {
+        x <= y
+    }
+    fun test_simple_struct_gt(x: Int, y: Int): bool {
+        x > y
+    }
+    fun test_simple_struct_ge(x: Int, y: Int): bool {
+        x >= y
+    }
+
+    //* Complex struct group
+    fun test_complex_struct_lt(x: Complex, y: Complex): bool {
+        // a and b are created to test our optimization
+        let a = &x;
+        let b = &y;
+
+        *a < *b &&
+        x < y
+    }
+    fun test_complex_struct_le(x: Complex, y: Complex): bool {
+        x <= y
+    }
+    fun test_complex_struct_gt(x: Complex, y: Complex): bool {
+        x > y
+    }
+    fun test_complex_struct_ge(x: Complex, y: Complex): bool {
+        x >= y
+    }
+
+    //* Complex struct with vector group
+    fun test_complex_struct_vec_lt(x: ComplexWithVec, y: ComplexWithVec): bool {
+        // a and b are created to test our optimization
+        let a = &x;
+        let b = &y;
+
+        *a < *b &&
+        x < y &&
+        x.b < y.b &&
+        x.c < y.c &&
+        x.c[0] < y.c[0] &&
+        x.d < y.d &&
+        x.d[0] < y.d[0] &&
+        x.d[0][0] < y.d[0][0]
+    }
+
+    //* Enum as special struct group
+    fun test_special_struct_vec_lt(x: ComplexWithVec, y: ComplexWithVec): bool {
+        // a and b are created to test our optimization
+        let a = &cmp::compare(&x, &y);
+        let b = &cmp::compare(&y, &x);
+
+        *a < *b &&
+        cmp::compare(&x, &y) < cmp::compare(&y, &x) &&
+        cmp::compare(&x.b, &y.b) < cmp::compare(&y.b, &x.b) &&
+        cmp::compare(&x.c, &y.c) < cmp::compare(&y.c, &x.c) &&
+        cmp::compare(&x.c[0], &y.c[0]) < cmp::compare(&y.c[0], &x.c[0]) &&
+        cmp::compare(&x.d, &y.d) < cmp::compare(&y.d, &x.d) &&
+        cmp::compare(&x.d[0], &y.d[0]) < cmp::compare(&y.d[0], &x.d[0]) &&
+        cmp::compare(&x.d[0][0], &y.d[0][0]) < cmp::compare(&y.d[0][0], &x.d[0][0])
+    }
+
+     //* entry functions for testing struct types
+    entry fun test_simple_struct(){
+        let x = Int {
+            a: 1,
+            b: 2,
+            c: 3,
+            d: 4,
+            e: 5,
+            f: 6
+        };
+        let y = Int {
+            a: 2,
+            b: 3,
+            c: 4,
+            d: 5,
+            e: 6,
+            f: 7
+        };
+
+        assert!(test_simple_struct_lt(x, y), 0);
+        assert!(test_simple_struct_le(x, y), 0);
+        assert!(test_simple_struct_le(x, x), 0);
+        assert!(test_simple_struct_le(y, y), 0);
+
+        assert!(test_simple_struct_gt(y, x), 0);
+        assert!(test_simple_struct_ge(y, x), 0);
+        assert!(test_simple_struct_ge(x, x), 0);
+        assert!(test_simple_struct_ge(y, y), 0);
+    }
+
+    entry fun test_complex_struct(){
+
+        let x = Complex {
+            a: 1,
+            b: Int {
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            }
+        };
+
+        let y = Complex {
+            a: 2,
+            b: Int {
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            }
+        };
+
+        assert!(test_complex_struct_lt(x, y), 0);
+        assert!(test_complex_struct_le(x, y), 0);
+        assert!(test_complex_struct_le(x, x), 0);
+        assert!(test_complex_struct_le(y, y), 0);
+
+        assert!(test_complex_struct_gt(y, x), 0);
+        assert!(test_complex_struct_ge(y, x), 0);
+        assert!(test_complex_struct_ge(x, x), 0);
+        assert!(test_complex_struct_ge(y, y), 0);
+    }
+
+     entry fun test_nested_complex_struct(){
+        let x = ComplexWithVec {
+            a: 1,
+            b: Int {
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            },
+            c: vector[
+                Int {
+                    a: 1,
+                    b: 2,
+                    c: 3,
+                    d: 4,
+                    e: 5,
+                    f: 6
+                },
+            ],
+            d: vector[
+                vector[
+                    Complex {
+                        a: 1,
+                        b: Int {
+                            a: 1,
+                            b: 2,
+                            c: 3,
+                            d: 4,
+                            e: 5,
+                            f: 6
+                        }
+                    }
+                ]
+            ],
+        };
+
+        let y = ComplexWithVec {
+            a: 2,
+            b: Int {
+                a: 2,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            },
+            c: vector[
+                Int {
+                    a: 2,
+                    b: 2,
+                    c: 3,
+                    d: 4,
+                    e: 5,
+                    f: 6
+                },
+            ],
+            d: vector[
+                vector[
+                    Complex {
+                        a: 2,
+                        b: Int {
+                            a: 2,
+                            b: 2,
+                            c: 3,
+                            d: 4,
+                            e: 5,
+                            f: 6
+                        }
+                    }
+                ]
+            ],
+        };
+
+        assert!(test_complex_struct_vec_lt(x, y), 0);
+     }
+
+     entry fun test_special_complex_struct(){
+        let x = ComplexWithVec {
+            a: 1,
+            b: Int {
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            },
+            c: vector[
+                Int {
+                    a: 1,
+                    b: 2,
+                    c: 3,
+                    d: 4,
+                    e: 5,
+                    f: 6
+                },
+            ],
+            d: vector[
+                vector[
+                    Complex {
+                        a: 1,
+                        b: Int {
+                            a: 1,
+                            b: 2,
+                            c: 3,
+                            d: 4,
+                            e: 5,
+                            f: 6
+                        }
+                    }
+                ]
+            ],
+        };
+
+        let y = ComplexWithVec {
+            a: 2,
+            b: Int {
+                a: 2,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            },
+            c: vector[
+                Int {
+                    a: 2,
+                    b: 2,
+                    c: 3,
+                    d: 4,
+                    e: 5,
+                    f: 6
+                },
+            ],
+            d: vector[
+                vector[
+                    Complex {
+                        a: 2,
+                        b: Int {
+                            a: 2,
+                            b: 2,
+                            c: 3,
+                            d: 4,
+                            e: 5,
+                            f: 6
+                        }
+                    }
+                ]
+            ],
+        };
+
+        assert!(test_special_struct_vec_lt(x, y), 0);
+     }
+}
+
+/// Module for testing generic types
+ module 0x99::generic_cmp {
+    use std::cmp;
+    public struct Int has drop, copy {
+        a: u8,
+        b: u16,
+        c: u32,
+        d: u64,
+        e: u128,
+        f: u256
+    }
+
+    public struct Complex has drop, copy {
+        a: u8,
+        b: Int,
+    }
+
+    struct Foo<T> has drop, copy { x: T }
+
+    struct Bar<T1, T2> has drop, copy {
+        x: T1,
+        y: vector<T2>,
+    }
+
+    //* Simple generic arg group
+    fun test_generic_arg_lt<T: drop + copy>(x: T, y: T): bool {
+        // a and b are created to test our optimization
+        let a = &cmp::compare(&x, &y);
+        let b = &cmp::compare(&y, &x);
+
+        *a < *b &&
+        x < y
+    }
+    fun test_generic_arg_le<T: drop + copy>(x: T, y: T): bool {
+        x <= y
+    }
+    fun test_generic_arg_gt<T: drop + copy>(x: T, y: T): bool {
+        x > y
+    }
+    fun test_generic_arg_ge<T: drop + copy>(x: T, y: T): bool {
+        x >= y
+    }
+
+
+    //* Simple generic struct arg group
+    fun test_generic_struct_lt(x: Foo<address>, y: Foo<address>): bool {
+        // a and b are created to test our optimization
+        let a = &cmp::compare(&x, &y);
+        let b = &cmp::compare(&y, &x);
+
+        *a < *b &&
+        x < y &&
+        x.x < y.x
+    }
+    fun test_generic_struct_le(x: Foo<address>, y: Foo<address>): bool {
+
+        x <= y &&
+        x.x <= y.x
+    }
+    fun test_generic_struct_gt(x: Foo<address>, y: Foo<address>): bool {
+        x > y &&
+        x.x > y.x
+    }
+    fun test_generic_struct_ge(x: Foo<address>, y: Foo<address>): bool {
+        x >= y &&
+        x.x >= y.x
+    }
+
+    //* Complex generic struct arg group
+    public fun test_generic_complex_struct_lt(x: Bar<Int, Complex>, y: Bar<Int, Complex>): bool {
+         // a and b are created to test our optimization
+        let a = &cmp::compare(&x, &y);
+        let b = &cmp::compare(&y, &x);
+
+        *a < *b &&
+        x < y &&
+        x.x < y.x &&
+        x.y < y.y &&
+        x.y[0] < y.y[0]
+    }
+    public fun test_generic_complex_struct_le(x: Bar<Int, Complex>, y: Bar<Int, Complex>): bool {
+        x <= y &&
+        x.x <= y.x &&
+        x.y <= y.y &&
+        x.y[0] <= y.y[0]
+    }
+    public fun test_generic_complex_struct_gt(x: Bar<Int, Complex>, y: Bar<Int, Complex>): bool {
+        x > y &&
+        x.x > y.x &&
+        x.y > y.y &&
+        x.y[0] > y.y[0]
+    }
+    public fun test_generic_complex_struct_ge(x: Bar<Int, Complex>, y: Bar<Int, Complex>): bool {
+        x >= y &&
+        x.x >= y.x &&
+        x.y >= y.y &&
+        x.y[0] >= y.y[0]
+    }
+
+    //* entry functions for testing generic types
+    entry fun test_generic_arg(){
+        let x = @0x1;
+        let y = @0x2;
+        assert!(test_generic_arg_lt(x, y), 0);
+        assert!(test_generic_arg_le(x, y), 0);
+        assert!(test_generic_arg_le(x, x), 0);
+        assert!(test_generic_arg_le(y, y), 0);
+
+        assert!(test_generic_arg_gt(y, x), 0);
+        assert!(test_generic_arg_ge(y, x), 0);
+        assert!(test_generic_arg_ge(x, x), 0);
+        assert!(test_generic_arg_ge(y, y), 0);
+
+    }
+
+    entry fun test_generic_struct(){
+        let x = Foo<address> {x: @0x1};
+        let y = Foo<address> {x: @0x2};
+
+        assert!(test_generic_struct_lt(x, y), 0);
+        assert!(test_generic_struct_le(x, y), 0);
+        assert!(test_generic_struct_le(x, x), 0);
+        assert!(test_generic_struct_le(y, y), 0);
+
+        assert!(test_generic_struct_gt(y, x), 0);
+        assert!(test_generic_struct_ge(y, x), 0);
+        assert!(test_generic_struct_ge(x, x), 0);
+        assert!(test_generic_struct_ge(y, y), 0);
+    }
+
+     entry fun test_generic_complex_struct(){
+        let x = Bar<Int, Complex> {
+            x: Int{
+                a: 1,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            },
+            y: vector[
+                Complex{
+                    a: 1,
+                    b: Int {
+                        a: 1,
+                        b: 2,
+                        c: 3,
+                        d: 4,
+                        e: 5,
+                        f: 6
+                    }
+                }
+            ]
+        };
+
+        let y = Bar<Int, Complex> {
+            x: Int{
+                a: 2,
+                b: 2,
+                c: 3,
+                d: 4,
+                e: 5,
+                f: 6
+            },
+            y: vector[
+                Complex{
+                    a: 2,
+                    b: Int {
+                        a: 2,
+                        b: 2,
+                        c: 3,
+                        d: 4,
+                        e: 5,
+                        f: 6
+                    }
+                }
+            ]
+        };
+
+        assert!(test_generic_complex_struct_lt(x, y), 0);
+        assert!(test_generic_complex_struct_le(x, y), 0);
+        assert!(test_generic_complex_struct_le(x, x), 0);
+        assert!(test_generic_complex_struct_le(y, y), 0);
+
+        assert!(test_generic_complex_struct_gt(y, x), 0);
+        assert!(test_generic_complex_struct_ge(y, x), 0);
+        assert!(test_generic_complex_struct_ge(x, x), 0);
+        assert!(test_generic_complex_struct_ge(y, y), 0);
+     }
+}
+
+/// Modules for testing function values
+module 0x99::module1 {
+    public fun test(): u64{
+        1
+    }
+    public fun test1(): u64{
+        1
+    }
+    public fun test2<T: drop>(_x: T){
+    }
+    public fun test3(x: u64): u64{
+        x + 1
+    }
+}
+module 0x99::module2 {
+    public fun test(): u64{
+        1
+    }
+}
+
+/// Function values are compared in the following order:
+/// 1. Module identification is compared by address and name
+/// 2. Function name is compared based on identity string
+/// 3. Type parameters are compared based on types (by discriminant index in their defining enum)
+/// 4. Captured values are compared
+
+module 0x99::function_value_cmp {
+    use 0x99::module1 as module1;
+    use 0x99::module2 as module2;
+
+    //* entry function for testing function values
+    entry fun test_module_name_cmp(){
+        // f1 < f2 due to module name `module1` < `module2`
+        // - `f1` named to `closure#0module1::test;`
+        // - `f2` named to `closure#0module2::test;`
+        let f1: ||u64 has drop = module1::test;
+        let f2: ||u64 has drop = module2::test;
+        assert!(f1 < f2, 0);
+    }
+    entry fun test_function_name_cmp(){
+        // f1 < f2 due to function name `test` < `test1`
+        // - `f1` named to `closure#0module1::test;`
+        // - `f2` named to `closure#0module1::test1;`
+        let f1: ||u64 has drop = module1::test;
+        let f2: ||u64 has drop = module1::test1;
+        assert!(f1 < f2, 0);
+
+        // f3 < f4 due to function name by lambda order
+        // - `f3` named to `closure#0function_value_cmp::__lambda__1__test_function_name_cmp;`
+        // - `f4` named to `closure#0function_value_cmp::__lambda__2__test_function_name_cmp;`
+        let f3: ||u64 has drop = ||1;
+        let f4: ||u64 has drop = ||1;
+        assert!(f3 < f4, 0);
+
+        // f5 < f6 due to function name by lambda order
+        // - `f5` named to `closure#0function_value_cmp::__lambda__3__test_function_name_cmp;`
+        // - `f6` named to `closure#0function_value_cmp::__lambda__4__test_function_name_cmp;`
+        let f5: ||u64 has drop = ||1;
+        let f6: ||u64 has drop = ||100;
+        assert!(f5 < f6, 0);
+    }
+    entry fun test_typed_arg_cmp(){
+        // f1 < f2 due to type parameter `u8` < `u64`
+        let x: u8 = 1;
+        let y: u64 = 1;
+        let f1: || has drop = ||module1::test2(x);
+        let f2: || has drop = ||module1::test2(y);
+        assert!(f1 < f2, 0);
+    }
+    entry fun test_captured_var_cmp(){
+        // f1 < f2 due to captured values `1` < `2`
+        let x = 1;
+        let y = 2;
+        let f1: ||u64 has drop = ||module1::test3(x);
+        let f2: ||u64 has drop = ||module1::test3(y);
+        assert!(f1 < f2, 0);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/script/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/script/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "two_signer_cmp"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/script/sources/script.move
+++ b/aptos-move/e2e-move-tests/src/tests/cmp_generic.data/script/sources/script.move
@@ -1,0 +1,8 @@
+script {
+    fun main(
+        first: signer,
+        second: signer
+    ) {
+            assert!(first <= second, 0);
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/generic_cmp.rs
+++ b/aptos-move/e2e-move-tests/src/tests/generic_cmp.rs
@@ -1,0 +1,158 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transactional tests for comparison operations, Lt/Le/Ge/Gt, over non-integer types,
+//! introduced in Move language version 2.2 and onwards.
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_framework::{BuildOptions, BuiltPackage};
+use aptos_language_e2e_tests::account::TransactionBuilder;
+use aptos_types::{account_address::AccountAddress, transaction::Script};
+
+#[test]
+fn function_generic_cmp() {
+    let mut h = MoveHarness::new();
+
+    // Load the code
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x99").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        &common::test_dir_path("cmp_generic.data/pack"),
+        BuildOptions::move_2().set_latest_language()
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::primitive_cmp::test_bool").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::primitive_cmp::test_address").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::primitive_cmp::test_vector").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::struct_cmp::test_simple_struct").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::struct_cmp::test_complex_struct").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::struct_cmp::test_nested_complex_struct").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::struct_cmp::test_special_complex_struct").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::generic_cmp::test_generic_arg").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::generic_cmp::test_generic_struct").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::generic_cmp::test_generic_complex_struct").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::function_value_cmp::test_module_name_cmp").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::function_value_cmp::test_function_name_cmp").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::function_value_cmp::test_typed_arg_cmp").unwrap(),
+        vec![],
+        vec![],
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::function_value_cmp::test_captured_var_cmp").unwrap(),
+        vec![],
+        vec![],
+    ));
+}
+
+/// Special case of comparing two signers
+#[test]
+fn function_signer_cmp() {
+    let mut h = MoveHarness::new();
+
+    let alice = h.new_account_at(AccountAddress::from_hex_literal("0xa11ce").unwrap());
+    let bob = h.new_account_at(AccountAddress::from_hex_literal("0xb0b01").unwrap());
+
+    let build_options = BuildOptions {
+        with_srcs: false,
+        with_abis: false,
+        with_source_maps: false,
+        with_error_map: false,
+        ..BuildOptions::move_2().set_latest_language()
+    };
+
+    let package = BuiltPackage::build(
+        common::test_dir_path("cmp_generic.data/script"),
+        build_options,
+    )
+    .expect("building package must succeed");
+
+    let code = package.extract_script_code()[0].clone();
+    let script = Script::new(code, vec![], vec![]);
+
+    let transaction = TransactionBuilder::new(alice.clone())
+        .secondary_signers(vec![bob.clone()])
+        .script(script)
+        .sequence_number(h.sequence_number(alice.address()))
+        .max_gas_amount(1_000_000)
+        .gas_unit_price(1)
+        .sign_multi_agent();
+
+    let output = h.executor.execute_transaction(transaction);
+    assert_success!(output.status().to_owned());
+}

--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -26,6 +26,7 @@ mod function_values;
 mod fungible_asset;
 mod gas;
 mod generate_upgrade_script;
+mod generic_cmp;
 mod governance_updates;
 mod infinite_loop;
 mod init_module;

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/dependency_ordering.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/dependency_ordering.rs
@@ -37,7 +37,8 @@ pub fn verify(
         .map(|(mident, _)| mident)
         .collect::<Vec<_>>();
     let graph = dependency_graph(&module_neighbors, &imm_module_idents);
-    let graph = add_implicit_vector_dependencies(graph);
+    let graph = add_implicit_module_dependencies(graph, AccountAddress::ONE, "vector");
+    let graph = add_implicit_module_dependencies(graph, AccountAddress::ONE, "cmp");
     match petgraph_toposort(&graph, None) {
         Err(cycle_node) => {
             let cycle_ident = *cycle_node.node_id();
@@ -180,29 +181,31 @@ impl<'a> Context<'a> {
     }
 }
 
-/// If the `vector` module is present in `graph`, then add dependency edges
-/// from every module (not in the `vector` module's dependency closure) to the
-/// `vector` module. This is because modules can have implicit dependencies
-/// on the `vector` module.
-fn add_implicit_vector_dependencies(
-    mut graph: DiGraphMap<&ModuleIdent, ()>,
-) -> DiGraphMap<&ModuleIdent, ()> {
-    let vector_module = graph.nodes().find(|m| {
-        m.value.address.into_addr_bytes().into_inner() == AccountAddress::ONE
-            && m.value.module.0.value.as_str() == "vector"
+/// If the target module (`module_address::module_name`) is present in `graph`,
+/// then add dependency edges from every module (not in the target module's dependency closure)
+/// to the target module. This is used to maintain implicit dependencies introduced
+/// by the compiler between user modules and modules like `vector` or `cmp`.
+fn add_implicit_module_dependencies<'a>(
+    mut graph: DiGraphMap<&'a ModuleIdent, ()>,
+    module_address: AccountAddress,
+    module_name: &str,
+) -> DiGraphMap<&'a ModuleIdent, ()> {
+    let target_module = graph.nodes().find(|m| {
+        m.value.address.into_addr_bytes().into_inner() == module_address
+            && m.value.module.0.value.as_str() == module_name
     });
-    if let Some(vector_module) = vector_module {
-        let mut dfs = Dfs::new(&graph, vector_module);
+    if let Some(target_module) = target_module {
+        let mut dfs = Dfs::new(&graph, target_module);
         // Get the transitive closure of the `vector` module and its dependencies.
-        let mut vector_dep_closure = BTreeSet::new();
+        let mut target_dep_closure = BTreeSet::new();
         while let Some(node) = dfs.next(&graph) {
-            vector_dep_closure.insert(node);
+            target_dep_closure.insert(node);
         }
         // For every module that is not in `vector_dep_closure`, add an edge to `vector_module`.
         let all_modules = graph.nodes().collect::<Vec<_>>();
         for module in all_modules {
-            if !vector_dep_closure.contains(module) {
-                graph.add_edge(module, vector_module, ());
+            if !target_dep_closure.contains(module) {
+                graph.add_edge(module, target_module, ());
             }
         }
     }

--- a/third_party/move/move-compiler-v2/src/env_pipeline/cmp_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/cmp_rewriter.rs
@@ -1,0 +1,368 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Comparison operation rewriter
+//! - The in-house Lt/Le/Gt/Ge operations only allow integer operands.
+//! - We visit Lt/Le/Gt/Ge operations
+//!   - If their operands are not references or integer primitive types,
+//!     - we rewrite the operation to use the `std::cmp::compare` function,
+//!     - and then interpret the result using `std::cmp::is_lt`, `std::cmp::is_le`, etc.
+//!
+//! Example:
+//!    x <= y
+//!    =======>
+//!    std::cmp::compare<T>(&x, &y).std::cmp::is_le()
+//!
+//! Key impls
+//! - `fn rewrite_cmp_operation`:
+//!   - Given an ast exp representing a comparison operation, e.g., `Call(Operation::Lt, [arg1, arg2])`,
+//!   - the function takes five steps:
+//!     1. check if `arg1` and `arg2` can be transformed based on their types
+//!     2. transform `arg1` and `arg2` into `&arg1` and `&arg2`
+//!     3. create a call to `std::cmp::compare`: `exp1 = Call(MoveFunction(std::cmp::compare), [&arg1, &arg2])`
+//!     4. create an immutable reference to the result of `std::cmp::compare`: `exp2 = Call(Borrow(Immutable), [exp1])`
+//!     5. generate a final call of `is_lt / is_le / is_gt / is_ge` to interpret the result of `std::cmp::compare`: `exp3 = Call(MoveFunction(std::cmp::is_le), [exp2])`
+//! - [TODO] An optimization to consider
+//!   - Once we have public enum, we can direly apply `==` to the result of `std::cmp::compare` (of the `Enum Ordering` type),
+//!   - which can avoid creating a reference to the result of `std::cmp::compare` and calling `is_lt / is_le / is_gt / is_ge`.
+//!
+//!
+//! Important notes about linking `std::cmp` module:
+//! - To ensure the `std::cmp` module is preserved in GlobalEnv during compilation,
+//!   - code is added in `third_party/move/move-model/src/lib.rs` to keep `std::cmp` and its dependencies during the ast expansion phase
+//! - To ensure implicit dependencies introduced by comparison rewriting are maintained
+//!   - code is added in `third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/dependency_ordering.rs` to add dependency between every user module and `std::cmp`.
+//! - If the user does not include `move-stdlib` for compilation,
+//!   - a compilation error "cannot find `std::cmp` module" will be raised.
+//!
+//! Important notes about specs
+//! - No extensions are made to comparison operations in specs.
+//! - Only primitive integer types are supported as before
+//!
+
+use crate::env_pipeline::rewrite_target::{
+    RewriteState, RewriteTarget, RewriteTargets, RewritingScope,
+};
+use move_core_types::account_address::AccountAddress;
+use move_model::{
+    ast::{Address, Exp, ExpData, ModuleName, Operation},
+    exp_rewriter::ExpRewriterFunctions,
+    model::{FunId, FunctionEnv, GlobalEnv, ModuleEnv, NodeId, QualifiedId},
+    ty::*,
+    well_known,
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    iter::Iterator,
+};
+
+/// Main interface for the comparison operation rewriter
+pub fn rewrite(env: &mut GlobalEnv) {
+    // Create a shared CmpRewriter instance for processing all target functions
+    let mut rewriter = CmpRewriter::new(env);
+    let mut targets = RewriteTargets::create(env, RewritingScope::CompilationTarget);
+    let todo: BTreeSet<_> = targets.keys().collect();
+    for target in todo {
+        if let RewriteTarget::MoveFun(func_id) = target {
+            let new_def = rewrite_target(&mut rewriter, func_id);
+            if let Some(def) = new_def {
+                *targets.state_mut(&target) = RewriteState::Def(def);
+            }
+        }
+    }
+    targets.write_to_env(env);
+}
+
+/// Rewrite each target function
+/// - The rewriting will go through the ExpRewriterFunctions trait
+/// - On a `Call` operation, the transformation will be redirected to `rewrite_call` defined later
+fn rewrite_target(rewriter: &mut CmpRewriter, func_id: QualifiedId<FunId>) -> Option<Exp> {
+    let func_env = rewriter.env.get_function(func_id);
+    let def_opt = func_env.get_def();
+    if let Some(def) = def_opt {
+        let rewritten_def = rewriter.rewrite_exp(def.clone());
+        if !ExpData::ptr_eq(&rewritten_def, def) {
+            return Some(rewritten_def);
+        }
+    }
+    None
+}
+
+struct CmpRewriter<'env> {
+    env: &'env GlobalEnv,
+    cmp_module: Option<ModuleEnv<'env>>,
+    cmp_functions: BTreeMap<&'static str, FunctionEnv<'env>>,
+}
+
+/// Override `rewrite_call` from `ExpRewriterFunctions` trait
+impl ExpRewriterFunctions for CmpRewriter<'_> {
+    fn rewrite_call(&mut self, call_id: NodeId, oper: &Operation, args: &[Exp]) -> Option<Exp> {
+        if matches!(
+            oper,
+            Operation::Lt | Operation::Le | Operation::Gt | Operation::Ge
+        ) {
+            self.rewrite_cmp_operation(call_id, oper, args)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'env> CmpRewriter<'env> {
+    /// Constants for the `std::cmp` module and its functions
+    const COMPARE: &'static str = "compare";
+    const IS_GE: &'static str = "is_ge";
+    const IS_GT: &'static str = "is_gt";
+    const IS_LE: &'static str = "is_le";
+    const IS_LT: &'static str = "is_lt";
+
+    fn new(env: &'env GlobalEnv) -> Self {
+        let cmp_module = Self::find_cmp_module(env);
+        let mut cmp_functions = BTreeMap::new();
+
+        if let Some(module) = &cmp_module {
+            for name in [
+                Self::COMPARE,
+                Self::IS_LT,
+                Self::IS_LE,
+                Self::IS_GT,
+                Self::IS_GE,
+            ] {
+                if let Some(func) = Self::find_cmp_function(module, name) {
+                    cmp_functions.insert(name, func);
+                }
+            }
+        }
+
+        Self {
+            env,
+            cmp_module,
+            cmp_functions,
+        }
+    }
+
+    /// Rewrite comparison operations
+    ///   - Designs detailed in the beginning of this file
+    fn rewrite_cmp_operation(
+        &mut self,
+        call_id: NodeId,
+        cmp_op: &Operation,
+        args: &[Exp],
+    ) -> Option<Exp> {
+        // Step 1: Check argument types
+        if args.iter().any(|arg| self.arg_cannot_transform(arg)) {
+            return None;
+        }
+
+        // Step 2: Transform `arg1` and `arg2` into `&arg1` and `&arg2`
+        let transformed_args: Vec<Exp> = args.iter().map(|arg| self.rewrite_cmp_arg(arg)).collect();
+
+        // Step 3: Create an inner call to `std::cmp::compare(&arg1, &arg2)`
+        let expected_arg_ty = self.env.get_node_type(args[0].as_ref().node_id());
+        let call_cmp = self.generate_call_to_compare(call_id, transformed_args, expected_arg_ty)?;
+
+        // Step 4: Create a immutable reference to the result of `std::cmp::compare(&arg1, &arg2)`
+        let immref_cmp_res = self.immborrow_compare_res(call_cmp);
+
+        //Step 5: Generate a final call of `is_lt / is_le / is_gt / is_ge` to interpret the result of `std::cmp::compare`
+        self.generate_call_to_final_res(call_id, cmp_op, vec![immref_cmp_res])
+    }
+
+    /// Generate a call to `std::cmp::compare(&arg1, &arg2)`
+    fn generate_call_to_compare(
+        &self,
+        cmp_op_id: NodeId,
+        args: Vec<Exp>,
+        expected_arg_ty: Type,
+    ) -> Option<Exp> {
+        // Reuse the loc info of the original comparison operation
+        let cmp_loc = self.env.get_node_loc(cmp_op_id);
+
+        // Check the `std::cmp` module
+        let cmp_module = match self.cmp_module.as_ref() {
+            Some(module) => module,
+            None => {
+                self.env.error(
+                    &cmp_loc,
+                    "cannot find `std::cmp` module. Include `move-stdlib` for compilation.",
+                );
+                let invalid_id = self.env.new_node(self.env.internal_loc(), Type::Error);
+                return Some(ExpData::Invalid(invalid_id).into_exp());
+            },
+        };
+        let cmp_module_id = cmp_module.get_id();
+
+        // Check the `std::cmp::compare` function
+        let compare_function = match self.cmp_functions.get(Self::COMPARE) {
+            Some(func) => func,
+            None => {
+                self.env.error(&cmp_loc, "cannot find `std::cmp::compare` function. Include `move-stdlib` for compilation.");
+                let invalid_id = self.env.new_node(self.env.internal_loc(), Type::Error);
+                return Some(ExpData::Invalid(invalid_id).into_exp());
+            },
+        };
+
+        // Create a new node sharing return type with `std::cmp::compare`
+        let cmp_ty = compare_function.get_result_type();
+        let new_cmp_node = self.env.new_node(cmp_loc, cmp_ty.clone());
+
+        // `std::cmp::compare` takes a type parameter,
+        // which should be instantiated with the type of the actual arguments
+        self.env
+            .set_node_instantiation(new_cmp_node, vec![expected_arg_ty]);
+
+        Some(
+            ExpData::Call(
+                new_cmp_node,
+                Operation::MoveFunction(cmp_module_id, compare_function.get_id()),
+                args,
+            )
+            .into_exp(),
+        )
+    }
+
+    /// Create a new immutable reference for the result of `std::cmp::compare`
+    fn immborrow_compare_res(&self, call_cmp: Exp) -> Exp {
+        // Create a new immutable reference for the return value of `std::cmp::compare`
+        let call_cmp_id = call_cmp.node_id();
+        let cmp_loc = self.env.get_node_loc(call_cmp_id);
+        let cmp_ty = self.env.get_node_type(call_cmp_id);
+        let new_ref_type = Type::Reference(ReferenceKind::Immutable, Box::new(cmp_ty));
+        let new_ref_id = self.env.new_node(cmp_loc, new_ref_type);
+
+        ExpData::Call(
+            new_ref_id,
+            Operation::Borrow(ReferenceKind::Immutable),
+            vec![call_cmp],
+        )
+        .into_exp()
+    }
+
+    /// Generate a final call to interpret the result of `std::cmp::compare`
+    fn generate_call_to_final_res(
+        &self,
+        ori_op_id: NodeId,
+        cmp_op: &Operation,
+        args: Vec<Exp>,
+    ) -> Option<Exp> {
+        // Reuse the loc info of the original comparison operation
+        let final_res_loc = self.env.get_node_loc(ori_op_id);
+
+        // Check the `std::cmp` module
+        let cmp_module = match self.cmp_module.as_ref() {
+            Some(module) => module,
+            None => {
+                self.env
+                    .error(&final_res_loc, "cannot find `std::cmp` module");
+                let invalid_id = self.env.new_node(self.env.internal_loc(), Type::Error);
+                return Some(ExpData::Invalid(invalid_id).into_exp());
+            },
+        };
+        let cmp_module_id = cmp_module.get_id();
+
+        let sym = match cmp_op {
+            Operation::Lt => Self::IS_LT,
+            Operation::Le => Self::IS_LE,
+            Operation::Gt => Self::IS_GT,
+            Operation::Ge => Self::IS_GE,
+            _ => return None,
+        };
+
+        // Check the `std::cmp::is_lt/is_le/is_gt/is_ge` function
+        let final_res_function = match self.cmp_functions.get(sym) {
+            Some(func) => func,
+            None => {
+                self.env.error(
+                    &final_res_loc,
+                    format!("cannot find `std::cmp::{}` function", sym).as_str(),
+                );
+                let invalid_id = self.env.new_node(self.env.internal_loc(), Type::Error);
+                return Some(ExpData::Invalid(invalid_id).into_exp());
+            },
+        };
+
+        let final_res_ty = Type::Primitive(PrimitiveType::Bool);
+        let final_res_id = self.env.new_node(final_res_loc, final_res_ty.clone());
+        Some(
+            ExpData::Call(
+                final_res_id,
+                Operation::MoveFunction(cmp_module_id, final_res_function.get_id()),
+                args,
+            )
+            .into_exp(),
+        )
+    }
+
+    /// We cannot rewrite references or integer primitive types
+    /// - References are not allowed in Lt/Le/Gt/Ge operations
+    /// - Integer primitive types are supported by the VM natively
+    fn arg_cannot_transform(&mut self, arg: &Exp) -> bool {
+        let arg_ty = self.env.get_node_type(arg.as_ref().node_id());
+        matches!(
+            arg_ty,
+            Type::Reference(_, _)
+                | Type::Primitive(
+                    PrimitiveType::U8
+                        | PrimitiveType::U16
+                        | PrimitiveType::U32
+                        | PrimitiveType::U64
+                        | PrimitiveType::U128
+                        | PrimitiveType::U256
+                        | PrimitiveType::Num
+                )
+        )
+    }
+
+    /// Insert a new immutable reference before the argument
+    fn rewrite_cmp_arg(&mut self, arg: &Exp) -> Exp {
+        if let Some(arg_ref) = self.remove_deref_from_arg(arg) {
+            return arg_ref;
+        }
+        // Insert a new immutable reference before the argument
+        let arg_loc = self.env.get_node_loc(arg.as_ref().node_id());
+        let arg_ty = self.env.get_node_type(arg.as_ref().node_id());
+        let new_ref_type = Type::Reference(ReferenceKind::Immutable, Box::new(arg_ty.clone()));
+        let new_ref_id = self.env.new_node(arg_loc, new_ref_type);
+        ExpData::Call(
+            new_ref_id,
+            Operation::Borrow(ReferenceKind::Immutable),
+            vec![arg.clone()],
+        )
+        .into_exp()
+    }
+
+    /// Optimization: if the argument is a dereference operation, we get the inner reference directly
+    fn remove_deref_from_arg(&mut self, arg: &Exp) -> Option<Exp> {
+        if let ExpData::Call(_, Operation::Deref, deref_args) = arg.as_ref() {
+            debug_assert!(
+                deref_args.len() == 1,
+                "there should be exactly one argument for dereference"
+            );
+            let deref_arg_ty = self.env.get_node_type(deref_args[0].as_ref().node_id());
+            if let Type::Reference(ReferenceKind::Immutable, _) = deref_arg_ty {
+                // If the deref argument is an immutable reference, we can return it directly
+                return Some(deref_args[0].clone());
+            }
+        }
+        None
+    }
+
+    /// Find the `std::cmp` module
+    fn find_cmp_module(env: &'env GlobalEnv) -> Option<ModuleEnv<'env>> {
+        // Find the `std::cmp` module
+        let cmp_module_name = ModuleName::new(
+            Address::Numerical(AccountAddress::ONE),
+            env.symbol_pool().make(well_known::CMP_MODULE),
+        );
+        env.find_module(&cmp_module_name)
+    }
+
+    /// Find function from the `std::cmp` module
+    fn find_cmp_function(
+        cmp_module: &ModuleEnv<'env>,
+        func_name: &str,
+    ) -> Option<FunctionEnv<'env>> {
+        let compare_sym = cmp_module.symbol_pool().make(func_name);
+        cmp_module.find_function(compare_sym)
+    }
+}

--- a/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
@@ -11,6 +11,7 @@ use std::io::Write;
 pub mod acquires_checker;
 pub mod ast_simplifier;
 pub mod closure_checker;
+pub mod cmp_rewriter;
 pub mod cyclic_instantiation_checker;
 pub mod flow_insensitive_checkers;
 pub mod function_checker;

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -97,6 +97,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Inherited(Experiment::CHECKS.to_string()),
         },
         Experiment {
+            name: Experiment::CMP_REWRITE.to_string(),
+            description: "Rewrite comparison operations".to_string(),
+            default: Given(true),
+        },
+        Experiment {
             name: Experiment::INLINING.to_string(),
             description: "Turns on or off inlining".to_string(),
             default: Given(true),
@@ -282,6 +287,7 @@ impl Experiment {
     pub const ATTACH_COMPILED_MODULE: &'static str = "attach-compiled-module";
     pub const CFG_SIMPLIFICATION: &'static str = "cfg-simplification";
     pub const CHECKS: &'static str = "checks";
+    pub const CMP_REWRITE: &'static str = "cmp-rewrite";
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";
     pub const FAIL_ON_WARNING: &'static str = "fail-on-warning";

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -42,6 +42,8 @@ pub const VECTOR_FUNCS_WITH_BYTECODE_INSTRS: &[&str] = &[
     "swap",
 ];
 
+pub const CMP_MODULE: &str = "cmp";
+
 pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
 pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";
 pub const TYPE_INFO_MOVE: &str = "type_info::type_of";


### PR DESCRIPTION
## Description

The in-house Lt/Le/Gt/Ge operations only allow integer operands. This PR introduces support for non-integer types. It replaces Lt/Le/Gt/Ge expressions (on non-integer types) at the model AST level with calls to the `std::cmp::compare` and `std::cmp::is_lt/is_le/is_gt/is_ge` functions from `Move-Stdlib` to perform the comparison. 

Example:
```
    x <= y

    ==>

    std::cmp::compare<T>(&x, &y).std::cmp::is_le()
```

The feature is only enabled in language version 2.2 and onward.

**Key implementation:**
- [`fn rewrite_cmp_operation`](https://github.com/aptos-labs/aptos-core/blob/jun/enable-generic-cmp/third_party/move/move-compiler-v2/src/env_pipeline/cmp_rewriter.rs#L108):
   - Given an ast exp representing a comparison operation, e.g., `Call(Operation::Lt, [arg1, arg2])`, the function takes five steps to rewrite the exp:
     1. check if `arg1` and `arg2` should be transformed based on their types
     2. transform `arg1` and `arg2` into `&arg1` and `&arg2`
     3. create a call to `std::cmp::compare`: `exp1 = Call(MoveFunction(std::cmp::compare), [&arg1, &arg2])`
     4. create an immutable reference to the result of `std::cmp::compare`: `exp2 = Call(Borrow(Immutable), [exp1])`
     5. generate a final call of `is_lt / is_le / is_gt / is_ge` to interpret the result of `std::cmp::compare`: `exp3 = Call(MoveFunction(std::cmp::is_le), [exp2])`

**Important notes about linking `std::cmp` module:**
 - To ensure the `std::cmp` module is preserved in GlobalEnv during compilation,
   - code is added in `third_party/move/move-model/src/lib.rs` to keep `std::cmp` and its dependencies during the ast expansion phase.
 - To ensure implicit dependencies introduced by comparison rewriting are maintained,
   - code is added in `third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/dependency_ordering.rs` to add dependency between every user module and `std::cmp`.
 - If the user does not include `move-stdlib` for compilation,
   - a compilation error `cannot find std::cmp module` will be raised.

 **Important notes about specs**
 - No extensions are made to comparison operations in specs.
 - Only primitive integer types are supported as before.

## How Has This Been Tested?
- [New e2e-move-tests](https://github.com/aptos-labs/aptos-core/blob/jun/enable-generic-cmp/aptos-move/e2e-move-tests/src/tests/generic_cmp.rs)
- Existing compiler-v2 tests
- Existing compiler-v2 transactional tests 

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
