### PR TITLE
[framework] remove deprecated :: type qualifiers

### DIFF
--- a/aptos-move/framework/aptos-experimental/doc/sigma_protos.md
+++ b/aptos-move/framework/aptos-experimental/doc/sigma_protos.md
@@ -517,30 +517,30 @@ Deserializes and returns an <code><a href="sigma_protos.md#0x7_sigma_protos_With
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="sigma_protos.md#0x7_sigma_protos_deserialize_withdrawal_subproof">deserialize_withdrawal_subproof</a>(proof_bytes: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): Option&lt;<a href="sigma_protos.md#0x7_sigma_protos_WithdrawalSubproof">WithdrawalSubproof</a>&gt; {
-    <b>if</b> (proof_bytes.length::&lt;u8&gt;() != 192) {
+    <b>if</b> (proof_bytes.length() != 192) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_WithdrawalSubproof">WithdrawalSubproof</a>&gt;()
     };
 
     <b>let</b> x1_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x1 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x1_bytes);
-    <b>if</b> (!x1.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x1.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_WithdrawalSubproof">WithdrawalSubproof</a>&gt;()
     };
-    <b>let</b> x1 = x1.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x1 = x1.extract();
 
     <b>let</b> x2_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x2 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x2_bytes);
-    <b>if</b> (!x2.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x2.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_WithdrawalSubproof">WithdrawalSubproof</a>&gt;()
     };
-    <b>let</b> x2 = x2.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x2 = x2.extract();
 
     <b>let</b> x3_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x3 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x3_bytes);
-    <b>if</b> (!x3.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x3.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_WithdrawalSubproof">WithdrawalSubproof</a>&gt;()
     };
-    <b>let</b> x3 = x3.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x3 = x3.extract();
 
     <b>let</b> alpha1_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> alpha1 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_scalar_from_bytes">ristretto255::new_scalar_from_bytes</a>(alpha1_bytes);
@@ -590,58 +590,58 @@ Deserializes and returns a <code><a href="sigma_protos.md#0x7_sigma_protos_Trans
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="sigma_protos.md#0x7_sigma_protos_deserialize_transfer_subproof">deserialize_transfer_subproof</a>(proof_bytes: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;): Option&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt; {
-    <b>if</b> (proof_bytes.length::&lt;u8&gt;() != 384) {
+    <b>if</b> (proof_bytes.length() != 384) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
 
     <b>let</b> x1_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x1 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x1_bytes);
-    <b>if</b> (!x1.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x1.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
-    <b>let</b> x1 = x1.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x1 = x1.extract();
 
     <b>let</b> x2_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x2 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x2_bytes);
-    <b>if</b> (!x2.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x2.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
-    <b>let</b> x2 = x2.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x2 = x2.extract();
 
     <b>let</b> x3_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x3 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x3_bytes);
-    <b>if</b> (!x3.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x3.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
-    <b>let</b> x3 = x3.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x3 = x3.extract();
 
     <b>let</b> x4_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x4 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x4_bytes);
-    <b>if</b> (!x4.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x4.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
-    <b>let</b> x4 = x4.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x4 = x4.extract();
 
     <b>let</b> x5_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x5 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x5_bytes);
-    <b>if</b> (!x5.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x5.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
-    <b>let</b> x5 = x5.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x5 = x5.extract();
 
     <b>let</b> x6_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x6 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x6_bytes);
-    <b>if</b> (!x6.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x6.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
-    <b>let</b> x6 = x6.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x6 = x6.extract();
 
     <b>let</b> x7_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> x7 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_point_from_bytes">ristretto255::new_point_from_bytes</a>(x7_bytes);
-    <b>if</b> (!x7.is_some::&lt;RistrettoPoint&gt;()) {
+    <b>if</b> (!x7.is_some()) {
         <b>return</b> std::option::none&lt;<a href="sigma_protos.md#0x7_sigma_protos_TransferSubproof">TransferSubproof</a>&gt;()
     };
-    <b>let</b> x7 = x7.extract::&lt;RistrettoPoint&gt;();
+    <b>let</b> x7 = x7.extract();
 
     <b>let</b> alpha1_bytes = cut_vector&lt;u8&gt;(&<b>mut</b> proof_bytes, 32);
     <b>let</b> alpha1 = <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_scalar_from_bytes">ristretto255::new_scalar_from_bytes</a>(alpha1_bytes);
@@ -720,18 +720,18 @@ $\Sigma$-protocol.
 
     <b>let</b> bytes = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
 
-    bytes.append::&lt;u8&gt;(<a href="sigma_protos.md#0x7_sigma_protos_FIAT_SHAMIR_SIGMA_DST">FIAT_SHAMIR_SIGMA_DST</a>);
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_basepoint_compressed">ristretto255::basepoint_compressed</a>()));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(
+    bytes.append(<a href="sigma_protos.md#0x7_sigma_protos_FIAT_SHAMIR_SIGMA_DST">FIAT_SHAMIR_SIGMA_DST</a>);
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_basepoint_compressed">ristretto255::basepoint_compressed</a>()));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(
         &<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(&pedersen::randomness_base_for_bulletproof())));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&y));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c1)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c2)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_to_bytes">ristretto255::scalar_to_bytes</a>(amount));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x1)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x2)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x3)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&y));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c1)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c2)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_scalar_to_bytes">ristretto255::scalar_to_bytes</a>(amount));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x1)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x2)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x3)));
 
     <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_scalar_from_sha2_512">ristretto255::new_scalar_from_sha2_512</a>(bytes)
 }
