### PR TITLE
[compiler-v2] Fix cyclic instantiaton checker to consider function types

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_16938.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_16938.exp
@@ -1,0 +1,75 @@
+
+Diagnostics:
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+  ┌─ tests/checking-lang-v2.2/bug_16938.move:4:9
+  │
+4 │     fun f<T>() {
+  │         ^
+  │
+  = `f<T>` uses `f<|T|>` at tests/checking-lang-v2.2/bug_16938.move:5
+
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+   ┌─ tests/checking-lang-v2.2/bug_16938.move:10:16
+   │
+10 │     public fun foo<T>(): || {
+   │                ^^^
+   │
+   = `foo<T>` uses `bar<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:11
+   = `bar<|&T|>` uses `foo<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:15
+
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+   ┌─ tests/checking-lang-v2.2/bug_16938.move:14:9
+   │
+14 │     fun bar<T>() {
+   │         ^^^
+   │
+   = `bar<T>` uses `foo<T>` at tests/checking-lang-v2.2/bug_16938.move:15
+   = `foo<T>` uses `bar<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:11
+
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+   ┌─ tests/checking-lang-v2.2/bug_16938.move:25:16
+   │
+25 │     public fun foo<T>(): ||(||) {
+   │                ^^^
+   │
+   = `foo<T>` uses `bar<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:26
+   = `bar<|&T|>` uses `maker<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:30
+   = `maker<|&T|>` uses `foo<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:34
+
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+   ┌─ tests/checking-lang-v2.2/bug_16938.move:29:9
+   │
+29 │     fun bar<T>(): || {
+   │         ^^^
+   │
+   = `bar<T>` uses `maker<T>` at tests/checking-lang-v2.2/bug_16938.move:30
+   = `maker<T>` uses `foo<T>` at tests/checking-lang-v2.2/bug_16938.move:34
+   = `foo<T>` uses `bar<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:26
+
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+   ┌─ tests/checking-lang-v2.2/bug_16938.move:33:9
+   │
+33 │     fun maker<T>(): ||(||(||)) {
+   │         ^^^^^
+   │
+   = `maker<T>` uses `foo<T>` at tests/checking-lang-v2.2/bug_16938.move:34
+   = `foo<T>` uses `bar<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:26
+   = `bar<|&T|>` uses `maker<|&T|>` at tests/checking-lang-v2.2/bug_16938.move:30
+
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+   ┌─ tests/checking-lang-v2.2/bug_16938.move:44:16
+   │
+44 │     public fun foo<T>(): || {
+   │                ^^^
+   │
+   = `foo<T>` uses `bar<||(T, T)>` at tests/checking-lang-v2.2/bug_16938.move:45
+   = `bar<||(T, T)>` uses `foo<||(||(T, T))>` at tests/checking-lang-v2.2/bug_16938.move:49
+
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
+   ┌─ tests/checking-lang-v2.2/bug_16938.move:48:9
+   │
+48 │     fun bar<T>() {
+   │         ^^^
+   │
+   = `bar<T>` uses `foo<||T>` at tests/checking-lang-v2.2/bug_16938.move:49
+   = `foo<||T>` uses `bar<||(||T, ||T)>` at tests/checking-lang-v2.2/bug_16938.move:45

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_16938.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/bug_16938.move
@@ -1,0 +1,56 @@
+module 0xc0ffee::m {
+    struct S<T> { f: T }
+
+    fun f<T>() {
+        f<|T|>();
+    }
+}
+
+module 0xc0ffee::n {
+    public fun foo<T>(): || {
+        bar<|&T|>
+    }
+
+    fun bar<T>() {
+        (foo<T>())();
+    }
+
+    fun test() {
+        let f = foo<||>();
+        f();
+    }
+}
+
+module 0xc0ffee::o {
+    public fun foo<T>(): ||(||) {
+        bar<|&T|>
+    }
+
+    fun bar<T>(): || {
+        maker<T>()()()
+    }
+
+    fun maker<T>(): ||(||(||)) {
+        foo<T>
+    }
+
+    fun test() {
+        let f = foo<||>();
+        f()();
+    }
+}
+
+module 0xc0ffee::p {
+    public fun foo<T>(): || {
+        bar<||(T, T)>
+    }
+
+    fun bar<T>() {
+        (foo<||T>())();
+    }
+
+    fun test() {
+        let f = foo<||>();
+        f();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/recursive_type_instantiation.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/recursive_type_instantiation.exp
@@ -1,73 +1,73 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:6:16
   │
 6 │     public fun simple_recursion<T>() {
   │                ^^^^^^^^^^^^^^^^
   │
-  = `simple_recursion<T>` calls `simple_recursion<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:7
+  = `simple_recursion<T>` uses `simple_recursion<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:7
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:10:9
    │
 10 │     fun two_level_recursion_0<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^
    │
-   = `two_level_recursion_0<T>` calls `two_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:11
-   = `two_level_recursion_1<T>` calls `two_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:15
+   = `two_level_recursion_0<T>` uses `two_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:11
+   = `two_level_recursion_1<T>` uses `two_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:15
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:14:9
    │
 14 │     fun two_level_recursion_1<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^
    │
-   = `two_level_recursion_1<T>` calls `two_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:15
-   = `two_level_recursion_0<S<T>>` calls `two_level_recursion_1<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:11
+   = `two_level_recursion_1<T>` uses `two_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:15
+   = `two_level_recursion_0<S<T>>` uses `two_level_recursion_1<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:11
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:18:9
    │
 18 │     fun three_level_recursion_0<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `three_level_recursion_0<T>` calls `three_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
-   = `three_level_recursion_1<T>` calls `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
-   = `three_level_recursion_2<T>` calls `three_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
+   = `three_level_recursion_0<T>` uses `three_level_recursion_1<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
+   = `three_level_recursion_1<T>` uses `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
+   = `three_level_recursion_2<T>` uses `three_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:22:9
    │
 22 │     fun three_level_recursion_1<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `three_level_recursion_1<T>` calls `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
-   = `three_level_recursion_2<T>` calls `three_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
-   = `three_level_recursion_0<S<T>>` calls `three_level_recursion_1<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
+   = `three_level_recursion_1<T>` uses `three_level_recursion_2<T>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
+   = `three_level_recursion_2<T>` uses `three_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
+   = `three_level_recursion_0<S<T>>` uses `three_level_recursion_1<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:26:9
    │
 26 │     fun three_level_recursion_2<T>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `three_level_recursion_2<T>` calls `three_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
-   = `three_level_recursion_0<S<T>>` calls `three_level_recursion_1<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
-   = `three_level_recursion_1<S<T>>` calls `three_level_recursion_2<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
+   = `three_level_recursion_2<T>` uses `three_level_recursion_0<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:27
+   = `three_level_recursion_0<S<T>>` uses `three_level_recursion_1<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:19
+   = `three_level_recursion_1<S<T>>` uses `three_level_recursion_2<S<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:23
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:30:9
    │
 30 │     fun recurse_at_different_position<T1, T2>() {
    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    │
-   = `recurse_at_different_position<T1, T2>` calls `recurse_at_different_position<T2, S<T1>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:31
+   = `recurse_at_different_position<T1, T2>` uses `recurse_at_different_position<T2, S<T1>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:31
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/recursive_type_instantiation.move:44:9
    │
 44 │     fun test_vec<T>() {
    │         ^^^^^^^^
    │
-   = `test_vec<T>` calls `test_vec<vector<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:45
+   = `test_vec<T>` uses `test_vec<vector<T>>` at tests/cyclic-instantiation-checker/recursive_type_instantiation.move:45

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/complex_1.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/complex_1.exp
@@ -1,29 +1,29 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/complex_1.move:13:9
    │
 13 │     fun c<T1, T2>() {
    │         ^
    │
-   = `c<T1, T2>` calls `d<T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:15
-   = `d<T2>` calls `b<u64, T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:20
-   = `b<u64, T2>` calls `c<S<T2>, bool>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:10
+   = `c<T1, T2>` uses `d<T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:15
+   = `d<T2>` uses `b<u64, T2>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:20
+   = `b<u64, T2>` uses `c<S<T2>, bool>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:10
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/complex_1.move:26:9
    │
 26 │     fun f<T>() {
    │         ^
    │
-   = `f<T>` calls `g<T>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:27
-   = `g<T>` calls `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:31
+   = `f<T>` uses `g<T>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:27
+   = `g<T>` uses `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:31
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/complex_1.move:30:9
    │
 30 │     fun g<T>() {
    │         ^
    │
-   = `g<T>` calls `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:31
-   = `f<S<T>>` calls `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:27
+   = `g<T>` uses `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:31
+   = `f<S<T>>` uses `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/complex_1.move:27

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.exp
@@ -1,31 +1,31 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:4:9
   │
 4 │     fun f<T1, T2, T3>() {
   │         ^
   │
-  = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
-  = `g<T2, T3, T1>` calls `h<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
-  = `h<T2, T3, S<T1>>` calls `f<T2, bool, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
+  = `f<T1, T2, T3>` uses `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
+  = `g<T2, T3, T1>` uses `h<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
+  = `h<T2, T3, S<T1>>` uses `f<T2, bool, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:8:9
   │
 8 │     fun g<T1, T2, T3>() {
   │         ^
   │
-  = `g<T1, T2, T3>` calls `h<T1, T2, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
-  = `h<T1, T2, S<T3>>` calls `f<T1, bool, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
-  = `f<T1, bool, S<T3>>` calls `g<bool, S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
+  = `g<T1, T2, T3>` uses `h<T1, T2, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
+  = `h<T1, T2, S<T3>>` uses `f<T1, bool, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
+  = `f<T1, bool, S<T3>>` uses `g<bool, S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:12:9
    │
 12 │     fun h<T1, T2, T3>() {
    │         ^
    │
-   = `h<T1, T2, T3>` calls `f<T1, bool, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
-   = `f<T1, bool, T3>` calls `g<bool, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
-   = `g<bool, T3, T1>` calls `h<bool, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9
+   = `h<T1, T2, T3>` uses `f<T1, bool, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:14
+   = `f<T1, bool, T3>` uses `g<bool, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:5
+   = `g<bool, T3, T1>` uses `h<bool, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_non_generic_types_ok.move:9

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.exp
@@ -1,31 +1,31 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:4:9
   │
 4 │     fun f<T1, T2, T3>() {
   │         ^
   │
-  = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
-  = `g<T2, T3, T1>` calls `h<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
-  = `h<T2, T3, S<T1>>` calls `f<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
+  = `f<T1, T2, T3>` uses `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
+  = `g<T2, T3, T1>` uses `h<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
+  = `h<T2, T3, S<T1>>` uses `f<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:8:9
   │
 8 │     fun g<T1, T2, T3>() {
   │         ^
   │
-  = `g<T1, T2, T3>` calls `h<T1, T2, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
-  = `h<T1, T2, S<T3>>` calls `f<T1, T2, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
-  = `f<T1, T2, S<T3>>` calls `g<T2, S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
+  = `g<T1, T2, T3>` uses `h<T1, T2, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
+  = `h<T1, T2, S<T3>>` uses `f<T1, T2, S<T3>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
+  = `f<T1, T2, S<T3>>` uses `g<T2, S<T3>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:12:9
    │
 12 │     fun h<T1, T2, T3>() {
    │         ^
    │
-   = `h<T1, T2, T3>` calls `f<T1, T2, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
-   = `f<T1, T2, T3>` calls `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
-   = `g<T2, T3, T1>` calls `h<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9
+   = `h<T1, T2, T3>` uses `f<T1, T2, T3>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:13
+   = `f<T1, T2, T3>` uses `g<T2, T3, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:5
+   = `g<T2, T3, T1>` uses `h<T2, T3, S<T1>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_three_args_type_con_shifting.move:9

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.exp
@@ -1,19 +1,19 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:4:9
   │
 4 │     fun f<T1, T2, T3>() {
   │         ^
   │
-  = `f<T1, T2, T3>` calls `g<T2, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:5
-  = `g<T2, T1>` calls `f<T2, S<T1>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:9
+  = `f<T1, T2, T3>` uses `g<T2, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:5
+  = `g<T2, T1>` uses `f<T2, S<T1>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:9
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:8:9
   │
 8 │     fun g<T1, T2>() {
   │         ^
   │
-  = `g<T1, T2>` calls `f<T1, S<T2>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:9
-  = `f<T1, S<T2>, u64>` calls `g<S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:5
+  = `g<T1, T2>` uses `f<T1, S<T2>, u64>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:9
+  = `f<T1, S<T2>, u64>` uses `g<S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_two_args_swapping_type_con.move:5

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.exp
@@ -1,19 +1,19 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:7:9
   │
 7 │     fun f<T>() {
   │         ^
   │
-  = `f<T>` calls `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:8
-  = `g<S<T>>` calls `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:12
+  = `f<T>` uses `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:8
+  = `g<S<T>>` uses `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:12
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:11:9
    │
 11 │     fun g<T>() {
    │         ^
    │
-   = `g<T>` calls `f<T>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:12
-   = `f<T>` calls `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:8
+   = `g<T>` uses `f<T>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:12
+   = `f<T>` uses `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/mutually_recursive_type_con.move:8

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_1.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_1.exp
@@ -1,9 +1,9 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/nested_types_1.move:4:9
   │
 4 │     fun foo<T>() {
   │         ^^^
   │
-  = `foo<T>` calls `foo<S<S<T>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_1.move:5
+  = `foo<T>` uses `foo<S<S<T>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_1.move:5

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_2.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/nested_types_2.exp
@@ -1,9 +1,9 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/nested_types_2.move:5:9
   │
 5 │     fun foo<T>() {
   │         ^^^
   │
-  = `foo<T>` calls `foo<R<u64, S<S<T>>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_2.move:6
+  = `foo<T>` uses `foo<R<u64, S<S<T>>>>` at tests/cyclic-instantiation-checker/v1-tests/nested_types_2.move:6

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.exp
@@ -1,9 +1,9 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.move:9:9
   │
 9 │     fun f<T>(n: u64, x: T): T {
   │         ^
   │
-  = `f<T>` calls `f<Box<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.move:11
+  = `f<T>` uses `f<Box<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_infinite_type_terminates.move:11

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.exp
@@ -1,9 +1,9 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.move:6:9
   │
 6 │     fun f<T>(x: T) {
   │         ^
   │
-  = `f<T>` calls `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.move:7
+  = `f<T>` uses `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/recursive_one_arg_type_con.move:7

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.exp
@@ -1,9 +1,9 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.move:7:9
   │
 7 │     fun f<T1, T2>(a: T1, x: T2) {
   │         ^
   │
-  = `f<T1, T2>` calls `f<S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.move:8
+  = `f<T1, T2>` uses `f<S<T2>, T1>` at tests/cyclic-instantiation-checker/v1-tests/recursive_two_args_swapping_type_con.move:8

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/two_loops.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-tests/two_loops.exp
@@ -1,17 +1,17 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-tests/two_loops.move:7:9
   │
 7 │     fun f<T>() {
   │         ^
   │
-  = `f<T>` calls `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:8
+  = `f<T>` uses `f<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:8
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-tests/two_loops.move:11:9
    │
 11 │     fun g<T>() {
    │         ^
    │
-   = `g<T>` calls `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:12
+   = `g<T>` uses `g<S<T>>` at tests/cyclic-instantiation-checker/v1-tests/two_loops.move:12

--- a/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.exp
@@ -1,139 +1,139 @@
 
 Diagnostics:
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
   ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:6:16
   │
 6 │     public fun t<T>() {
   │                ^
   │
-  = `t<T>` calls `t<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:7
+  = `t<T>` uses `t<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:7
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:10:16
    │
 10 │     public fun x<T>() {
    │                ^
    │
-   = `x<T>` calls `y<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:11
-   = `y<Box<T>>` calls `x<Box<Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:14
+   = `x<T>` uses `y<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:11
+   = `y<Box<T>>` uses `x<Box<Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:14
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:13:16
    │
 13 │     public fun y<T>() {
    │                ^
    │
-   = `y<T>` calls `x<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:14
-   = `x<Box<T>>` calls `y<Box<Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:11
+   = `y<T>` uses `x<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:14
+   = `x<Box<T>>` uses `y<Box<Box<T>>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:11
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:17:16
    │
 17 │     public fun a<A>() {
    │                ^
    │
-   = `a<A>` calls `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
-   = `b<A>` calls `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
-   = `c<A>` calls `a<Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
+   = `a<A>` uses `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
+   = `b<A>` uses `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
+   = `c<A>` uses `a<Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:20:16
    │
 20 │     public fun b<B>() {
    │                ^
    │
-   = `b<B>` calls `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
-   = `c<B>` calls `a<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
-   = `a<Box<B>>` calls `b<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
+   = `b<B>` uses `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
+   = `c<B>` uses `a<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
+   = `a<Box<B>>` uses `b<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:23:16
    │
 23 │     public fun c<C>() {
    │                ^
    │
-   = `c<C>` calls `a<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
-   = `a<Box<C>>` calls `b<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
-   = `b<Box<C>>` calls `c<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
+   = `c<C>` uses `a<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:24
+   = `a<Box<C>>` uses `b<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:18
+   = `b<Box<C>>` uses `c<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:21
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:37:16
    │
 37 │     public fun z<T>() {
    │                ^
    │
-   = `z<T>` calls `z<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:38
+   = `z<T>` uses `z<Box<T>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:38
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:41:16
    │
 41 │     public fun a<A>() {
    │                ^
    │
-   = `a<A>` calls `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
-   = `b<A>` calls `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
-   = `c<A>` calls `d<Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
-   = `d<Box<A>>` calls `a<Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `a<A>` uses `b<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `b<A>` uses `c<A>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `c<A>` uses `d<Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `d<Box<A>>` uses `a<Box<A>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:44:16
    │
 44 │     public fun b<B>() {
    │                ^
    │
-   = `b<B>` calls `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
-   = `c<B>` calls `d<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
-   = `d<Box<B>>` calls `a<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
-   = `a<Box<B>>` calls `b<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `b<B>` uses `c<B>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `c<B>` uses `d<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `d<Box<B>>` uses `a<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `a<Box<B>>` uses `b<Box<B>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:47:16
    │
 47 │     public fun c<C>() {
    │                ^
    │
-   = `c<C>` calls `d<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
-   = `d<Box<C>>` calls `a<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
-   = `a<Box<C>>` calls `b<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
-   = `b<Box<C>>` calls `c<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `c<C>` uses `d<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `d<Box<C>>` uses `a<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `a<Box<C>>` uses `b<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `b<Box<C>>` uses `c<Box<C>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:50:16
    │
 50 │     public fun d<D>() {
    │                ^
    │
-   = `d<D>` calls `a<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
-   = `a<D>` calls `b<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
-   = `b<D>` calls `c<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
-   = `c<D>` calls `d<Box<D>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
+   = `d<D>` uses `a<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:51
+   = `a<D>` uses `b<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:42
+   = `b<D>` uses `c<D>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:45
+   = `c<D>` uses `d<Box<D>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:48
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:58:16
    │
 58 │     public fun tl<TL>() {
    │                ^^
    │
-   = `tl<TL>` calls `tr<TL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
-   = `tr<TL>` calls `bl<Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
-   = `bl<Box<TL>>` calls `tl<Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
+   = `tl<TL>` uses `tr<TL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
+   = `tr<TL>` uses `bl<Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
+   = `bl<Box<TL>>` uses `tl<Box<TL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:61:16
    │
 61 │     public fun tr<TR>() {
    │                ^^
    │
-   = `tr<TR>` calls `bl<Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
-   = `bl<Box<TR>>` calls `tl<Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
-   = `tl<Box<TR>>` calls `tr<Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
+   = `tr<TR>` uses `bl<Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
+   = `bl<Box<TR>>` uses `tl<Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
+   = `tl<Box<TR>>` uses `tr<Box<TR>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
 
-error: cyclic type instantiation: a cycle of recursive calls causes a type to grow without bound
+error: cyclic type instantiation: a cycle of recursive uses causes a type to grow without bound
    ┌─ tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:68:16
    │
 68 │     public fun bl<BL>() {
    │                ^^
    │
-   = `bl<BL>` calls `tl<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
-   = `tl<BL>` calls `tr<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
-   = `tr<BL>` calls `bl<Box<BL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62
+   = `bl<BL>` uses `tl<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:69
+   = `tl<BL>` uses `tr<BL>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:59
+   = `tr<BL>` uses `bl<Box<BL>>` at tests/cyclic-instantiation-checker/v1-typing/infinite_instantiations_invalid.move:62


### PR DESCRIPTION
## Description

Cyclic instantiation checker in the compiler was not addressing function values in various aspects, leading to a panic and a bytecode verifier error.

We address this by:
- considering function types (and other types that can be contained in it)
- considering recursive use of closures

Closes #16938.

## How Has This Been Tested?
- Added several new tests
- Existing tests have been updated (the only changes are the wordings in the error messages)

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
