### PR TITLE
[Storage Service] Add new request types for txn V2 data.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -404,7 +404,11 @@ pub struct AptosDataClientConfig {
     pub latency_monitor_loop_interval_ms: u64,
     /// Maximum number of epoch ending ledger infos per chunk
     pub max_epoch_chunk_size: u64,
-    /// Maximum number of output reductions before transactions are returned
+    /// Maximum number of output reductions (division by 2) before transactions are returned,
+    /// e.g., if 1000 outputs are requested in a single data chunk, and this is set to 1, then
+    /// we'll accept anywhere between 1000 and 500 outputs. Any less, and the server should
+    /// return transactions instead of outputs.
+    // TODO: migrate away from this, and use cleaner chunk packing configs and logic.
     pub max_num_output_reductions: u64,
     /// Maximum lag (in seconds) we'll tolerate when sending optimistic fetch requests
     pub max_optimistic_fetch_lag_secs: u64,

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -102,6 +102,17 @@ impl<T: StorageReaderInterface> Handler<T> {
             request.get_label(),
         );
 
+        // If the request is for v2 data, drop the message (v2 is not supported yet)
+        if request.data_request.is_transaction_data_v2_request() {
+            warn!(LogSchema::new(LogEntry::StorageServiceError)
+                .error(&Error::InvalidRequest(
+                    "Received a v2 data request, which is not supported yet!".into()
+                ))
+                .peer_network_id(&peer_network_id)
+                .request(&request));
+            return;
+        }
+
         // Handle any optimistic fetch requests
         if request.data_request.is_optimistic_fetch() {
             self.handle_optimistic_fetch_request(peer_network_id, request, response_sender);

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -2,13 +2,18 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    requests::DataRequest::{
-        GetEpochEndingLedgerInfos, GetNewTransactionOutputsWithProof,
-        GetNewTransactionsOrOutputsWithProof, GetNewTransactionsWithProof,
-        GetNumberOfStatesAtVersion, GetServerProtocolVersion, GetStateValuesWithProof,
-        GetStorageServerSummary, GetTransactionOutputsWithProof, GetTransactionsOrOutputsWithProof,
-        GetTransactionsWithProof, SubscribeTransactionOutputsWithProof,
-        SubscribeTransactionsOrOutputsWithProof, SubscribeTransactionsWithProof,
+    requests::{
+        DataRequest::{
+            GetEpochEndingLedgerInfos, GetNewTransactionDataWithProof,
+            GetNewTransactionOutputsWithProof, GetNewTransactionsOrOutputsWithProof,
+            GetNewTransactionsWithProof, GetNumberOfStatesAtVersion, GetServerProtocolVersion,
+            GetStateValuesWithProof, GetStorageServerSummary, GetTransactionDataWithProof,
+            GetTransactionOutputsWithProof, GetTransactionsOrOutputsWithProof,
+            GetTransactionsWithProof, SubscribeTransactionDataWithProof,
+            SubscribeTransactionOutputsWithProof, SubscribeTransactionsOrOutputsWithProof,
+            SubscribeTransactionsWithProof,
+        },
+        TransactionDataRequestType,
     },
     responses::Error::DegenerateRangeError,
     Epoch, StorageServiceRequest, COMPRESSION_SUFFIX_LABEL,
@@ -488,71 +493,23 @@ impl DataSummary {
 
                 can_serve_states && can_create_proof
             },
-            GetTransactionOutputsWithProof(request) => {
-                let desired_range =
-                    match CompleteDataRange::new(request.start_version, request.end_version) {
-                        Ok(desired_range) => desired_range,
-                        Err(_) => return false,
-                    };
-
-                let can_serve_outputs = self
-                    .transaction_outputs
-                    .map(|range| range.superset_of(&desired_range))
-                    .unwrap_or(false);
-
-                let can_create_proof = self
-                    .synced_ledger_info
-                    .as_ref()
-                    .map(|li| li.ledger_info().version() >= request.proof_version)
-                    .unwrap_or(false);
-
-                can_serve_outputs && can_create_proof
-            },
-            GetTransactionsWithProof(request) => {
-                let desired_range =
-                    match CompleteDataRange::new(request.start_version, request.end_version) {
-                        Ok(desired_range) => desired_range,
-                        Err(_) => return false,
-                    };
-
-                let can_serve_txns = self
-                    .transactions
-                    .map(|range| range.superset_of(&desired_range))
-                    .unwrap_or(false);
-
-                let can_create_proof = self
-                    .synced_ledger_info
-                    .as_ref()
-                    .map(|li| li.ledger_info().version() >= request.proof_version)
-                    .unwrap_or(false);
-
-                can_serve_txns && can_create_proof
-            },
-            GetTransactionsOrOutputsWithProof(request) => {
-                let desired_range =
-                    match CompleteDataRange::new(request.start_version, request.end_version) {
-                        Ok(desired_range) => desired_range,
-                        Err(_) => return false,
-                    };
-
-                let can_serve_txns = self
-                    .transactions
-                    .map(|range| range.superset_of(&desired_range))
-                    .unwrap_or(false);
-
-                let can_serve_outputs = self
-                    .transaction_outputs
-                    .map(|range| range.superset_of(&desired_range))
-                    .unwrap_or(false);
-
-                let can_create_proof = self
-                    .synced_ledger_info
-                    .as_ref()
-                    .map(|li| li.ledger_info().version() >= request.proof_version)
-                    .unwrap_or(false);
-
-                can_serve_txns && can_serve_outputs && can_create_proof
-            },
+            GetTransactionOutputsWithProof(request) => self
+                .can_service_transaction_outputs_with_proof(
+                    request.start_version,
+                    request.end_version,
+                    request.proof_version,
+                ),
+            GetTransactionsWithProof(request) => self.can_service_transactions_with_proof(
+                request.start_version,
+                request.end_version,
+                request.proof_version,
+            ),
+            GetTransactionsOrOutputsWithProof(request) => self
+                .can_service_transactions_or_outputs_with_proof(
+                    request.start_version,
+                    request.end_version,
+                    request.proof_version,
+                ),
             SubscribeTransactionOutputsWithProof(_) => can_service_subscription_request(
                 aptos_data_client_config,
                 time_service,
@@ -568,7 +525,113 @@ impl DataSummary {
                 time_service,
                 self.synced_ledger_info.as_ref(),
             ),
+
+            // Transaction data v2 requests (transactions with auxiliary data)
+            GetTransactionDataWithProof(request) => match request.transaction_data_request_type {
+                TransactionDataRequestType::TransactionData(_) => self
+                    .can_service_transactions_with_proof(
+                        request.start_version,
+                        request.end_version,
+                        request.proof_version,
+                    ),
+                TransactionDataRequestType::TransactionOutputData => self
+                    .can_service_transaction_outputs_with_proof(
+                        request.start_version,
+                        request.end_version,
+                        request.proof_version,
+                    ),
+                TransactionDataRequestType::TransactionOrOutputData(_) => self
+                    .can_service_transactions_or_outputs_with_proof(
+                        request.start_version,
+                        request.end_version,
+                        request.proof_version,
+                    ),
+            },
+            GetNewTransactionDataWithProof(_) => can_service_optimistic_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
+            SubscribeTransactionDataWithProof(_) => can_service_subscription_request(
+                aptos_data_client_config,
+                time_service,
+                self.synced_ledger_info.as_ref(),
+            ),
         }
+    }
+
+    /// Returns true iff the peer can create a proof for the given version
+    fn can_create_proof(&self, proof_version: u64) -> bool {
+        self.synced_ledger_info
+            .as_ref()
+            .map(|li| li.ledger_info().version() >= proof_version)
+            .unwrap_or(false)
+    }
+
+    /// Returns true iff the peer can service the transaction outputs in the given range
+    fn can_service_transaction_outputs(&self, desired_range: &CompleteDataRange<u64>) -> bool {
+        self.transaction_outputs
+            .map(|range| range.superset_of(desired_range))
+            .unwrap_or(false)
+    }
+
+    /// Returns true iff the peer can service the transactions in the given range
+    fn can_service_transactions(&self, desired_range: &CompleteDataRange<u64>) -> bool {
+        self.transactions
+            .map(|range| range.superset_of(desired_range))
+            .unwrap_or(false)
+    }
+
+    /// Returns true iff the peer can service the transaction outputs and proof
+    fn can_service_transaction_outputs_with_proof(
+        &self,
+        start_version: u64,
+        end_version: u64,
+        proof_version: u64,
+    ) -> bool {
+        let desired_range = match CompleteDataRange::new(start_version, end_version) {
+            Ok(desired_range) => desired_range,
+            Err(_) => return false,
+        };
+
+        let can_service_outputs = self.can_service_transaction_outputs(&desired_range);
+        let can_create_proof = self.can_create_proof(proof_version);
+        can_service_outputs && can_create_proof
+    }
+
+    /// Returns true iff the peer can service the transactions or outputs and proof
+    fn can_service_transactions_or_outputs_with_proof(
+        &self,
+        start_version: u64,
+        end_version: u64,
+        proof_version: u64,
+    ) -> bool {
+        let desired_range = match CompleteDataRange::new(start_version, end_version) {
+            Ok(desired_range) => desired_range,
+            Err(_) => return false,
+        };
+
+        let can_service_transactions = self.can_service_transactions(&desired_range);
+        let can_service_outputs = self.can_service_transaction_outputs(&desired_range);
+        let can_create_proof = self.can_create_proof(proof_version);
+        can_service_transactions && can_service_outputs && can_create_proof
+    }
+
+    /// Returns true iff the peer can service the transactions and proof
+    fn can_service_transactions_with_proof(
+        &self,
+        start_version: u64,
+        end_version: u64,
+        proof_version: u64,
+    ) -> bool {
+        let desired_range = match CompleteDataRange::new(start_version, end_version) {
+            Ok(desired_range) => desired_range,
+            Err(_) => return false,
+        };
+
+        let can_service_transactions = self.can_service_transactions(&desired_range);
+        let can_create_proof = self.can_create_proof(proof_version);
+        can_service_transactions && can_create_proof
     }
 
     /// Returns the version of the synced ledger info (if one exists)

--- a/state-sync/storage-service/types/src/tests.rs
+++ b/state-sync/storage-service/types/src/tests.rs
@@ -3,11 +3,14 @@
 
 use crate::{
     requests::{
-        DataRequest, EpochEndingLedgerInfoRequest, NewTransactionOutputsWithProofRequest,
+        DataRequest, EpochEndingLedgerInfoRequest, GetNewTransactionDataWithProofRequest,
+        GetTransactionDataWithProofRequest, NewTransactionOutputsWithProofRequest,
         NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StateValuesWithProofRequest, SubscribeTransactionOutputsWithProofRequest,
+        StateValuesWithProofRequest, SubscribeTransactionDataWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
-        SubscriptionStreamMetadata, TransactionOutputsWithProofRequest,
+        SubscriptionStreamMetadata, TransactionData, TransactionDataRequestType,
+        TransactionOrOutputData, TransactionOutputsWithProofRequest,
         TransactionsOrOutputsWithProofRequest, TransactionsWithProofRequest,
     },
     responses::{CompleteDataRange, DataSummary, ProtocolMetadata},
@@ -91,349 +94,381 @@ fn test_data_summary_service_epoch_ending_ledger_infos() {
 
 #[test]
 fn test_data_summary_service_optimistic_fetch() {
-    // Create a data client config with the specified max optimistic fetch lag
-    let max_optimistic_fetch_lag_secs = 50;
-    let data_client_config = AptosDataClientConfig {
-        max_optimistic_fetch_lag_secs,
-        ..Default::default()
-    };
+    // Test both v1 and v2 transaction requests
+    for use_request_v2 in [false, true] {
+        // Create a data client config with the specified max optimistic fetch lag
+        let max_optimistic_fetch_lag_secs = 50;
+        let data_client_config = AptosDataClientConfig {
+            max_optimistic_fetch_lag_secs,
+            ..Default::default()
+        };
 
-    // Create a mock time service and get the current timestamp
-    let time_service = TimeService::mock();
-    let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+        // Create a mock time service and get the current timestamp
+        let time_service = TimeService::mock();
+        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
 
-    // Create a data summary with the specified synced ledger info
-    let highest_synced_version = 10_000;
-    let data_summary = DataSummary {
-        synced_ledger_info: Some(create_ledger_info_at_version_and_timestamp(
-            highest_synced_version,
-            timestamp_usecs,
-        )),
-        ..Default::default()
-    };
+        // Create a data summary with the specified synced ledger info
+        let highest_synced_version = 10_000;
+        let data_summary = DataSummary {
+            synced_ledger_info: Some(create_ledger_info_at_version_and_timestamp(
+                highest_synced_version,
+                timestamp_usecs,
+            )),
+            ..Default::default()
+        };
 
-    // Elapse the time service by half the max optimistic fetch lag
-    time_service
-        .clone()
-        .into_mock()
-        .advance_secs(max_optimistic_fetch_lag_secs / 2);
+        // Elapse the time service by half the max optimistic fetch lag
+        time_service
+            .clone()
+            .into_mock()
+            .advance_secs(max_optimistic_fetch_lag_secs / 2);
 
-    // Verify that optimistic fetch requests can be serviced
-    for compression in [true, false] {
-        let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
-        verify_can_service_optimistic_fetch_requests(
-            &data_client_config,
-            &data_summary,
-            time_service.clone(),
-            compression,
-            known_versions,
-            true,
-        );
-    }
+        // Verify that optimistic fetch requests can be serviced
+        for compression in [true, false] {
+            let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
+            verify_can_service_optimistic_fetch_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                time_service.clone(),
+                compression,
+                known_versions,
+                true,
+            );
+        }
 
-    // Elapse the time service by the max optimistic fetch lag
-    time_service
-        .clone()
-        .into_mock()
-        .advance_secs(max_optimistic_fetch_lag_secs);
+        // Elapse the time service by the max optimistic fetch lag
+        time_service
+            .clone()
+            .into_mock()
+            .advance_secs(max_optimistic_fetch_lag_secs);
 
-    // Verify that optimistic fetch requests can no longer be serviced
-    // (as the max lag has been exceeded for the given data summary).
-    for compression in [true, false] {
-        let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
-        verify_can_service_optimistic_fetch_requests(
-            &data_client_config,
-            &data_summary,
-            time_service.clone(),
-            compression,
-            known_versions,
-            false,
-        );
+        // Verify that optimistic fetch requests can no longer be serviced
+        // (as the max lag has been exceeded for the given data summary).
+        for compression in [true, false] {
+            let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
+            verify_can_service_optimistic_fetch_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                time_service.clone(),
+                compression,
+                known_versions,
+                false,
+            );
+        }
     }
 }
 
 #[test]
 fn test_data_summary_service_subscription() {
-    // Create a data client config with the specified max subscription lag
-    let max_subscription_lag_secs = 100;
-    let data_client_config = AptosDataClientConfig {
-        max_subscription_lag_secs,
-        ..Default::default()
-    };
+    // Test both v1 and v2 transaction requests
+    for use_request_v2 in [false, true] {
+        // Create a data client config with the specified max subscription lag
+        let max_subscription_lag_secs = 100;
+        let data_client_config = AptosDataClientConfig {
+            max_subscription_lag_secs,
+            ..Default::default()
+        };
 
-    // Create a mock time service and get the current timestamp
-    let time_service = TimeService::mock();
-    let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
+        // Create a mock time service and get the current timestamp
+        let time_service = TimeService::mock();
+        let timestamp_usecs = time_service.now_unix_time().as_micros() as u64;
 
-    // Create a data summary with the specified synced ledger info
-    let highest_synced_version = 50_000;
-    let data_summary = DataSummary {
-        synced_ledger_info: Some(create_ledger_info_at_version_and_timestamp(
-            highest_synced_version,
-            timestamp_usecs,
-        )),
-        ..Default::default()
-    };
+        // Create a data summary with the specified synced ledger info
+        let highest_synced_version = 50_000;
+        let data_summary = DataSummary {
+            synced_ledger_info: Some(create_ledger_info_at_version_and_timestamp(
+                highest_synced_version,
+                timestamp_usecs,
+            )),
+            ..Default::default()
+        };
 
-    // Elapse the time service by half the max subscription lag
-    time_service
-        .clone()
-        .into_mock()
-        .advance_secs(max_subscription_lag_secs / 2);
+        // Elapse the time service by half the max subscription lag
+        time_service
+            .clone()
+            .into_mock()
+            .advance_secs(max_subscription_lag_secs / 2);
 
-    // Verify that subscription requests can be serviced
-    for compression in [true, false] {
-        let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
-        verify_can_service_subscription_requests(
-            &data_client_config,
-            &data_summary,
-            time_service.clone(),
-            compression,
-            known_versions,
-            true,
-        );
-    }
+        // Verify that subscription requests can be serviced
+        for compression in [true, false] {
+            let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
+            verify_can_service_subscription_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                time_service.clone(),
+                compression,
+                known_versions,
+                true,
+            );
+        }
 
-    // Elapse the time service by the max subscription lag
-    time_service
-        .clone()
-        .into_mock()
-        .advance_secs(max_subscription_lag_secs);
+        // Elapse the time service by the max subscription lag
+        time_service
+            .clone()
+            .into_mock()
+            .advance_secs(max_subscription_lag_secs);
 
-    // Verify that subscription requests can no longer be serviced
-    // (as the max lag has been exceeded for the given data summary).
-    for compression in [true, false] {
-        let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
-        verify_can_service_subscription_requests(
-            &data_client_config,
-            &data_summary,
-            time_service.clone(),
-            compression,
-            known_versions,
-            false,
-        );
+        // Verify that subscription requests can no longer be serviced
+        // (as the max lag has been exceeded for the given data summary).
+        for compression in [true, false] {
+            let known_versions = vec![0, 1, highest_synced_version, highest_synced_version * 2];
+            verify_can_service_subscription_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                time_service.clone(),
+                compression,
+                known_versions,
+                false,
+            );
+        }
     }
 }
 
 #[test]
 fn test_data_summary_service_transactions() {
-    // Create a data client config and data summary
-    let data_client_config = AptosDataClientConfig::default();
-    let data_summary = DataSummary {
-        synced_ledger_info: Some(create_ledger_info_at_version(250)),
-        transactions: Some(create_data_range(100, 200)),
-        ..Default::default()
-    };
+    // Test both v1 and v2 transaction requests
+    for use_request_v2 in [false, true] {
+        // Create a data client config and data summary
+        let data_client_config = AptosDataClientConfig::default();
+        let data_summary = DataSummary {
+            synced_ledger_info: Some(create_ledger_info_at_version(250)),
+            transactions: Some(create_data_range(100, 200)),
+            ..Default::default()
+        };
 
-    // Verify the different requests that can be serviced
-    for compression in [true, false] {
-        // Test the valid data ranges and proofs
-        let valid_ranges_and_proofs = vec![
-            (100, 200, 225),
-            (125, 175, 225),
-            (100, 100, 225),
-            (150, 150, 225),
-            (200, 200, 225),
-            (200, 200, 250),
-        ];
-        verify_can_service_transaction_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            valid_ranges_and_proofs,
-            true,
-        );
+        // Verify the different requests that can be serviced
+        for compression in [true, false] {
+            // Test the valid data ranges and proofs
+            let valid_ranges_and_proofs = vec![
+                (100, 200, 225),
+                (125, 175, 225),
+                (100, 100, 225),
+                (150, 150, 225),
+                (200, 200, 225),
+                (200, 200, 250),
+            ];
+            verify_can_service_transaction_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                valid_ranges_and_proofs,
+                true,
+            );
 
-        // Test the missing data ranges and proofs
-        let missing_data_ranges = vec![
-            (99, 200, 225),
-            (100, 201, 225),
-            (50, 250, 225),
-            (50, 150, 225),
-            (150, 250, 225),
-        ];
-        verify_can_service_transaction_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            missing_data_ranges,
-            false,
-        );
+            // Test the missing data ranges and proofs
+            let missing_data_ranges = vec![
+                (99, 200, 225),
+                (100, 201, 225),
+                (50, 250, 225),
+                (50, 150, 225),
+                (150, 250, 225),
+            ];
+            verify_can_service_transaction_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                missing_data_ranges,
+                false,
+            );
 
-        // Test the invalid data ranges and proofs
-        let invalid_proof_versions = vec![
-            (100, 200, 300),
-            (125, 175, 300),
-            (100, 100, 300),
-            (150, 150, 300),
-            (200, 200, 300),
-            (200, 200, 251),
-        ];
-        verify_can_service_transaction_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            invalid_proof_versions,
-            false,
-        );
+            // Test the invalid data ranges and proofs
+            let invalid_proof_versions = vec![
+                (100, 200, 300),
+                (125, 175, 300),
+                (100, 100, 300),
+                (150, 150, 300),
+                (200, 200, 300),
+                (200, 200, 251),
+            ];
+            verify_can_service_transaction_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                invalid_proof_versions,
+                false,
+            );
+        }
     }
 }
 
 #[test]
 fn test_data_summary_service_transaction_outputs() {
-    // Create a data client config and data summary
-    let data_client_config = AptosDataClientConfig::default();
-    let data_summary = DataSummary {
-        synced_ledger_info: Some(create_ledger_info_at_version(250)),
-        transaction_outputs: Some(create_data_range(100, 200)),
-        ..Default::default()
-    };
+    // Test both v1 and v2 transaction requests
+    for use_request_v2 in [false, true] {
+        // Create a data client config and data summary
+        let data_client_config = AptosDataClientConfig::default();
+        let data_summary = DataSummary {
+            synced_ledger_info: Some(create_ledger_info_at_version(250)),
+            transaction_outputs: Some(create_data_range(100, 200)),
+            ..Default::default()
+        };
 
-    // Verify the different requests that can be serviced
-    for compression in [true, false] {
-        // Test the valid data ranges and proofs
-        let valid_ranges_and_proofs = vec![
-            (100, 200, 225),
-            (125, 175, 225),
-            (100, 100, 225),
-            (150, 150, 225),
-            (200, 200, 225),
-            (200, 200, 250),
-        ];
-        verify_can_service_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            valid_ranges_and_proofs,
-            true,
-        );
+        // Verify the different requests that can be serviced
+        for compression in [true, false] {
+            // Test the valid data ranges and proofs
+            let valid_ranges_and_proofs = vec![
+                (100, 200, 225),
+                (125, 175, 225),
+                (100, 100, 225),
+                (150, 150, 225),
+                (200, 200, 225),
+                (200, 200, 250),
+            ];
+            verify_can_service_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                valid_ranges_and_proofs,
+                true,
+            );
 
-        // Test the missing data ranges and proofs
-        let missing_data_ranges = vec![
-            (99, 200, 225),
-            (100, 201, 225),
-            (50, 250, 225),
-            (50, 150, 225),
-            (150, 250, 225),
-        ];
-        verify_can_service_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            missing_data_ranges,
-            false,
-        );
+            // Test the missing data ranges and proofs
+            let missing_data_ranges = vec![
+                (99, 200, 225),
+                (100, 201, 225),
+                (50, 250, 225),
+                (50, 150, 225),
+                (150, 250, 225),
+            ];
+            verify_can_service_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                missing_data_ranges,
+                false,
+            );
 
-        // Test the valid data ranges and invalid proofs
-        let invalid_proof_versions = vec![
-            (100, 200, 300),
-            (125, 175, 300),
-            (100, 100, 300),
-            (150, 150, 300),
-            (200, 200, 300),
-            (200, 200, 251),
-        ];
-        verify_can_service_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            invalid_proof_versions,
-            false,
-        );
+            // Test the valid data ranges and invalid proofs
+            let invalid_proof_versions = vec![
+                (100, 200, 300),
+                (125, 175, 300),
+                (100, 100, 300),
+                (150, 150, 300),
+                (200, 200, 300),
+                (200, 200, 251),
+            ];
+            verify_can_service_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                invalid_proof_versions,
+                false,
+            );
 
-        // Test the invalid data ranges and proofs
-        let invalid_ranges = vec![(175, 125, 225), (201, 200, 201), (202, 200, 200)];
-        verify_can_service_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            invalid_ranges,
-            false,
-        );
+            // Test the invalid data ranges and proofs
+            let invalid_ranges = vec![(175, 125, 225), (201, 200, 201), (202, 200, 200)];
+            verify_can_service_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                invalid_ranges,
+                false,
+            );
+        }
     }
 }
 
 #[test]
 fn test_data_summary_service_transactions_or_outputs() {
-    // Create a data client config and data summary
-    let data_client_config = AptosDataClientConfig::default();
-    let data_summary = DataSummary {
-        synced_ledger_info: Some(create_ledger_info_at_version(250)),
-        transactions: Some(create_data_range(50, 200)),
-        transaction_outputs: Some(create_data_range(100, 250)),
-        ..Default::default()
-    };
+    // Test both v1 and v2 transaction requests
+    for use_request_v2 in [false, true] {
+        // Create a data client config and data summary
+        let data_client_config = AptosDataClientConfig::default();
+        let data_summary = DataSummary {
+            synced_ledger_info: Some(create_ledger_info_at_version(250)),
+            transactions: Some(create_data_range(50, 200)),
+            transaction_outputs: Some(create_data_range(100, 250)),
+            ..Default::default()
+        };
 
-    // Verify the different requests that can be serviced
-    for compression in [true, false] {
-        // Test the valid data ranges and proofs
-        let valid_ranges_and_proofs = vec![
-            (100, 200, 225),
-            (125, 175, 225),
-            (100, 100, 225),
-            (150, 150, 225),
-            (200, 200, 225),
-            (200, 200, 250),
-        ];
-        verify_can_service_transaction_or_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            valid_ranges_and_proofs,
-            true,
-        );
+        // Verify the different requests that can be serviced
+        for compression in [true, false] {
+            // Test the valid data ranges and proofs
+            let valid_ranges_and_proofs = vec![
+                (100, 200, 225),
+                (125, 175, 225),
+                (100, 100, 225),
+                (150, 150, 225),
+                (200, 200, 225),
+                (200, 200, 250),
+            ];
+            verify_can_service_transaction_or_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                valid_ranges_and_proofs,
+                true,
+            );
 
-        // Test the missing output ranges and proofs
-        let missing_output_ranges = vec![(51, 200, 225), (99, 100, 225), (51, 71, 225)];
-        verify_can_service_transaction_or_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            missing_output_ranges,
-            false,
-        );
+            // Test the missing output ranges and proofs
+            let missing_output_ranges = vec![(51, 200, 225), (99, 100, 225), (51, 71, 225)];
+            verify_can_service_transaction_or_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                missing_output_ranges,
+                false,
+            );
 
-        // Test the missing transaction ranges and proofs
-        let missing_transaction_ranges = vec![(200, 202, 225), (150, 201, 225), (201, 225, 225)];
-        verify_can_service_transaction_or_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            missing_transaction_ranges,
-            false,
-        );
+            // Test the missing transaction ranges and proofs
+            let missing_transaction_ranges =
+                vec![(200, 202, 225), (150, 201, 225), (201, 225, 225)];
+            verify_can_service_transaction_or_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                missing_transaction_ranges,
+                false,
+            );
 
-        // Test the valid data ranges and invalid proofs
-        let invalid_proof_versions = vec![
-            (100, 200, 300),
-            (125, 175, 300),
-            (100, 100, 300),
-            (150, 150, 300),
-            (200, 200, 300),
-            (200, 200, 251),
-        ];
-        verify_can_service_transaction_or_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            invalid_proof_versions,
-            false,
-        );
+            // Test the valid data ranges and invalid proofs
+            let invalid_proof_versions = vec![
+                (100, 200, 300),
+                (125, 175, 300),
+                (100, 100, 300),
+                (150, 150, 300),
+                (200, 200, 300),
+                (200, 200, 251),
+            ];
+            verify_can_service_transaction_or_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                invalid_proof_versions,
+                false,
+            );
 
-        // Test the invalid data ranges and proofs
-        let invalid_ranges = vec![(175, 125, 225), (201, 200, 201), (202, 200, 200)];
-        verify_can_service_transaction_or_output_requests(
-            &data_client_config,
-            &data_summary,
-            compression,
-            invalid_ranges,
-            false,
-        );
+            // Test the invalid data ranges and proofs
+            let invalid_ranges = vec![(175, 125, 225), (201, 200, 201), (202, 200, 200)];
+            verify_can_service_transaction_or_output_requests(
+                use_request_v2,
+                &data_client_config,
+                &data_summary,
+                compression,
+                invalid_ranges,
+                false,
+            );
+        }
     }
 }
 
 #[test]
-fn test_data_summary_can_service_state_chunk_request() {
+fn test_data_summary_service_state_chunk_request() {
     // Create a data client config and data summary
     let data_client_config = AptosDataClientConfig::default();
     let data_summary = DataSummary {
@@ -489,6 +524,39 @@ fn test_protocol_metadata_service() {
         assert!(metadata.can_service(&create_epoch_ending_request(100, 10000, compression)));
         assert!(metadata.can_service(&create_outputs_request(200, 100, 9999989, compression)));
         assert!(metadata.can_service(&create_state_values_request(200, 100, 200, compression)));
+    }
+}
+
+#[test]
+fn test_is_transaction_data_v2_request() {
+    // Create transaction data v1 requests
+    let transactions_request = create_transactions_request(200, 100, 101, false);
+    let outputs_request = create_outputs_request(200, 100, 101, false);
+    let transactions_or_outputs_request =
+        create_transactions_or_outputs_request(200, 100, 101, false);
+
+    // Verify that none of them are v2 requests
+    for request in [
+        transactions_request,
+        outputs_request,
+        transactions_or_outputs_request,
+    ] {
+        assert!(!request.data_request.is_transaction_data_v2_request());
+    }
+
+    // Create transaction data v2 requests
+    let transactions_request_v2 = create_transactions_request_v2(200, 100, 101, false);
+    let outputs_request_v2 = create_outputs_request_v2(200, 100, 101, false);
+    let transactions_or_outputs_request_v2 =
+        create_transactions_or_outputs_request_v2(200, 100, 101, false);
+
+    // Verify that all of them are v2 requests
+    for request in [
+        transactions_request_v2,
+        outputs_request_v2,
+        transactions_or_outputs_request_v2,
+    ] {
+        assert!(request.data_request.is_transaction_data_v2_request());
     }
 }
 
@@ -579,6 +647,34 @@ fn create_optimistic_fetch_request(
     StorageServiceRequest::new(data_request, use_compression)
 }
 
+/// Creates a new optimistic request (v2)
+fn create_optimistic_fetch_request_v2(
+    known_version: u64,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    // Generate a random number
+    let random_number = get_random_u64();
+
+    // Determine the data request type based on the random number
+    let transaction_data_request_type = if random_number % 3 == 0 {
+        TransactionDataRequestType::TransactionData(TransactionData {
+            include_events: false,
+        })
+    } else if random_number % 3 == 1 {
+        TransactionDataRequestType::TransactionOutputData
+    } else {
+        TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+            include_events: false,
+        })
+    };
+    let data_request = create_new_transaction_data_request(
+        transaction_data_request_type,
+        known_version,
+        get_random_u64(),
+    );
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
 /// Creates a request for transaction outputs
 fn create_outputs_request(
     proof_version: Version,
@@ -592,6 +688,23 @@ fn create_outputs_request(
             start_version,
             end_version,
         });
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
+/// Creates a request for transaction outputs (v2)
+fn create_outputs_request_v2(
+    proof_version: Version,
+    start_version: Version,
+    end_version: Version,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
+    let data_request = create_transaction_data_request(
+        transaction_data_request_type,
+        proof_version,
+        start_version,
+        end_version,
+    );
     StorageServiceRequest::new(data_request, use_compression)
 }
 
@@ -634,37 +747,156 @@ fn create_subscription_request(known_version: u64, use_compression: bool) -> Sto
     StorageServiceRequest::new(data_request, use_compression)
 }
 
+/// Creates a new subscription request (v2)
+fn create_subscription_request_v2(
+    known_version: u64,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    // Create a new subscription stream metadata
+    let subscription_stream_metadata = SubscriptionStreamMetadata {
+        known_version_at_stream_start: known_version,
+        known_epoch_at_stream_start: get_random_u64(),
+        subscription_stream_id: get_random_u64(),
+    };
+
+    // Generate a random number
+    let random_number = get_random_u64();
+
+    // Determine the data request type based on the random number
+    let transaction_data_request_type = if random_number % 3 == 0 {
+        TransactionDataRequestType::TransactionData(TransactionData {
+            include_events: false,
+        })
+    } else if random_number % 3 == 1 {
+        TransactionDataRequestType::TransactionOutputData
+    } else {
+        TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+            include_events: false,
+        })
+    };
+    let data_request = create_transaction_subscription_data_request(
+        transaction_data_request_type,
+        subscription_stream_metadata,
+        get_random_u64(),
+    );
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
+/// Creates a request for transaction subscription data
+fn create_transaction_subscription_data_request(
+    transaction_data_request_type: TransactionDataRequestType,
+    subscription_stream_metadata: SubscriptionStreamMetadata,
+    subscription_stream_index: u64,
+) -> DataRequest {
+    DataRequest::SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest {
+        transaction_data_request_type,
+        subscription_stream_metadata,
+        subscription_stream_index,
+        max_response_bytes: get_random_u64(),
+    })
+}
+
+/// Creates a request for new transaction data with proof
+fn create_new_transaction_data_request(
+    transaction_data_request_type: TransactionDataRequestType,
+    known_version: Version,
+    known_epoch: u64,
+) -> DataRequest {
+    DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+        transaction_data_request_type,
+        known_version,
+        known_epoch,
+        max_response_bytes: get_random_u64(),
+    })
+}
+
+/// Creates a request for transaction data with proof
+fn create_transaction_data_request(
+    transaction_data_request_type: TransactionDataRequestType,
+    proof_version: Version,
+    start_version: Version,
+    end_version: Version,
+) -> DataRequest {
+    DataRequest::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
+        transaction_data_request_type,
+        proof_version,
+        start_version,
+        end_version,
+        max_response_bytes: get_random_u64(),
+    })
+}
+
 /// Creates a request for transactions
 fn create_transactions_request(
-    proof: Version,
-    start: Version,
-    end: Version,
+    proof_version: Version,
+    start_version: Version,
+    end_version: Version,
     use_compression: bool,
 ) -> StorageServiceRequest {
     let data_request = DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
-        proof_version: proof,
-        start_version: start,
-        end_version: end,
+        proof_version,
+        start_version,
+        end_version,
         include_events: true,
     });
     StorageServiceRequest::new(data_request, use_compression)
 }
 
+/// Creates a request for transactions (v2)
+fn create_transactions_request_v2(
+    proof_version: Version,
+    start_version: Version,
+    end_version: Version,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    let transaction_data_request_type =
+        TransactionDataRequestType::TransactionData(TransactionData {
+            include_events: false,
+        });
+    let data_request = create_transaction_data_request(
+        transaction_data_request_type,
+        proof_version,
+        start_version,
+        end_version,
+    );
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
 /// Creates a request for transactions or outputs
 fn create_transactions_or_outputs_request(
-    proof: Version,
-    start: Version,
-    end: Version,
+    proof_version: Version,
+    start_version: Version,
+    end_version: Version,
     use_compression: bool,
 ) -> StorageServiceRequest {
     let data_request =
         DataRequest::GetTransactionsOrOutputsWithProof(TransactionsOrOutputsWithProofRequest {
-            proof_version: proof,
-            start_version: start,
-            end_version: end,
+            proof_version,
+            start_version,
+            end_version,
             include_events: true,
             max_num_output_reductions: 3,
         });
+    StorageServiceRequest::new(data_request, use_compression)
+}
+
+/// Creates a request for transactions or outputs (v2)
+fn create_transactions_or_outputs_request_v2(
+    proof_version: Version,
+    start_version: Version,
+    end_version: Version,
+    use_compression: bool,
+) -> StorageServiceRequest {
+    let transaction_data_request_type =
+        TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+            include_events: false,
+        });
+    let data_request = create_transaction_data_request(
+        transaction_data_request_type,
+        proof_version,
+        start_version,
+        end_version,
+    );
     StorageServiceRequest::new(data_request, use_compression)
 }
 
@@ -725,6 +957,7 @@ fn verify_can_service_epoch_ending_requests(
 /// the specified data summary. If `expect_service` is true, then the
 /// request should be serviceable.
 fn verify_can_service_optimistic_fetch_requests(
+    use_request_v2: bool,
     data_client_config: &AptosDataClientConfig,
     data_summary: &DataSummary,
     time_service: TimeService,
@@ -734,7 +967,11 @@ fn verify_can_service_optimistic_fetch_requests(
 ) {
     for known_version in known_versions {
         // Create the optimistic fetch request
-        let request = create_optimistic_fetch_request(known_version, compression);
+        let request = if use_request_v2 {
+            create_optimistic_fetch_request_v2(known_version, compression)
+        } else {
+            create_optimistic_fetch_request(known_version, compression)
+        };
 
         // Verify the serviceability of the request
         verify_serviceability(
@@ -776,6 +1013,7 @@ fn verify_can_service_state_chunk_requests(
 /// the specified data summary. If `expect_service` is true, then the
 /// request should be serviceable.
 fn verify_can_service_subscription_requests(
+    use_request_v2: bool,
     data_client_config: &AptosDataClientConfig,
     data_summary: &DataSummary,
     time_service: TimeService,
@@ -785,7 +1023,11 @@ fn verify_can_service_subscription_requests(
 ) {
     for known_version in known_versions {
         // Create the subscription request
-        let request = create_subscription_request(known_version, compression);
+        let request = if use_request_v2 {
+            create_subscription_request_v2(known_version, compression)
+        } else {
+            create_subscription_request(known_version, compression)
+        };
 
         // Verify the serviceability of the request
         verify_serviceability(
@@ -802,6 +1044,7 @@ fn verify_can_service_subscription_requests(
 /// the specified data summary. If `expect_service` is true, then the
 /// request should be serviceable.
 fn verify_can_service_transaction_requests(
+    use_request_v2: bool,
     data_client_config: &AptosDataClientConfig,
     data_summary: &DataSummary,
     use_compression: bool,
@@ -810,8 +1053,16 @@ fn verify_can_service_transaction_requests(
 ) {
     for (start_version, end_version, proof_version) in transaction_ranges {
         // Create the transaction request
-        let request =
-            create_transactions_request(proof_version, start_version, end_version, use_compression);
+        let request = if use_request_v2 {
+            create_transactions_request_v2(
+                proof_version,
+                start_version,
+                end_version,
+                use_compression,
+            )
+        } else {
+            create_transactions_request(proof_version, start_version, end_version, use_compression)
+        };
 
         // Verify the serviceability of the request
         verify_serviceability(
@@ -828,6 +1079,7 @@ fn verify_can_service_transaction_requests(
 /// ranges against the specified data summary. If `expect_service` is
 /// true, then the request should be serviceable.
 fn verify_can_service_transaction_or_output_requests(
+    use_request_v2: bool,
     data_client_config: &AptosDataClientConfig,
     data_summary: &DataSummary,
     use_compression: bool,
@@ -836,12 +1088,21 @@ fn verify_can_service_transaction_or_output_requests(
 ) {
     for (start_version, end_version, proof_version) in transaction_ranges {
         // Create the transaction or output request
-        let request = create_transactions_or_outputs_request(
-            proof_version,
-            start_version,
-            end_version,
-            use_compression,
-        );
+        let request = if use_request_v2 {
+            create_transactions_or_outputs_request_v2(
+                proof_version,
+                start_version,
+                end_version,
+                use_compression,
+            )
+        } else {
+            create_transactions_or_outputs_request(
+                proof_version,
+                start_version,
+                end_version,
+                use_compression,
+            )
+        };
 
         // Verify the serviceability of the request
         verify_serviceability(
@@ -858,6 +1119,7 @@ fn verify_can_service_transaction_or_output_requests(
 /// the specified data summary. If `expect_service` is true, then the
 /// request should be serviceable.
 fn verify_can_service_output_requests(
+    use_request_v2: bool,
     data_client_config: &AptosDataClientConfig,
     data_summary: &DataSummary,
     use_compression: bool,
@@ -866,8 +1128,11 @@ fn verify_can_service_output_requests(
 ) {
     for (start_version, end_version, proof_version) in output_ranges {
         // Create the output request
-        let request =
-            create_outputs_request(proof_version, start_version, end_version, use_compression);
+        let request = if use_request_v2 {
+            create_outputs_request_v2(proof_version, start_version, end_version, use_compression)
+        } else {
+            create_outputs_request(proof_version, start_version, end_version, use_compression)
+        };
 
         // Verify the serviceability of the request
         verify_serviceability(


### PR DESCRIPTION
## Description
This PR adds new RPC request types to the storage service for transaction data v2 (i.e., transactions with auxiliary data). It also includes all the basic tests for serviceability.

Note: we've updated the storage service to drop the requests if it receives them (e.g., from a malicious client). In the next PR, we'll begin processing the requests.

## Testing Plan
New and existing test infrastructure.
