### PR TITLE
[Move Prover] Add native support of cmp

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -2020,7 +2020,7 @@ not equal the number of singers.
 <pre><code><b>pragma</b> aborts_if_is_partial;
 <b>pragma</b> verify_duration_estimate = 120;
 <b>aborts_if</b> !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_spec_is_enabled">features::spec_is_enabled</a>(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_FEE_PAYER_ENABLED">features::FEE_PAYER_ENABLED</a>);
-<b>let</b> gas_payer = <a href="create_signer.md#0x1_create_signer_create_signer">create_signer::create_signer</a>(fee_payer_address);
+<b>let</b> gas_payer = <a href="create_signer.md#0x1_create_signer_spec_create_signer">create_signer::spec_create_signer</a>(fee_payer_address);
 <b>include</b> <a href="transaction_validation.md#0x1_transaction_validation_PrologueCommonAbortsIf">PrologueCommonAbortsIf</a> {
     gas_payer,
     replay_protector: ReplayProtector::SequenceNumber(txn_sequence_number),

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.spec.move
@@ -257,7 +257,7 @@ spec aptos_framework::transaction_validation {
         pragma verify_duration_estimate = 120;
 
         aborts_if !features::spec_is_enabled(features::FEE_PAYER_ENABLED);
-        let gas_payer = create_signer::create_signer(fee_payer_address);
+        let gas_payer = create_signer::spec_create_signer(fee_payer_address);
         include PrologueCommonAbortsIf {
             gas_payer,
             replay_protector: ReplayProtector::SequenceNumber(txn_sequence_number),

--- a/aptos-move/framework/move-stdlib/doc/cmp.md
+++ b/aptos-move/framework/move-stdlib/doc/cmp.md
@@ -14,7 +14,14 @@
 -  [Function `is_gt`](#0x1_cmp_is_gt)
 -  [Function `is_ge`](#0x1_cmp_is_ge)
 -  [Specification](#@Specification_0)
+    -  [Enum `Ordering`](#@Specification_0_Ordering)
     -  [Function `compare`](#@Specification_0_compare)
+    -  [Function `is_eq`](#@Specification_0_is_eq)
+    -  [Function `is_ne`](#@Specification_0_is_ne)
+    -  [Function `is_lt`](#@Specification_0_is_lt)
+    -  [Function `is_le`](#@Specification_0_is_le)
+    -  [Function `is_gt`](#@Specification_0_is_gt)
+    -  [Function `is_ge`](#@Specification_0_is_ge)
 
 
 <pre><code></code></pre>
@@ -263,6 +270,74 @@ and if equal we proceed to the next.
 ## Specification
 
 
+<a id="@Specification_0_Ordering"></a>
+
+### Enum `Ordering`
+
+
+<pre><code>enum <a href="cmp.md#0x1_cmp_Ordering">Ordering</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<dl>
+
+<details>
+<summary>Less</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+
+<details>
+<summary>Equal</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+
+<details>
+<summary>Greater</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+</dl>
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+</code></pre>
+
+
+
 <a id="@Specification_0_compare"></a>
 
 ### Function `compare`
@@ -274,7 +349,115 @@ and if equal we proceed to the next.
 
 
 
-<pre><code><b>pragma</b> opaque;
+<pre><code><b>pragma</b> intrinsic;
+</code></pre>
+
+
+
+<a id="@Specification_0_is_eq"></a>
+
+### Function `is_eq`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp_is_eq">is_eq</a>(self: &<a href="cmp.md#0x1_cmp_Ordering">cmp::Ordering</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_0_is_ne"></a>
+
+### Function `is_ne`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp_is_ne">is_ne</a>(self: &<a href="cmp.md#0x1_cmp_Ordering">cmp::Ordering</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_0_is_lt"></a>
+
+### Function `is_lt`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp_is_lt">is_lt</a>(self: &<a href="cmp.md#0x1_cmp_Ordering">cmp::Ordering</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_0_is_le"></a>
+
+### Function `is_le`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp_is_le">is_le</a>(self: &<a href="cmp.md#0x1_cmp_Ordering">cmp::Ordering</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_0_is_gt"></a>
+
+### Function `is_gt`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp_is_gt">is_gt</a>(self: &<a href="cmp.md#0x1_cmp_Ordering">cmp::Ordering</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_0_is_ge"></a>
+
+### Function `is_ge`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp_is_ge">is_ge</a>(self: &<a href="cmp.md#0x1_cmp_Ordering">cmp::Ordering</a>): bool
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> intrinsic;
+<b>pragma</b> opaque;
+<b>pragma</b> verify = <b>false</b>;
 </code></pre>
 
 

--- a/aptos-move/framework/tests/move_prover_tests.rs
+++ b/aptos-move/framework/tests/move_prover_tests.rs
@@ -78,28 +78,8 @@ pub fn run_prover_for_pkg(
 }
 
 #[test]
-fn move_framework_prover_tests_shard1() {
-    run_prover_for_pkg("aptos-framework", 5, Some(1));
-}
-
-#[test]
-fn move_framework_prover_tests_shard2() {
-    run_prover_for_pkg("aptos-framework", 5, Some(2));
-}
-
-#[test]
-fn move_framework_prover_tests_shard3() {
-    run_prover_for_pkg("aptos-framework", 5, Some(3));
-}
-
-#[test]
-fn move_framework_prover_tests_shard4() {
-    run_prover_for_pkg("aptos-framework", 5, Some(4));
-}
-
-#[test]
-fn move_framework_prover_tests_shard5() {
-    run_prover_for_pkg("aptos-framework", 5, Some(5));
+fn move_framework_prover_tests() {
+    run_prover_for_pkg("aptos-framework", 1, None);
 }
 
 #[test]

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -607,6 +607,8 @@ pub struct GlobalEnv {
     /// Whether the v2 compiler has generated this model.
     /// TODO: replace with a proper version number once we have this in file format
     pub(crate) generated_by_v2: bool,
+    /// A set of types that are instantiated in cmp module.
+    pub cmp_types: RefCell<BTreeSet<Type>>,
 }
 
 /// A helper type for implementing fmt::Display depending on GlobalEnv
@@ -668,6 +670,7 @@ impl GlobalEnv {
             address_alias_map: Default::default(),
             everything_is_target: Default::default(),
             generated_by_v2: false,
+            cmp_types: RefCell::new(Default::default()),
         }
     }
 
@@ -3605,6 +3608,10 @@ impl<'env> ModuleEnv<'env> {
             || self.is_module_in_std("smart_table")
             || self.is_module_in_ext("table")
             || self.is_module_in_ext("table_with_length")
+    }
+
+    pub fn is_cmp(&self) -> bool {
+        self.is_module_in_std("cmp")
     }
 }
 

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -1086,6 +1086,89 @@ impl Type {
         matches!(self, Type::Var(_))
     }
 
+    /// Returns all internal types contained in this type (including itself), skipping reference types.
+    pub fn get_all_contained_types_with_skip_reference(&self, env: &GlobalEnv) -> Vec<Type> {
+        match self {
+            Type::Primitive(_) => vec![self.clone()],
+            Type::Tuple(ts) => ts
+                .iter()
+                .flat_map(|t| t.get_all_contained_types_with_skip_reference(env))
+                .collect(),
+            Type::Vector(et) => {
+                let mut types = et.get_all_contained_types_with_skip_reference(env);
+                types.push(self.clone());
+                types
+            },
+            Type::Struct(_, _, ts) => {
+                let struct_env = self.get_struct(env).unwrap().0;
+                let mut new_types = ts
+                    .iter()
+                    .zip(struct_env.data.type_params.iter())
+                    .filter(|(_, param)| !param.1.is_phantom)
+                    .flat_map(|(t, _)| t.get_all_contained_types_with_skip_reference(env))
+                    .collect_vec();
+                new_types.push(self.clone());
+                if struct_env.has_variants() {
+                    for variant in struct_env.get_variants() {
+                        for field in struct_env.get_fields_of_variant(variant) {
+                            new_types.extend(
+                                field
+                                    .get_type()
+                                    .instantiate(ts)
+                                    .get_all_contained_types_with_skip_reference(env),
+                            );
+                        }
+                    }
+                } else {
+                    for field in struct_env.get_fields() {
+                        new_types.extend(
+                            field
+                                .get_type()
+                                .instantiate(ts)
+                                .get_all_contained_types_with_skip_reference(env),
+                        );
+                    }
+                }
+                new_types
+            },
+            Type::Fun(arg, result, _) => {
+                let mut types = arg.get_all_contained_types_with_skip_reference(env);
+                types.extend(result.get_all_contained_types_with_skip_reference(env));
+                types
+            },
+            Type::Reference(_, bt) => {
+                let mut types = bt.get_all_contained_types_with_skip_reference(env);
+                types.push(self.clone());
+                types
+            },
+            Type::TypeDomain(bt) => {
+                let mut types = bt.get_all_contained_types_with_skip_reference(env);
+                types.push(self.clone());
+                types
+            },
+            Type::ResourceDomain(_, _, Some(bt)) => {
+                let mut types = bt
+                    .iter()
+                    .flat_map(|t| t.get_all_contained_types_with_skip_reference(env))
+                    .collect_vec();
+                types.push(self.clone());
+                types
+            },
+            Type::ResourceDomain(_, _, None) => {
+                vec![self.clone()]
+            },
+            Type::Var(..) => {
+                vec![self.clone()]
+            },
+            Type::Error => {
+                vec![self.clone()]
+            },
+            Type::TypeParameter(..) => {
+                vec![self.clone()]
+            },
+        }
+    }
+
     /// Returns true if this is any number type.
     pub fn is_number(&self) -> bool {
         if let Type::Primitive(p) = self {

--- a/third_party/move/move-prover/boogie-backend/src/lib.rs
+++ b/third_party/move/move-prover/boogie-backend/src/lib.rs
@@ -55,6 +55,7 @@ const TABLE_ARRAY_THEORY: &[u8] = include_bytes!("prelude/table-array-theory.bpl
 // TODO use named addresses
 const BCS_MODULE: &str = "0x1::bcs";
 const EVENT_MODULE: &str = "0x1::event";
+const CMP_MODULE: &str = "0x1::cmp";
 
 mod boogie_helpers;
 pub mod boogie_wrapper;
@@ -208,7 +209,6 @@ pub fn add_prelude(
         .into_iter()
         .collect_vec();
     all_types.append(&mut bv_all_types);
-    context.insert("uninterpreted_instances", &all_types);
 
     // obtain bv number types appearing in the program, which is currently used to generate cast functions for bv types
     let number_types = mono_info
@@ -320,6 +320,68 @@ pub fn add_prelude(
     context.insert("bcs_instances", &bcs_instances);
     let event_instances = filter_native_ensure_one_inst(EVENT_MODULE);
     context.insert("event_instances", &event_instances);
+
+    // handle cmp module
+    let filter_native_with_contained_types_with_bv_flag = |module: &str, bv_flag: bool| {
+        mono_info
+            .native_inst
+            .iter()
+            .filter(|(id, _)| env.get_module(**id).get_full_name_str() == module)
+            .flat_map(|(_, insts)| {
+                insts.iter().map(|inst| {
+                    inst.iter()
+                        .flat_map(|i| i.get_all_contained_types_with_skip_reference(env))
+                        .map(|i| (i.clone(), TypeInfo::new(env, options, &i, bv_flag)))
+                        .collect::<Vec<_>>()
+                })
+            })
+            .sorted()
+            .collect_vec()
+    };
+    let filter_native_with_contained_types = |module: &str| {
+        let mut filtered = filter_native_with_contained_types_with_bv_flag(module, false);
+        let mut filtered_bv = filter_native_with_contained_types_with_bv_flag(module, true);
+        filtered.append(&mut filtered_bv);
+        filtered.into_iter().flatten().collect_vec()
+    };
+    let mut cmp_instances = filter_native_with_contained_types(CMP_MODULE);
+    cmp_instances.sort();
+    cmp_instances.dedup();
+    let mut cmp_struct_types = vec![];
+    let mut cmp_int_types = all_types
+        .clone()
+        .into_iter()
+        .filter(|ty| ty.name == "int")
+        .collect_vec();
+    for (ty, ty_info) in &cmp_instances {
+        if ty.is_struct() {
+            cmp_struct_types.push(ty.clone());
+        }
+        if ty.is_number() && !ty_info.suffix.contains("bv") && !cmp_int_types.contains(ty_info) {
+            cmp_int_types.push(ty_info.clone());
+        }
+    }
+    cmp_int_types.sort();
+    cmp_int_types.dedup();
+    cmp_struct_types.sort();
+    cmp_struct_types.dedup();
+    context.insert("cmp_int_instances", &cmp_int_types);
+    env.cmp_types.borrow_mut().extend(cmp_struct_types);
+
+    let filter_cmp_instances_with_name_prefix = |name_prefix: &str| {
+        cmp_instances
+            .clone()
+            .into_iter()
+            .filter(|ty| ty.1.name.starts_with(name_prefix))
+            .map(|ty| ty.1)
+            .collect_vec()
+    };
+    let cmp_vector_instances = filter_cmp_instances_with_name_prefix("Vec");
+    context.insert("cmp_vector_instances", &cmp_vector_instances);
+    let cmp_table_instances = filter_cmp_instances_with_name_prefix("Table");
+    context.insert("cmp_table_instances", &cmp_table_instances);
+
+    context.insert("uninterpreted_instances", &all_types);
 
     // TODO: we have defined {{std}} for adaptable resolution of stdlib addresses but
     //   not used it yet in the templates.

--- a/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
+++ b/third_party/move/move-prover/boogie-backend/src/prelude/prelude.bpl
@@ -32,7 +32,9 @@ options provided to the prover.
 {%- set S = "'" ~ instance.suffix ~ "'" -%}
 {%- set T = instance.name -%}
 
+{%-if S != "'$1_cmp_Ordering'" %}
 function $Arbitrary_value_of{{S}}(): {{T}};
+{% endif %}
 
 {% endfor %}
 

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -1251,8 +1251,9 @@ impl SpecTranslator<'_> {
             .env
             .get_extension::<GlobalNumberOperationState>()
             .expect("global number operation state");
-        let is_vector_table_module = module_env.is_std_vector() || module_env.is_table();
-        let bv_flag = if is_vector_table_module && !args.is_empty() {
+        let is_vector_table_cmp_module =
+            module_env.is_std_vector() || module_env.is_table() || module_env.is_cmp();
+        let bv_flag = if is_vector_table_cmp_module && !args.is_empty() {
             global_state.get_node_num_oper(args[0].node_id()) == Bitwise
         } else {
             global_state.get_node_num_oper(node_id) == Bitwise
@@ -1441,12 +1442,6 @@ impl SpecTranslator<'_> {
         args: &[Exp],
     ) {
         let struct_env = self.env.get_module(module_id).into_struct(struct_id);
-        if struct_env.is_intrinsic() {
-            self.env.error(
-                &self.env.get_node_loc(node_id),
-                "cannot test variants of intrinsic struct",
-            );
-        }
         let struct_type = &self.get_node_type(args[0].node_id());
         let (_, _, _) = struct_type.skip_reference().require_struct();
         let inst = self.env.get_node_instantiation(node_id);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds native support using cmp::compare to Move prover, which is the prerequisite of supporting ordered_map and big_ordered_map in Move prover.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Unit tests are added to `cmp.move`.


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Move prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
