### PR TITLE
13 find unnecessary casts x as u64 when x is already u64

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -5,6 +5,7 @@
 
 mod almost_swapped;
 mod blocks_in_conditions;
+mod find_unnecessary_casts;
 mod needless_bool;
 mod needless_deref_ref;
 mod needless_ref_deref;
@@ -23,10 +24,11 @@ pub fn get_default_linter_pipeline() -> Vec<Box<dyn ExpChecker>> {
     vec![
         Box::<almost_swapped::AlmostSwapped>::default(),
         Box::<blocks_in_conditions::BlocksInConditions>::default(),
+        Box::<find_unnecessary_casts::FindUnnecessaryCasts>::default(),
         Box::<needless_bool::NeedlessBool>::default(),
-        Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),
         Box::<needless_deref_ref::NeedlessDerefRef>::default(),
         Box::<needless_ref_deref::NeedlessRefDeref>::default(),
+        Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),
         Box::<nonminimal_bool::NonminimalBool>::default(),
         Box::<self_assignment::SelfAssignment>::default(),
         Box::<simpler_numeric_expression::SimplerNumericExpression>::default(),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/find_unnecessary_casts.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/find_unnecessary_casts.rs
@@ -1,0 +1,49 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for unnecessary type casts
+//! where the source expression already has the same type as the target type.
+//!
+//! For example:
+//! * `x as u64` when `x` is already of type `u64` => unnecessary cast, use `x` directly
+//!
+//! The linter helps improve code readability by removing redundant type information.
+
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{ExpData, Operation},
+    model::FunctionEnv,
+};
+
+#[derive(Default)]
+pub struct FindUnnecessaryCasts;
+
+impl ExpChecker for FindUnnecessaryCasts {
+    fn get_name(&self) -> String {
+        "find_unnecessary_casts".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
+        let ExpData::Call(id, Operation::Cast, args) = expr else {
+            return;
+        };
+
+        if args.len() != 1 {
+            return;
+        }
+
+        let source_expr = &args[0];
+        let env = function.env();
+
+        let source_type = env.get_node_type(source_expr.node_id());
+        let target_type = env.get_node_type(*id);
+
+        if source_type == target_type {
+            self.report(
+                env,
+                &env.get_node_loc(*id),
+                "Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.",
+            );
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.exp
@@ -1,0 +1,172 @@
+
+Diagnostics:
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:13:17
+   │
+13 │         let y = (x as u64);
+   │                 ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:18:33
+   │
+18 │         let result = helper_u64(x as u64);
+   │                                 ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:23:9
+   │
+23 │         (x as u64)
+   │         ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:29:22
+   │
+29 │         let result = ((a + b) as u32);
+   │                      ^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:33:17
+   │
+33 │         let x = (U8_VALUE as u8);
+   │                 ^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:38:13
+   │
+38 │         if ((x as u64) > 0) { };
+   │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:43:17
+   │
+43 │         assert!((x as u16) > 0, 0);
+   │                 ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:49:19
+   │
+49 │         let sum = (a as u64) + (b as u64);
+   │                   ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: [lint] Unnecessary cast: the expression is already of the target type. Consider removing the cast for better readability.
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:49:32
+   │
+49 │         let sum = (a as u64) + (b as u64);
+   │                                ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(find_unnecessary_casts)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#find_unnecessary_casts.
+
+warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:13:17
+   │
+13 │         let y = (x as u64);
+   │                 ^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `result` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_result`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:18:22
+   │
+18 │         let result = helper_u64(x as u64);
+   │                      ^^^^^^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `result` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_result`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:29:22
+   │
+29 │         let result = ((a + b) as u32);
+   │                      ^^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:33:17
+   │
+33 │         let x = (U8_VALUE as u8);
+   │                 ^^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `sum` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_sum`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:49:19
+   │
+49 │         let sum = (a as u64) + (b as u64);
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:56:17
+   │
+56 │         let y = (x as u64);
+   │                 ^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `big` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_big`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:61:19
+   │
+61 │         let big = (small as u256);
+   │                   ^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:65:17
+   │
+65 │         let x = (U8_VALUE as u256);
+   │                 ^^^^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:70:17
+   │
+70 │         let y = x;
+   │                 ^
+
+warning: This assignment/binding to the left-hand-side variable `small` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_small`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:75:21
+   │
+75 │         let small = (big as u8);
+   │                     ^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `bigger` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_bigger`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:80:22
+   │
+80 │         let bigger = (int_val as u128);
+   │                      ^^^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:88:17
+   │
+88 │         let y = (x as u64);
+   │                 ^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `sum` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_sum`), or renaming to `_`
+   ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:95:19
+   │
+95 │         let sum = (a as u32) + (b as u32);
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:105:17
+    │
+105 │         let y = (x as u64);
+    │                 ^^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `result` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_result`), or renaming to `_`
+    ┌─ tests/model_ast_lints/find_unnecessary_casts_test.move:111:22
+    │
+111 │         let result = (a as u8) + (b as u8);
+    │                      ^^^^^^^^^^^^^^^^^^^^^

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/find_unnecessary_casts_test.move
@@ -1,0 +1,113 @@
+module 0xc0ffee::unnecessary_casts_test {
+
+    const U8_VALUE: u8 = 255;
+    const U64_VALUE: u64 = 1000;
+
+    fun helper_u64(x: u64): u64 { x }
+    fun helper_u8(x: u8): u8 { x }
+
+    // ========== POSITIVE TESTS (should warn) ==========
+
+    public fun test_cast_in_let_warn() {
+        let x: u64 = 42;
+        let y = (x as u64);
+    }
+
+    public fun test_cast_in_function_arg_warn() {
+        let x: u64 = 100;
+        let result = helper_u64(x as u64);
+    }
+
+    public fun test_cast_in_return_warn(): u64 {
+        let x: u64 = 42;
+        (x as u64)
+    }
+
+    public fun test_cast_in_expression_warn() {
+        let a: u32 = 10;
+        let b: u32 = 20;
+        let result = ((a + b) as u32);
+    }
+
+    public fun test_cast_const_warn() {
+        let x = (U8_VALUE as u8);
+    }
+
+    public fun test_cast_in_conditional_warn() {
+        let x: u64 = 5;
+        if ((x as u64) > 0) { };
+    }
+
+    public fun test_cast_in_assert_warn() {
+        let x: u16 = 100;
+        assert!((x as u16) > 0, 0);
+    }
+
+    public fun test_multiple_casts_warn() {
+        let a: u64 = 1;
+        let b: u64 = 2;
+        let sum = (a as u64) + (b as u64);
+    }
+
+    // ========== NEGATIVE TESTS (should not warn) ==========
+
+    public fun test_necessary_cast_no_warn() {
+        let x: u8 = 10;
+        let y = (x as u64);
+    }
+
+    public fun test_different_types_no_warn() {
+        let small: u8 = 255;
+        let big = (small as u256);
+    }
+
+    public fun test_const_different_type_no_warn() {
+        let x = (U8_VALUE as u256);
+    }
+
+    public fun test_no_cast_no_warn() {
+        let x: u64 = 42;
+        let y = x;
+    }
+
+    public fun test_downcast_no_warn() {
+        let big: u64 = 100;
+        let small = (big as u8);
+    }
+
+    public fun test_cross_type_cast_no_warn() {
+        let int_val: u32 = 500;
+        let bigger = (int_val as u128);
+    }
+
+    // ========== LINT SKIP TESTS ==========
+
+    #[lint::skip(find_unnecessary_casts)]
+    public fun test_skip_function_no_warn() {
+        let x: u64 = 42;
+        let y = (x as u64);
+    }
+
+    #[lint::skip(find_unnecessary_casts)]
+    public fun test_skip_multiple_casts_no_warn() {
+        let a: u32 = 1;
+        let b: u32 = 2;
+        let sum = (a as u32) + (b as u32);
+    }
+}
+
+// Module-level lint skip test
+#[lint::skip(find_unnecessary_casts)]
+module 0xc0ffee::unnecessary_casts_skip_module {
+
+    public fun test_module_skip_no_warn() {
+        let x: u64 = 100;
+        let y = (x as u64);
+    }
+
+    public fun test_module_skip_multiple_no_warn() {
+        let a: u8 = 5;
+        let b: u8 = 10;
+        let result = (a as u8) + (b as u8);
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