@@ -784,26 +784,26 @@ Computes a Fiat-Shamir challenge <code>rho = H(G, H, Y, Y', C, D, c, c_1, c_2, \
 
     <b>let</b> bytes = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>&lt;u8&gt;();
 
-    bytes.append::&lt;u8&gt;(<a href="sigma_protos.md#0x7_sigma_protos_FIAT_SHAMIR_SIGMA_DST">FIAT_SHAMIR_SIGMA_DST</a>);
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_basepoint_compressed">ristretto255::basepoint_compressed</a>()));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(
+    bytes.append(<a href="sigma_protos.md#0x7_sigma_protos_FIAT_SHAMIR_SIGMA_DST">FIAT_SHAMIR_SIGMA_DST</a>);
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_basepoint_compressed">ristretto255::basepoint_compressed</a>()));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(
         &<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(&pedersen::randomness_base_for_bulletproof())));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&y));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&y_prime));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(big_c)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(big_c_prime)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(big_d)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c1)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c2)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(bar_c)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x1)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x2)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x3)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x4)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x5)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x6)));
-    bytes.append::&lt;u8&gt;(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x7)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&y));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&y_prime));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(big_c)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(big_c_prime)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(big_d)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c1)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(c2)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(bar_c)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x1)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x2)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x3)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x4)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x5)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x6)));
+    bytes.append(<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_to_bytes">ristretto255::point_to_bytes</a>(&<a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_point_compress">ristretto255::point_compress</a>(x7)));
 
     <a href="../../aptos-framework/../aptos-stdlib/doc/ristretto255.md#0x1_ristretto255_new_scalar_from_sha2_512">ristretto255::new_scalar_from_sha2_512</a>(bytes)
 }

