### PR TITLE
[aptos-cli] stabilize build from source for brew

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1062,10 +1062,12 @@ install_libudev-dev
 
 install_python3
 if [[ "$SKIP_PRE_COMMIT" == "false" ]]; then
-  if [[ "$PACKAGE_MANAGER" != "pacman" ]]; then
-    pip3 install pre-commit
-  else
+  if [[ "$PACKAGE_MANAGER == brew" ]]; then
+    install_pkg pre-commit "$PACKAGE_MANAGER"
+  elif [[ "$PACKAGE_MANAGER" == "pacman" ]]; then
     install_pkg python-pre-commit "$PACKAGE_MANAGER"
+  else
+    pip3 install pre-commit
   fi
 
   # For now best effort install, will need to improve later


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
Due to this [PEP](https://peps.python.org/pep-0668/) some users like me will be unable to use pip3. This change fixes this by using the package_manager instead.
The error was: `error: externally-managed-environment`

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
Tested on Mac with brew package_management and fixed the error.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->
None, this is a simple change of package_manager being used.

## Type of Change
- [ ] New feature
- [x ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x ] I have performed a self-review of my own code
- [x ] I have commented my code, particularly in hard-to-understand areas
- [x ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x ] I tested both happy and unhappy path of the functionality
- [x ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
