### PR TITLE
Prune transaction summaries only in ledger db

### DIFF
--- a/storage/aptosdb/src/pruner/ledger_pruner/transaction_pruner.rs
+++ b/storage/aptosdb/src/pruner/ledger_pruner/transaction_pruner.rs
@@ -49,6 +49,8 @@ impl DBSubPruner for TransactionPruner {
             target_version,
             &mut batch,
         )?;
+        self.transaction_store
+            .prune_transaction_summaries_by_account(&candidate_transactions, &mut batch)?;
         batch.put::<DbMetadataSchema>(
             &DbMetadataKey::TransactionPrunerProgress,
             &DbMetadataValue::Version(target_version),

--- a/storage/aptosdb/src/utils/truncation_helper.rs
+++ b/storage/aptosdb/src/utils/truncation_helper.rs
@@ -385,6 +385,7 @@ fn delete_transaction_index_data(
             .zip(transactions)
             .collect::<Vec<_>>();
         transaction_store.prune_transaction_by_account(&transactions, batch)?;
+        transaction_store.prune_transaction_summaries_by_account(&transactions, batch)?;
     }
 
     Ok(())


### PR DESCRIPTION
## Description
Prune transaction summaries only in ledger db and do not prune in indexer db.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
