### PR TITLE
[Transaction Filter] Extend filtering support.

### DIFF
--- a/config/src/config/transaction_filters_config.rs
+++ b/config/src/config/transaction_filters_config.rs
@@ -10,11 +10,11 @@ use serde::{Deserialize, Serialize};
 #[derive(Clone, Debug, Default, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct TransactionFiltersConfig {
-    pub api_filter: TransactionFilterConfig, // Filter configuration for the API (e.g., transaction simulation)
-    pub consensus_filter: BlockTransactionFilterConfig, // Filter configuration for consensus
-    pub execution_filter: BlockTransactionFilterConfig, // Filter configuration for execution
-    pub mempool_filter: TransactionFilterConfig, // Filter configuration for mempool
-    pub quorum_store_filter: BatchTransactionFilterConfig, // Filter configuration for quorum store
+    pub api_filter: TransactionFilterConfig, // Filter for the API (e.g., txn simulation)
+    pub consensus_filter: BlockTransactionFilterConfig, // Filter for consensus (e.g., proposal voting)
+    pub execution_filter: BlockTransactionFilterConfig, // Filter for execution (e.g., block execution)
+    pub mempool_filter: TransactionFilterConfig,        // Filter for mempool (e.g., txn submission)
+    pub quorum_store_filter: BatchTransactionFilterConfig, // Filter for quorum store (e.g., batch voting)
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -96,6 +96,7 @@ aptos-mempool = { workspace = true, features = ["fuzzing"] }
 aptos-netcore = { workspace = true }
 aptos-network = { workspace = true, features = ["fuzzing"] }
 aptos-safety-rules = { workspace = true, features = ["testing"] }
+aptos-transaction-filters = { workspace = true, features = ["fuzzing"] }
 aptos-types = { workspace = true, features = ["testing"] }
 aptos-vm = { workspace = true, features = ["fuzzing"] }
 aptos-vm-validator = { workspace = true }

--- a/consensus/src/block_storage/block_store.rs
+++ b/consensus/src/block_storage/block_store.rs
@@ -22,6 +22,7 @@ use crate::{
 };
 use anyhow::{bail, ensure, format_err, Context};
 use aptos_bitvec::BitVec;
