### PR TITLE
[vm] [bytecode-verifier] Fix instantiation loop verifier

### DIFF
--- a/third_party/move/move-bytecode-verifier/src/instantiation_loops.rs
+++ b/third_party/move/move-bytecode-verifier/src/instantiation_loops.rs
@@ -217,15 +217,106 @@ impl<'a> InstantiationLoopChecker<'a> {
     ) {
         if let Some(code) = &caller_def.code {
             for instr in &code.code {
-                if let Bytecode::CallGeneric(callee_inst_idx) = instr {
-                    // Get the id of the definition of the function being called.
-                    // Skip if the function is not defined in the current module, as we do not
-                    // have mutual recursions across module boundaries.
-                    let callee_si = self.module.function_instantiation_at(*callee_inst_idx);
-                    if let Some(callee_idx) = self.func_handle_def_map.get(&callee_si.handle) {
-                        let callee_idx = *callee_idx;
-                        self.build_graph_call(caller_idx, callee_idx, callee_si.type_parameters)
-                    }
+                match instr {
+                    Bytecode::CallGeneric(callee_inst_idx)
+                    | Bytecode::PackClosureGeneric(callee_inst_idx, _) => {
+                        // Get the id of the definition of the function being called/packed into a closure.
+                        // Skip if the function is not defined in the current module, as we do not
+                        // have mutual recursions across module boundaries.
+                        let callee_si = self.module.function_instantiation_at(*callee_inst_idx);
+                        if let Some(callee_idx) = self.func_handle_def_map.get(&callee_si.handle) {
+                            let callee_idx = *callee_idx;
+                            self.build_graph_call(caller_idx, callee_idx, callee_si.type_parameters)
+                        }
+                    },
+                    Bytecode::Pop
+                    | Bytecode::Ret
+                    | Bytecode::BrTrue(_)
+                    | Bytecode::BrFalse(_)
+                    | Bytecode::Branch(_)
+                    | Bytecode::LdU8(_)
+                    | Bytecode::LdU16(_)
+                    | Bytecode::LdU32(_)
+                    | Bytecode::LdU64(_)
+                    | Bytecode::LdU128(_)
+                    | Bytecode::LdU256(_)
+                    | Bytecode::LdConst(_)
+                    | Bytecode::LdTrue
+                    | Bytecode::LdFalse
+                    | Bytecode::CopyLoc(_)
+                    | Bytecode::MoveLoc(_)
+                    | Bytecode::StLoc(_)
+                    | Bytecode::FreezeRef
+                    | Bytecode::MutBorrowLoc(_)
+                    | Bytecode::ImmBorrowLoc(_)
+                    | Bytecode::MutBorrowField(_)
+                    | Bytecode::ImmBorrowField(_)
+                    | Bytecode::MutBorrowFieldGeneric(_)
+                    | Bytecode::ImmBorrowFieldGeneric(_)
+                    | Bytecode::Call(_)
+                    | Bytecode::Pack(_)
+                    | Bytecode::Unpack(_)
+                    | Bytecode::ReadRef
+                    | Bytecode::WriteRef
+                    | Bytecode::CastU8
+                    | Bytecode::CastU16
+                    | Bytecode::CastU32
+                    | Bytecode::CastU64
+                    | Bytecode::CastU128
+                    | Bytecode::CastU256
+                    | Bytecode::Add
+                    | Bytecode::Sub
+                    | Bytecode::Mul
+                    | Bytecode::Mod
+                    | Bytecode::Div
+                    | Bytecode::BitOr
+                    | Bytecode::BitAnd
+                    | Bytecode::Xor
+                    | Bytecode::Shl
+                    | Bytecode::Shr
+                    | Bytecode::Or
+                    | Bytecode::And
+                    | Bytecode::Not
+                    | Bytecode::Eq
+                    | Bytecode::Neq
+                    | Bytecode::Lt
+                    | Bytecode::Gt
+                    | Bytecode::Le
+                    | Bytecode::Ge
+                    | Bytecode::Abort
+                    | Bytecode::Nop
+                    | Bytecode::Exists(_)
+                    | Bytecode::ExistsGeneric(_)
+                    | Bytecode::MoveFrom(_)
+                    | Bytecode::MoveFromGeneric(_)
+                    | Bytecode::MoveTo(_)
+                    | Bytecode::MoveToGeneric(_)
+                    | Bytecode::VecPack(_, _)
+                    | Bytecode::VecLen(_)
+                    | Bytecode::VecImmBorrow(_)
+                    | Bytecode::VecMutBorrow(_)
+                    | Bytecode::VecPushBack(_)
+                    | Bytecode::VecPopBack(_)
+                    | Bytecode::VecUnpack(_, _)
+                    | Bytecode::VecSwap(_)
+                    | Bytecode::UnpackGeneric(_)
+                    | Bytecode::PackGeneric(_)
+                    | Bytecode::PackVariant(_)
+                    | Bytecode::UnpackVariant(_)
+                    | Bytecode::PackVariantGeneric(_)
+                    | Bytecode::UnpackVariantGeneric(_)
+                    | Bytecode::TestVariant(_)
+                    | Bytecode::TestVariantGeneric(_)
+                    | Bytecode::MutBorrowVariantField(_)
+                    | Bytecode::MutBorrowVariantFieldGeneric(_)
+                    | Bytecode::ImmBorrowVariantField(_)
+                    | Bytecode::ImmBorrowVariantFieldGeneric(_)
+                    | Bytecode::MutBorrowGlobal(_)
+                    | Bytecode::ImmBorrowGlobal(_)
+                    | Bytecode::MutBorrowGlobalGeneric(_)
+                    | Bytecode::ImmBorrowGlobalGeneric(_)
+                    | Bytecode::PackClosure(_, _)
+                    | Bytecode::CallClosure(_) => {},
                 }
             }
         }

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_a.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_a.exp
@@ -1,0 +1,20 @@
+processed 1 task
+
+task 0 'publish'. lines 1-9:
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `LOOP_IN_INSTANTIATION_GRAPH`:
+Error message: edges with constructors: [f0#0 --StructInstantiation(StructHandleIndex(0), [TypeParameter(0)])--> f0#0], nodes: [f0#0]
+  ┌─ TEMPFILE:2:1
+  │  
+2 │ ╭ module 0x8675309::M {
+3 │ │     struct S<T> { f: T }
+4 │ │     fun f<T>() {
+5 │ │         let ff = || f<S<T>>();
+6 │ │         ff();
+7 │ │     }
+8 │ │ }
+  │ ╰─^
+  │  
+  = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_a.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_a.move
@@ -1,0 +1,9 @@
+//# publish
+module 0x8675309::M {
+    struct S<T> { f: T }
+
+    fun f<T>() {
+        let ff = || f<S<T>>();
+        ff();
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_b.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_b.exp
@@ -1,0 +1,20 @@
+processed 1 task
+
+task 0 'publish'. lines 1-15:
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `LOOP_IN_INSTANTIATION_GRAPH`:
+Error message: edges with constructors: [f1#0 --Function([Reference(TypeParameter(0))], [], )--> f0#0], nodes: [f1#0, f0#0]
+   ┌─ TEMPFILE:2:1
+   │  
+ 2 │ ╭ module 0xc0ffee::m {
+ 3 │ │     public fun foo<T>(): || {
+ 4 │ │         bar<|&T|>
+ 5 │ │     }
+   · │
+12 │ │     }
+13 │ │ }
+   │ ╰─^
+   │  
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_b.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-recursive-type-check/bug_16939_b.move
@@ -1,0 +1,15 @@
+//# publish
+module 0xc0ffee::m {
+    public fun foo<T>(): || {
+        bar<|&T|>
+    }
+
+    fun bar<T>() {
+        (foo<T>())();
+    }
+
+    fun test() {
+        let f = foo<||>();
+        f();
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -34,6 +34,7 @@ const COMMON_EXCLUSIONS: &[&str] = &[
     "/operator_eval/",
     "/no-recursive-check/",
     "/no-access-check/",
+    "/no-recursive-type-check/",
 ];
 
 /// Note that any config which has different output for a test directory
@@ -101,6 +102,14 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::ACCESS_CHECK, false)],
         language_version: LanguageVersion::latest(),
         include: &["/no-access-check/"],
+        exclude: &[],
+    },
+    TestConfig {
+        name: "no-recursive-type-check",
+        runner: |p| run(p, get_config_by_name("no-recursive-type-check")),
+        experiments: &[(Experiment::RECURSIVE_TYPE_CHECK, false)],
+        language_version: LanguageVersion::latest(),
+        include: &["/no-recursive-type-check/"],
         exclude: &[],
     },
 ];


### PR DESCRIPTION
## Description

The bytecode verifier pass "instantiation loop checker" was missing a check for the recently introduced bytecode `PackClosureGeneric`. This PR fixes it, and also adds explicit bytecodes in a `match`, so that future bytecode addition will have to reason through this.

Closes #16939.

## How Has This Been Tested?
- Added new transactional tests turning the corresponding compiler check off, showing that we now produce a bytecode verification error.

## Key Areas to Review

Completeness of the fix.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move/Aptos Virtual Machine
