### PR TITLE
[Bug] Fix an issue in decompiling nested loops

### DIFF
--- a/third_party/move/tools/move-decompiler/tests/nested_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/nested_loops.exp
@@ -1,0 +1,235 @@
+
+module 0x99::m {
+    fun nested_for_loops() {
+        let _t4;
+        let _t3;
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        _t2 = false;
+        'l0: loop {
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 10)) break;
+            _t0 = _t0 + 1;
+            _t3 = _t1;
+            _t4 = false;
+            loop {
+                if (_t4) _t3 = _t3 + 1 else _t4 = true;
+                if (!(_t3 < 10)) continue 'l0;
+                _t0 = _t0 + 1
+            };
+            break
+        };
+    }
+    fun nested_for_while_loop_loops() {
+        let _t4;
+        let _t3;
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        _t2 = false;
+        'l0: loop {
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 5)) break;
+            _t0 = _t0 + 1;
+            _t3 = _t1;
+            'l1: loop {
+                if (!(_t3 < 10)) continue 'l0;
+                _t0 = _t0 + 1;
+                _t4 = _t3;
+                _t3 = _t3 + 1;
+                loop {
+                    _t0 = _t0 + 1;
+                    if (_t4 > 10) continue 'l1;
+                    _t4 = _t4 + 1
+                };
+                break
+            };
+            break
+        };
+    }
+    fun nested_for_while_loops() {
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        _t2 = false;
+        'l0: loop {
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 5)) break;
+            _t0 = _t0 + 1;
+            loop {
+                if (!(_t0 < 5)) continue 'l0;
+                _t0 = _t0 + 10
+            };
+            break
+        };
+    }
+    fun nested_loop_for_loops() {
+        let _t4;
+        let _t3;
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        'l0: loop {
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            if (_t0 > 3) break;
+            _t3 = 0;
+            _t4 = false;
+            loop {
+                if (_t4) _t3 = _t3 + 1 else _t4 = true;
+                if (!(_t3 < 5)) continue 'l0;
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1
+            };
+            break
+        };
+    }
+    fun nested_loop_loops() {
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        'l0: loop {
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            if (_t0 > 3) break;
+            loop {
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1;
+                if (_t2 > 7) continue 'l0
+            };
+            break
+        };
+    }
+    fun nested_loop_while_loops() {
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        'l0: loop {
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            if (_t0 > 3) break;
+            loop {
+                if (!(_t2 < 7)) continue 'l0;
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1
+            };
+            break
+        };
+    }
+    fun nested_while_loops() {
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        'l0: while (_t0 < 3) {
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            loop {
+                if (!(_t2 < 7)) continue 'l0;
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1
+            };
+            break
+        };
+    }
+    fun three_layer_for_loops() {
+        let _t6;
+        let _t5;
+        let _t4;
+        let _t3;
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        _t2 = false;
+        'l0: loop {
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 10)) break;
+            _t0 = _t0 + 1;
+            _t3 = _t1;
+            _t4 = false;
+            'l1: loop {
+                if (_t4) _t3 = _t3 + 1 else _t4 = true;
+                if (!(_t3 < 10)) continue 'l0;
+                _t0 = _t0 + 1;
+                _t5 = _t3;
+                _t6 = false;
+                loop {
+                    if (_t6) _t5 = _t5 + 1 else _t6 = true;
+                    if (!(_t5 < 10)) continue 'l1;
+                    _t0 = _t0 + 1
+                };
+                break
+            };
+            break
+        };
+    }
+    fun three_layer_loop_loops() {
+        let _t3;
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        'l0: loop {
+            _t0 = _t0 + 1;
+            _t2 = _t1;
+            if (_t1 > 10) break;
+            _t1 = _t1 + 1;
+            'l1: loop {
+                _t0 = _t0 + 1;
+                _t3 = _t2;
+                if (_t2 > 10) continue 'l0;
+                _t2 = _t2 + 1;
+                loop {
+                    _t0 = _t0 + 1;
+                    if (_t3 > 10) continue 'l1;
+                    _t3 = _t3 + 1
+                };
+                break
+            };
+            break
+        };
+    }
+    fun three_layer_while_loops() {
+        let _t3;
+        let _t2;
+        let _t1;
+        let _t0;
+        _t0 = 0;
+        _t1 = 0;
+        'l0: while (_t1 < 10) {
+            _t0 = _t0 + 1;
+            _t2 = _t1;
+            _t1 = _t1 + 1;
+            'l1: loop {
+                if (!(_t2 < 10)) continue 'l0;
+                _t0 = _t0 + 1;
+                _t3 = _t2;
+                _t2 = _t2 + 1;
+                loop {
+                    if (!(_t3 < 10)) continue 'l1;
+                    _t0 = _t0 + 1;
+                    _t3 = _t3 + 1
+                };
+                break
+            };
+            break
+        };
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/nested_loops.move
+++ b/third_party/move/tools/move-decompiler/tests/nested_loops.move
@@ -1,0 +1,163 @@
+//* Test cases with nested loops
+module 0x99::m {
+    fun nested_for_loops() {
+        let y = 0;
+        for (i in 0..10) {
+            y = y + 1;
+            for (j in i..10) {
+              y = y + 1;
+            };
+        };
+    }
+
+    fun nested_while_loops() {
+        let x = 0;
+        let z = 0;
+        let y;
+        while (x < 3) {
+            x = x + 1;
+            y = 0;
+            while (y < 7) {
+                y = y + 1;
+                z = z + 1;
+            }
+        };
+    }
+
+    fun nested_loop_loops () {
+        let x = 0;
+        let z = 0;
+        let y;
+        loop {
+            x = x + 1;
+            y = 0;
+            if (x > 3)
+                break;
+            loop {
+                y = y + 1;
+                z = z + 1;
+                if (y > 7)
+                    break;
+            };
+        };
+  }
+
+    fun nested_for_while_loops() {
+        let y = 0;
+        for (i in 0..5) {
+            y = y + 1;
+            while (y < 5) {
+                y = y + 10;
+            };
+        };
+    }
+
+    fun nested_loop_while_loops() {
+        let x = 0;
+        let z = 0;
+        let y;
+        loop {
+            x = x + 1;
+            y = 0;
+            if (x > 3)
+                break;
+            while (y < 7) {
+                y = y + 1;
+                z = z + 1;
+            }
+        };
+    }
+
+    fun nested_loop_for_loops() {
+        let x = 0;
+        let z = 0;
+        let y;
+        loop {
+            x = x + 1;
+            y = 0;
+            if (x > 3)
+                break;
+            for (i in 0..5) {
+                y = y + 1;
+                z = z + 1;
+            }
+        };
+    }
+
+    fun three_layer_for_loops(){
+        let y = 0;
+        for (i in 0..10) {
+            y = y + 1;
+            for (j in i..10) {
+              y = y + 1;
+              for (k in j..10) {
+                y = y + 1;
+              };
+            };
+        };
+    }
+
+    fun three_layer_while_loops(){
+        let y = 0;
+        let i = 0;
+        while(i < 10) {
+            y = y + 1;
+            let j = i;
+            i = i + 1;
+            while(j < 10) {
+              y = y + 1;
+              let k = j;
+              j = j + 1;
+              while(k < 10) {
+                y = y + 1;
+                k = k + 1;
+              };
+            };
+        };
+    }
+
+    fun three_layer_loop_loops(){
+        let y = 0;
+        let i = 0;
+        loop {
+            y = y + 1;
+            let j = i;
+            if (i > 10)
+                break;
+            i = i + 1;
+            loop {
+              y = y + 1;
+              let k = j;
+              if (j >  10)
+                break;
+              j = j + 1;
+              loop {
+                y = y + 1;
+                if (k > 10)
+                    break;
+                k = k + 1;
+              };
+            };
+        };
+    }
+
+    fun nested_for_while_loop_loops(){
+        let y = 0;
+        let i = 0;
+        for(i in 0..5) {
+            y = y + 1;
+            let j = i;
+            while(j < 10) {
+              y = y + 1;
+              let k = j;
+              j = j + 1;
+              loop {
+                y = y + 1;
+                if (k > 10)
+                    break;
+                k = k + 1;
+              };
+            };
+        };
+    }
+}


### PR DESCRIPTION
## Description
The [`astifier`](https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-model/bytecode/src/astifier.rs) component in the decompiler adds a virtual edge from each block in a loop to every successor block outside of the loop, when topologically sorting the stackless bytecode cfg (after original loop backedges are removed). This can bring loops back and fail the topological sorting, when nested loops exist. Below is an example where:

- An outer loop exists (including B, C, D)
- An inner loop exists (including C, D)
- Backedges D->C, C->B are removed
- Yet, B is an outer successor of C when dealing with the inner loop. Thus, a virtual edge C->B was re-introduced, preventing topological sorting.

<img width="454" alt="cfg" src="https://github.com/user-attachments/assets/8280a044-649a-4dcf-a432-ebcf25c268c6" /> 

This PR introduces checks to make sure the above does not happen when adding virtual edges.

## How Has This Been Tested?
- New decompiler [test cases](https://github.com/aptos-labs/aptos-core/blob/jun/fix-astfier-issues/third_party/move/tools/move-decompiler/tests/nested_loops.move)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (decompiler)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

