### PR TITLE
[Storage] Disable pre-commit for fullnodes.

### DIFF
--- a/config/src/config/config_optimizer.rs
+++ b/config/src/config/config_optimizer.rs
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    ConsensusObserverConfig, Identity, IdentityFromConfig, IdentitySource, IndexerGrpcConfig,
-    StorageConfig,
+    ConsensusConfig, ConsensusObserverConfig, Identity, IdentityFromConfig, IdentitySource,
+    IndexerGrpcConfig, StorageConfig,
 };
 use crate::{
     config::{
@@ -110,6 +110,9 @@ impl ConfigOptimizer for NodeConfig {
         let mut optimizers_with_modifications = vec![];
         if AdminServiceConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(AdminServiceConfig::get_optimizer_name());
+        }
+        if ConsensusConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
+            optimizers_with_modifications.push(ConsensusConfig::get_optimizer_name());
         }
         if ConsensusObserverConfig::optimize(node_config, local_config_yaml, node_type, chain_id)? {
             optimizers_with_modifications.push(ConsensusObserverConfig::get_optimizer_name());

--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -6,13 +6,15 @@
 
 use super::DEFEAULT_MAX_BATCH_TXNS;
 use crate::config::{
-    config_sanitizer::ConfigSanitizer, node_config_loader::NodeType, Error, NodeConfig,
-    QuorumStoreConfig, ReliableBroadcastConfig, SafetyRulesConfig, BATCH_PADDING_BYTES,
+    config_optimizer::ConfigOptimizer, config_sanitizer::ConfigSanitizer,
+    node_config_loader::NodeType, Error, NodeConfig, QuorumStoreConfig, ReliableBroadcastConfig,
+    SafetyRulesConfig, BATCH_PADDING_BYTES,
 };
 use aptos_crypto::_once_cell::sync::Lazy;
 use aptos_types::chain_id::ChainId;
 use cfg_if::cfg_if;
 use serde::{Deserialize, Serialize};
+use serde_yaml::Value;
 use std::path::PathBuf;
 
 // NOTE: when changing, make sure to update QuorumStoreBackPressureConfig::backlog_txn_limit_count as well.
@@ -518,6 +520,29 @@ impl ConfigSanitizer for ConsensusConfig {
     }
 }
 
+// TODO: Re-enable pre-commit for VFNs and PFNs once the feature supports
+// a rollback mechanism (to tolerate execution divergence in fullnodes).
+impl ConfigOptimizer for ConsensusConfig {
+    fn optimize(
+        node_config: &mut NodeConfig,
+        local_config_yaml: &Value,
+        node_type: NodeType,
+        _chain_id: Option<ChainId>,
+    ) -> Result<bool, Error> {
+        let consensus_config = &mut node_config.consensus;
+        let local_consensus_config_yaml = &local_config_yaml["consensus"];
+
+        // Disable pre-commit for VFNs and PFNs (if they are not manually set)
+        let mut modified_config = false;
+        if local_consensus_config_yaml["enable_pre_commit"].is_null() && !node_type.is_validator() {
+            consensus_config.enable_pre_commit = false;
+            modified_config = true;
+        }
+
+        Ok(modified_config)
+    }
+}
+
 /// Returns true iff consensus-only-perf-test is enabled
 fn is_consensus_only_perf_test_enabled() -> bool {
     cfg_if! {
@@ -777,5 +802,73 @@ mod test {
         let error =
             ConsensusConfig::sanitize(&node_config, NodeType::ValidatorFullnode, None).unwrap_err();
         assert!(matches!(error, Error::ConfigSanitizerFailed(_, _)));
+    }
+
+    #[test]
+    fn test_optimize_pre_commit() {
+        // Create a node config with pre-commit enabled
+        let mut node_config = create_config_with_pre_commit_enabled();
+
+        // Optimize the config for a validator
+        let modified_config = ConsensusConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+            NodeType::Validator,
+            None,
+        )
+        .unwrap();
+
+        // Verify that the config was not modified, and that pre-commit is still enabled
+        assert!(!modified_config);
+        assert!(node_config.consensus.enable_pre_commit);
+
+        // Next, optimize the config for a validator fullnode
+        let modified_config = ConsensusConfig::optimize(
+            &mut node_config,
+            &serde_yaml::from_str("{}").unwrap(), // An empty local config,
+            NodeType::ValidatorFullnode,
+            None,
+        )
+        .unwrap();
+
+        // Verify that the config was modified, and that pre-commit is disabled
+        assert!(modified_config);
+        assert!(!node_config.consensus.enable_pre_commit);
+
+        // Create a node config with pre-commit enabled
+        let mut node_config = create_config_with_pre_commit_enabled();
+
+        // Create a local config with pre-commit manually enabled
+        let local_config_yaml = serde_yaml::from_str(
+            r#"
+            consensus:
+                enable_pre_commit: false
+            "#,
+        )
+        .unwrap();
+
+        // Optimize the config for a public fullnode (using the local config)
+        let modified_config = ConsensusConfig::optimize(
+            &mut node_config,
+            &local_config_yaml,
+            NodeType::PublicFullnode,
+            None,
+        )
+        .unwrap();
+
+        // Verify that the config was not modified, and that pre-commit is still enabled
+        assert!(!modified_config);
+        assert!(node_config.consensus.enable_pre_commit);
+    }
+
+    /// Creates a node config with pre-commit enabled
+    fn create_config_with_pre_commit_enabled() -> NodeConfig {
+        NodeConfig {
+            consensus: ConsensusConfig {
+                enable_pre_commit: true,
+                ..Default::default()
+            },
+            ..Default::default()
+        }
     }
 }


### PR DESCRIPTION
## Description
This PR disables pre-commit in storage for fullnodes. This is only a temporary change, until a rollback mechanism can be added to storage to tolerate execution divergence in fullnodes.

## Testing Plan
New and existing test infrastructure.