### PR TITLE
Patch transaction_validation.move auth key check

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
+++ b/aptos-move/e2e-move-tests/src/tests/fee_payer.rs
@@ -38,7 +38,7 @@ fn test_existing_account_with_fee_payer() {
             FeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         ],
-        vec![],
+        vec![FeatureFlag::DEFAULT_ACCOUNT_RESOURCE],
     );
 
     let alice = h.new_account_with_balance_and_sequence_number(0, 0);
@@ -73,7 +73,7 @@ fn test_existing_account_with_fee_payer_aborts() {
             FeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         ],
-        vec![],
+        vec![FeatureFlag::DEFAULT_ACCOUNT_RESOURCE],
     );
 
     let alice = h.new_account_with_balance_and_sequence_number(0, 0);
@@ -109,7 +109,7 @@ fn test_account_not_exist_with_fee_payer() {
             FeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         ],
-        vec![],
+        vec![FeatureFlag::DEFAULT_ACCOUNT_RESOURCE],
     );
 
     let alice = Account::new();
@@ -151,7 +151,7 @@ fn test_account_not_exist_with_fee_payer_insufficient_gas() {
             FeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         ],
-        vec![],
+        vec![FeatureFlag::DEFAULT_ACCOUNT_RESOURCE],
     );
 
     let alice = Account::new();
@@ -195,7 +195,7 @@ fn test_account_not_exist_and_move_abort_with_fee_payer_create_account() {
             FeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         ],
-        vec![],
+        vec![FeatureFlag::DEFAULT_ACCOUNT_RESOURCE],
     );
 
     let alice = Account::new();
@@ -256,7 +256,7 @@ fn test_account_not_exist_out_of_gas_with_fee_payer() {
             FeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         ],
-        vec![],
+        vec![FeatureFlag::DEFAULT_ACCOUNT_RESOURCE],
     );
 
     let alice = Account::new();
@@ -298,7 +298,7 @@ fn test_account_not_exist_move_abort_with_fee_payer_out_of_gas() {
             FeatureFlag::GAS_PAYER_ENABLED,
             FeatureFlag::SPONSORED_AUTOMATIC_ACCOUNT_V1_CREATION,
         ],
-        vec![],
+        vec![FeatureFlag::DEFAULT_ACCOUNT_RESOURCE],
     );
 
     let alice = Account::new();

--- a/aptos-move/framework/aptos-framework/doc/transaction_validation.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_validation.md
@@ -554,10 +554,16 @@ Only called during genesis to initialize system resources for this module.
     // Check <b>if</b> the authentication key is valid
     <b>if</b> (!<a href="transaction_validation.md#0x1_transaction_validation_skip_auth_key_check">skip_auth_key_check</a>(is_simulation, &txn_authentication_key)) {
         <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_is_some">option::is_some</a>(&txn_authentication_key)) {
-            <b>assert</b>!(
-                txn_authentication_key == <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(sender_address)),
-                <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
-            );
+            <b>if</b> (
+                sender_address == gas_payer_address ||
+                <a href="account.md#0x1_account_exists_at">account::exists_at</a>(sender_address) ||
+                !<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_sponsored_automatic_account_creation_enabled">features::sponsored_automatic_account_creation_enabled</a>()
+            ) {
+                <b>assert</b>!(
+                    txn_authentication_key == <a href="../../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(<a href="account.md#0x1_account_get_authentication_key">account::get_authentication_key</a>(sender_address)),
+                    <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="transaction_validation.md#0x1_transaction_validation_PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY">PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY</a>),
+                );
+            };
         } <b>else</b> {
             <b>assert</b>!(
                 <a href="transaction_validation.md#0x1_transaction_validation_allow_missing_txn_authentication_key">allow_missing_txn_authentication_key</a>(sender_address),

--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -147,10 +147,16 @@ module aptos_framework::transaction_validation {
         // Check if the authentication key is valid
         if (!skip_auth_key_check(is_simulation, &txn_authentication_key)) {
             if (option::is_some(&txn_authentication_key)) {
-                assert!(
-                    txn_authentication_key == option::some(account::get_authentication_key(sender_address)),
-                    error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
-                );
+                if (
+                    sender_address == gas_payer_address ||
+                    account::exists_at(sender_address) ||
+                    !features::sponsored_automatic_account_creation_enabled()
+                ) {
+                    assert!(
+                        txn_authentication_key == option::some(account::get_authentication_key(sender_address)),
+                        error::invalid_argument(PROLOGUE_EINVALID_ACCOUNT_AUTH_KEY),
+                    );
+                };
             } else {
                 assert!(
                     allow_missing_txn_authentication_key(sender_address),


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
This is to patch an issue where sponsored txns were failing.

Now we will only do the auth key check if any of the following is true
1. Its not sponsored
2. The account exists
3. sponsored_automatic_account_creation is NOT enabled

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

The existing move harness tests with stateless accounts disabled

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