--- a/aptos-move/framework/aptos-experimental/sources/veiled_coin/sigma_protos.move
+++ b/aptos-move/framework/aptos-experimental/sources/veiled_coin/sigma_protos.move
@@ -307,30 +307,30 @@ module aptos_experimental::sigma_protos {
 
     /// Deserializes and returns an `WithdrawalSubproof` given its byte representation.
     public fun deserialize_withdrawal_subproof(proof_bytes: vector<u8>): Option<WithdrawalSubproof> {
-        if (proof_bytes.length::<u8>() != 192) {
+        if (proof_bytes.length() != 192) {
             return std::option::none<WithdrawalSubproof>()
         };
 
         let x1_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x1 = ristretto255::new_point_from_bytes(x1_bytes);
-        if (!x1.is_some::<RistrettoPoint>()) {
+        if (!x1.is_some()) {
             return std::option::none<WithdrawalSubproof>()
         };
-        let x1 = x1.extract::<RistrettoPoint>();
+        let x1 = x1.extract();
 
         let x2_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x2 = ristretto255::new_point_from_bytes(x2_bytes);
-        if (!x2.is_some::<RistrettoPoint>()) {
+        if (!x2.is_some()) {
             return std::option::none<WithdrawalSubproof>()
         };
-        let x2 = x2.extract::<RistrettoPoint>();
+        let x2 = x2.extract();
 
         let x3_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x3 = ristretto255::new_point_from_bytes(x3_bytes);
-        if (!x3.is_some::<RistrettoPoint>()) {
+        if (!x3.is_some()) {
             return std::option::none<WithdrawalSubproof>()
         };
-        let x3 = x3.extract::<RistrettoPoint>();
+        let x3 = x3.extract();
 
         let alpha1_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let alpha1 = ristretto255::new_scalar_from_bytes(alpha1_bytes);
@@ -360,58 +360,58 @@ module aptos_experimental::sigma_protos {
 
     /// Deserializes and returns a `TransferSubproof` given its byte representation.
     public fun deserialize_transfer_subproof(proof_bytes: vector<u8>): Option<TransferSubproof> {
-        if (proof_bytes.length::<u8>() != 384) {
+        if (proof_bytes.length() != 384) {
             return std::option::none<TransferSubproof>()
         };
 
         let x1_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x1 = ristretto255::new_point_from_bytes(x1_bytes);
-        if (!x1.is_some::<RistrettoPoint>()) {
+        if (!x1.is_some()) {
             return std::option::none<TransferSubproof>()
         };
-        let x1 = x1.extract::<RistrettoPoint>();
+        let x1 = x1.extract();
 
         let x2_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x2 = ristretto255::new_point_from_bytes(x2_bytes);
-        if (!x2.is_some::<RistrettoPoint>()) {
+        if (!x2.is_some()) {
             return std::option::none<TransferSubproof>()
         };
-        let x2 = x2.extract::<RistrettoPoint>();
+        let x2 = x2.extract();
 
         let x3_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x3 = ristretto255::new_point_from_bytes(x3_bytes);
-        if (!x3.is_some::<RistrettoPoint>()) {
+        if (!x3.is_some()) {
             return std::option::none<TransferSubproof>()
         };
-        let x3 = x3.extract::<RistrettoPoint>();
+        let x3 = x3.extract();
 
         let x4_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x4 = ristretto255::new_point_from_bytes(x4_bytes);
-        if (!x4.is_some::<RistrettoPoint>()) {
+        if (!x4.is_some()) {
             return std::option::none<TransferSubproof>()
         };
-        let x4 = x4.extract::<RistrettoPoint>();
+        let x4 = x4.extract();
 
         let x5_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x5 = ristretto255::new_point_from_bytes(x5_bytes);
-        if (!x5.is_some::<RistrettoPoint>()) {
+        if (!x5.is_some()) {
             return std::option::none<TransferSubproof>()
         };
-        let x5 = x5.extract::<RistrettoPoint>();
+        let x5 = x5.extract();
 
         let x6_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x6 = ristretto255::new_point_from_bytes(x6_bytes);
-        if (!x6.is_some::<RistrettoPoint>()) {
+        if (!x6.is_some()) {
             return std::option::none<TransferSubproof>()
         };
-        let x6 = x6.extract::<RistrettoPoint>();
+        let x6 = x6.extract();
 
         let x7_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let x7 = ristretto255::new_point_from_bytes(x7_bytes);
-        if (!x7.is_some::<RistrettoPoint>()) {
+        if (!x7.is_some()) {
             return std::option::none<TransferSubproof>()
         };
-        let x7 = x7.extract::<RistrettoPoint>();
+        let x7 = x7.extract();
 
         let alpha1_bytes = cut_vector<u8>(&mut proof_bytes, 32);
         let alpha1 = ristretto255::new_scalar_from_bytes(alpha1_bytes);
@@ -474,18 +474,18 @@ module aptos_experimental::sigma_protos {
 
         let bytes = vector::empty<u8>();
 
-        bytes.append::<u8>(FIAT_SHAMIR_SIGMA_DST);
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::basepoint_compressed()));
-        bytes.append::<u8>(ristretto255::point_to_bytes(
+        bytes.append(FIAT_SHAMIR_SIGMA_DST);
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::basepoint_compressed()));
+        bytes.append(ristretto255::point_to_bytes(
             &ristretto255::point_compress(&pedersen::randomness_base_for_bulletproof())));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&y));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(c1)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(c2)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(c)));
-        bytes.append::<u8>(ristretto255::scalar_to_bytes(amount));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x1)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x2)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x3)));
+        bytes.append(ristretto255::point_to_bytes(&y));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(c1)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(c2)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(c)));
+        bytes.append(ristretto255::scalar_to_bytes(amount));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x1)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x2)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x3)));
 
         ristretto255::new_scalar_from_sha2_512(bytes)
     }
@@ -518,26 +518,26 @@ module aptos_experimental::sigma_protos {
 
         let bytes = vector::empty<u8>();
 
-        bytes.append::<u8>(FIAT_SHAMIR_SIGMA_DST);
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::basepoint_compressed()));
-        bytes.append::<u8>(ristretto255::point_to_bytes(
+        bytes.append(FIAT_SHAMIR_SIGMA_DST);
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::basepoint_compressed()));
+        bytes.append(ristretto255::point_to_bytes(
             &ristretto255::point_compress(&pedersen::randomness_base_for_bulletproof())));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&y));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&y_prime));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(big_c)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(big_c_prime)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(big_d)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(c)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(c1)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(c2)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(bar_c)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x1)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x2)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x3)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x4)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x5)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x6)));
-        bytes.append::<u8>(ristretto255::point_to_bytes(&ristretto255::point_compress(x7)));
+        bytes.append(ristretto255::point_to_bytes(&y));
+        bytes.append(ristretto255::point_to_bytes(&y_prime));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(big_c)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(big_c_prime)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(big_d)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(c)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(c1)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(c2)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(bar_c)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x1)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x2)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x3)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x4)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x5)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x6)));
+        bytes.append(ristretto255::point_to_bytes(&ristretto255::point_compress(x7)));
 
         ristretto255::new_scalar_from_sha2_512(bytes)
     }
@@ -723,12 +723,12 @@ module aptos_experimental::sigma_protos {
         let alpha3_bytes = ristretto255::scalar_to_bytes(&proof.alpha3);
 
         let bytes = vector::empty<u8>();
-        bytes.append::<u8>(alpha3_bytes);
-        bytes.append::<u8>(alpha2_bytes);
-        bytes.append::<u8>(alpha1_bytes);
-        bytes.append::<u8>(x3_bytes);
-        bytes.append::<u8>(x2_bytes);
-        bytes.append::<u8>(x1_bytes);
+        bytes.append(alpha3_bytes);
+        bytes.append(alpha2_bytes);
+        bytes.append(alpha1_bytes);
+        bytes.append(x3_bytes);
+        bytes.append(x2_bytes);
+        bytes.append(x1_bytes);
 
         bytes
     }
