### PR TITLE
[linter] Added equal_operands_in_pure_bin_op lint

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -5,6 +5,7 @@
 
 mod almost_swapped;
 mod blocks_in_conditions;
+mod equal_operands_in_pure_bin_op;
 mod needless_bool;
 mod needless_deref_ref;
 mod needless_ref_deref;
@@ -23,6 +24,7 @@ pub fn get_default_linter_pipeline() -> Vec<Box<dyn ExpChecker>> {
     vec![
         Box::<almost_swapped::AlmostSwapped>::default(),
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
+        Box::<equal_operands_in_pure_bin_op::EqualOperandsInPureBinOp>::default(),
         Box::<needless_bool::NeedlessBool>::default(),
         Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),
         Box::<needless_deref_ref::NeedlessDerefRef>::default(),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/equal_operands_in_pure_bin_op.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/equal_operands_in_pure_bin_op.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{Exp, ExpData, Operation},
+    model::FunctionEnv,
+};
+
+#[derive(Default)]
+pub struct EqualOperandsInPureBinOp;
+
+impl ExpChecker for EqualOperandsInPureBinOp {
+    fn get_name(&self) -> String {
+        "equal_operands_in_pure_bin_op".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, env: &FunctionEnv, expr: &ExpData) {
+        if let ExpData::Call(nid, op, params) = expr {
+            if !(params.len() == 2 && expr_are_equal(&params[0], &params[1])) {
+                return;
+            }
+
+            let Some(msg) = pure_bin_op_result(op, params, env) else {
+                return;
+            };
+
+            let env = env.env();
+
+            self.report(env, &env.get_node_loc(*nid), msg.as_str())
+        }
+    }
+}
+
+/// This function performs a structural comparison of two expressions. It handles the following expression types:
+/// - Local variables: compared by symbol equality
+/// - Values: compared by value equality
+/// - Temporaries: compared by temporary ID equality
+/// - Function calls: compared by operation type and recursive argument comparison
+///     - In this case, also checks that the operation is NOT a MoveFunction,
+///       as they could be side-effecting.
+fn expr_are_equal(expr1: &ExpData, expr2: &ExpData) -> bool {
+    use ExpData::*;
+    match (expr1, expr2) {
+        (LocalVar(_, s1), LocalVar(_, s2)) => s1 == s2,
+        (Value(_, v1), Value(_, v2)) => v1 == v2,
+        (Temporary(_, t1), Temporary(_, t2)) => t1 == t2,
+        (Call(_, op1, args1), Call(_, op2, args2)) => {
+            (!matches!(op1, Operation::MoveFunction(..)))
+                && op1 == op2
+                && args1.len() == args2.len()
+                && args1
+                    .iter()
+                    .zip(args2.iter())
+                    .all(|(a1, a2)| expr_are_equal(a1, a2))
+        },
+        _ => false,
+    }
+}
+
+fn pure_bin_op_result(op: &Operation, exprs: &[Exp], env: &FunctionEnv) -> Option<String> {
+    use Operation::*;
+
+    let res = match op {
+        Mod | Xor => "0".to_string(),
+        Le | Ge | Eq => "True".to_string(),
+        BitOr | BitAnd => exprs[0].display_for_fun(env).to_string(),
+        Div => "1".to_string(),
+        Neq | Lt | Gt => "False".to_string(),
+        // | And | Or // Already matched in another lint
+        _ => return None,
+    };
+
+    Some(format!("This (pure) operation always returns {res}."))
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_pure_bin_op.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_pure_bin_op.exp
@@ -1,0 +1,100 @@
+
+Diagnostics:
+warning: [lint] This (pure) operation always returns 0.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:14:13
+   │
+14 │         if (x % x == 2) {
+   │             ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns 0.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:17:13
+   │
+17 │         if ((x+1) ^ (x+1) == 2) {
+   │             ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns True.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:20:13
+   │
+20 │         if (x <= x) {
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns True.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:23:13
+   │
+23 │         if (x >= x) {
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns True.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:26:13
+   │
+26 │         if (x == x) {
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns x.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:29:13
+   │
+29 │         if (x | x == 2) {
+   │             ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns x.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:32:13
+   │
+32 │         if (x & x == 2) {
+   │             ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns 1.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:35:13
+   │
+35 │         if (x / x == 2) {
+   │             ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns False.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:43:13
+   │
+43 │         if (hnc.n.n.i != hnc.n.n.i) {
+   │             ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns False.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:46:13
+   │
+46 │         if (x < x) {
+   │             ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.
+
+warning: [lint] This (pure) operation always returns False.
+   ┌─ tests/model_ast_lints/equal_operands_in_pure_bin_op.move:49:13
+   │
+49 │         if (x > x) {
+   │             ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_pure_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_pure_bin_op.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_pure_bin_op.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_pure_bin_op.move
@@ -1,0 +1,70 @@
+module 0xc0ffee::m {
+
+    struct Counter has key, store, drop { i: u64 }
+
+    struct NestedCounter has key, store, drop {
+        n: Counter
+    }
+
+    struct HyperNestedCounter has key, store, drop {
+        n: NestedCounter
+    }
+
+    public fun test1(x: u64) {
+        if (x % x == 2) {
+            abort 1;
+        };
+        if ((x+1) ^ (x+1) == 2) {
+            abort 1;
+        };
+        if (x <= x) {
+            abort 1;
+        };
+        if (x >= x) {
+            abort 1;
+        };
+        if (x == x) {
+            abort 1;
+        };
+        if (x | x == 2) {
+            abort 1;
+        };
+        if (x & x == 2) {
+            abort 1;
+        };
+        if (x / x == 2) {
+            abort 1;
+        };
+
+        let c = Counter { i: x };
+        let nc = NestedCounter { n: c };
+        let hnc = HyperNestedCounter { n: nc };
+
+        if (hnc.n.n.i != hnc.n.n.i) {
+            abort 1;
+        };
+        if (x < x) {
+            abort 1;
+        };
+        if (x > x) {
+            abort 1;
+        };
+
+        if (a_fn(x) > a_fn(x)) { // This should not warn
+            abort 1;
+        };
+    }
+
+    #[lint::skip(equal_operands_in_pure_bin_op)]
+    public fun test2(x: u64) {
+        if (x % x == 0) {
+            abort 1;
+        };
+    }
+
+    public fun a_fn(a: u64): u64 {
+        a
+    }
+
+
+}


### PR DESCRIPTION
## Description
This PR adds a new lint to aptos move lint: Checking for pure binary operations with the same operands on both sides, as requested in https://github.com/aptos-labs/aptos-core/issues/15221

## How Has This Been Tested?
Added test in `move_linter/tests` folder

## Key Areas to Review
- Recognized patterns are enough?
- Lint message, should we justify _why_ is it always `{True, False, 1, 0}`?.

## Type of Change
New feature

## Which Components or Systems Does This Change Impact?
Other (move_linter)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
