### PR TITLE
Remove redundant comment in test case

### DIFF
--- a/third_party/move/move-compiler-v2/tests/ability-check/fv_as_keys/compiler_ok_case.move
+++ b/third_party/move/move-compiler-v2/tests/ability-check/fv_as_keys/compiler_ok_case.move
@@ -18,7 +18,6 @@ module 0x99::basic_struct {
 
   public fun test_driver(acc: &signer){
     // ok case
-    // note: while this case passes the compiler, it will not pass the VM because we cannot store functions with reference args
     let f: | &||u64 |u64 has copy+store+drop = test;
     add_resource_with_struct(acc, f);
   }


### PR DESCRIPTION
## Description
This PR removes a redundant comment from a test case merged into PR #16878

## How Has This Been Tested?
- Existing test cases

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
