### PR TITLE
[hot state] Allow getting LRU entry from HotStateView

### DIFF
--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -218,7 +218,7 @@ impl CachedStateView {
         let ret = if let Some(slot) = self.speculative.get_state_slot(state_key) {
             COUNTER.inc_with(&["sv_hit_speculative"]);
             slot
-        } else if let Some(slot) = self.hot.get_state_slot(state_key)? {
+        } else if let Some(slot) = self.hot.get_state_slot(state_key) {
             COUNTER.inc_with(&["sv_hit_hot"]);
             slot
         } else if let Some(base_version) = self.base_version() {

--- a/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
@@ -2,17 +2,23 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot, StateViewResult};
+use aptos_types::state_store::{hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot};
 
 /// A view into the hot state store, whose content overlays on top of the cold state store content.
 pub trait HotStateView: Send + Sync {
-    fn get_state_slot(&self, state_key: &StateKey) -> StateViewResult<Option<StateSlot>>;
+    fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot>;
+
+    fn get_lru_entry(&self, state_key: &StateKey) -> Option<LRUEntry<StateKey>>;
 }
 
 pub struct EmptyHotState;
 
 impl HotStateView for EmptyHotState {
-    fn get_state_slot(&self, _state_key: &StateKey) -> StateViewResult<Option<StateSlot>> {
-        Ok(None)
+    fn get_state_slot(&self, _state_key: &StateKey) -> Option<StateSlot> {
+        None
+    }
+
+    fn get_lru_entry(&self, _state_key: &StateKey) -> Option<LRUEntry<StateKey>> {
+        None
     }
 }

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -1,0 +1,10 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#[derive(Clone, Debug)]
+pub struct LRUEntry<K> {
+    /// The key that is slightly newer than the current entry. `None` for the newest entry.
+    pub prev: Option<K>,
+    /// The key that is slightly older than the current entry. `None` for the oldest entry.
+    pub next: Option<K>,
+}

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -17,6 +17,7 @@ use std::hash::Hash;
 use std::ops::Deref;
 
 pub mod errors;
+pub mod hot_state;
 pub mod state_key;
 pub mod state_slot;
 pub mod state_storage_usage;


### PR DESCRIPTION

This change adds a new method `get_lru_entry` on `HotStateView` to allow the
caller to retrieve the LRU entry from hot state.