@@ -752,18 +752,18 @@ module aptos_experimental::sigma_protos {
         let alpha5_bytes = ristretto255::scalar_to_bytes(&proof.alpha5);
 
         let bytes = vector::empty<u8>();
-        bytes.append::<u8>(alpha5_bytes);
-        bytes.append::<u8>(alpha4_bytes);
-        bytes.append::<u8>(alpha3_bytes);
-        bytes.append::<u8>(alpha2_bytes);
-        bytes.append::<u8>(alpha1_bytes);
-        bytes.append::<u8>(x7_bytes);
-        bytes.append::<u8>(x6_bytes);
-        bytes.append::<u8>(x5_bytes);
-        bytes.append::<u8>(x4_bytes);
-        bytes.append::<u8>(x3_bytes);
-        bytes.append::<u8>(x2_bytes);
-        bytes.append::<u8>(x1_bytes);
+        bytes.append(alpha5_bytes);
+        bytes.append(alpha4_bytes);
+        bytes.append(alpha3_bytes);
+        bytes.append(alpha2_bytes);
+        bytes.append(alpha1_bytes);
+        bytes.append(x7_bytes);
+        bytes.append(x6_bytes);
+        bytes.append(x5_bytes);
+        bytes.append(x4_bytes);
+        bytes.append(x3_bytes);
+        bytes.append(x2_bytes);
+        bytes.append(x1_bytes);
 
         bytes
     }
@@ -932,7 +932,7 @@ module aptos_experimental::sigma_protos {
 
         let sigma_proof_bytes = serialize_transfer_subproof(&sigma_proof);
 
-        let deserialized_proof = deserialize_transfer_subproof(sigma_proof_bytes).extract::<TransferSubproof>();
+        let deserialized_proof = deserialize_transfer_subproof(sigma_proof_bytes).extract();
 
         assert!(ristretto255::point_equals(&sigma_proof.x1, &deserialized_proof.x1), 1);
         assert!(ristretto255::point_equals(&sigma_proof.x2, &deserialized_proof.x2), 1);


### PR DESCRIPTION
## Description
This PR removes deprecated `::` type qualifiers from method calls in the experimental framework to improve Move 2.2 compatibility and eliminate compilation warnings.

**Context & Framework Requirements:**
The `aptos-experimental` framework uses Move 2.2 language features (specifically function type ability constraints like `|address, u64| -> bool has drop + copy`) which require compilation with `--language-version 2.2`. This PR modernizes the deprecated syntax to align with Move 2.2 standards.

**Changes Made:**
- Replace deprecated `length::<u8>()` with `length()`
- Replace deprecated `is_some::<Type>()` with `is_some()`  
- Replace deprecated `extract::<Type>()` with `extract()`
- Replace deprecated `append::<u8>()` with `append()`

File modified: 
- `sources/veiled_coin/sigma_protos.move` Syntax
- `doc/sigma_protos.md` - Updated documentation to reflect syntax changes

**Value:** Eliminates deprecation warnings and prepares the codebase for future Move versions where the deprecated syntax will be removed.

## Bisect-able History Note
This framework requires --language-version 2.2 for compilation.
Build command: aptos move test --package-dir . --language-version 2.2

**Question for Maintainers:** Should experimental modules be treated differently for bisect-able history requirements, or is there a preferred approach for modules that require Move 2.2 features?

## How Has This Been Tested?
- Ran `aptos move test --package-dir . --language-version 2.2` - all tests pass with no deprecation warnings
- Ran `./scripts/rust_lint.sh` - all applicable linting checks pass  
- Verified `grep -r "::<" sources/` returns no matches after changes
- Confirmed identical functionality with modern syntax

**Required Build Command:** 
```bash
aptos move test --package-dir . --language-version 2.2
```

## Key Areas to Review
- **File:** `sources/veiled_coin/sigma_protos.move` - All syntax modernization
- **Risk Level:** Very Low - mechanical syntax updates with zero logic changes
- **Backward Compatible:** Modern syntax works with both Move 2.1 and 2.2
- **Framework Constraint:** Requires Move 2.2 due to experimental features

The changes are purely syntactic modernization that maintains identical behavior while using contemporary Move syntax standards.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [[CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md)](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation