### PR TITLE
[decompiler] fix issues; support closure

### DIFF
--- a/third_party/move/tools/move-decompiler/tests/closure.exp
+++ b/third_party/move/tools/move-decompiler/tests/closure.exp
@@ -1,0 +1,188 @@
+
+module 0x99::basic_enum {
+    enum FV<T> has key {
+        V1 {
+            v1: |&mut T|(T) has copy + store,
+        }
+    }
+    fun increment_by_one(x: &mut u64): u64 {
+        *x = *x + 1;
+        *x
+    }
+    fun test_fun_vec(s: &signer) {
+        move_to<u64>(FV::V1<u64>{v1: |arg0| increment_by_one(arg0)}, s);
+    }
+}
+
+module 0x99::basic_struct {
+    struct Wrapper<T> has key {
+        fv: T,
+    }
+    fun add_resource_with_struct(acc: &signer, f: |&||(u64)|(u64) has copy + drop + store) {
+        move_to<|&||(u64)|(u64) has copy + drop + store>(Wrapper<|&||(u64)|(u64) has copy + drop + store>{fv: f}, acc);
+    }
+    fun test(f: &||(u64)): u64 {
+        let _t1;
+        if (f == f) _t1 = 1 else _t1 = 2;
+        _t1
+    }
+    public fun test_driver(acc: &signer) {
+        add_resource_with_struct(acc, |arg0| test(arg0));
+    }
+}
+
+module 0x99::lambda_arg {
+    public fun test(): u64 {
+        foo(|arg0| __lambda__1__test(arg0), 10)
+    }
+    fun __lambda__1__test(param$0: u64): u64 {
+        3
+    }
+    fun foo(f: |u64|(u64), x: u64): u64 {
+        f(x)
+    }
+    public fun main() {
+        if (!(test() == 3)) abort 5;
+    }
+}
+
+module 0x99::lambda_basic {
+    fun map(x: u64, f: |u64|(u64) has drop): u64 {
+        f(x)
+    }
+    fun no_name_clash(x: u64, c: u64): u64 {
+        map(x, |arg0| __lambda__1__no_name_clash(c, arg0))
+    }
+    fun __lambda__1__no_name_clash(c: u64, y: u64): u64 {
+        y + c
+    }
+    fun with_name_clash1(x: u64, c: u64): u64 {
+        map(x, |arg0| __lambda__1__with_name_clash1(c, arg0))
+    }
+    fun __lambda__1__with_name_clash1(c: u64, x: u64): u64 {
+        x + c
+    }
+    fun with_name_clash2(x: u64, c: u64): u64 {
+        map(x, |arg0| __lambda__1__with_name_clash2(c, arg0))
+    }
+    fun __lambda__1__with_name_clash2(c: u64, x: u64): u64 {
+        c + 1 + x
+    }
+}
+
+module 0x99::lambda_fun_wrapper {
+    struct Work has drop {
+        _0: |u64|(u64) has drop,
+    }
+    fun t1(): bool {
+        Work{_0: |arg0| __lambda__1__t1(arg0)} == Work{_0: |arg0| __lambda__2__t1(arg0)}
+    }
+    fun __lambda__1__t1(x: u64): u64 {
+        x + 1
+    }
+    fun __lambda__2__t1(x: u64): u64 {
+        x + 2
+    }
+    fun t2() {
+        take_work(Work{_0: |arg0| __lambda__1__t2(arg0)});
+    }
+    fun __lambda__1__t2(x: u64): u64 {
+        x + 1
+    }
+    fun take_work(_work: Work) {
+        ()
+    }
+}
+
+module 0x99::lambda_generics {
+    struct S<T> has drop {
+        x: T,
+    }
+    fun id<T>(self: S<T>): S<T> {
+        self
+    }
+    fun inlined<T: drop>(f: |S<T>|(S<T>), s: S<T>) {
+        ()
+    }
+    fun test_receiver_inference(s: S<u64>) {
+        inlined<u64>(|arg0| id(arg0), s);
+    }
+}
+
+module 0x99::lambda_inline {
+    fun g() {
+        ()
+    }
+}
+
+module 0x99::lambda_inline1 {
+    public fun test() {
+        let _t1;
+        let _t0;
+        let _t2;
+        _t2 = 1 + 1;
+        _t0 = 1000 + 1;
+        _t1 = 100 + 1;
+        _t2 = _t2 + 1;
+        _t1 = _t1 + 1;
+        _t2 = _t2 * _t0 + _t1 + 3 * _t2 + 5 * _t1 + 7 * (_t0 + 1);
+        if (!(_t2 == 9637)) abort _t2;
+    }
+}
+
+module 0x99::lambda_no_param {
+    public fun test() {
+        ()
+    }
+}
+
+module 0x99::lambda_no_param1 {
+    public fun test() {
+        if (!(foo(|(arg0,arg1)| __lambda__1__test(arg0, arg1), |(arg0,arg1)| __lambda__2__test(arg0, arg1), 10, 100) == 110)) abort 0;
+    }
+    fun __lambda__1__test(x: u64, param$1: u64): u64 {
+        x
+    }
+    fun foo(f: |(u64, u64)|(u64), g: |(u64, u64)|(u64), x: u64, _y: u64): u64 {
+        f(x, _y) + g(x, _y)
+    }
+    fun __lambda__2__test(param$0: u64, y: u64): u64 {
+        y
+    }
+}
+
+module 0x99::lambda_pattern {
+    struct S<T> {
+        x: T,
+    }
+    fun consume<T>(s: S<T>, x: T, f: |(S<T>, T)|(T)): T {
+        f(s, x)
+    }
+    fun pattern(s: S<u64>, x: u64): u64 {
+        consume<u64>(s, x, |(arg0,arg1)| __lambda__1__pattern(arg0, arg1))
+    }
+    fun __lambda__1__pattern(param$0: S<u64>, _y: u64): u64 {
+        let _t4;
+        S<u64>{x: _t4} = param$0;
+        _y = _t4;
+        _y + _y
+    }
+}
+
+module 0x99::nested_lambda {
+    fun map1(x: u64, f: |u64|(u64)): u64 {
+        f(x)
+    }
+    fun map2(x: u8, f: |u8|(u8)): u8 {
+        f(x)
+    }
+    fun nested(x: u64, c: u64): u64 {
+        map1(x, |arg0| __lambda__2__nested(c, arg0))
+    }
+    fun __lambda__2__nested(c: u64, y: u64): u64 {
+        map2(y - c as u8, |arg0| __lambda__1__nested(c, arg0)) as u64
+    }
+    fun __lambda__1__nested(c: u64, y: u8): u8 {
+        y + (c as u8)
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/closure.move
+++ b/third_party/move/tools/move-decompiler/tests/closure.move
@@ -1,0 +1,196 @@
+module 0x99::basic_enum {
+    #[persistent]
+    fun increment_by_one(x: &mut u64): u64 { *x = *x + 1; *x }
+
+    enum FV<T> has key {
+        V1 { v1: |&mut T|T has copy+store},
+    }
+
+    fun test_fun_vec(s: &signer) {
+        // ok case
+        let f1: |&mut u64|u64 has copy+store = increment_by_one;
+        let v1 = FV::V1{v1: f1};
+        move_to(s, v1);
+    }
+}
+
+module 0x99::basic_struct {
+  struct Wrapper<T> has key {
+    fv: T
+  }
+
+  #[persistent]
+   fun test(f: &||u64): u64 {
+    if (f == f)
+        1
+    else
+        2
+   }
+
+  // all abilities satisfied
+  fun add_resource_with_struct(acc: &signer, f: | &||u64 |u64 has copy+store+drop) {
+    move_to<Wrapper<| &||u64 |u64 has copy+store+drop>>(acc, Wrapper { fv: f});
+  }
+
+  public fun test_driver(acc: &signer){
+    // ok case
+    let f: | &||u64 |u64 has copy+store+drop = test;
+    add_resource_with_struct(acc, f);
+  }
+}
+
+module 0x99::nested_lambda {
+
+    /// A higher order function on ints
+    fun map1(x: u64, f: |u64|u64): u64 {
+        f(x)
+    }
+
+    /// Another higher order function on ints
+    fun map2(x: u8, f: |u8|u8): u8 {
+        f(x)
+    }
+
+    /// A tests which nests things
+    fun nested(x: u64, c: u64): u64 {
+        map1(x, |y| (map2((y - c as u8), |y| y + (c as u8)) as u64))
+    }
+}
+
+
+module 0x99::lambda_basic {
+    /// A higher order function on ints
+    fun map(x: u64, f: |u64|u64 has drop): u64 {
+        f(x)
+    }
+
+    /// Tests basic usage, without name overlap
+    fun no_name_clash(x: u64, c: u64): u64 {
+        map(x, |y| y + c)
+    }
+
+    /// Basic usage in the presence of name clask
+    fun with_name_clash1(x: u64, c: u64): u64 {
+        map(x, |x| x + c)
+    }
+
+    /// More clashes
+    fun with_name_clash2(x: u64, c: u64): u64 {
+        map(x, |x| {
+            let x = c + 1;
+            x
+        } + x)
+    }
+}
+
+module 0x99::lambda_pattern {
+
+    /// Test struct
+    struct S<T> {
+        x: T
+    }
+
+    /// A higher order function on `S`
+    fun consume<T>(s: S<T>, x: T, f: |S<T>, T|T): T {
+        f(s, x)
+    }
+
+    /// Lambda with pattern
+    fun pattern(s: S<u64>, x: u64): u64 {
+        consume(s, x, |S{x}, _y| { let y = x; x + y})
+    }
+}
+
+module 0x99::lambda_fun_wrapper {
+    struct Work(|u64|u64) has drop;
+
+    fun take_work(_work: Work) {}
+
+    fun t1():bool {
+        let work = Work(|x| x + 1);
+        work == (|x| x + 2)
+    }
+
+    fun t2() {
+        take_work(|x| x + 1)
+    }
+}
+
+module 0x99::lambda_no_param {
+    inline fun foo(f:|u64, u64| u64, g: |u64, u64| u64, x: u64, _y: u64): u64 {
+        f(x, _y) + g(x, _y)
+    }
+
+    public fun test() {
+        assert!(foo(|_, _| 3, |_, _| 10, 10, 100) == 13, 0);
+    }
+}
+
+module 0x99::lambda_no_param1 {
+    fun foo(f:|u64, u64| u64, g: |u64, u64| u64, x: u64, _y: u64): u64 {
+        f(x, _y) + g(x, _y)
+    }
+
+    public fun test() {
+        assert!(foo(|x, _| x, |_, y| y, 10, 100) == 110, 0);
+    }
+}
+
+module 0x99::lambda_inline {
+    inline fun foo(f: |&u64|) {
+    }
+
+    fun g() {
+        foo(|v| {
+            v == &1;
+        });
+    }
+}
+
+module 0x99::lambda_inline1 {
+    inline fun foo(f:|u64, u64, u64| u64, g: |u64, u64, u64| u64, x: u64, _: u64, y: u64, z: u64): u64 {
+	let r1 = f({x = x + 1; x}, {y = y + 1; y}, {z = z + 1; z});
+	let r2 = g({x = x + 1; x}, {y = y + 1; y}, {z  = z + 1 ; z});
+	r1 + r2 + 3*x + 5*y + 7*z
+    }
+
+    public fun test() {
+	let r = foo(|x, _, z| x*z, |_, y, _| y, 1, 10, 100, 1000);
+        assert!(r == 9637, r);
+    }
+}
+
+module 0x99::lambda_arg {
+    fun foo(f:|u64| u64, x: u64): u64 {
+        f(x)
+    }
+
+    public fun test(): u64 {
+        foo(|_| 3, 10)
+    }
+
+    public fun main() {
+        assert!(test() == 3, 5);
+    }
+}
+
+module 0x99::lambda_generics {
+
+    struct S<T> has drop { x: T }
+
+
+    fun inlined<T:drop>(f: |S<T>|S<T>, s: S<T>) {
+        f(s);
+    }
+
+    fun id<T>(self: S<T>): S<T> {
+        self
+    }
+
+    fun test_receiver_inference(s: S<u64>) {
+        // In the lambda the type of `s` is not known when the expression is checked,
+        // and the receiver function `id` is resolved later when the parameter type is unified
+        // with the lambda expression
+        inlined(|s| s.id(), s)
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/nested_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/nested_loops.exp
@@ -1,5 +1,5 @@
 
-module 0x99::m {
+module 0x99::nested_loops {
     fun nested_for_loops() {
         let _t4;
         let _t3;

--- a/third_party/move/tools/move-decompiler/tests/nested_loops.move
+++ b/third_party/move/tools/move-decompiler/tests/nested_loops.move
@@ -1,5 +1,5 @@
 //* Test cases with nested loops
-module 0x99::m {
+module 0x99::nested_loops {
     fun nested_for_loops() {
         let y = 0;
         for (i in 0..10) {

--- a/third_party/move/tools/move-decompiler/tests/noexit_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/noexit_loops.exp
@@ -1,0 +1,71 @@
+
+module 0x99::noexit_loops {
+    struct R {
+    }
+    fun bar(_x: u64) {
+        ()
+    }
+    fun baz(_: &u64) {
+        ()
+    }
+    fun f1() {
+        let _t0;
+        _t0 = 0;
+        loop _t0 = _t0 + 1
+    }
+    fun f10() {
+        loop continue
+    }
+    fun f11() {
+        loop continue
+    }
+    fun f12() {
+        ()
+    }
+    fun f13(cond: bool) {
+        let _t2;
+        if (cond) _t2 = 0 else _t2 = 1;
+        loop continue
+    }
+    fun f14(p: bool, q: bool) {
+        if (p && q) loop continue;
+    }
+    fun f15() {
+        let _t0;
+        _t0 = 0;
+    }
+    fun f16() {
+        loop continue
+    }
+    fun f2(): u64 {
+        let _t0;
+        _t0 = 1 + 1;
+        loop _t0 = _t0 + 1
+    }
+    fun f3(): u64 {
+        let _t0;
+        _t0 = 1;
+        loop _t0 = _t0 + foo(_t0)
+    }
+    fun foo(x: u64): u64 {
+        x + 1
+    }
+    fun f4(): R {
+        loop continue
+    }
+    fun f5(): u64 {
+        loop continue
+    }
+    fun f6() {
+        loop continue
+    }
+    fun f7(): R {
+        loop continue
+    }
+    fun f8() {
+        loop continue
+    }
+    fun f9() {
+        loop continue
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/noexit_loops.move
+++ b/third_party/move/tools/move-decompiler/tests/noexit_loops.move
@@ -1,0 +1,132 @@
+//* Test cases with no-exit loops
+module 0x99::noexit_loops {
+    fun f1() {
+        let x = 0;
+        'outer: loop {
+            // inner loop; can never go out
+            loop {
+                x = x + 1;
+                'inner: loop if (true) loop {
+                    if (false) continue 'outer else break 'inner;
+                    break
+                } else continue 'outer
+            };
+            break
+        }
+    }
+
+    fun f2(): u64 {
+        let x = 1;
+        loop { x = x + 1; break };
+        loop { x = x + 1 };
+        x
+    }
+
+    fun foo(x: u64): u64 {
+        x = x + 1;
+        x
+    }
+    fun f3(): u64 {
+        let x = 1;
+        while (true) {
+            x = x + foo(x)
+        };
+        x
+    }
+
+    struct R {}
+
+    fun f4(): R {
+        loop {}
+    }
+
+    fun f5(): u64 {
+        loop { let x = 0; x; }
+    }
+
+    fun bar(_x: u64) {}
+    fun f6() {
+        bar(loop {})
+    }
+
+    fun f7(): R {
+        let x: R = loop { 0; };
+        x
+    }
+
+    fun f8() {
+        let () = loop { break };
+        let () = loop { if (false) break };
+    }
+
+    fun f9() {
+        while (true) ();
+        while (false) ()
+    }
+
+    fun f10() {
+        while ({ let foo = true; foo }) ();
+        while ({ let bar = false; bar }) ()
+    }
+
+    fun f11() {
+        loop {
+            continue;
+            break
+        };
+    }
+
+    fun f12() {
+        loop {
+            if (return) break;
+        }
+    }
+
+    fun baz(_: &u64) {}
+    fun f13(cond: bool) {
+        1 + if (cond) 0 else { 1 } + 2;
+        1 + loop {} + 2;
+        1 + return + 0;
+
+        baz(&if (cond) 0 else 1);
+        baz(&loop {});
+        baz(&return);
+        baz(&abort 0);
+    }
+
+    fun f14(p: bool, q: bool) {
+        while (p) {
+            if (q) {
+                loop {};
+                let i = 0;
+                i = i + 1;
+            } else {
+                break;
+            };
+            let i = 0;
+            i = i + 1;
+        }
+    }
+
+    fun f15(){
+         let x = 0;
+        'outer: loop {
+            // inner loop; just run once
+            'inner: loop {
+                x = x + 1;
+                'innermost: loop {
+                    if (true) loop {
+                        if (false) continue 'outer else break 'inner;
+                        break
+                    } else continue 'outer
+                }
+            };
+            break
+        }
+
+    }
+
+    fun f16() {
+        loop { loop { loop {}; }; };
+    }
+}


### PR DESCRIPTION
## Description
This PR addresses three issues in the [astifier](https://github.com/aptos-labs/aptos-core/blob/jun/fix-astfier-issues/third_party/move/move-model/bytecode/src/astifier.rs) component of the decompiler.
- Revise a recent fix introduced by https://github.com/aptos-labs/aptos-core/pull/16908 to ensure topological sorting works as expected.
- Add support to deal with cyclic label substitution.
    - Given a block like `Label L1; goto L2`, the astifier substitutes `L1` with `L2`. This can create cyclic substitutions when encountering endless loops (e.g., `Label L1; goto L2`, `Label L2; goto L3`, `Label L3; goto L1`). The current implementation panics on such cases.
    - This PR prevents cyclic substitutions by replacing all labels with the last one. In the example above, both `L1` and `L2` will be substituted with `L3`. 
    - Test cases show the revision works fine. Further attention will be paid to make sure the revision does not break follow-up steps.
- Add support to handle closure operations. Now the following stackless bytecode can be lifted to ast exps:
    - `Call::Operation(Closure)`
    - `Call::Operation(Invoke)`

## How Has This Been Tested?
New decompiler test case:
- [Nested loops](https://github.com/aptos-labs/aptos-core/blob/jun/fix-astfier-issues/third_party/move/tools/move-decompiler/tests/nested_loops.move)
- [Endless loops](https://github.com/aptos-labs/aptos-core/blob/jun/fix-astfier-issues/third_party/move/tools/move-decompiler/tests/noexit_loops.move)
- [Closure operations](https://github.com/aptos-labs/aptos-core/blob/jun/fix-astfier-issues/third_party/move/tools/move-decompiler/tests/closure.move)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Move decompiler)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation
