### PR TITLE
[consensus] relax write option for rocksdb

### DIFF
--- a/consensus/src/consensusdb/mod.rs
+++ b/consensus/src/consensusdb/mod.rs
@@ -155,7 +155,7 @@ impl ConsensusDB {
     /// Write the whole schema batch including all data necessary to mutate the ledger
     /// state of some transaction by leveraging rocksdb atomicity support.
     fn commit(&self, batch: SchemaBatch) -> Result<(), DbError> {
-        self.db.write_schemas(batch)?;
+        self.db.write_schemas_relaxed(batch)?;
         Ok(())
     }
 


### PR DESCRIPTION
    /// If this flag is false, and the machine crashes, some recent
    /// writes may be lost.  Note that if it is just the process that
    /// crashes (i.e., the machine does not reboot), no writes will be
    /// lost even if sync==false.

consensus & quorum db is protected by BFT guarantees, it's okay to relax the single node write guarantees as long as one honest node is able to persist the write without machine failure.