### PR TITLE
[vm][tests] Runtime visibility checks for pack closure

### DIFF
--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -2277,6 +2277,7 @@ impl Frame {
                                 vec![],
                             )
                             .map(Rc::new)?;
+                        RTTCheck::check_pack_closure_visibility(&self.function, &function)?;
 
                         let captured = interpreter.operand_stack.popn(mask.captured_count())?;
                         let lazy_function = LazyLoadedFunction::new_resolved(
@@ -2316,6 +2317,7 @@ impl Frame {
                                 ty_args,
                             )
                             .map(Rc::new)?;
+                        RTTCheck::check_pack_closure_visibility(&self.function, &function)?;
 
                         let captured = interpreter.operand_stack.popn(mask.captured_count())?;
                         let lazy_function = LazyLoadedFunction::new_resolved(

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -79,6 +79,18 @@ pub(crate) trait RuntimeTypeCheck {
         }
     }
 
+    /// Checks if the caller can pack a function as a closure.
+    fn check_pack_closure_visibility(
+        caller: &LoadedFunction,
+        function: &LoadedFunction,
+    ) -> PartialVMResult<()> {
+        if caller.module_id() == function.module_id() {
+            return Ok(());
+        }
+        // Same visibility rules as for regular cross-contract calls should apply.
+        Self::check_cross_module_regular_call_visibility(caller, function)
+    }
+
     /// Performs a runtime check of the caller is allowed to call a cross-module callee. Applies
     /// only on regular static calls (no dynamic dispatch!), with caller and callee being coming
     /// from different modules.

--- a/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure.exp
@@ -1,0 +1,46 @@
+processed 13 tasks
+
+task 4 'run'. lines 54-54:
+Error: Function execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: 0x2::a,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 0)],
+}
+
+task 7 'run'. lines 60-60:
+Error: Function execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: 0x2::c,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 0)],
+}
+
+task 8 'run'. lines 62-62:
+Error: Function execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: 0x2::c,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
+}
+
+task 10 'run'. lines 66-74:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
+}
+
+task 11 'run'. lines 76-84:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
+}

--- a/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure.move
+++ b/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure.move
@@ -1,0 +1,94 @@
+//# publish
+module 0x2::a {
+    // Empty module for 0x2::b to link against when declaring as a friend.
+}
+
+//# publish
+module 0x2::b {
+    friend 0x2::a;
+
+    fun private_function() {}
+    public(friend) fun friend_function() {}
+    public fun public_function() {}
+}
+
+
+//# publish
+module 0x2::a {
+    use 0x2::b;
+
+    public fun call_private_function() {
+        let f = || b::private_function();
+        f();
+    }
+    public fun call_friend_function() {
+        let f = || b::friend_function();
+        f();
+    }
+
+    public fun call_public_function() {
+        let f = || b::public_function();
+        f();
+    }
+}
+
+//# publish
+module 0x2::c {
+    use 0x2::b;
+
+    public fun call_private_function() {
+        let f = || b::private_function();
+        f();
+    }
+    public fun call_friend_function() {
+        let f = || b::friend_function();
+        f();
+    }
+
+    public fun call_public_function() {
+        let f = || b::public_function();
+        f();
+    }
+}
+
+//# run 0x2::a::call_private_function
+
+//# run 0x2::a::call_friend_function
+
+//# run 0x2::a::call_public_function
+
+//# run 0x2::c::call_private_function
+
+//# run 0x2::c::call_friend_function
+
+//# run 0x2::c::call_public_function
+
+//# run --signers 0x1
+script {
+    use 0x2::b;
+
+    fun main(_account: signer) {
+        let f = || b::private_function();
+        f();
+    }
+}
+
+//# run --signers 0x1
+script {
+    use 0x2::b;
+
+    fun main(_account: signer) {
+        let f = || b::friend_function();
+        f();
+    }
+}
+
+//# run --signers 0x1
+script {
+    use 0x2::b;
+
+    fun main(_account: signer) {
+        let f = || b::public_function();
+        f();
+    }
+}

--- a/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure_generic.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure_generic.exp
@@ -1,0 +1,46 @@
+processed 13 tasks
+
+task 4 'run'. lines 54-54:
+Error: Function execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: 0x2::a,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 0)],
+}
+
+task 7 'run'. lines 60-60:
+Error: Function execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: 0x2::c,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 0)],
+}
+
+task 8 'run'. lines 62-62:
+Error: Function execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: 0x2::c,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
+}
+
+task 10 'run'. lines 66-74:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
+}
+
+task 11 'run'. lines 76-84:
+Error: Script execution failed with VMError: {
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 0)],
+}

--- a/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure_generic.move
+++ b/third_party/move/move-vm/transactional-tests/tests/paranoid-tests/encapsulation_safety/cross_module_pack_closure_generic.move
@@ -1,0 +1,94 @@
+//# publish
+module 0x2::a {
+    // Empty module for 0x2::b to link against when declaring as a friend.
+}
+
+//# publish
+module 0x2::b {
+    friend 0x2::a;
+
+    fun private_function<T>() {}
+    public(friend) fun friend_function<T>() {}
+    public fun public_function<T>() {}
+}
+
+
+//# publish
+module 0x2::a {
+    use 0x2::b;
+
+    public fun call_private_function() {
+        let f = || b::private_function<u8>();
+        f();
+    }
+    public fun call_friend_function() {
+        let f = || b::friend_function<u8>();
+        f();
+    }
+
+    public fun call_public_function() {
+        let f = || b::public_function<u8>();
+        f();
+    }
+}
+
+//# publish
+module 0x2::c {
+    use 0x2::b;
+
+    public fun call_private_function() {
+        let f = || b::private_function<u8>();
+        f();
+    }
+    public fun call_friend_function() {
+        let f = || b::friend_function<u8>();
+        f();
+    }
+
+    public fun call_public_function() {
+        let f = || b::public_function<u8>();
+        f();
+    }
+}
+
+//# run 0x2::a::call_private_function
+
+//# run 0x2::a::call_friend_function
+
+//# run 0x2::a::call_public_function
+
+//# run 0x2::c::call_private_function
+
+//# run 0x2::c::call_friend_function
+
+//# run 0x2::c::call_public_function
+
+//# run --signers 0x1
+script {
+    use 0x2::b;
+
+    fun main(_account: signer) {
+        let f = || b::private_function<u8>();
+        f();
+    }
+}
+
+//# run --signers 0x1
+script {
+    use 0x2::b;
+
+    fun main(_account: signer) {
+        let f = || b::friend_function<u8>();
+        f();
+    }
+}
+
+//# run --signers 0x1
+script {
+    use 0x2::b;
+
+    fun main(_account: signer) {
+        let f = || b::public_function<u8>();
+        f();
+    }
+}

--- a/third_party/move/move-vm/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-vm/transactional-tests/tests/tests.rs
@@ -75,7 +75,7 @@ static TEST_CONFIGS: Lazy<Vec<TestConfig>> = Lazy::new(|| {
         TestConfig {
             name: "paranoid-mode-only",
             runner: Arc::new(SkipBytecodeVerifierRunner),
-            experiments: &[],
+            experiments: &[("access-use-function-check", false)],
             language_version: LanguageVersion::latest(),
             // Verifier config is irrelevant here, because we disable verifier for these tests.
             // Importantly, paranoid checks are enabled.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
