### PR TITLE
deprecate token v1 collection creation

### DIFF
--- a/aptos-move/framework/aptos-token/doc/token.md
+++ b/aptos-move/framework/aptos-token/doc/token.md
@@ -1856,6 +1856,16 @@ The collection already exists
 
 
 
+<a id="0x3_token_ECOLLECTION_CREATION_DISABLED"></a>
+
+New token v1 collection creation is disabled
+
+
+<pre><code><b>const</b> <a href="token.md#0x3_token_ECOLLECTION_CREATION_DISABLED">ECOLLECTION_CREATION_DISABLED</a>: u64 = 41;
+</code></pre>
+
+
+
 <a id="0x3_token_ECOLLECTION_NAME_TOO_LONG"></a>
 
 The collection name is too long
@@ -3558,6 +3568,7 @@ Create a new collection to hold tokens
     maximum: u64,
     mutate_setting: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;bool&gt;
 ) <b>acquires</b> <a href="token.md#0x3_token_Collections">Collections</a> {
+    <b>assert</b>!(!std::features::is_new_token_v1_collection_creation_disabled(), <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="token.md#0x3_token_ECOLLECTION_CREATION_DISABLED">ECOLLECTION_CREATION_DISABLED</a>));
     <b>assert</b>!(name.length() &lt;= <a href="token.md#0x3_token_MAX_COLLECTION_NAME_LENGTH">MAX_COLLECTION_NAME_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_ECOLLECTION_NAME_TOO_LONG">ECOLLECTION_NAME_TOO_LONG</a>));
     <b>assert</b>!(uri.length() &lt;= <a href="token.md#0x3_token_MAX_URI_LENGTH">MAX_URI_LENGTH</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="token.md#0x3_token_EURI_TOO_LONG">EURI_TOO_LONG</a>));
     <b>let</b> account_addr = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer_address_of">signer::address_of</a>(creator);

--- a/aptos-move/framework/aptos-token/sources/token.move
+++ b/aptos-move/framework/aptos-token/sources/token.move
@@ -152,6 +152,9 @@ module aptos_token::token {
     /// The property is reserved by token standard
     const EPROPERTY_RESERVED_BY_STANDARD: u64 = 40;
 
+    /// New token v1 collection creation is disabled
+    const ECOLLECTION_CREATION_DISABLED: u64 = 41;
+
     //
     // Core data structures for holding tokens
     //
@@ -1166,6 +1169,7 @@ module aptos_token::token {
         maximum: u64,
         mutate_setting: vector<bool>
     ) acquires Collections {
+        assert!(!std::features::is_new_token_v1_collection_creation_disabled(), error::invalid_state(ECOLLECTION_CREATION_DISABLED));
         assert!(name.length() <= MAX_COLLECTION_NAME_LENGTH, error::invalid_argument(ECOLLECTION_NAME_TOO_LONG));
         assert!(uri.length() <= MAX_URI_LENGTH, error::invalid_argument(EURI_TOO_LONG));
         let account_addr = signer::address_of(creator);

--- a/aptos-move/framework/move-stdlib/doc/features.md
+++ b/aptos-move/framework/move-stdlib/doc/features.md
@@ -155,6 +155,7 @@ return true.
 -  [Function `is_calculate_transaction_fee_for_distribution_enabled`](#0x1_features_is_calculate_transaction_fee_for_distribution_enabled)
 -  [Function `get_distribute_transaction_fee_feature`](#0x1_features_get_distribute_transaction_fee_feature)
 -  [Function `is_distribute_transaction_fee_enabled`](#0x1_features_is_distribute_transaction_fee_enabled)
+-  [Function `is_new_token_v1_collection_creation_disabled`](#0x1_features_is_new_token_v1_collection_creation_disabled)
 -  [Function `change_feature_flags`](#0x1_features_change_feature_flags)
 -  [Function `change_feature_flags_internal`](#0x1_features_change_feature_flags_internal)
 -  [Function `change_feature_flags_for_next_epoch`](#0x1_features_change_feature_flags_for_next_epoch)
@@ -540,6 +541,15 @@ Lifetime: transient
 
 
 <pre><code><b>const</b> <a href="features.md#0x1_features_DERIVABLE_ACCOUNT_ABSTRACTION">DERIVABLE_ACCOUNT_ABSTRACTION</a>: u64 = 88;
+</code></pre>
+
+
+
+<a id="0x1_features_DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION"></a>
+
+
+
+<pre><code><b>const</b> <a href="features.md#0x1_features_DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION">DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION</a>: u64 = 98;
 </code></pre>
 
 
@@ -3947,6 +3957,30 @@ Deprecated feature
 
 <pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_distribute_transaction_fee_enabled">is_distribute_transaction_fee_enabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
     <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_DISTRIBUTE_TRANSACTION_FEE">DISTRIBUTE_TRANSACTION_FEE</a>)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_features_is_new_token_v1_collection_creation_disabled"></a>
+
+## Function `is_new_token_v1_collection_creation_disabled`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_new_token_v1_collection_creation_disabled">is_new_token_v1_collection_creation_disabled</a>(): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="features.md#0x1_features_is_new_token_v1_collection_creation_disabled">is_new_token_v1_collection_creation_disabled</a>(): bool <b>acquires</b> <a href="features.md#0x1_features_Features">Features</a> {
+    <a href="features.md#0x1_features_is_enabled">is_enabled</a>(<a href="features.md#0x1_features_DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION">DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION</a>)
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -732,6 +732,12 @@ module std::features {
         is_enabled(DISTRIBUTE_TRANSACTION_FEE)
     }
 
+    const DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION: u64 = 98;
+
+    public fun is_new_token_v1_collection_creation_disabled(): bool acquires Features {
+        is_enabled(DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION)
+    }
+
     // ============================================================================================
     // Feature Flag Implementation
 

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -143,6 +143,7 @@ pub enum FeatureFlag {
 
     CALCULATE_TRANSACTION_FEE_FOR_DISTRIBUTION = 96,
     DISTRIBUTE_TRANSACTION_FEE = 97,
+    DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION = 98,
 }
 
 impl FeatureFlag {
@@ -242,6 +243,7 @@ impl FeatureFlag {
             // TODO(grao): Enable priority fee feature flags.
             // FeatureFlag::CALCULATE_TRANSACTION_FEE_FOR_DISTRIBUTION,
             // FeatureFlag::DISTRIBUTE_TRANSACTION_FEE,
+            FeatureFlag::DISABLE_NEW_TOKEN_V1_COLLECTION_CREATION,
         ]
     }
 }


### PR DESCRIPTION
## Description
We will support the existing token v1 collections but we will force people to issue new NFT with token v2.
So here we ban the creation of any new collections of token v1.

## How Has This Been Tested?
y



## Type of Change
- [ ] New feature
- [ ] Bug fix
- [x] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

