### PR TITLE
[Storage Service] Add new response types for txn V2 data.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -147,6 +147,8 @@ impl Default for StateSyncDriverConfig {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageServiceConfig {
+    /// Whether transaction data v2 is enabled
+    pub enable_transaction_data_v2: bool,
     /// Maximum number of epoch ending ledger infos per chunk
     pub max_epoch_chunk_size: u64,
     /// Maximum number of invalid requests per peer
@@ -180,6 +182,7 @@ pub struct StorageServiceConfig {
 impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
+            enable_transaction_data_v2: false, // TODO: flip this once V2 data is enabled
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_invalid_requests_per_peer: 500,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB

--- a/state-sync/storage-service/server/src/tests/cache.rs
+++ b/state-sync/storage-service/server/src/tests/cache.rs
@@ -4,7 +4,6 @@
 use crate::tests::{mock, mock::MockClient, utils};
 use aptos_config::config::StorageServiceConfig;
 use aptos_crypto::hash::HashValue;
-use aptos_storage_service_types::responses::{DataResponse, StorageServiceResponse};
 use aptos_types::{
     proof::definition::SparseMerkleRangeProof, state_store::state_value::StateValueChunkWithProof,
 };
@@ -15,142 +14,159 @@ use mockall::{
 
 #[tokio::test]
 async fn test_cachable_requests_compression() {
-    // Create test data
-    let start_version = 0;
-    let end_version = 454;
-    let proof_version = end_version;
-    let include_events = false;
-    let compression_options = [true, false];
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create test data
+        let start_version = 0;
+        let end_version = 454;
+        let proof_version = end_version;
+        let include_events = false;
+        let compression_options = [true, false];
 
-    // Create the mock db reader
-    let mut db_reader = mock::create_mock_db_reader();
-    let mut expectation_sequence = Sequence::new();
-    let mut transaction_lists_with_proof = vec![];
-    for _ in compression_options {
-        // Create and save test transaction lists
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            start_version,
-            end_version,
-            proof_version,
-            include_events,
-        );
-        transaction_lists_with_proof.push(transaction_list_with_proof.clone());
-
-        // Expect the data to be fetched from storage exactly once
-        db_reader
-            .expect_get_transactions()
-            .times(1)
-            .with(
-                eq(start_version),
-                eq(end_version - start_version + 1),
-                eq(proof_version),
-                eq(include_events),
-            )
-            .return_once(move |_, _, _, _| Ok(transaction_list_with_proof))
-            .in_sequence(&mut expectation_sequence);
-    }
-
-    // Create the storage client and server
-    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
-    utils::update_storage_server_summary(&mut service, end_version, 10);
-    tokio::spawn(service.start());
-
-    // Repeatedly fetch the data and verify the responses
-    for (i, use_compression) in compression_options.iter().enumerate() {
-        for _ in 0..10 {
-            let response = utils::get_transactions_with_proof(
-                &mut mock_client,
+        // Create the mock db reader
+        let mut db_reader = mock::create_mock_db_reader();
+        let mut transaction_lists_with_proof = vec![];
+        let mut persisted_auxiliary_infos_list = vec![];
+        for _ in compression_options {
+            // Create and save test transaction lists
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
                 start_version,
                 end_version,
                 proof_version,
                 include_events,
-                *use_compression,
-            )
-            .await
-            .unwrap();
+            );
+            transaction_lists_with_proof.push(transaction_list_with_proof.clone());
 
-            // Verify the response is correct
-            assert_eq!(response.is_compressed(), *use_compression);
-            match response.get_data_response().unwrap() {
-                DataResponse::TransactionsWithProof(response) => {
-                    assert_eq!(response, transaction_lists_with_proof[i]);
-                },
-                _ => panic!("Expected transactions with proof but got: {:?}", response),
-            };
+            // Create and save persisted auxiliary infos
+            let persisted_auxiliary_infos =
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
+            persisted_auxiliary_infos_list.push(persisted_auxiliary_infos.clone());
+
+            // Expect the data to be fetched from storage exactly once
+            utils::expect_get_transactions(
+                &mut db_reader,
+                start_version,
+                end_version - start_version + 1,
+                proof_version,
+                include_events,
+                transaction_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
+            );
+        }
+
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
+
+        // Create the storage client and server
+        let (mut mock_client, mut service, _, _, _) =
+            MockClient::new(Some(db_reader), Some(storage_config));
+        utils::update_storage_server_summary(&mut service, end_version, 10);
+        tokio::spawn(service.start());
+
+        // Repeatedly fetch the data and verify the responses
+        for (i, use_compression) in compression_options.iter().enumerate() {
+            for _ in 0..10 {
+                let response = utils::get_transactions_with_proof(
+                    &mut mock_client,
+                    start_version,
+                    end_version,
+                    proof_version,
+                    include_events,
+                    *use_compression,
+                    use_request_v2,
+                )
+                .await
+                .unwrap();
+
+                // Verify the response is correct
+                assert_eq!(response.is_compressed(), *use_compression);
+                utils::verify_transaction_with_proof_response(
+                    use_request_v2,
+                    transaction_lists_with_proof[i].clone(),
+                    persisted_auxiliary_infos_list[i].clone(),
+                    response,
+                );
+            }
         }
     }
 }
 
 #[tokio::test]
 async fn test_cachable_requests_data_versions() {
-    // Create test data
-    let start_versions = [0, 76, 101, 230, 300, 454];
-    let end_version = 454;
-    let proof_version = end_version;
-    let include_events = false;
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create test data
+        let start_versions = [0, 76, 101, 230, 300, 454];
+        let end_version = 454;
+        let proof_version = end_version;
+        let include_events = false;
 
-    // Create the mock db reader
-    let mut db_reader = mock::create_mock_db_reader();
-    let mut expectation_sequence = Sequence::new();
-    let mut transaction_lists_with_proof = vec![];
-    for start_version in start_versions {
-        // Create and save test transaction lists
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            start_version,
-            end_version,
-            proof_version,
-            include_events,
-        );
-        transaction_lists_with_proof.push(transaction_list_with_proof.clone());
-
-        // Expect the data to be fetched from storage once
-        db_reader
-            .expect_get_transactions()
-            .times(1)
-            .with(
-                eq(start_version),
-                eq(end_version - start_version + 1),
-                eq(proof_version),
-                eq(include_events),
-            )
-            .return_once(move |_, _, _, _| Ok(transaction_list_with_proof))
-            .in_sequence(&mut expectation_sequence);
-    }
-
-    // Create the storage client and server
-    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
-    utils::update_storage_server_summary(&mut service, end_version, 10);
-    tokio::spawn(service.start());
-
-    // Repeatedly fetch the data and verify the responses
-    for (i, start_version) in start_versions.iter().enumerate() {
-        for _ in 0..10 {
-            let response = utils::get_transactions_with_proof(
-                &mut mock_client,
-                *start_version,
+        // Create the mock db reader
+        let mut db_reader = mock::create_mock_db_reader();
+        let mut transaction_lists_with_proof = vec![];
+        let mut persisted_auxiliary_infos_list = vec![];
+        for start_version in start_versions {
+            // Create and save test transaction lists
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                start_version,
                 end_version,
                 proof_version,
                 include_events,
-                true,
-            )
-            .await
-            .unwrap();
+            );
+            transaction_lists_with_proof.push(transaction_list_with_proof.clone());
 
-            // Verify the response is correct
-            match response {
-                StorageServiceResponse::CompressedResponse(_, _) => {
-                    match response.get_data_response().unwrap() {
-                        DataResponse::TransactionsWithProof(transactions_with_proof) => {
-                            assert_eq!(transactions_with_proof, transaction_lists_with_proof[i])
-                        },
-                        _ => panic!(
-                            "Expected compressed transactions with proof but got: {:?}",
-                            response
-                        ),
-                    }
-                },
-                _ => panic!("Expected compressed response but got: {:?}", response),
-            };
+            // Create and save persisted auxiliary infos
+            let persisted_auxiliary_infos =
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
+            persisted_auxiliary_infos_list.push(persisted_auxiliary_infos.clone());
+
+            // Expect the data to be fetched from storage once
+            utils::expect_get_transactions(
+                &mut db_reader,
+                start_version,
+                end_version - start_version + 1,
+                proof_version,
+                include_events,
+                transaction_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
+            );
+        }
+
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
+
+        // Create the storage client and server
+        let (mut mock_client, mut service, _, _, _) =
+            MockClient::new(Some(db_reader), Some(storage_config));
+        utils::update_storage_server_summary(&mut service, end_version, 10);
+        tokio::spawn(service.start());
+
+        // Repeatedly fetch the data and verify the responses
+        for (i, start_version) in start_versions.iter().enumerate() {
+            for _ in 0..10 {
+                let response = utils::get_transactions_with_proof(
+                    &mut mock_client,
+                    *start_version,
+                    end_version,
+                    proof_version,
+                    include_events,
+                    true,
+                    use_request_v2,
+                )
+                .await
+                .unwrap();
+
+                // Verify the response is correct
+                assert!(response.is_compressed());
+                utils::verify_transaction_with_proof_response(
+                    use_request_v2,
+                    transaction_lists_with_proof[i].clone(),
+                    persisted_auxiliary_infos_list[i].clone(),
+                    response,
+                );
+            }
         }
     }
 }

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -42,7 +42,7 @@ use aptos_types::{
         state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
-        AccountOrderedTransactionsWithProof, TransactionListWithProof,
+        AccountOrderedTransactionsWithProof, PersistedAuxiliaryInfo, TransactionListWithProof,
         TransactionOutputListWithProof, TransactionWithProof, Version,
     },
     PeerId,
@@ -354,6 +354,12 @@ mock! {
         fn get_epoch_snapshot_prune_window(&self) -> aptos_storage_interface::Result<usize>;
 
         fn is_state_merkle_pruner_enabled(&self) -> aptos_storage_interface::Result<bool>;
+
+        fn get_persisted_auxiliary_info_iterator(
+            &self,
+            start_version: Version,
+            num_persisted_auxiliary_info: usize,
+        ) -> aptos_storage_interface::Result<Box<dyn Iterator<Item = aptos_storage_interface::Result<PersistedAuxiliaryInfo>>>>;
     }
 }
 

--- a/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
@@ -7,7 +7,8 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_storage_service_types::requests::{
-    DataRequest, NewTransactionOutputsWithProofRequest, StorageServiceRequest,
+    DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionOutputsWithProofRequest,
+    StorageServiceRequest, TransactionDataRequestType,
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
@@ -15,48 +16,312 @@ use futures::channel::oneshot::Receiver;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_new_transaction_outputs() {
-    // Test small and large chunk sizes
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [1, 100, max_output_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [1, 100, max_output_chunk_size] {
+            // Create test data
+            let highest_version = 5060;
+            let highest_epoch = 30;
+            let lowest_version = 101;
+            let peer_version = highest_version - chunk_size;
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let output_list_with_proof = utils::create_output_list_with_proof(
+                peer_version + 1,
+                highest_version,
+                highest_version,
+            );
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                highest_version,
+                use_request_v2,
+            );
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
+            );
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version + 1,
+                highest_version - peer_version,
+                highest_version,
+                output_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
+            );
+
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
+
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_config));
+            let active_optimistic_fetches = service.get_optimistic_fetches();
+            tokio::spawn(service.start());
+
+            // Send a request to optimistically fetch new transaction outputs
+            let mut response_receiver = get_new_outputs_with_proof(
+                &mut mock_client,
+                peer_version,
+                highest_epoch,
+                use_request_v2,
+            )
+            .await;
+
+            // Wait until the optimistic fetch is active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
+
+            // Verify no optimistic fetch response has been received yet
+            assert_none!(response_receiver.try_recv().unwrap());
+
+            // Force the optimistic fetch handler to work
+            utils::force_optimistic_fetch_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
+
+            // Verify a response is received and that it contains the correct data
+            utils::verify_new_transaction_outputs_with_proof(
+                &mut mock_client,
+                response_receiver,
+                use_request_v2,
+                output_list_with_proof,
+                highest_ledger_info,
+                persisted_auxiliary_infos,
+            )
+            .await;
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_new_transaction_outputs_different_networks() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [100, max_output_chunk_size] {
+            // Create test data
+            let highest_version = 5060;
+            let highest_epoch = 30;
+            let lowest_version = 101;
+            let peer_version_1 = highest_version - chunk_size;
+            let peer_version_2 = highest_version - (chunk_size - 50);
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let output_list_with_proof_1 = utils::create_output_list_with_proof(
+                peer_version_1 + 1,
+                highest_version,
+                highest_version,
+            );
+            let output_list_with_proof_2 = utils::create_output_list_with_proof(
+                peer_version_2 + 1,
+                highest_version,
+                highest_version,
+            );
+            let persisted_auxiliary_infos_1 = utils::create_persisted_auxiliary_infos(
+                peer_version_1 + 1,
+                highest_version,
+                use_request_v2,
+            );
+            let persisted_auxiliary_infos_2 = utils::create_persisted_auxiliary_infos(
+                peer_version_2 + 1,
+                highest_version,
+                use_request_v2,
+            );
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
+            );
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version_1 + 1,
+                highest_version - peer_version_1,
+                highest_version,
+                output_list_with_proof_1.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos_1.clone(),
+            );
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version_2 + 1,
+                highest_version - peer_version_2,
+                highest_version,
+                output_list_with_proof_2.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos_2.clone(),
+            );
+
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
+
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_config));
+            let active_optimistic_fetches = service.get_optimistic_fetches();
+            tokio::spawn(service.start());
+
+            // Send a request to optimistically fetch new transaction outputs for peer 1
+            let peer_id = PeerId::random();
+            let peer_network_1 = PeerNetworkId::new(NetworkId::Validator, peer_id);
+            let mut response_receiver_1 = get_new_outputs_with_proof_for_peer(
+                &mut mock_client,
+                peer_version_1,
+                highest_epoch,
+                Some(peer_network_1),
+                use_request_v2,
+            )
+            .await;
+
+            // Send a request to optimistically fetch new transaction outputs for peer 2
+            let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
+            let mut response_receiver_2 = get_new_outputs_with_proof_for_peer(
+                &mut mock_client,
+                peer_version_2,
+                highest_epoch,
+                Some(peer_network_2),
+                use_request_v2,
+            )
+            .await;
+
+            // Wait until the optimistic fetches are active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2).await;
+
+            // Verify no optimistic fetch response has been received yet
+            assert_none!(response_receiver_1.try_recv().unwrap());
+            assert_none!(response_receiver_2.try_recv().unwrap());
+
+            // Force the optimistic fetch handler to work
+            utils::force_optimistic_fetch_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
+
+            // Verify a response is received and that it contains the correct data
+            utils::verify_new_transaction_outputs_with_proof(
+                &mut mock_client,
+                response_receiver_1,
+                use_request_v2,
+                output_list_with_proof_1,
+                highest_ledger_info.clone(),
+                persisted_auxiliary_infos_1,
+            )
+            .await;
+            utils::verify_new_transaction_outputs_with_proof(
+                &mut mock_client,
+                response_receiver_2,
+                use_request_v2,
+                output_list_with_proof_2,
+                highest_ledger_info,
+                persisted_auxiliary_infos_2,
+            )
+            .await;
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "Canceled")]
+async fn test_get_new_transaction_outputs_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
+
+    // Send a new transaction output v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    let response_receiver = get_new_outputs_with_proof(
+        &mut mock_client,
+        0,
+        0,
+        true, // use_request_v2
+    )
+    .await;
+
+    // Wait for the response, which should never come
+    response_receiver.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_new_transaction_outputs_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Create test data
-        let highest_version = 5060;
-        let highest_epoch = 30;
-        let lowest_version = 101;
-        let peer_version = highest_version - chunk_size;
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+        let highest_version = 10000;
+        let highest_epoch = 10000;
+        let lowest_version = 0;
+        let peer_version = highest_version - 1000;
+        let peer_epoch = highest_epoch - 1000;
+        let epoch_change_version = peer_version + 1;
+        let epoch_change_proof = EpochChangeProof {
+            ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
+                peer_epoch,
+                epoch_change_version,
+            )],
+            more: false,
+        };
         let output_list_with_proof = utils::create_output_list_with_proof(
             peer_version + 1,
-            highest_version,
-            highest_version,
+            epoch_change_version,
+            epoch_change_version,
+        );
+        let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+            peer_version + 1,
+            epoch_change_version,
+            use_request_v2,
         );
 
         // Create the mock db reader
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        let mut db_reader = mock::create_mock_db_with_summary_updates(
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
+            lowest_version,
+        );
         utils::expect_get_transaction_outputs(
             &mut db_reader,
             peer_version + 1,
-            highest_version - peer_version,
-            highest_version,
+            epoch_change_version - peer_version,
+            epoch_change_version,
             output_list_with_proof.clone(),
+            use_request_v2,
+            persisted_auxiliary_infos.clone(),
         );
+        utils::expect_get_epoch_ending_ledger_infos(
+            &mut db_reader,
+            peer_epoch,
+            peer_epoch + 1,
+            epoch_change_proof.clone(),
+        );
+
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
 
         // Create the storage client and server
         let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), None);
+            MockClient::new(Some(db_reader), Some(storage_config));
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
         // Send a request to optimistically fetch new transaction outputs
-        let mut response_receiver =
-            get_new_outputs_with_proof(&mut mock_client, peer_version, highest_epoch).await;
+        let response_receiver =
+            get_new_outputs_with_proof(&mut mock_client, peer_version, peer_epoch, use_request_v2)
+                .await;
 
         // Wait until the optimistic fetch is active
         utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-        // Verify no optimistic fetch response has been received yet
-        assert_none!(response_receiver.try_recv().unwrap());
 
         // Force the optimistic fetch handler to work
         utils::force_optimistic_fetch_handler_to_run(
@@ -70,35 +335,44 @@ async fn test_get_new_transaction_outputs() {
         utils::verify_new_transaction_outputs_with_proof(
             &mut mock_client,
             response_receiver,
+            use_request_v2,
             output_list_with_proof,
-            highest_ledger_info,
+            epoch_change_proof.ledger_info_with_sigs[0].clone(),
+            persisted_auxiliary_infos,
         )
         .await;
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transaction_outputs_different_networks() {
-    // Test small and large chunk sizes
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [100, max_output_chunk_size] {
+async fn test_get_new_transaction_outputs_max_chunk() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config with a configured max chunk size
+        let max_transaction_output_chunk_size = 400;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_output_chunk_size,
+            enable_transaction_data_v2: use_request_v2,
+            ..StorageServiceConfig::default()
+        };
+
         // Create test data
-        let highest_version = 5060;
+        let highest_version = 65660;
         let highest_epoch = 30;
         let lowest_version = 101;
-        let peer_version_1 = highest_version - chunk_size;
-        let peer_version_2 = highest_version - (chunk_size - 50);
+        let requested_chunk_size = max_transaction_output_chunk_size + 100;
+        let peer_version = highest_version - requested_chunk_size;
         let highest_ledger_info =
             utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-        let output_list_with_proof_1 = utils::create_output_list_with_proof(
-            peer_version_1 + 1,
-            highest_version,
+        let output_list_with_proof = utils::create_output_list_with_proof(
+            peer_version + 1,
+            peer_version + max_transaction_output_chunk_size,
             highest_version,
         );
-        let output_list_with_proof_2 = utils::create_output_list_with_proof(
-            peer_version_2 + 1,
-            highest_version,
-            highest_version,
+        let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+            peer_version + 1,
+            peer_version + max_transaction_output_chunk_size,
+            use_request_v2,
         );
 
         // Create the mock db reader
@@ -106,52 +380,31 @@ async fn test_get_new_transaction_outputs_different_networks() {
             mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
         utils::expect_get_transaction_outputs(
             &mut db_reader,
-            peer_version_1 + 1,
-            highest_version - peer_version_1,
+            peer_version + 1,
+            max_transaction_output_chunk_size,
             highest_version,
-            output_list_with_proof_1.clone(),
-        );
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            peer_version_2 + 1,
-            highest_version - peer_version_2,
-            highest_version,
-            output_list_with_proof_2.clone(),
+            output_list_with_proof.clone(),
+            use_request_v2,
+            persisted_auxiliary_infos.clone(),
         );
 
         // Create the storage client and server
         let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), None);
+            MockClient::new(Some(db_reader), Some(storage_service_config));
         let active_optimistic_fetches = service.get_optimistic_fetches();
         tokio::spawn(service.start());
 
-        // Send a request to optimistically fetch new transaction outputs for peer 1
-        let peer_id = PeerId::random();
-        let peer_network_1 = PeerNetworkId::new(NetworkId::Validator, peer_id);
-        let mut response_receiver_1 = get_new_outputs_with_proof_for_peer(
+        // Send a request to optimistically fetch new transaction outputs
+        let response_receiver = get_new_outputs_with_proof(
             &mut mock_client,
-            peer_version_1,
+            peer_version,
             highest_epoch,
-            Some(peer_network_1),
+            use_request_v2,
         )
         .await;
 
-        // Send a request to optimistically fetch new transaction outputs for peer 2
-        let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
-        let mut response_receiver_2 = get_new_outputs_with_proof_for_peer(
-            &mut mock_client,
-            peer_version_2,
-            highest_epoch,
-            Some(peer_network_2),
-        )
-        .await;
-
-        // Wait until the optimistic fetches are active
-        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2).await;
-
-        // Verify no optimistic fetch response has been received yet
-        assert_none!(response_receiver_1.try_recv().unwrap());
-        assert_none!(response_receiver_2.try_recv().unwrap());
+        // Wait until the optimistic fetch is active
+        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
         // Force the optimistic fetch handler to work
         utils::force_optimistic_fetch_handler_to_run(
@@ -164,156 +417,14 @@ async fn test_get_new_transaction_outputs_different_networks() {
         // Verify a response is received and that it contains the correct data
         utils::verify_new_transaction_outputs_with_proof(
             &mut mock_client,
-            response_receiver_1,
-            output_list_with_proof_1,
-            highest_ledger_info.clone(),
-        )
-        .await;
-        utils::verify_new_transaction_outputs_with_proof(
-            &mut mock_client,
-            response_receiver_2,
-            output_list_with_proof_2,
+            response_receiver,
+            use_request_v2,
+            output_list_with_proof,
             highest_ledger_info,
+            persisted_auxiliary_infos,
         )
         .await;
     }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transaction_outputs_epoch_change() {
-    // Create test data
-    let highest_version = 10000;
-    let highest_epoch = 10000;
-    let lowest_version = 0;
-    let peer_version = highest_version - 1000;
-    let peer_epoch = highest_epoch - 1000;
-    let epoch_change_version = peer_version + 1;
-    let epoch_change_proof = EpochChangeProof {
-        ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
-            peer_epoch,
-            epoch_change_version,
-        )],
-        more: false,
-    };
-    let output_list_with_proof = utils::create_output_list_with_proof(
-        peer_version + 1,
-        epoch_change_version,
-        epoch_change_version,
-    );
-
-    // Create the mock db reader
-    let mut db_reader = mock::create_mock_db_with_summary_updates(
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
-        lowest_version,
-    );
-    utils::expect_get_transaction_outputs(
-        &mut db_reader,
-        peer_version + 1,
-        epoch_change_version - peer_version,
-        epoch_change_version,
-        output_list_with_proof.clone(),
-    );
-    utils::expect_get_epoch_ending_ledger_infos(
-        &mut db_reader,
-        peer_epoch,
-        peer_epoch + 1,
-        epoch_change_proof.clone(),
-    );
-
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), None);
-    let active_optimistic_fetches = service.get_optimistic_fetches();
-    tokio::spawn(service.start());
-
-    // Send a request to optimistically fetch new transaction outputs
-    let response_receiver =
-        get_new_outputs_with_proof(&mut mock_client, peer_version, peer_epoch).await;
-
-    // Wait until the optimistic fetch is active
-    utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-    // Force the optimistic fetch handler to work
-    utils::force_optimistic_fetch_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
-
-    // Verify a response is received and that it contains the correct data
-    utils::verify_new_transaction_outputs_with_proof(
-        &mut mock_client,
-        response_receiver,
-        output_list_with_proof,
-        epoch_change_proof.ledger_info_with_sigs[0].clone(),
-    )
-    .await;
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transaction_outputs_max_chunk() {
-    // Create a storage service config with a configured max chunk size
-    let max_transaction_output_chunk_size = 400;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_output_chunk_size,
-        ..StorageServiceConfig::default()
-    };
-
-    // Create test data
-    let highest_version = 65660;
-    let highest_epoch = 30;
-    let lowest_version = 101;
-    let requested_chunk_size = max_transaction_output_chunk_size + 100;
-    let peer_version = highest_version - requested_chunk_size;
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-    let output_list_with_proof = utils::create_output_list_with_proof(
-        peer_version + 1,
-        peer_version + max_transaction_output_chunk_size,
-        highest_version,
-    );
-
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    utils::expect_get_transaction_outputs(
-        &mut db_reader,
-        peer_version + 1,
-        max_transaction_output_chunk_size,
-        highest_version,
-        output_list_with_proof.clone(),
-    );
-
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_optimistic_fetches = service.get_optimistic_fetches();
-    tokio::spawn(service.start());
-
-    // Send a request to optimistically fetch new transaction outputs
-    let response_receiver =
-        get_new_outputs_with_proof(&mut mock_client, peer_version, highest_epoch).await;
-
-    // Wait until the optimistic fetch is active
-    utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-    // Force the optimistic fetch handler to work
-    utils::force_optimistic_fetch_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
-
-    // Verify a response is received and that it contains the correct data
-    utils::verify_new_transaction_outputs_with_proof(
-        &mut mock_client,
-        response_receiver,
-        output_list_with_proof,
-        highest_ledger_info,
-    )
-    .await;
 }
 
 /// Creates and sends a request for new transaction outputs
@@ -321,8 +432,16 @@ async fn get_new_outputs_with_proof(
     mock_client: &mut MockClient,
     known_version: u64,
     known_epoch: u64,
+    use_request_v2: bool,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
-    get_new_outputs_with_proof_for_peer(mock_client, known_version, known_epoch, None).await
+    get_new_outputs_with_proof_for_peer(
+        mock_client,
+        known_version,
+        known_epoch,
+        None,
+        use_request_v2,
+    )
+    .await
 }
 
 /// Creates and sends a request for new transaction outputs for the specified peer
@@ -331,13 +450,23 @@ async fn get_new_outputs_with_proof_for_peer(
     known_version: u64,
     known_epoch: u64,
     peer_network_id: Option<PeerNetworkId>,
+    use_request_v2: bool,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
-    let data_request =
+    let data_request = if use_request_v2 {
+        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
+        DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            known_version,
+            known_epoch,
+            max_response_bytes: 0,
+        })
+    } else {
         DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
             known_version,
             known_epoch,
-        });
+        })
+    };
     let storage_request = StorageServiceRequest::new(data_request, true);
 
     // Send the request

--- a/state-sync/storage-service/server/src/tests/new_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions.rs
@@ -7,7 +7,8 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_storage_service_types::requests::{
-    DataRequest, NewTransactionsWithProofRequest, StorageServiceRequest,
+    DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionsWithProofRequest,
+    StorageServiceRequest, TransactionData, TransactionDataRequestType,
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
@@ -15,59 +16,337 @@ use futures::channel::oneshot::Receiver;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_new_transactions() {
-    // Test small and large chunk sizes
-    let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
-    for chunk_size in [1, 100, max_transaction_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
+        for chunk_size in [1, 100, max_transaction_chunk_size] {
+            // Test event inclusion
+            for include_events in [true, false] {
+                // Create test data
+                let highest_version = 45576;
+                let highest_epoch = 43;
+                let lowest_version = 4566;
+                let peer_version = highest_version - chunk_size;
+                let highest_ledger_info =
+                    utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+                let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                    peer_version + 1,
+                    highest_version,
+                    highest_version,
+                    include_events,
+                );
+                let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                    peer_version + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+
+                // Create the mock db reader
+                let mut db_reader = mock::create_mock_db_with_summary_updates(
+                    highest_ledger_info.clone(),
+                    lowest_version,
+                );
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version + 1,
+                    highest_version - peer_version,
+                    highest_version,
+                    include_events,
+                    transaction_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
+                );
+
+                // Create a storage service config
+                let storage_config = utils::create_storage_config(use_request_v2);
+
+                // Create the storage client and server
+                let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                let active_optimistic_fetches = service.get_optimistic_fetches();
+                tokio::spawn(service.start());
+
+                // Send a request to optimistically fetch new transactions
+                let mut response_receiver = get_new_transactions_with_proof(
+                    &mut mock_client,
+                    peer_version,
+                    highest_epoch,
+                    include_events,
+                    use_request_v2,
+                )
+                .await;
+
+                // Wait until the optimistic fetch is active
+                utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1)
+                    .await;
+
+                // Verify no optimistic fetch response has been received yet
+                assert_none!(response_receiver.try_recv().unwrap());
+
+                // Force the optimistic fetch handler to work
+                utils::force_optimistic_fetch_handler_to_run(
+                    &mut mock_client,
+                    &mock_time,
+                    &storage_service_notifier,
+                )
+                .await;
+
+                // Verify a response is received and that it contains the correct data
+                utils::verify_new_transactions_with_proof(
+                    &mut mock_client,
+                    response_receiver,
+                    use_request_v2,
+                    transaction_list_with_proof,
+                    highest_ledger_info,
+                    persisted_auxiliary_infos,
+                )
+                .await;
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_new_transactions_different_networks() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
+        for chunk_size in [100, max_transaction_chunk_size] {
+            // Test event inclusion
+            for include_events in [true, false] {
+                // Create test data
+                let highest_version = 45576;
+                let highest_epoch = 43;
+                let lowest_version = 4566;
+                let peer_version_1 = highest_version - chunk_size;
+                let peer_version_2 = highest_version - (chunk_size - 10);
+                let highest_ledger_info =
+                    utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+                let transaction_list_with_proof_1 = utils::create_transaction_list_with_proof(
+                    peer_version_1 + 1,
+                    highest_version,
+                    highest_version,
+                    include_events,
+                );
+                let transaction_list_with_proof_2 = utils::create_transaction_list_with_proof(
+                    peer_version_2 + 1,
+                    highest_version,
+                    highest_version,
+                    include_events,
+                );
+                let persisted_auxiliary_infos_1 = utils::create_persisted_auxiliary_infos(
+                    peer_version_1 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+                let persisted_auxiliary_infos_2 = utils::create_persisted_auxiliary_infos(
+                    peer_version_2 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+
+                // Create the mock db reader
+                let mut db_reader = mock::create_mock_db_with_summary_updates(
+                    highest_ledger_info.clone(),
+                    lowest_version,
+                );
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version_1 + 1,
+                    highest_version - peer_version_1,
+                    highest_version,
+                    include_events,
+                    transaction_list_with_proof_1.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_1.clone(),
+                );
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version_2 + 1,
+                    highest_version - peer_version_2,
+                    highest_version,
+                    include_events,
+                    transaction_list_with_proof_2.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_2.clone(),
+                );
+
+                // Create a storage service config
+                let storage_config = utils::create_storage_config(use_request_v2);
+
+                // Create the storage client and server
+                let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                let active_optimistic_fetches = service.get_optimistic_fetches();
+                tokio::spawn(service.start());
+
+                // Send a request to optimistically fetch new transactions for peer 1
+                let peer_id = PeerId::random();
+                let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
+                let mut response_receiver_1 = get_new_transactions_with_proof_for_peer(
+                    &mut mock_client,
+                    peer_version_1,
+                    highest_epoch,
+                    include_events,
+                    Some(peer_network_1),
+                    use_request_v2,
+                )
+                .await;
+
+                // Send a request to optimistically fetch new transactions for peer 2
+                let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
+                let mut response_receiver_2 = get_new_transactions_with_proof_for_peer(
+                    &mut mock_client,
+                    peer_version_2,
+                    highest_epoch,
+                    include_events,
+                    Some(peer_network_2),
+                    use_request_v2,
+                )
+                .await;
+
+                // Wait until the optimistic fetches are active
+                utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2)
+                    .await;
+
+                // Verify no optimistic fetch response has been received yet
+                assert_none!(response_receiver_1.try_recv().unwrap());
+                assert_none!(response_receiver_2.try_recv().unwrap());
+
+                // Force the optimistic fetch handler to work
+                utils::force_optimistic_fetch_handler_to_run(
+                    &mut mock_client,
+                    &mock_time,
+                    &storage_service_notifier,
+                )
+                .await;
+
+                // Verify a response is received and that it contains the correct data for both peers
+                utils::verify_new_transactions_with_proof(
+                    &mut mock_client,
+                    response_receiver_1,
+                    use_request_v2,
+                    transaction_list_with_proof_1,
+                    highest_ledger_info.clone(),
+                    persisted_auxiliary_infos_1,
+                )
+                .await;
+                utils::verify_new_transactions_with_proof(
+                    &mut mock_client,
+                    response_receiver_2,
+                    use_request_v2,
+                    transaction_list_with_proof_2,
+                    highest_ledger_info,
+                    persisted_auxiliary_infos_2,
+                )
+                .await;
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "Canceled")]
+async fn test_get_new_transactions_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
+
+    // Send a new transaction v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    let response_receiver = get_new_transactions_with_proof(
+        &mut mock_client,
+        0,
+        0,
+        true,
+        true, // use_request_v2
+    )
+    .await;
+
+    // Wait for the response, which should never come
+    response_receiver.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_new_transactions_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Test event inclusion
         for include_events in [true, false] {
             // Create test data
             let highest_version = 45576;
-            let highest_epoch = 43;
+            let highest_epoch = 1032;
             let lowest_version = 4566;
-            let peer_version = highest_version - chunk_size;
-            let highest_ledger_info =
-                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let peer_version = highest_version - 100;
+            let peer_epoch = highest_epoch - 20;
+            let epoch_change_version = peer_version + 45;
+            let epoch_change_proof = EpochChangeProof {
+                ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
+                    peer_epoch,
+                    epoch_change_version,
+                )],
+                more: false,
+            };
             let transaction_list_with_proof = utils::create_transaction_list_with_proof(
                 peer_version + 1,
-                highest_version,
-                highest_version,
+                epoch_change_version,
+                epoch_change_version,
                 include_events,
+            );
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                epoch_change_version,
+                use_request_v2,
             );
 
             // Create the mock db reader
             let mut db_reader = mock::create_mock_db_with_summary_updates(
-                highest_ledger_info.clone(),
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
                 lowest_version,
             );
             utils::expect_get_transactions(
                 &mut db_reader,
                 peer_version + 1,
-                highest_version - peer_version,
-                highest_version,
+                epoch_change_version - peer_version,
+                epoch_change_version,
                 include_events,
                 transaction_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
             );
+            utils::expect_get_epoch_ending_ledger_infos(
+                &mut db_reader,
+                peer_epoch,
+                peer_epoch + 1,
+                epoch_change_proof.clone(),
+            );
+
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
 
             // Create the storage client and server
             let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-                MockClient::new(Some(db_reader), None);
+                MockClient::new(Some(db_reader), Some(storage_config));
             let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
             // Send a request to optimistically fetch new transactions
-            let mut response_receiver = get_new_transactions_with_proof(
+            let response_receiver = get_new_transactions_with_proof(
                 &mut mock_client,
                 peer_version,
-                highest_epoch,
+                peer_epoch,
                 include_events,
+                use_request_v2,
             )
             .await;
 
             // Wait until the optimistic fetch is active
             utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-            // Verify no optimistic fetch response has been received yet
-            assert_none!(response_receiver.try_recv().unwrap());
 
             // Force the optimistic fetch handler to work
             utils::force_optimistic_fetch_handler_to_run(
@@ -81,8 +360,10 @@ async fn test_get_new_transactions() {
             utils::verify_new_transactions_with_proof(
                 &mut mock_client,
                 response_receiver,
+                use_request_v2,
                 transaction_list_with_proof,
-                highest_ledger_info,
+                epoch_change_proof.ledger_info_with_sigs[0].clone(),
+                persisted_auxiliary_infos,
             )
             .await;
         }
@@ -90,31 +371,37 @@ async fn test_get_new_transactions() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transactions_different_networks() {
-    // Test small and large chunk sizes
-    let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
-    for chunk_size in [100, max_transaction_chunk_size] {
+async fn test_get_new_transactions_max_chunk() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config with a configured max chunk size
+        let max_transaction_chunk_size = 200;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_chunk_size,
+            enable_transaction_data_v2: use_request_v2,
+            ..StorageServiceConfig::default()
+        };
+
         // Test event inclusion
         for include_events in [true, false] {
             // Create test data
-            let highest_version = 45576;
-            let highest_epoch = 43;
-            let lowest_version = 4566;
-            let peer_version_1 = highest_version - chunk_size;
-            let peer_version_2 = highest_version - (chunk_size - 10);
+            let highest_version = 1034556;
+            let highest_epoch = 343;
+            let lowest_version = 3453;
+            let requested_chunk_size = max_transaction_chunk_size + 1;
+            let peer_version = highest_version - requested_chunk_size;
             let highest_ledger_info =
                 utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-            let transaction_list_with_proof_1 = utils::create_transaction_list_with_proof(
-                peer_version_1 + 1,
-                highest_version,
-                highest_version,
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                peer_version + 1,
+                peer_version + max_transaction_chunk_size,
+                peer_version + max_transaction_chunk_size,
                 include_events,
             );
-            let transaction_list_with_proof_2 = utils::create_transaction_list_with_proof(
-                peer_version_2 + 1,
-                highest_version,
-                highest_version,
-                include_events,
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                peer_version + max_transaction_chunk_size,
+                use_request_v2,
             );
 
             // Create the mock db reader
@@ -124,56 +411,33 @@ async fn test_get_new_transactions_different_networks() {
             );
             utils::expect_get_transactions(
                 &mut db_reader,
-                peer_version_1 + 1,
-                highest_version - peer_version_1,
+                peer_version + 1,
+                max_transaction_chunk_size,
                 highest_version,
                 include_events,
-                transaction_list_with_proof_1.clone(),
-            );
-            utils::expect_get_transactions(
-                &mut db_reader,
-                peer_version_2 + 1,
-                highest_version - peer_version_2,
-                highest_version,
-                include_events,
-                transaction_list_with_proof_2.clone(),
+                transaction_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
             );
 
             // Create the storage client and server
             let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-                MockClient::new(Some(db_reader), None);
+                MockClient::new(Some(db_reader), Some(storage_service_config));
             let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
-            // Send a request to optimistically fetch new transactions for peer 1
-            let peer_id = PeerId::random();
-            let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
-            let mut response_receiver_1 = get_new_transactions_with_proof_for_peer(
+            // Send a request to optimistically fetch new transactions
+            let response_receiver = get_new_transactions_with_proof(
                 &mut mock_client,
-                peer_version_1,
+                peer_version,
                 highest_epoch,
                 include_events,
-                Some(peer_network_1),
+                use_request_v2,
             )
             .await;
 
-            // Send a request to optimistically fetch new transactions for peer 2
-            let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
-            let mut response_receiver_2 = get_new_transactions_with_proof_for_peer(
-                &mut mock_client,
-                peer_version_2,
-                highest_epoch,
-                include_events,
-                Some(peer_network_2),
-            )
-            .await;
-
-            // Wait until the optimistic fetches are active
-            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2).await;
-
-            // Verify no optimistic fetch response has been received yet
-            assert_none!(response_receiver_1.try_recv().unwrap());
-            assert_none!(response_receiver_2.try_recv().unwrap());
+            // Wait until the optimistic fetch is active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
             // Force the optimistic fetch handler to work
             utils::force_optimistic_fetch_handler_to_run(
@@ -183,179 +447,17 @@ async fn test_get_new_transactions_different_networks() {
             )
             .await;
 
-            // Verify a response is received and that it contains the correct data for both peers
+            // Verify a response is received and that it contains the correct data
             utils::verify_new_transactions_with_proof(
                 &mut mock_client,
-                response_receiver_1,
-                transaction_list_with_proof_1,
-                highest_ledger_info.clone(),
-            )
-            .await;
-            utils::verify_new_transactions_with_proof(
-                &mut mock_client,
-                response_receiver_2,
-                transaction_list_with_proof_2,
+                response_receiver,
+                use_request_v2,
+                transaction_list_with_proof,
                 highest_ledger_info,
+                persisted_auxiliary_infos,
             )
             .await;
         }
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transactions_epoch_change() {
-    // Test event inclusion
-    for include_events in [true, false] {
-        // Create test data
-        let highest_version = 45576;
-        let highest_epoch = 1032;
-        let lowest_version = 4566;
-        let peer_version = highest_version - 100;
-        let peer_epoch = highest_epoch - 20;
-        let epoch_change_version = peer_version + 45;
-        let epoch_change_proof = EpochChangeProof {
-            ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
-                peer_epoch,
-                epoch_change_version,
-            )],
-            more: false,
-        };
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            epoch_change_version,
-            epoch_change_version,
-            include_events,
-        );
-
-        // Create the mock db reader
-        let mut db_reader = mock::create_mock_db_with_summary_updates(
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
-            lowest_version,
-        );
-        utils::expect_get_transactions(
-            &mut db_reader,
-            peer_version + 1,
-            epoch_change_version - peer_version,
-            epoch_change_version,
-            include_events,
-            transaction_list_with_proof.clone(),
-        );
-        utils::expect_get_epoch_ending_ledger_infos(
-            &mut db_reader,
-            peer_epoch,
-            peer_epoch + 1,
-            epoch_change_proof.clone(),
-        );
-
-        // Create the storage client and server
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), None);
-        let active_optimistic_fetches = service.get_optimistic_fetches();
-        tokio::spawn(service.start());
-
-        // Send a request to optimistically fetch new transactions
-        let response_receiver = get_new_transactions_with_proof(
-            &mut mock_client,
-            peer_version,
-            peer_epoch,
-            include_events,
-        )
-        .await;
-
-        // Wait until the optimistic fetch is active
-        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-        // Force the optimistic fetch handler to work
-        utils::force_optimistic_fetch_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
-
-        // Verify a response is received and that it contains the correct data
-        utils::verify_new_transactions_with_proof(
-            &mut mock_client,
-            response_receiver,
-            transaction_list_with_proof,
-            epoch_change_proof.ledger_info_with_sigs[0].clone(),
-        )
-        .await;
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transactions_max_chunk() {
-    // Create a storage service config with a configured max chunk size
-    let max_transaction_chunk_size = 200;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_chunk_size,
-        ..StorageServiceConfig::default()
-    };
-
-    // Test event inclusion
-    for include_events in [true, false] {
-        // Create test data
-        let highest_version = 1034556;
-        let highest_epoch = 343;
-        let lowest_version = 3453;
-        let requested_chunk_size = max_transaction_chunk_size + 1;
-        let peer_version = highest_version - requested_chunk_size;
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            peer_version + max_transaction_chunk_size,
-            peer_version + max_transaction_chunk_size,
-            include_events,
-        );
-
-        // Create the mock db reader
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        utils::expect_get_transactions(
-            &mut db_reader,
-            peer_version + 1,
-            max_transaction_chunk_size,
-            highest_version,
-            include_events,
-            transaction_list_with_proof.clone(),
-        );
-
-        // Create the storage client and server
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_service_config));
-        let active_optimistic_fetches = service.get_optimistic_fetches();
-        tokio::spawn(service.start());
-
-        // Send a request to optimistically fetch new transactions
-        let response_receiver = get_new_transactions_with_proof(
-            &mut mock_client,
-            peer_version,
-            highest_epoch,
-            include_events,
-        )
-        .await;
-
-        // Wait until the optimistic fetch is active
-        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-        // Force the optimistic fetch handler to work
-        utils::force_optimistic_fetch_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
-
-        // Verify a response is received and that it contains the correct data
-        utils::verify_new_transactions_with_proof(
-            &mut mock_client,
-            response_receiver,
-            transaction_list_with_proof,
-            highest_ledger_info,
-        )
-        .await;
     }
 }
 
@@ -365,6 +467,7 @@ async fn get_new_transactions_with_proof(
     known_version: u64,
     known_epoch: u64,
     include_events: bool,
+    use_request_v2: bool,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     get_new_transactions_with_proof_for_peer(
         mock_client,
@@ -372,6 +475,7 @@ async fn get_new_transactions_with_proof(
         known_epoch,
         include_events,
         None,
+        use_request_v2,
     )
     .await
 }
@@ -383,13 +487,25 @@ async fn get_new_transactions_with_proof_for_peer(
     known_epoch: u64,
     include_events: bool,
     peer_network_id: Option<PeerNetworkId>,
+    use_request_v2: bool,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
-    let data_request = DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
-        known_version,
-        known_epoch,
-        include_events,
-    });
+    let data_request = if use_request_v2 {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionData(TransactionData { include_events });
+        DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            known_version,
+            known_epoch,
+            max_response_bytes: 0,
+        })
+    } else {
+        DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+            known_version,
+            known_epoch,
+            include_events,
+        })
+    };
     let storage_request = StorageServiceRequest::new(data_request, true);
 
     // Send the request

--- a/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
@@ -7,7 +7,8 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_storage_service_types::requests::{
-    DataRequest, NewTransactionsOrOutputsWithProofRequest, StorageServiceRequest,
+    DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
+    StorageServiceRequest, TransactionDataRequestType, TransactionOrOutputData,
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
@@ -15,50 +16,426 @@ use futures::channel::oneshot::Receiver;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_new_transactions_or_outputs() {
-    // Test small and large chunk sizes
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [1, 100, max_output_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [1, 100, max_output_chunk_size] {
+            // Test fallback to transaction syncing
+            for fallback_to_transactions in [false, true] {
+                // Create test data
+                let highest_version = 5060;
+                let highest_epoch = 30;
+                let lowest_version = 101;
+                let peer_version = highest_version - chunk_size;
+                let highest_ledger_info =
+                    utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+                let output_list_with_proof = utils::create_output_list_with_proof(
+                    peer_version + 1,
+                    highest_version,
+                    highest_version,
+                );
+                let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                    peer_version + 1,
+                    highest_version,
+                    highest_version,
+                    false,
+                );
+                let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                    peer_version + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+
+                // Create the mock db reader
+                let mut db_reader = mock::create_mock_db_with_summary_updates(
+                    highest_ledger_info.clone(),
+                    lowest_version,
+                );
+                utils::expect_get_transaction_outputs(
+                    &mut db_reader,
+                    peer_version + 1,
+                    highest_version - peer_version,
+                    highest_version,
+                    output_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
+                );
+                if fallback_to_transactions {
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        peer_version + 1,
+                        highest_version - peer_version,
+                        highest_version,
+                        false,
+                        transaction_list_with_proof.clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos.clone(),
+                    );
+                }
+
+                // Create the storage client and server
+                let storage_config = utils::configure_network_chunk_limit(
+                    fallback_to_transactions,
+                    &output_list_with_proof,
+                    &transaction_list_with_proof,
+                    use_request_v2,
+                );
+                let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                let active_optimistic_fetches = service.get_optimistic_fetches();
+                tokio::spawn(service.start());
+
+                // Send a request to optimistically fetch new transactions or outputs
+                let mut response_receiver = get_new_transactions_or_outputs_with_proof(
+                    &mut mock_client,
+                    peer_version,
+                    highest_epoch,
+                    false,
+                    0, // Outputs cannot be reduced and will fallback to transactions
+                    use_request_v2,
+                )
+                .await;
+
+                // Wait until the optimistic fetch is active
+                utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1)
+                    .await;
+
+                // Verify no optimistic fetch response has been received yet
+                assert_none!(response_receiver.try_recv().unwrap());
+
+                // Force the optimistic fetch handler to work
+                utils::force_optimistic_fetch_handler_to_run(
+                    &mut mock_client,
+                    &mock_time,
+                    &storage_service_notifier,
+                )
+                .await;
+
+                // Verify a response is received and that it contains the correct data
+                if fallback_to_transactions {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver,
+                        use_request_v2,
+                        Some(transaction_list_with_proof),
+                        None,
+                        highest_ledger_info,
+                        persisted_auxiliary_infos,
+                    )
+                    .await;
+                } else {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver,
+                        use_request_v2,
+                        None,
+                        Some(output_list_with_proof),
+                        highest_ledger_info,
+                        persisted_auxiliary_infos,
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_new_transactions_or_outputs_different_network() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [100, max_output_chunk_size] {
+            // Test fallback to transaction syncing
+            for fallback_to_transactions in [false, true] {
+                // Create test data
+                let highest_version = 5060;
+                let highest_epoch = 30;
+                let lowest_version = 101;
+                let peer_version_1 = highest_version - chunk_size;
+                let peer_version_2 = highest_version - chunk_size + 1;
+                let highest_ledger_info =
+                    utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+                let output_list_with_proof_1 = utils::create_output_list_with_proof(
+                    peer_version_1 + 1,
+                    highest_version,
+                    highest_version,
+                );
+                let output_list_with_proof_2 = utils::create_output_list_with_proof(
+                    peer_version_2 + 1,
+                    highest_version,
+                    highest_version,
+                );
+                let transaction_list_with_proof_1 = utils::create_transaction_list_with_proof(
+                    peer_version_1 + 1,
+                    highest_version,
+                    highest_version,
+                    false,
+                );
+                let transaction_list_with_proof_2 = utils::create_transaction_list_with_proof(
+                    peer_version_2 + 1,
+                    highest_version,
+                    highest_version,
+                    false,
+                );
+                let persisted_auxiliary_infos_1 = utils::create_persisted_auxiliary_infos(
+                    peer_version_1 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+                let persisted_auxiliary_infos_2 = utils::create_persisted_auxiliary_infos(
+                    peer_version_2 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+
+                // Create the mock db reader
+                let mut db_reader = mock::create_mock_db_with_summary_updates(
+                    highest_ledger_info.clone(),
+                    lowest_version,
+                );
+                utils::expect_get_transaction_outputs(
+                    &mut db_reader,
+                    peer_version_1 + 1,
+                    highest_version - peer_version_1,
+                    highest_version,
+                    output_list_with_proof_1.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_1.clone(),
+                );
+                utils::expect_get_transaction_outputs(
+                    &mut db_reader,
+                    peer_version_2 + 1,
+                    highest_version - peer_version_2,
+                    highest_version,
+                    output_list_with_proof_2.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_2.clone(),
+                );
+                if fallback_to_transactions {
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        peer_version_1 + 1,
+                        highest_version - peer_version_1,
+                        highest_version,
+                        false,
+                        transaction_list_with_proof_1.clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos_1.clone(),
+                    );
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        peer_version_2 + 1,
+                        highest_version - peer_version_2,
+                        highest_version,
+                        false,
+                        transaction_list_with_proof_2.clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos_2.clone(),
+                    );
+                }
+
+                // Create the storage client and server
+                let storage_config = utils::configure_network_chunk_limit(
+                    fallback_to_transactions,
+                    &output_list_with_proof_1,
+                    &transaction_list_with_proof_1,
+                    use_request_v2,
+                );
+                let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                let active_optimistic_fetches = service.get_optimistic_fetches();
+                tokio::spawn(service.start());
+
+                // Send a request to optimistically fetch new transactions or outputs for peer 1
+                let peer_id = PeerId::random();
+                let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
+                let mut response_receiver_1 = get_new_transactions_or_outputs_with_proof_for_peer(
+                    &mut mock_client,
+                    peer_version_1,
+                    highest_epoch,
+                    false,
+                    0, // Outputs cannot be reduced and will fallback to transactions
+                    Some(peer_network_1),
+                    use_request_v2,
+                )
+                .await;
+
+                // Send a request to optimistically fetch new transactions or outputs for peer 1
+                let peer_network_2 = PeerNetworkId::new(NetworkId::Validator, peer_id);
+                let mut response_receiver_2 = get_new_transactions_or_outputs_with_proof_for_peer(
+                    &mut mock_client,
+                    peer_version_2,
+                    highest_epoch,
+                    false,
+                    0, // Outputs cannot be reduced and will fallback to transactions
+                    Some(peer_network_2),
+                    use_request_v2,
+                )
+                .await;
+
+                // Wait until the optimistic fetches are active
+                utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2)
+                    .await;
+
+                // Verify no optimistic fetch response has been received yet
+                assert_none!(response_receiver_1.try_recv().unwrap());
+                assert_none!(response_receiver_2.try_recv().unwrap());
+
+                // Force the optimistic fetch handler to work
+                utils::force_optimistic_fetch_handler_to_run(
+                    &mut mock_client,
+                    &mock_time,
+                    &storage_service_notifier,
+                )
+                .await;
+
+                // Verify a response is received and that it contains the correct data
+                if fallback_to_transactions {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_1,
+                        use_request_v2,
+                        Some(transaction_list_with_proof_1.clone()),
+                        None,
+                        highest_ledger_info.clone(),
+                        persisted_auxiliary_infos_1.clone(),
+                    )
+                    .await;
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_2,
+                        use_request_v2,
+                        Some(transaction_list_with_proof_2.clone()),
+                        None,
+                        highest_ledger_info,
+                        persisted_auxiliary_infos_2.clone(),
+                    )
+                    .await;
+                } else {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_1,
+                        use_request_v2,
+                        None,
+                        Some(output_list_with_proof_1.clone()),
+                        highest_ledger_info.clone(),
+                        persisted_auxiliary_infos_1.clone(),
+                    )
+                    .await;
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_2,
+                        use_request_v2,
+                        None,
+                        Some(output_list_with_proof_2.clone()),
+                        highest_ledger_info,
+                        persisted_auxiliary_infos_2.clone(),
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "Canceled")]
+async fn test_get_new_transactions_or_outputs_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
+
+    // Send a new transaction or output v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    let response_receiver = get_new_transactions_or_outputs_with_proof(
+        &mut mock_client,
+        0,
+        0,
+        true,
+        0,
+        true, // use_request_v2
+    )
+    .await;
+
+    // Wait for the response, which should never come
+    response_receiver.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_get_new_transactions_or_outputs_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Test fallback to transaction syncing
         for fallback_to_transactions in [false, true] {
             // Create test data
-            let highest_version = 5060;
-            let highest_epoch = 30;
-            let lowest_version = 101;
-            let peer_version = highest_version - chunk_size;
-            let highest_ledger_info =
-                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let highest_version = 10000;
+            let highest_epoch = 10000;
+            let lowest_version = 0;
+            let peer_version = highest_version - 1000;
+            let peer_epoch = highest_epoch - 1000;
+            let epoch_change_version = peer_version + 1;
+            let epoch_change_proof = EpochChangeProof {
+                ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
+                    peer_epoch,
+                    epoch_change_version,
+                )],
+                more: false,
+            };
             let output_list_with_proof = utils::create_output_list_with_proof(
                 peer_version + 1,
-                highest_version,
-                highest_version,
+                epoch_change_version,
+                epoch_change_version,
             );
             let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-                highest_version,
-                highest_version,
-                highest_version,
+                peer_version + 1,
+                epoch_change_version,
+                epoch_change_version,
                 false,
-            ); // Creates a small transaction list
+            );
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                epoch_change_version,
+                use_request_v2,
+            );
 
             // Create the mock db reader
             let mut db_reader = mock::create_mock_db_with_summary_updates(
-                highest_ledger_info.clone(),
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
                 lowest_version,
+            );
+            utils::expect_get_epoch_ending_ledger_infos(
+                &mut db_reader,
+                peer_epoch,
+                peer_epoch + 1,
+                epoch_change_proof.clone(),
             );
             utils::expect_get_transaction_outputs(
                 &mut db_reader,
                 peer_version + 1,
-                highest_version - peer_version,
-                highest_version,
+                epoch_change_version - peer_version,
+                epoch_change_version,
                 output_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
             );
             if fallback_to_transactions {
                 utils::expect_get_transactions(
                     &mut db_reader,
                     peer_version + 1,
-                    highest_version - peer_version,
-                    highest_version,
+                    epoch_change_version - peer_version,
+                    epoch_change_version,
                     false,
                     transaction_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
                 );
             }
 
@@ -67,28 +444,27 @@ async fn test_get_new_transactions_or_outputs() {
                 fallback_to_transactions,
                 &output_list_with_proof,
                 &transaction_list_with_proof,
+                use_request_v2,
             );
             let (mut mock_client, service, storage_service_notifier, mock_time, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
             let active_optimistic_fetches = service.get_optimistic_fetches();
             tokio::spawn(service.start());
 
-            // Send a request to optimistically fetch new transactions or outputs
-            let mut response_receiver = get_new_transactions_or_outputs_with_proof(
+            // Send a request to optimistically fetch new transaction outputs
+            let response_receiver = get_new_transactions_or_outputs_with_proof(
                 &mut mock_client,
                 peer_version,
-                highest_epoch,
+                peer_epoch,
                 false,
-                0, // Outputs cannot be reduced and will fallback to transactions
+                5,
+                use_request_v2,
             )
             .await;
 
             // Wait until the optimistic fetch is active
             utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
 
-            // Verify no optimistic fetch response has been received yet
-            assert_none!(response_receiver.try_recv().unwrap());
-
             // Force the optimistic fetch handler to work
             utils::force_optimistic_fetch_handler_to_run(
                 &mut mock_client,
@@ -102,404 +478,153 @@ async fn test_get_new_transactions_or_outputs() {
                 utils::verify_new_transactions_or_outputs_with_proof(
                     &mut mock_client,
                     response_receiver,
+                    use_request_v2,
                     Some(transaction_list_with_proof),
                     None,
-                    highest_ledger_info,
+                    epoch_change_proof.ledger_info_with_sigs[0].clone(),
+                    persisted_auxiliary_infos.clone(),
                 )
                 .await;
             } else {
                 utils::verify_new_transactions_or_outputs_with_proof(
                     &mut mock_client,
                     response_receiver,
+                    use_request_v2,
                     None,
                     Some(output_list_with_proof),
-                    highest_ledger_info,
+                    epoch_change_proof.ledger_info_with_sigs[0].clone(),
+                    persisted_auxiliary_infos.clone(),
                 )
                 .await;
             }
-        }
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transactions_or_outputs_different_network() {
-    // Test small and large chunk sizes
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [100, max_output_chunk_size] {
-        // Test fallback to transaction syncing
-        for fallback_to_transactions in [false, true] {
-            // Create test data
-            let highest_version = 5060;
-            let highest_epoch = 30;
-            let lowest_version = 101;
-            let peer_version_1 = highest_version - chunk_size;
-            let peer_version_2 = highest_version - (chunk_size - 50);
-            let highest_ledger_info =
-                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-            let output_list_with_proof_1 = utils::create_output_list_with_proof(
-                peer_version_1 + 1,
-                highest_version,
-                highest_version,
-            );
-            let output_list_with_proof_2 = utils::create_output_list_with_proof(
-                peer_version_2 + 1,
-                highest_version,
-                highest_version,
-            );
-            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-                highest_version,
-                highest_version,
-                highest_version,
-                false,
-            ); // Creates a small transaction list
-
-            // Create the mock db reader
-            let mut db_reader = mock::create_mock_db_with_summary_updates(
-                highest_ledger_info.clone(),
-                lowest_version,
-            );
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
-                peer_version_1 + 1,
-                highest_version - peer_version_1,
-                highest_version,
-                output_list_with_proof_1.clone(),
-            );
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
-                peer_version_2 + 1,
-                highest_version - peer_version_2,
-                highest_version,
-                output_list_with_proof_2.clone(),
-            );
-            if fallback_to_transactions {
-                utils::expect_get_transactions(
-                    &mut db_reader,
-                    peer_version_1 + 1,
-                    highest_version - peer_version_1,
-                    highest_version,
-                    false,
-                    transaction_list_with_proof.clone(),
-                );
-                utils::expect_get_transactions(
-                    &mut db_reader,
-                    peer_version_2 + 1,
-                    highest_version - peer_version_2,
-                    highest_version,
-                    false,
-                    transaction_list_with_proof.clone(),
-                );
-            }
-
-            // Create the storage client and server
-            let storage_config = utils::configure_network_chunk_limit(
-                fallback_to_transactions,
-                &output_list_with_proof_1,
-                &transaction_list_with_proof,
-            );
-            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-                MockClient::new(Some(db_reader), Some(storage_config));
-            let active_optimistic_fetches = service.get_optimistic_fetches();
-            tokio::spawn(service.start());
-
-            // Send a request to optimistically fetch new transactions or outputs for peer 1
-            let peer_id = PeerId::random();
-            let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
-            let mut response_receiver_1 = get_new_transactions_or_outputs_with_proof_for_peer(
-                &mut mock_client,
-                peer_version_1,
-                highest_epoch,
-                false,
-                0, // Outputs cannot be reduced and will fallback to transactions
-                Some(peer_network_1),
-            )
-            .await;
-
-            // Send a request to optimistically fetch new transactions or outputs for peer 1
-            let peer_network_2 = PeerNetworkId::new(NetworkId::Validator, peer_id);
-            let mut response_receiver_2 = get_new_transactions_or_outputs_with_proof_for_peer(
-                &mut mock_client,
-                peer_version_2,
-                highest_epoch,
-                false,
-                0, // Outputs cannot be reduced and will fallback to transactions
-                Some(peer_network_2),
-            )
-            .await;
-
-            // Wait until the optimistic fetches are active
-            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 2).await;
-
-            // Verify no optimistic fetch response has been received yet
-            assert_none!(response_receiver_1.try_recv().unwrap());
-            assert_none!(response_receiver_2.try_recv().unwrap());
-
-            // Force the optimistic fetch handler to work
-            utils::force_optimistic_fetch_handler_to_run(
-                &mut mock_client,
-                &mock_time,
-                &storage_service_notifier,
-            )
-            .await;
-
-            // Verify a response is received and that it contains the correct data
-            if fallback_to_transactions {
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver_1,
-                    Some(transaction_list_with_proof.clone()),
-                    None,
-                    highest_ledger_info.clone(),
-                )
-                .await;
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver_2,
-                    Some(transaction_list_with_proof),
-                    None,
-                    highest_ledger_info,
-                )
-                .await;
-            } else {
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver_1,
-                    None,
-                    Some(output_list_with_proof_1.clone()),
-                    highest_ledger_info.clone(),
-                )
-                .await;
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver_2,
-                    None,
-                    Some(output_list_with_proof_2.clone()),
-                    highest_ledger_info,
-                )
-                .await;
-            }
-        }
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_get_new_transactions_or_outputs_epoch_change() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let highest_version = 10000;
-        let highest_epoch = 10000;
-        let lowest_version = 0;
-        let peer_version = highest_version - 1000;
-        let peer_epoch = highest_epoch - 1000;
-        let epoch_change_version = peer_version + 1;
-        let epoch_change_proof = EpochChangeProof {
-            ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
-                peer_epoch,
-                epoch_change_version,
-            )],
-            more: false,
-        };
-        let output_list_with_proof = utils::create_output_list_with_proof(
-            peer_version + 1,
-            epoch_change_version,
-            epoch_change_version,
-        );
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            peer_version + 1,
-            epoch_change_version,
-            false,
-        ); // Creates a small transaction list
-
-        // Create the mock db reader
-        let mut db_reader = mock::create_mock_db_with_summary_updates(
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
-            lowest_version,
-        );
-        utils::expect_get_epoch_ending_ledger_infos(
-            &mut db_reader,
-            peer_epoch,
-            peer_epoch + 1,
-            epoch_change_proof.clone(),
-        );
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            peer_version + 1,
-            epoch_change_version - peer_version,
-            epoch_change_version,
-            output_list_with_proof.clone(),
-        );
-        if fallback_to_transactions {
-            utils::expect_get_transactions(
-                &mut db_reader,
-                peer_version + 1,
-                epoch_change_version - peer_version,
-                epoch_change_version,
-                false,
-                transaction_list_with_proof.clone(),
-            );
-        }
-
-        // Create the storage client and server
-        let storage_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_list_with_proof,
-            &transaction_list_with_proof,
-        );
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_config));
-        let active_optimistic_fetches = service.get_optimistic_fetches();
-        tokio::spawn(service.start());
-
-        // Send a request to optimistically fetch new transaction outputs
-        let response_receiver = get_new_transactions_or_outputs_with_proof(
-            &mut mock_client,
-            peer_version,
-            peer_epoch,
-            false,
-            5,
-        )
-        .await;
-
-        // Wait until the optimistic fetch is active
-        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-        // Force the optimistic fetch handler to work
-        utils::force_optimistic_fetch_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
-
-        // Verify a response is received and that it contains the correct data
-        if fallback_to_transactions {
-            utils::verify_new_transactions_or_outputs_with_proof(
-                &mut mock_client,
-                response_receiver,
-                Some(transaction_list_with_proof),
-                None,
-                epoch_change_proof.ledger_info_with_sigs[0].clone(),
-            )
-            .await;
-        } else {
-            utils::verify_new_transactions_or_outputs_with_proof(
-                &mut mock_client,
-                response_receiver,
-                None,
-                Some(output_list_with_proof),
-                epoch_change_proof.ledger_info_with_sigs[0].clone(),
-            )
-            .await;
         }
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_get_new_transactions_or_outputs_max_chunk() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let highest_version = 65660;
-        let highest_epoch = 30;
-        let lowest_version = 101;
-        let max_transaction_output_chunk_size = 600;
-        let requested_chunk_size = max_transaction_output_chunk_size + 1;
-        let peer_version = highest_version - requested_chunk_size;
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-        let output_list_with_proof = utils::create_output_list_with_proof(
-            peer_version + 1,
-            peer_version + max_transaction_output_chunk_size,
-            highest_version,
-        );
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            peer_version + 1,
-            peer_version + max_transaction_output_chunk_size,
-            false,
-        ); // Creates a small transaction list
-
-        // Create the mock db reader
-        let max_num_output_reductions = 5;
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        for i in 0..=max_num_output_reductions {
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test fallback to transaction syncing
+        for fallback_to_transactions in [false, true] {
+            // Create test data
+            let highest_version = 65660;
+            let highest_epoch = 30;
+            let lowest_version = 101;
+            let max_transaction_output_chunk_size = 600;
+            let requested_chunk_size = max_transaction_output_chunk_size + 1;
+            let peer_version = highest_version - requested_chunk_size;
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let output_list_with_proof = utils::create_output_list_with_proof(
                 peer_version + 1,
-                (max_transaction_output_chunk_size as u32 / (u32::pow(2, i as u32))) as u64,
+                peer_version + max_transaction_output_chunk_size,
                 highest_version,
-                output_list_with_proof.clone(),
             );
-        }
-        if fallback_to_transactions {
-            utils::expect_get_transactions(
-                &mut db_reader,
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
                 peer_version + 1,
-                max_transaction_output_chunk_size,
-                highest_version,
+                peer_version + max_transaction_output_chunk_size,
+                peer_version + max_transaction_output_chunk_size,
                 false,
-                transaction_list_with_proof.clone(),
             );
-        }
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                peer_version + max_transaction_output_chunk_size,
+                use_request_v2,
+            );
 
-        // Create the storage service config
-        let mut storage_service_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_list_with_proof,
-            &transaction_list_with_proof,
-        );
-        storage_service_config.max_transaction_output_chunk_size =
-            max_transaction_output_chunk_size;
+            // Create the mock db reader
+            let max_num_output_reductions = 5;
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
+            );
+            for i in 0..=max_num_output_reductions {
+                utils::expect_get_transaction_outputs(
+                    &mut db_reader,
+                    peer_version + 1,
+                    (max_transaction_output_chunk_size as u32 / (u32::pow(2, i as u32))) as u64,
+                    highest_version,
+                    output_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
+                );
+            }
+            if fallback_to_transactions {
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version + 1,
+                    max_transaction_output_chunk_size,
+                    highest_version,
+                    false,
+                    transaction_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
+                );
+            }
 
-        // Create the storage client and server
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_service_config));
-        let active_optimistic_fetches = service.get_optimistic_fetches();
-        tokio::spawn(service.start());
+            // Create the storage service config
+            let mut storage_service_config = utils::configure_network_chunk_limit(
+                fallback_to_transactions,
+                &output_list_with_proof,
+                &transaction_list_with_proof,
+                use_request_v2,
+            );
+            storage_service_config.max_transaction_output_chunk_size =
+                max_transaction_output_chunk_size;
 
-        // Send a request to optimistically fetch new transaction outputs
-        let response_receiver = get_new_transactions_or_outputs_with_proof(
-            &mut mock_client,
-            peer_version,
-            highest_epoch,
-            false,
-            max_num_output_reductions,
-        )
-        .await;
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_service_config));
+            let active_optimistic_fetches = service.get_optimistic_fetches();
+            tokio::spawn(service.start());
 
-        // Wait until the optimistic fetch is active
-        utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
-
-        // Force the optimistic fetch handler to work
-        utils::force_optimistic_fetch_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
-
-        // Verify a response is received and that it contains the correct data
-        if fallback_to_transactions {
-            utils::verify_new_transactions_or_outputs_with_proof(
+            // Send a request to optimistically fetch new transaction outputs
+            let response_receiver = get_new_transactions_or_outputs_with_proof(
                 &mut mock_client,
-                response_receiver,
-                Some(transaction_list_with_proof),
-                None,
-                highest_ledger_info,
+                peer_version,
+                highest_epoch,
+                false,
+                max_num_output_reductions,
+                use_request_v2,
             )
             .await;
-        } else {
-            utils::verify_new_transactions_or_outputs_with_proof(
+
+            // Wait until the optimistic fetch is active
+            utils::wait_for_active_optimistic_fetches(active_optimistic_fetches.clone(), 1).await;
+
+            // Force the optimistic fetch handler to work
+            utils::force_optimistic_fetch_handler_to_run(
                 &mut mock_client,
-                response_receiver,
-                None,
-                Some(output_list_with_proof),
-                highest_ledger_info,
+                &mock_time,
+                &storage_service_notifier,
             )
             .await;
+
+            // Verify a response is received and that it contains the correct data
+            if fallback_to_transactions {
+                utils::verify_new_transactions_or_outputs_with_proof(
+                    &mut mock_client,
+                    response_receiver,
+                    use_request_v2,
+                    Some(transaction_list_with_proof),
+                    None,
+                    highest_ledger_info,
+                    persisted_auxiliary_infos.clone(),
+                )
+                .await;
+            } else {
+                utils::verify_new_transactions_or_outputs_with_proof(
+                    &mut mock_client,
+                    response_receiver,
+                    use_request_v2,
+                    None,
+                    Some(output_list_with_proof),
+                    highest_ledger_info,
+                    persisted_auxiliary_infos.clone(),
+                )
+                .await;
+            }
         }
     }
 }
@@ -511,6 +636,7 @@ async fn get_new_transactions_or_outputs_with_proof(
     known_epoch: u64,
     include_events: bool,
     max_num_output_reductions: u64,
+    use_request_v2: bool,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     get_new_transactions_or_outputs_with_proof_for_peer(
         mock_client,
@@ -519,6 +645,7 @@ async fn get_new_transactions_or_outputs_with_proof(
         include_events,
         max_num_output_reductions,
         None,
+        use_request_v2,
     )
     .await
 }
@@ -531,16 +658,30 @@ async fn get_new_transactions_or_outputs_with_proof_for_peer(
     include_events: bool,
     max_num_output_reductions: u64,
     peer_network_id: Option<PeerNetworkId>,
+    use_request_v2: bool,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
-    let data_request = DataRequest::GetNewTransactionsOrOutputsWithProof(
-        NewTransactionsOrOutputsWithProofRequest {
+    let data_request = if use_request_v2 {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+                include_events,
+            });
+        DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+            transaction_data_request_type,
             known_version,
             known_epoch,
-            include_events,
-            max_num_output_reductions,
-        },
-    );
+            max_response_bytes: 0,
+        })
+    } else {
+        DataRequest::GetNewTransactionsOrOutputsWithProof(
+            NewTransactionsOrOutputsWithProofRequest {
+                known_version,
+                known_epoch,
+                include_events,
+                max_num_output_reductions,
+            },
+        )
+    };
     let storage_request = StorageServiceRequest::new(data_request, true);
 
     // Send the request

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -15,9 +15,10 @@ use aptos_config::{
 };
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, NewTransactionOutputsWithProofRequest,
+        DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionOutputsWithProofRequest,
         NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StorageServiceRequest,
+        StorageServiceRequest, TransactionData, TransactionDataRequestType,
+        TransactionOrOutputData,
     },
     responses::StorageServerSummary,
 };
@@ -33,361 +34,388 @@ use tokio::runtime::Handle;
 
 #[tokio::test]
 async fn test_peers_with_ready_optimistic_fetches() {
-    // Create a mock time service
-    let time_service = TimeService::mock();
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a mock time service
+        let time_service = TimeService::mock();
 
-    // Create two peers and optimistic fetch requests
-    let peer_network_1 = PeerNetworkId::random();
-    let peer_network_2 = PeerNetworkId::random();
-    let optimistic_fetch_1 =
-        create_optimistic_fetch_request(time_service.clone(), Some(1), Some(1));
-    let optimistic_fetch_2 =
-        create_optimistic_fetch_request(time_service.clone(), Some(10), Some(1));
-
-    // Insert the optimistic fetches into the pending map
-    let optimistic_fetches = Arc::new(DashMap::new());
-    optimistic_fetches.insert(peer_network_1, optimistic_fetch_1);
-    optimistic_fetches.insert(peer_network_2, optimistic_fetch_2);
-
-    // Create epoch ending test data
-    let epoch_ending_ledger_info = utils::create_epoch_ending_ledger_info(1, 5);
-    let epoch_change_proof = EpochChangeProof {
-        ledger_info_with_sigs: vec![epoch_ending_ledger_info],
-        more: false,
-    };
-
-    // Create the mock db reader
-    let mut db_reader = mock::create_mock_db_reader();
-    utils::expect_get_epoch_ending_ledger_infos(&mut db_reader, 1, 2, epoch_change_proof);
-
-    // Create the storage reader
-    let storage_service_config = StorageServiceConfig::default();
-    let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
-
-    // Create test data with an empty storage server summary
-    let cached_storage_server_summary =
-        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-    let lru_response_cache = Cache::new(0);
-    let request_moderator = Arc::new(RequestModerator::new(
-        AptosDataClientConfig::default(),
-        cached_storage_server_summary.clone(),
-        mock::create_peers_and_metadata(vec![]),
-        storage_service_config,
-        time_service.clone(),
-    ));
-    let subscriptions = Arc::new(DashMap::new());
-
-    // Verify that there are no peers with ready optimistic fetches
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
-            storage_service_config,
-            cached_storage_server_summary.clone(),
-            optimistic_fetches.clone(),
-            lru_response_cache.clone(),
-            request_moderator.clone(),
-            storage_reader.clone(),
-            subscriptions.clone(),
+        // Create two peers and optimistic fetch requests
+        let peer_network_1 = PeerNetworkId::random();
+        let peer_network_2 = PeerNetworkId::random();
+        let optimistic_fetch_1 =
+            create_optimistic_fetch_request(time_service.clone(), Some(1), Some(1), use_request_v2);
+        let optimistic_fetch_2 = create_optimistic_fetch_request(
             time_service.clone(),
-        )
-        .await
-        .unwrap();
-    assert!(peers_with_ready_optimistic_fetches.is_empty());
+            Some(10),
+            Some(1),
+            use_request_v2,
+        );
 
-    // Update the storage server summary so that there is new data for optimistic fetch 1
-    let synced_ledger_info =
-        utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 2, 1);
+        // Insert the optimistic fetches into the pending map
+        let optimistic_fetches = Arc::new(DashMap::new());
+        optimistic_fetches.insert(peer_network_1, optimistic_fetch_1);
+        optimistic_fetches.insert(peer_network_2, optimistic_fetch_2);
 
-    // Verify that optimistic fetch 1 is ready
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
-            storage_service_config,
+        // Create epoch ending test data
+        let epoch_ending_ledger_info = utils::create_epoch_ending_ledger_info(1, 5);
+        let epoch_change_proof = EpochChangeProof {
+            ledger_info_with_sigs: vec![epoch_ending_ledger_info],
+            more: false,
+        };
+
+        // Create the mock db reader
+        let mut db_reader = mock::create_mock_db_reader();
+        utils::expect_get_epoch_ending_ledger_infos(&mut db_reader, 1, 2, epoch_change_proof);
+
+        // Create the storage reader
+        let storage_service_config = StorageServiceConfig::default();
+        let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
+
+        // Create test data with an empty storage server summary
+        let cached_storage_server_summary =
+            Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+        let lru_response_cache = Cache::new(0);
+        let request_moderator = Arc::new(RequestModerator::new(
+            AptosDataClientConfig::default(),
             cached_storage_server_summary.clone(),
-            optimistic_fetches.clone(),
-            lru_response_cache.clone(),
-            request_moderator.clone(),
-            storage_reader.clone(),
-            subscriptions.clone(),
-            time_service.clone(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(peers_with_ready_optimistic_fetches, vec![(
-        peer_network_1,
-        synced_ledger_info
-    )]);
-
-    // Manually remove optimistic fetch 1 from the map
-    optimistic_fetches.remove(&peer_network_1);
-
-    // Update the storage server summary so that there is new data for optimistic fetch 2,
-    // but the optimistic fetch is invalid because it doesn't respect an epoch boundary.
-    let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 100, 2);
-
-    // Verify that optimistic fetch 2 is not returned because it was invalid
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
+            mock::create_peers_and_metadata(vec![]),
             storage_service_config,
-            cached_storage_server_summary,
-            optimistic_fetches,
-            lru_response_cache,
-            request_moderator,
-            storage_reader,
-            subscriptions,
-            time_service,
-        )
-        .await
-        .unwrap();
-    assert_eq!(peers_with_ready_optimistic_fetches, vec![]);
+            time_service.clone(),
+        ));
+        let subscriptions = Arc::new(DashMap::new());
 
-    // Verify that optimistic fetches no longer contains peer 2
-    assert!(peers_with_ready_optimistic_fetches.is_empty());
+        // Verify that there are no peers with ready optimistic fetches
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary.clone(),
+                optimistic_fetches.clone(),
+                lru_response_cache.clone(),
+                request_moderator.clone(),
+                storage_reader.clone(),
+                subscriptions.clone(),
+                time_service.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(peers_with_ready_optimistic_fetches.is_empty());
+
+        // Update the storage server summary so that there is new data for optimistic fetch 1
+        let synced_ledger_info =
+            utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 2, 1);
+
+        // Verify that optimistic fetch 1 is ready
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary.clone(),
+                optimistic_fetches.clone(),
+                lru_response_cache.clone(),
+                request_moderator.clone(),
+                storage_reader.clone(),
+                subscriptions.clone(),
+                time_service.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(peers_with_ready_optimistic_fetches, vec![(
+            peer_network_1,
+            synced_ledger_info
+        )]);
+
+        // Manually remove optimistic fetch 1 from the map
+        optimistic_fetches.remove(&peer_network_1);
+
+        // Update the storage server summary so that there is new data for optimistic fetch 2,
+        // but the optimistic fetch is invalid because it doesn't respect an epoch boundary.
+        let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 100, 2);
+
+        // Verify that optimistic fetch 2 is not returned because it was invalid
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary,
+                optimistic_fetches,
+                lru_response_cache,
+                request_moderator,
+                storage_reader,
+                subscriptions,
+                time_service,
+            )
+            .await
+            .unwrap();
+        assert_eq!(peers_with_ready_optimistic_fetches, vec![]);
+
+        // Verify that optimistic fetches no longer contains peer 2
+        assert!(peers_with_ready_optimistic_fetches.is_empty());
+    }
 }
 
 #[tokio::test]
 async fn test_peers_with_ready_optimistic_fetches_update() {
-    // Create a mock time service
-    let time_service = TimeService::mock();
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a mock time service
+        let time_service = TimeService::mock();
 
-    // Create two peers and optimistic fetch requests
-    let peer_network_1 = PeerNetworkId::random();
-    let peer_network_2 = PeerNetworkId::random();
-    let optimistic_fetch_1 =
-        create_optimistic_fetch_request(time_service.clone(), Some(1), Some(1));
-    let optimistic_fetch_2 =
-        create_optimistic_fetch_request(time_service.clone(), Some(10), Some(1));
+        // Create two peers and optimistic fetch requests
+        let peer_network_1 = PeerNetworkId::random();
+        let peer_network_2 = PeerNetworkId::random();
+        let optimistic_fetch_1 =
+            create_optimistic_fetch_request(time_service.clone(), Some(1), Some(1), use_request_v2);
+        let optimistic_fetch_2 = create_optimistic_fetch_request(
+            time_service.clone(),
+            Some(10),
+            Some(1),
+            use_request_v2,
+        );
 
-    // Insert the optimistic fetches into the pending map
-    let optimistic_fetches = Arc::new(DashMap::new());
-    optimistic_fetches.insert(peer_network_1, optimistic_fetch_1);
-    optimistic_fetches.insert(peer_network_2, optimistic_fetch_2);
+        // Insert the optimistic fetches into the pending map
+        let optimistic_fetches = Arc::new(DashMap::new());
+        optimistic_fetches.insert(peer_network_1, optimistic_fetch_1);
+        optimistic_fetches.insert(peer_network_2, optimistic_fetch_2);
 
-    // Create the storage reader
-    let db_reader = mock::create_mock_db_reader();
-    let storage_service_config = StorageServiceConfig::default();
-    let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
+        // Create the storage reader
+        let db_reader = mock::create_mock_db_reader();
+        let storage_service_config = StorageServiceConfig::default();
+        let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
 
-    // Create test data with an empty storage server summary
-    let cached_storage_server_summary =
-        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-    let lru_response_cache = Cache::new(0);
-    let request_moderator = Arc::new(RequestModerator::new(
-        AptosDataClientConfig::default(),
-        cached_storage_server_summary.clone(),
-        mock::create_peers_and_metadata(vec![]),
-        storage_service_config,
-        time_service.clone(),
-    ));
-    let subscriptions = Arc::new(DashMap::new());
-
-    // Update the storage server summary so that there is new data for optimistic fetch 1
-    let highest_synced_version = 5;
-    let synced_ledger_info = utils::update_storage_summary_cache(
-        cached_storage_server_summary.clone(),
-        highest_synced_version,
-        1,
-    );
-
-    // Verify that optimistic fetch 1 is ready
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
-            storage_service_config,
+        // Create test data with an empty storage server summary
+        let cached_storage_server_summary =
+            Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+        let lru_response_cache = Cache::new(0);
+        let request_moderator = Arc::new(RequestModerator::new(
+            AptosDataClientConfig::default(),
             cached_storage_server_summary.clone(),
+            mock::create_peers_and_metadata(vec![]),
+            storage_service_config,
+            time_service.clone(),
+        ));
+        let subscriptions = Arc::new(DashMap::new());
+
+        // Update the storage server summary so that there is new data for optimistic fetch 1
+        let highest_synced_version = 5;
+        let synced_ledger_info = utils::update_storage_summary_cache(
+            cached_storage_server_summary.clone(),
+            highest_synced_version,
+            1,
+        );
+
+        // Verify that optimistic fetch 1 is ready
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary.clone(),
+                optimistic_fetches.clone(),
+                lru_response_cache.clone(),
+                request_moderator.clone(),
+                storage_reader.clone(),
+                subscriptions.clone(),
+                time_service.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(peers_with_ready_optimistic_fetches, vec![(
+            peer_network_1,
+            synced_ledger_info
+        )]);
+
+        // Update optimistic fetch 1 to have a new higher known version
+        let optimistic_fetch_1 = create_optimistic_fetch_request(
+            time_service.clone(),
+            Some(highest_synced_version),
+            Some(1),
+            use_request_v2,
+        );
+        optimistic_fetches.insert(peer_network_1, optimistic_fetch_1);
+
+        // Handle the ready optimistic fetches
+        optimistic_fetch::handle_ready_optimistic_fetches(
+            Handle::current(),
+            cached_storage_server_summary.clone(),
+            storage_service_config,
             optimistic_fetches.clone(),
             lru_response_cache.clone(),
             request_moderator.clone(),
             storage_reader.clone(),
             subscriptions.clone(),
             time_service.clone(),
+            peers_with_ready_optimistic_fetches,
         )
-        .await
-        .unwrap();
-    assert_eq!(peers_with_ready_optimistic_fetches, vec![(
-        peer_network_1,
-        synced_ledger_info
-    )]);
+        .await;
 
-    // Update optimistic fetch 1 to have a new higher known version
-    let optimistic_fetch_1 = create_optimistic_fetch_request(
-        time_service.clone(),
-        Some(highest_synced_version),
-        Some(1),
-    );
-    optimistic_fetches.insert(peer_network_1, optimistic_fetch_1);
+        // Verify that there are still 2 optimistic fetches pending (the
+        // first one was not removed because it was updated!)
+        assert_eq!(optimistic_fetches.len(), 2);
 
-    // Handle the ready optimistic fetches
-    optimistic_fetch::handle_ready_optimistic_fetches(
-        Handle::current(),
-        cached_storage_server_summary.clone(),
-        storage_service_config,
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-        peers_with_ready_optimistic_fetches,
-    )
-    .await;
-
-    // Verify that there are still 2 optimistic fetches pending (the
-    // first one was not removed because it was updated!)
-    assert_eq!(optimistic_fetches.len(), 2);
-
-    // Update the storage server summary so that there is new data for optimistic fetch 1
-    let synced_ledger_info = utils::update_storage_summary_cache(
-        cached_storage_server_summary.clone(),
-        highest_synced_version + 1,
-        1,
-    );
-
-    // Verify that optimistic fetch 1 is ready (again!)
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
-            storage_service_config,
+        // Update the storage server summary so that there is new data for optimistic fetch 1
+        let synced_ledger_info = utils::update_storage_summary_cache(
             cached_storage_server_summary.clone(),
-            optimistic_fetches.clone(),
-            lru_response_cache.clone(),
-            request_moderator.clone(),
-            storage_reader.clone(),
-            subscriptions.clone(),
-            time_service.clone(),
-        )
-        .await
-        .unwrap();
-    assert_eq!(peers_with_ready_optimistic_fetches, vec![(
-        peer_network_1,
-        synced_ledger_info
-    )]);
+            highest_synced_version + 1,
+            1,
+        );
+
+        // Verify that optimistic fetch 1 is ready (again!)
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary.clone(),
+                optimistic_fetches.clone(),
+                lru_response_cache.clone(),
+                request_moderator.clone(),
+                storage_reader.clone(),
+                subscriptions.clone(),
+                time_service.clone(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(peers_with_ready_optimistic_fetches, vec![(
+            peer_network_1,
+            synced_ledger_info
+        )]);
+    }
 }
 
 #[tokio::test]
 async fn test_remove_expired_optimistic_fetches() {
-    // Create a storage service config
-    let max_optimistic_fetch_period_ms = 100;
-    let storage_service_config = StorageServiceConfig {
-        max_optimistic_fetch_period_ms,
-        ..Default::default()
-    };
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_optimistic_fetch_period_ms = 100;
+        let storage_service_config = StorageServiceConfig {
+            max_optimistic_fetch_period_ms,
+            ..Default::default()
+        };
 
-    // Create the mock storage reader and time service
-    let db_reader = mock::create_mock_db_reader();
-    let storage = StorageReader::new(storage_service_config, Arc::new(db_reader));
-    let time_service = TimeService::mock();
+        // Create the mock storage reader and time service
+        let db_reader = mock::create_mock_db_reader();
+        let storage = StorageReader::new(storage_service_config, Arc::new(db_reader));
+        let time_service = TimeService::mock();
 
-    // Create the test components
-    let cached_storage_server_summary =
-        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-    let lru_response_cache = Cache::new(0);
-    let request_moderator = Arc::new(RequestModerator::new(
-        AptosDataClientConfig::default(),
-        cached_storage_server_summary.clone(),
-        mock::create_peers_and_metadata(vec![]),
-        storage_service_config,
-        time_service.clone(),
-    ));
-    let subscriptions = Arc::new(DashMap::new());
+        // Create the test components
+        let cached_storage_server_summary =
+            Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+        let lru_response_cache = Cache::new(0);
+        let request_moderator = Arc::new(RequestModerator::new(
+            AptosDataClientConfig::default(),
+            cached_storage_server_summary.clone(),
+            mock::create_peers_and_metadata(vec![]),
+            storage_service_config,
+            time_service.clone(),
+        ));
+        let subscriptions = Arc::new(DashMap::new());
 
-    // Create the first batch of test optimistic fetches
-    let num_optimistic_fetches_in_batch = 10;
-    let optimistic_fetches = Arc::new(DashMap::new());
-    for _ in 0..num_optimistic_fetches_in_batch {
-        let optimistic_fetch =
-            create_optimistic_fetch_request(time_service.clone(), Some(9), Some(9));
-        optimistic_fetches.insert(PeerNetworkId::random(), optimistic_fetch);
+        // Create the first batch of test optimistic fetches
+        let num_optimistic_fetches_in_batch = 10;
+        let optimistic_fetches = Arc::new(DashMap::new());
+        for _ in 0..num_optimistic_fetches_in_batch {
+            let optimistic_fetch = create_optimistic_fetch_request(
+                time_service.clone(),
+                Some(9),
+                Some(9),
+                use_request_v2,
+            );
+            optimistic_fetches.insert(PeerNetworkId::random(), optimistic_fetch);
+        }
+
+        // Verify the number of active optimistic fetches
+        assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
+
+        // Elapse a small amount of time (not enough to expire the optimistic fetches)
+        utils::elapse_time(max_optimistic_fetch_period_ms / 2, &time_service).await;
+
+        // Update the storage server summary so that there is new data
+        let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 1, 1);
+
+        // Remove the expired optimistic fetches and verify none were removed
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary.clone(),
+                optimistic_fetches.clone(),
+                lru_response_cache.clone(),
+                request_moderator.clone(),
+                storage.clone(),
+                subscriptions.clone(),
+                time_service.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(peers_with_ready_optimistic_fetches.is_empty());
+        assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
+
+        // Create another batch of optimistic fetches
+        for _ in 0..num_optimistic_fetches_in_batch {
+            let optimistic_fetch = create_optimistic_fetch_request(
+                time_service.clone(),
+                Some(9),
+                Some(9),
+                use_request_v2,
+            );
+            optimistic_fetches.insert(PeerNetworkId::random(), optimistic_fetch);
+        }
+
+        // Verify the new number of active optimistic fetches
+        assert_eq!(
+            optimistic_fetches.len(),
+            num_optimistic_fetches_in_batch * 2
+        );
+
+        // Elapse enough time to expire the first batch of optimistic fetches
+        utils::elapse_time(max_optimistic_fetch_period_ms, &time_service).await;
+
+        // Remove the expired optimistic fetches and verify the first batch was removed
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary.clone(),
+                optimistic_fetches.clone(),
+                lru_response_cache.clone(),
+                request_moderator.clone(),
+                storage.clone(),
+                subscriptions.clone(),
+                time_service.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(peers_with_ready_optimistic_fetches.is_empty());
+        assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
+
+        // Elapse enough time to expire the second batch of optimistic fetches
+        utils::elapse_time(max_optimistic_fetch_period_ms + 1, &time_service).await;
+
+        // Remove the expired optimistic fetches and verify the second batch was removed
+        let peers_with_ready_optimistic_fetches =
+            optimistic_fetch::get_peers_with_ready_optimistic_fetches(
+                Handle::current(),
+                storage_service_config,
+                cached_storage_server_summary.clone(),
+                optimistic_fetches.clone(),
+                lru_response_cache,
+                request_moderator,
+                storage.clone(),
+                subscriptions,
+                time_service.clone(),
+            )
+            .await
+            .unwrap();
+        assert!(peers_with_ready_optimistic_fetches.is_empty());
+        assert!(optimistic_fetches.is_empty());
     }
-
-    // Verify the number of active optimistic fetches
-    assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
-
-    // Elapse a small amount of time (not enough to expire the optimistic fetches)
-    utils::elapse_time(max_optimistic_fetch_period_ms / 2, &time_service).await;
-
-    // Update the storage server summary so that there is new data
-    let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 1, 1);
-
-    // Remove the expired optimistic fetches and verify none were removed
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
-            storage_service_config,
-            cached_storage_server_summary.clone(),
-            optimistic_fetches.clone(),
-            lru_response_cache.clone(),
-            request_moderator.clone(),
-            storage.clone(),
-            subscriptions.clone(),
-            time_service.clone(),
-        )
-        .await
-        .unwrap();
-    assert!(peers_with_ready_optimistic_fetches.is_empty());
-    assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
-
-    // Create another batch of optimistic fetches
-    for _ in 0..num_optimistic_fetches_in_batch {
-        let optimistic_fetch =
-            create_optimistic_fetch_request(time_service.clone(), Some(9), Some(9));
-        optimistic_fetches.insert(PeerNetworkId::random(), optimistic_fetch);
-    }
-
-    // Verify the new number of active optimistic fetches
-    assert_eq!(
-        optimistic_fetches.len(),
-        num_optimistic_fetches_in_batch * 2
-    );
-
-    // Elapse enough time to expire the first batch of optimistic fetches
-    utils::elapse_time(max_optimistic_fetch_period_ms, &time_service).await;
-
-    // Remove the expired optimistic fetches and verify the first batch was removed
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
-            storage_service_config,
-            cached_storage_server_summary.clone(),
-            optimistic_fetches.clone(),
-            lru_response_cache.clone(),
-            request_moderator.clone(),
-            storage.clone(),
-            subscriptions.clone(),
-            time_service.clone(),
-        )
-        .await
-        .unwrap();
-    assert!(peers_with_ready_optimistic_fetches.is_empty());
-    assert_eq!(optimistic_fetches.len(), num_optimistic_fetches_in_batch);
-
-    // Elapse enough time to expire the second batch of optimistic fetches
-    utils::elapse_time(max_optimistic_fetch_period_ms + 1, &time_service).await;
-
-    // Remove the expired optimistic fetches and verify the second batch was removed
-    let peers_with_ready_optimistic_fetches =
-        optimistic_fetch::get_peers_with_ready_optimistic_fetches(
-            Handle::current(),
-            storage_service_config,
-            cached_storage_server_summary.clone(),
-            optimistic_fetches.clone(),
-            lru_response_cache,
-            request_moderator,
-            storage.clone(),
-            subscriptions,
-            time_service.clone(),
-        )
-        .await
-        .unwrap();
-    assert!(peers_with_ready_optimistic_fetches.is_empty());
-    assert!(optimistic_fetches.is_empty());
 }
 
 /// Creates a random request for optimistic fetch data
 fn create_optimistic_fetch_data_request(
     known_version: Option<u64>,
     known_epoch: Option<u64>,
+    use_request_v2: bool,
 ) -> DataRequest {
     let known_version = known_version.unwrap_or_default();
     let known_epoch = known_epoch.unwrap_or_default();
@@ -396,25 +424,68 @@ fn create_optimistic_fetch_data_request(
     let mut rng = OsRng;
     let random_number: u8 = rng.gen();
     match random_number % 3 {
-        0 => DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
-            known_version,
-            known_epoch,
-            include_events: false,
-        }),
-        1 => {
-            DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
-                known_version,
-                known_epoch,
-            })
+        0 => {
+            if use_request_v2 {
+                let transaction_data_request_type =
+                    TransactionDataRequestType::TransactionData(TransactionData {
+                        include_events: true,
+                    });
+                DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+                    transaction_data_request_type,
+                    known_version,
+                    known_epoch,
+                    max_response_bytes: 0,
+                })
+            } else {
+                DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
+                    known_version,
+                    known_epoch,
+                    include_events: true,
+                })
+            }
         },
-        2 => DataRequest::GetNewTransactionsOrOutputsWithProof(
-            NewTransactionsOrOutputsWithProofRequest {
-                known_version,
-                known_epoch,
-                include_events: true,
-                max_num_output_reductions: 1,
-            },
-        ),
+        1 => {
+            if use_request_v2 {
+                let transaction_data_request_type =
+                    TransactionDataRequestType::TransactionOutputData;
+                DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+                    transaction_data_request_type,
+                    known_version,
+                    known_epoch,
+                    max_response_bytes: 0,
+                })
+            } else {
+                DataRequest::GetNewTransactionOutputsWithProof(
+                    NewTransactionOutputsWithProofRequest {
+                        known_version,
+                        known_epoch,
+                    },
+                )
+            }
+        },
+        2 => {
+            if use_request_v2 {
+                let transaction_data_request_type =
+                    TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+                        include_events: true,
+                    });
+                DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+                    transaction_data_request_type,
+                    known_version,
+                    known_epoch,
+                    max_response_bytes: 0,
+                })
+            } else {
+                DataRequest::GetNewTransactionsOrOutputsWithProof(
+                    NewTransactionsOrOutputsWithProofRequest {
+                        known_version,
+                        known_epoch,
+                        include_events: true,
+                        max_num_output_reductions: 1,
+                    },
+                )
+            }
+        },
         num => panic!("This shouldn't be possible! Got num: {:?}", num),
     }
 }
@@ -424,9 +495,11 @@ fn create_optimistic_fetch_request(
     time_service: TimeService,
     known_version: Option<u64>,
     known_epoch: Option<u64>,
+    use_request_v2: bool,
 ) -> OptimisticFetchRequest {
     // Create a storage service request
-    let data_request = create_optimistic_fetch_data_request(known_version, known_epoch);
+    let data_request =
+        create_optimistic_fetch_data_request(known_version, known_epoch, use_request_v2);
     let storage_service_request = StorageServiceRequest::new(data_request, true);
 
     // Create the response sender

--- a/state-sync/storage-service/server/src/tests/subscribe_transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transaction_outputs.rs
@@ -11,84 +11,238 @@ use claims::assert_none;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transaction_outputs_different_networks() {
-    // Test small and large chunk sizes
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [100, max_output_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [100, max_output_chunk_size] {
+            // Create test data
+            let highest_version = 45576;
+            let highest_epoch = 43;
+            let lowest_version = 4566;
+            let peer_version_1 = highest_version - chunk_size;
+            let peer_version_2 = highest_version - (chunk_size - 10);
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let output_list_with_proof_1 = utils::create_output_list_with_proof(
+                peer_version_1 + 1,
+                highest_version,
+                highest_version,
+            );
+            let output_list_with_proof_2 = utils::create_output_list_with_proof(
+                peer_version_2 + 1,
+                highest_version,
+                highest_version,
+            );
+            let persisted_auxiliary_infos_1 = utils::create_persisted_auxiliary_infos(
+                peer_version_1 + 1,
+                highest_version,
+                use_request_v2,
+            );
+            let persisted_auxiliary_infos_2 = utils::create_persisted_auxiliary_infos(
+                peer_version_2 + 1,
+                highest_version,
+                use_request_v2,
+            );
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
+            );
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version_1 + 1,
+                highest_version - peer_version_1,
+                highest_version,
+                output_list_with_proof_1.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos_1.clone(),
+            );
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version_2 + 1,
+                highest_version - peer_version_2,
+                highest_version,
+                output_list_with_proof_2.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos_2.clone(),
+            );
+
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
+
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_config));
+            let active_subscriptions = service.get_subscriptions();
+            tokio::spawn(service.start());
+
+            // Send a request to subscribe to transaction outputs for peer 1
+            let peer_id = PeerId::random();
+            let subscription_stream_id = 200;
+            let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
+            let mut response_receiver_1 = utils::subscribe_to_transaction_outputs_for_peer(
+                &mut mock_client,
+                peer_version_1,
+                highest_epoch,
+                subscription_stream_id,
+                0,
+                Some(peer_network_1),
+                use_request_v2,
+            )
+            .await;
+
+            // Send a request to subscribe to transaction outputs for peer 2
+            let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
+            let mut response_receiver_2 = utils::subscribe_to_transaction_outputs_for_peer(
+                &mut mock_client,
+                peer_version_2,
+                highest_epoch,
+                subscription_stream_id,
+                0,
+                Some(peer_network_2),
+                use_request_v2,
+            )
+            .await;
+
+            // Wait until the subscriptions are active
+            utils::wait_for_active_subscriptions(active_subscriptions.clone(), 2).await;
+
+            // Verify no subscription response has been received yet
+            assert_none!(response_receiver_1.try_recv().unwrap());
+            assert_none!(response_receiver_2.try_recv().unwrap());
+
+            // Force the subscription handler to work
+            utils::force_subscription_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
+
+            // Verify a response is received and that it contains the correct data for both peers
+            utils::verify_new_transaction_outputs_with_proof(
+                &mut mock_client,
+                response_receiver_1,
+                use_request_v2,
+                output_list_with_proof_1,
+                highest_ledger_info.clone(),
+                persisted_auxiliary_infos_1,
+            )
+            .await;
+            utils::verify_new_transaction_outputs_with_proof(
+                &mut mock_client,
+                response_receiver_2,
+                use_request_v2,
+                output_list_with_proof_2,
+                highest_ledger_info,
+                persisted_auxiliary_infos_2,
+            )
+            .await;
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "Canceled")]
+async fn test_subscribe_transaction_outputs_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
+
+    // Send a transaction output v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    let response_receiver = utils::subscribe_to_transaction_outputs(
+        &mut mock_client,
+        0,
+        0,
+        0,
+        0,
+        true, // Use transaction v2
+    )
+    .await;
+
+    // Wait for the response, which should never come
+    response_receiver.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscribe_transaction_outputs_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Create test data
         let highest_version = 45576;
-        let highest_epoch = 43;
+        let highest_epoch = 1032;
         let lowest_version = 4566;
-        let peer_version_1 = highest_version - chunk_size;
-        let peer_version_2 = highest_version - (chunk_size - 10);
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-        let output_list_with_proof_1 = utils::create_output_list_with_proof(
-            peer_version_1 + 1,
-            highest_version,
-            highest_version,
+        let peer_version = highest_version - 100;
+        let peer_epoch = highest_epoch - 20;
+        let epoch_change_version = peer_version + 45;
+        let epoch_change_proof = EpochChangeProof {
+            ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
+                peer_epoch,
+                epoch_change_version,
+            )],
+            more: false,
+        };
+        let output_list_with_proof = utils::create_output_list_with_proof(
+            peer_version + 1,
+            epoch_change_version,
+            epoch_change_version,
         );
-        let output_list_with_proof_2 = utils::create_output_list_with_proof(
-            peer_version_2 + 1,
-            highest_version,
-            highest_version,
+        let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+            peer_version + 1,
+            epoch_change_version,
+            use_request_v2,
         );
 
         // Create the mock db reader
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            peer_version_1 + 1,
-            highest_version - peer_version_1,
-            highest_version,
-            output_list_with_proof_1.clone(),
+        let mut db_reader = mock::create_mock_db_with_summary_updates(
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
+            lowest_version,
         );
         utils::expect_get_transaction_outputs(
             &mut db_reader,
-            peer_version_2 + 1,
-            highest_version - peer_version_2,
-            highest_version,
-            output_list_with_proof_2.clone(),
+            peer_version + 1,
+            epoch_change_version - peer_version,
+            epoch_change_version,
+            output_list_with_proof.clone(),
+            use_request_v2,
+            persisted_auxiliary_infos.clone(),
         );
+        utils::expect_get_epoch_ending_ledger_infos(
+            &mut db_reader,
+            peer_epoch,
+            peer_epoch + 1,
+            epoch_change_proof.clone(),
+        );
+
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
 
         // Create the storage client and server
         let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), None);
+            MockClient::new(Some(db_reader), Some(storage_config));
         let active_subscriptions = service.get_subscriptions();
         tokio::spawn(service.start());
 
-        // Send a request to subscribe to transaction outputs for peer 1
-        let peer_id = PeerId::random();
-        let subscription_stream_id = 200;
-        let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
-        let mut response_receiver_1 = utils::subscribe_to_transaction_outputs_for_peer(
+        // Send a request to subscribe to transaction outputs
+        let response_receiver = utils::subscribe_to_transaction_outputs(
             &mut mock_client,
-            peer_version_1,
-            highest_epoch,
-            subscription_stream_id,
+            peer_version,
+            peer_epoch,
+            utils::get_random_u64(),
             0,
-            Some(peer_network_1),
+            use_request_v2,
         )
         .await;
 
-        // Send a request to subscribe to transaction outputs for peer 2
-        let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
-        let mut response_receiver_2 = utils::subscribe_to_transaction_outputs_for_peer(
-            &mut mock_client,
-            peer_version_2,
-            highest_epoch,
-            subscription_stream_id,
-            0,
-            Some(peer_network_2),
-        )
-        .await;
-
-        // Wait until the subscriptions are active
-        utils::wait_for_active_subscriptions(active_subscriptions.clone(), 2).await;
-
-        // Verify no subscription response has been received yet
-        assert_none!(response_receiver_1.try_recv().unwrap());
-        assert_none!(response_receiver_2.try_recv().unwrap());
+        // Wait until the subscription is active
+        utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
 
         // Force the subscription handler to work
         utils::force_subscription_handler_to_run(
@@ -98,238 +252,329 @@ async fn test_subscribe_transaction_outputs_different_networks() {
         )
         .await;
 
-        // Verify a response is received and that it contains the correct data for both peers
+        // Verify a response is received and that it contains the correct data
         utils::verify_new_transaction_outputs_with_proof(
             &mut mock_client,
-            response_receiver_1,
-            output_list_with_proof_1,
-            highest_ledger_info.clone(),
-        )
-        .await;
-        utils::verify_new_transaction_outputs_with_proof(
-            &mut mock_client,
-            response_receiver_2,
-            output_list_with_proof_2,
-            highest_ledger_info,
+            response_receiver,
+            use_request_v2,
+            output_list_with_proof,
+            epoch_change_proof.ledger_info_with_sigs[0].clone(),
+            persisted_auxiliary_infos,
         )
         .await;
     }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_subscribe_transaction_outputs_epoch_change() {
-    // Create test data
-    let highest_version = 45576;
-    let highest_epoch = 1032;
-    let lowest_version = 4566;
-    let peer_version = highest_version - 100;
-    let peer_epoch = highest_epoch - 20;
-    let epoch_change_version = peer_version + 45;
-    let epoch_change_proof = EpochChangeProof {
-        ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
-            peer_epoch,
-            epoch_change_version,
-        )],
-        more: false,
-    };
-    let output_list_with_proof = utils::create_output_list_with_proof(
-        peer_version + 1,
-        epoch_change_version,
-        epoch_change_version,
-    );
-
-    // Create the mock db reader
-    let mut db_reader = mock::create_mock_db_with_summary_updates(
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
-        lowest_version,
-    );
-    utils::expect_get_transaction_outputs(
-        &mut db_reader,
-        peer_version + 1,
-        epoch_change_version - peer_version,
-        epoch_change_version,
-        output_list_with_proof.clone(),
-    );
-    utils::expect_get_epoch_ending_ledger_infos(
-        &mut db_reader,
-        peer_epoch,
-        peer_epoch + 1,
-        epoch_change_proof.clone(),
-    );
-
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), None);
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
-
-    // Send a request to subscribe to transaction outputs
-    let response_receiver = utils::subscribe_to_transaction_outputs(
-        &mut mock_client,
-        peer_version,
-        peer_epoch,
-        utils::get_random_u64(),
-        0,
-    )
-    .await;
-
-    // Wait until the subscription is active
-    utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
-
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
-
-    // Verify a response is received and that it contains the correct data
-    utils::verify_new_transaction_outputs_with_proof(
-        &mut mock_client,
-        response_receiver,
-        output_list_with_proof,
-        epoch_change_proof.ledger_info_with_sigs[0].clone(),
-    )
-    .await;
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transaction_outputs_max_chunk() {
-    // Create a storage service config with a configured max chunk size
-    let max_transaction_output_chunk_size = 301;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_output_chunk_size,
-        ..StorageServiceConfig::default()
-    };
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config with a configured max chunk size
+        let max_transaction_output_chunk_size = 301;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_output_chunk_size,
+            enable_transaction_data_v2: use_request_v2,
+            ..StorageServiceConfig::default()
+        };
 
-    // Create test data
-    let highest_version = 1034556;
-    let highest_epoch = 343;
-    let lowest_version = 3453;
-    let requested_chunk_size = max_transaction_output_chunk_size + 100;
-    let peer_version = highest_version - requested_chunk_size;
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-    let output_list_with_proof = utils::create_output_list_with_proof(
-        peer_version + 1,
-        peer_version + requested_chunk_size,
-        highest_version,
-    );
+        // Create test data
+        let highest_version = 1034556;
+        let highest_epoch = 343;
+        let lowest_version = 3453;
+        let requested_chunk_size = max_transaction_output_chunk_size + 100;
+        let peer_version = highest_version - requested_chunk_size;
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+        let output_list_with_proof = utils::create_output_list_with_proof(
+            peer_version + 1,
+            peer_version + max_transaction_output_chunk_size,
+            peer_version + max_transaction_output_chunk_size,
+        );
+        let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+            peer_version + 1,
+            peer_version + max_transaction_output_chunk_size,
+            use_request_v2,
+        );
 
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    utils::expect_get_transaction_outputs(
-        &mut db_reader,
-        peer_version + 1,
-        max_transaction_output_chunk_size,
-        highest_version,
-        output_list_with_proof.clone(),
-    );
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        utils::expect_get_transaction_outputs(
+            &mut db_reader,
+            peer_version + 1,
+            max_transaction_output_chunk_size,
+            highest_version,
+            output_list_with_proof.clone(),
+            use_request_v2,
+            persisted_auxiliary_infos.clone(),
+        );
 
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_service_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
 
-    // Send a request to subscribe to new transaction outputs
-    let response_receiver = utils::subscribe_to_transaction_outputs(
-        &mut mock_client,
-        peer_version,
-        highest_epoch,
-        utils::get_random_u64(),
-        0,
-    )
-    .await;
+        // Send a request to subscribe to new transaction outputs
+        let response_receiver = utils::subscribe_to_transaction_outputs(
+            &mut mock_client,
+            peer_version,
+            highest_epoch,
+            utils::get_random_u64(),
+            0,
+            use_request_v2,
+        )
+        .await;
 
-    // Wait until the subscription is active
-    utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
+        // Wait until the subscription is active
+        utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
 
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
+        // Force the subscription handler to work
+        utils::force_subscription_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
-    // Verify a response is received and that it contains the correct data
-    utils::verify_new_transaction_outputs_with_proof(
-        &mut mock_client,
-        response_receiver,
-        output_list_with_proof,
-        highest_ledger_info,
-    )
-    .await;
+        // Verify a response is received and that it contains the correct data
+        utils::verify_new_transaction_outputs_with_proof(
+            &mut mock_client,
+            response_receiver,
+            use_request_v2,
+            output_list_with_proof,
+            highest_ledger_info,
+            persisted_auxiliary_infos,
+        )
+        .await;
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transaction_outputs_streaming() {
-    // Create a storage service config
-    let max_transaction_output_chunk_size = 200;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_output_chunk_size,
-        ..Default::default()
-    };
-
-    // Create test data
-    let num_stream_requests = 30;
-    let highest_version = 45576;
-    let highest_epoch = 43;
-    let lowest_version = 4566;
-    let peer_version = highest_version - (num_stream_requests * max_transaction_output_chunk_size);
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-
-    // Create the output lists with proofs
-    let output_lists_with_proofs: Vec<_> = (0..num_stream_requests)
-        .map(|i| {
-            let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
-            let end_version = start_version + max_transaction_output_chunk_size - 1;
-            utils::create_output_list_with_proof(start_version, end_version, highest_version)
-        })
-        .collect();
-
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    for i in 0..num_stream_requests {
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            peer_version + (i * max_transaction_output_chunk_size) + 1,
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_transaction_output_chunk_size = 200;
+        let storage_service_config = StorageServiceConfig {
             max_transaction_output_chunk_size,
-            highest_version,
-            output_lists_with_proofs[i as usize].clone(),
-        );
+            enable_transaction_data_v2: use_request_v2,
+            ..Default::default()
+        };
+
+        // Create test data
+        let num_stream_requests = 30;
+        let highest_version = 45576;
+        let highest_epoch = 43;
+        let lowest_version = 4566;
+        let peer_version =
+            highest_version - (num_stream_requests * max_transaction_output_chunk_size);
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+
+        // Create the output lists with proofs
+        let output_lists_with_proofs: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                let end_version = start_version + max_transaction_output_chunk_size - 1;
+                utils::create_output_list_with_proof(start_version, end_version, highest_version)
+            })
+            .collect();
+
+        // Create the persisted auxiliary infos
+        let persisted_auxiliary_infos: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                let end_version = start_version + max_transaction_output_chunk_size - 1;
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2)
+            })
+            .collect();
+
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        for i in 0..num_stream_requests {
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version + (i * max_transaction_output_chunk_size) + 1,
+                max_transaction_output_chunk_size,
+                highest_version,
+                output_lists_with_proofs[i as usize].clone(),
+                use_request_v2,
+                persisted_auxiliary_infos[i as usize].clone(),
+            );
+        }
+
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_service_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
+
+        // Create a new peer and stream ID
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = utils::get_random_u64();
+
+        // Send multiple batches of requests to the server and verify the responses
+        let num_batches_to_send = 6;
+        for batch_id in 0..num_batches_to_send {
+            // Send the request batch to subscribe to transaction outputs
+            let num_requests_per_batch = num_stream_requests / num_batches_to_send;
+            let first_request_index = batch_id * num_requests_per_batch;
+            let last_request_index =
+                (batch_id * num_requests_per_batch) + num_requests_per_batch - 1;
+            let mut response_receivers = utils::send_output_subscription_request_batch(
+                &mut mock_client,
+                peer_network_id,
+                first_request_index,
+                last_request_index,
+                stream_id,
+                peer_version,
+                highest_epoch,
+                use_request_v2,
+            )
+            .await;
+
+            // Wait until the stream requests are active
+            utils::wait_for_active_stream_requests(
+                active_subscriptions.clone(),
+                peer_network_id,
+                num_requests_per_batch as usize,
+            )
+            .await;
+
+            // Force the subscription handler to work
+            utils::force_cache_update_notification(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+                true,
+                true,
+            )
+            .await;
+
+            // Continuously run the subscription service until the batch responses are received
+            for stream_request_index in first_request_index..=last_request_index {
+                // Verify that the correct response is received
+                utils::verify_output_subscription_response(
+                    output_lists_with_proofs.clone(),
+                    persisted_auxiliary_infos.clone(),
+                    highest_ledger_info.clone(),
+                    &mut mock_client,
+                    &mut response_receivers,
+                    stream_request_index,
+                    use_request_v2,
+                )
+                .await;
+            }
+        }
     }
+}
 
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscribe_transaction_outputs_streaming_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_transaction_output_chunk_size = 5;
+        let max_num_active_subscriptions = 50;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_output_chunk_size,
+            max_num_active_subscriptions,
+            enable_transaction_data_v2: use_request_v2,
+            ..Default::default()
+        };
 
-    // Create a new peer and stream ID
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = utils::get_random_u64();
+        // Create test data
+        let highest_version = 1000;
+        let highest_epoch = 2;
+        let lowest_version = 0;
+        let peer_version = highest_version - 500;
+        let peer_epoch = highest_epoch - 1;
+        let epoch_change_version = peer_version + 97;
 
-    // Send multiple batches of requests to the server and verify the responses
-    let num_batches_to_send = 6;
-    for batch_id in 0..num_batches_to_send {
+        // Create the highest ledger info and epoch change proof
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+        let epoch_change_ledger_info =
+            utils::create_epoch_ending_ledger_info(peer_epoch, epoch_change_version);
+        let epoch_change_proof = EpochChangeProof {
+            ledger_info_with_sigs: vec![epoch_change_ledger_info.clone()],
+            more: false,
+        };
+
+        // Create the output lists with proofs
+        let chunk_start_and_end_versions = utils::create_data_chunks_with_epoch_boundary(
+            max_transaction_output_chunk_size,
+            max_num_active_subscriptions,
+            peer_version,
+            epoch_change_version,
+        );
+        let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+            .iter()
+            .map(|(start_version, end_version)| {
+                utils::create_output_list_with_proof(*start_version, *end_version, highest_version)
+            })
+            .collect();
+
+        // Create the persisted auxiliary infos
+        let persisted_auxiliary_infos: Vec<_> = chunk_start_and_end_versions
+            .iter()
+            .map(|(start_version, end_version)| {
+                utils::create_persisted_auxiliary_infos(
+                    *start_version,
+                    *end_version,
+                    use_request_v2,
+                )
+            })
+            .collect();
+
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        utils::expect_get_epoch_ending_ledger_infos(
+            &mut db_reader,
+            peer_epoch,
+            peer_epoch + 1,
+            epoch_change_proof.clone(),
+        );
+        for (i, (start_version, end_version)) in chunk_start_and_end_versions.iter().enumerate() {
+            let proof_version = if *end_version <= epoch_change_version {
+                epoch_change_version
+            } else {
+                highest_version
+            };
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                *start_version,
+                end_version - start_version + 1,
+                proof_version,
+                output_lists_with_proofs[i].clone(),
+                use_request_v2,
+                persisted_auxiliary_infos[i].clone(),
+            );
+        }
+
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_service_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
+
+        // Create a new peer and stream ID
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = utils::get_random_u64();
+
         // Send the request batch to subscribe to transaction outputs
-        let num_requests_per_batch = num_stream_requests / num_batches_to_send;
-        let first_request_index = batch_id * num_requests_per_batch;
-        let last_request_index = (batch_id * num_requests_per_batch) + num_requests_per_batch - 1;
         let mut response_receivers = utils::send_output_subscription_request_batch(
             &mut mock_client,
             peer_network_id,
-            first_request_index,
-            last_request_index,
+            0,
+            max_num_active_subscriptions - 1,
             stream_id,
             peer_version,
-            highest_epoch,
+            peer_epoch,
+            use_request_v2,
         )
         .await;
 
@@ -337,29 +582,39 @@ async fn test_subscribe_transaction_outputs_streaming() {
         utils::wait_for_active_stream_requests(
             active_subscriptions.clone(),
             peer_network_id,
-            num_requests_per_batch as usize,
+            max_num_active_subscriptions as usize,
         )
         .await;
 
         // Force the subscription handler to work
-        utils::force_cache_update_notification(
+        utils::force_subscription_handler_to_run(
             &mut mock_client,
             &mock_time,
             &storage_service_notifier,
-            true,
-            true,
         )
         .await;
 
-        // Continuously run the subscription service until the batch responses are received
-        for stream_request_index in first_request_index..=last_request_index {
+        // Continuously run the subscription service until all the responses are received
+        for stream_request_index in 0..max_num_active_subscriptions {
+            // Determine the target ledger info for the response
+            let first_output_version = output_lists_with_proofs[stream_request_index as usize]
+                .first_transaction_output_version
+                .unwrap();
+            let target_ledger_info = if first_output_version > epoch_change_version {
+                highest_ledger_info.clone()
+            } else {
+                epoch_change_ledger_info.clone()
+            };
+
             // Verify that the correct response is received
             utils::verify_output_subscription_response(
                 output_lists_with_proofs.clone(),
-                highest_ledger_info.clone(),
+                persisted_auxiliary_infos.clone(),
+                target_ledger_info.clone(),
                 &mut mock_client,
                 &mut response_receivers,
                 stream_request_index,
+                use_request_v2,
             )
             .await;
         }
@@ -367,231 +622,121 @@ async fn test_subscribe_transaction_outputs_streaming() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_subscribe_transaction_outputs_streaming_epoch_change() {
-    // Create a storage service config
-    let max_transaction_output_chunk_size = 5;
-    let max_num_active_subscriptions = 50;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_output_chunk_size,
-        max_num_active_subscriptions,
-        ..Default::default()
-    };
-
-    // Create test data
-    let highest_version = 1000;
-    let highest_epoch = 2;
-    let lowest_version = 0;
-    let peer_version = highest_version - 500;
-    let peer_epoch = highest_epoch - 1;
-    let epoch_change_version = peer_version + 97;
-
-    // Create the highest ledger info and epoch change proof
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-    let epoch_change_ledger_info =
-        utils::create_epoch_ending_ledger_info(peer_epoch, epoch_change_version);
-    let epoch_change_proof = EpochChangeProof {
-        ledger_info_with_sigs: vec![epoch_change_ledger_info.clone()],
-        more: false,
-    };
-
-    // Create the output lists with proofs
-    let chunk_start_and_end_versions = utils::create_data_chunks_with_epoch_boundary(
-        max_transaction_output_chunk_size,
-        max_num_active_subscriptions,
-        peer_version,
-        epoch_change_version,
-    );
-    let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-        .iter()
-        .map(|(start_version, end_version)| {
-            utils::create_output_list_with_proof(*start_version, *end_version, highest_version)
-        })
-        .collect();
-
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    utils::expect_get_epoch_ending_ledger_infos(
-        &mut db_reader,
-        peer_epoch,
-        peer_epoch + 1,
-        epoch_change_proof.clone(),
-    );
-    for (i, (start_version, end_version)) in chunk_start_and_end_versions.iter().enumerate() {
-        let proof_version = if *end_version <= epoch_change_version {
-            epoch_change_version
-        } else {
-            highest_version
-        };
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            *start_version,
-            end_version - start_version + 1,
-            proof_version,
-            output_lists_with_proofs[i].clone(),
-        );
-    }
-
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
-
-    // Create a new peer and stream ID
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = utils::get_random_u64();
-
-    // Send the request batch to subscribe to transaction outputs
-    let mut response_receivers = utils::send_output_subscription_request_batch(
-        &mut mock_client,
-        peer_network_id,
-        0,
-        max_num_active_subscriptions - 1,
-        stream_id,
-        peer_version,
-        peer_epoch,
-    )
-    .await;
-
-    // Wait until the stream requests are active
-    utils::wait_for_active_stream_requests(
-        active_subscriptions.clone(),
-        peer_network_id,
-        max_num_active_subscriptions as usize,
-    )
-    .await;
-
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
-
-    // Continuously run the subscription service until all the responses are received
-    for stream_request_index in 0..max_num_active_subscriptions {
-        // Determine the target ledger info for the response
-        let first_output_version = output_lists_with_proofs[stream_request_index as usize]
-            .first_transaction_output_version
-            .unwrap();
-        let target_ledger_info = if first_output_version > epoch_change_version {
-            highest_ledger_info.clone()
-        } else {
-            epoch_change_ledger_info.clone()
-        };
-
-        // Verify that the correct response is received
-        utils::verify_output_subscription_response(
-            output_lists_with_proofs.clone(),
-            target_ledger_info.clone(),
-            &mut mock_client,
-            &mut response_receivers,
-            stream_request_index,
-        )
-        .await;
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transaction_outputs_streaming_loop() {
-    // Create a storage service config
-    let max_transaction_output_chunk_size = 100;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_output_chunk_size,
-        ..Default::default()
-    };
-
-    // Create test data
-    let num_stream_requests = 30;
-    let highest_version = 45576;
-    let highest_epoch = 43;
-    let lowest_version = 4566;
-    let peer_version = highest_version - (num_stream_requests * max_transaction_output_chunk_size);
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-
-    // Create the output lists with proofs
-    let output_lists_with_proofs: Vec<_> = (0..num_stream_requests)
-        .map(|i| {
-            let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
-            let end_version = start_version + max_transaction_output_chunk_size - 1;
-            utils::create_output_list_with_proof(start_version, end_version, highest_version)
-        })
-        .collect();
-
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    for i in 0..num_stream_requests {
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            peer_version + (i * max_transaction_output_chunk_size) + 1,
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_transaction_output_chunk_size = 100;
+        let storage_service_config = StorageServiceConfig {
             max_transaction_output_chunk_size,
-            highest_version,
-            output_lists_with_proofs[i as usize].clone(),
-        );
-    }
+            enable_transaction_data_v2: use_request_v2,
+            ..Default::default()
+        };
 
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
+        // Create test data
+        let num_stream_requests = 30;
+        let highest_version = 45576;
+        let highest_epoch = 43;
+        let lowest_version = 4566;
+        let peer_version =
+            highest_version - (num_stream_requests * max_transaction_output_chunk_size);
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
 
-    // Create a new peer and stream ID
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = utils::get_random_u64();
+        // Create the output lists with proofs
+        let output_lists_with_proofs: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                let end_version = start_version + max_transaction_output_chunk_size - 1;
+                utils::create_output_list_with_proof(start_version, end_version, highest_version)
+            })
+            .collect();
 
-    // Send the requests to the server and verify the responses
-    let mut response_receivers = utils::send_output_subscription_request_batch(
-        &mut mock_client,
-        peer_network_id,
-        0,
-        num_stream_requests - 1,
-        stream_id,
-        peer_version,
-        highest_epoch,
-    )
-    .await;
+        // Create the persisted auxiliary infos
+        let persisted_auxiliary_infos: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                let end_version = start_version + max_transaction_output_chunk_size - 1;
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2)
+            })
+            .collect();
 
-    // Wait until the stream requests are active
-    utils::wait_for_active_stream_requests(
-        active_subscriptions.clone(),
-        peer_network_id,
-        num_stream_requests as usize,
-    )
-    .await;
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        for i in 0..num_stream_requests {
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version + (i * max_transaction_output_chunk_size) + 1,
+                max_transaction_output_chunk_size,
+                highest_version,
+                output_lists_with_proofs[i as usize].clone(),
+                use_request_v2,
+                persisted_auxiliary_infos[i as usize].clone(),
+            );
+        }
 
-    // Verify the state of the subscription stream
-    utils::verify_subscription_stream_entry(
-        active_subscriptions.clone(),
-        peer_network_id,
-        num_stream_requests,
-        peer_version,
-        highest_epoch,
-        max_transaction_output_chunk_size,
-    );
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_service_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
 
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
+        // Create a new peer and stream ID
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = utils::get_random_u64();
 
-    // Verify all responses are received
-    for stream_request_index in 0..num_stream_requests {
-        let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
-        utils::verify_new_transaction_outputs_with_proof(
+        // Send the requests to the server and verify the responses
+        let mut response_receivers = utils::send_output_subscription_request_batch(
             &mut mock_client,
-            response_receiver,
-            output_lists_with_proofs[stream_request_index as usize].clone(),
-            highest_ledger_info.clone(),
+            peer_network_id,
+            0,
+            num_stream_requests - 1,
+            stream_id,
+            peer_version,
+            highest_epoch,
+            use_request_v2,
         )
         .await;
+
+        // Wait until the stream requests are active
+        utils::wait_for_active_stream_requests(
+            active_subscriptions.clone(),
+            peer_network_id,
+            num_stream_requests as usize,
+        )
+        .await;
+
+        // Verify the state of the subscription stream
+        utils::verify_subscription_stream_entry(
+            active_subscriptions.clone(),
+            peer_network_id,
+            num_stream_requests,
+            peer_version,
+            highest_epoch,
+            max_transaction_output_chunk_size,
+        );
+
+        // Force the subscription handler to work
+        utils::force_subscription_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
+
+        // Verify all responses are received
+        for stream_request_index in 0..num_stream_requests {
+            let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
+            utils::verify_new_transaction_outputs_with_proof(
+                &mut mock_client,
+                response_receiver,
+                use_request_v2,
+                output_lists_with_proofs[stream_request_index as usize].clone(),
+                highest_ledger_info.clone(),
+                persisted_auxiliary_infos[stream_request_index as usize].clone(),
+            )
+            .await;
+        }
     }
 }

--- a/state-sync/storage-service/server/src/tests/subscribe_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transactions.rs
@@ -8,8 +8,10 @@ use aptos_config::{
 };
 use aptos_network::protocols::network::RpcError;
 use aptos_types::{
-    epoch_change::EpochChangeProof, ledger_info::LedgerInfoWithSignatures,
-    transaction::TransactionListWithProof, PeerId,
+    epoch_change::EpochChangeProof,
+    ledger_info::LedgerInfoWithSignatures,
+    transaction::{PersistedAuxiliaryInfo, TransactionListWithProof},
+    PeerId,
 };
 use bytes::Bytes;
 use claims::assert_none;
@@ -18,94 +20,252 @@ use std::collections::HashMap;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transactions_different_networks() {
-    // Test small and large chunk sizes
-    let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
-    for chunk_size in [100, max_transaction_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
+        for chunk_size in [100, max_transaction_chunk_size] {
+            // Test event inclusion
+            for include_events in [true, false] {
+                // Create test data
+                let highest_version = 45576;
+                let highest_epoch = 43;
+                let lowest_version = 4566;
+                let peer_version_1 = highest_version - chunk_size;
+                let peer_version_2 = highest_version - (chunk_size - 10);
+                let highest_ledger_info =
+                    utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+                let transaction_list_with_proof_1 = utils::create_transaction_list_with_proof(
+                    peer_version_1 + 1,
+                    highest_version,
+                    highest_version,
+                    include_events,
+                );
+                let transaction_list_with_proof_2 = utils::create_transaction_list_with_proof(
+                    peer_version_2 + 1,
+                    highest_version,
+                    highest_version,
+                    include_events,
+                );
+                let persisted_auxiliary_infos_1 = utils::create_persisted_auxiliary_infos(
+                    peer_version_1 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+                let persisted_auxiliary_infos_2 = utils::create_persisted_auxiliary_infos(
+                    peer_version_2 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+
+                // Create the mock db reader
+                let mut db_reader = mock::create_mock_db_with_summary_updates(
+                    highest_ledger_info.clone(),
+                    lowest_version,
+                );
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version_1 + 1,
+                    highest_version - peer_version_1,
+                    highest_version,
+                    include_events,
+                    transaction_list_with_proof_1.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_1.clone(),
+                );
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version_2 + 1,
+                    highest_version - peer_version_2,
+                    highest_version,
+                    include_events,
+                    transaction_list_with_proof_2.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_2.clone(),
+                );
+
+                // Create a storage service config
+                let storage_config = utils::create_storage_config(use_request_v2);
+
+                // Create the storage client and server
+                let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                let active_subscriptions = service.get_subscriptions();
+                tokio::spawn(service.start());
+
+                // Send a request to subscribe to transactions for peer 1
+                let peer_id = PeerId::random();
+                let subscription_stream_id = 200;
+                let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
+                let mut response_receiver_1 = utils::subscribe_to_transactions_for_peer(
+                    &mut mock_client,
+                    peer_version_1,
+                    highest_epoch,
+                    include_events,
+                    subscription_stream_id,
+                    0,
+                    Some(peer_network_1),
+                    use_request_v2,
+                )
+                .await;
+
+                // Send a request to subscribe to transactions for peer 2
+                let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
+                let mut response_receiver_2 = utils::subscribe_to_transactions_for_peer(
+                    &mut mock_client,
+                    peer_version_2,
+                    highest_epoch,
+                    include_events,
+                    subscription_stream_id,
+                    0,
+                    Some(peer_network_2),
+                    use_request_v2,
+                )
+                .await;
+
+                // Wait until the subscriptions are active
+                utils::wait_for_active_subscriptions(active_subscriptions.clone(), 2).await;
+
+                // Verify no subscription response has been received yet
+                assert_none!(response_receiver_1.try_recv().unwrap());
+                assert_none!(response_receiver_2.try_recv().unwrap());
+
+                // Force the subscription handler to work
+                utils::force_subscription_handler_to_run(
+                    &mut mock_client,
+                    &mock_time,
+                    &storage_service_notifier,
+                )
+                .await;
+
+                // Verify a response is received and that it contains the correct data for both peers
+                utils::verify_new_transactions_with_proof(
+                    &mut mock_client,
+                    response_receiver_1,
+                    use_request_v2,
+                    transaction_list_with_proof_1,
+                    highest_ledger_info.clone(),
+                    persisted_auxiliary_infos_1.clone(),
+                )
+                .await;
+                utils::verify_new_transactions_with_proof(
+                    &mut mock_client,
+                    response_receiver_2,
+                    use_request_v2,
+                    transaction_list_with_proof_2,
+                    highest_ledger_info,
+                    persisted_auxiliary_infos_2.clone(),
+                )
+                .await;
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "Canceled")]
+async fn test_subscribe_transactions_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
+
+    // Send a transaction v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    let response_receiver = utils::subscribe_to_transactions(
+        &mut mock_client,
+        0,
+        0,
+        true,
+        0,
+        0,
+        true, // Use transaction v2
+    )
+    .await;
+
+    // Wait for the response, which should never come
+    response_receiver.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscribe_transactions_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Test event inclusion
         for include_events in [true, false] {
             // Create test data
             let highest_version = 45576;
-            let highest_epoch = 43;
+            let highest_epoch = 1032;
             let lowest_version = 4566;
-            let peer_version_1 = highest_version - chunk_size;
-            let peer_version_2 = highest_version - (chunk_size - 10);
-            let highest_ledger_info =
-                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-            let transaction_list_with_proof_1 = utils::create_transaction_list_with_proof(
-                peer_version_1 + 1,
-                highest_version,
-                highest_version,
+            let peer_version = highest_version - 100;
+            let peer_epoch = highest_epoch - 20;
+            let epoch_change_version = peer_version + 45;
+            let epoch_change_proof = EpochChangeProof {
+                ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
+                    peer_epoch,
+                    epoch_change_version,
+                )],
+                more: false,
+            };
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                peer_version + 1,
+                epoch_change_version,
+                epoch_change_version,
                 include_events,
             );
-            let transaction_list_with_proof_2 = utils::create_transaction_list_with_proof(
-                peer_version_2 + 1,
-                highest_version,
-                highest_version,
-                include_events,
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                epoch_change_version,
+                use_request_v2,
             );
 
             // Create the mock db reader
             let mut db_reader = mock::create_mock_db_with_summary_updates(
-                highest_ledger_info.clone(),
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
                 lowest_version,
             );
             utils::expect_get_transactions(
                 &mut db_reader,
-                peer_version_1 + 1,
-                highest_version - peer_version_1,
-                highest_version,
+                peer_version + 1,
+                epoch_change_version - peer_version,
+                epoch_change_version,
                 include_events,
-                transaction_list_with_proof_1.clone(),
+                transaction_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
             );
-            utils::expect_get_transactions(
+            utils::expect_get_epoch_ending_ledger_infos(
                 &mut db_reader,
-                peer_version_2 + 1,
-                highest_version - peer_version_2,
-                highest_version,
-                include_events,
-                transaction_list_with_proof_2.clone(),
+                peer_epoch,
+                peer_epoch + 1,
+                epoch_change_proof.clone(),
             );
+
+            // Create the storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
 
             // Create the storage client and server
             let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-                MockClient::new(Some(db_reader), None);
+                MockClient::new(Some(db_reader), Some(storage_config));
             let active_subscriptions = service.get_subscriptions();
             tokio::spawn(service.start());
 
-            // Send a request to subscribe to transactions for peer 1
-            let peer_id = PeerId::random();
-            let subscription_stream_id = 200;
-            let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
-            let mut response_receiver_1 = utils::subscribe_to_transactions_for_peer(
+            // Send a request to subscribe to transactions
+            let response_receiver = utils::subscribe_to_transactions(
                 &mut mock_client,
-                peer_version_1,
-                highest_epoch,
+                peer_version,
+                peer_epoch,
                 include_events,
-                subscription_stream_id,
+                utils::get_random_u64(),
                 0,
-                Some(peer_network_1),
+                use_request_v2,
             )
             .await;
 
-            // Send a request to subscribe to transactions for peer 2
-            let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
-            let mut response_receiver_2 = utils::subscribe_to_transactions_for_peer(
-                &mut mock_client,
-                peer_version_2,
-                highest_epoch,
-                include_events,
-                subscription_stream_id,
-                0,
-                Some(peer_network_2),
-            )
-            .await;
-
-            // Wait until the subscriptions are active
-            utils::wait_for_active_subscriptions(active_subscriptions.clone(), 2).await;
-
-            // Verify no subscription response has been received yet
-            assert_none!(response_receiver_1.try_recv().unwrap());
-            assert_none!(response_receiver_2.try_recv().unwrap());
+            // Wait until the subscription is active
+            utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
 
             // Force the subscription handler to work
             utils::force_subscription_handler_to_run(
@@ -115,19 +275,14 @@ async fn test_subscribe_transactions_different_networks() {
             )
             .await;
 
-            // Verify a response is received and that it contains the correct data for both peers
+            // Verify a response is received and that it contains the correct data
             utils::verify_new_transactions_with_proof(
                 &mut mock_client,
-                response_receiver_1,
-                transaction_list_with_proof_1,
-                highest_ledger_info.clone(),
-            )
-            .await;
-            utils::verify_new_transactions_with_proof(
-                &mut mock_client,
-                response_receiver_2,
-                transaction_list_with_proof_2,
-                highest_ledger_info,
+                response_receiver,
+                use_request_v2,
+                transaction_list_with_proof,
+                epoch_change_proof.ledger_info_with_sigs[0].clone(),
+                persisted_auxiliary_infos,
             )
             .await;
         }
@@ -135,126 +290,157 @@ async fn test_subscribe_transactions_different_networks() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_subscribe_transactions_epoch_change() {
-    // Test event inclusion
-    for include_events in [true, false] {
-        // Create test data
-        let highest_version = 45576;
-        let highest_epoch = 1032;
-        let lowest_version = 4566;
-        let peer_version = highest_version - 100;
-        let peer_epoch = highest_epoch - 20;
-        let epoch_change_version = peer_version + 45;
-        let epoch_change_proof = EpochChangeProof {
-            ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
-                peer_epoch,
-                epoch_change_version,
-            )],
-            more: false,
+async fn test_subscribe_transactions_max_chunk() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config with a configured max chunk size
+        let max_transaction_chunk_size = 400;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_chunk_size,
+            enable_transaction_data_v2: use_request_v2,
+            ..StorageServiceConfig::default()
         };
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            epoch_change_version,
-            epoch_change_version,
-            include_events,
-        );
 
-        // Create the mock db reader
-        let mut db_reader = mock::create_mock_db_with_summary_updates(
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
-            lowest_version,
-        );
-        utils::expect_get_transactions(
-            &mut db_reader,
-            peer_version + 1,
-            epoch_change_version - peer_version,
-            epoch_change_version,
-            include_events,
-            transaction_list_with_proof.clone(),
-        );
-        utils::expect_get_epoch_ending_ledger_infos(
-            &mut db_reader,
-            peer_epoch,
-            peer_epoch + 1,
-            epoch_change_proof.clone(),
-        );
+        // Test event inclusion
+        for include_events in [true, false] {
+            // Create test data
+            let highest_version = 1034556;
+            let highest_epoch = 343;
+            let lowest_version = 3453;
+            let requested_chunk_size = max_transaction_chunk_size + 1;
+            let peer_version = highest_version - requested_chunk_size;
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                peer_version + 1,
+                peer_version + max_transaction_chunk_size,
+                peer_version + max_transaction_chunk_size,
+                include_events,
+            );
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                peer_version + max_transaction_chunk_size,
+                use_request_v2,
+            );
 
-        // Create the storage client and server
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), None);
-        let active_subscriptions = service.get_subscriptions();
-        tokio::spawn(service.start());
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
+            );
+            utils::expect_get_transactions(
+                &mut db_reader,
+                peer_version + 1,
+                max_transaction_chunk_size,
+                highest_version,
+                include_events,
+                transaction_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
+            );
 
-        // Send a request to subscribe to transactions
-        let response_receiver = utils::subscribe_to_transactions(
-            &mut mock_client,
-            peer_version,
-            peer_epoch,
-            include_events,
-            utils::get_random_u64(),
-            0,
-        )
-        .await;
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_service_config));
+            let active_subscriptions = service.get_subscriptions();
+            tokio::spawn(service.start());
 
-        // Wait until the subscription is active
-        utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
+            // Send a request to subscribe to new transactions
+            let response_receiver = utils::subscribe_to_transactions(
+                &mut mock_client,
+                peer_version,
+                highest_epoch,
+                include_events,
+                utils::get_random_u64(),
+                0,
+                use_request_v2,
+            )
+            .await;
 
-        // Force the subscription handler to work
-        utils::force_subscription_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
+            // Wait until the subscription is active
+            utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
 
-        // Verify a response is received and that it contains the correct data
-        utils::verify_new_transactions_with_proof(
-            &mut mock_client,
-            response_receiver,
-            transaction_list_with_proof,
-            epoch_change_proof.ledger_info_with_sigs[0].clone(),
-        )
-        .await;
+            // Force the subscription handler to work
+            utils::force_subscription_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
+
+            // Verify a response is received and that it contains the correct data
+            utils::verify_new_transactions_with_proof(
+                &mut mock_client,
+                response_receiver,
+                use_request_v2,
+                transaction_list_with_proof,
+                highest_ledger_info,
+                persisted_auxiliary_infos,
+            )
+            .await;
+        }
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_subscribe_transactions_max_chunk() {
-    // Create a storage service config with a configured max chunk size
-    let max_transaction_chunk_size = 400;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_chunk_size,
-        ..StorageServiceConfig::default()
-    };
+async fn test_subscribe_transactions_streaming() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_transaction_chunk_size = 100;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_chunk_size,
+            enable_transaction_data_v2: use_request_v2,
+            ..Default::default()
+        };
 
-    // Test event inclusion
-    for include_events in [true, false] {
         // Create test data
-        let highest_version = 1034556;
-        let highest_epoch = 343;
-        let lowest_version = 3453;
-        let requested_chunk_size = max_transaction_chunk_size + 1;
-        let peer_version = highest_version - requested_chunk_size;
+        let num_stream_requests = 20;
+        let highest_version = 100_000;
+        let highest_epoch = 10;
+        let lowest_version = 10_000;
+        let peer_version = 50_000;
         let highest_ledger_info =
             utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            peer_version + requested_chunk_size,
-            peer_version + requested_chunk_size,
-            include_events,
-        );
+
+        // Create the transaction lists with proofs
+        let transaction_lists_with_proofs: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_chunk_size) + 1;
+                let end_version = start_version + max_transaction_chunk_size - 1;
+                utils::create_transaction_list_with_proof(
+                    start_version,
+                    end_version,
+                    highest_version,
+                    false,
+                )
+            })
+            .collect();
+
+        // Create the persisted auxiliary infos
+        let persisted_auxiliary_infos: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_chunk_size) + 1;
+                let end_version = start_version + max_transaction_chunk_size - 1;
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2)
+            })
+            .collect();
 
         // Create the mock db reader
         let mut db_reader =
             mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        utils::expect_get_transactions(
-            &mut db_reader,
-            peer_version + 1,
-            max_transaction_chunk_size,
-            highest_version,
-            include_events,
-            transaction_list_with_proof.clone(),
-        );
+        for i in 0..num_stream_requests {
+            utils::expect_get_transactions(
+                &mut db_reader,
+                peer_version + (i * max_transaction_chunk_size) + 1,
+                max_transaction_chunk_size,
+                highest_version,
+                false,
+                transaction_lists_with_proofs[i as usize].clone(),
+                use_request_v2,
+                persisted_auxiliary_infos[i as usize].clone(),
+            );
+        }
 
         // Create the storage client and server
         let (mut mock_client, service, storage_service_notifier, mock_time, _) =
@@ -262,19 +448,186 @@ async fn test_subscribe_transactions_max_chunk() {
         let active_subscriptions = service.get_subscriptions();
         tokio::spawn(service.start());
 
-        // Send a request to subscribe to new transactions
-        let response_receiver = utils::subscribe_to_transactions(
-            &mut mock_client,
+        // Create a new peer and stream ID
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = utils::get_random_u64();
+
+        // Send multiple batches of requests to the server and verify the responses
+        let num_batches_to_send = 10;
+        for batch_id in 0..num_batches_to_send {
+            // Send the request batch to subscribe to transaction outputs
+            let num_requests_per_batch = num_stream_requests / num_batches_to_send;
+            let first_request_index = batch_id * num_requests_per_batch;
+            let last_request_index =
+                (batch_id * num_requests_per_batch) + num_requests_per_batch - 1;
+            let mut response_receivers = send_transaction_subscription_request_batch(
+                &mut mock_client,
+                peer_network_id,
+                first_request_index,
+                last_request_index,
+                stream_id,
+                peer_version,
+                highest_epoch,
+                use_request_v2,
+            )
+            .await;
+
+            // Wait until the stream requests are active
+            utils::wait_for_active_stream_requests(
+                active_subscriptions.clone(),
+                peer_network_id,
+                num_requests_per_batch as usize,
+            )
+            .await;
+
+            // Force the subscription handler to work
+            utils::force_cache_update_notification(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+                true,
+                true,
+            )
+            .await;
+
+            // Continuously run the subscription service until the batch responses are received
+            for stream_request_index in first_request_index..=last_request_index {
+                // Verify that the correct response is received
+                verify_transaction_subscription_response(
+                    transaction_lists_with_proofs.clone(),
+                    persisted_auxiliary_infos.clone(),
+                    highest_ledger_info.clone(),
+                    &mut mock_client,
+                    &mut response_receivers,
+                    stream_request_index,
+                    use_request_v2,
+                )
+                .await;
+            }
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscribe_transactions_streaming_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_transaction_chunk_size = 50;
+        let max_num_active_subscriptions = 25;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_chunk_size,
+            max_num_active_subscriptions,
+            enable_transaction_data_v2: use_request_v2,
+            ..Default::default()
+        };
+
+        // Create test data
+        let highest_version = 10_000;
+        let highest_epoch = 2;
+        let lowest_version = 0;
+        let peer_version = highest_version - 5000;
+        let peer_epoch = highest_epoch - 1;
+        let epoch_change_version = peer_version + 97;
+
+        // Create the highest ledger info and epoch change proof
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+        let epoch_change_ledger_info =
+            utils::create_epoch_ending_ledger_info(peer_epoch, epoch_change_version);
+        let epoch_change_proof = EpochChangeProof {
+            ledger_info_with_sigs: vec![epoch_change_ledger_info.clone()],
+            more: false,
+        };
+
+        // Create the transaction lists with proofs
+        let chunk_start_and_end_versions = utils::create_data_chunks_with_epoch_boundary(
+            max_transaction_chunk_size,
+            max_num_active_subscriptions,
             peer_version,
-            highest_epoch,
-            include_events,
-            utils::get_random_u64(),
+            epoch_change_version,
+        );
+        let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+            .iter()
+            .map(|(start_version, end_version)| {
+                utils::create_transaction_list_with_proof(
+                    *start_version,
+                    *end_version,
+                    highest_version,
+                    false,
+                )
+            })
+            .collect();
+
+        // Create the persisted auxiliary infos
+        let persisted_auxiliary_infos: Vec<_> = chunk_start_and_end_versions
+            .iter()
+            .map(|(start_version, end_version)| {
+                utils::create_persisted_auxiliary_infos(
+                    *start_version,
+                    *end_version,
+                    use_request_v2,
+                )
+            })
+            .collect();
+
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        utils::expect_get_epoch_ending_ledger_infos(
+            &mut db_reader,
+            peer_epoch,
+            peer_epoch + 1,
+            epoch_change_proof.clone(),
+        );
+        for (i, (start_version, end_version)) in chunk_start_and_end_versions.iter().enumerate() {
+            let proof_version = if *end_version <= epoch_change_version {
+                epoch_change_version
+            } else {
+                highest_version
+            };
+            utils::expect_get_transactions(
+                &mut db_reader,
+                *start_version,
+                end_version - start_version + 1,
+                proof_version,
+                false,
+                transaction_lists_with_proofs[i].clone(),
+                use_request_v2,
+                persisted_auxiliary_infos[i].clone(),
+            );
+        }
+
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_service_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
+
+        // Create a new peer and stream ID
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = utils::get_random_u64();
+
+        // Send the request batch to subscribe to transaction outputs
+        let mut response_receivers = send_transaction_subscription_request_batch(
+            &mut mock_client,
+            peer_network_id,
             0,
+            max_num_active_subscriptions - 1,
+            stream_id,
+            peer_version,
+            peer_epoch,
+            use_request_v2,
         )
         .await;
 
-        // Wait until the subscription is active
-        utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
+        // Wait until the stream requests are active
+        utils::wait_for_active_stream_requests(
+            active_subscriptions.clone(),
+            peer_network_id,
+            max_num_active_subscriptions as usize,
+        )
+        .await;
 
         // Force the subscription handler to work
         utils::force_subscription_handler_to_run(
@@ -284,118 +637,27 @@ async fn test_subscribe_transactions_max_chunk() {
         )
         .await;
 
-        // Verify a response is received and that it contains the correct data
-        utils::verify_new_transactions_with_proof(
-            &mut mock_client,
-            response_receiver,
-            transaction_list_with_proof,
-            highest_ledger_info,
-        )
-        .await;
-    }
-}
+        // Continuously run the subscription service until all the responses are received
+        for stream_request_index in 0..max_num_active_subscriptions {
+            // Determine the target ledger info for the response
+            let first_output_version = transaction_lists_with_proofs[stream_request_index as usize]
+                .first_transaction_version
+                .unwrap();
+            let target_ledger_info = if first_output_version > epoch_change_version {
+                highest_ledger_info.clone()
+            } else {
+                epoch_change_ledger_info.clone()
+            };
 
-#[tokio::test(flavor = "multi_thread")]
-async fn test_subscribe_transactions_streaming() {
-    // Create a storage service config
-    let max_transaction_chunk_size = 100;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_chunk_size,
-        ..Default::default()
-    };
-
-    // Create test data
-    let num_stream_requests = 20;
-    let highest_version = 100_000;
-    let highest_epoch = 10;
-    let lowest_version = 10_000;
-    let peer_version = 50_000;
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-
-    // Create the transaction lists with proofs
-    let transaction_lists_with_proofs: Vec<_> = (0..num_stream_requests)
-        .map(|i| {
-            let start_version = peer_version + (i * max_transaction_chunk_size) + 1;
-            let end_version = start_version + max_transaction_chunk_size - 1;
-            utils::create_transaction_list_with_proof(
-                start_version,
-                end_version,
-                highest_version,
-                false,
-            )
-        })
-        .collect();
-
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    for i in 0..num_stream_requests {
-        utils::expect_get_transactions(
-            &mut db_reader,
-            peer_version + (i * max_transaction_chunk_size) + 1,
-            max_transaction_chunk_size,
-            highest_version,
-            false,
-            transaction_lists_with_proofs[i as usize].clone(),
-        );
-    }
-
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
-
-    // Create a new peer and stream ID
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = utils::get_random_u64();
-
-    // Send multiple batches of requests to the server and verify the responses
-    let num_batches_to_send = 10;
-    for batch_id in 0..num_batches_to_send {
-        // Send the request batch to subscribe to transaction outputs
-        let num_requests_per_batch = num_stream_requests / num_batches_to_send;
-        let first_request_index = batch_id * num_requests_per_batch;
-        let last_request_index = (batch_id * num_requests_per_batch) + num_requests_per_batch - 1;
-        let mut response_receivers = send_transaction_subscription_request_batch(
-            &mut mock_client,
-            peer_network_id,
-            first_request_index,
-            last_request_index,
-            stream_id,
-            peer_version,
-            highest_epoch,
-        )
-        .await;
-
-        // Wait until the stream requests are active
-        utils::wait_for_active_stream_requests(
-            active_subscriptions.clone(),
-            peer_network_id,
-            num_requests_per_batch as usize,
-        )
-        .await;
-
-        // Force the subscription handler to work
-        utils::force_cache_update_notification(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-            true,
-            true,
-        )
-        .await;
-
-        // Continuously run the subscription service until the batch responses are received
-        for stream_request_index in first_request_index..=last_request_index {
             // Verify that the correct response is received
             verify_transaction_subscription_response(
                 transaction_lists_with_proofs.clone(),
-                highest_ledger_info.clone(),
+                persisted_auxiliary_infos.clone(),
+                target_ledger_info.clone(),
                 &mut mock_client,
                 &mut response_receivers,
                 stream_request_index,
+                use_request_v2,
             )
             .await;
         }
@@ -403,244 +665,127 @@ async fn test_subscribe_transactions_streaming() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-async fn test_subscribe_transactions_streaming_epoch_change() {
-    // Create a storage service config
-    let max_transaction_chunk_size = 50;
-    let max_num_active_subscriptions = 25;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_chunk_size,
-        max_num_active_subscriptions,
-        ..Default::default()
-    };
-
-    // Create test data
-    let highest_version = 10_000;
-    let highest_epoch = 2;
-    let lowest_version = 0;
-    let peer_version = highest_version - 5000;
-    let peer_epoch = highest_epoch - 1;
-    let epoch_change_version = peer_version + 97;
-
-    // Create the highest ledger info and epoch change proof
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-    let epoch_change_ledger_info =
-        utils::create_epoch_ending_ledger_info(peer_epoch, epoch_change_version);
-    let epoch_change_proof = EpochChangeProof {
-        ledger_info_with_sigs: vec![epoch_change_ledger_info.clone()],
-        more: false,
-    };
-
-    // Create the transaction lists with proofs
-    let chunk_start_and_end_versions = utils::create_data_chunks_with_epoch_boundary(
-        max_transaction_chunk_size,
-        max_num_active_subscriptions,
-        peer_version,
-        epoch_change_version,
-    );
-    let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-        .iter()
-        .map(|(start_version, end_version)| {
-            utils::create_transaction_list_with_proof(
-                *start_version,
-                *end_version,
-                highest_version,
-                false,
-            )
-        })
-        .collect();
-
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    utils::expect_get_epoch_ending_ledger_infos(
-        &mut db_reader,
-        peer_epoch,
-        peer_epoch + 1,
-        epoch_change_proof.clone(),
-    );
-    for (i, (start_version, end_version)) in chunk_start_and_end_versions.iter().enumerate() {
-        let proof_version = if *end_version <= epoch_change_version {
-            epoch_change_version
-        } else {
-            highest_version
-        };
-        utils::expect_get_transactions(
-            &mut db_reader,
-            *start_version,
-            end_version - start_version + 1,
-            proof_version,
-            false,
-            transaction_lists_with_proofs[i].clone(),
-        );
-    }
-
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
-
-    // Create a new peer and stream ID
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = utils::get_random_u64();
-
-    // Send the request batch to subscribe to transaction outputs
-    let mut response_receivers = send_transaction_subscription_request_batch(
-        &mut mock_client,
-        peer_network_id,
-        0,
-        max_num_active_subscriptions - 1,
-        stream_id,
-        peer_version,
-        peer_epoch,
-    )
-    .await;
-
-    // Wait until the stream requests are active
-    utils::wait_for_active_stream_requests(
-        active_subscriptions.clone(),
-        peer_network_id,
-        max_num_active_subscriptions as usize,
-    )
-    .await;
-
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
-
-    // Continuously run the subscription service until all the responses are received
-    for stream_request_index in 0..max_num_active_subscriptions {
-        // Determine the target ledger info for the response
-        let first_output_version = transaction_lists_with_proofs[stream_request_index as usize]
-            .first_transaction_version
-            .unwrap();
-        let target_ledger_info = if first_output_version > epoch_change_version {
-            highest_ledger_info.clone()
-        } else {
-            epoch_change_ledger_info.clone()
-        };
-
-        // Verify that the correct response is received
-        verify_transaction_subscription_response(
-            transaction_lists_with_proofs.clone(),
-            target_ledger_info.clone(),
-            &mut mock_client,
-            &mut response_receivers,
-            stream_request_index,
-        )
-        .await;
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transactions_streaming_loop() {
-    // Create a storage service config
-    let max_transaction_chunk_size = 100;
-    let storage_service_config = StorageServiceConfig {
-        max_transaction_chunk_size,
-        ..Default::default()
-    };
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_transaction_chunk_size = 100;
+        let storage_service_config = StorageServiceConfig {
+            max_transaction_chunk_size,
+            enable_transaction_data_v2: use_request_v2,
+            ..Default::default()
+        };
 
-    // Create test data
-    let num_stream_requests = 20;
-    let highest_version = 100_000;
-    let highest_epoch = 10;
-    let lowest_version = 10_000;
-    let peer_version = 50_000;
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+        // Create test data
+        let num_stream_requests = 20;
+        let highest_version = 100_000;
+        let highest_epoch = 10;
+        let lowest_version = 10_000;
+        let peer_version = 50_000;
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
 
-    // Create the transaction lists with proofs
-    let transaction_lists_with_proofs: Vec<_> = (0..num_stream_requests)
-        .map(|i| {
-            let start_version = peer_version + (i * max_transaction_chunk_size) + 1;
-            let end_version = start_version + max_transaction_chunk_size - 1;
-            utils::create_transaction_list_with_proof(
-                start_version,
-                end_version,
+        // Create the transaction lists with proofs
+        let transaction_lists_with_proofs: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_chunk_size) + 1;
+                let end_version = start_version + max_transaction_chunk_size - 1;
+                utils::create_transaction_list_with_proof(
+                    start_version,
+                    end_version,
+                    highest_version,
+                    false,
+                )
+            })
+            .collect();
+
+        // Create the persisted auxiliary infos
+        let persisted_auxiliary_infos: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_chunk_size) + 1;
+                let end_version = start_version + max_transaction_chunk_size - 1;
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2)
+            })
+            .collect();
+
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        for i in 0..num_stream_requests {
+            utils::expect_get_transactions(
+                &mut db_reader,
+                peer_version + (i * max_transaction_chunk_size) + 1,
+                max_transaction_chunk_size,
                 highest_version,
                 false,
-            )
-        })
-        .collect();
+                transaction_lists_with_proofs[i as usize].clone(),
+                use_request_v2,
+                persisted_auxiliary_infos[i as usize].clone(),
+            );
+        }
 
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    for i in 0..num_stream_requests {
-        utils::expect_get_transactions(
-            &mut db_reader,
-            peer_version + (i * max_transaction_chunk_size) + 1,
-            max_transaction_chunk_size,
-            highest_version,
-            false,
-            transaction_lists_with_proofs[i as usize].clone(),
-        );
-    }
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_service_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
 
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
+        // Create a new peer and stream ID
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = utils::get_random_u64();
 
-    // Create a new peer and stream ID
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = utils::get_random_u64();
-
-    // Send the requests to the server and verify the responses
-    let mut response_receivers = send_transaction_subscription_request_batch(
-        &mut mock_client,
-        peer_network_id,
-        0,
-        num_stream_requests - 1,
-        stream_id,
-        peer_version,
-        highest_epoch,
-    )
-    .await;
-
-    // Wait until the stream requests are active
-    utils::wait_for_active_stream_requests(
-        active_subscriptions.clone(),
-        peer_network_id,
-        num_stream_requests as usize,
-    )
-    .await;
-
-    // Verify the state of the subscription stream
-    utils::verify_subscription_stream_entry(
-        active_subscriptions.clone(),
-        peer_network_id,
-        num_stream_requests,
-        peer_version,
-        highest_epoch,
-        max_transaction_chunk_size,
-    );
-
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
-
-    // Verify all responses are received
-    for stream_request_index in 0..num_stream_requests {
-        let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
-        utils::verify_new_transactions_with_proof(
+        // Send the requests to the server and verify the responses
+        let mut response_receivers = send_transaction_subscription_request_batch(
             &mut mock_client,
-            response_receiver,
-            transaction_lists_with_proofs[stream_request_index as usize].clone(),
-            highest_ledger_info.clone(),
+            peer_network_id,
+            0,
+            num_stream_requests - 1,
+            stream_id,
+            peer_version,
+            highest_epoch,
+            use_request_v2,
         )
         .await;
+
+        // Wait until the stream requests are active
+        utils::wait_for_active_stream_requests(
+            active_subscriptions.clone(),
+            peer_network_id,
+            num_stream_requests as usize,
+        )
+        .await;
+
+        // Verify the state of the subscription stream
+        utils::verify_subscription_stream_entry(
+            active_subscriptions.clone(),
+            peer_network_id,
+            num_stream_requests,
+            peer_version,
+            highest_epoch,
+            max_transaction_chunk_size,
+        );
+
+        // Force the subscription handler to work
+        utils::force_subscription_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
+
+        // Verify all responses are received
+        for stream_request_index in 0..num_stream_requests {
+            let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
+            utils::verify_new_transactions_with_proof(
+                &mut mock_client,
+                response_receiver,
+                use_request_v2,
+                transaction_lists_with_proofs[stream_request_index as usize].clone(),
+                highest_ledger_info.clone(),
+                persisted_auxiliary_infos[stream_request_index as usize].clone(),
+            )
+            .await;
+        }
     }
 }
 
@@ -654,6 +799,7 @@ async fn send_transaction_subscription_request_batch(
     stream_id: u64,
     peer_version: u64,
     peer_epoch: u64,
+    use_request_v2: bool,
 ) -> HashMap<u64, Receiver<Result<Bytes, RpcError>>> {
     // Shuffle the stream request indices to emulate out of order requests
     let stream_request_indices =
@@ -671,6 +817,7 @@ async fn send_transaction_subscription_request_batch(
             stream_id,
             stream_request_index,
             Some(peer_network_id),
+            use_request_v2,
         )
         .await;
 
@@ -685,17 +832,21 @@ async fn send_transaction_subscription_request_batch(
 /// and that the response contains the correct data.
 async fn verify_transaction_subscription_response(
     expected_transaction_lists_with_proofs: Vec<TransactionListWithProof>,
+    expected_persisted_auxiliary_infos: Vec<Option<Vec<PersistedAuxiliaryInfo>>>,
     expected_target_ledger_info: LedgerInfoWithSignatures,
     mock_client: &mut MockClient,
     response_receivers: &mut HashMap<u64, Receiver<Result<Bytes, RpcError>>>,
     stream_request_index: u64,
+    use_request_v2: bool,
 ) {
     let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
     utils::verify_new_transactions_with_proof(
         mock_client,
         response_receiver,
+        use_request_v2,
         expected_transaction_lists_with_proofs[stream_request_index as usize].clone(),
         expected_target_ledger_info,
+        expected_persisted_auxiliary_infos[stream_request_index as usize].clone(),
     )
     .await;
 }

--- a/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
@@ -10,7 +10,9 @@ use aptos_network::protocols::network::RpcError;
 use aptos_types::{
     epoch_change::EpochChangeProof,
     ledger_info::LedgerInfoWithSignatures,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof},
+    transaction::{
+        PersistedAuxiliaryInfo, TransactionListWithProof, TransactionOutputListWithProof,
+    },
     PeerId,
 };
 use bytes::Bytes;
@@ -20,121 +22,334 @@ use std::collections::HashMap;
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transactions_or_outputs_different_network() {
-    // Test small and large chunk sizes
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [100, max_output_chunk_size] {
-        // Test fallback to transaction syncing
-        for fallback_to_transactions in [false, true] {
-            // Create test data
-            let highest_version = 5060;
-            let highest_epoch = 30;
-            let lowest_version = 101;
-            let peer_version_1 = highest_version - chunk_size;
-            let peer_version_2 = highest_version - (chunk_size - 50);
-            let highest_ledger_info =
-                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-            let output_list_with_proof_1 = utils::create_output_list_with_proof(
-                peer_version_1 + 1,
-                highest_version,
-                highest_version,
-            );
-            let output_list_with_proof_2 = utils::create_output_list_with_proof(
-                peer_version_2 + 1,
-                highest_version,
-                highest_version,
-            );
-            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-                highest_version,
-                highest_version,
-                highest_version,
-                false,
-            ); // Creates a small transaction list
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk sizes
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [100, max_output_chunk_size] {
+            // Test fallback to transaction syncing
+            for fallback_to_transactions in [false, true] {
+                // Create test data
+                let highest_version = 5060;
+                let highest_epoch = 30;
+                let lowest_version = 101;
+                let peer_version_1 = highest_version - chunk_size;
+                let peer_version_2 = highest_version - chunk_size + 1;
+                let highest_ledger_info =
+                    utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+                let output_list_with_proof_1 = utils::create_output_list_with_proof(
+                    peer_version_1 + 1,
+                    highest_version,
+                    highest_version,
+                );
+                let output_list_with_proof_2 = utils::create_output_list_with_proof(
+                    peer_version_2 + 1,
+                    highest_version,
+                    highest_version,
+                );
+                let transaction_list_with_proof_1 = utils::create_transaction_list_with_proof(
+                    peer_version_1 + 1,
+                    highest_version,
+                    highest_version,
+                    false,
+                );
+                let transaction_list_with_proof_2 = utils::create_transaction_list_with_proof(
+                    peer_version_2 + 1,
+                    highest_version,
+                    highest_version,
+                    false,
+                );
+                let persisted_auxiliary_infos_1 = utils::create_persisted_auxiliary_infos(
+                    peer_version_1 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
+                let persisted_auxiliary_infos_2 = utils::create_persisted_auxiliary_infos(
+                    peer_version_2 + 1,
+                    highest_version,
+                    use_request_v2,
+                );
 
-            // Create the mock db reader
-            let mut db_reader = mock::create_mock_db_with_summary_updates(
-                highest_ledger_info.clone(),
-                lowest_version,
-            );
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
-                peer_version_1 + 1,
-                highest_version - peer_version_1,
-                highest_version,
-                output_list_with_proof_1.clone(),
-            );
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
-                peer_version_2 + 1,
-                highest_version - peer_version_2,
-                highest_version,
-                output_list_with_proof_2.clone(),
-            );
-            if fallback_to_transactions {
-                utils::expect_get_transactions(
+                // Create the mock db reader
+                let mut db_reader = mock::create_mock_db_with_summary_updates(
+                    highest_ledger_info.clone(),
+                    lowest_version,
+                );
+                utils::expect_get_transaction_outputs(
                     &mut db_reader,
                     peer_version_1 + 1,
                     highest_version - peer_version_1,
                     highest_version,
-                    false,
-                    transaction_list_with_proof.clone(),
+                    output_list_with_proof_1.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_1.clone(),
                 );
-                utils::expect_get_transactions(
+                utils::expect_get_transaction_outputs(
                     &mut db_reader,
                     peer_version_2 + 1,
                     highest_version - peer_version_2,
                     highest_version,
+                    output_list_with_proof_2.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos_2.clone(),
+                );
+                if fallback_to_transactions {
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        peer_version_1 + 1,
+                        highest_version - peer_version_1,
+                        highest_version,
+                        false,
+                        transaction_list_with_proof_1.clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos_1.clone(),
+                    );
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        peer_version_2 + 1,
+                        highest_version - peer_version_2,
+                        highest_version,
+                        false,
+                        transaction_list_with_proof_2.clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos_2.clone(),
+                    );
+                }
+
+                // Create the storage client and server
+                let storage_config = utils::configure_network_chunk_limit(
+                    fallback_to_transactions,
+                    &output_list_with_proof_1,
+                    &transaction_list_with_proof_1,
+                    use_request_v2,
+                );
+                let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                let active_subscriptions = service.get_subscriptions();
+                tokio::spawn(service.start());
+
+                // Send a request to subscribe to transactions or outputs for peer 1
+                let peer_id = PeerId::random();
+                let subscription_stream_id = 56756;
+                let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
+                let mut response_receiver_1 = utils::subscribe_to_transactions_or_outputs_for_peer(
+                    &mut mock_client,
+                    peer_version_1,
+                    highest_epoch,
+                    false,
+                    0, // Outputs cannot be reduced and will fallback to transactions
+                    subscription_stream_id,
+                    0,
+                    Some(peer_network_1),
+                    use_request_v2,
+                )
+                .await;
+
+                // Send a request to subscribe to transactions or outputs for peer 2
+                let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
+                let mut response_receiver_2 = utils::subscribe_to_transactions_or_outputs_for_peer(
+                    &mut mock_client,
+                    peer_version_2,
+                    highest_epoch,
+                    false,
+                    0, // Outputs cannot be reduced and will fallback to transactions
+                    subscription_stream_id,
+                    0,
+                    Some(peer_network_2),
+                    use_request_v2,
+                )
+                .await;
+
+                // Wait until the subscriptions are active
+                utils::wait_for_active_subscriptions(active_subscriptions.clone(), 2).await;
+
+                // Verify no response has been received yet
+                assert_none!(response_receiver_1.try_recv().unwrap());
+                assert_none!(response_receiver_2.try_recv().unwrap());
+
+                // Force the subscription handler to work
+                utils::force_subscription_handler_to_run(
+                    &mut mock_client,
+                    &mock_time,
+                    &storage_service_notifier,
+                )
+                .await;
+
+                // Verify a response is received and that it contains the correct data
+                if fallback_to_transactions {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_1,
+                        use_request_v2,
+                        Some(transaction_list_with_proof_1.clone()),
+                        None,
+                        highest_ledger_info.clone(),
+                        persisted_auxiliary_infos_1.clone(),
+                    )
+                    .await;
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_2,
+                        use_request_v2,
+                        Some(transaction_list_with_proof_2.clone()),
+                        None,
+                        highest_ledger_info,
+                        persisted_auxiliary_infos_2.clone(),
+                    )
+                    .await;
+                } else {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_1,
+                        use_request_v2,
+                        None,
+                        Some(output_list_with_proof_1.clone()),
+                        highest_ledger_info.clone(),
+                        persisted_auxiliary_infos_1.clone(),
+                    )
+                    .await;
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver_2,
+                        use_request_v2,
+                        None,
+                        Some(output_list_with_proof_2.clone()),
+                        highest_ledger_info,
+                        persisted_auxiliary_infos_2.clone(),
+                    )
+                    .await;
+                }
+            }
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "Canceled")]
+async fn test_subscribe_transactions_or_outputs_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
+
+    // Send a transaction or output v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    let response_receiver = utils::subscribe_to_transactions_or_outputs(
+        &mut mock_client,
+        0,
+        0,
+        false,
+        0,
+        0,
+        0,
+        true, // Use transaction v2
+    )
+    .await;
+
+    // Wait for the response, which should never come
+    response_receiver.await.unwrap().unwrap();
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_subscribe_transactions_or_outputs_epoch_change() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test fallback to transaction syncing
+        for fallback_to_transactions in [false, true] {
+            // Create test data
+            let highest_version = 10000;
+            let highest_epoch = 10000;
+            let lowest_version = 0;
+            let peer_version = highest_version - 1000;
+            let peer_epoch = highest_epoch - 1000;
+            let epoch_change_version = peer_version + 1;
+            let epoch_change_proof = EpochChangeProof {
+                ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
+                    peer_epoch,
+                    epoch_change_version,
+                )],
+                more: false,
+            };
+            let output_list_with_proof = utils::create_output_list_with_proof(
+                peer_version + 1,
+                epoch_change_version,
+                epoch_change_version,
+            );
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                peer_version + 1,
+                epoch_change_version,
+                epoch_change_version,
+                false,
+            );
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                epoch_change_version,
+                use_request_v2,
+            );
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
+                lowest_version,
+            );
+            utils::expect_get_epoch_ending_ledger_infos(
+                &mut db_reader,
+                peer_epoch,
+                peer_epoch + 1,
+                epoch_change_proof.clone(),
+            );
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version + 1,
+                epoch_change_version - peer_version,
+                epoch_change_version,
+                output_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
+            );
+            if fallback_to_transactions {
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version + 1,
+                    epoch_change_version - peer_version,
+                    epoch_change_version,
                     false,
                     transaction_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
                 );
             }
 
             // Create the storage client and server
             let storage_config = utils::configure_network_chunk_limit(
                 fallback_to_transactions,
-                &output_list_with_proof_1,
+                &output_list_with_proof,
                 &transaction_list_with_proof,
+                use_request_v2,
             );
             let (mut mock_client, service, storage_service_notifier, mock_time, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
             let active_subscriptions = service.get_subscriptions();
             tokio::spawn(service.start());
 
-            // Send a request to subscribe to transactions or outputs for peer 1
-            let peer_id = PeerId::random();
-            let subscription_stream_id = 56756;
-            let peer_network_1 = PeerNetworkId::new(NetworkId::Public, peer_id);
-            let mut response_receiver_1 = utils::subscribe_to_transactions_or_outputs_for_peer(
+            // Send a request to subscribe to new transactions or outputs
+            let response_receiver = utils::subscribe_to_transactions_or_outputs(
                 &mut mock_client,
-                peer_version_1,
-                highest_epoch,
+                peer_version,
+                peer_epoch,
                 false,
-                0, // Outputs cannot be reduced and will fallback to transactions
-                subscription_stream_id,
+                5,
+                utils::get_random_u64(),
                 0,
-                Some(peer_network_1),
+                use_request_v2,
             )
             .await;
 
-            // Send a request to subscribe to transactions or outputs for peer 2
-            let peer_network_2 = PeerNetworkId::new(NetworkId::Vfn, peer_id);
-            let mut response_receiver_2 = utils::subscribe_to_transactions_or_outputs_for_peer(
-                &mut mock_client,
-                peer_version_2,
-                highest_epoch,
-                false,
-                0, // Outputs cannot be reduced and will fallback to transactions
-                subscription_stream_id,
-                0,
-                Some(peer_network_2),
-            )
-            .await;
-
-            // Wait until the subscriptions are active
-            utils::wait_for_active_subscriptions(active_subscriptions.clone(), 2).await;
-
-            // Verify no response has been received yet
-            assert_none!(response_receiver_1.try_recv().unwrap());
-            assert_none!(response_receiver_2.try_recv().unwrap());
+            // Wait until the subscription is active
+            utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
 
             // Force the subscription handler to work
             utils::force_subscription_handler_to_run(
@@ -148,400 +363,321 @@ async fn test_subscribe_transactions_or_outputs_different_network() {
             if fallback_to_transactions {
                 utils::verify_new_transactions_or_outputs_with_proof(
                     &mut mock_client,
-                    response_receiver_1,
-                    Some(transaction_list_with_proof.clone()),
-                    None,
-                    highest_ledger_info.clone(),
-                )
-                .await;
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver_2,
+                    response_receiver,
+                    use_request_v2,
                     Some(transaction_list_with_proof),
                     None,
-                    highest_ledger_info,
+                    epoch_change_proof.ledger_info_with_sigs[0].clone(),
+                    persisted_auxiliary_infos.clone(),
                 )
                 .await;
             } else {
                 utils::verify_new_transactions_or_outputs_with_proof(
                     &mut mock_client,
-                    response_receiver_1,
+                    response_receiver,
+                    use_request_v2,
                     None,
-                    Some(output_list_with_proof_1.clone()),
-                    highest_ledger_info.clone(),
-                )
-                .await;
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver_2,
-                    None,
-                    Some(output_list_with_proof_2.clone()),
-                    highest_ledger_info,
+                    Some(output_list_with_proof),
+                    epoch_change_proof.ledger_info_with_sigs[0].clone(),
+                    persisted_auxiliary_infos.clone(),
                 )
                 .await;
             }
-        }
-    }
-}
-
-#[tokio::test(flavor = "multi_thread")]
-async fn test_subscribe_transactions_or_outputs_epoch_change() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let highest_version = 10000;
-        let highest_epoch = 10000;
-        let lowest_version = 0;
-        let peer_version = highest_version - 1000;
-        let peer_epoch = highest_epoch - 1000;
-        let epoch_change_version = peer_version + 1;
-        let epoch_change_proof = EpochChangeProof {
-            ledger_info_with_sigs: vec![utils::create_test_ledger_info_with_sigs(
-                peer_epoch,
-                epoch_change_version,
-            )],
-            more: false,
-        };
-        let output_list_with_proof = utils::create_output_list_with_proof(
-            peer_version + 1,
-            epoch_change_version,
-            epoch_change_version,
-        );
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            peer_version + 1,
-            epoch_change_version,
-            false,
-        ); // Creates a small transaction list
-
-        // Create the mock db reader
-        let mut db_reader = mock::create_mock_db_with_summary_updates(
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version),
-            lowest_version,
-        );
-        utils::expect_get_epoch_ending_ledger_infos(
-            &mut db_reader,
-            peer_epoch,
-            peer_epoch + 1,
-            epoch_change_proof.clone(),
-        );
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            peer_version + 1,
-            epoch_change_version - peer_version,
-            epoch_change_version,
-            output_list_with_proof.clone(),
-        );
-        if fallback_to_transactions {
-            utils::expect_get_transactions(
-                &mut db_reader,
-                peer_version + 1,
-                epoch_change_version - peer_version,
-                epoch_change_version,
-                false,
-                transaction_list_with_proof.clone(),
-            );
-        }
-
-        // Create the storage client and server
-        let storage_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_list_with_proof,
-            &transaction_list_with_proof,
-        );
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_config));
-        let active_subscriptions = service.get_subscriptions();
-        tokio::spawn(service.start());
-
-        // Send a request to subscribe to new transactions or outputs
-        let response_receiver = utils::subscribe_to_transactions_or_outputs(
-            &mut mock_client,
-            peer_version,
-            peer_epoch,
-            false,
-            5,
-            utils::get_random_u64(),
-            0,
-        )
-        .await;
-
-        // Wait until the subscription is active
-        utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
-
-        // Force the subscription handler to work
-        utils::force_subscription_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
-
-        // Verify a response is received and that it contains the correct data
-        if fallback_to_transactions {
-            utils::verify_new_transactions_or_outputs_with_proof(
-                &mut mock_client,
-                response_receiver,
-                Some(transaction_list_with_proof),
-                None,
-                epoch_change_proof.ledger_info_with_sigs[0].clone(),
-            )
-            .await;
-        } else {
-            utils::verify_new_transactions_or_outputs_with_proof(
-                &mut mock_client,
-                response_receiver,
-                None,
-                Some(output_list_with_proof),
-                epoch_change_proof.ledger_info_with_sigs[0].clone(),
-            )
-            .await;
         }
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transactions_or_outputs_max_chunk() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let highest_version = 65660;
-        let highest_epoch = 30;
-        let lowest_version = 101;
-        let max_transaction_output_chunk_size =
-            StorageServiceConfig::default().max_transaction_output_chunk_size;
-        let requested_chunk_size = max_transaction_output_chunk_size + 100;
-        let peer_version = highest_version - requested_chunk_size;
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-        let output_list_with_proof = utils::create_output_list_with_proof(
-            peer_version + 1,
-            peer_version + requested_chunk_size,
-            highest_version,
-        );
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            peer_version + 1,
-            peer_version + 1,
-            peer_version + requested_chunk_size,
-            false,
-        ); // Creates a small transaction list
-
-        // Create the mock db reader
-        let max_num_output_reductions = 5;
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        for i in 0..=max_num_output_reductions {
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test fallback to transaction syncing
+        for fallback_to_transactions in [false, true] {
+            // Create test data
+            let highest_version = 65660;
+            let highest_epoch = 30;
+            let lowest_version = 101;
+            let max_transaction_output_chunk_size =
+                StorageServiceConfig::default().max_transaction_output_chunk_size;
+            let requested_chunk_size = max_transaction_output_chunk_size + 100;
+            let peer_version = highest_version - requested_chunk_size;
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let output_list_with_proof = utils::create_output_list_with_proof(
                 peer_version + 1,
-                (max_transaction_output_chunk_size as u32 / (u32::pow(2, i as u32))) as u64,
+                peer_version + max_transaction_output_chunk_size,
                 highest_version,
-                output_list_with_proof.clone(),
             );
-        }
-        if fallback_to_transactions {
-            utils::expect_get_transactions(
-                &mut db_reader,
+            let transaction_list_with_proof = utils::create_transaction_list_with_proof(
                 peer_version + 1,
-                max_transaction_output_chunk_size,
-                highest_version,
+                peer_version + max_transaction_output_chunk_size,
+                peer_version + max_transaction_output_chunk_size,
                 false,
-                transaction_list_with_proof.clone(),
             );
-        }
+            let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                peer_version + 1,
+                peer_version + max_transaction_output_chunk_size,
+                use_request_v2,
+            );
 
-        // Create the storage client and server
-        let storage_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_list_with_proof,
-            &transaction_list_with_proof,
-        );
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_config));
-        let active_subscriptions = service.get_subscriptions();
-        tokio::spawn(service.start());
+            // Create the mock db reader
+            let max_num_output_reductions = 5;
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
+            );
+            for i in 0..=max_num_output_reductions {
+                utils::expect_get_transaction_outputs(
+                    &mut db_reader,
+                    peer_version + 1,
+                    (max_transaction_output_chunk_size as u32 / (u32::pow(2, i as u32))) as u64,
+                    highest_version,
+                    output_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
+                );
+            }
+            if fallback_to_transactions {
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    peer_version + 1,
+                    max_transaction_output_chunk_size,
+                    highest_version,
+                    false,
+                    transaction_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
+                );
+            }
 
-        // Send a request to subscribe to new transactions or outputs
-        let response_receiver = utils::subscribe_to_transactions_or_outputs(
-            &mut mock_client,
-            peer_version,
-            highest_epoch,
-            false,
-            max_num_output_reductions,
-            utils::get_random_u64(),
-            0,
-        )
-        .await;
+            // Create the storage client and server
+            let storage_config = utils::configure_network_chunk_limit(
+                fallback_to_transactions,
+                &output_list_with_proof,
+                &transaction_list_with_proof,
+                use_request_v2,
+            );
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_config));
+            let active_subscriptions = service.get_subscriptions();
+            tokio::spawn(service.start());
 
-        // Wait until the subscription is active
-        utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
-
-        // Force the subscription handler to work
-        utils::force_subscription_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
-
-        // Verify a response is received and that it contains the correct data
-        if fallback_to_transactions {
-            utils::verify_new_transactions_or_outputs_with_proof(
+            // Send a request to subscribe to new transactions or outputs
+            let response_receiver = utils::subscribe_to_transactions_or_outputs(
                 &mut mock_client,
-                response_receiver,
-                Some(transaction_list_with_proof),
-                None,
-                highest_ledger_info,
+                peer_version,
+                highest_epoch,
+                false,
+                max_num_output_reductions,
+                utils::get_random_u64(),
+                0,
+                use_request_v2,
             )
             .await;
-        } else {
-            utils::verify_new_transactions_or_outputs_with_proof(
+
+            // Wait until the subscription is active
+            utils::wait_for_active_subscriptions(active_subscriptions.clone(), 1).await;
+
+            // Force the subscription handler to work
+            utils::force_subscription_handler_to_run(
                 &mut mock_client,
-                response_receiver,
-                None,
-                Some(output_list_with_proof),
-                highest_ledger_info,
+                &mock_time,
+                &storage_service_notifier,
             )
             .await;
+
+            // Verify a response is received and that it contains the correct data
+            if fallback_to_transactions {
+                utils::verify_new_transactions_or_outputs_with_proof(
+                    &mut mock_client,
+                    response_receiver,
+                    use_request_v2,
+                    Some(transaction_list_with_proof),
+                    None,
+                    highest_ledger_info,
+                    persisted_auxiliary_infos.clone(),
+                )
+                .await;
+            } else {
+                utils::verify_new_transactions_or_outputs_with_proof(
+                    &mut mock_client,
+                    response_receiver,
+                    use_request_v2,
+                    None,
+                    Some(output_list_with_proof),
+                    highest_ledger_info,
+                    persisted_auxiliary_infos.clone(),
+                )
+                .await;
+            }
         }
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transaction_or_outputs_streaming() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let max_transaction_output_chunk_size = 90;
-        let num_stream_requests = 30;
-        let highest_version = 45576;
-        let highest_epoch = 43;
-        let lowest_version = 2;
-        let peer_version = 1;
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test fallback to transaction syncing
+        for fallback_to_transactions in [false, true] {
+            // Create test data
+            let max_transaction_output_chunk_size = 90;
+            let num_stream_requests = 30;
+            let highest_version = 45576;
+            let highest_epoch = 43;
+            let lowest_version = 2;
+            let peer_version = 1;
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
 
-        // Create the transaction and output lists with proofs
-        let chunk_start_and_end_versions = (0..num_stream_requests)
-            .map(|i| {
-                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
-                let end_version = start_version + max_transaction_output_chunk_size - 1;
-                (start_version, end_version)
-            })
-            .collect::<Vec<_>>();
-        let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-            .iter()
-            .map(|(start_version, end_version)| {
-                utils::create_output_list_with_proof(*start_version, *end_version, highest_version)
-            })
-            .collect();
-        let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-            .iter()
-            .map(|(start_version, end_version)| {
-                utils::create_transaction_list_with_proof(
-                    *start_version,
-                    *end_version,
-                    highest_version,
-                    false,
-                )
-            })
-            .collect();
+            // Create the transaction and output lists with proofs
+            let chunk_start_and_end_versions = (0..num_stream_requests)
+                .map(|i| {
+                    let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                    let end_version = start_version + max_transaction_output_chunk_size - 1;
+                    (start_version, end_version)
+                })
+                .collect::<Vec<_>>();
+            let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_output_list_with_proof(
+                        *start_version,
+                        *end_version,
+                        highest_version,
+                    )
+                })
+                .collect();
+            let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_transaction_list_with_proof(
+                        *start_version,
+                        *end_version,
+                        highest_version,
+                        false,
+                    )
+                })
+                .collect();
 
-        // Create the mock db reader
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        for (i, (start_version, _)) in chunk_start_and_end_versions.iter().enumerate() {
-            // Set expectations for transaction output reads
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
-                *start_version,
-                max_transaction_output_chunk_size,
-                highest_version,
-                output_lists_with_proofs[i].clone(),
+            // Create the persisted auxiliary infos
+            let persisted_auxiliary_infos: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_persisted_auxiliary_infos(
+                        *start_version,
+                        *end_version,
+                        use_request_v2,
+                    )
+                })
+                .collect();
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
             );
-
-            // Set expectations for transaction reads
-            if fallback_to_transactions {
-                utils::expect_get_transactions(
+            for (i, (start_version, _)) in chunk_start_and_end_versions.iter().enumerate() {
+                // Set expectations for transaction output reads
+                utils::expect_get_transaction_outputs(
                     &mut db_reader,
                     *start_version,
                     max_transaction_output_chunk_size,
                     highest_version,
-                    false,
-                    transaction_lists_with_proofs[i].clone(),
+                    output_lists_with_proofs[i].clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos[i].clone(),
                 );
+
+                // Set expectations for transaction reads
+                if fallback_to_transactions {
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        *start_version,
+                        max_transaction_output_chunk_size,
+                        highest_version,
+                        false,
+                        transaction_lists_with_proofs[i].clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos[i].clone(),
+                    );
+                }
             }
-        }
 
-        // Create the storage service config
-        let mut storage_service_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_lists_with_proofs[0],
-            &transaction_lists_with_proofs[0],
-        );
-        storage_service_config.max_transaction_output_chunk_size =
-            max_transaction_output_chunk_size;
+            // Create the storage service config
+            let mut storage_service_config = utils::configure_network_chunk_limit(
+                fallback_to_transactions,
+                &output_lists_with_proofs[0],
+                &transaction_lists_with_proofs[0],
+                use_request_v2,
+            );
+            storage_service_config.max_transaction_output_chunk_size =
+                max_transaction_output_chunk_size;
 
-        // Create the storage client and server
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_service_config));
-        let active_subscriptions = service.get_subscriptions();
-        tokio::spawn(service.start());
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_service_config));
+            let active_subscriptions = service.get_subscriptions();
+            tokio::spawn(service.start());
 
-        // Create a new peer and stream ID
-        let peer_network_id = PeerNetworkId::random();
-        let stream_id = utils::get_random_u64();
+            // Create a new peer and stream ID
+            let peer_network_id = PeerNetworkId::random();
+            let stream_id = utils::get_random_u64();
 
-        // Send multiple batches of requests to the server and verify the responses
-        let num_batches_to_send = 5;
-        for batch_id in 0..num_batches_to_send {
-            // Send the request batch to subscribe to transaction outputs
-            let num_requests_per_batch = num_stream_requests / num_batches_to_send;
-            let first_request_index = batch_id * num_requests_per_batch;
-            let last_request_index =
-                (batch_id * num_requests_per_batch) + num_requests_per_batch - 1;
-            let mut response_receivers = send_transaction_or_output_subscription_request_batch(
-                &mut mock_client,
-                peer_network_id,
-                first_request_index,
-                last_request_index,
-                stream_id,
-                peer_version,
-                highest_epoch,
-            )
-            .await;
-
-            // Wait until the stream requests are active
-            utils::wait_for_active_stream_requests(
-                active_subscriptions.clone(),
-                peer_network_id,
-                num_requests_per_batch as usize,
-            )
-            .await;
-
-            // Force the subscription handler to work
-            utils::force_cache_update_notification(
-                &mut mock_client,
-                &mock_time,
-                &storage_service_notifier,
-                true,
-                true,
-            )
-            .await;
-
-            // Continuously run the subscription service until the batch responses are received
-            for stream_request_index in first_request_index..=last_request_index {
-                // Verify that the correct response is received
-                verify_transaction_or_output_subscription_response(
-                    transaction_lists_with_proofs.clone(),
-                    output_lists_with_proofs.clone(),
-                    highest_ledger_info.clone(),
-                    fallback_to_transactions,
+            // Send multiple batches of requests to the server and verify the responses
+            let num_batches_to_send = 5;
+            for batch_id in 0..num_batches_to_send {
+                // Send the request batch to subscribe to transaction outputs
+                let num_requests_per_batch = num_stream_requests / num_batches_to_send;
+                let first_request_index = batch_id * num_requests_per_batch;
+                let last_request_index =
+                    (batch_id * num_requests_per_batch) + num_requests_per_batch - 1;
+                let mut response_receivers = send_transaction_or_output_subscription_request_batch(
                     &mut mock_client,
-                    &mut response_receivers,
-                    stream_request_index,
+                    peer_network_id,
+                    first_request_index,
+                    last_request_index,
+                    stream_id,
+                    peer_version,
+                    highest_epoch,
+                    use_request_v2,
                 )
                 .await;
+
+                // Wait until the stream requests are active
+                utils::wait_for_active_stream_requests(
+                    active_subscriptions.clone(),
+                    peer_network_id,
+                    num_requests_per_batch as usize,
+                )
+                .await;
+
+                // Force the subscription handler to work
+                utils::force_cache_update_notification(
+                    &mut mock_client,
+                    &mock_time,
+                    &storage_service_notifier,
+                    true,
+                    true,
+                )
+                .await;
+
+                // Continuously run the subscription service until the batch responses are received
+                for stream_request_index in first_request_index..=last_request_index {
+                    // Verify that the correct response is received
+                    verify_transaction_or_output_subscription_response(
+                        transaction_lists_with_proofs.clone(),
+                        output_lists_with_proofs.clone(),
+                        persisted_auxiliary_infos.clone(),
+                        highest_ledger_info.clone(),
+                        fallback_to_transactions,
+                        &mut mock_client,
+                        &mut response_receivers,
+                        stream_request_index,
+                        use_request_v2,
+                    )
+                    .await;
+                }
             }
         }
     }
@@ -549,321 +685,382 @@ async fn test_subscribe_transaction_or_outputs_streaming() {
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transactions_or_outputs_streaming_epoch_change() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let max_transaction_output_chunk_size = 10;
-        let max_num_active_subscriptions = 50;
-        let highest_version = 1000;
-        let highest_epoch = 2;
-        let lowest_version = 0;
-        let peer_version = highest_version - 900;
-        let peer_epoch = highest_epoch - 1;
-        let epoch_change_version = peer_version + 97;
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test fallback to transaction syncing
+        for fallback_to_transactions in [false, true] {
+            // Create test data
+            let max_transaction_output_chunk_size = 10;
+            let max_num_active_subscriptions = 50;
+            let highest_version = 1000;
+            let highest_epoch = 2;
+            let lowest_version = 0;
+            let peer_version = highest_version - 900;
+            let peer_epoch = highest_epoch - 1;
+            let epoch_change_version = peer_version + 97;
 
-        // Create the highest ledger info and epoch change proof
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-        let epoch_change_ledger_info =
-            utils::create_epoch_ending_ledger_info(peer_epoch, epoch_change_version);
-        let epoch_change_proof = EpochChangeProof {
-            ledger_info_with_sigs: vec![epoch_change_ledger_info.clone()],
-            more: false,
-        };
-
-        // Create the transaction and output lists with proofs
-        let chunk_start_and_end_versions = utils::create_data_chunks_with_epoch_boundary(
-            max_transaction_output_chunk_size,
-            max_num_active_subscriptions,
-            peer_version,
-            epoch_change_version,
-        );
-        let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-            .iter()
-            .map(|(start_version, end_version)| {
-                utils::create_output_list_with_proof(*start_version, *end_version, highest_version)
-            })
-            .collect();
-        let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-            .iter()
-            .map(|(start_version, end_version)| {
-                utils::create_transaction_list_with_proof(
-                    *start_version,
-                    *end_version,
-                    highest_version,
-                    false,
-                )
-            })
-            .collect();
-
-        // Create the mock db reader
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        utils::expect_get_epoch_ending_ledger_infos(
-            &mut db_reader,
-            peer_epoch,
-            peer_epoch + 1,
-            epoch_change_proof.clone(),
-        );
-        for (i, (start_version, end_version)) in chunk_start_and_end_versions.iter().enumerate() {
-            // Set expectations for transaction output reads
-            let proof_version = if *end_version <= epoch_change_version {
-                epoch_change_version
-            } else {
-                highest_version
+            // Create the highest ledger info and epoch change proof
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+            let epoch_change_ledger_info =
+                utils::create_epoch_ending_ledger_info(peer_epoch, epoch_change_version);
+            let epoch_change_proof = EpochChangeProof {
+                ledger_info_with_sigs: vec![epoch_change_ledger_info.clone()],
+                more: false,
             };
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
-                *start_version,
-                end_version - start_version + 1,
-                proof_version,
-                output_lists_with_proofs[i].clone(),
-            );
 
-            // Set expectations for transaction reads
-            if fallback_to_transactions {
-                utils::expect_get_transactions(
+            // Create the transaction and output lists with proofs
+            let chunk_start_and_end_versions = utils::create_data_chunks_with_epoch_boundary(
+                max_transaction_output_chunk_size,
+                max_num_active_subscriptions,
+                peer_version,
+                epoch_change_version,
+            );
+            let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_output_list_with_proof(
+                        *start_version,
+                        *end_version,
+                        highest_version,
+                    )
+                })
+                .collect();
+            let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_transaction_list_with_proof(
+                        *start_version,
+                        *end_version,
+                        highest_version,
+                        false,
+                    )
+                })
+                .collect();
+
+            // Create the persisted auxiliary infos
+            let persisted_auxiliary_infos: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_persisted_auxiliary_infos(
+                        *start_version,
+                        *end_version,
+                        use_request_v2,
+                    )
+                })
+                .collect();
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
+            );
+            utils::expect_get_epoch_ending_ledger_infos(
+                &mut db_reader,
+                peer_epoch,
+                peer_epoch + 1,
+                epoch_change_proof.clone(),
+            );
+            for (i, (start_version, end_version)) in chunk_start_and_end_versions.iter().enumerate()
+            {
+                // Set expectations for transaction output reads
+                let proof_version = if *end_version <= epoch_change_version {
+                    epoch_change_version
+                } else {
+                    highest_version
+                };
+                utils::expect_get_transaction_outputs(
                     &mut db_reader,
                     *start_version,
                     end_version - start_version + 1,
                     proof_version,
-                    false,
-                    transaction_lists_with_proofs[i].clone(),
+                    output_lists_with_proofs[i].clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos[i].clone(),
                 );
+
+                // Set expectations for transaction reads
+                if fallback_to_transactions {
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        *start_version,
+                        end_version - start_version + 1,
+                        proof_version,
+                        false,
+                        transaction_lists_with_proofs[i].clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos[i].clone(),
+                    );
+                }
             }
-        }
 
-        // Create the storage service config
-        let mut storage_service_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_lists_with_proofs[0],
-            &transaction_lists_with_proofs[0],
-        );
-        storage_service_config.max_transaction_output_chunk_size =
-            max_transaction_output_chunk_size;
-        storage_service_config.max_num_active_subscriptions = max_num_active_subscriptions;
-
-        // Create the storage client and server
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_service_config));
-        let active_subscriptions = service.get_subscriptions();
-        tokio::spawn(service.start());
-
-        // Create a new peer and stream ID
-        let peer_network_id = PeerNetworkId::random();
-        let stream_id = utils::get_random_u64();
-
-        // Send the request batch to subscribe to transactions or outputs
-        let mut response_receivers = send_transaction_or_output_subscription_request_batch(
-            &mut mock_client,
-            peer_network_id,
-            0,
-            max_num_active_subscriptions - 1,
-            stream_id,
-            peer_version,
-            peer_epoch,
-        )
-        .await;
-
-        // Wait until the stream requests are active
-        utils::wait_for_active_stream_requests(
-            active_subscriptions.clone(),
-            peer_network_id,
-            max_num_active_subscriptions as usize,
-        )
-        .await;
-
-        // Force the subscription handler to work
-        utils::force_subscription_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
-
-        // Continuously run the subscription service until all the responses are received
-        for stream_request_index in 0..max_num_active_subscriptions {
-            // Determine the target ledger info for the response
-            let first_version = output_lists_with_proofs[stream_request_index as usize]
-                .first_transaction_output_version
-                .unwrap();
-            let target_ledger_info = if first_version > epoch_change_version {
-                highest_ledger_info.clone()
-            } else {
-                epoch_change_ledger_info.clone()
-            };
-
-            // If we're syncing to the epoch change, then we don't need
-            // to fallback as the configured network limit won't be reached.
-            let epoch_change_version = epoch_change_ledger_info.ledger_info().version();
-            let fallback_to_transactions = if fallback_to_transactions
-                && (first_version < epoch_change_version)
-                && (first_version + max_transaction_output_chunk_size) >= epoch_change_version
-            {
-                false
-            } else {
-                fallback_to_transactions
-            };
-
-            // Verify that the correct response is received
-            verify_transaction_or_output_subscription_response(
-                transaction_lists_with_proofs.clone(),
-                output_lists_with_proofs.clone(),
-                target_ledger_info.clone(),
+            // Create the storage service config
+            let mut storage_service_config = utils::configure_network_chunk_limit(
                 fallback_to_transactions,
+                &output_lists_with_proofs[0],
+                &transaction_lists_with_proofs[0],
+                use_request_v2,
+            );
+            storage_service_config.max_transaction_output_chunk_size =
+                max_transaction_output_chunk_size;
+            storage_service_config.max_num_active_subscriptions = max_num_active_subscriptions;
+
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_service_config));
+            let active_subscriptions = service.get_subscriptions();
+            tokio::spawn(service.start());
+
+            // Create a new peer and stream ID
+            let peer_network_id = PeerNetworkId::random();
+            let stream_id = utils::get_random_u64();
+
+            // Send the request batch to subscribe to transactions or outputs
+            let mut response_receivers = send_transaction_or_output_subscription_request_batch(
                 &mut mock_client,
-                &mut response_receivers,
-                stream_request_index,
+                peer_network_id,
+                0,
+                max_num_active_subscriptions - 1,
+                stream_id,
+                peer_version,
+                peer_epoch,
+                use_request_v2,
             )
             .await;
+
+            // Wait until the stream requests are active
+            utils::wait_for_active_stream_requests(
+                active_subscriptions.clone(),
+                peer_network_id,
+                max_num_active_subscriptions as usize,
+            )
+            .await;
+
+            // Force the subscription handler to work
+            utils::force_subscription_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
+
+            // Continuously run the subscription service until all the responses are received
+            for stream_request_index in 0..max_num_active_subscriptions {
+                // Determine the target ledger info for the response
+                let first_version = output_lists_with_proofs[stream_request_index as usize]
+                    .first_transaction_output_version
+                    .unwrap();
+                let target_ledger_info = if first_version > epoch_change_version {
+                    highest_ledger_info.clone()
+                } else {
+                    epoch_change_ledger_info.clone()
+                };
+
+                // If we're syncing to the epoch change, then we don't need
+                // to fallback as the configured network limit won't be reached.
+                let epoch_change_version = epoch_change_ledger_info.ledger_info().version();
+                let fallback_to_transactions = if fallback_to_transactions
+                    && (first_version < epoch_change_version)
+                    && (first_version + max_transaction_output_chunk_size) >= epoch_change_version
+                {
+                    false
+                } else {
+                    fallback_to_transactions
+                };
+
+                // Verify that the correct response is received
+                verify_transaction_or_output_subscription_response(
+                    transaction_lists_with_proofs.clone(),
+                    output_lists_with_proofs.clone(),
+                    persisted_auxiliary_infos.clone(),
+                    target_ledger_info.clone(),
+                    fallback_to_transactions,
+                    &mut mock_client,
+                    &mut response_receivers,
+                    stream_request_index,
+                    use_request_v2,
+                )
+                .await;
+            }
         }
     }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscribe_transaction_or_outputs_streaming_loop() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let max_transaction_output_chunk_size = 90;
-        let num_stream_requests = 30;
-        let highest_version = 45576;
-        let highest_epoch = 43;
-        let lowest_version = 2;
-        let peer_version = 1;
-        let highest_ledger_info =
-            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test fallback to transaction syncing
+        for fallback_to_transactions in [false, true] {
+            // Create test data
+            let max_transaction_output_chunk_size = 90;
+            let num_stream_requests = 30;
+            let highest_version = 45576;
+            let highest_epoch = 43;
+            let lowest_version = 2;
+            let peer_version = 1;
+            let highest_ledger_info =
+                utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
 
-        // Create the transaction and output lists with proofs
-        let chunk_start_and_end_versions = (0..num_stream_requests)
-            .map(|i| {
-                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
-                let end_version = start_version + max_transaction_output_chunk_size - 1;
-                (start_version, end_version)
-            })
-            .collect::<Vec<_>>();
-        let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-            .iter()
-            .map(|(start_version, end_version)| {
-                utils::create_output_list_with_proof(*start_version, *end_version, highest_version)
-            })
-            .collect();
-        let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
-            .iter()
-            .map(|(start_version, end_version)| {
-                utils::create_transaction_list_with_proof(
-                    *start_version,
-                    *end_version,
-                    highest_version,
-                    false,
-                )
-            })
-            .collect();
+            // Create the transaction and output lists with proofs
+            let chunk_start_and_end_versions = (0..num_stream_requests)
+                .map(|i| {
+                    let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                    let end_version = start_version + max_transaction_output_chunk_size - 1;
+                    (start_version, end_version)
+                })
+                .collect::<Vec<_>>();
+            let output_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_output_list_with_proof(
+                        *start_version,
+                        *end_version,
+                        highest_version,
+                    )
+                })
+                .collect();
+            let transaction_lists_with_proofs: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_transaction_list_with_proof(
+                        *start_version,
+                        *end_version,
+                        highest_version,
+                        false,
+                    )
+                })
+                .collect();
 
-        // Create the mock db reader
-        let mut db_reader =
-            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-        for (i, (start_version, _)) in chunk_start_and_end_versions.iter().enumerate() {
-            // Set expectations for transaction output reads
-            utils::expect_get_transaction_outputs(
-                &mut db_reader,
-                *start_version,
-                max_transaction_output_chunk_size,
-                highest_version,
-                output_lists_with_proofs[i].clone(),
+            // Create the persisted auxiliary infos
+            let persisted_auxiliary_infos: Vec<_> = chunk_start_and_end_versions
+                .iter()
+                .map(|(start_version, end_version)| {
+                    utils::create_persisted_auxiliary_infos(
+                        *start_version,
+                        *end_version,
+                        use_request_v2,
+                    )
+                })
+                .collect();
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_with_summary_updates(
+                highest_ledger_info.clone(),
+                lowest_version,
             );
-
-            // Set expectations for transaction reads
-            if fallback_to_transactions {
-                utils::expect_get_transactions(
+            for (i, (start_version, _)) in chunk_start_and_end_versions.iter().enumerate() {
+                // Set expectations for transaction output reads
+                utils::expect_get_transaction_outputs(
                     &mut db_reader,
                     *start_version,
                     max_transaction_output_chunk_size,
                     highest_version,
-                    false,
-                    transaction_lists_with_proofs[i].clone(),
+                    output_lists_with_proofs[i].clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos[i].clone(),
                 );
+
+                // Set expectations for transaction reads
+                if fallback_to_transactions {
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        *start_version,
+                        max_transaction_output_chunk_size,
+                        highest_version,
+                        false,
+                        transaction_lists_with_proofs[i].clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos[i].clone(),
+                    );
+                }
             }
-        }
 
-        // Create the storage service config
-        let mut storage_service_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_lists_with_proofs[0],
-            &transaction_lists_with_proofs[0],
-        );
-        storage_service_config.max_transaction_output_chunk_size =
-            max_transaction_output_chunk_size;
+            // Create the storage service config
+            let mut storage_service_config = utils::configure_network_chunk_limit(
+                fallback_to_transactions,
+                &output_lists_with_proofs[0],
+                &transaction_lists_with_proofs[0],
+                use_request_v2,
+            );
+            storage_service_config.max_transaction_output_chunk_size =
+                max_transaction_output_chunk_size;
 
-        // Create the storage client and server
-        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-            MockClient::new(Some(db_reader), Some(storage_service_config));
-        let active_subscriptions = service.get_subscriptions();
-        tokio::spawn(service.start());
+            // Create the storage client and server
+            let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+                MockClient::new(Some(db_reader), Some(storage_service_config));
+            let active_subscriptions = service.get_subscriptions();
+            tokio::spawn(service.start());
 
-        // Create a new peer and stream ID
-        let peer_network_id = PeerNetworkId::random();
-        let stream_id = utils::get_random_u64();
+            // Create a new peer and stream ID
+            let peer_network_id = PeerNetworkId::random();
+            let stream_id = utils::get_random_u64();
 
-        // Send the requests to the server and verify the responses
-        let mut response_receivers = send_transaction_or_output_subscription_request_batch(
-            &mut mock_client,
-            peer_network_id,
-            0,
-            num_stream_requests - 1,
-            stream_id,
-            peer_version,
-            highest_epoch,
-        )
-        .await;
+            // Send the requests to the server and verify the responses
+            let mut response_receivers = send_transaction_or_output_subscription_request_batch(
+                &mut mock_client,
+                peer_network_id,
+                0,
+                num_stream_requests - 1,
+                stream_id,
+                peer_version,
+                highest_epoch,
+                use_request_v2,
+            )
+            .await;
 
-        // Wait until the stream requests are active
-        utils::wait_for_active_stream_requests(
-            active_subscriptions.clone(),
-            peer_network_id,
-            num_stream_requests as usize,
-        )
-        .await;
+            // Wait until the stream requests are active
+            utils::wait_for_active_stream_requests(
+                active_subscriptions.clone(),
+                peer_network_id,
+                num_stream_requests as usize,
+            )
+            .await;
 
-        // Verify the state of the subscription stream
-        utils::verify_subscription_stream_entry(
-            active_subscriptions.clone(),
-            peer_network_id,
-            num_stream_requests,
-            peer_version,
-            highest_epoch,
-            max_transaction_output_chunk_size,
-        );
+            // Verify the state of the subscription stream
+            utils::verify_subscription_stream_entry(
+                active_subscriptions.clone(),
+                peer_network_id,
+                num_stream_requests,
+                peer_version,
+                highest_epoch,
+                max_transaction_output_chunk_size,
+            );
 
-        // Force the subscription handler to work
-        utils::force_subscription_handler_to_run(
-            &mut mock_client,
-            &mock_time,
-            &storage_service_notifier,
-        )
-        .await;
+            // Force the subscription handler to work
+            utils::force_subscription_handler_to_run(
+                &mut mock_client,
+                &mock_time,
+                &storage_service_notifier,
+            )
+            .await;
 
-        // Verify all responses are received
-        for stream_request_index in 0..num_stream_requests {
-            let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
-            if fallback_to_transactions {
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver,
-                    Some(transaction_lists_with_proofs[stream_request_index as usize].clone()),
-                    None,
-                    highest_ledger_info.clone(),
-                )
-                .await;
-            } else {
-                utils::verify_new_transactions_or_outputs_with_proof(
-                    &mut mock_client,
-                    response_receiver,
-                    None,
-                    Some(output_lists_with_proofs[stream_request_index as usize].clone()),
-                    highest_ledger_info.clone(),
-                )
-                .await;
+            // Verify all responses are received
+            for stream_request_index in 0..num_stream_requests {
+                let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
+                if fallback_to_transactions {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver,
+                        use_request_v2,
+                        Some(transaction_lists_with_proofs[stream_request_index as usize].clone()),
+                        None,
+                        highest_ledger_info.clone(),
+                        persisted_auxiliary_infos[stream_request_index as usize].clone(),
+                    )
+                    .await;
+                } else {
+                    utils::verify_new_transactions_or_outputs_with_proof(
+                        &mut mock_client,
+                        response_receiver,
+                        use_request_v2,
+                        None,
+                        Some(output_lists_with_proofs[stream_request_index as usize].clone()),
+                        highest_ledger_info.clone(),
+                        persisted_auxiliary_infos[stream_request_index as usize].clone(),
+                    )
+                    .await;
+                }
             }
         }
     }
@@ -879,6 +1076,7 @@ async fn send_transaction_or_output_subscription_request_batch(
     stream_id: u64,
     peer_version: u64,
     peer_epoch: u64,
+    use_request_v2: bool,
 ) -> HashMap<u64, Receiver<Result<Bytes, RpcError>>> {
     // Shuffle the stream request indices to emulate out of order requests
     let stream_request_indices =
@@ -897,6 +1095,7 @@ async fn send_transaction_or_output_subscription_request_batch(
             stream_id,
             stream_request_index,
             Some(peer_network_id),
+            use_request_v2,
         )
         .await;
 
@@ -912,29 +1111,35 @@ async fn send_transaction_or_output_subscription_request_batch(
 async fn verify_transaction_or_output_subscription_response(
     expected_transaction_lists_with_proofs: Vec<TransactionListWithProof>,
     expected_output_lists_with_proofs: Vec<TransactionOutputListWithProof>,
+    expected_persisted_auxiliary_infos: Vec<Option<Vec<PersistedAuxiliaryInfo>>>,
     expected_target_ledger_info: LedgerInfoWithSignatures,
     fallback_to_transactions: bool,
     mock_client: &mut MockClient,
     response_receivers: &mut HashMap<u64, Receiver<Result<Bytes, RpcError>>>,
     stream_request_index: u64,
+    use_request_v2: bool,
 ) {
     let response_receiver = response_receivers.remove(&stream_request_index).unwrap();
     if fallback_to_transactions {
         utils::verify_new_transactions_or_outputs_with_proof(
             mock_client,
             response_receiver,
+            use_request_v2,
             Some(expected_transaction_lists_with_proofs[stream_request_index as usize].clone()),
             None,
             expected_target_ledger_info.clone(),
+            expected_persisted_auxiliary_infos[stream_request_index as usize].clone(),
         )
         .await;
     } else {
         utils::verify_new_transactions_or_outputs_with_proof(
             mock_client,
             response_receiver,
+            use_request_v2,
             None,
             Some(expected_output_lists_with_proofs[stream_request_index as usize].clone()),
             expected_target_ledger_info.clone(),
+            expected_persisted_auxiliary_infos[stream_request_index as usize].clone(),
         )
         .await;
     }

--- a/state-sync/storage-service/server/src/tests/subscription.rs
+++ b/state-sync/storage-service/server/src/tests/subscription.rs
@@ -16,9 +16,11 @@ use aptos_config::{
 };
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, StorageServiceRequest, SubscribeTransactionDataWithProofRequest,
+        SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
-        SubscriptionStreamMetadata,
+        SubscriptionStreamMetadata, TransactionData, TransactionDataRequestType,
+        TransactionOrOutputData,
     },
     responses::StorageServerSummary,
     StorageServiceError,
@@ -35,937 +37,1032 @@ use tokio::runtime::Handle;
 
 #[tokio::test]
 async fn test_peers_with_ready_subscriptions() {
-    // Create a mock time service and subscriptions map
-    let time_service = TimeService::mock();
-    let subscriptions = Arc::new(DashMap::new());
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a mock time service and subscriptions map
+        let time_service = TimeService::mock();
+        let subscriptions = Arc::new(DashMap::new());
 
-    // Create three peers with ready subscriptions
-    let mut peer_network_ids = vec![];
-    for known_version in &[1, 5, 10] {
-        // Create a random peer network id
-        let peer_network_id = PeerNetworkId::random();
-        peer_network_ids.push(peer_network_id);
+        // Create three peers with ready subscriptions
+        let mut peer_network_ids = vec![];
+        for known_version in &[1, 5, 10] {
+            // Create a random peer network id
+            let peer_network_id = PeerNetworkId::random();
+            peer_network_ids.push(peer_network_id);
 
-        // Create a subscription stream and insert it into the pending map
-        let subscription_stream_requests = create_subscription_stream_requests(
+            // Create a subscription stream and insert it into the pending map
+            let subscription_stream_requests = create_subscription_stream_requests(
+                time_service.clone(),
+                Some(*known_version),
+                Some(1),
+                Some(0),
+                Some(0),
+                use_request_v2,
+            );
+            subscriptions.insert(peer_network_id, subscription_stream_requests);
+        }
+
+        // Create epoch ending test data at version 9
+        let epoch_ending_ledger_info = utils::create_epoch_ending_ledger_info(1, 9);
+        let epoch_change_proof = EpochChangeProof {
+            ledger_info_with_sigs: vec![epoch_ending_ledger_info],
+            more: false,
+        };
+
+        // Create the mock db reader
+        let mut db_reader = mock::create_mock_db_reader();
+        utils::expect_get_epoch_ending_ledger_infos(&mut db_reader, 1, 2, epoch_change_proof);
+
+        // Create the storage reader
+        let storage_service_config = StorageServiceConfig::default();
+        let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
+
+        // Create test data with an empty storage server summary
+        let cached_storage_server_summary =
+            Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+        let optimistic_fetches = Arc::new(DashMap::new());
+        let lru_response_cache = Cache::new(0);
+        let request_moderator = Arc::new(RequestModerator::new(
+            AptosDataClientConfig::default(),
+            cached_storage_server_summary.clone(),
+            mock::create_peers_and_metadata(vec![]),
+            StorageServiceConfig::default(),
             time_service.clone(),
-            Some(*known_version),
-            Some(1),
-            Some(0),
-            Some(0),
-        );
-        subscriptions.insert(peer_network_id, subscription_stream_requests);
+        ));
+
+        // Verify that there are no peers with ready subscriptions
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(peers_with_ready_subscriptions.is_empty());
+
+        // Update the storage server summary so that there is new data (at version 2)
+        let highest_synced_ledger_info =
+            utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 2, 1);
+
+        // Verify that peer 1 has a ready subscription
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(peers_with_ready_subscriptions, vec![(
+            peer_network_ids[0],
+            highest_synced_ledger_info
+        )]);
+
+        // Manually remove subscription 1 from the map
+        subscriptions.remove(&peer_network_ids[0]);
+
+        // Update the storage server summary so that there is new data (at version 8)
+        let highest_synced_ledger_info =
+            utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 8, 1);
+
+        // Verify that peer 2 has a ready subscription
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(peers_with_ready_subscriptions, vec![(
+            peer_network_ids[1],
+            highest_synced_ledger_info
+        )]);
+
+        // Manually remove subscription 2 from the map
+        subscriptions.remove(&peer_network_ids[1]);
+
+        // Update the storage server summary so that there is new data (at version 100)
+        let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 100, 2);
+
+        // Verify that subscription 3 is not returned because it was invalid
+        // (i.e., the epoch ended at version 9, but the peer didn't respect it).
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(peers_with_ready_subscriptions, vec![]);
+
+        // Verify that the subscriptions are now empty
+        assert!(subscriptions.is_empty());
     }
-
-    // Create epoch ending test data at version 9
-    let epoch_ending_ledger_info = utils::create_epoch_ending_ledger_info(1, 9);
-    let epoch_change_proof = EpochChangeProof {
-        ledger_info_with_sigs: vec![epoch_ending_ledger_info],
-        more: false,
-    };
-
-    // Create the mock db reader
-    let mut db_reader = mock::create_mock_db_reader();
-    utils::expect_get_epoch_ending_ledger_infos(&mut db_reader, 1, 2, epoch_change_proof);
-
-    // Create the storage reader
-    let storage_service_config = StorageServiceConfig::default();
-    let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
-
-    // Create test data with an empty storage server summary
-    let cached_storage_server_summary =
-        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-    let optimistic_fetches = Arc::new(DashMap::new());
-    let lru_response_cache = Cache::new(0);
-    let request_moderator = Arc::new(RequestModerator::new(
-        AptosDataClientConfig::default(),
-        cached_storage_server_summary.clone(),
-        mock::create_peers_and_metadata(vec![]),
-        StorageServiceConfig::default(),
-        time_service.clone(),
-    ));
-
-    // Verify that there are no peers with ready subscriptions
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert!(peers_with_ready_subscriptions.is_empty());
-
-    // Update the storage server summary so that there is new data (at version 2)
-    let highest_synced_ledger_info =
-        utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 2, 1);
-
-    // Verify that peer 1 has a ready subscription
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(peers_with_ready_subscriptions, vec![(
-        peer_network_ids[0],
-        highest_synced_ledger_info
-    )]);
-
-    // Manually remove subscription 1 from the map
-    subscriptions.remove(&peer_network_ids[0]);
-
-    // Update the storage server summary so that there is new data (at version 8)
-    let highest_synced_ledger_info =
-        utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 8, 1);
-
-    // Verify that peer 2 has a ready subscription
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(peers_with_ready_subscriptions, vec![(
-        peer_network_ids[1],
-        highest_synced_ledger_info
-    )]);
-
-    // Manually remove subscription 2 from the map
-    subscriptions.remove(&peer_network_ids[1]);
-
-    // Update the storage server summary so that there is new data (at version 100)
-    let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 100, 2);
-
-    // Verify that subscription 3 is not returned because it was invalid
-    // (i.e., the epoch ended at version 9, but the peer didn't respect it).
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(peers_with_ready_subscriptions, vec![]);
-
-    // Verify that the subscriptions are now empty
-    assert!(subscriptions.is_empty());
 }
 
 #[tokio::test]
 async fn test_remove_expired_subscriptions_no_new_data() {
-    // Create a storage service config
-    let max_subscription_period_ms = 100;
-    let storage_service_config = StorageServiceConfig {
-        max_subscription_period_ms,
-        ..Default::default()
-    };
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_subscription_period_ms = 100;
+        let storage_service_config = StorageServiceConfig {
+            max_subscription_period_ms,
+            ..Default::default()
+        };
 
-    // Create the mock storage reader and time service
-    let db_reader = mock::create_mock_db_reader();
-    let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
-    let time_service = TimeService::mock();
+        // Create the mock storage reader and time service
+        let db_reader = mock::create_mock_db_reader();
+        let storage_reader = StorageReader::new(storage_service_config, Arc::new(db_reader));
+        let time_service = TimeService::mock();
 
-    // Create test data with an empty storage server summary
-    let cached_storage_server_summary =
-        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-    let optimistic_fetches = Arc::new(DashMap::new());
-    let lru_response_cache = Cache::new(0);
-    let request_moderator = Arc::new(RequestModerator::new(
-        AptosDataClientConfig::default(),
-        cached_storage_server_summary.clone(),
-        mock::create_peers_and_metadata(vec![]),
-        StorageServiceConfig::default(),
-        time_service.clone(),
-    ));
+        // Create test data with an empty storage server summary
+        let cached_storage_server_summary =
+            Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+        let optimistic_fetches = Arc::new(DashMap::new());
+        let lru_response_cache = Cache::new(0);
+        let request_moderator = Arc::new(RequestModerator::new(
+            AptosDataClientConfig::default(),
+            cached_storage_server_summary.clone(),
+            mock::create_peers_and_metadata(vec![]),
+            StorageServiceConfig::default(),
+            time_service.clone(),
+        ));
 
-    // Create the first batch of test subscriptions
-    let num_subscriptions_in_batch = 10;
-    let subscriptions = Arc::new(DashMap::new());
-    for _ in 0..num_subscriptions_in_batch {
-        let subscription_stream_requests =
-            create_subscription_stream_requests(time_service.clone(), Some(9), Some(9), None, None);
-        subscriptions.insert(PeerNetworkId::random(), subscription_stream_requests);
+        // Create the first batch of test subscriptions
+        let num_subscriptions_in_batch = 10;
+        let subscriptions = Arc::new(DashMap::new());
+        for _ in 0..num_subscriptions_in_batch {
+            let subscription_stream_requests = create_subscription_stream_requests(
+                time_service.clone(),
+                Some(9),
+                Some(9),
+                None,
+                None,
+                use_request_v2,
+            );
+            subscriptions.insert(PeerNetworkId::random(), subscription_stream_requests);
+        }
+
+        // Verify the number of active subscriptions
+        assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
+
+        // Elapse a small amount of time (not enough to expire the subscriptions)
+        utils::elapse_time(max_subscription_period_ms / 2, &time_service).await;
+
+        // Update the storage server summary so that there is new data
+        let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 1, 1);
+
+        // Remove the expired subscriptions and verify none were removed
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(peers_with_ready_subscriptions.is_empty());
+        assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
+
+        // Create another batch of test subscriptions
+        for _ in 0..num_subscriptions_in_batch {
+            let subscription_stream_requests = create_subscription_stream_requests(
+                time_service.clone(),
+                Some(9),
+                Some(9),
+                None,
+                None,
+                use_request_v2,
+            );
+            subscriptions.insert(PeerNetworkId::random(), subscription_stream_requests);
+        }
+
+        // Verify the new number of active subscriptions
+        assert_eq!(subscriptions.len(), num_subscriptions_in_batch * 2);
+
+        // Elapse enough time to expire the first batch of subscriptions
+        utils::elapse_time(max_subscription_period_ms, &time_service).await;
+
+        // Remove the expired subscriptions and verify the first batch was removed
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(peers_with_ready_subscriptions.is_empty());
+        assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
+
+        // Elapse enough time to expire the second batch of subscriptions
+        utils::elapse_time(max_subscription_period_ms, &time_service).await;
+
+        // Remove the expired subscriptions and verify the second batch was removed
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(peers_with_ready_subscriptions.is_empty());
+        assert!(subscriptions.is_empty());
     }
-
-    // Verify the number of active subscriptions
-    assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
-
-    // Elapse a small amount of time (not enough to expire the subscriptions)
-    utils::elapse_time(max_subscription_period_ms / 2, &time_service).await;
-
-    // Update the storage server summary so that there is new data
-    let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 1, 1);
-
-    // Remove the expired subscriptions and verify none were removed
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert!(peers_with_ready_subscriptions.is_empty());
-    assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
-
-    // Create another batch of test subscriptions
-    for _ in 0..num_subscriptions_in_batch {
-        let subscription_stream_requests =
-            create_subscription_stream_requests(time_service.clone(), Some(9), Some(9), None, None);
-        subscriptions.insert(PeerNetworkId::random(), subscription_stream_requests);
-    }
-
-    // Verify the new number of active subscriptions
-    assert_eq!(subscriptions.len(), num_subscriptions_in_batch * 2);
-
-    // Elapse enough time to expire the first batch of subscriptions
-    utils::elapse_time(max_subscription_period_ms, &time_service).await;
-
-    // Remove the expired subscriptions and verify the first batch was removed
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert!(peers_with_ready_subscriptions.is_empty());
-    assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
-
-    // Elapse enough time to expire the second batch of subscriptions
-    utils::elapse_time(max_subscription_period_ms, &time_service).await;
-
-    // Remove the expired subscriptions and verify the second batch was removed
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert!(peers_with_ready_subscriptions.is_empty());
-    assert!(subscriptions.is_empty());
 }
 
 #[tokio::test]
 async fn test_remove_expired_subscriptions_blocked_stream() {
-    // Create a storage service config
-    let max_subscription_period_ms = 100;
-    let storage_service_config = StorageServiceConfig {
-        max_subscription_period_ms,
-        ..Default::default()
-    };
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_subscription_period_ms = 100;
+        let storage_service_config = StorageServiceConfig {
+            max_subscription_period_ms,
+            ..Default::default()
+        };
 
-    // Create a mock time service
-    let time_service = TimeService::mock();
+        // Create a mock time service
+        let time_service = TimeService::mock();
 
-    // Create a batch of test subscriptions
-    let num_subscriptions_in_batch = 10;
-    let subscriptions = Arc::new(DashMap::new());
-    let mut peer_network_ids = vec![];
-    for i in 0..num_subscriptions_in_batch {
-        // Create a new peer
-        let peer_network_id = PeerNetworkId::random();
-        peer_network_ids.push(peer_network_id);
+        // Create a batch of test subscriptions
+        let num_subscriptions_in_batch = 10;
+        let subscriptions = Arc::new(DashMap::new());
+        let mut peer_network_ids = vec![];
+        for i in 0..num_subscriptions_in_batch {
+            // Create a new peer
+            let peer_network_id = PeerNetworkId::random();
+            peer_network_ids.push(peer_network_id);
 
-        // Create a subscription stream request for the peer
-        let subscription_stream_requests = create_subscription_stream_requests(
+            // Create a subscription stream request for the peer
+            let subscription_stream_requests = create_subscription_stream_requests(
+                time_service.clone(),
+                Some(1),
+                Some(1),
+                Some(i as u64),
+                Some(0),
+                use_request_v2,
+            );
+            subscriptions.insert(peer_network_id, subscription_stream_requests);
+        }
+
+        // Create test data with an empty storage server summary
+        let cached_storage_server_summary =
+            Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+        let optimistic_fetches = Arc::new(DashMap::new());
+        let lru_response_cache = Cache::new(0);
+        let request_moderator = Arc::new(RequestModerator::new(
+            AptosDataClientConfig::default(),
+            cached_storage_server_summary.clone(),
+            mock::create_peers_and_metadata(vec![]),
+            StorageServiceConfig::default(),
             time_service.clone(),
-            Some(1),
-            Some(1),
-            Some(i as u64),
-            Some(0),
+        ));
+        let storage_reader = StorageReader::new(
+            storage_service_config,
+            Arc::new(mock::create_mock_db_reader()),
         );
-        subscriptions.insert(peer_network_id, subscription_stream_requests);
+
+        // Update the storage server summary so that there is new data (at version 5)
+        let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 5, 1);
+
+        // Handle the active subscriptions
+        subscription::handle_active_subscriptions(
+            Handle::current(),
+            cached_storage_server_summary.clone(),
+            storage_service_config,
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+
+        // Verify that all subscription streams are now empty because
+        // the pending requests were sent.
+        assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
+        for subscription in subscriptions.iter() {
+            assert!(subscription.value().first_pending_request().is_none());
+        }
+
+        // Elapse enough time to expire the blocked streams
+        utils::elapse_time(max_subscription_period_ms + 1, &time_service).await;
+
+        // Add a new subscription request to the first subscription stream
+        let subscription_request = create_subscription_request(
+            &time_service,
+            Some(1),
+            Some(1),
+            Some(0),
+            Some(1),
+            use_request_v2,
+        );
+        add_subscription_request_to_stream(
+            subscription_request,
+            subscriptions.clone(),
+            &peer_network_ids[0],
+        )
+        .unwrap();
+
+        // Remove the expired subscriptions and verify the second batch was removed
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(peers_with_ready_subscriptions.is_empty());
+        assert_eq!(subscriptions.len(), 1);
+        assert!(subscriptions.contains_key(&peer_network_ids[0]));
     }
-
-    // Create test data with an empty storage server summary
-    let cached_storage_server_summary =
-        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-    let optimistic_fetches = Arc::new(DashMap::new());
-    let lru_response_cache = Cache::new(0);
-    let request_moderator = Arc::new(RequestModerator::new(
-        AptosDataClientConfig::default(),
-        cached_storage_server_summary.clone(),
-        mock::create_peers_and_metadata(vec![]),
-        StorageServiceConfig::default(),
-        time_service.clone(),
-    ));
-    let storage_reader = StorageReader::new(
-        storage_service_config,
-        Arc::new(mock::create_mock_db_reader()),
-    );
-
-    // Update the storage server summary so that there is new data (at version 5)
-    let _ = utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 5, 1);
-
-    // Handle the active subscriptions
-    subscription::handle_active_subscriptions(
-        Handle::current(),
-        cached_storage_server_summary.clone(),
-        storage_service_config,
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-
-    // Verify that all subscription streams are now empty because
-    // the pending requests were sent.
-    assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
-    for subscription in subscriptions.iter() {
-        assert!(subscription.value().first_pending_request().is_none());
-    }
-
-    // Elapse enough time to expire the blocked streams
-    utils::elapse_time(max_subscription_period_ms + 1, &time_service).await;
-
-    // Add a new subscription request to the first subscription stream
-    let subscription_request =
-        create_subscription_request(&time_service, Some(1), Some(1), Some(0), Some(1));
-    add_subscription_request_to_stream(
-        subscription_request,
-        subscriptions.clone(),
-        &peer_network_ids[0],
-    )
-    .unwrap();
-
-    // Remove the expired subscriptions and verify the second batch was removed
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert!(peers_with_ready_subscriptions.is_empty());
-    assert_eq!(subscriptions.len(), 1);
-    assert!(subscriptions.contains_key(&peer_network_ids[0]));
 }
 
 #[tokio::test]
 async fn test_remove_expired_subscriptions_blocked_stream_index() {
-    // Create a storage service config
-    let max_subscription_period_ms = 100;
-    let storage_service_config = StorageServiceConfig {
-        max_subscription_period_ms,
-        ..Default::default()
-    };
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_subscription_period_ms = 100;
+        let storage_service_config = StorageServiceConfig {
+            max_subscription_period_ms,
+            ..Default::default()
+        };
 
-    // Create a mock time service
-    let time_service = TimeService::mock();
+        // Create a mock time service
+        let time_service = TimeService::mock();
 
-    // Create the first batch of test subscriptions
-    let num_subscriptions_in_batch = 10;
-    let subscriptions = Arc::new(DashMap::new());
-    for _ in 0..num_subscriptions_in_batch {
-        let subscription_stream_requests = create_subscription_stream_requests(
+        // Create the first batch of test subscriptions
+        let num_subscriptions_in_batch = 10;
+        let subscriptions = Arc::new(DashMap::new());
+        for _ in 0..num_subscriptions_in_batch {
+            let subscription_stream_requests = create_subscription_stream_requests(
+                time_service.clone(),
+                Some(1),
+                Some(1),
+                None,
+                Some(0),
+                use_request_v2,
+            );
+            subscriptions.insert(PeerNetworkId::random(), subscription_stream_requests);
+        }
+
+        // Create test data with an empty storage server summary
+        let cached_storage_server_summary =
+            Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
+        let optimistic_fetches = Arc::new(DashMap::new());
+        let lru_response_cache = Cache::new(0);
+        let request_moderator = Arc::new(RequestModerator::new(
+            AptosDataClientConfig::default(),
+            cached_storage_server_summary.clone(),
+            mock::create_peers_and_metadata(vec![]),
+            StorageServiceConfig::default(),
             time_service.clone(),
+        ));
+        let storage_reader = StorageReader::new(
+            storage_service_config,
+            Arc::new(mock::create_mock_db_reader()),
+        );
+
+        // Update the storage server summary so that there is new data (at version 5)
+        let highest_synced_ledger_info =
+            utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 5, 1);
+
+        // Verify that all peers have ready subscriptions (but don't serve them!)
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            peers_with_ready_subscriptions.len(),
+            num_subscriptions_in_batch
+        );
+
+        // Elapse enough time to expire the subscriptions
+        utils::elapse_time(max_subscription_period_ms + 1, &time_service).await;
+
+        // Remove the expired subscriptions and verify they were all removed
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(peers_with_ready_subscriptions.is_empty());
+        assert!(subscriptions.is_empty());
+
+        // Create another batch of test subscriptions (where the stream is
+        // blocked on the next index to serve).
+        let mut peer_network_ids = vec![];
+        for i in 0..num_subscriptions_in_batch {
+            // Create a new peer
+            let peer_network_id = PeerNetworkId::random();
+            peer_network_ids.push(peer_network_id);
+
+            // Create a subscription stream request for the peer
+            let subscription_stream_requests = create_subscription_stream_requests(
+                time_service.clone(),
+                Some(1),
+                Some(1),
+                None,
+                Some(i as u64 + 1),
+                use_request_v2,
+            );
+            subscriptions.insert(peer_network_id, subscription_stream_requests);
+        }
+
+        // Verify the number of active subscriptions
+        assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
+
+        // Verify that none of the subscriptions are ready to be served (they are blocked)
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert!(peers_with_ready_subscriptions.is_empty());
+
+        // Elapse enough time to expire the batch of subscriptions
+        utils::elapse_time(max_subscription_period_ms + 1, &time_service).await;
+
+        // Add a new subscription request to the first subscription stream (to unblock it)
+        let subscription_request = create_subscription_request(
+            &time_service,
             Some(1),
             Some(1),
             None,
             Some(0),
+            use_request_v2,
         );
-        subscriptions.insert(PeerNetworkId::random(), subscription_stream_requests);
-    }
+        add_subscription_request_to_stream(
+            subscription_request,
+            subscriptions.clone(),
+            &peer_network_ids[0],
+        )
+        .unwrap();
 
-    // Create test data with an empty storage server summary
-    let cached_storage_server_summary =
-        Arc::new(ArcSwap::from(Arc::new(StorageServerSummary::default())));
-    let optimistic_fetches = Arc::new(DashMap::new());
-    let lru_response_cache = Cache::new(0);
-    let request_moderator = Arc::new(RequestModerator::new(
-        AptosDataClientConfig::default(),
-        cached_storage_server_summary.clone(),
-        mock::create_peers_and_metadata(vec![]),
-        StorageServiceConfig::default(),
-        time_service.clone(),
-    ));
-    let storage_reader = StorageReader::new(
-        storage_service_config,
-        Arc::new(mock::create_mock_db_reader()),
-    );
-
-    // Update the storage server summary so that there is new data (at version 5)
-    let highest_synced_ledger_info =
-        utils::update_storage_summary_cache(cached_storage_server_summary.clone(), 5, 1);
-
-    // Verify that all peers have ready subscriptions (but don't serve them!)
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(
-        peers_with_ready_subscriptions.len(),
-        num_subscriptions_in_batch
-    );
-
-    // Elapse enough time to expire the subscriptions
-    utils::elapse_time(max_subscription_period_ms + 1, &time_service).await;
-
-    // Remove the expired subscriptions and verify they were all removed
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert!(peers_with_ready_subscriptions.is_empty());
-    assert!(subscriptions.is_empty());
-
-    // Create another batch of test subscriptions (where the stream is
-    // blocked on the next index to serve).
-    let mut peer_network_ids = vec![];
-    for i in 0..num_subscriptions_in_batch {
-        // Create a new peer
-        let peer_network_id = PeerNetworkId::random();
-        peer_network_ids.push(peer_network_id);
-
-        // Create a subscription stream request for the peer
-        let subscription_stream_requests = create_subscription_stream_requests(
+        // Verify that the first peer subscription stream is unblocked
+        let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
             time_service.clone(),
-            Some(1),
-            Some(1),
-            None,
-            Some(i as u64 + 1),
-        );
-        subscriptions.insert(peer_network_id, subscription_stream_requests);
+        )
+        .await
+        .unwrap();
+        assert_eq!(peers_with_ready_subscriptions.len(), 1);
+        assert!(peers_with_ready_subscriptions
+            .contains(&(peer_network_ids[0], highest_synced_ledger_info)));
+
+        // Remove the expired subscriptions and verify all but one were removed
+        let _ = subscription::get_peers_with_ready_subscriptions(
+            Handle::current(),
+            storage_service_config,
+            cached_storage_server_summary.clone(),
+            optimistic_fetches.clone(),
+            lru_response_cache.clone(),
+            request_moderator.clone(),
+            storage_reader.clone(),
+            subscriptions.clone(),
+            time_service.clone(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(subscriptions.len(), 1);
+        assert!(subscriptions.contains_key(&peer_network_ids[0]));
     }
-
-    // Verify the number of active subscriptions
-    assert_eq!(subscriptions.len(), num_subscriptions_in_batch);
-
-    // Verify that none of the subscriptions are ready to be served (they are blocked)
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert!(peers_with_ready_subscriptions.is_empty());
-
-    // Elapse enough time to expire the batch of subscriptions
-    utils::elapse_time(max_subscription_period_ms + 1, &time_service).await;
-
-    // Add a new subscription request to the first subscription stream (to unblock it)
-    let subscription_request =
-        create_subscription_request(&time_service, Some(1), Some(1), None, Some(0));
-    add_subscription_request_to_stream(
-        subscription_request,
-        subscriptions.clone(),
-        &peer_network_ids[0],
-    )
-    .unwrap();
-
-    // Verify that the first peer subscription stream is unblocked
-    let peers_with_ready_subscriptions = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(peers_with_ready_subscriptions.len(), 1);
-    assert!(
-        peers_with_ready_subscriptions.contains(&(peer_network_ids[0], highest_synced_ledger_info))
-    );
-
-    // Remove the expired subscriptions and verify all but one were removed
-    let _ = subscription::get_peers_with_ready_subscriptions(
-        Handle::current(),
-        storage_service_config,
-        cached_storage_server_summary.clone(),
-        optimistic_fetches.clone(),
-        lru_response_cache.clone(),
-        request_moderator.clone(),
-        storage_reader.clone(),
-        subscriptions.clone(),
-        time_service.clone(),
-    )
-    .await
-    .unwrap();
-    assert_eq!(subscriptions.len(), 1);
-    assert!(subscriptions.contains_key(&peer_network_ids[0]));
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscription_invalid_requests() {
-    // Create a mock time service
-    let time_service = TimeService::mock();
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a mock time service
+        let time_service = TimeService::mock();
 
-    // Create a new batch of subscriptions that includes a single stream and request
-    let subscriptions = Arc::new(DashMap::new());
-    let peer_network_id = PeerNetworkId::random();
-    let peer_known_version = 10;
-    let peer_known_epoch = 1;
-    let subscription_stream_id = utils::get_random_u64();
-    let subscription_stream_requests = create_subscription_stream_requests(
-        time_service.clone(),
-        Some(peer_known_version),
-        Some(peer_known_epoch),
-        Some(subscription_stream_id),
-        Some(0),
-    );
-    subscriptions.insert(peer_network_id, subscription_stream_requests);
+        // Create a new batch of subscriptions that includes a single stream and request
+        let subscriptions = Arc::new(DashMap::new());
+        let peer_network_id = PeerNetworkId::random();
+        let peer_known_version = 10;
+        let peer_known_epoch = 1;
+        let subscription_stream_id = utils::get_random_u64();
+        let subscription_stream_requests = create_subscription_stream_requests(
+            time_service.clone(),
+            Some(peer_known_version),
+            Some(peer_known_epoch),
+            Some(subscription_stream_id),
+            Some(0),
+            use_request_v2,
+        );
+        subscriptions.insert(peer_network_id, subscription_stream_requests);
 
-    // Add a request to the stream that is invalid (the stream id is incorrect)
-    let subscription_request = create_subscription_request(
-        &time_service,
-        Some(peer_known_version),
-        Some(peer_known_epoch),
-        Some(subscription_stream_id + 1),
-        Some(1),
-    );
-    let (error, _) = add_subscription_request_to_stream(
-        subscription_request,
-        subscriptions.clone(),
-        &peer_network_id,
-    )
-    .unwrap_err();
-    assert_matches!(error, Error::InvalidRequest(_));
+        // Add a request to the stream that is invalid (the stream id is incorrect)
+        let subscription_request = create_subscription_request(
+            &time_service,
+            Some(peer_known_version),
+            Some(peer_known_epoch),
+            Some(subscription_stream_id + 1),
+            Some(1),
+            use_request_v2,
+        );
+        let (error, _) = add_subscription_request_to_stream(
+            subscription_request,
+            subscriptions.clone(),
+            &peer_network_id,
+        )
+        .unwrap_err();
+        assert_matches!(error, Error::InvalidRequest(_));
 
-    // Add a request to the stream that is invalid (the known version is incorrect)
-    let subscription_request = create_subscription_request(
-        &time_service,
-        Some(peer_known_version + 1),
-        Some(peer_known_epoch),
-        Some(subscription_stream_id),
-        Some(1),
-    );
-    let (error, _) = add_subscription_request_to_stream(
-        subscription_request,
-        subscriptions.clone(),
-        &peer_network_id,
-    )
-    .unwrap_err();
-    assert_matches!(error, Error::InvalidRequest(_));
+        // Add a request to the stream that is invalid (the known version is incorrect)
+        let subscription_request = create_subscription_request(
+            &time_service,
+            Some(peer_known_version + 1),
+            Some(peer_known_epoch),
+            Some(subscription_stream_id),
+            Some(1),
+            use_request_v2,
+        );
+        let (error, _) = add_subscription_request_to_stream(
+            subscription_request,
+            subscriptions.clone(),
+            &peer_network_id,
+        )
+        .unwrap_err();
+        assert_matches!(error, Error::InvalidRequest(_));
 
-    // Add a request to the stream that is invalid (the known epoch is incorrect)
-    let subscription_request = create_subscription_request(
-        &time_service,
-        Some(peer_known_version),
-        Some(peer_known_epoch + 1),
-        Some(subscription_stream_id),
-        Some(1),
-    );
-    let (error, _) = add_subscription_request_to_stream(
-        subscription_request,
-        subscriptions.clone(),
-        &peer_network_id,
-    )
-    .unwrap_err();
-    assert_matches!(error, Error::InvalidRequest(_));
+        // Add a request to the stream that is invalid (the known epoch is incorrect)
+        let subscription_request = create_subscription_request(
+            &time_service,
+            Some(peer_known_version),
+            Some(peer_known_epoch + 1),
+            Some(subscription_stream_id),
+            Some(1),
+            use_request_v2,
+        );
+        let (error, _) = add_subscription_request_to_stream(
+            subscription_request,
+            subscriptions.clone(),
+            &peer_network_id,
+        )
+        .unwrap_err();
+        assert_matches!(error, Error::InvalidRequest(_));
 
-    // Update the next index to serve for the stream
-    let next_index_to_serve = 10;
-    let mut subscription = subscriptions.get_mut(&peer_network_id).unwrap();
-    let subscription_stream_requests = subscription.value_mut();
-    subscription_stream_requests.set_next_index_to_serve(next_index_to_serve);
-    drop(subscription);
+        // Update the next index to serve for the stream
+        let next_index_to_serve = 10;
+        let mut subscription = subscriptions.get_mut(&peer_network_id).unwrap();
+        let subscription_stream_requests = subscription.value_mut();
+        subscription_stream_requests.set_next_index_to_serve(next_index_to_serve);
+        drop(subscription);
 
-    // Add a request to the stream that is invalid (the stream index is less than the next index to serve)
-    let subscription_request = create_subscription_request(
-        &time_service,
-        Some(peer_known_version),
-        Some(peer_known_epoch),
-        Some(subscription_stream_id),
-        Some(next_index_to_serve - 1),
-    );
-    let (error, _) = add_subscription_request_to_stream(
-        subscription_request,
-        subscriptions.clone(),
-        &peer_network_id,
-    )
-    .unwrap_err();
-    assert_matches!(error, Error::InvalidRequest(_));
+        // Add a request to the stream that is invalid (the stream index is less than the next index to serve)
+        let subscription_request = create_subscription_request(
+            &time_service,
+            Some(peer_known_version),
+            Some(peer_known_epoch),
+            Some(subscription_stream_id),
+            Some(next_index_to_serve - 1),
+            use_request_v2,
+        );
+        let (error, _) = add_subscription_request_to_stream(
+            subscription_request,
+            subscriptions.clone(),
+            &peer_network_id,
+        )
+        .unwrap_err();
+        assert_matches!(error, Error::InvalidRequest(_));
+    }
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscription_max_pending_requests() {
-    // Create a storage service config
-    let max_transaction_output_chunk_size = 5;
-    let max_num_active_subscriptions = 10;
-    let storage_service_config = StorageServiceConfig {
-        max_num_active_subscriptions,
-        max_transaction_output_chunk_size,
-        ..Default::default()
-    };
-
-    // Create test data
-    let num_stream_requests = max_num_active_subscriptions * 10; // Send more requests than allowed
-    let highest_version = 45576;
-    let highest_epoch = 43;
-    let lowest_version = 0;
-    let peer_version = 50;
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-
-    // Create the output lists with proofs
-    let output_lists_with_proofs: Vec<_> = (0..num_stream_requests)
-        .map(|i| {
-            let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
-            let end_version = start_version + max_transaction_output_chunk_size - 1;
-            utils::create_output_list_with_proof(start_version, end_version, highest_version)
-        })
-        .collect();
-
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    for stream_request_index in 0..num_stream_requests {
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            peer_version + (stream_request_index * max_transaction_output_chunk_size) + 1,
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let max_transaction_output_chunk_size = 5;
+        let max_num_active_subscriptions = 10;
+        let storage_service_config = StorageServiceConfig {
+            max_num_active_subscriptions,
             max_transaction_output_chunk_size,
-            highest_version,
-            output_lists_with_proofs[stream_request_index as usize].clone(),
+            enable_transaction_data_v2: use_request_v2,
+            ..Default::default()
+        };
+
+        // Create test data
+        let num_stream_requests = max_num_active_subscriptions * 10; // Send more requests than allowed
+        let highest_version = 45576;
+        let highest_epoch = 43;
+        let lowest_version = 0;
+        let peer_version = 50;
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+
+        // Create the output lists with proofs
+        let output_lists_with_proofs: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                let end_version = start_version + max_transaction_output_chunk_size - 1;
+                utils::create_output_list_with_proof(start_version, end_version, highest_version)
+            })
+            .collect();
+
+        // Create the persisted auxiliary infos
+        let persisted_auxiliary_infos: Vec<_> = (0..num_stream_requests)
+            .map(|i| {
+                let start_version = peer_version + (i * max_transaction_output_chunk_size) + 1;
+                let end_version = start_version + max_transaction_output_chunk_size - 1;
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2)
+            })
+            .collect();
+
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        for stream_request_index in 0..num_stream_requests {
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                peer_version + (stream_request_index * max_transaction_output_chunk_size) + 1,
+                max_transaction_output_chunk_size,
+                highest_version,
+                output_lists_with_proofs[stream_request_index as usize].clone(),
+                use_request_v2,
+                persisted_auxiliary_infos[stream_request_index as usize].clone(),
+            );
+        }
+
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_service_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
+
+        // Send the maximum number of stream requests
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = 101;
+        let mut response_receivers = utils::send_output_subscription_request_batch(
+            &mut mock_client,
+            peer_network_id,
+            0,
+            max_num_active_subscriptions - 1,
+            stream_id,
+            peer_version,
+            highest_epoch,
+            use_request_v2,
+        )
+        .await;
+
+        // Wait until the maximum number of stream requests are active
+        utils::wait_for_active_stream_requests(
+            active_subscriptions.clone(),
+            peer_network_id,
+            max_num_active_subscriptions as usize,
+        )
+        .await;
+
+        // Send another batch of stream requests (to exceed the maximum number of
+        // subscriptions), and verify that the client receives a failure for each request.
+        for stream_request_index in max_num_active_subscriptions..max_num_active_subscriptions * 2 {
+            // Send the transaction output subscription request
+            let response_receiver = utils::subscribe_to_transaction_outputs_for_peer(
+                &mut mock_client,
+                peer_version,
+                highest_epoch,
+                stream_id,
+                stream_request_index,
+                Some(peer_network_id),
+                use_request_v2,
+            )
+            .await;
+
+            // Verify that the client receives an invalid request error
+            let response = mock_client
+                .wait_for_response(response_receiver)
+                .await
+                .unwrap_err();
+            assert!(matches!(response, StorageServiceError::InvalidRequest(_)));
+        }
+
+        // Verify the request indices that are pending
+        verify_pending_subscription_request_indices(
+            active_subscriptions.clone(),
+            peer_network_id,
+            0,
+            max_num_active_subscriptions,
+            num_stream_requests,
+        );
+
+        // Force the subscription handler to work
+        utils::force_subscription_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
+
+        // Continuously run the subscription service until all of the responses are sent
+        for stream_request_index in 0..max_num_active_subscriptions {
+            // Verify that the correct response is received
+            utils::verify_output_subscription_response(
+                output_lists_with_proofs.clone(),
+                persisted_auxiliary_infos.clone(),
+                highest_ledger_info.clone(),
+                &mut mock_client,
+                &mut response_receivers,
+                stream_request_index,
+                use_request_v2,
+            )
+            .await;
+        }
+
+        // Send another batch of requests for transaction outputs
+        let _response_receivers = utils::send_output_subscription_request_batch(
+            &mut mock_client,
+            peer_network_id,
+            max_num_active_subscriptions,
+            (max_num_active_subscriptions * 2) - 1,
+            stream_id,
+            peer_version,
+            highest_epoch,
+            use_request_v2,
+        )
+        .await;
+
+        // Wait until the maximum number of stream requests are active
+        utils::wait_for_active_stream_requests(
+            active_subscriptions.clone(),
+            peer_network_id,
+            max_num_active_subscriptions as usize,
+        )
+        .await;
+
+        // Send another batch of stream requests (to exceed the maximum number of
+        // subscriptions), and verify that the client receives a failure for each request.
+        for stream_request_index in
+            max_num_active_subscriptions * 2..max_num_active_subscriptions * 3
+        {
+            // Send the transaction output subscription request
+            let response_receiver = utils::subscribe_to_transaction_outputs_for_peer(
+                &mut mock_client,
+                peer_version,
+                highest_epoch,
+                stream_id,
+                stream_request_index,
+                Some(peer_network_id),
+                use_request_v2,
+            )
+            .await;
+
+            // Verify that the client receives an invalid request error
+            let response = mock_client
+                .wait_for_response(response_receiver)
+                .await
+                .unwrap_err();
+            assert!(matches!(response, StorageServiceError::InvalidRequest(_)));
+        }
+
+        // Verify the request indices that are pending
+        verify_pending_subscription_request_indices(
+            active_subscriptions,
+            peer_network_id,
+            max_num_active_subscriptions,
+            max_num_active_subscriptions * 2,
+            num_stream_requests,
         );
     }
-
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), Some(storage_service_config));
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
-
-    // Send the maximum number of stream requests
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = 101;
-    let mut response_receivers = utils::send_output_subscription_request_batch(
-        &mut mock_client,
-        peer_network_id,
-        0,
-        max_num_active_subscriptions - 1,
-        stream_id,
-        peer_version,
-        highest_epoch,
-    )
-    .await;
-
-    // Wait until the maximum number of stream requests are active
-    utils::wait_for_active_stream_requests(
-        active_subscriptions.clone(),
-        peer_network_id,
-        max_num_active_subscriptions as usize,
-    )
-    .await;
-
-    // Send another batch of stream requests (to exceed the maximum number of
-    // subscriptions), and verify that the client receives a failure for each request.
-    for stream_request_index in max_num_active_subscriptions..max_num_active_subscriptions * 2 {
-        // Send the transaction output subscription request
-        let response_receiver = utils::subscribe_to_transaction_outputs_for_peer(
-            &mut mock_client,
-            peer_version,
-            highest_epoch,
-            stream_id,
-            stream_request_index,
-            Some(peer_network_id),
-        )
-        .await;
-
-        // Verify that the client receives an invalid request error
-        let response = mock_client
-            .wait_for_response(response_receiver)
-            .await
-            .unwrap_err();
-        assert!(matches!(response, StorageServiceError::InvalidRequest(_)));
-    }
-
-    // Verify the request indices that are pending
-    verify_pending_subscription_request_indices(
-        active_subscriptions.clone(),
-        peer_network_id,
-        0,
-        max_num_active_subscriptions,
-        num_stream_requests,
-    );
-
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
-
-    // Continuously run the subscription service until all of the responses are sent
-    for stream_request_index in 0..max_num_active_subscriptions {
-        // Verify that the correct response is received
-        utils::verify_output_subscription_response(
-            output_lists_with_proofs.clone(),
-            highest_ledger_info.clone(),
-            &mut mock_client,
-            &mut response_receivers,
-            stream_request_index,
-        )
-        .await;
-    }
-
-    // Send another batch of requests for transaction outputs
-    let _response_receivers = utils::send_output_subscription_request_batch(
-        &mut mock_client,
-        peer_network_id,
-        max_num_active_subscriptions,
-        (max_num_active_subscriptions * 2) - 1,
-        stream_id,
-        peer_version,
-        highest_epoch,
-    )
-    .await;
-
-    // Wait until the maximum number of stream requests are active
-    utils::wait_for_active_stream_requests(
-        active_subscriptions.clone(),
-        peer_network_id,
-        max_num_active_subscriptions as usize,
-    )
-    .await;
-
-    // Send another batch of stream requests (to exceed the maximum number of
-    // subscriptions), and verify that the client receives a failure for each request.
-    for stream_request_index in max_num_active_subscriptions * 2..max_num_active_subscriptions * 3 {
-        // Send the transaction output subscription request
-        let response_receiver = utils::subscribe_to_transaction_outputs_for_peer(
-            &mut mock_client,
-            peer_version,
-            highest_epoch,
-            stream_id,
-            stream_request_index,
-            Some(peer_network_id),
-        )
-        .await;
-
-        // Verify that the client receives an invalid request error
-        let response = mock_client
-            .wait_for_response(response_receiver)
-            .await
-            .unwrap_err();
-        assert!(matches!(response, StorageServiceError::InvalidRequest(_)));
-    }
-
-    // Verify the request indices that are pending
-    verify_pending_subscription_request_indices(
-        active_subscriptions,
-        peer_network_id,
-        max_num_active_subscriptions,
-        max_num_active_subscriptions * 2,
-        num_stream_requests,
-    );
 }
 
 #[tokio::test(flavor = "multi_thread")]
 async fn test_subscription_overwrite_streams() {
-    // Create test data
-    let highest_version = 45576;
-    let highest_epoch = 43;
-    let lowest_version = 0;
-    let peer_version = highest_version - 100;
-    let highest_ledger_info =
-        utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
-    let output_list_with_proof =
-        utils::create_output_list_with_proof(peer_version + 1, highest_version, highest_version);
-    let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-        peer_version + 1,
-        highest_version,
-        highest_version,
-        false,
-    );
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create test data
+        let highest_version = 45576;
+        let highest_epoch = 43;
+        let lowest_version = 0;
+        let peer_version = highest_version - 100;
+        let highest_ledger_info =
+            utils::create_test_ledger_info_with_sigs(highest_epoch, highest_version);
+        let output_list_with_proof = utils::create_output_list_with_proof(
+            peer_version + 1,
+            highest_version,
+            highest_version,
+        );
+        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+            peer_version + 1,
+            highest_version,
+            highest_version,
+            false,
+        );
+        let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+            peer_version + 1,
+            highest_version,
+            use_request_v2,
+        );
 
-    // Create the mock db reader
-    let mut db_reader =
-        mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
-    utils::expect_get_transaction_outputs(
-        &mut db_reader,
-        peer_version + 1,
-        highest_version - peer_version,
-        highest_version,
-        output_list_with_proof.clone(),
-    );
-    utils::expect_get_transactions(
-        &mut db_reader,
-        peer_version + 1,
-        highest_version - peer_version,
-        highest_version,
-        false,
-        transaction_list_with_proof.clone(),
-    );
+        // Create the mock db reader
+        let mut db_reader =
+            mock::create_mock_db_with_summary_updates(highest_ledger_info.clone(), lowest_version);
+        utils::expect_get_transaction_outputs(
+            &mut db_reader,
+            peer_version + 1,
+            highest_version - peer_version,
+            highest_version,
+            output_list_with_proof.clone(),
+            use_request_v2,
+            persisted_auxiliary_infos.clone(),
+        );
+        utils::expect_get_transactions(
+            &mut db_reader,
+            peer_version + 1,
+            highest_version - peer_version,
+            highest_version,
+            false,
+            transaction_list_with_proof.clone(),
+            use_request_v2,
+            persisted_auxiliary_infos.clone(),
+        );
 
-    // Create the storage client and server
-    let (mut mock_client, service, storage_service_notifier, mock_time, _) =
-        MockClient::new(Some(db_reader), None);
-    let active_subscriptions = service.get_subscriptions();
-    tokio::spawn(service.start());
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
 
-    // Create a peer network ID and stream ID
-    let peer_network_id = PeerNetworkId::random();
-    let stream_id = utils::get_random_u64();
+        // Create the storage client and server
+        let (mut mock_client, service, storage_service_notifier, mock_time, _) =
+            MockClient::new(Some(db_reader), Some(storage_config));
+        let active_subscriptions = service.get_subscriptions();
+        tokio::spawn(service.start());
 
-    // Send multiple requests to subscribe to transaction outputs with the stream ID
-    let num_stream_requests = 10;
-    let mut response_receivers = utils::send_output_subscription_request_batch(
-        &mut mock_client,
-        peer_network_id,
-        0,
-        num_stream_requests - 1,
-        stream_id,
-        peer_version,
-        highest_epoch,
-    )
-    .await;
+        // Create a peer network ID and stream ID
+        let peer_network_id = PeerNetworkId::random();
+        let stream_id = utils::get_random_u64();
 
-    // Wait until the stream requests are active
-    utils::wait_for_active_stream_requests(
-        active_subscriptions.clone(),
-        peer_network_id,
-        num_stream_requests as usize,
-    )
-    .await;
+        // Send multiple requests to subscribe to transaction outputs with the stream ID
+        let num_stream_requests = 10;
+        let mut response_receivers = utils::send_output_subscription_request_batch(
+            &mut mock_client,
+            peer_network_id,
+            0,
+            num_stream_requests - 1,
+            stream_id,
+            peer_version,
+            highest_epoch,
+            use_request_v2,
+        )
+        .await;
 
-    // Verify no subscription response has been received yet
-    utils::verify_no_subscription_responses(&mut response_receivers);
+        // Wait until the stream requests are active
+        utils::wait_for_active_stream_requests(
+            active_subscriptions.clone(),
+            peer_network_id,
+            num_stream_requests as usize,
+        )
+        .await;
 
-    // Force the subscription handler to work
-    utils::force_subscription_handler_to_run(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-    )
-    .await;
+        // Verify no subscription response has been received yet
+        utils::verify_no_subscription_responses(&mut response_receivers);
 
-    // Verify that the correct response is received (when it comes through)
-    utils::verify_output_subscription_response(
-        vec![output_list_with_proof.clone()],
-        highest_ledger_info.clone(),
-        &mut mock_client,
-        &mut response_receivers,
-        0,
-    )
-    .await;
+        // Force the subscription handler to work
+        utils::force_subscription_handler_to_run(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+        )
+        .await;
 
-    // Send a request to subscribe to transactions with a new stream ID
-    let new_stream_id = utils::get_random_u64();
-    let response_receiver = utils::subscribe_to_transactions_for_peer(
-        &mut mock_client,
-        peer_version,
-        highest_epoch,
-        false,
-        new_stream_id,
-        0,
-        Some(peer_network_id),
-    )
-    .await;
+        // Verify that the correct response is received (when it comes through)
+        utils::verify_output_subscription_response(
+            vec![output_list_with_proof.clone()],
+            vec![persisted_auxiliary_infos.clone()],
+            highest_ledger_info.clone(),
+            &mut mock_client,
+            &mut response_receivers,
+            0,
+            use_request_v2,
+        )
+        .await;
 
-    // Wait until the stream requests are active
-    utils::wait_for_active_stream_requests(active_subscriptions.clone(), peer_network_id, 1).await;
+        // Send a request to subscribe to transactions with a new stream ID
+        let new_stream_id = utils::get_random_u64();
+        let response_receiver = utils::subscribe_to_transactions_for_peer(
+            &mut mock_client,
+            peer_version,
+            highest_epoch,
+            false,
+            new_stream_id,
+            0,
+            Some(peer_network_id),
+            use_request_v2,
+        )
+        .await;
 
-    // Verify the new stream ID has been used
-    utils::verify_active_stream_id_for_peer(
-        active_subscriptions.clone(),
-        peer_network_id,
-        new_stream_id,
-    );
+        // Wait until the stream requests are active
+        utils::wait_for_active_stream_requests(active_subscriptions.clone(), peer_network_id, 1)
+            .await;
 
-    // Force the subscription handler to work
-    utils::force_cache_update_notification(
-        &mut mock_client,
-        &mock_time,
-        &storage_service_notifier,
-        true,
-        true,
-    )
-    .await;
+        // Verify the new stream ID has been used
+        utils::verify_active_stream_id_for_peer(
+            active_subscriptions.clone(),
+            peer_network_id,
+            new_stream_id,
+        );
 
-    // Verify a response is received and that it contains the correct data
-    utils::verify_new_transactions_with_proof(
-        &mut mock_client,
-        response_receiver,
-        transaction_list_with_proof,
-        highest_ledger_info,
-    )
-    .await;
+        // Force the subscription handler to work
+        utils::force_cache_update_notification(
+            &mut mock_client,
+            &mock_time,
+            &storage_service_notifier,
+            true,
+            true,
+        )
+        .await;
+
+        // Verify a response is received and that it contains the correct data
+        utils::verify_new_transactions_with_proof(
+            &mut mock_client,
+            response_receiver,
+            use_request_v2,
+            transaction_list_with_proof,
+            highest_ledger_info,
+            persisted_auxiliary_infos,
+        )
+        .await;
+    }
 }
 
 /// Adds a subscription request to the subscription stream for the given peer
@@ -986,6 +1083,7 @@ fn create_subscription_data_request(
     known_epoch_at_stream_start: Option<u64>,
     subscription_stream_id: Option<u64>,
     subscription_stream_index: Option<u64>,
+    use_request_v2: bool,
 ) -> DataRequest {
     // Get the request data
     let known_version_at_stream_start = known_version_at_stream_start.unwrap_or_default();
@@ -1003,25 +1101,74 @@ fn create_subscription_data_request(
     // Generate the random data request
     let random_number = utils::get_random_u64();
     match random_number % 3 {
-        0 => DataRequest::SubscribeTransactionOutputsWithProof(
-            SubscribeTransactionOutputsWithProofRequest {
-                subscription_stream_metadata,
-                subscription_stream_index,
-            },
-        ),
-        1 => DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
-            subscription_stream_metadata,
-            include_events: false,
-            subscription_stream_index,
-        }),
-        2 => DataRequest::SubscribeTransactionsOrOutputsWithProof(
-            SubscribeTransactionsOrOutputsWithProofRequest {
-                subscription_stream_metadata,
-                include_events: false,
-                max_num_output_reductions: 0,
-                subscription_stream_index,
-            },
-        ),
+        0 => {
+            if use_request_v2 {
+                let transaction_data_request_type =
+                    TransactionDataRequestType::TransactionData(TransactionData {
+                        include_events: true,
+                    });
+                DataRequest::SubscribeTransactionDataWithProof(
+                    SubscribeTransactionDataWithProofRequest {
+                        transaction_data_request_type,
+                        subscription_stream_metadata,
+                        subscription_stream_index,
+                        max_response_bytes: 0,
+                    },
+                )
+            } else {
+                DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
+                    subscription_stream_metadata,
+                    subscription_stream_index,
+                    include_events: true,
+                })
+            }
+        },
+        1 => {
+            if use_request_v2 {
+                let transaction_data_request_type =
+                    TransactionDataRequestType::TransactionOutputData;
+                DataRequest::SubscribeTransactionDataWithProof(
+                    SubscribeTransactionDataWithProofRequest {
+                        transaction_data_request_type,
+                        subscription_stream_metadata,
+                        subscription_stream_index,
+                        max_response_bytes: 0,
+                    },
+                )
+            } else {
+                DataRequest::SubscribeTransactionOutputsWithProof(
+                    SubscribeTransactionOutputsWithProofRequest {
+                        subscription_stream_metadata,
+                        subscription_stream_index,
+                    },
+                )
+            }
+        },
+        2 => {
+            if use_request_v2 {
+                let transaction_data_request_type =
+                    TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+                        include_events: true,
+                    });
+                DataRequest::SubscribeTransactionDataWithProof(
+                    SubscribeTransactionDataWithProofRequest {
+                        transaction_data_request_type,
+                        subscription_stream_metadata,
+                        subscription_stream_index,
+                        max_response_bytes: 0,
+                    },
+                )
+            } else {
+                DataRequest::SubscribeTransactionsOrOutputsWithProof(
+                    SubscribeTransactionsOrOutputsWithProofRequest {
+                        subscription_stream_metadata,
+                        include_events: false,
+                        max_num_output_reductions: 0,
+                        subscription_stream_index,
+                    },
+                )
+            }
+        },
         number => panic!("This shouldn't be possible! Got: {:?}", number),
     }
 }
@@ -1033,6 +1180,7 @@ fn create_subscription_request(
     known_epoch: Option<u64>,
     subscription_stream_id: Option<u64>,
     subscription_stream_index: Option<u64>,
+    use_request_v2: bool,
 ) -> SubscriptionRequest {
     // Create a storage service request
     let data_request = create_subscription_data_request(
@@ -1040,6 +1188,7 @@ fn create_subscription_request(
         known_epoch,
         subscription_stream_id,
         subscription_stream_index,
+        use_request_v2,
     );
     let storage_service_request = StorageServiceRequest::new(data_request, true);
 
@@ -1062,6 +1211,7 @@ fn create_subscription_stream_requests(
     known_epoch: Option<u64>,
     subscription_stream_id: Option<u64>,
     subscription_stream_index: Option<u64>,
+    use_request_v2: bool,
 ) -> SubscriptionStreamRequests {
     // Create a new subscription request
     let subscription_request = create_subscription_request(
@@ -1070,6 +1220,7 @@ fn create_subscription_stream_requests(
         known_epoch,
         subscription_stream_id,
         subscription_stream_index,
+        use_request_v2,
     );
 
     // Create and return the subscription stream containing the request

--- a/state-sync/storage-service/server/src/tests/transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transaction_outputs.rs
@@ -4,171 +4,238 @@
 use crate::tests::{mock, mock::MockClient, utils};
 use aptos_config::config::StorageServiceConfig;
 use aptos_storage_service_types::{
-    requests::{DataRequest, TransactionOutputsWithProofRequest},
-    responses::{DataResponse, StorageServiceResponse},
+    requests::{
+        DataRequest, GetTransactionDataWithProofRequest, TransactionDataRequestType,
+        TransactionOutputsWithProofRequest,
+    },
+    responses::{DataResponse, StorageServiceResponse, TransactionDataResponseType},
     StorageServiceError,
 };
+use aptos_types::transaction::{PersistedAuxiliaryInfo, TransactionOutputListWithProof};
 use claims::assert_matches;
 use mockall::{predicate::eq, Sequence};
 
 #[tokio::test]
 async fn test_get_transaction_outputs_with_proof() {
-    // Test small and large chunk requests
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [1, 100, max_output_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk requests
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [1, 100, max_output_chunk_size] {
+            // Create test data
+            let start_version = 0;
+            let end_version = start_version + chunk_size - 1;
+            let proof_version = end_version;
+            let output_list_with_proof =
+                utils::create_output_list_with_proof(start_version, end_version, proof_version);
+            let persisted_auxiliary_infos =
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
+
+            // Create the mock db reader
+            let mut db_reader = mock::create_mock_db_reader();
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                start_version,
+                chunk_size,
+                proof_version,
+                output_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
+            );
+
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
+
+            // Create the storage client and server
+            let (mut mock_client, mut service, _, _, _) =
+                MockClient::new(Some(db_reader), Some(storage_config));
+            utils::update_storage_server_summary(&mut service, proof_version + 100, 10);
+            tokio::spawn(service.start());
+
+            // Create a request to fetch transactions outputs with a proof
+            let response = get_outputs_with_proof(
+                &mut mock_client,
+                start_version,
+                end_version,
+                end_version,
+                true,
+                use_request_v2,
+            )
+            .await
+            .unwrap();
+
+            // Verify the response is correct
+            verify_output_with_proof_response(
+                use_request_v2,
+                output_list_with_proof,
+                persisted_auxiliary_infos,
+                response,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_transaction_outputs_with_proof_chunk_limit() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Create test data
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        let chunk_size = max_output_chunk_size * 10; // Set a chunk request larger than the max
         let start_version = 0;
-        let end_version = start_version + chunk_size - 1;
+        let end_version = start_version + max_output_chunk_size - 1;
         let proof_version = end_version;
         let output_list_with_proof =
             utils::create_output_list_with_proof(start_version, end_version, proof_version);
+        let persisted_auxiliary_infos =
+            utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
 
         // Create the mock db reader
         let mut db_reader = mock::create_mock_db_reader();
         utils::expect_get_transaction_outputs(
             &mut db_reader,
             start_version,
-            chunk_size,
+            max_output_chunk_size,
             proof_version,
             output_list_with_proof.clone(),
+            use_request_v2,
+            persisted_auxiliary_infos.clone(),
         );
 
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
+
         // Create the storage client and server
-        let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
-        utils::update_storage_server_summary(&mut service, proof_version + 100, 10);
+        let (mut mock_client, mut service, _, _, _) =
+            MockClient::new(Some(db_reader), Some(storage_config));
+        utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
         tokio::spawn(service.start());
 
-        // Create a request to fetch transactions outputs with a proof
+        // Create a request to fetch transaction outputs with a proof
         let response = get_outputs_with_proof(
             &mut mock_client,
             start_version,
-            end_version,
+            start_version + chunk_size - 1,
             end_version,
             true,
+            use_request_v2,
         )
         .await
         .unwrap();
 
         // Verify the response is correct
-        match response.get_data_response().unwrap() {
-            DataResponse::TransactionOutputsWithProof(outputs_with_proof) => {
-                assert_eq!(outputs_with_proof, output_list_with_proof)
-            },
-            _ => panic!(
-                "Expected transaction outputs with proof but got: {:?}",
-                response
-            ),
-        };
+        verify_output_with_proof_response(
+            use_request_v2,
+            output_list_with_proof,
+            persisted_auxiliary_infos,
+            response,
+        );
     }
 }
 
 #[tokio::test]
-async fn test_get_transaction_outputs_with_proof_chunk_limit() {
-    // Create test data
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    let chunk_size = max_output_chunk_size * 10; // Set a chunk request larger than the max
-    let start_version = 0;
-    let end_version = start_version + max_output_chunk_size - 1;
-    let proof_version = end_version;
-    let output_list_with_proof =
-        utils::create_output_list_with_proof(start_version, end_version, proof_version);
-
-    // Create the mock db reader
-    let mut db_reader = mock::create_mock_db_reader();
-    utils::expect_get_transaction_outputs(
-        &mut db_reader,
-        start_version,
-        max_output_chunk_size,
-        proof_version,
-        output_list_with_proof.clone(),
-    );
+#[should_panic(expected = "Canceled")]
+async fn test_get_transaction_outputs_with_proof_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
 
     // Create the storage client and server
-    let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
-    utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
     tokio::spawn(service.start());
 
-    // Create a request to fetch transactions outputs with a proof
-    let response = get_outputs_with_proof(
+    // Send a transaction v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    get_outputs_with_proof(
         &mut mock_client,
-        start_version,
-        start_version + chunk_size - 1,
-        end_version,
+        0,
+        10,
+        10,
         true,
+        true, // Use transaction v2
     )
     .await
     .unwrap();
-
-    // Verify the response is correct
-    match response.get_data_response().unwrap() {
-        DataResponse::TransactionOutputsWithProof(outputs_with_proof) => {
-            assert_eq!(outputs_with_proof, output_list_with_proof)
-        },
-        _ => panic!(
-            "Expected transaction outputs with proof but got: {:?}",
-            response
-        ),
-    };
 }
 
 #[tokio::test]
 async fn test_get_transaction_outputs_with_proof_invalid() {
-    // Create the storage client and server
-    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
-    tokio::spawn(service.start());
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
 
-    // Test invalid ranges
-    let start_version = 1000;
-    for end_version in [0, 999] {
-        let response = get_outputs_with_proof(
-            &mut mock_client,
-            start_version,
-            end_version,
-            end_version,
-            true,
-        )
-        .await
-        .unwrap_err();
-        assert_matches!(response, StorageServiceError::InvalidRequest(_));
+        // Create the storage client and server
+        let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+        tokio::spawn(service.start());
+
+        // Test invalid ranges
+        let start_version = 1000;
+        for end_version in [0, 999] {
+            let response = get_outputs_with_proof(
+                &mut mock_client,
+                start_version,
+                end_version,
+                end_version,
+                true,
+                use_request_v2,
+            )
+            .await
+            .unwrap_err();
+            assert_matches!(response, StorageServiceError::InvalidRequest(_));
+        }
     }
 }
 
 #[tokio::test]
 async fn test_get_transaction_outputs_with_proof_network_limit() {
-    // Test different byte limits
-    for network_limit_bytes in [1, 5 * 1024, 50 * 1024, 100 * 1024] {
-        get_outputs_with_proof_network_limit(network_limit_bytes).await;
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test different byte limits
+        for network_limit_bytes in [1, 5 * 1024, 50 * 1024] {
+            get_outputs_with_proof_network_limit(network_limit_bytes, use_request_v2).await;
+        }
     }
 }
 
 #[tokio::test]
 async fn test_get_transaction_outputs_with_proof_not_serviceable() {
-    // Test small and large chunk requests
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [2, 100, max_output_chunk_size] {
-        // Create test data
-        let start_version = 0;
-        let end_version = start_version + chunk_size - 1;
-        let proof_version = end_version;
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk requests
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [2, 100, max_output_chunk_size] {
+            // Create test data
+            let start_version = 0;
+            let end_version = start_version + chunk_size - 1;
+            let proof_version = end_version;
 
-        // Create the storage client and server (that cannot service the request)
-        let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
-        utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
-        tokio::spawn(service.start());
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
 
-        // Create a request to fetch transactions outputs with a proof
-        let response = get_outputs_with_proof(
-            &mut mock_client,
-            start_version,
-            end_version,
-            end_version,
-            true,
-        )
-        .await
-        .unwrap_err();
+            // Create the storage client and server (that cannot service the request)
+            let (mut mock_client, mut service, _, _, _) =
+                MockClient::new(None, Some(storage_config));
+            utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
+            tokio::spawn(service.start());
 
-        // Verify the request is not serviceable
-        assert_matches!(response, StorageServiceError::InvalidRequest(_));
+            // Create a request to fetch transactions outputs with a proof
+            let response = get_outputs_with_proof(
+                &mut mock_client,
+                start_version,
+                end_version,
+                end_version,
+                true,
+                use_request_v2,
+            )
+            .await
+            .unwrap_err();
+
+            // Verify the request is not serviceable
+            assert_matches!(response, StorageServiceError::InvalidRequest(_));
+        }
     }
 }
 
@@ -179,19 +246,30 @@ async fn get_outputs_with_proof(
     end_version: u64,
     proof_version: u64,
     use_compression: bool,
+    use_request_v2: bool,
 ) -> Result<StorageServiceResponse, StorageServiceError> {
-    let data_request =
+    let data_request = if use_request_v2 {
+        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
+        DataRequest::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            proof_version,
+            start_version,
+            end_version,
+            max_response_bytes: 0,
+        })
+    } else {
         DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
             proof_version,
             start_version,
             end_version,
-        });
+        })
+    };
     utils::send_storage_request(mock_client, use_compression, data_request).await
 }
 
-/// A helper method to request a transaction outputs with proof chunk using the
+/// A helper method to request a transaction outputs with proof chunk using
 /// the specified network limit.
-async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64) {
+async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64, use_request_v2: bool) {
     for use_compression in [true, false] {
         // Create test data
         let max_output_chunk_size =
@@ -205,6 +283,7 @@ async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64) {
         let mut expectation_sequence = Sequence::new();
         let mut chunk_size = max_output_chunk_size;
         while chunk_size >= 1 {
+            // Expect a call to get outputs with the specified chunk size
             let output_list_with_proof = utils::create_output_list_using_sizes(
                 start_version,
                 chunk_size,
@@ -216,12 +295,30 @@ async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64) {
                 .with(eq(start_version), eq(chunk_size), eq(proof_version))
                 .in_sequence(&mut expectation_sequence)
                 .returning(move |_, _, _| Ok(output_list_with_proof.clone()));
+
+            // Expect a call to get persisted auxiliary infos if v2 is enabled
+            if use_request_v2 {
+                let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                    start_version,
+                    start_version + chunk_size - 1,
+                    use_request_v2,
+                )
+                .unwrap();
+                let persisted_auxiliary_infos = persisted_auxiliary_infos.into_iter().map(Ok);
+                db_reader
+                    .expect_get_persisted_auxiliary_info_iterator()
+                    .times(1)
+                    .with(eq(start_version), eq(chunk_size as usize))
+                    .returning(move |_, _| Ok(Box::new(persisted_auxiliary_infos.clone())));
+            }
+
             chunk_size /= 2;
         }
 
         // Create a storage config with the specified max network byte limit
         let storage_config = StorageServiceConfig {
             max_network_chunk_bytes: network_limit_bytes,
+            enable_transaction_data_v2: use_request_v2,
             ..Default::default()
         };
 
@@ -238,23 +335,92 @@ async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64) {
             start_version + (max_output_chunk_size * 10), // Request more than the max chunk
             proof_version,
             use_compression,
+            use_request_v2,
         )
         .await
         .unwrap();
 
         // Verify the response is correct
-        match response.get_data_response().unwrap() {
+        let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
+        let num_outputs = match response.get_data_response().unwrap() {
             DataResponse::TransactionOutputsWithProof(outputs_with_proof) => {
-                let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
-                let num_outputs = outputs_with_proof.transactions_and_outputs.len() as u64;
-                if num_response_bytes > network_limit_bytes {
-                    assert_eq!(num_outputs, 1); // Data cannot be reduced more than a single item
-                } else {
-                    let max_outputs = network_limit_bytes / min_bytes_per_output;
-                    assert!(num_outputs <= max_outputs); // Verify data fits correctly into the limit
-                }
+                outputs_with_proof.transactions_and_outputs.len() as u64
+            },
+            DataResponse::TransactionDataWithProof(transaction_data_with_proof) => {
+                let output_list_with_proof_v2 = transaction_data_with_proof
+                    .transaction_output_list_with_proof
+                    .unwrap();
+                output_list_with_proof_v2
+                    .get_output_list_with_proof()
+                    .transactions_and_outputs
+                    .len() as u64
             },
             _ => panic!("Expected outputs with proof but got: {:?}", response),
         };
+        if num_response_bytes > network_limit_bytes {
+            assert_eq!(num_outputs, 1); // Data cannot be reduced more than a single item
+        } else {
+            let max_outputs = network_limit_bytes / min_bytes_per_output;
+            assert!(num_outputs <= max_outputs); // Verify data fits correctly into the limit
+        }
+    }
+}
+
+/// Verifies the response for a transaction output with proof request
+fn verify_output_with_proof_response(
+    use_request_v2: bool,
+    output_list_with_proof: TransactionOutputListWithProof,
+    persisted_auxiliary_infos: Option<Vec<PersistedAuxiliaryInfo>>,
+    response: StorageServiceResponse,
+) {
+    // Get the data response
+    let data_response = response.get_data_response().unwrap();
+
+    // Verify the response type (v1 or v2)
+    match &data_response {
+        DataResponse::TransactionOutputsWithProof(_) => assert!(!use_request_v2),
+        DataResponse::TransactionDataWithProof(_) => {
+            assert!(use_request_v2)
+        },
+        _ => panic!(
+            "Expected transaction outputs with proof but got: {:?}",
+            data_response
+        ),
+    }
+
+    // Verify the response data
+    match data_response {
+        DataResponse::TransactionOutputsWithProof(outputs_with_proof) => {
+            assert_eq!(outputs_with_proof, output_list_with_proof)
+        },
+        DataResponse::TransactionDataWithProof(transaction_data_with_proof) => {
+            // Verify the data type
+            assert_eq!(
+                transaction_data_with_proof.transaction_data_response_type,
+                TransactionDataResponseType::TransactionOutputData
+            );
+
+            // Verify the transactions
+            assert!(transaction_data_with_proof
+                .transaction_list_with_proof
+                .is_none());
+
+            // Verify the outputs and auxiliary infos
+            let output_list_with_proof_v2 = transaction_data_with_proof
+                .transaction_output_list_with_proof
+                .unwrap();
+            assert_eq!(
+                output_list_with_proof_v2.get_output_list_with_proof(),
+                &output_list_with_proof
+            );
+            assert_eq!(
+                output_list_with_proof_v2.get_persisted_auxiliary_infos(),
+                &persisted_auxiliary_infos.unwrap(),
+            );
+        },
+        _ => panic!(
+            "Expected transaction outputs with proof but got: {:?}",
+            data_response
+        ),
     }
 }

--- a/state-sync/storage-service/server/src/tests/transactions.rs
+++ b/state-sync/storage-service/server/src/tests/transactions.rs
@@ -9,14 +9,88 @@ use mockall::{predicate::eq, Sequence};
 
 #[tokio::test]
 async fn test_get_transactions_with_proof() {
-    // Test small and large chunk requests
-    let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
-    for chunk_size in [1, 100, max_transaction_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk requests
+        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
+        for chunk_size in [1, 100, max_transaction_chunk_size] {
+            // Test event inclusion
+            for include_events in [true, false] {
+                // Create test data
+                let start_version = 0;
+                let end_version = start_version + chunk_size - 1;
+                let proof_version = end_version;
+                let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                    start_version,
+                    end_version,
+                    proof_version,
+                    include_events,
+                );
+                let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                    start_version,
+                    end_version,
+                    use_request_v2,
+                );
+
+                // Create the mock db reader
+                let mut db_reader = mock::create_mock_db_reader();
+                utils::expect_get_transactions(
+                    &mut db_reader,
+                    start_version,
+                    chunk_size,
+                    proof_version,
+                    include_events,
+                    transaction_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
+                );
+
+                // Create a storage service config
+                let storage_config = utils::create_storage_config(use_request_v2);
+
+                // Create the storage client and server
+                let (mut mock_client, mut service, _, _, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                utils::update_storage_server_summary(&mut service, proof_version, 10);
+                tokio::spawn(service.start());
+
+                // Create a request to fetch transactions with a proof
+                let response = utils::get_transactions_with_proof(
+                    &mut mock_client,
+                    start_version,
+                    end_version,
+                    proof_version,
+                    include_events,
+                    true,
+                    use_request_v2,
+                )
+                .await
+                .unwrap();
+
+                // Verify the response is correct
+                utils::verify_transaction_with_proof_response(
+                    use_request_v2,
+                    transaction_list_with_proof,
+                    persisted_auxiliary_infos,
+                    response,
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_with_chunk_proof_limit() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Test event inclusion
         for include_events in [true, false] {
             // Create test data
+            let max_transaction_chunk_size =
+                StorageServiceConfig::default().max_transaction_chunk_size;
+            let chunk_size = max_transaction_chunk_size * 10; // Set a chunk request larger than the max
             let start_version = 0;
-            let end_version = start_version + chunk_size - 1;
+            let end_version = start_version + max_transaction_chunk_size - 1;
             let proof_version = end_version;
             let transaction_list_with_proof = utils::create_transaction_list_with_proof(
                 start_version,
@@ -24,170 +98,167 @@ async fn test_get_transactions_with_proof() {
                 proof_version,
                 include_events,
             );
+            let persisted_auxiliary_infos =
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
 
             // Create the mock db reader
             let mut db_reader = mock::create_mock_db_reader();
             utils::expect_get_transactions(
                 &mut db_reader,
                 start_version,
-                chunk_size,
+                max_transaction_chunk_size,
                 proof_version,
                 include_events,
                 transaction_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
             );
 
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
+
             // Create the storage client and server
-            let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
-            utils::update_storage_server_summary(&mut service, proof_version, 10);
+            let (mut mock_client, mut service, _, _, _) =
+                MockClient::new(Some(db_reader), Some(storage_config));
+            utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
             tokio::spawn(service.start());
 
             // Create a request to fetch transactions with a proof
             let response = utils::get_transactions_with_proof(
                 &mut mock_client,
                 start_version,
-                end_version,
+                start_version + chunk_size - 1,
                 proof_version,
                 include_events,
                 true,
+                use_request_v2,
             )
             .await
             .unwrap();
 
             // Verify the response is correct
-            match response.get_data_response().unwrap() {
-                DataResponse::TransactionsWithProof(transactions_with_proof) => {
-                    assert_eq!(transactions_with_proof, transaction_list_with_proof)
-                },
-                _ => panic!("Expected transactions with proof but got: {:?}", response),
-            };
+            utils::verify_transaction_with_proof_response(
+                use_request_v2,
+                transaction_list_with_proof,
+                persisted_auxiliary_infos,
+                response,
+            );
         }
     }
 }
 
 #[tokio::test]
-async fn test_get_transactions_with_chunk_limit() {
-    // Test event inclusion
-    for include_events in [true, false] {
-        // Create test data
-        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
-        let chunk_size = max_transaction_chunk_size * 10; // Set a chunk request larger than the max
-        let start_version = 0;
-        let end_version = start_version + max_transaction_chunk_size - 1;
-        let proof_version = end_version;
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            start_version,
-            end_version,
-            proof_version,
-            include_events,
-        );
+#[should_panic(expected = "Canceled")]
+async fn test_get_transactions_with_proof_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
 
-        // Create the mock db reader
-        let mut db_reader = mock::create_mock_db_reader();
-        utils::expect_get_transactions(
-            &mut db_reader,
-            start_version,
-            max_transaction_chunk_size,
-            proof_version,
-            include_events,
-            transaction_list_with_proof.clone(),
-        );
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
 
-        // Create the storage client and server
-        let (mut mock_client, mut service, _, _, _) = MockClient::new(Some(db_reader), None);
-        utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
-        tokio::spawn(service.start());
-
-        // Create a request to fetch transactions with a proof
-        let response = utils::get_transactions_with_proof(
-            &mut mock_client,
-            start_version,
-            start_version + chunk_size - 1,
-            proof_version,
-            include_events,
-            true,
-        )
-        .await
-        .unwrap();
-
-        // Verify the response is correct
-        match response.get_data_response().unwrap() {
-            DataResponse::TransactionsWithProof(transactions_with_proof) => {
-                assert_eq!(transactions_with_proof, transaction_list_with_proof)
-            },
-            _ => panic!("Expected transactions with proof but got: {:?}", response),
-        };
-    }
+    // Send a transaction v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    utils::get_transactions_with_proof(
+        &mut mock_client,
+        0,
+        10,
+        10,
+        true,
+        true,
+        true, // Use transaction v2
+    )
+    .await
+    .unwrap();
 }
 
 #[tokio::test]
 async fn test_get_transactions_with_proof_invalid() {
-    // Create the storage client and server
-    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
-    tokio::spawn(service.start());
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
 
-    // Test invalid ranges
-    let start_version = 1000;
-    for end_version in [0, 999] {
-        let response = utils::get_transactions_with_proof(
-            &mut mock_client,
-            start_version,
-            end_version,
-            end_version,
-            true,
-            true,
-        )
-        .await
-        .unwrap_err();
-        assert_matches!(response, StorageServiceError::InvalidRequest(_));
-    }
-}
+        // Create the storage client and server
+        let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+        tokio::spawn(service.start());
 
-#[tokio::test]
-async fn test_get_transactions_with_proof_network_limit() {
-    // Test different byte limits
-    for network_limit_bytes in [1, 1024, 10 * 1024, 100 * 1024] {
-        get_transactions_with_proof_network_limit(network_limit_bytes).await;
-    }
-}
-
-#[tokio::test]
-async fn test_get_transactions_with_proof_not_serviceable() {
-    // Test small and large chunk requests
-    let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
-    for chunk_size in [2, 100, max_transaction_chunk_size] {
-        // Test event inclusion
-        for include_events in [true, false] {
-            // Create test data
-            let start_version = 0;
-            let end_version = start_version + chunk_size - 1;
-            let proof_version = end_version;
-
-            // Create the storage client and server (that cannot service the request)
-            let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
-            utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
-            tokio::spawn(service.start());
-
-            // Create a request to fetch transactions with a proof
+        // Test invalid ranges
+        let start_version = 1000;
+        for end_version in [0, 999] {
             let response = utils::get_transactions_with_proof(
                 &mut mock_client,
                 start_version,
                 end_version,
-                proof_version,
-                include_events,
+                end_version,
                 true,
+                true,
+                use_request_v2,
             )
             .await
             .unwrap_err();
-
-            // Verify the request is not serviceable
             assert_matches!(response, StorageServiceError::InvalidRequest(_));
         }
     }
 }
 
-/// A helper method to request a transactions with proof chunk using the
+#[tokio::test]
+async fn test_get_transactions_with_proof_network_limit() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test different byte limits
+        for network_limit_bytes in [1, 1024, 10 * 1024] {
+            get_transactions_with_proof_network_limit(network_limit_bytes, use_request_v2).await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_with_proof_not_serviceable() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk requests
+        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
+        for chunk_size in [2, 100, max_transaction_chunk_size] {
+            // Test event inclusion
+            for include_events in [true, false] {
+                // Create test data
+                let start_version = 0;
+                let end_version = start_version + chunk_size - 1;
+                let proof_version = end_version;
+
+                // Create a storage service config
+                let storage_config = utils::create_storage_config(use_request_v2);
+
+                // Create the storage client and server (that cannot service the request)
+                let (mut mock_client, mut service, _, _, _) =
+                    MockClient::new(None, Some(storage_config));
+                utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
+                tokio::spawn(service.start());
+
+                // Create a request to fetch transactions with a proof
+                let response = utils::get_transactions_with_proof(
+                    &mut mock_client,
+                    start_version,
+                    end_version,
+                    proof_version,
+                    include_events,
+                    true,
+                    use_request_v2,
+                )
+                .await
+                .unwrap_err();
+
+                // Verify the request is not serviceable
+                assert_matches!(response, StorageServiceError::InvalidRequest(_));
+            }
+        }
+    }
+}
+
+/// A helper method to request a transactions with proof chunk using
 /// the specified network limit.
-async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64) {
+async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64, use_request_v2: bool) {
     for use_compression in [true, false] {
         for include_events in [true, false] {
             // Create test data
@@ -202,6 +273,7 @@ async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64) {
             let mut expectation_sequence = Sequence::new();
             let mut chunk_size = max_transaction_chunk_size;
             while chunk_size >= 1 {
+                // Expect a call to get transactions with the specified chunk size
                 let transaction_list_with_proof = utils::create_transaction_list_using_sizes(
                     start_version,
                     chunk_size,
@@ -219,12 +291,30 @@ async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64) {
                     )
                     .in_sequence(&mut expectation_sequence)
                     .returning(move |_, _, _, _| Ok(transaction_list_with_proof.clone()));
+
+                // Expect a call to get persisted auxiliary infos if v2 is enabled
+                if use_request_v2 {
+                    let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                        start_version,
+                        start_version + chunk_size - 1,
+                        use_request_v2,
+                    )
+                    .unwrap();
+                    let persisted_auxiliary_infos = persisted_auxiliary_infos.into_iter().map(Ok);
+                    db_reader
+                        .expect_get_persisted_auxiliary_info_iterator()
+                        .times(1)
+                        .with(eq(start_version), eq(chunk_size as usize))
+                        .returning(move |_, _| Ok(Box::new(persisted_auxiliary_infos.clone())));
+                }
+
                 chunk_size /= 2;
             }
 
             // Create a storage config with the specified max network byte limit
             let storage_config = StorageServiceConfig {
                 max_network_chunk_bytes: network_limit_bytes,
+                enable_transaction_data_v2: use_request_v2,
                 ..Default::default()
             };
 
@@ -242,24 +332,34 @@ async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64) {
                 proof_version,
                 include_events,
                 use_compression,
+                use_request_v2,
             )
             .await
             .unwrap();
 
             // Verify the response is correct
-            match response.get_data_response().unwrap() {
+            let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
+            let num_transactions = match response.get_data_response().unwrap() {
                 DataResponse::TransactionsWithProof(transactions_with_proof) => {
-                    let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
-                    let num_transactions = transactions_with_proof.transactions.len() as u64;
-                    if num_response_bytes > network_limit_bytes {
-                        assert_eq!(num_transactions, 1); // Data cannot be reduced more than a single item
-                    } else {
-                        let max_transactions = network_limit_bytes / min_bytes_per_transaction;
-                        assert!(num_transactions <= max_transactions); // Verify data fits correctly into the limit
-                    }
+                    transactions_with_proof.transactions.len() as u64
+                },
+                DataResponse::TransactionDataWithProof(transaction_data_with_proof) => {
+                    let transaction_list_with_proof_v2 = transaction_data_with_proof
+                        .transaction_list_with_proof
+                        .unwrap();
+                    transaction_list_with_proof_v2
+                        .get_transaction_list_with_proof()
+                        .transactions
+                        .len() as u64
                 },
                 _ => panic!("Expected transactions with proof but got: {:?}", response),
             };
+            if num_response_bytes > network_limit_bytes {
+                assert_eq!(num_transactions, 1); // Data cannot be reduced more than a single item
+            } else {
+                let max_transactions = network_limit_bytes / min_bytes_per_transaction;
+                assert!(num_transactions <= max_transactions); // Verify data fits correctly into the limit
+            }
         }
     }
 }

--- a/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
@@ -4,54 +4,161 @@
 use crate::tests::{mock, mock::MockClient, utils};
 use aptos_config::config::StorageServiceConfig;
 use aptos_storage_service_types::{
-    requests::{DataRequest, TransactionsOrOutputsWithProofRequest},
-    responses::{DataResponse, StorageServiceResponse},
+    requests::{
+        DataRequest, GetTransactionDataWithProofRequest, TransactionDataRequestType,
+        TransactionOrOutputData, TransactionsOrOutputsWithProofRequest,
+    },
+    responses::{DataResponse, StorageServiceResponse, TransactionDataResponseType},
     StorageServiceError,
 };
-use aptos_types::transaction::{TransactionListWithProof, TransactionOutputListWithProof};
+use aptos_types::transaction::{
+    PersistedAuxiliaryInfo, TransactionListWithProof, TransactionOutputListWithProof,
+};
 use claims::assert_matches;
 use mockall::{predicate::eq, Sequence};
 
 #[tokio::test]
 async fn test_get_transactions_or_outputs_with_proof() {
-    // Test small and large chunk requests
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [1, 100, max_output_chunk_size] {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk requests
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [1, 100, max_output_chunk_size] {
+            // Test fallback to transaction syncing
+            for fallback_to_transactions in [false, true] {
+                // Create test data
+                let start_version = 0;
+                let end_version = start_version + chunk_size - 1;
+                let proof_version = end_version;
+                let output_list_with_proof =
+                    utils::create_output_list_with_proof(start_version, end_version, proof_version);
+                let transaction_list_with_proof = utils::create_transaction_list_with_proof(
+                    start_version,
+                    end_version,
+                    proof_version,
+                    false,
+                );
+                let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                    start_version,
+                    end_version,
+                    use_request_v2,
+                );
+
+                // Create the mock db reader
+                let max_num_output_reductions = 5;
+                let mut db_reader = mock::create_mock_db_reader();
+                for i in 0..=max_num_output_reductions {
+                    utils::expect_get_transaction_outputs(
+                        &mut db_reader,
+                        start_version,
+                        (chunk_size as u32 / (u32::pow(2, i as u32))) as u64,
+                        proof_version,
+                        output_list_with_proof.clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos.clone(),
+                    );
+                }
+                if fallback_to_transactions {
+                    utils::expect_get_transactions(
+                        &mut db_reader,
+                        start_version,
+                        chunk_size,
+                        proof_version,
+                        false,
+                        transaction_list_with_proof.clone(),
+                        use_request_v2,
+                        persisted_auxiliary_infos.clone(),
+                    );
+                }
+
+                // Create the storage client and server
+                let storage_config = utils::configure_network_chunk_limit(
+                    fallback_to_transactions,
+                    &output_list_with_proof,
+                    &transaction_list_with_proof,
+                    use_request_v2,
+                );
+                let (mut mock_client, mut service, _, _, _) =
+                    MockClient::new(Some(db_reader), Some(storage_config));
+                utils::update_storage_server_summary(&mut service, proof_version + 100, 10);
+                tokio::spawn(service.start());
+
+                // Create a request to fetch transactions or outputs with a proof
+                let response = get_transactions_or_outputs_with_proof(
+                    &mut mock_client,
+                    start_version,
+                    end_version,
+                    end_version,
+                    false,
+                    max_num_output_reductions,
+                    true,
+                    use_request_v2,
+                )
+                .await
+                .unwrap();
+
+                // Verify the response is correct
+                verify_transactions_or_output_response(
+                    use_request_v2,
+                    fallback_to_transactions,
+                    &output_list_with_proof,
+                    &transaction_list_with_proof,
+                    &persisted_auxiliary_infos,
+                    &response,
+                );
+            }
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_or_outputs_with_proof_chunk_limit() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
         // Test fallback to transaction syncing
         for fallback_to_transactions in [false, true] {
             // Create test data
+            let max_output_chunk_size =
+                StorageServiceConfig::default().max_transaction_output_chunk_size;
+            let max_transaction_chunk_size =
+                StorageServiceConfig::default().max_transaction_chunk_size;
+            let chunk_size = max_output_chunk_size * 10; // Set a chunk request larger than the max
             let start_version = 0;
-            let end_version = start_version + chunk_size - 1;
+            let end_version = start_version + max_output_chunk_size - 1;
             let proof_version = end_version;
             let output_list_with_proof =
                 utils::create_output_list_with_proof(start_version, end_version, proof_version);
             let transaction_list_with_proof = utils::create_transaction_list_with_proof(
                 start_version,
-                start_version,
+                end_version,
                 proof_version,
                 false,
-            ); // Creates a small transaction list
+            );
+            let persisted_auxiliary_infos =
+                utils::create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
 
             // Create the mock db reader
-            let max_num_output_reductions = 5;
             let mut db_reader = mock::create_mock_db_reader();
-            for i in 0..=max_num_output_reductions {
-                utils::expect_get_transaction_outputs(
-                    &mut db_reader,
-                    start_version,
-                    (chunk_size as u32 / (u32::pow(2, i as u32))) as u64,
-                    proof_version,
-                    output_list_with_proof.clone(),
-                );
-            }
+            utils::expect_get_transaction_outputs(
+                &mut db_reader,
+                start_version,
+                max_output_chunk_size,
+                proof_version,
+                output_list_with_proof.clone(),
+                use_request_v2,
+                persisted_auxiliary_infos.clone(),
+            );
             if fallback_to_transactions {
                 utils::expect_get_transactions(
                     &mut db_reader,
                     start_version,
-                    chunk_size,
+                    max_transaction_chunk_size,
                     proof_version,
                     false,
                     transaction_list_with_proof.clone(),
+                    use_request_v2,
+                    persisted_auxiliary_infos.clone(),
                 );
             }
 
@@ -60,10 +167,132 @@ async fn test_get_transactions_or_outputs_with_proof() {
                 fallback_to_transactions,
                 &output_list_with_proof,
                 &transaction_list_with_proof,
+                use_request_v2,
             );
             let (mut mock_client, mut service, _, _, _) =
                 MockClient::new(Some(db_reader), Some(storage_config));
-            utils::update_storage_server_summary(&mut service, proof_version + 100, 10);
+            utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
+            tokio::spawn(service.start());
+
+            // Create a request to fetch transactions or outputs with a proof
+            let response = get_transactions_or_outputs_with_proof(
+                &mut mock_client,
+                start_version,
+                start_version + chunk_size - 1,
+                end_version,
+                false,
+                0,
+                false,
+                use_request_v2,
+            )
+            .await
+            .unwrap();
+
+            // Verify the response is correct
+            verify_transactions_or_output_response(
+                use_request_v2,
+                fallback_to_transactions,
+                &output_list_with_proof,
+                &transaction_list_with_proof,
+                &persisted_auxiliary_infos,
+                &response,
+            );
+        }
+    }
+}
+
+#[tokio::test]
+#[should_panic(expected = "Canceled")]
+async fn test_get_transactions_or_outputs_with_proof_disable_v2() {
+    // Create a storage service config with transaction v2 disabled
+    let storage_config = utils::create_storage_config(false);
+
+    // Create the storage client and server
+    let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+    tokio::spawn(service.start());
+
+    // Send a transaction v2 request. This will cause a test panic
+    // as no response will be received (the receiver is dropped).
+    get_transactions_or_outputs_with_proof(
+        &mut mock_client,
+        0,
+        10,
+        10,
+        false,
+        3,
+        true,
+        true, // Use transaction v2
+    )
+    .await
+    .unwrap();
+}
+
+#[tokio::test]
+async fn test_get_transactions_or_outputs_with_proof_invalid() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Create a storage service config
+        let storage_config = utils::create_storage_config(use_request_v2);
+
+        // Create the storage client and server
+        let (mut mock_client, service, _, _, _) = MockClient::new(None, Some(storage_config));
+        tokio::spawn(service.start());
+
+        // Test invalid ranges
+        let start_version = 1000;
+        for end_version in [0, 999] {
+            let response = get_transactions_or_outputs_with_proof(
+                &mut mock_client,
+                start_version,
+                end_version,
+                end_version,
+                false,
+                3,
+                true,
+                use_request_v2,
+            )
+            .await
+            .unwrap_err();
+            assert_matches!(response, StorageServiceError::InvalidRequest(_));
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_or_outputs_with_proof_network_limit() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test different byte limits
+        for network_limit_bytes in [1, 2 * 1024, 4 * 1024] {
+            get_transactions_or_outputs_with_proof_network_limit(
+                network_limit_bytes,
+                use_request_v2,
+            )
+            .await;
+        }
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_or_outputs_with_proof_not_serviceable() {
+    // Test both v1 and v2 data requests
+    for use_request_v2 in [false, true] {
+        // Test small and large chunk requests
+        let max_output_chunk_size =
+            StorageServiceConfig::default().max_transaction_output_chunk_size;
+        for chunk_size in [2, 100, max_output_chunk_size] {
+            // Create test data
+            let start_version = 0;
+            let end_version = start_version + chunk_size - 1;
+            let proof_version = end_version;
+
+            // Create a storage service config
+            let storage_config = utils::create_storage_config(use_request_v2);
+
+            // Create the storage client and server (that cannot service the request)
+            let (mut mock_client, mut service, _, _, _) =
+                MockClient::new(None, Some(storage_config));
+            utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
             tokio::spawn(service.start());
 
             // Create a request to fetch transactions or outputs with a proof
@@ -73,160 +302,16 @@ async fn test_get_transactions_or_outputs_with_proof() {
                 end_version,
                 end_version,
                 false,
-                max_num_output_reductions,
+                5,
                 true,
+                use_request_v2,
             )
             .await
-            .unwrap();
+            .unwrap_err();
 
-            // Verify the response is correct
-            verify_transactions_or_output_response(
-                fallback_to_transactions,
-                &output_list_with_proof,
-                &transaction_list_with_proof,
-                &response,
-            );
+            // Verify the request is not serviceable
+            assert_matches!(response, StorageServiceError::InvalidRequest(_));
         }
-    }
-}
-
-#[tokio::test]
-async fn test_get_transactions_or_outputs_with_proof_chunk_limit() {
-    // Test fallback to transaction syncing
-    for fallback_to_transactions in [false, true] {
-        // Create test data
-        let max_output_chunk_size =
-            StorageServiceConfig::default().max_transaction_output_chunk_size;
-        let max_transaction_chunk_size = StorageServiceConfig::default().max_transaction_chunk_size;
-        let chunk_size = max_output_chunk_size * 10; // Set a chunk request larger than the max
-        let start_version = 0;
-        let end_version = start_version + max_output_chunk_size - 1;
-        let proof_version = end_version;
-        let output_list_with_proof =
-            utils::create_output_list_with_proof(start_version, end_version, proof_version);
-        let transaction_list_with_proof = utils::create_transaction_list_with_proof(
-            start_version,
-            start_version,
-            proof_version,
-            false,
-        ); // Creates a small transaction list
-
-        // Create the mock db reader
-        let mut db_reader = mock::create_mock_db_reader();
-        utils::expect_get_transaction_outputs(
-            &mut db_reader,
-            start_version,
-            max_output_chunk_size,
-            proof_version,
-            output_list_with_proof.clone(),
-        );
-        if fallback_to_transactions {
-            utils::expect_get_transactions(
-                &mut db_reader,
-                start_version,
-                max_transaction_chunk_size,
-                proof_version,
-                false,
-                transaction_list_with_proof.clone(),
-            );
-        }
-
-        // Create the storage client and server
-        let storage_config = utils::configure_network_chunk_limit(
-            fallback_to_transactions,
-            &output_list_with_proof,
-            &transaction_list_with_proof,
-        );
-        let (mut mock_client, mut service, _, _, _) =
-            MockClient::new(Some(db_reader), Some(storage_config));
-        utils::update_storage_server_summary(&mut service, proof_version + chunk_size, 10);
-        tokio::spawn(service.start());
-
-        // Create a request to fetch transactions outputs with a proof
-        let response = get_transactions_or_outputs_with_proof(
-            &mut mock_client,
-            start_version,
-            start_version + chunk_size - 1,
-            end_version,
-            false,
-            0,
-            false,
-        )
-        .await
-        .unwrap();
-
-        // Verify the response is correct
-        verify_transactions_or_output_response(
-            fallback_to_transactions,
-            &output_list_with_proof,
-            &transaction_list_with_proof,
-            &response,
-        );
-    }
-}
-
-#[tokio::test]
-async fn test_get_transactions_or_outputs_with_proof_invalid() {
-    // Create the storage client and server
-    let (mut mock_client, service, _, _, _) = MockClient::new(None, None);
-    tokio::spawn(service.start());
-
-    // Test invalid ranges
-    let start_version = 1000;
-    for end_version in [0, 999] {
-        let response = get_transactions_or_outputs_with_proof(
-            &mut mock_client,
-            start_version,
-            end_version,
-            end_version,
-            false,
-            3,
-            true,
-        )
-        .await
-        .unwrap_err();
-        assert_matches!(response, StorageServiceError::InvalidRequest(_));
-    }
-}
-
-#[tokio::test]
-async fn test_get_transactions_or_outputs_with_proof_network_limit() {
-    // Test different byte limits
-    for network_limit_bytes in [1, 2 * 1024, 10 * 1024, 30 * 1024] {
-        get_transactions_or_outputs_with_proof_network_limit(network_limit_bytes).await;
-    }
-}
-
-#[tokio::test]
-async fn test_get_transactions_or_outputs_with_proof_not_serviceable() {
-    // Test small and large chunk requests
-    let max_output_chunk_size = StorageServiceConfig::default().max_transaction_output_chunk_size;
-    for chunk_size in [2, 100, max_output_chunk_size] {
-        // Create test data
-        let start_version = 0;
-        let end_version = start_version + chunk_size - 1;
-        let proof_version = end_version;
-
-        // Create the storage client and server (that cannot service the request)
-        let (mut mock_client, mut service, _, _, _) = MockClient::new(None, None);
-        utils::update_storage_server_summary(&mut service, proof_version - 1, 10);
-        tokio::spawn(service.start());
-
-        // Create a request to fetch transactions or outputs with a proof
-        let response = get_transactions_or_outputs_with_proof(
-            &mut mock_client,
-            start_version,
-            end_version,
-            end_version,
-            false,
-            5,
-            true,
-        )
-        .await
-        .unwrap_err();
-
-        // Verify the request is not serviceable
-        assert_matches!(response, StorageServiceError::InvalidRequest(_));
     }
 }
 
@@ -239,21 +324,38 @@ async fn get_transactions_or_outputs_with_proof(
     include_events: bool,
     max_num_output_reductions: u64,
     use_compression: bool,
+    use_request_v2: bool,
 ) -> Result<StorageServiceResponse, StorageServiceError> {
-    let data_request =
+    let data_request = if use_request_v2 {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+                include_events,
+            });
+        DataRequest::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            proof_version,
+            start_version,
+            end_version,
+            max_response_bytes: 0,
+        })
+    } else {
         DataRequest::GetTransactionsOrOutputsWithProof(TransactionsOrOutputsWithProofRequest {
             proof_version,
             start_version,
             end_version,
             include_events,
             max_num_output_reductions,
-        });
+        })
+    };
     utils::send_storage_request(mock_client, use_compression, data_request).await
 }
 
-/// A helper method to request transactions or outputs with proof using the
+/// A helper method to request transactions or outputs with proof using
 /// the specified network limit.
-async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_bytes: u64) {
+async fn get_transactions_or_outputs_with_proof_network_limit(
+    network_limit_bytes: u64,
+    use_request_v2: bool,
+) {
     for use_compression in [true, false] {
         for include_events in [true, false] {
             // Create test data
@@ -267,9 +369,15 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
             // Create the mock db reader
             let mut db_reader = mock::create_mock_db_reader();
             let mut expectation_sequence = Sequence::new();
+
+            // Expect calls to get outputs with the specified chunk sizes
             let mut chunk_size = max_output_size;
             let mut max_num_output_reductions = 0;
             while chunk_size >= 1 {
+                if use_request_v2 && max_num_output_reductions > 0 {
+                    break; // No need to reduce outputs more than once in v2
+                }
+
                 let output_list_with_proof = utils::create_output_list_using_sizes(
                     start_version,
                     chunk_size,
@@ -284,6 +392,8 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
                 chunk_size /= 2;
                 max_num_output_reductions += 1;
             }
+
+            // Expect calls to get transactions with the specified chunk sizes
             let mut chunk_size = max_transaction_size;
             while chunk_size >= 1 {
                 let transaction_list_with_proof = utils::create_transaction_list_using_sizes(
@@ -306,9 +416,30 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
                 chunk_size /= 2;
             }
 
+            // Expect calls to get persisted auxiliary infos if v2 is enabled
+            if use_request_v2 {
+                let mut chunk_size = max_transaction_size;
+                while chunk_size >= 1 {
+                    let persisted_auxiliary_infos = utils::create_persisted_auxiliary_infos(
+                        start_version,
+                        start_version + chunk_size - 1,
+                        use_request_v2,
+                    )
+                    .unwrap();
+                    let persisted_auxiliary_infos = persisted_auxiliary_infos.into_iter().map(Ok);
+                    db_reader
+                        .expect_get_persisted_auxiliary_info_iterator()
+                        .times(1)
+                        .with(eq(start_version), eq(chunk_size as usize))
+                        .returning(move |_, _| Ok(Box::new(persisted_auxiliary_infos.clone())));
+                    chunk_size /= 2;
+                }
+            }
+
             // Create the storage client and server
             let storage_config = StorageServiceConfig {
                 max_network_chunk_bytes: network_limit_bytes,
+                enable_transaction_data_v2: use_request_v2,
                 ..Default::default()
             };
             let (mut mock_client, mut service, _, _, _) =
@@ -325,40 +456,56 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
                 include_events,
                 max_num_output_reductions,
                 use_compression,
+                use_request_v2,
             )
             .await
             .unwrap();
 
             // Verify the response is correct
             match response.get_data_response().unwrap() {
-                DataResponse::TransactionsOrOutputsWithProof(
-                    transactions_or_outputs_with_proof,
-                ) => {
-                    let (transactions_with_proof, outputs_with_proof) =
-                        transactions_or_outputs_with_proof;
-
+                DataResponse::TransactionsOrOutputsWithProof((
+                    transactions_with_proof,
+                    outputs_with_proof,
+                )) => {
                     if let Some(transactions_with_proof) = transactions_with_proof {
-                        let num_response_bytes =
-                            bcs::serialized_size(&transactions_with_proof).unwrap() as u64;
-                        let num_transactions = transactions_with_proof.transactions.len() as u64;
-                        if num_response_bytes > network_limit_bytes {
-                            assert_eq!(num_transactions, 1); // Data cannot be reduced more than a single item
-                        } else {
-                            let max_transactions = network_limit_bytes / min_bytes_per_transaction;
-                            assert!(num_transactions <= max_transactions);
-                        }
+                        check_transaction_response_bytes(
+                            network_limit_bytes,
+                            min_bytes_per_transaction,
+                            &transactions_with_proof,
+                        );
                     } else if let Some(outputs_with_proof) = outputs_with_proof {
-                        let num_response_bytes =
-                            bcs::serialized_size(&outputs_with_proof).unwrap() as u64;
-                        let num_outputs = outputs_with_proof.transactions_and_outputs.len() as u64;
-                        if num_response_bytes > network_limit_bytes {
-                            assert_eq!(num_outputs, 1); // Data cannot be reduced more than a single item
-                        } else {
-                            let max_outputs = network_limit_bytes / min_bytes_per_output;
-                            assert!(num_outputs <= max_outputs);
-                        }
+                        check_output_response_bytes(
+                            network_limit_bytes,
+                            min_bytes_per_output,
+                            &outputs_with_proof,
+                        );
                     } else {
                         panic!("No transactions or outputs were returned!");
+                    }
+                },
+                DataResponse::TransactionDataWithProof(transaction_data_with_proof_response) => {
+                    match transaction_data_with_proof_response.transaction_data_response_type {
+                        TransactionDataResponseType::TransactionData => {
+                            let transaction_list_with_proof_v2 =
+                                transaction_data_with_proof_response
+                                    .transaction_list_with_proof
+                                    .unwrap();
+                            check_transaction_response_bytes(
+                                network_limit_bytes,
+                                min_bytes_per_transaction,
+                                transaction_list_with_proof_v2.get_transaction_list_with_proof(),
+                            );
+                        },
+                        TransactionDataResponseType::TransactionOutputData => {
+                            let output_list_with_proof_v2 = transaction_data_with_proof_response
+                                .transaction_output_list_with_proof
+                                .unwrap();
+                            check_output_response_bytes(
+                                network_limit_bytes,
+                                min_bytes_per_output,
+                                output_list_with_proof_v2.get_output_list_with_proof(),
+                            );
+                        },
                     }
                 },
                 _ => panic!(
@@ -370,17 +517,71 @@ async fn get_transactions_or_outputs_with_proof_network_limit(network_limit_byte
     }
 }
 
+/// Checks that the number of bytes in the output response is valid
+fn check_output_response_bytes(
+    network_limit_bytes: u64,
+    min_bytes_per_output: u64,
+    outputs_with_proof: &TransactionOutputListWithProof,
+) {
+    let num_response_bytes = bcs::serialized_size(&outputs_with_proof).unwrap() as u64;
+    let num_outputs = outputs_with_proof.transactions_and_outputs.len() as u64;
+
+    if num_response_bytes > network_limit_bytes {
+        assert_eq!(num_outputs, 1); // Data cannot be reduced more than a single item
+    } else {
+        let max_outputs = network_limit_bytes / min_bytes_per_output;
+        assert!(num_outputs <= max_outputs);
+    }
+}
+
+/// Checks that the number of bytes in the transaction response is valid
+fn check_transaction_response_bytes(
+    network_limit_bytes: u64,
+    min_bytes_per_transaction: u64,
+    transactions_with_proof: &TransactionListWithProof,
+) {
+    let num_response_bytes = bcs::serialized_size(&transactions_with_proof).unwrap() as u64;
+    let num_transactions = transactions_with_proof.transactions.len() as u64;
+
+    if num_response_bytes > network_limit_bytes {
+        assert_eq!(num_transactions, 1); // Data cannot be reduced more than a single item
+    } else {
+        let max_transactions = network_limit_bytes / min_bytes_per_transaction;
+        assert!(num_transactions <= max_transactions);
+    }
+}
+
 /// Verifies that a transactions or outputs with proof response is received
 /// and that the response contains the correct data.
 fn verify_transactions_or_output_response(
+    use_request_v2: bool,
     fallback_to_transactions: bool,
     output_list_with_proof: &TransactionOutputListWithProof,
     transaction_list_with_proof: &TransactionListWithProof,
+    persisted_auxiliary_infos: &Option<Vec<PersistedAuxiliaryInfo>>,
     response: &StorageServiceResponse,
 ) {
-    match response.get_data_response().unwrap() {
-        DataResponse::TransactionsOrOutputsWithProof(transactions_or_outputs_with_proof) => {
-            let (transactions_with_proof, outputs_with_proof) = transactions_or_outputs_with_proof;
+    // Get the data response
+    let data_response = response.get_data_response().unwrap();
+
+    // Verify the response type (v1 or v2)
+    match &data_response {
+        DataResponse::TransactionsOrOutputsWithProof(_) => assert!(!use_request_v2),
+        DataResponse::TransactionDataWithProof(_) => {
+            assert!(use_request_v2)
+        },
+        _ => panic!(
+            "Expected transactions or outputs with proof but got: {:?}",
+            response
+        ),
+    }
+
+    // Verify the response data
+    match data_response {
+        DataResponse::TransactionsOrOutputsWithProof((
+            transactions_with_proof,
+            outputs_with_proof,
+        )) => {
             if fallback_to_transactions {
                 assert_eq!(
                     transactions_with_proof.unwrap(),
@@ -390,9 +591,50 @@ fn verify_transactions_or_output_response(
                 assert_eq!(outputs_with_proof.unwrap(), output_list_with_proof.clone());
             }
         },
+        DataResponse::TransactionDataWithProof(transaction_data_with_proof) => {
+            if fallback_to_transactions {
+                // Verify the data type
+                assert_eq!(
+                    transaction_data_with_proof.transaction_data_response_type,
+                    TransactionDataResponseType::TransactionData
+                );
+
+                // Verify the transaction data and auxiliary infos
+                let transaction_list_with_proof_v2 = transaction_data_with_proof
+                    .transaction_list_with_proof
+                    .unwrap();
+                assert_eq!(
+                    transaction_list_with_proof_v2.get_transaction_list_with_proof(),
+                    transaction_list_with_proof
+                );
+                assert_eq!(
+                    transaction_list_with_proof_v2.get_persisted_auxiliary_infos(),
+                    &persisted_auxiliary_infos.clone().unwrap(),
+                );
+            } else {
+                // Verify the data type
+                assert_eq!(
+                    transaction_data_with_proof.transaction_data_response_type,
+                    TransactionDataResponseType::TransactionOutputData
+                );
+
+                // Verify the output data and auxiliary infos
+                let output_list_with_proof_v2 = transaction_data_with_proof
+                    .transaction_output_list_with_proof
+                    .unwrap();
+                assert_eq!(
+                    output_list_with_proof_v2.get_output_list_with_proof(),
+                    output_list_with_proof
+                );
+                assert_eq!(
+                    output_list_with_proof_v2.get_persisted_auxiliary_infos(),
+                    &persisted_auxiliary_infos.clone().unwrap(),
+                );
+            }
+        },
         _ => panic!(
             "Expected transactions or outputs with proof but got: {:?}",
             response
         ),
-    };
+    }
 }

--- a/state-sync/storage-service/server/src/utils.rs
+++ b/state-sync/storage-service/server/src/utils.rs
@@ -10,7 +10,10 @@ use aptos_config::network_id::PeerNetworkId;
 use aptos_metrics_core::HistogramVec;
 use aptos_storage_service_types::{
     requests::{DataRequest, EpochEndingLedgerInfoRequest, StorageServiceRequest},
-    responses::{DataResponse, StorageServerSummary, StorageServiceResponse},
+    responses::{
+        DataResponse, NewTransactionDataWithProofResponse, StorageServerSummary,
+        StorageServiceResponse,
+    },
 };
 use aptos_time_service::TimeService;
 use aptos_types::ledger_info::LedgerInfoWithSignatures;
@@ -144,6 +147,17 @@ pub fn notify_peer_of_new_data<T: StorageReaderInterface>(
                         "Failed to get a transaction or output response for peer!".into(),
                     ));
                 }
+            },
+            Ok(DataResponse::TransactionDataWithProof(transaction_data_with_proof)) => {
+                DataResponse::NewTransactionDataWithProof(NewTransactionDataWithProofResponse {
+                    transaction_data_response_type: transaction_data_with_proof
+                        .transaction_data_response_type,
+                    transaction_list_with_proof: transaction_data_with_proof
+                        .transaction_list_with_proof,
+                    transaction_output_list_with_proof: transaction_data_with_proof
+                        .transaction_output_list_with_proof,
+                    ledger_info_with_signatures: target_ledger_info,
+                })
             },
             data_response => {
                 return Err(Error::UnexpectedErrorEncountered(format!(

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -4,6 +4,7 @@
 use aptos_storage_interface::state_store::{
     state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
 };
+use aptos_types::transaction::PersistedAuxiliaryInfo;
 use aptos_types::{block_info::BlockHeight, transaction::IndexedTransactionSummary};
 
 impl DbReader for AptosDB {

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -362,6 +362,23 @@ impl DbReader for AptosDB {
         })
     }
 
+    /// Returns an iterator that yields the requested number of persisted auxiliary
+    /// info's starting from the specified version. Note: the caller should ensure
+    /// that the iterator does not query data beyond the latest version.
+    fn get_persisted_auxiliary_info_iterator(
+        &self,
+        start_version: Version,
+        num_persisted_auxiliary_info: usize,
+    ) -> Result<Box<dyn Iterator<Item = Result<PersistedAuxiliaryInfo>> + '_>> {
+        gauged_api("get_persisted_auxiliary_info_iterator", || {
+            let iter = self
+                .ledger_db
+                .persisted_auxiliary_info_db()
+                .get_persisted_auxiliary_info_iter(start_version, num_persisted_auxiliary_info)?;
+            Ok(Box::new(iter) as Box<dyn Iterator<Item = Result<PersistedAuxiliaryInfo>> + '_>)
+        })
+    }
+
     /// TODO(bowu): Deprecate after internal index migration
     fn get_events(
         &self,

--- a/storage/aptosdb/src/db/include/aptosdb_testonly.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_testonly.rs
@@ -6,7 +6,7 @@ use aptos_config::config::{
 };
 use aptos_executor_types::transactions_with_output::TransactionsToKeep;
 use aptos_storage_interface::state_store::state_summary::ProvableStateSummary;
-use aptos_types::transaction::{PersistedAuxiliaryInfo, TransactionStatus, TransactionToCommit};
+use aptos_types::transaction::{TransactionStatus, TransactionToCommit};
 use std::default::Default;
 
 impl AptosDB {

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -25,8 +25,8 @@ use aptos_types::{
         table::{TableHandle, TableInfo},
     },
     transaction::{
-        AccountOrderedTransactionsWithProof, IndexedTransactionSummary, Transaction,
-        TransactionAuxiliaryData, TransactionInfo, TransactionListWithProof,
+        AccountOrderedTransactionsWithProof, IndexedTransactionSummary, PersistedAuxiliaryInfo,
+        Transaction, TransactionAuxiliaryData, TransactionInfo, TransactionListWithProof,
         TransactionOutputListWithProof, TransactionToCommit, TransactionWithProof, Version,
     },
     write_set::WriteSet,
@@ -165,6 +165,15 @@ pub trait DbReader: Send + Sync {
             &self,
             version: Version,
         ) -> Result<Option<TransactionAuxiliaryData>>;
+
+        /// See [AptosDB::get_persisted_auxiliary_info_iterator].
+        ///
+        /// [AptosDB::get_persisted_auxiliary_info_iterator]: ../aptosdb/struct.AptosDB.html#method.get_persisted_auxiliary_info_iterator
+        fn get_persisted_auxiliary_info_iterator(
+            &self,
+            start_version: Version,
+            num_persisted_auxiliary_info: usize,
+        ) -> Result<Box<dyn Iterator<Item = Result<PersistedAuxiliaryInfo>> + '_>>;
 
         /// See [AptosDB::get_first_txn_version].
         ///


### PR DESCRIPTION
Notes:
- 95% of this PR is me updating 60+ unit tests. 😓 The line count is also artificially increased because the diffs can't tell when I've added lines around code blocks 👀

## Description
This PR adds new RPC response types for transaction v2 data in state sync. It offers the following commits:
1. Add the new response types, including the transaction v2 lists and the storage service functionality to read the auxiliary data from the DB.
2. Update unit tests to the various components. This is the large commit, and just boilerplate.

## Testing Plan
New and existing test infrastructure.