### PR TITLE
[vm] Fix function value tags

### DIFF
--- a/testsuite/fuzzer/fuzz/fuzz_targets/move/type_tag_to_string.rs
+++ b/testsuite/fuzzer/fuzz/fuzz_targets/move/type_tag_to_string.rs
@@ -5,6 +5,7 @@
 use arbitrary::Arbitrary;
 use libfuzzer_sys::{fuzz_target, Corpus};
 use move_core_types::{ability::AbilitySet, identifier::Identifier, language_storage::TypeTag};
+
 mod utils;
 
 #[derive(Arbitrary, Debug)]
@@ -24,8 +25,14 @@ fn is_valid_type_tag(type_tag: &TypeTag) -> bool {
         TypeTag::Vector(inner_type_tag) => is_valid_type_tag(inner_type_tag),
         TypeTag::Function(function_tag) => {
             function_tag.abilities.into_u8() <= AbilitySet::ALL.into_u8()
-                && function_tag.args.iter().all(is_valid_type_tag)
-                && function_tag.results.iter().all(is_valid_type_tag)
+                && function_tag
+                    .args
+                    .iter()
+                    .all(|t| is_valid_type_tag(t.inner_tag()))
+                && function_tag
+                    .results
+                    .iter()
+                    .all(|t| is_valid_type_tag(t.inner_tag()))
         },
         _ => true, // Primitive types are always valid
     }

--- a/testsuite/generate-format/src/api.rs
+++ b/testsuite/generate-format/src/api.rs
@@ -97,6 +97,7 @@ pub fn get_registry() -> Result<Registry> {
     // 2. Trace the main entry point(s) + every enum separately.
     // stdlib types
     tracer.trace_type::<contract_event::ContractEvent>(&samples)?;
+    tracer.trace_type::<language_storage::FunctionParamOrReturnTag>(&samples)?;
     tracer.trace_type::<language_storage::TypeTag>(&samples)?;
     tracer.trace_type::<ValidatorTransaction>(&samples)?;
     tracer.trace_type::<BlockMetadataExt>(&samples)?;

--- a/testsuite/generate-format/src/aptos.rs
+++ b/testsuite/generate-format/src/aptos.rs
@@ -91,6 +91,7 @@ pub fn get_registry() -> Result<Registry> {
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<contract_event::ContractEvent>(&samples)?;
+    tracer.trace_type::<language_storage::FunctionParamOrReturnTag>(&samples)?;
     tracer.trace_type::<language_storage::TypeTag>(&samples)?;
     tracer.trace_type::<ValidatorTransaction>(&samples)?;
     tracer.trace_type::<BlockMetadataExt>(&samples)?;

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -90,6 +90,7 @@ pub fn get_registry() -> Result<Registry> {
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<contract_event::ContractEvent>(&samples)?;
+    tracer.trace_type::<language_storage::FunctionParamOrReturnTag>(&samples)?;
     tracer.trace_type::<language_storage::TypeTag>(&samples)?;
     tracer.trace_type::<ValidatorTransaction>(&samples)?;
     tracer.trace_type::<BlockMetadataExt>(&samples)?;

--- a/testsuite/generate-format/src/move_abi.rs
+++ b/testsuite/generate-format/src/move_abi.rs
@@ -19,6 +19,7 @@ pub fn get_registry() -> Result<Registry> {
 
     // 2. Trace the main entry point(s) + every enum separately.
     tracer.trace_type::<transaction::EntryABI>(&samples)?;
+    tracer.trace_type::<language_storage::FunctionParamOrReturnTag>(&samples)?;
     tracer.trace_type::<language_storage::TypeTag>(&samples)?;
 
     // aliases within StructTag

--- a/testsuite/generate-format/tests/staged/api.yaml
+++ b/testsuite/generate-format/tests/staged/api.yaml
@@ -361,6 +361,20 @@ FeeDistribution:
               MAP:
                 KEY: U64
                 VALUE: U64
+FunctionParamOrReturnTag:
+  ENUM:
+    0:
+      Reference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    1:
+      MutableReference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    2:
+      Value:
+        NEWTYPE:
+          TYPENAME: TypeTag
 FunctionInfo:
   STRUCT:
     - module_address:
@@ -371,10 +385,10 @@ FunctionTag:
   STRUCT:
     - args:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - results:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - abilities:
         TYPENAME: AbilitySet
 G1Bytes:

--- a/testsuite/generate-format/tests/staged/aptos.yaml
+++ b/testsuite/generate-format/tests/staged/aptos.yaml
@@ -307,6 +307,20 @@ FeeDistribution:
               MAP:
                 KEY: U64
                 VALUE: U64
+FunctionParamOrReturnTag:
+  ENUM:
+    0:
+      Reference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    1:
+      MutableReference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    2:
+      Value:
+        NEWTYPE:
+          TYPENAME: TypeTag
 FunctionInfo:
   STRUCT:
     - module_address:
@@ -317,10 +331,10 @@ FunctionTag:
   STRUCT:
     - args:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - results:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - abilities:
         TYPENAME: AbilitySet
 G1Bytes:

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -608,6 +608,20 @@ FeeDistribution:
               MAP:
                 KEY: U64
                 VALUE: U64
+FunctionParamOrReturnTag:
+  ENUM:
+    0:
+      Reference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    1:
+      MutableReference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    2:
+      Value:
+        NEWTYPE:
+          TYPENAME: TypeTag
 FunctionInfo:
   STRUCT:
     - module_address:
@@ -618,10 +632,10 @@ FunctionTag:
   STRUCT:
     - args:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - results:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - abilities:
         TYPENAME: AbilitySet
 G1Bytes:

--- a/testsuite/generate-format/tests/staged/move_abi.yaml
+++ b/testsuite/generate-format/tests/staged/move_abi.yaml
@@ -21,14 +21,28 @@ EntryABI:
       EntryFunction:
         NEWTYPE:
           TYPENAME: ScriptFunctionABI
+FunctionParamOrReturnTag:
+  ENUM:
+    0:
+      Reference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    1:
+      MutableReference:
+        NEWTYPE:
+          TYPENAME: TypeTag
+    2:
+      Value:
+        NEWTYPE:
+          TYPENAME: TypeTag
 FunctionTag:
   STRUCT:
     - args:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - results:
         SEQ:
-          TYPENAME: TypeTag
+          TYPENAME: FunctionParamOrReturnTag
     - abilities:
         TYPENAME: AbilitySet
 Identifier:

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/funs_as_storage_key.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/funs_as_storage_key.exp
@@ -1,7 +1,10 @@
-processed 4 tasks
+processed 13 tasks
 
-task 2 'run'. lines 72-72:
+task 5 'run'. lines 162-162:
 return values: true
 
-task 3 'run'. lines 74-74:
+task 6 'run'. lines 164-164:
 return values: true
+
+task 12 'run'. lines 176-176:
+return values: 6

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/funs_as_storage_key.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/funs_as_storage_key.move
@@ -69,6 +69,108 @@ module 0x42::mod3 {
     }
 }
 
+//# publish
+module 0x42::mod4 {
+    struct Wrapper<T> has key {
+        fv: T
+    }
+
+    #[persistent]
+    fun test(ref: &u64, _mut_ref: &mut u8): &u64 {
+        ref
+    }
+
+    fun initialize(acc: &signer) {
+        move_to<Wrapper<|&u64, &mut u8|&u64 has copy+store+drop>>(acc, Wrapper { fv: 0x42::mod4::test});
+    }
+
+    fun check_exists(_acc: &signer) {
+        let exists = exists<Wrapper<|&u64, &mut u8|&u64 has copy+store+drop>>(@0x42);
+        assert!(exists, 404);
+    }
+}
+
+//# publish
+module 0x42::mod5 {
+    struct VecWrapper<T> has key {
+        fvs: vector<T>
+    }
+
+    #[persistent]
+    fun test(ref: &u64, _mut_ref: &mut u8): &u64 {
+        ref
+    }
+
+    fun initialize(acc: &signer) {
+        move_to<VecWrapper<|&u64, &mut u8|&u64 has copy+store+drop>>(acc, VecWrapper { fvs: vector[0x42::mod5::test]});
+    }
+
+    fun check_exists(_acc: &signer) {
+        let exists = exists<VecWrapper<|&u64, &mut u8|&u64 has copy+store+drop>>(@0x42);
+        assert!(exists, 404);
+    }
+}
+
+//# publish
+module 0x42::mod6 {
+    struct VecWrapper<T> has key {
+        fvs: vector<T>
+    }
+
+    #[persistent]
+    fun test1(x: &mut u8) {
+        *x = *x + 1;
+    }
+
+    #[persistent]
+    fun test2(x: &mut u8) {
+        *x = *x + 2;
+    }
+
+    #[persistent]
+    fun test3(x: &mut u8) {
+        *x = *x + 3;
+    }
+
+    fun initialize(acc: &signer) {
+        let fvs = vector[
+            0x42::mod6::test1,
+            0x42::mod6::test2,
+            0x42::mod6::test3,
+        ];
+        move_to<VecWrapper<|&mut u8| has copy+store+drop>>(acc, VecWrapper { fvs });
+    }
+
+    fun compute(_acc: &signer): u8 {
+        let do_not_exist = !exists<VecWrapper<|&mut u8| has store+drop>>(@0x42)
+            && !exists<VecWrapper<|&mut u8| has store>>(@0x42);
+        assert!(do_not_exist, 404);
+
+        let wrapper = &borrow_global<VecWrapper<|&mut u8| has copy+store+drop>>(@0x42).fvs;
+        let x = 0;
+
+        let i = 0;
+        while (i < 3) {
+            let f = std::vector::borrow(wrapper, i);
+            (*f)(&mut x);
+            i = i + 1;
+        };
+        x
+    }
+}
+
 //# run 0x42::mod3::test_items --signers 0x42 --args true
 
 //# run 0x42::mod3::test_items --signers 0x42 --args false
+
+//# run 0x42::mod4::initialize --signers 0x42
+
+//# run 0x42::mod4::check_exists --signers 0x42
+
+//# run 0x42::mod5::initialize --signers 0x42
+
+//# run 0x42::mod5::check_exists --signers 0x42
+
+//# run 0x42::mod6::initialize --signers 0x42
+
+//# run 0x42::mod6::compute --signers 0x42

--- a/third_party/move/move-core/types/src/language_storage.rs
+++ b/third_party/move/move-core/types/src/language_storage.rs
@@ -6,6 +6,7 @@ use crate::{
     ability::AbilitySet,
     account_address::AccountAddress,
     identifier::{IdentStr, Identifier},
+    language_storage::FunctionParamOrReturnTag::{MutableReference, Reference, Value},
     parser::{parse_module_id, parse_struct_tag, parse_type_tag},
     safe_serialize,
 };
@@ -137,8 +138,13 @@ impl<'a> Iterator for TypeTagPreorderTraversalIter<'a> {
                     Struct(struct_tag) => self.stack.extend(struct_tag.type_args.iter().rev()),
                     Function(fun_tag) => {
                         let FunctionTag { args, results, .. } = fun_tag.as_ref();
-                        self.stack
-                            .extend(results.iter().rev().chain(args.iter().rev()))
+                        self.stack.extend(
+                            results
+                                .iter()
+                                .map(|t| t.inner_tag())
+                                .rev()
+                                .chain(args.iter().map(|t| t.inner_tag()).rev()),
+                        )
                     },
                 }
                 Some(ty)
@@ -257,8 +263,8 @@ impl FromStr for StructTag {
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
 #[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
 pub struct FunctionTag {
-    pub args: Vec<TypeTag>,
-    pub results: Vec<TypeTag>,
+    pub args: Vec<FunctionParamOrReturnTag>,
+    pub results: Vec<FunctionParamOrReturnTag>,
     pub abilities: AbilitySet,
 }
 
@@ -267,7 +273,7 @@ impl FunctionTag {
     ///
     /// INVARIANT: If two function tags are different, they must have different canonical strings.
     pub fn to_canonical_string(&self) -> String {
-        let fmt_list = |l: &[TypeTag]| -> String {
+        let fmt_list = |l: &[FunctionParamOrReturnTag]| -> String {
             l.iter()
                 .map(|t| t.to_canonical_string())
                 .collect::<Vec<_>>()
@@ -287,6 +293,42 @@ impl FunctionTag {
             fmt_list(&self.results),
             self.abilities.display_postfix()
         )
+    }
+}
+
+/// Represents an argument or return tag for [FunctionTag]. This is needed because function tags
+/// carry information about return and argument types which can be references. So direct return
+/// or paramter tags can be references, but not the inner tags.
+#[derive(Serialize, Deserialize, Debug, PartialEq, Hash, Eq, Clone, PartialOrd, Ord)]
+#[cfg_attr(
+    any(test, feature = "fuzzing"),
+    derive(arbitrary::Arbitrary, dearbitrary::Dearbitrary)
+)]
+#[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
+#[cfg_attr(any(test, feature = "fuzzing"), proptest(no_params))]
+pub enum FunctionParamOrReturnTag {
+    Reference(TypeTag),
+    MutableReference(TypeTag),
+    Value(TypeTag),
+}
+
+impl FunctionParamOrReturnTag {
+    /// Returns a canonical string representation of function tag's argument or return tag. If any
+    /// two tags are different, their canonical representation must be also different.
+    pub fn to_canonical_string(&self) -> String {
+        use FunctionParamOrReturnTag::*;
+        match self {
+            Reference(tag) => format!("&{}", tag.to_canonical_string()),
+            MutableReference(tag) => format!("&mut {}", tag.to_canonical_string()),
+            Value(tag) => tag.to_canonical_string(),
+        }
+    }
+
+    /// Returns the inner tag for this argument or return tag.
+    pub fn inner_tag(&self) -> &TypeTag {
+        match self {
+            Reference(tag) | MutableReference(tag) | Value(tag) => tag,
+        }
     }
 }
 
@@ -423,8 +465,8 @@ mod tests {
     }
 
     fn make_function_tag(
-        args: Vec<TypeTag>,
-        results: Vec<TypeTag>,
+        args: Vec<FunctionParamOrReturnTag>,
+        results: Vec<FunctionParamOrReturnTag>,
         abilities: AbilitySet,
     ) -> TypeTag {
         TypeTag::Function(Box::new(FunctionTag {
@@ -436,6 +478,7 @@ mod tests {
 
     #[test]
     fn test_to_canonical_string() {
+        use FunctionParamOrReturnTag::*;
         use TypeTag::*;
 
         let data = [
@@ -467,25 +510,33 @@ mod tests {
             ),
             (make_function_tag(vec![], vec![], AbilitySet::EMPTY), "||()"),
             (
-                make_function_tag(vec![], vec![U8, U64], AbilitySet::EMPTY),
-                "||(u8, u64)",
+                make_function_tag(
+                    vec![],
+                    vec![MutableReference(U8), Value(U64)],
+                    AbilitySet::EMPTY,
+                ),
+                "||(&mut u8, u64)",
             ),
             (
-                make_function_tag(vec![U8, U64], vec![], AbilitySet::EMPTY),
-                "|u8, u64|()",
+                make_function_tag(vec![Reference(U8), Value(U64)], vec![], AbilitySet::EMPTY),
+                "|&u8, u64|()",
             ),
             (
                 make_struct_tag(AccountAddress::ONE, "a", "A", vec![make_function_tag(
-                    vec![make_function_tag(
-                        vec![make_function_tag(
+                    vec![Value(make_function_tag(
+                        vec![Value(make_function_tag(
                             vec![],
                             vec![],
                             AbilitySet::singleton(Ability::Copy),
-                        )],
+                        ))],
                         vec![],
                         AbilitySet::EMPTY,
-                    )],
-                    vec![make_function_tag(vec![], vec![], AbilitySet::ALL)],
+                    ))],
+                    vec![FunctionParamOrReturnTag::Value(make_function_tag(
+                        vec![],
+                        vec![],
+                        AbilitySet::ALL,
+                    ))],
                     AbilitySet::EMPTY,
                 )]),
                 "0x1::a::A<||||() has copy|()|(||() has copy + drop + store + key)>",

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -21,7 +21,7 @@ use move_binary_format::{
 };
 use move_core_types::{
     ability::{Ability, AbilitySet},
-    language_storage::{FunctionTag, StructTag, TypeTag},
+    language_storage::{FunctionParamOrReturnTag, FunctionTag, StructTag, TypeTag},
     u256::U256,
 };
 use num::BigInt;
@@ -1496,8 +1496,22 @@ impl Type {
                     results,
                     abilities,
                 } = fun.as_ref();
-                let from_vec = |ts: &[TypeTag]| {
-                    Type::tuple(ts.iter().map(|t| Type::from_type_tag(t, env)).collect_vec())
+                let from_vec = |ts: &[FunctionParamOrReturnTag]| {
+                    Type::tuple(
+                        ts.iter()
+                            .map(|t| match t {
+                                FunctionParamOrReturnTag::Reference(t) => Reference(
+                                    ReferenceKind::Immutable,
+                                    Box::new(Type::from_type_tag(t, env)),
+                                ),
+                                FunctionParamOrReturnTag::MutableReference(t) => Reference(
+                                    ReferenceKind::Mutable,
+                                    Box::new(Type::from_type_tag(t, env)),
+                                ),
+                                FunctionParamOrReturnTag::Value(t) => Type::from_type_tag(t, env),
+                            })
+                            .collect_vec(),
+                    )
                 };
                 Fun(
                     Box::new(from_vec(args)),

--- a/third_party/move/move-vm/types/src/values/serialization_tests.rs
+++ b/third_party/move/move-vm/types/src/values/serialization_tests.rs
@@ -18,7 +18,7 @@ mod tests {
         account_address::AccountAddress,
         function::{ClosureMask, MoveClosure, FUNCTION_DATA_SERIALIZATION_FORMAT_V1},
         identifier::Identifier,
-        language_storage::{FunctionTag, ModuleId, StructTag, TypeTag},
+        language_storage::{FunctionParamOrReturnTag, FunctionTag, ModuleId, StructTag, TypeTag},
         u256,
         value::{IdentifierMappingKind, MoveStruct, MoveStructLayout, MoveTypeLayout, MoveValue},
     };
@@ -214,13 +214,15 @@ mod tests {
         vec![
             TypeTag::Address,
             TypeTag::Function(Box::new(FunctionTag {
-                args: vec![TypeTag::Struct(Box::new(StructTag {
-                    address: AccountAddress::TEN,
-                    module: Identifier::new("mod").unwrap(),
-                    name: Identifier::new("st").unwrap(),
-                    type_args: vec![TypeTag::Signer],
-                }))],
-                results: vec![TypeTag::Address],
+                args: vec![FunctionParamOrReturnTag::Value(TypeTag::Struct(Box::new(
+                    StructTag {
+                        address: AccountAddress::TEN,
+                        module: Identifier::new("mod").unwrap(),
+                        name: Identifier::new("st").unwrap(),
+                        type_args: vec![TypeTag::Signer],
+                    },
+                )))],
+                results: vec![FunctionParamOrReturnTag::Value(TypeTag::Address)],
                 abilities: AbilitySet::PUBLIC_FUNCTIONS,
             })),
         ]


### PR DESCRIPTION
## Description

Function value argument and return types can be references, but before type tags did not support references. Adding support for this case by having an explicit `FunctionArgOrReturnTag` stored in function tag's argument and returns lists:

```rust
pub enum FunctionArgOrReturnTag {
    Reference(TypeTag),
    MutableReference(TypeTag),
    Value(TypeTag),
}
```

## How Has This Been Tested?

Transactional test.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?

- [x] Move/Aptos Virtual Machine

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