+use aptos_config::config::BlockTransactionFilterConfig;
 use aptos_consensus_types::{
     block::Block,
     common::Round,
@@ -591,6 +592,15 @@ impl BlockStore {
         tokio::time::timeout(duration, self.payload_manager.get_transactions(block, None))
             .await??;
         Ok(())
+    }
+
+    pub fn check_denied_inline_transactions(
+        &self,
+        block: &Block,
+        block_txn_filter_config: &BlockTransactionFilterConfig,
+    ) -> anyhow::Result<()> {
+        self.payload_manager
+            .check_denied_inline_transactions(block, block_txn_filter_config)
     }
 
     pub fn check_payload(&self, proposal: &Block) -> Result<(), BitVec> {

--- a/consensus/src/counters.rs
+++ b/consensus/src/counters.rs
@@ -1254,6 +1254,15 @@ pub static UNEXPECTED_PROPOSAL_EXT_COUNT: Lazy<IntCounter> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Count of the number of rejected proposals due to denied inline transactions
+pub static REJECTED_PROPOSAL_DENY_TXN_COUNT: Lazy<IntCounter> = Lazy::new(|| {
+    register_int_counter!(
+        "aptos_consensus_rejected_proposal_deny_txn_count",
+        "Count of the number of rejected proposals due to denied inline transactions"
+    )
+    .unwrap()
+});
+
 /// Histogram for the number of txns to be executed in a block.
 pub static MAX_TXNS_FROM_BLOCK_TO_EXECUTE: Lazy<Histogram> = Lazy::new(|| {
     register_histogram!(

--- a/consensus/src/dag/tests/helpers.rs
+++ b/consensus/src/dag/tests/helpers.rs
@@ -9,6 +9,7 @@ use crate::{
     payload_manager::TPayloadManager,
 };
 use aptos_bitvec::BitVec;
+use aptos_config::config::BlockTransactionFilterConfig;
 use aptos_consensus_types::{
     block::Block,
     common::{Author, Payload, Round},
@@ -26,6 +27,14 @@ impl TPayloadManager for MockPayloadManager {
     fn prefetch_payload_data(&self, _payload: &Payload, _author: Author, _timestamp: u64) {}
 
     fn notify_commit(&self, _block_timestamp: u64, _payloads: Vec<Payload>) {}
+
+    fn check_denied_inline_transactions(
+        &self,
+        _block: &Block,
+        _block_txn_filter_config: &BlockTransactionFilterConfig,
+    ) -> anyhow::Result<()> {
+        Ok(())
+    }
 
     fn check_payload_availability(&self, _block: &Block) -> Result<(), BitVec> {
         unimplemented!()

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -59,7 +59,8 @@ use anyhow::{anyhow, bail, ensure, Context};
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{
-    BatchTransactionFilterConfig, ConsensusConfig, DagConsensusConfig, NodeConfig,
+    BatchTransactionFilterConfig, BlockTransactionFilterConfig, ConsensusConfig,
+    DagConsensusConfig, NodeConfig,
 };
 use aptos_consensus_types::{
     block_retrieval::BlockRetrievalRequest,
@@ -176,6 +177,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     pending_blocks: Arc<Mutex<PendingBlocks>>,
     key_storage: PersistentSafetyStorage,
 
+    consensus_txn_filter_config: BlockTransactionFilterConfig,
     quorum_store_txn_filter_config: BatchTransactionFilterConfig,
 }
 
@@ -204,6 +206,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
         let sr_config = &node_config.consensus.safety_rules;
         let safety_rules_manager = SafetyRulesManager::new(sr_config);
         let key_storage = safety_rules_manager::storage(sr_config);
+        let consensus_txn_filter_config = node_config.transaction_filters.consensus_filter.clone();
         let quorum_store_txn_filter_config =
             node_config.transaction_filters.quorum_store_filter.clone();
 
@@ -249,6 +252,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             consensus_publisher,
             pending_blocks: Arc::new(Mutex::new(PendingBlocks::new())),
             key_storage,
+            consensus_txn_filter_config,
             quorum_store_txn_filter_config,
         }
     }
@@ -966,6 +970,7 @@ impl<P: OnChainConfigProvider> EpochManager<P> {
             self.storage.clone(),
             onchain_consensus_config,
             buffered_proposal_tx,
+            self.consensus_txn_filter_config.clone(),
             self.config.clone(),
             onchain_randomness_config,
             onchain_jwk_consensus_config,

--- a/consensus/src/payload_manager/co_payload_manager.rs
+++ b/consensus/src/payload_manager/co_payload_manager.rs
@@ -10,6 +10,7 @@ use crate::{
     payload_manager::TPayloadManager,
 };
 use aptos_bitvec::BitVec;
+use aptos_config::config::BlockTransactionFilterConfig;
 use aptos_consensus_types::{
     block::Block,
     common::{Author, Payload, Round},
@@ -96,6 +97,14 @@ impl TPayloadManager for ConsensusObserverPayloadManager {
     fn notify_commit(&self, _block_timestamp: u64, _payloads: Vec<Payload>) {}
 
     fn prefetch_payload_data(&self, _payload: &Payload, _author: Author, _timestamp: u64) {}
+
+    fn check_denied_inline_transactions(
+        &self,
+        _block: &Block,
+        _block_txn_filter_config: &BlockTransactionFilterConfig,
+    ) -> anyhow::Result<()> {
+        Ok(()) // Consensus observer doesn't filter transactions
+    }
 
     fn check_payload_availability(&self, _block: &Block) -> Result<(), BitVec> {
         unreachable!("this method isn't used in ConsensusObserver")

--- a/consensus/src/payload_manager/direct_mempool_payload_manager.rs
+++ b/consensus/src/payload_manager/direct_mempool_payload_manager.rs
@@ -3,6 +3,7 @@
 
 use crate::payload_manager::TPayloadManager;
 use aptos_bitvec::BitVec;
+use aptos_config::config::BlockTransactionFilterConfig;
 use aptos_consensus_types::{
     block::Block,
     common::{Author, Payload},
@@ -26,6 +27,48 @@ impl TPayloadManager for DirectMempoolPayloadManager {
 
     fn prefetch_payload_data(&self, _payload: &Payload, _author: Author, _timestamp: u64) {}
 
+    fn check_denied_inline_transactions(
+        &self,
+        block: &Block,
+        block_txn_filter_config: &BlockTransactionFilterConfig,
+    ) -> anyhow::Result<()> {
+        // If the filter is disabled, return early
+        if !block_txn_filter_config.is_enabled() {
+            return Ok(());
+        }
+
+        // Get the inline transactions for the block proposal. Note: all
+        // transactions in a direct mempool payload are inline transactions.
+        let (inline_transactions, _, _) = get_transactions_from_block(block)?;
+        if inline_transactions.is_empty() {
+            return Ok(());
+        }
+
+        // Fetch the block metadata
+        let block_id = block.id();
+        let block_author = block.author();
+        let block_epoch = block.epoch();
+        let block_timestamp = block.timestamp_usecs();
+
+        // Identify any denied inline transactions
+        let block_transaction_filter = block_txn_filter_config.block_transaction_filter();
+        let denied_inline_transactions = block_transaction_filter.get_denied_block_transactions(
+            block_id,
+            block_author,
+            block_epoch,
+            block_timestamp,
+            inline_transactions,
+        );
+        if !denied_inline_transactions.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Inline transactions for DirectMempoolPayload denied by block transaction filter: {:?}",
+                denied_inline_transactions
+            ));
+        }
+
+        Ok(()) // No transactions were denied
+    }
+
     fn check_payload_availability(&self, _block: &Block) -> Result<(), BitVec> {
         Ok(())
     }
@@ -35,19 +78,26 @@ impl TPayloadManager for DirectMempoolPayloadManager {
         block: &Block,
         _block_signers: Option<BitVec>,
     ) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)> {
-        let Some(payload) = block.payload() else {
-            return Ok((Vec::new(), None, None));
-        };
+        get_transactions_from_block(block)
+    }
+}
 
-        match payload {
-            Payload::DirectMempool(txns) => Ok((txns.clone(), None, None)),
-            _ => unreachable!(
-                "DirectMempoolPayloadManager: Unacceptable payload type {}. Epoch: {}, Round: {}, Block: {}",
-                payload,
-                block.block_data().epoch(),
-                block.block_data().round(),
-                block.id()
-            ),
-        }
+/// Returns the direct mempool transactions from a block's payload.
+fn get_transactions_from_block(
+    block: &Block,
+) -> ExecutorResult<(Vec<SignedTransaction>, Option<u64>, Option<u64>)> {
+    let Some(payload) = block.payload() else {
+        return Ok((Vec::new(), None, None));
+    };
+
+    match payload {
+        Payload::DirectMempool(txns) => Ok((txns.clone(), None, None)),
+        _ => unreachable!(
+            "DirectMempoolPayloadManager: Unacceptable payload type {}. Epoch: {}, Round: {}, Block: {}",
+            payload,
+            block.block_data().epoch(),
+            block.block_data().round(),
+            block.id()
+        ),
     }
 }

--- a/consensus/src/payload_manager/mod.rs
+++ b/consensus/src/payload_manager/mod.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_bitvec::BitVec;
+use aptos_config::config::BlockTransactionFilterConfig;
 use aptos_consensus_types::{
     block::Block,
     common::{Author, Payload},
@@ -29,6 +30,15 @@ pub trait TPayloadManager: Send + Sync {
     /// Prefetch the data for a payload. This is used to ensure that the data for a payload is
     /// available when block is executed.
     fn prefetch_payload_data(&self, payload: &Payload, author: Author, timestamp: u64);
+
+    /// Check if the block contains any inline transactions that need
+    /// to be denied (e.g., due to block transaction filtering).
+    /// This is only used when processing block proposals.
+    fn check_denied_inline_transactions(
+        &self,
+        block: &Block,
+        block_txn_filter_config: &BlockTransactionFilterConfig,
+    ) -> anyhow::Result<()>;
 
     /// Check if the transactions corresponding are available. This is specific to payload
     /// manager implementations. For optimistic quorum store, we only check if optimistic

--- a/consensus/src/payload_manager/mod.rs
+++ b/consensus/src/payload_manager/mod.rs
@@ -17,6 +17,8 @@ mod quorum_store_payload_manager;
 
 pub use co_payload_manager::ConsensusObserverPayloadManager;
 pub use direct_mempool_payload_manager::DirectMempoolPayloadManager;
+#[cfg(test)]
+pub use quorum_store_payload_manager::TQuorumStoreCommitNotifier;
 pub use quorum_store_payload_manager::{QuorumStoreCommitNotifier, QuorumStorePayloadManager};
 
 /// A trait that defines the interface for a payload manager. The payload manager is responsible for

--- a/consensus/src/payload_manager/quorum_store_payload_manager.rs
+++ b/consensus/src/payload_manager/quorum_store_payload_manager.rs
@@ -11,6 +11,7 @@ use crate::{
     quorum_store::{batch_store::BatchReader, quorum_store_coordinator::CoordinatorCommand},
 };
 use aptos_bitvec::BitVec;
+use aptos_config::config::BlockTransactionFilterConfig;
 use aptos_consensus_types::{
     block::Block,
     common::{Author, Payload, ProofWithData},
@@ -289,6 +290,47 @@ impl TPayloadManager for QuorumStorePayloadManager {
         };
     }
 
+    fn check_denied_inline_transactions(
+        &self,
+        block: &Block,
+        block_txn_filter_config: &BlockTransactionFilterConfig,
+    ) -> anyhow::Result<()> {
+        // If the filter is disabled, return early
+        if !block_txn_filter_config.is_enabled() {
+            return Ok(());
+        }
+
+        // Get the inline transactions for the block proposal
+        let inline_transactions = get_inline_transactions(block);
+        if inline_transactions.is_empty() {
+            return Ok(());
+        }
+
+        // Fetch the block metadata
+        let block_id = block.id();
+        let block_author = block.author();
+        let block_epoch = block.epoch();
+        let block_timestamp = block.timestamp_usecs();
+
+        // Identify any denied inline transactions
+        let block_transaction_filter = block_txn_filter_config.block_transaction_filter();
+        let denied_inline_transactions = block_transaction_filter.get_denied_block_transactions(
+            block_id,
+            block_author,
+            block_epoch,
+            block_timestamp,
+            inline_transactions,
+        );
+        if !denied_inline_transactions.is_empty() {
+            return Err(anyhow::anyhow!(
+                "Inline transactions for QuorumStorePayload denied by block transaction filter: {:?}",
+                denied_inline_transactions
+            ));
+        }
+
+        Ok(()) // No transactions were denied
+    }
+
     fn check_payload_availability(&self, block: &Block) -> Result<(), BitVec> {
         let Some(payload) = block.payload() else {
             return Ok(());
@@ -486,6 +528,36 @@ impl TPayloadManager for QuorumStorePayloadManager {
             transaction_payload.transaction_limit(),
             transaction_payload.gas_limit(),
         ))
+    }
+}
+
+/// Extracts and returns all inline transactions from the payload in the given block
+fn get_inline_transactions(block: &Block) -> Vec<SignedTransaction> {
+    // If the block has no payload, return an empty vector
+    let Some(payload) = block.payload() else {
+        return vec![];
+    };
+
+    // Fetch the inline transactions from the payload
+    match payload {
+        Payload::QuorumStoreInlineHybrid(inline_batches, ..) => {
+            // Flatten the inline batches and return the transactions
+            inline_batches
+                .iter()
+                .flat_map(|(_batch_info, txns)| txns.clone())
+                .collect()
+        },
+        Payload::QuorumStoreInlineHybridV2(inline_batches, ..) => {
+            // Flatten the inline batches and return the transactions
+            inline_batches
+                .iter()
+                .flat_map(|(_batch_info, txns)| txns.clone())
+                .collect()
+        },
+        Payload::OptQuorumStore(opt_qs_payload) => opt_qs_payload.inline_batches().transactions(),
+        _ => {
+            vec![] // Other payload types do not have inline transactions
+        },
     }
 }
 

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -35,7 +35,7 @@ use crate::{
 };
 use anyhow::{bail, ensure, Context};
 use aptos_channels::aptos_channel;
-use aptos_config::config::ConsensusConfig;
+use aptos_config::config::{BlockTransactionFilterConfig, ConsensusConfig};
 use aptos_consensus_types::{
     block::Block,
     block_data::BlockType,
@@ -274,6 +274,7 @@ pub struct RoundManager {
     onchain_config: OnChainConsensusConfig,
     vtxn_config: ValidatorTxnConfig,
     buffered_proposal_tx: aptos_channel::Sender<Author, VerifiedEvent>,
+    block_txn_filter_config: BlockTransactionFilterConfig,
     local_config: ConsensusConfig,
     randomness_config: OnChainRandomnessConfig,
     jwk_consensus_config: OnChainJWKConsensusConfig,
@@ -305,6 +306,7 @@ impl RoundManager {
         storage: Arc<dyn PersistentLivenessStorage>,
         onchain_config: OnChainConsensusConfig,
         buffered_proposal_tx: aptos_channel::Sender<Author, VerifiedEvent>,
+        block_txn_filter_config: BlockTransactionFilterConfig,
         local_config: ConsensusConfig,
         randomness_config: OnChainRandomnessConfig,
         jwk_consensus_config: OnChainJWKConsensusConfig,
@@ -334,6 +336,7 @@ impl RoundManager {
             onchain_config,
             vtxn_config,
             buffered_proposal_tx,
+            block_txn_filter_config,
             local_config,
             randomness_config,
             jwk_consensus_config,
@@ -1157,6 +1160,20 @@ impl RoundManager {
             author,
             proposal,
         );
+
+        // If the proposal contains any inline transactions that need to be denied
+        // (e.g., due to filtering) drop the message and do not vote for the block.
+        if let Err(error) = self
+            .block_store
+            .check_denied_inline_transactions(&proposal, &self.block_txn_filter_config)
+        {
+            counters::REJECTED_PROPOSAL_DENY_TXN_COUNT.inc();
+            bail!(
+                "[RoundManager] Proposal for block {} contains denied inline transactions: {}. Dropping proposal!",
+                proposal.id(),
+                error
+            );
+        }
 
         if !proposal.is_opt_block() {
             // Validate that failed_authors list is correctly specified in the block.

--- a/consensus/src/round_manager_fuzzing.rs
+++ b/consensus/src/round_manager_fuzzing.rs
@@ -27,7 +27,10 @@ use crate::{
     util::{mock_time_service::SimulatedTimeService, time_service::TimeService},
 };
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
-use aptos_config::{config::ConsensusConfig, network_id::NetworkId};
+use aptos_config::{
+    config::{BlockTransactionFilterConfig, ConsensusConfig},
+    network_id::NetworkId,
+};
 use aptos_consensus_types::{proposal_msg::ProposalMsg, utils::PayloadTxnsSize};
 use aptos_infallible::Mutex;
 use aptos_network::{
@@ -215,6 +218,7 @@ fn create_node_for_fuzzing() -> RoundManager {
         storage,
         OnChainConsensusConfig::default(),
         round_manager_tx,
+        BlockTransactionFilterConfig::default(),
         ConsensusConfig::default(),
         OnChainRandomnessConfig::default_enabled(),
         OnChainJWKConsensusConfig::default_enabled(),

--- a/consensus/src/round_manager_tests/consensus_test.rs
+++ b/consensus/src/round_manager_tests/consensus_test.rs
@@ -199,6 +199,8 @@ fn new_round_on_quorum_cert() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let node = &mut nodes[0];
     let genesis = node.block_store.ordered_root();
@@ -259,6 +261,8 @@ fn vote_on_successful_proposal() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let node = &mut nodes[0];
 
@@ -305,6 +309,8 @@ fn delay_proposal_processing_in_sync_only() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let node = &mut nodes[0];
 
@@ -371,6 +377,8 @@ fn no_vote_on_old_proposal() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let node = &mut nodes[0];
     let genesis_qc = certificate_for_genesis();
@@ -429,6 +437,8 @@ fn no_vote_on_mismatch_round() {
         None,
         None,
         None,
+        None,
+        false,
     )
     .pop()
     .unwrap();
@@ -492,9 +502,11 @@ fn sync_info_carried_on_timeout_vote() {
         1,
         None,
         None,
+        None,
         Some(config_with_round_timeout_msg_disabled()),
         None,
         None,
+        false,
     );
     let mut node = nodes.pop().unwrap();
 
@@ -560,6 +572,8 @@ fn no_vote_on_invalid_proposer() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let incorrect_proposer = nodes.pop().unwrap();
     let mut node = nodes.pop().unwrap();
@@ -628,6 +642,8 @@ fn new_round_on_timeout_certificate() {
         None,
         None,
         None,
+        None,
+        false,
     )
     .pop()
     .unwrap();
@@ -706,6 +722,8 @@ fn reject_invalid_failed_authors() {
         None,
         None,
         None,
+        None,
+        false,
     )
     .pop()
     .unwrap();
@@ -802,6 +820,8 @@ fn response_on_block_retrieval() {
         None,
         None,
         None,
+        None,
+        false,
     )
     .pop()
     .unwrap();
@@ -922,6 +942,8 @@ fn recover_on_restart() {
         None,
         None,
         None,
+        None,
+        false,
     )
     .pop()
     .unwrap();
@@ -996,9 +1018,11 @@ fn nil_vote_on_timeout() {
         1,
         None,
         None,
+        None,
         Some(config_with_round_timeout_msg_disabled()),
         None,
         None,
+        false,
     );
     let node = &mut nodes[0];
     let genesis = node.block_store.ordered_root();
@@ -1043,9 +1067,11 @@ fn timeout_round_on_timeout() {
         1,
         None,
         None,
+        None,
         Some(local_config),
         None,
         None,
+        false,
     );
     let node = &mut nodes[0];
     let genesis = node.block_store.ordered_root();
@@ -1079,9 +1105,11 @@ fn vote_resent_on_timeout() {
         1,
         None,
         None,
+        None,
         Some(config_with_round_timeout_msg_disabled()),
         None,
         None,
+        false,
     );
     let node = &mut nodes[0];
     timed_block_on(&runtime, async {
@@ -1124,9 +1152,11 @@ fn timeout_sent_on_timeout_after_vote() {
         1,
         None,
         None,
+        None,
         Some(local_config),
         None,
         None,
+        false,
     );
     let node = &mut nodes[0];
     timed_block_on(&runtime, async {
@@ -1167,6 +1197,8 @@ fn sync_on_partial_newer_sync_info() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let mut node = nodes.pop().unwrap();
     runtime.spawn(playground.start());
@@ -1229,9 +1261,11 @@ fn safety_rules_crash() {
         1,
         None,
         None,
+        None,
         Some(config_with_round_timeout_msg_disabled()),
         None,
         None,
+        false,
     );
     let mut node = nodes.pop().unwrap();
     runtime.spawn(playground.start());
@@ -1310,9 +1344,11 @@ fn echo_timeout() {
         4,
         None,
         None,
+        None,
         Some(config_with_round_timeout_msg_disabled()),
         None,
         None,
+        false,
     );
     runtime.spawn(playground.start());
     timed_block_on(&runtime, async {
@@ -1370,6 +1406,8 @@ fn echo_round_timeout_msg() {
         None,
         None,
         None,
+        None,
+        false,
     );
     runtime.spawn(playground.start());
     timed_block_on(&runtime, async {
@@ -1428,6 +1466,8 @@ fn no_next_test() {
         None,
         None,
         None,
+        None,
+        false,
     );
     runtime.spawn(playground.start());
 
@@ -1465,6 +1505,8 @@ fn commit_pipeline_test() {
         None,
         None,
         None,
+        None,
+        false,
     );
     runtime.spawn(playground.start());
     let behind_node = 6;
@@ -1506,6 +1548,8 @@ fn block_retrieval_test() {
         None,
         None,
         None,
+        None,
+        false,
     );
     runtime.spawn(playground.start());
 
@@ -1573,6 +1617,8 @@ fn block_retrieval_timeout_test() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let timeout_config = playground.timeout_config();
     runtime.spawn(playground.start());
@@ -1667,6 +1713,8 @@ pub fn forking_retrieval_test() {
         None,
         None,
         None,
+        None,
+        false,
     );
     runtime.spawn(playground.start());
 

--- a/consensus/src/round_manager_tests/mod.rs
+++ b/consensus/src/round_manager_tests/mod.rs
@@ -29,7 +29,7 @@ use crate::{
 };
 use aptos_channels::{self, aptos_channel, message_queues::QueueStyle};
 use aptos_config::{
-    config::ConsensusConfig,
+    config::{BlockTransactionFilterConfig, ConsensusConfig},
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_consensus_types::{
@@ -435,6 +435,7 @@ impl NodeSetup {
             storage.clone(),
             onchain_consensus_config.clone(),
             round_manager_tx,
+            BlockTransactionFilterConfig::default(),
             local_config,
             onchain_randomness_config.clone(),
             onchain_jwk_consensus_config.clone(),

--- a/consensus/src/round_manager_tests/mod.rs
+++ b/consensus/src/round_manager_tests/mod.rs
@@ -17,9 +17,13 @@ use crate::{
     network::{IncomingBlockRetrievalRequest, NetworkSender},
     network_interface::{CommitMessage, ConsensusMsg, ConsensusNetworkClient, DIRECT_SEND, RPC},
     network_tests::{NetworkPlayground, TwinId},
-    payload_manager::DirectMempoolPayloadManager,
+    payload_manager::{
+        DirectMempoolPayloadManager, QuorumStorePayloadManager, TPayloadManager,
+        TQuorumStoreCommitNotifier,
+    },
     persistent_liveness_storage::RecoveryData,
     pipeline::buffer_manager::OrderedBlocks,
+    quorum_store::batch_store::BatchReader,
     round_manager::RoundManager,
     test_utils::{
         mock_execution_client::MockExecutionClient, MockOptQSPayloadProvider,
@@ -39,6 +43,7 @@ use aptos_consensus_types::{
     opt_proposal_msg::OptProposalMsg,
     order_vote_msg::OrderVoteMsg,
     pipeline::commit_decision::CommitDecision,
+    proof_of_store::BatchInfo,
     proposal_msg::ProposalMsg,
     round_timeout::RoundTimeoutMsg,
     utils::PayloadTxnsSize,
@@ -46,6 +51,7 @@ use aptos_consensus_types::{
     wrapped_ledger_info::WrappedLedgerInfo,
 };
 use aptos_crypto::HashValue;
+use aptos_executor_types::ExecutorResult;
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::info;
 use aptos_network::{
@@ -72,12 +78,17 @@ use aptos_types::{
     validator_signer::ValidatorSigner,
     validator_verifier::{random_validator_verifier, ValidatorVerifier},
     waypoint::Waypoint,
+    PeerId,
 };
-use futures::{channel::mpsc, executor::block_on, stream::select, FutureExt, Stream, StreamExt};
+use futures::{
+    channel::mpsc, executor::block_on, future::Shared, stream::select, FutureExt, Stream, StreamExt,
+};
 use maplit::hashmap;
 use std::{
     collections::VecDeque,
+    future::Future,
     iter::FromIterator,
+    pin::Pin,
     sync::{
         atomic::{AtomicBool, Ordering},
         Arc,
@@ -88,6 +99,7 @@ use tokio::{runtime::Handle, task::JoinHandle};
 
 mod consensus_test;
 mod opt_proposal_test;
+mod txn_filter_proposal_test;
 mod vtxn_on_proposal_test;
 
 fn config_with_round_timeout_msg_disabled() -> ConsensusConfig {
@@ -173,6 +185,7 @@ pub struct NodeSetup {
     _state_sync_receiver: mpsc::UnboundedReceiver<Vec<SignedTransaction>>,
     id: usize,
     onchain_consensus_config: OnChainConsensusConfig,
+    block_txn_filter_config: BlockTransactionFilterConfig,
     local_consensus_config: ConsensusConfig,
     onchain_randomness_config: OnChainRandomnessConfig,
     onchain_jwk_consensus_config: OnChainJWKConsensusConfig,
@@ -183,6 +196,7 @@ pub struct NodeSetup {
     round_timeout_queue: VecDeque<RoundTimeoutMsg>,
     commit_decision_queue: VecDeque<CommitDecision>,
     processed_opt_proposal_rx: aptos_channels::UnboundedReceiver<OptBlockData>,
+    use_quorum_store_payloads: bool,
 }
 
 impl NodeSetup {
@@ -203,9 +217,11 @@ impl NodeSetup {
         num_nodes: usize,
         proposer_indices: Option<Vec<usize>>,
         onchain_consensus_config: Option<OnChainConsensusConfig>,
+        block_txn_filter_config: Option<BlockTransactionFilterConfig>,
         local_consensus_config: Option<ConsensusConfig>,
         onchain_randomness_config: Option<OnChainRandomnessConfig>,
         onchain_jwk_consensus_config: Option<OnChainJWKConsensusConfig>,
+        use_quorum_store_payloads: bool,
     ) -> Vec<Self> {
         Self::create_nodes_with_validator_set(
             playground,
@@ -213,10 +229,12 @@ impl NodeSetup {
             num_nodes,
             proposer_indices,
             onchain_consensus_config,
+            block_txn_filter_config,
             local_consensus_config,
             onchain_randomness_config,
             onchain_jwk_consensus_config,
             None,
+            use_quorum_store_payloads,
         )
     }
 
@@ -226,10 +244,12 @@ impl NodeSetup {
         num_nodes: usize,
         proposer_indices: Option<Vec<usize>>,
         onchain_consensus_config: Option<OnChainConsensusConfig>,
+        block_txn_filter_config: Option<BlockTransactionFilterConfig>,
         local_consensus_config: Option<ConsensusConfig>,
         onchain_randomness_config: Option<OnChainRandomnessConfig>,
         onchain_jwk_consensus_config: Option<OnChainJWKConsensusConfig>,
         validator_set: Option<(Vec<ValidatorSigner>, ValidatorVerifier)>,
+        use_quorum_store_payloads: bool,
     ) -> Vec<Self> {
         let mut onchain_consensus_config = onchain_consensus_config.unwrap_or_default();
         // With order votes feature, the validators additionally send order votes.
@@ -251,6 +271,7 @@ impl NodeSetup {
             onchain_randomness_config.unwrap_or_else(OnChainRandomnessConfig::default_if_missing);
         let onchain_jwk_consensus_config = onchain_jwk_consensus_config
             .unwrap_or_else(OnChainJWKConsensusConfig::default_if_missing);
+        let block_txn_filter_config = block_txn_filter_config.unwrap_or_default();
         let local_consensus_config = local_consensus_config.unwrap_or_default();
         let (signers, validators) =
             validator_set.unwrap_or_else(|| random_validator_verifier(num_nodes, None, false));
@@ -301,9 +322,11 @@ impl NodeSetup {
                 safety_rules_manager,
                 id,
                 onchain_consensus_config.clone(),
+                block_txn_filter_config.clone(),
                 local_consensus_config.clone(),
                 onchain_randomness_config.clone(),
                 onchain_jwk_consensus_config.clone(),
+                use_quorum_store_payloads,
             ));
         }
         nodes
@@ -319,9 +342,11 @@ impl NodeSetup {
         safety_rules_manager: SafetyRulesManager,
         id: usize,
         onchain_consensus_config: OnChainConsensusConfig,
+        block_txn_filter_config: BlockTransactionFilterConfig,
         local_consensus_config: ConsensusConfig,
         onchain_randomness_config: OnChainRandomnessConfig,
         onchain_jwk_consensus_config: OnChainJWKConsensusConfig,
+        use_quorum_store_payloads: bool,
     ) -> Self {
         let _entered_runtime = executor.enter();
         let epoch_state = Arc::new(EpochState::new(1, storage.get_validator_set().into()));
@@ -368,6 +393,19 @@ impl NodeSetup {
         ));
         let time_service = Arc::new(ClockTimeService::new(executor));
 
+        let payload_manager: Arc<dyn TPayloadManager> = if use_quorum_store_payloads {
+            Arc::new(QuorumStorePayloadManager::new(
+                Arc::new(MockBatchReader) as Arc<dyn BatchReader>,
+                Box::new(MockQuorumStoreCommitNotifier) as Box<dyn TQuorumStoreCommitNotifier>,
+                None,
+                vec![],
+                hashmap![],
+                false,
+            ))
+        } else {
+            Arc::new(DirectMempoolPayloadManager::new())
+        };
+
         let window_size = onchain_consensus_config.window_size();
         let block_store = Arc::new(BlockStore::new(
             storage.clone(),
@@ -376,7 +414,7 @@ impl NodeSetup {
             10, // max pruned blocks in mem
             time_service.clone(),
             10,
-            Arc::from(DirectMempoolPayloadManager::new()),
+            payload_manager,
             false,
             window_size,
             Arc::new(Mutex::new(PendingBlocks::new())),
@@ -435,7 +473,7 @@ impl NodeSetup {
             storage.clone(),
             onchain_consensus_config.clone(),
             round_manager_tx,
-            BlockTransactionFilterConfig::default(),
+            block_txn_filter_config.clone(),
             local_config,
             onchain_randomness_config.clone(),
             onchain_jwk_consensus_config.clone(),
@@ -458,6 +496,7 @@ impl NodeSetup {
             _state_sync_receiver,
             id,
             onchain_consensus_config,
+            block_txn_filter_config,
             local_consensus_config,
             onchain_randomness_config,
             onchain_jwk_consensus_config,
@@ -468,6 +507,7 @@ impl NodeSetup {
             round_timeout_queue: VecDeque::new(),
             commit_decision_queue: VecDeque::new(),
             processed_opt_proposal_rx: opt_proposal_loopback_rx,
+            use_quorum_store_payloads,
         }
     }
 
@@ -489,9 +529,11 @@ impl NodeSetup {
             self.safety_rules_manager,
             self.id,
             self.onchain_consensus_config.clone(),
+            self.block_txn_filter_config.clone(),
             self.local_consensus_config.clone(),
             self.onchain_randomness_config.clone(),
             self.onchain_jwk_consensus_config.clone(),
+            self.use_quorum_store_payloads,
         )
     }
 
@@ -685,5 +727,35 @@ impl NodeSetup {
             .commit_to_storage(ordered_blocks)
             .await
             .unwrap();
+    }
+}
+
+/// A mock quorum store commit notifier that provides limited functionality
+struct MockQuorumStoreCommitNotifier;
+
+impl TQuorumStoreCommitNotifier for MockQuorumStoreCommitNotifier {
+    fn notify(&self, _block_timestamp: u64, _batches: Vec<BatchInfo>) {
+        unimplemented!()
+    }
+}
+
+/// A mock batch reader that provides limited functionality
+struct MockBatchReader;
+
+impl BatchReader for MockBatchReader {
+    fn exists(&self, _digest: &HashValue) -> Option<PeerId> {
+        None
+    }
+
+    fn get_batch(
+        &self,
+        _batch_info: BatchInfo,
+        _signers: Vec<PeerId>,
+    ) -> Shared<Pin<Box<dyn Future<Output = ExecutorResult<Vec<SignedTransaction>>> + Send>>> {
+        unimplemented!()
+    }
+
+    fn update_certified_timestamp(&self, _certified_time: u64) {
+        unimplemented!()
     }
 }

--- a/consensus/src/round_manager_tests/opt_proposal_test.rs
+++ b/consensus/src/round_manager_tests/opt_proposal_test.rs
@@ -40,9 +40,11 @@ fn test_opt_proposal_proposed_no_failures() {
         1,
         None,
         None,
+        None,
         Some(config_with_opt_proposal_enabled()),
         None,
         None,
+        false,
     );
     let genesis = nodes[0].block_store.ordered_root();
 
@@ -93,9 +95,11 @@ fn test_normal_proposal_after_opt_proposal_timeout() {
         1,
         None,
         None,
+        None,
         Some(config_with_opt_proposal_enabled()),
         None,
         None,
+        false,
     );
     let genesis = nodes[0].block_store.ordered_root();
 
@@ -167,9 +171,11 @@ fn test_one_proposal_per_round_honest_proposer() {
         1,
         None,
         None,
+        None,
         Some(config_with_opt_proposal_enabled()),
         None,
         None,
+        false,
     );
     let genesis = nodes[0].block_store.ordered_root();
     let node = &mut nodes[0];
@@ -264,9 +270,11 @@ fn test_process_either_optimistic_or_normal_proposal() {
         1,
         None,
         None,
+        None,
         Some(config_with_opt_proposal_enabled()),
         None,
         None,
+        false,
     );
     let genesis = nodes[0].block_store.ordered_root();
     let node = &mut nodes[0];

--- a/consensus/src/round_manager_tests/txn_filter_proposal_test.rs
+++ b/consensus/src/round_manager_tests/txn_filter_proposal_test.rs
@@ -1,0 +1,277 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    network_tests::NetworkPlayground,
+    round_manager::round_manager_tests::NodeSetup,
+    test_utils::{consensus_runtime, timed_block_on},
+};
+use aptos_config::config::BlockTransactionFilterConfig;
+use aptos_consensus_types::{
+    block::{block_test_utils::certificate_for_genesis, Block},
+    common::{Payload, ProofWithData},
+    proof_of_store::BatchInfo,
+};
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519Signature},
+    HashValue, PrivateKey, Uniform,
+};
+use aptos_transaction_filters::{
+    block_transaction_filter::{BlockTransactionFilter, BlockTransactionMatcher},
+    transaction_filter::TransactionMatcher,
+};
+use aptos_types::{
+    account_address::AccountAddress,
+    chain_id::ChainId,
+    quorum_store::BatchId,
+    transaction::{RawTransaction, Script, SignedTransaction, TransactionPayload},
+    PeerId,
+};
+
+// Verify that the round manager will not vote if a block
+// proposal contains any denied inline transactions.
+#[test]
+fn test_no_vote_on_denied_inline_transactions() {
+    // Test both direct mempool and quorum store payloads
+    for use_quorum_store_payloads in [false, true] {
+        // Create test transactions
+        let transactions = create_test_transactions();
+
+        // Create a block filter config that denies the first transaction sender
+        let block_txn_filter = BlockTransactionFilter::empty()
+            .add_multiple_matchers_filter(false, vec![BlockTransactionMatcher::Transaction(
+                TransactionMatcher::Sender(transactions[0].sender()),
+            )])
+            .add_all_filter(true);
+        let block_txn_filter_config = BlockTransactionFilterConfig::new(true, block_txn_filter);
+
+        // Create a new network playground
+        let runtime = consensus_runtime();
+        let mut playground = NetworkPlayground::new(runtime.handle().clone());
+
+        // Create a new consensus node. Note: To observe the votes we're
+        // going to check proposal processing on the non-proposer node
+        // (which will send the votes to the proposer).
+        let mut nodes = NodeSetup::create_nodes(
+            &mut playground,
+            runtime.handle().clone(),
+            1,
+            None,
+            None,
+            Some(block_txn_filter_config),
+            None,
+            None,
+            None,
+            use_quorum_store_payloads,
+        );
+        let node = &mut nodes[0];
+
+        // Create a block proposal with inline transactions that will be denied
+        let payload = create_payload(transactions, use_quorum_store_payloads);
+        let denied_block = Block::new_proposal(
+            payload,
+            1,
+            1,
+            certificate_for_genesis(),
+            &node.signer,
+            Vec::new(),
+        )
+        .unwrap();
+
+        // Verify that the node does not vote on a block with denied inline transactions
+        timed_block_on(&runtime, async {
+            assert!(node
+                .round_manager
+                .process_proposal(denied_block)
+                .await
+                .is_err());
+        });
+    }
+}
+
+// Verify that the round manager will not invoke
+// the filter if the config is disabled.
+#[test]
+fn test_vote_on_disabled_filter() {
+    // Test both direct mempool and quorum store payloads
+    for use_quorum_store_payloads in [false, true] {
+        // Create a block filter config that denies all transactions, however,
+        // the filter is disabled, so it should not be invoked.
+        let block_txn_filter = BlockTransactionFilter::empty().add_all_filter(false);
+        let block_txn_filter_config = BlockTransactionFilterConfig::new(false, block_txn_filter);
+
+        // Create a new network playground
+        let runtime = consensus_runtime();
+        let mut playground = NetworkPlayground::new(runtime.handle().clone());
+
+        // Create a new consensus node. Note: To observe the votes we're
+        // going to check proposal processing on the non-proposer node
+        // (which will send the votes to the proposer).
+        let mut nodes = NodeSetup::create_nodes(
+            &mut playground,
+            runtime.handle().clone(),
+            1,
+            None,
+            None,
+            Some(block_txn_filter_config),
+            None,
+            None,
+            None,
+            use_quorum_store_payloads,
+        );
+        let node = &mut nodes[0];
+
+        // Create a block proposal with inline transactions
+        let transactions = create_test_transactions();
+        let payload = create_payload(transactions, use_quorum_store_payloads);
+        let allowed_block = Block::new_proposal(
+            payload,
+            1,
+            1,
+            certificate_for_genesis(),
+            &node.signer,
+            Vec::new(),
+        )
+        .unwrap();
+        let allowed_block_id = allowed_block.id();
+
+        // Verify that the node votes on the block correctly
+        timed_block_on(&runtime, async {
+            node.round_manager
+                .process_proposal(allowed_block)
+                .await
+                .unwrap();
+            let vote_msg = node.next_vote().await;
+            assert_eq!(
+                vote_msg.vote().vote_data().proposed().id(),
+                allowed_block_id
+            );
+        });
+    }
+}
+
+// Verify that the round manager will still vote on a block
+// if there are no denied inline transactions that match.
+#[test]
+fn test_vote_on_no_filter_matches() {
+    // Test both direct mempool and quorum store payloads
+    for use_quorum_store_payloads in [false, true] {
+        // Create test transactions
+        let transactions = create_test_transactions();
+
+        // Create a block filter config that denies the first transaction sender
+        let block_txn_filter = BlockTransactionFilter::empty()
+            .add_multiple_matchers_filter(false, vec![BlockTransactionMatcher::Transaction(
+                TransactionMatcher::Sender(transactions[0].sender()),
+            )])
+            .add_all_filter(true);
+        let block_txn_filter_config = BlockTransactionFilterConfig::new(true, block_txn_filter);
+
+        // Create a new network playground
+        let runtime = consensus_runtime();
+        let mut playground = NetworkPlayground::new(runtime.handle().clone());
+
+        // Create a new consensus node. Note: To observe the votes we're
+        // going to check proposal processing on the non-proposer node
+        // (which will send the votes to the proposer).
+        let mut nodes = NodeSetup::create_nodes(
+            &mut playground,
+            runtime.handle().clone(),
+            1,
+            None,
+            None,
+            Some(block_txn_filter_config),
+            None,
+            None,
+            None,
+            use_quorum_store_payloads,
+        );
+        let node = &mut nodes[0];
+
+        // Create a block proposal with inline transactions that don't include the denied sender
+        let payload = create_payload(transactions[1..].to_vec(), use_quorum_store_payloads);
+        let allowed_block = Block::new_proposal(
+            payload,
+            1,
+            1,
+            certificate_for_genesis(),
+            &node.signer,
+            Vec::new(),
+        )
+        .unwrap();
+        let allowed_block_id = allowed_block.id();
+
+        // Verify that the node votes on the block correctly
+        timed_block_on(&runtime, async {
+            node.round_manager
+                .process_proposal(allowed_block)
+                .await
+                .unwrap();
+            let vote_msg = node.next_vote().await;
+            assert_eq!(
+                vote_msg.vote().vote_data().proposed().id(),
+                allowed_block_id
+            );
+        });
+    }
+}
+
+/// Creates and returns a new batch info with the specified number of transactions
+fn create_batch_info(num_transactions: usize) -> BatchInfo {
+    BatchInfo::new(
+        PeerId::ZERO,
+        BatchId::new(0),
+        1,
+        0,
+        HashValue::random(),
+        num_transactions as u64,
+        1,
+        0,
+    )
+}
+
+/// Creates and returns a payload based on the provided transactions and whether to use QS
+fn create_payload(
+    transactions: Vec<SignedTransaction>,
+    use_quorum_store_payloads: bool,
+) -> Payload {
+    if use_quorum_store_payloads {
+        let inline_batch = (create_batch_info(transactions.len()), transactions);
+        Payload::QuorumStoreInlineHybrid(vec![inline_batch], ProofWithData::empty(), None)
+    } else {
+        Payload::DirectMempool(transactions)
+    }
+}
+
+/// Creates and returns a list of test transactions
+fn create_test_transactions() -> Vec<SignedTransaction> {
+    let mut transactions = vec![];
+
+    for i in 0..10 {
+        // Create the raw transaction
+        let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+        let raw_transaction = RawTransaction::new(
+            AccountAddress::random(),
+            i,
+            transaction_payload,
+            0,
+            0,
+            0,
+            ChainId::new(10),
+        );
+
+        // Create a signed transaction
+        let private_key = Ed25519PrivateKey::generate_for_testing();
+        let public_key = private_key.public_key();
+        let signed_transaction = SignedTransaction::new(
+            raw_transaction,
+            public_key,
+            Ed25519Signature::dummy_signature(),
+        );
+
+        // Add the signed transaction to the list
+        transactions.push(signed_transaction);
+    }
+
+    transactions
+}

--- a/consensus/src/round_manager_tests/vtxn_on_proposal_test.rs
+++ b/consensus/src/round_manager_tests/vtxn_on_proposal_test.rs
@@ -46,6 +46,8 @@ fn no_vote_on_proposal_ext_when_feature_disabled() {
         None,
         None,
         None,
+        None,
+        false,
     );
     let node = &mut nodes[0];
     let genesis_qc = certificate_for_genesis();
@@ -227,9 +229,11 @@ fn assert_process_proposal_result(
         None,
         Some(OnChainConsensusConfig::default_for_genesis()),
         None,
+        None,
         randomness_config,
         jwk_consensus_config,
         validator_set,
+        false,
     );
 
     let node = &mut nodes[0];
@@ -294,9 +298,11 @@ fn no_vote_on_proposal_ext_when_receiving_limit_exceeded() {
             vtxn: vtxn_config,
             window_size: DEFAULT_WINDOW_SIZE,
         }),
+        None,
         Some(local_config),
         Some(randomness_config),
         None,
+        false,
     );
     let node = &mut nodes[0];
     let genesis_qc = certificate_for_genesis();

--- a/crates/aptos-transaction-filters/src/block_transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/block_transaction_filter.rs
@@ -65,6 +65,30 @@ impl BlockTransactionFilter {
         }
     }
 
+    /// Identifies the transactions in the given block that are denied by the filter.
+    /// Note: this returns the inverse of `filter_block_transactions`.
+    pub fn get_denied_block_transactions(
+        &self,
+        block_id: HashValue,
+        block_author: Option<AccountAddress>,
+        block_epoch: u64,
+        block_timestamp_usecs: u64,
+        transactions: Vec<SignedTransaction>,
+    ) -> Vec<SignedTransaction> {
+        transactions
+            .into_iter()
+            .filter(|txn| {
+                !self.allows_transaction(
+                    block_id,
+                    block_author,
+                    block_epoch,
+                    block_timestamp_usecs,
+                    txn,
+                )
+            })
+            .collect()
+    }
+
     /// Filters the transactions in the given block and returns only those that are allowed
     pub fn filter_block_transactions(
         &self,


### PR DESCRIPTION
## Description
This PR extends transaction filtering support to consensus. It offers the following commits:
1. Adopt the block transaction filter when processing payloads, and reject/drop any proposals that include denied inline transactions.
2. Add new unit tests for the logic.


## Testing Plan
New and existing test infrastructure.