### PR TITLE
[decompiler]: fix issues in control flow optimizations

### DIFF
--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/abort_example.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/abort_example.exp
@@ -83,15 +83,18 @@ loop {
 _t8: u64 = 0;
 _t1: u64 = _t8;
 loop {
-  _t9: u64 = _t1;
-  _t10: u64 = length;
-  _t11: bool = Lt(_t9, _t10);
-  if (Not(_t11)) break;
-  _t12: u64 = _t1;
-  _t13: u64 = 1;
-  _t14: u64 = Add(_t12, _t13);
-  _t1: u64 = _t14;
-  continue
+  loop {
+    _t9: u64 = _t1;
+    _t10: u64 = length;
+    _t11: bool = Lt(_t9, _t10);
+    if (Not(_t11)) break[1];
+    _t12: u64 = _t1;
+    _t13: u64 = 1;
+    _t14: u64 = Add(_t12, _t13);
+    _t1: u64 = _t14;
+    continue
+  };
+  break
 };
 _t15: u64 = _t1;
 return _t15
@@ -107,9 +110,12 @@ loop {
 };
 _t1: u64 = 0;
 loop {
-  if (Not(Lt(_t1, length))) break;
-  _t1: u64 = Add(_t1, 1);
-  continue
+  loop {
+    if (Not(Lt(_t1, length))) break[1];
+    _t1: u64 = Add(_t1, 1);
+    continue
+  };
+  break
 };
 return _t1
 
@@ -118,9 +124,12 @@ if (Not(Gt(length, 0))) Abort(1);
 if (Not(Lt(length, 100))) Abort(2);
 _t1: u64 = 0;
 loop {
-  if (Not(Lt(_t1, length))) break;
-  _t1: u64 = Add(_t1, 1);
-  continue
+  loop {
+    if (Not(Lt(_t1, length))) break[1];
+    _t1: u64 = Add(_t1, 1);
+    continue
+  };
+  break
 };
 return _t1
 
@@ -131,9 +140,12 @@ return _t1
   if (Not(Lt(length, 100))) Abort(2);
   _t1: u64 = 0;
   loop {
-    if (Not(Lt(_t1, length))) break;
-    _t1: u64 = Add(_t1, 1);
-    continue
+    loop {
+      if (Not(Lt(_t1, length))) break[1];
+      _t1: u64 = Add(_t1, 1);
+      continue
+    };
+    break
   };
   return _t1
 }
@@ -145,7 +157,13 @@ module 0x815::m {
         if (!(length > 0)) abort 1;
         if (!(length < 100)) abort 2;
         _t1 = 0;
-        while (_t1 < length) _t1 = _t1 + 1;
+        'l0: loop {
+            loop {
+                if (!(_t1 < length)) break 'l0;
+                _t1 = _t1 + 1
+            };
+            break
+        };
         _t1
     }
 }

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/bit_vector_loop_example.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/bit_vector_loop_example.exp
@@ -383,61 +383,67 @@ loop {
       break[1]
     };
     loop {
-      _t14: u64 = _t3;
-      _t15: &mut vector<bool> = _t2;
-      _t16: &vector<bool> = Freeze(true)(_t15);
-      _t17: u64 = vector::length<bool>(_t16);
-      _t18: bool = Lt(_t14, _t17);
-      if (Not(_t18)) break;
-      _t19: &mut vector<bool> = _t2;
-      _t20: u64 = _t3;
-      _t21: &mut bool = vector::borrow_mut<bool>(_t19, _t20);
-      _t5: &mut bool = _t21;
-      _t22: bool = false;
-      _t23: &mut bool = _t5;
-      _t23 = _t22;
-      _t24: u64 = _t3;
-      _t25: u64 = 1;
-      _t26: u64 = Add(_t24, _t25);
-      _t3: u64 = _t26;
-      continue
+      loop {
+        _t14: u64 = _t3;
+        _t15: &mut vector<bool> = _t2;
+        _t16: &vector<bool> = Freeze(true)(_t15);
+        _t17: u64 = vector::length<bool>(_t16);
+        _t18: bool = Lt(_t14, _t17);
+        if (Not(_t18)) break[1];
+        _t19: &mut vector<bool> = _t2;
+        _t20: u64 = _t3;
+        _t21: &mut bool = vector::borrow_mut<bool>(_t19, _t20);
+        _t5: &mut bool = _t21;
+        _t22: bool = false;
+        _t23: &mut bool = _t5;
+        _t23 = _t22;
+        _t24: u64 = _t3;
+        _t25: u64 = 1;
+        _t26: u64 = Add(_t24, _t25);
+        _t3: u64 = _t26;
+        continue
+      };
+      break
     };
     _t27: &mut vector<bool> = _t2;
     break[1]
   };
   loop {
-    _t29: u64 = _t3;
-    _t30: &mut BitVector = self;
-    _t31: &u64 = select m::BitVector.length(_t30);
-    _t32: u64 = Deref(_t31);
-    _t33: bool = Lt(_t29, _t32);
-    if (Not(_t33)) break;
-    _t34: &mut BitVector = self;
-    _t35: &BitVector = Freeze(true)(_t34);
-    _t36: u64 = _t3;
-    _t37: bool = m::is_index_set(_t35, _t36);
     loop {
+      _t29: u64 = _t3;
+      _t30: &mut BitVector = self;
+      _t31: &u64 = select m::BitVector.length(_t30);
+      _t32: u64 = Deref(_t31);
+      _t33: bool = Lt(_t29, _t32);
+      if (Not(_t33)) break[1];
+      _t34: &mut BitVector = self;
+      _t35: &BitVector = Freeze(true)(_t34);
+      _t36: u64 = _t3;
+      _t37: bool = m::is_index_set(_t35, _t36);
       loop {
-        if (Not(_t37)) break;
-        _t38: &mut BitVector = self;
-        _t39: u64 = _t3;
-        _t40: u64 = amount;
-        _t41: u64 = Sub(_t39, _t40);
-        m::set(_t38, _t41);
-        break[1]
+        loop {
+          if (Not(_t37)) break;
+          _t38: &mut BitVector = self;
+          _t39: u64 = _t3;
+          _t40: u64 = amount;
+          _t41: u64 = Sub(_t39, _t40);
+          m::set(_t38, _t41);
+          break[1]
+        };
+        _t45: &mut BitVector = self;
+        _t46: u64 = _t3;
+        _t47: u64 = amount;
+        _t48: u64 = Sub(_t46, _t47);
+        m::unset(_t45, _t48);
+        break
       };
-      _t45: &mut BitVector = self;
-      _t46: u64 = _t3;
-      _t47: u64 = amount;
-      _t48: u64 = Sub(_t46, _t47);
-      m::unset(_t45, _t48);
-      break
+      _t42: u64 = _t3;
+      _t43: u64 = 1;
+      _t44: u64 = Add(_t42, _t43);
+      _t3: u64 = _t44;
+      continue
     };
-    _t42: u64 = _t3;
-    _t43: u64 = 1;
-    _t44: u64 = Add(_t42, _t43);
-    _t3: u64 = _t44;
-    continue
+    break
   };
   _t49: &mut BitVector = self;
   _t50: &u64 = select m::BitVector.length(_t49);
@@ -446,20 +452,23 @@ loop {
   _t53: u64 = Sub(_t51, _t52);
   _t3: u64 = _t53;
   loop {
-    _t54: u64 = _t3;
-    _t55: &mut BitVector = self;
-    _t56: &u64 = select m::BitVector.length(_t55);
-    _t57: u64 = Deref(_t56);
-    _t58: bool = Lt(_t54, _t57);
-    if (Not(_t58)) break;
-    _t59: &mut BitVector = self;
-    _t60: u64 = _t3;
-    m::unset(_t59, _t60);
-    _t61: u64 = _t3;
-    _t62: u64 = 1;
-    _t63: u64 = Add(_t61, _t62);
-    _t3: u64 = _t63;
-    continue
+    loop {
+      _t54: u64 = _t3;
+      _t55: &mut BitVector = self;
+      _t56: &u64 = select m::BitVector.length(_t55);
+      _t57: u64 = Deref(_t56);
+      _t58: bool = Lt(_t54, _t57);
+      if (Not(_t58)) break[1];
+      _t59: &mut BitVector = self;
+      _t60: u64 = _t3;
+      m::unset(_t59, _t60);
+      _t61: u64 = _t3;
+      _t62: u64 = 1;
+      _t63: u64 = Add(_t61, _t62);
+      _t3: u64 = _t63;
+      continue
+    };
+    break
   };
   _t64: &mut BitVector = self;
   break
@@ -480,33 +489,42 @@ loop {
       break[1]
     };
     loop {
-      if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break;
-      vector::borrow_mut<bool>(_t2, _t3) = false;
-      _t3: u64 = Add(_t3, 1);
-      continue
+      loop {
+        if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break[1];
+        vector::borrow_mut<bool>(_t2, _t3) = false;
+        _t3: u64 = Add(_t3, 1);
+        continue
+      };
+      break
     };
     break[1]
   };
   loop {
-    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
     loop {
+      if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break[1];
       loop {
-        if (Not(m::is_index_set(Freeze(true)(self), _t3))) break;
-        m::set(self, Sub(_t3, amount));
-        break[1]
+        loop {
+          if (Not(m::is_index_set(Freeze(true)(self), _t3))) break;
+          m::set(self, Sub(_t3, amount));
+          break[1]
+        };
+        m::unset(self, Sub(_t3, amount));
+        break
       };
-      m::unset(self, Sub(_t3, amount));
-      break
+      _t3: u64 = Add(_t3, 1);
+      continue
     };
-    _t3: u64 = Add(_t3, 1);
-    continue
+    break
   };
   _t3: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
   loop {
-    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
-    m::unset(self, _t3);
-    _t3: u64 = Add(_t3, 1);
-    continue
+    loop {
+      if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break[1];
+      m::unset(self, _t3);
+      _t3: u64 = Add(_t3, 1);
+      continue
+    };
+    break
   };
   break
 };
@@ -515,37 +533,51 @@ return Tuple()
 --- If-Transformed Generated AST
 loop {
   loop {
-    if Ge(amount, Deref(select m::BitVector.length(self))) {
-      _t2: &mut vector<bool> = select m::BitVector.bit_field(self);
-      _t3: u64 = 0
-    } else {
+    loop {
+      if Ge(amount, Deref(select m::BitVector.length(self))) {
+        _t2: &mut vector<bool> = select m::BitVector.bit_field(self);
+        _t3: u64 = 0;
+        break
+      };
       _t3: u64 = amount;
-      break
+      break[1]
     };
     loop {
-      if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break;
-      vector::borrow_mut<bool>(_t2, _t3) = false;
-      _t3: u64 = Add(_t3, 1);
-      continue
+      loop {
+        if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break[1];
+        vector::borrow_mut<bool>(_t2, _t3) = false;
+        _t3: u64 = Add(_t3, 1);
+        continue
+      };
+      break
     };
     break[1]
   };
   loop {
-    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
-    if m::is_index_set(Freeze(true)(self), _t3) {
-      m::set(self, Sub(_t3, amount))
-    } else {
-      m::unset(self, Sub(_t3, amount))
+    loop {
+      if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break[1];
+      loop {
+        if m::is_index_set(Freeze(true)(self), _t3) {
+          m::set(self, Sub(_t3, amount));
+          break
+        };
+        m::unset(self, Sub(_t3, amount));
+        break
+      };
+      _t3: u64 = Add(_t3, 1);
+      continue
     };
-    _t3: u64 = Add(_t3, 1);
-    continue
+    break
   };
   _t3: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
   loop {
-    if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
-    m::unset(self, _t3);
-    _t3: u64 = Add(_t3, 1);
-    continue
+    loop {
+      if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break[1];
+      m::unset(self, _t3);
+      _t3: u64 = Add(_t3, 1);
+      continue
+    };
+    break
   };
   break
 };
@@ -558,37 +590,51 @@ return Tuple()
     let _t2: &mut vector<bool>;
     loop {
       loop {
-        if Ge(amount, Deref(select m::BitVector.length(self))) {
-          _t2: &mut vector<bool> = select m::BitVector.bit_field(self);
-          _t3: u64 = 0
-        } else {
+        loop {
+          if Ge(amount, Deref(select m::BitVector.length(self))) {
+            _t2: &mut vector<bool> = select m::BitVector.bit_field(self);
+            _t3: u64 = 0;
+            break
+          };
           _t3: u64 = amount;
-          break
+          break[1]
         };
         loop {
-          if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break;
-          vector::borrow_mut<bool>(_t2, _t3) = false;
-          _t3: u64 = Add(_t3, 1);
-          continue
+          loop {
+            if (Not(Lt(_t3, vector::length<bool>(Freeze(true)(_t2))))) break[1];
+            vector::borrow_mut<bool>(_t2, _t3) = false;
+            _t3: u64 = Add(_t3, 1);
+            continue
+          };
+          break
         };
         break[1]
       };
       loop {
-        if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
-        if m::is_index_set(Freeze(true)(self), _t3) {
-          m::set(self, Sub(_t3, amount))
-        } else {
-          m::unset(self, Sub(_t3, amount))
+        loop {
+          if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break[1];
+          loop {
+            if m::is_index_set(Freeze(true)(self), _t3) {
+              m::set(self, Sub(_t3, amount));
+              break
+            };
+            m::unset(self, Sub(_t3, amount));
+            break
+          };
+          _t3: u64 = Add(_t3, 1);
+          continue
         };
-        _t3: u64 = Add(_t3, 1);
-        continue
+        break
       };
       _t3: u64 = Sub(Deref(select m::BitVector.length(self)), amount);
       loop {
-        if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break;
-        m::unset(self, _t3);
-        _t3: u64 = Add(_t3, 1);
-        continue
+        loop {
+          if (Not(Lt(_t3, Deref(select m::BitVector.length(self))))) break[1];
+          m::unset(self, _t3);
+          _t3: u64 = Add(_t3, 1);
+          continue
+        };
+        break
       };
       break
     };
@@ -702,29 +748,50 @@ module 0x1::m {
     public fun shift_left(self: &mut BitVector, amount: u64) {
         let _t3;
         let _t2;
-        'l0: loop {
-            loop {
-                if (amount >= *&self.length) {
-                    _t2 = &mut self.bit_field;
-                    _t3 = 0
-                } else {
+        'l2: loop {
+            'l0: loop {
+                loop {
+                    if (amount >= *&self.length) {
+                        _t2 = &mut self.bit_field;
+                        _t3 = 0;
+                        break
+                    };
                     _t3 = amount;
+                    break 'l0
+                };
+                'l1: loop {
+                    loop {
+                        if (!(_t3 < 0x1::vector::length<bool>(/*freeze*/_t2))) break 'l1;
+                        *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
+                        _t3 = _t3 + 1
+                    };
                     break
                 };
-                while (_t3 < 0x1::vector::length<bool>(/*freeze*/_t2)) {
-                    *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
+                break 'l2
+            };
+            'l3: loop {
+                loop {
+                    if (!(_t3 < *&self.length)) break 'l3;
+                    loop {
+                        if (is_index_set(/*freeze*/self, _t3)) {
+                            set(self, _t3 - amount);
+                            break
+                        };
+                        unset(self, _t3 - amount);
+                        break
+                    };
                     _t3 = _t3 + 1
                 };
-                break 'l0
-            };
-            while (_t3 < *&self.length) {
-                if (is_index_set(/*freeze*/self, _t3)) set(self, _t3 - amount) else unset(self, _t3 - amount);
-                _t3 = _t3 + 1
+                break
             };
             _t3 = *&self.length - amount;
-            while (_t3 < *&self.length) {
-                unset(self, _t3);
-                _t3 = _t3 + 1
+            'l4: loop {
+                loop {
+                    if (!(_t3 < *&self.length)) break 'l4;
+                    unset(self, _t3);
+                    _t3 = _t3 + 1
+                };
+                break
             };
             break
         };

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/conditionals.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/conditionals.exp
@@ -122,20 +122,26 @@ loop {
 return _t1
 
 --- If-Transformed Generated AST
-if c {
-  _t1: u8 = 1
-} else {
-  _t1: u8 = 2
+loop {
+  if c {
+    _t1: u8 = 1;
+    break
+  };
+  _t1: u8 = 2;
+  break
 };
 return _t1
 
 --- Var-Bound Generated AST
 {
   let _t1: u8;
-  if c {
-    _t1: u8 = 1
-  } else {
-    _t1: u8 = 2
+  loop {
+    if c {
+      _t1: u8 = 1;
+      break
+    };
+    _t1: u8 = 2;
+    break
   };
   return _t1
 }
@@ -227,28 +233,34 @@ loop {
 return _t2
 
 --- If-Transformed Generated AST
-if c {
+loop {
+  if Not(c) {
+    _t2: u8 = 3;
+    break
+  };
   if d {
-    _t2: u8 = 1
-  } else {
-    _t2: u8 = 2
-  }
-} else {
-  _t2: u8 = 3
+    _t2: u8 = 1;
+    break
+  };
+  _t2: u8 = 2;
+  break
 };
 return _t2
 
 --- Var-Bound Generated AST
 {
   let _t2: u8;
-  if c {
+  loop {
+    if Not(c) {
+      _t2: u8 = 3;
+      break
+    };
     if d {
-      _t2: u8 = 1
-    } else {
-      _t2: u8 = 2
-    }
-  } else {
-    _t2: u8 = 3
+      _t2: u8 = 1;
+      break
+    };
+    _t2: u8 = 2;
+    break
   };
   return _t2
 }
@@ -312,20 +324,26 @@ loop {
 return _t1
 
 --- If-Transformed Generated AST
-if c {
-  _t1: u64 = 1
-} else {
-  _t1: u64 = 2
+loop {
+  if c {
+    _t1: u64 = 1;
+    break
+  };
+  _t1: u64 = 2;
+  break
 };
 return _t1
 
 --- Var-Bound Generated AST
 {
   let _t1: u64;
-  if c {
-    _t1: u64 = 1
-  } else {
-    _t1: u64 = 2
+  loop {
+    if c {
+      _t1: u64 = 1;
+      break
+    };
+    _t1: u64 = 2;
+    break
   };
   return _t1
 }
@@ -415,28 +433,34 @@ loop {
 return _t2
 
 --- If-Transformed Generated AST
-if c {
-  _t2: u8 = 1
-} else {
+loop {
+  if c {
+    _t2: u8 = 1;
+    break
+  };
   if d {
-    _t2: u8 = 2
-  } else {
-    _t2: u8 = 3
-  }
+    _t2: u8 = 2;
+    break
+  };
+  _t2: u8 = 3;
+  break
 };
 return _t2
 
 --- Var-Bound Generated AST
 {
   let _t2: u8;
-  if c {
-    _t2: u8 = 1
-  } else {
+  loop {
+    if c {
+      _t2: u8 = 1;
+      break
+    };
     if d {
-      _t2: u8 = 2
-    } else {
-      _t2: u8 = 3
-    }
+      _t2: u8 = 2;
+      break
+    };
+    _t2: u8 = 3;
+    break
   };
   return _t2
 }
@@ -545,10 +569,13 @@ return _t1
 --- If-Transformed Generated AST
 x: u64 = Add(x, x);
 x: u64 = Mul(x, x);
-if Gt(x, 0) {
-  _t1: u64 = Add(x, 1)
-} else {
-  _t1: u64 = Sub(x, 1)
+loop {
+  if Gt(x, 0) {
+    _t1: u64 = Add(x, 1);
+    break
+  };
+  _t1: u64 = Sub(x, 1);
+  break
 };
 return _t1
 
@@ -557,10 +584,13 @@ return _t1
   let _t1: u64;
   x: u64 = Add(x, x);
   x: u64 = Mul(x, x);
-  if Gt(x, 0) {
-    _t1: u64 = Add(x, 1)
-  } else {
-    _t1: u64 = Sub(x, 1)
+  loop {
+    if Gt(x, 0) {
+      _t1: u64 = Add(x, 1);
+      break
+    };
+    _t1: u64 = Sub(x, 1);
+    break
   };
   return _t1
 }
@@ -575,29 +605,72 @@ module 0x815::m {
     }
     fun if_else_1(c: bool): u8 {
         let _t1;
-        if (c) _t1 = 1u8 else _t1 = 2u8;
+        loop {
+            if (c) {
+                _t1 = 1u8;
+                break
+            };
+            _t1 = 2u8;
+            break
+        };
         _t1
     }
     fun if_else_2(c: bool, d: bool): u8 {
         let _t2;
-        if (c) if (d) _t2 = 1u8 else _t2 = 2u8 else _t2 = 3u8;
+        loop {
+            if (!c) {
+                _t2 = 3u8;
+                break
+            };
+            if (d) {
+                _t2 = 1u8;
+                break
+            };
+            _t2 = 2u8;
+            break
+        };
         _t2
     }
     fun if_else_3(c: bool): u64 {
         let _t1;
-        if (c) _t1 = 1 else _t1 = 2;
+        loop {
+            if (c) {
+                _t1 = 1;
+                break
+            };
+            _t1 = 2;
+            break
+        };
         _t1
     }
     fun if_else_if(c: bool, d: bool): u8 {
         let _t2;
-        if (c) _t2 = 1u8 else if (d) _t2 = 2u8 else _t2 = 3u8;
+        loop {
+            if (c) {
+                _t2 = 1u8;
+                break
+            };
+            if (d) {
+                _t2 = 2u8;
+                break
+            };
+            _t2 = 3u8;
+            break
+        };
         _t2
     }
     fun if_else_with_shared_exp(x: u64): u64 {
         let _t1;
         x = x + x;
         x = x * x;
-        if (x > 0) _t1 = x + 1 else _t1 = x - 1;
+        loop {
+            if (x > 0) {
+                _t1 = x + 1;
+                break
+            };
+            _t1 = x - 1;
+            break
+        };
         _t1
     }
 }

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/loops.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/loops.exp
@@ -175,58 +175,70 @@ fun m::nested_loop($t0|x: u64): u64 {
 
 --- Raw Generated AST
 loop {
-  _t1: u64 = x;
-  _t2: u64 = 0;
-  _t3: bool = Gt(_t1, _t2);
-  if (Not(_t3)) break;
-  _t4: u64 = x;
-  _t5: u64 = 10;
-  _t6: bool = Gt(_t4, _t5);
   loop {
-    if (Not(_t6)) break;
-    _t7: u64 = x;
-    _t8: u64 = 1;
-    _t9: u64 = Sub(_t7, _t8);
-    x: u64 = _t9;
-    break
+    _t1: u64 = x;
+    _t2: u64 = 0;
+    _t3: bool = Gt(_t1, _t2);
+    if (Not(_t3)) break[1];
+    _t4: u64 = x;
+    _t5: u64 = 10;
+    _t6: bool = Gt(_t4, _t5);
+    loop {
+      if (Not(_t6)) break;
+      _t7: u64 = x;
+      _t8: u64 = 1;
+      _t9: u64 = Sub(_t7, _t8);
+      x: u64 = _t9;
+      break
+    };
+    _t10: u64 = x;
+    _t11: u64 = 1;
+    _t12: u64 = Sub(_t10, _t11);
+    x: u64 = _t12;
+    continue
   };
-  _t10: u64 = x;
-  _t11: u64 = 1;
-  _t12: u64 = Sub(_t10, _t11);
-  x: u64 = _t12;
-  continue
+  break
 };
 _t13: u64 = x;
 return _t13
 
 --- Assign-Transformed Generated AST
 loop {
-  if (Not(Gt(x, 0))) break;
   loop {
-    if (Not(Gt(x, 10))) break;
+    if (Not(Gt(x, 0))) break[1];
+    loop {
+      if (Not(Gt(x, 10))) break;
+      x: u64 = Sub(x, 1);
+      break
+    };
     x: u64 = Sub(x, 1);
-    break
+    continue
   };
-  x: u64 = Sub(x, 1);
-  continue
+  break
 };
 return x
 
 --- If-Transformed Generated AST
 loop {
-  if (Not(Gt(x, 0))) break;
-  if (Gt(x, 10)) x: u64 = Sub(x, 1);
-  x: u64 = Sub(x, 1);
-  continue
+  loop {
+    if (Not(Gt(x, 0))) break[1];
+    if (Gt(x, 10)) x: u64 = Sub(x, 1);
+    x: u64 = Sub(x, 1);
+    continue
+  };
+  break
 };
 return x
 
 --- Var-Bound Generated AST
 loop {
-  if (Not(Gt(x, 0))) break;
-  if (Gt(x, 10)) x: u64 = Sub(x, 1);
-  x: u64 = Sub(x, 1);
-  continue
+  loop {
+    if (Not(Gt(x, 0))) break[1];
+    if (Gt(x, 10)) x: u64 = Sub(x, 1);
+    x: u64 = Sub(x, 1);
+    continue
+  };
+  break
 };
 return x
 
@@ -262,39 +274,51 @@ fun m::while_1($t0|c: u64) {
 
 --- Raw Generated AST
 loop {
-  _t1: u64 = c;
-  _t2: u64 = 0;
-  _t3: bool = Gt(_t1, _t2);
-  if (Not(_t3)) break;
-  _t4: u64 = c;
-  _t5: u64 = 1;
-  _t6: u64 = Sub(_t4, _t5);
-  c: u64 = _t6;
-  continue
+  loop {
+    _t1: u64 = c;
+    _t2: u64 = 0;
+    _t3: bool = Gt(_t1, _t2);
+    if (Not(_t3)) break[1];
+    _t4: u64 = c;
+    _t5: u64 = 1;
+    _t6: u64 = Sub(_t4, _t5);
+    c: u64 = _t6;
+    continue
+  };
+  break
 };
 return Tuple()
 
 --- Assign-Transformed Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
-  c: u64 = Sub(c, 1);
-  continue
+  loop {
+    if (Not(Gt(c, 0))) break[1];
+    c: u64 = Sub(c, 1);
+    continue
+  };
+  break
 };
 return Tuple()
 
 --- If-Transformed Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
-  c: u64 = Sub(c, 1);
-  continue
+  loop {
+    if (Not(Gt(c, 0))) break[1];
+    c: u64 = Sub(c, 1);
+    continue
+  };
+  break
 };
 return Tuple()
 
 --- Var-Bound Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
-  c: u64 = Sub(c, 1);
-  continue
+  loop {
+    if (Not(Gt(c, 0))) break[1];
+    c: u64 = Sub(c, 1);
+    continue
+  };
+  break
 };
 return Tuple()
 
@@ -350,19 +374,22 @@ fun m::while_2($t0|c: u64): u64 {
 
 --- Raw Generated AST
 loop {
-  _t1: u64 = c;
-  _t2: u64 = 0;
-  _t3: bool = Gt(_t1, _t2);
-  if (Not(_t3)) break;
-  _t4: u64 = c;
-  _t5: u64 = 10;
-  _t6: bool = Ge(_t4, _t5);
-  if (Not(_t6)) continue;
-  _t7: u64 = c;
-  _t8: u64 = 10;
-  _t9: u64 = Sub(_t7, _t8);
-  c: u64 = _t9;
-  continue
+  loop {
+    _t1: u64 = c;
+    _t2: u64 = 0;
+    _t3: bool = Gt(_t1, _t2);
+    if (Not(_t3)) break[1];
+    _t4: u64 = c;
+    _t5: u64 = 10;
+    _t6: bool = Ge(_t4, _t5);
+    if (Not(_t6)) continue;
+    _t7: u64 = c;
+    _t8: u64 = 10;
+    _t9: u64 = Sub(_t7, _t8);
+    c: u64 = _t9;
+    continue
+  };
+  break
 };
 _t10: u64 = c;
 _t11: u64 = 1;
@@ -371,28 +398,37 @@ return _t12
 
 --- Assign-Transformed Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
-  if (Not(Ge(c, 10))) continue;
-  c: u64 = Sub(c, 10);
-  continue
+  loop {
+    if (Not(Gt(c, 0))) break[1];
+    if (Not(Ge(c, 10))) continue;
+    c: u64 = Sub(c, 10);
+    continue
+  };
+  break
 };
 return Add(c, 1)
 
 --- If-Transformed Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
-  if (Not(Ge(c, 10))) continue;
-  c: u64 = Sub(c, 10);
-  continue
+  loop {
+    if (Not(Gt(c, 0))) break[1];
+    if (Not(Ge(c, 10))) continue;
+    c: u64 = Sub(c, 10);
+    continue
+  };
+  break
 };
 return Add(c, 1)
 
 --- Var-Bound Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
-  if (Not(Ge(c, 10))) continue;
-  c: u64 = Sub(c, 10);
-  continue
+  loop {
+    if (Not(Gt(c, 0))) break[1];
+    if (Not(Ge(c, 10))) continue;
+    c: u64 = Sub(c, 10);
+    continue
+  };
+  break
 };
 return Add(c, 1)
 
@@ -453,66 +489,90 @@ fun m::while_3($t0|c: u64): u64 {
 
 --- Raw Generated AST
 loop {
-  _t1: u64 = c;
-  _t2: u64 = 0;
-  _t3: bool = Gt(_t1, _t2);
-  if (Not(_t3)) break;
   loop {
-    _t4: u64 = c;
-    _t5: u64 = 10;
-    _t6: bool = Gt(_t4, _t5);
-    if (Not(_t6)) break;
-    _t7: u64 = c;
-    _t8: u64 = 10;
-    _t9: u64 = Sub(_t7, _t8);
-    c: u64 = _t9;
+    _t1: u64 = c;
+    _t2: u64 = 0;
+    _t3: bool = Gt(_t1, _t2);
+    if (Not(_t3)) break[1];
+    loop {
+      loop {
+        _t4: u64 = c;
+        _t5: u64 = 10;
+        _t6: bool = Gt(_t4, _t5);
+        if (Not(_t6)) break[1];
+        _t7: u64 = c;
+        _t8: u64 = 10;
+        _t9: u64 = Sub(_t7, _t8);
+        c: u64 = _t9;
+        continue
+      };
+      break
+    };
+    _t10: u64 = c;
+    _t11: u64 = 1;
+    _t12: u64 = Sub(_t10, _t11);
+    c: u64 = _t12;
     continue
   };
-  _t10: u64 = c;
-  _t11: u64 = 1;
-  _t12: u64 = Sub(_t10, _t11);
-  c: u64 = _t12;
-  continue
+  break
 };
 _t13: u64 = c;
 return _t13
 
 --- Assign-Transformed Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
   loop {
-    if (Not(Gt(c, 10))) break;
-    c: u64 = Sub(c, 10);
+    if (Not(Gt(c, 0))) break[1];
+    loop {
+      loop {
+        if (Not(Gt(c, 10))) break[1];
+        c: u64 = Sub(c, 10);
+        continue
+      };
+      break
+    };
+    c: u64 = Sub(c, 1);
     continue
   };
-  c: u64 = Sub(c, 1);
-  continue
+  break
 };
 return c
 
 --- If-Transformed Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
   loop {
-    if (Not(Gt(c, 10))) break;
-    c: u64 = Sub(c, 10);
+    if (Not(Gt(c, 0))) break[1];
+    loop {
+      loop {
+        if (Not(Gt(c, 10))) break[1];
+        c: u64 = Sub(c, 10);
+        continue
+      };
+      break
+    };
+    c: u64 = Sub(c, 1);
     continue
   };
-  c: u64 = Sub(c, 1);
-  continue
+  break
 };
 return c
 
 --- Var-Bound Generated AST
 loop {
-  if (Not(Gt(c, 0))) break;
   loop {
-    if (Not(Gt(c, 10))) break;
-    c: u64 = Sub(c, 10);
+    if (Not(Gt(c, 0))) break[1];
+    loop {
+      loop {
+        if (Not(Gt(c, 10))) break[1];
+        c: u64 = Sub(c, 10);
+        continue
+      };
+      break
+    };
+    c: u64 = Sub(c, 1);
     continue
   };
-  c: u64 = Sub(c, 1);
-  continue
+  break
 };
 return c
 
@@ -529,26 +589,50 @@ module 0x815::m {
         c
     }
     fun nested_loop(x: u64): u64 {
-        while (x > 0) {
-            if (x > 10) x = x - 1;
-            x = x - 1
+        'l0: loop {
+            loop {
+                if (!(x > 0)) break 'l0;
+                if (x > 10) x = x - 1;
+                x = x - 1
+            };
+            break
         };
         x
     }
     fun while_1(c: u64) {
-        while (c > 0) c = c - 1;
+        'l0: loop {
+            loop {
+                if (!(c > 0)) break 'l0;
+                c = c - 1
+            };
+            break
+        };
     }
     fun while_2(c: u64): u64 {
-        while (c > 0) {
-            if (!(c >= 10)) continue;
-            c = c - 10
+        'l0: loop {
+            loop {
+                if (!(c > 0)) break 'l0;
+                if (!(c >= 10)) continue;
+                c = c - 10
+            };
+            break
         };
         c + 1
     }
     fun while_3(c: u64): u64 {
-        while (c > 0) {
-            while (c > 10) c = c - 10;
-            c = c - 1
+        'l0: loop {
+            loop {
+                if (!(c > 0)) break 'l0;
+                'l1: loop {
+                    loop {
+                        if (!(c > 10)) break 'l1;
+                        c = c - 10
+                    };
+                    break
+                };
+                c = c - 1
+            };
+            break
         };
         c
     }

--- a/third_party/move/move-model/bytecode/ast-generator-tests/tests/match.exp
+++ b/third_party/move/move-model/bytecode/ast-generator-tests/tests/match.exp
@@ -99,22 +99,28 @@ loop {
 return _t1
 
 --- If-Transformed Generated AST
-if test_variants m::Entity::Person(self) {
-  _t1: u64 = Deref(select_variants m::Entity.Person.id(self))
-} else {
+loop {
+  if test_variants m::Entity::Person(self) {
+    _t1: u64 = Deref(select_variants m::Entity.Person.id(self));
+    break
+  };
   if (Not(test_variants m::Entity::Institution(self))) Abort(14566554180833181697);
-  _t1: u64 = Deref(select_variants m::Entity.Institution.id(self))
+  _t1: u64 = Deref(select_variants m::Entity.Institution.id(self));
+  break
 };
 return _t1
 
 --- Var-Bound Generated AST
 {
   let _t1: u64;
-  if test_variants m::Entity::Person(self) {
-    _t1: u64 = Deref(select_variants m::Entity.Person.id(self))
-  } else {
+  loop {
+    if test_variants m::Entity::Person(self) {
+      _t1: u64 = Deref(select_variants m::Entity.Person.id(self));
+      break
+    };
     if (Not(test_variants m::Entity::Institution(self))) Abort(14566554180833181697);
-    _t1: u64 = Deref(select_variants m::Entity.Institution.id(self))
+    _t1: u64 = Deref(select_variants m::Entity.Institution.id(self));
+    break
   };
   return _t1
 }
@@ -249,16 +255,19 @@ return _t2
 
 --- If-Transformed Generated AST
 _t1: &Entity = Borrow(Immutable)(self);
-if And(test_variants m::Entity::Person(_t1), Gt(Deref(select_variants m::Entity.Person.id(_t1)), 0)) {
-  m::Entity::Person{ id: _t20 } = self;
-  _t2: u64 = _t20
-} else {
+loop {
+  if And(test_variants m::Entity::Person(_t1), Gt(Deref(select_variants m::Entity.Person.id(_t1)), 0)) {
+    m::Entity::Person{ id: _t20 } = self;
+    _t2: u64 = _t20;
+    break
+  };
   if test_variants m::Entity::Institution(_t1) {
     m::Entity::Institution{ id: _t9, admin: _t10 } = self;
-    _t2: u64 = _t9
-  } else {
-    _t2: u64 = 0
-  }
+    _t2: u64 = _t9;
+    break
+  };
+  _t2: u64 = 0;
+  break
 };
 return _t2
 
@@ -274,16 +283,19 @@ return _t2
         {
           let _t1: &Entity;
           _t1: &Entity = Borrow(Immutable)(self);
-          if And(test_variants m::Entity::Person(_t1), Gt(Deref(select_variants m::Entity.Person.id(_t1)), 0)) {
-            m::Entity::Person{ id: _t20 } = self;
-            _t2: u64 = _t20
-          } else {
+          loop {
+            if And(test_variants m::Entity::Person(_t1), Gt(Deref(select_variants m::Entity.Person.id(_t1)), 0)) {
+              m::Entity::Person{ id: _t20 } = self;
+              _t2: u64 = _t20;
+              break
+            };
             if test_variants m::Entity::Institution(_t1) {
               m::Entity::Institution{ id: _t9, admin: _t10 } = self;
-              _t2: u64 = _t9
-            } else {
-              _t2: u64 = 0
-            }
+              _t2: u64 = _t9;
+              break
+            };
+            _t2: u64 = 0;
+            break
           };
           return _t2
         }
@@ -305,9 +317,14 @@ module 0x815::m {
     }
     fun id(self: &Entity): u64 {
         let _t1;
-        if (self is Person) _t1 = *&self.id else {
+        loop {
+            if (self is Person) {
+                _t1 = *&self.id;
+                break
+            };
             if (!(self is Institution)) abort 14566554180833181697;
-            _t1 = *&self.id
+            _t1 = *&self.id;
+            break
         };
         _t1
     }
@@ -318,13 +335,20 @@ module 0x815::m {
         let _t20;
         let _t1;
         _t1 = &self;
-        if ((_t1 is Person) && *&_t1.id > 0) {
-            Entity::Person{id: _t20} = self;
-            _t2 = _t20
-        } else if (_t1 is Institution) {
-            Entity::Institution{id: _t9,admin: _t10} = self;
-            _t2 = _t9
-        } else _t2 = 0;
+        loop {
+            if ((_t1 is Person) && *&_t1.id > 0) {
+                Entity::Person{id: _t20} = self;
+                _t2 = _t20;
+                break
+            };
+            if (_t1 is Institution) {
+                Entity::Institution{id: _t9,admin: _t10} = self;
+                _t2 = _t9;
+                break
+            };
+            _t2 = 0;
+            break
+        };
         _t2
     }
 }

--- a/third_party/move/move-model/src/exp_builder.rs
+++ b/third_party/move/move-model/src/exp_builder.rs
@@ -156,28 +156,6 @@ impl<'a> ExpBuilder<'a> {
         }
     }
 
-    /// Pushes a loop block close to the point where it matters, i.e. where there is
-    /// another loop or a break/continue.
-    pub fn push_loop_block_into(&self, exp: Exp) -> Exp {
-        match exp.as_ref() {
-            ExpData::Loop(..) | ExpData::LoopCont(..) => self.loop_(exp),
-            ExpData::Sequence(id, elems) => {
-                if let Some(i) = elems
-                    .iter()
-                    .position(|e| matches!(e.as_ref(), ExpData::Loop(..) | ExpData::LoopCont(..)))
-                {
-                    let mut new_elems = elems[0..i].to_vec();
-                    let default_loc = self.env().get_node_loc(*id);
-                    new_elems.push(self.loop_(self.seq(&default_loc, elems[i..].to_vec())));
-                    self.seq(&default_loc, new_elems)
-                } else {
-                    exp
-                }
-            },
-            _ => exp,
-        }
-    }
-
     pub fn unfold(&self, substitution: &BTreeMap<Symbol, Exp>, exp: Exp) -> Exp {
         ExpData::rewrite(exp, &mut |e: Exp| {
             if let ExpData::LocalVar(_, name) = e.as_ref() {

--- a/third_party/move/tools/move-decompiler/tests/bit_vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/bit_vector.exp
@@ -17,7 +17,14 @@ module 0x1::bit_vector {
         _t2 = start_index;
         loop {
             {
-                while (_t2 < *&self.length && is_index_set(self, _t2)) _t2 = _t2 + 1;
+                'l0: loop {
+                    loop {
+                        if (!(_t2 < *&self.length)) break 'l0;
+                        if (!is_index_set(self, _t2)) break 'l0;
+                        _t2 = _t2 + 1
+                    };
+                    break
+                };
                 break
             };
             break
@@ -31,9 +38,13 @@ module 0x1::bit_vector {
         if (!(length < 1024)) abort 131073;
         _t1 = 0;
         _t2 = 0x1::vector::empty<bool>();
-        while (_t1 < length) {
-            0x1::vector::push_back<bool>(&mut _t2, false);
-            _t1 = _t1 + 1
+        'l0: loop {
+            loop {
+                if (!(_t1 < length)) break 'l0;
+                0x1::vector::push_back<bool>(&mut _t2, false);
+                _t1 = _t1 + 1
+            };
+            break
         };
         BitVector{length: length,bit_field: _t2}
     }
@@ -45,30 +56,51 @@ module 0x1::bit_vector {
         let _t4;
         let _t3;
         let _t2;
-        'l0: loop {
-            loop {
-                if (amount >= *&self.length) {
-                    _t2 = &mut self.bit_field;
-                    _t3 = 0;
-                    _t4 = 0x1::vector::length<bool>(/*freeze*/_t2)
-                } else {
+        'l2: loop {
+            'l0: loop {
+                loop {
+                    if (amount >= *&self.length) {
+                        _t2 = &mut self.bit_field;
+                        _t3 = 0;
+                        _t4 = 0x1::vector::length<bool>(/*freeze*/_t2);
+                        break
+                    };
                     _t3 = amount;
+                    break 'l0
+                };
+                'l1: loop {
+                    loop {
+                        if (!(_t3 < _t4)) break 'l1;
+                        *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
+                        _t3 = _t3 + 1
+                    };
                     break
                 };
-                while (_t3 < _t4) {
-                    *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
+                break 'l2
+            };
+            'l3: loop {
+                loop {
+                    if (!(_t3 < *&self.length)) break 'l3;
+                    loop {
+                        if (is_index_set(/*freeze*/self, _t3)) {
+                            set(self, _t3 - amount);
+                            break
+                        };
+                        unset(self, _t3 - amount);
+                        break
+                    };
                     _t3 = _t3 + 1
                 };
-                break 'l0
-            };
-            while (_t3 < *&self.length) {
-                if (is_index_set(/*freeze*/self, _t3)) set(self, _t3 - amount) else unset(self, _t3 - amount);
-                _t3 = _t3 + 1
+                break
             };
             _t3 = *&self.length - amount;
-            while (_t3 < *&self.length) {
-                unset(self, _t3);
-                _t3 = _t3 + 1
+            'l4: loop {
+                loop {
+                    if (!(_t3 < *&self.length)) break 'l4;
+                    unset(self, _t3);
+                    _t3 = _t3 + 1
+                };
+                break
             };
             break
         };

--- a/third_party/move/tools/move-decompiler/tests/cfg_opt.exp
+++ b/third_party/move/tools/move-decompiler/tests/cfg_opt.exp
@@ -1,0 +1,134 @@
+
+module 0x99::cfg_opt_complex {
+    enum Admin has drop {
+        Superuser,
+        User {
+            _0: u64,
+        }
+    }
+    enum Entity has drop {
+        Person {
+            id: u64,
+        }
+        Institution {
+            id: u64,
+            admin: Admin,
+        }
+    }
+    fun admin_id(self: &Entity): u64 {
+        let _t8;
+        let _t6;
+        let _t3;
+        let _t1;
+        let _t2;
+        let _t5;
+        'l2: loop {
+            while (!((self is Institution) && (&self.admin is Superuser))) {
+                'l0: loop {
+                    while (self is Institution) {
+                        _t5 = &self.admin;
+                        if (!(_t5 is User)) break;
+                        _t2 = &_t5._0;
+                        if (*_t2 > 10) break 'l0;
+                        break
+                    };
+                    'l1: loop {
+                        while (self is Institution) {
+                            _t5 = &self.admin;
+                            if (!(_t5 is User)) break;
+                            if (!(*&_t5._0 <= 10)) break;
+                            break 'l1
+                        };
+                        _t1 = self;
+                        while (_t1 is Person) {
+                            _t2 = &_t1.id;
+                            if (!(*_t2 > 10)) break;
+                            _t3 = *_t2;
+                            break 'l2
+                        };
+                        if (_t1 is Institution) {
+                            _t3 = *&_t1.id;
+                            break 'l2
+                        };
+                        _t3 = 0;
+                        break 'l2
+                    };
+                    _t1 = self;
+                    'l3: loop {
+                        while (_t1 is Person) {
+                            _t2 = &_t1.id;
+                            if (!(*_t2 > 10)) break;
+                            _t6 = *_t2;
+                            break 'l3
+                        };
+                        if (_t1 is Institution) {
+                            _t6 = *&_t1.id;
+                            break
+                        };
+                        _t6 = 0;
+                        break
+                    };
+                    _t3 = _t6 + 5;
+                    break 'l2
+                };
+                _t1 = self;
+                'l4: loop {
+                    while (_t1 is Person) {
+                        _t2 = &_t1.id;
+                        if (!(*_t2 > 10)) break;
+                        _t6 = *_t2;
+                        break 'l4
+                    };
+                    if (_t1 is Institution) {
+                        _t6 = *&_t1.id;
+                        break
+                    };
+                    _t6 = 0;
+                    break
+                };
+                _t3 = *_t2 + _t6;
+                break 'l2
+            };
+            'l5: loop {
+                while (self is Person) {
+                    _t2 = &self.id;
+                    if (!(*_t2 > 10)) break;
+                    _t8 = *_t2;
+                    break 'l5
+                };
+                if (self is Institution) {
+                    _t8 = *&self.id;
+                    break
+                };
+                _t8 = 0;
+                break
+            };
+            _t3 = 1 + _t8;
+            break
+        };
+        _t3
+    }
+}
+
+module 0x99::cfg_opt_simple {
+    fun test1(x: u64, y: u64): u64 {
+        'l0: loop {
+            loop {
+                if (!(x > 1 || y > 2)) break 'l0;
+                y = y + 1
+            };
+            break
+        };
+        x + 1 + y
+    }
+    fun test2(x: u64, y: u64): u64 {
+        'l0: loop {
+            loop {
+                if (!(x > 1 || y > 2)) break 'l0;
+                y = y + 1
+            };
+            break
+        };
+        x + y
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/cfg_opt.move
+++ b/third_party/move/tools/move-decompiler/tests/cfg_opt.move
@@ -1,0 +1,56 @@
+module 0x99::cfg_opt_simple {
+    fun test1(x: u64, y: u64): u64 {
+       'outer: loop{
+            loop{
+                if (x > 1) break;
+                if (y > 2) break;
+                x = x + 1;
+                break 'outer
+            };
+            y = y + 1
+        };
+        x + y
+    }
+
+    fun test2(x: u64, y: u64): u64 {
+        'outer: loop{
+            loop{
+                if (x > 1) break;
+                if (y > 2) break;
+                break 'outer
+            };
+            y = y + 1
+        };
+        x + y
+    }
+}
+
+module 0x99::cfg_opt_complex {
+    enum Entity has drop {
+        Person { id: u64 },
+        Institution { id: u64, admin: Admin }
+    }
+
+    enum Admin has drop {
+        Superuser,
+        User(u64)
+    }
+
+    // Ensure function is inlined so we create nested matches in the next one.
+    inline fun id(self: &Entity): u64 {
+        match (self) {
+            Person{id} if *id > 10 => *id,
+            Institution{id, ..} => *id,
+            _ => 0
+        }
+    }
+
+    fun admin_id(self: &Entity): u64 {
+        match (self) {
+            Institution{admin: Admin::Superuser, ..} => 1 + self.id(),
+            Institution{admin: Admin::User(id), ..} if *id > 10 => *id + self.id(),
+            Institution{admin: Admin::User(id), ..} if  *id <= 10 => self.id() + 5,
+            _ => self.id()
+        }
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/closure.exp
+++ b/third_party/move/tools/move-decompiler/tests/closure.exp
@@ -23,7 +23,14 @@ module 0x99::basic_struct {
     }
     fun test(f: &||(u64)): u64 {
         let _t1;
-        if (f == f) _t1 = 1 else _t1 = 2;
+        loop {
+            if (f == f) {
+                _t1 = 1;
+                break
+            };
+            _t1 = 2;
+            break
+        };
         _t1
     }
     public fun test_driver(acc: &signer) {

--- a/third_party/move/tools/move-decompiler/tests/fixed_point32.exp
+++ b/third_party/move/tools/move-decompiler/tests/fixed_point32.exp
@@ -19,7 +19,14 @@ module 0x1::fixed_point32 {
         _t3 = (denominator as u128) << 32u8;
         if (!(_t3 != 0u128)) abort 65537;
         _t4 = ((numerator as u128) << 64u8) / _t3;
-        if (_t4 != 0u128) _t5 = true else _t5 = numerator == 0;
+        loop {
+            if (_t4 != 0u128) {
+                _t5 = true;
+                break
+            };
+            _t5 = numerator == 0;
+            break
+        };
         if (!_t5) abort 131077;
         if (!(_t4 <= 18446744073709551615u128)) abort 131077;
         FixedPoint32{value: _t4 as u64}
@@ -48,12 +55,26 @@ module 0x1::fixed_point32 {
     }
     public fun max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
         let _t2;
-        if (*&(&num1).value > *&(&num2).value) _t2 = num1 else _t2 = num2;
+        loop {
+            if (*&(&num1).value > *&(&num2).value) {
+                _t2 = num1;
+                break
+            };
+            _t2 = num2;
+            break
+        };
         _t2
     }
     public fun min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
         let _t2;
-        if (*&(&num1).value < *&(&num2).value) _t2 = num1 else _t2 = num2;
+        loop {
+            if (*&(&num1).value < *&(&num2).value) {
+                _t2 = num1;
+                break
+            };
+            _t2 = num2;
+            break
+        };
         _t2
     }
     public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64 {
@@ -67,7 +88,14 @@ module 0x1::fixed_point32 {
         let _t1;
         _t1 = floor(self) << 32u8;
         _t2 = _t1 + 2147483648;
-        if (*&(&self).value < _t2) _t2 = _t1 >> 32u8 else _t2 = ceil(self);
+        loop {
+            if (*&(&self).value < _t2) {
+                _t2 = _t1 >> 32u8;
+                break
+            };
+            _t2 = ceil(self);
+            break
+        };
         _t2
     }
 }

--- a/third_party/move/tools/move-decompiler/tests/nested_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/nested_loops.exp
@@ -10,15 +10,32 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
-            if (_t2) _t1 = _t1 + 1 else _t2 = true;
-            if (!(_t1 < 10)) break;
-            _t0 = _t0 + 1;
-            _t3 = _t1;
-            _t4 = false;
-            loop {
-                if (_t4) _t3 = _t3 + 1 else _t4 = true;
-                if (!(_t3 < 10)) continue 'l0;
-                _t0 = _t0 + 1
+            'l1: loop {
+                loop {
+                    if (_t2) {
+                        _t1 = _t1 + 1;
+                        break
+                    };
+                    _t2 = true;
+                    break
+                };
+                if (!(_t1 < 10)) break 'l0;
+                _t0 = _t0 + 1;
+                _t3 = _t1;
+                _t4 = false;
+                loop {
+                    loop {
+                        if (_t4) {
+                            _t3 = _t3 + 1;
+                            break
+                        };
+                        _t4 = true;
+                        break
+                    };
+                    if (!(_t3 < 10)) continue 'l1;
+                    _t0 = _t0 + 1
+                };
+                break
             };
             break
         };
@@ -33,19 +50,29 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
-            if (_t2) _t1 = _t1 + 1 else _t2 = true;
-            if (!(_t1 < 5)) break;
-            _t0 = _t0 + 1;
-            _t3 = _t1;
             'l1: loop {
-                if (!(_t3 < 10)) continue 'l0;
-                _t0 = _t0 + 1;
-                _t4 = _t3;
-                _t3 = _t3 + 1;
                 loop {
+                    if (_t2) {
+                        _t1 = _t1 + 1;
+                        break
+                    };
+                    _t2 = true;
+                    break
+                };
+                if (!(_t1 < 5)) break 'l0;
+                _t0 = _t0 + 1;
+                _t3 = _t1;
+                'l2: loop {
+                    if (!(_t3 < 10)) continue 'l1;
                     _t0 = _t0 + 1;
-                    if (_t4 > 10) continue 'l1;
-                    _t4 = _t4 + 1
+                    _t4 = _t3;
+                    _t3 = _t3 + 1;
+                    loop {
+                        _t0 = _t0 + 1;
+                        if (_t4 > 10) continue 'l2;
+                        _t4 = _t4 + 1
+                    };
+                    break
                 };
                 break
             };
@@ -60,12 +87,22 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
-            if (_t2) _t1 = _t1 + 1 else _t2 = true;
-            if (!(_t1 < 5)) break;
-            _t0 = _t0 + 1;
-            loop {
-                if (!(_t0 < 5)) continue 'l0;
-                _t0 = _t0 + 10
+            'l1: loop {
+                loop {
+                    if (_t2) {
+                        _t1 = _t1 + 1;
+                        break
+                    };
+                    _t2 = true;
+                    break
+                };
+                if (!(_t1 < 5)) break 'l0;
+                _t0 = _t0 + 1;
+                loop {
+                    if (!(_t0 < 5)) continue 'l1;
+                    _t0 = _t0 + 10
+                };
+                break
             };
             break
         };
@@ -79,16 +116,26 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
-            _t0 = _t0 + 1;
-            _t2 = 0;
-            if (_t0 > 3) break;
-            _t3 = 0;
-            _t4 = false;
-            loop {
-                if (_t4) _t3 = _t3 + 1 else _t4 = true;
-                if (!(_t3 < 5)) continue 'l0;
-                _t2 = _t2 + 1;
-                _t1 = _t1 + 1
+            'l1: loop {
+                _t0 = _t0 + 1;
+                _t2 = 0;
+                if (_t0 > 3) break 'l0;
+                _t3 = 0;
+                _t4 = false;
+                loop {
+                    loop {
+                        if (_t4) {
+                            _t3 = _t3 + 1;
+                            break
+                        };
+                        _t4 = true;
+                        break
+                    };
+                    if (!(_t3 < 5)) continue 'l1;
+                    _t2 = _t2 + 1;
+                    _t1 = _t1 + 1
+                };
+                break
             };
             break
         };
@@ -100,13 +147,16 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
-            _t0 = _t0 + 1;
-            _t2 = 0;
-            if (_t0 > 3) break;
-            loop {
-                _t2 = _t2 + 1;
-                _t1 = _t1 + 1;
-                if (_t2 > 7) continue 'l0
+            'l1: loop {
+                _t0 = _t0 + 1;
+                _t2 = 0;
+                if (_t0 > 3) break 'l0;
+                loop {
+                    _t2 = _t2 + 1;
+                    _t1 = _t1 + 1;
+                    if (_t2 > 7) continue 'l1
+                };
+                break
             };
             break
         };
@@ -118,13 +168,16 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
-            _t0 = _t0 + 1;
-            _t2 = 0;
-            if (_t0 > 3) break;
-            loop {
-                if (!(_t2 < 7)) continue 'l0;
-                _t2 = _t2 + 1;
-                _t1 = _t1 + 1
+            'l1: loop {
+                _t0 = _t0 + 1;
+                _t2 = 0;
+                if (_t0 > 3) break 'l0;
+                loop {
+                    if (!(_t2 < 7)) continue 'l1;
+                    _t2 = _t2 + 1;
+                    _t1 = _t1 + 1
+                };
+                break
             };
             break
         };
@@ -135,13 +188,17 @@ module 0x99::nested_loops {
         let _t0;
         _t0 = 0;
         _t1 = 0;
-        'l0: while (_t0 < 3) {
-            _t0 = _t0 + 1;
-            _t2 = 0;
-            loop {
-                if (!(_t2 < 7)) continue 'l0;
-                _t2 = _t2 + 1;
-                _t1 = _t1 + 1
+        'l0: loop {
+            'l1: loop {
+                if (!(_t0 < 3)) break 'l0;
+                _t0 = _t0 + 1;
+                _t2 = 0;
+                loop {
+                    if (!(_t2 < 7)) continue 'l1;
+                    _t2 = _t2 + 1;
+                    _t1 = _t1 + 1
+                };
+                break
             };
             break
         };
@@ -158,21 +215,45 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
-            if (_t2) _t1 = _t1 + 1 else _t2 = true;
-            if (!(_t1 < 10)) break;
-            _t0 = _t0 + 1;
-            _t3 = _t1;
-            _t4 = false;
             'l1: loop {
-                if (_t4) _t3 = _t3 + 1 else _t4 = true;
-                if (!(_t3 < 10)) continue 'l0;
-                _t0 = _t0 + 1;
-                _t5 = _t3;
-                _t6 = false;
                 loop {
-                    if (_t6) _t5 = _t5 + 1 else _t6 = true;
-                    if (!(_t5 < 10)) continue 'l1;
-                    _t0 = _t0 + 1
+                    if (_t2) {
+                        _t1 = _t1 + 1;
+                        break
+                    };
+                    _t2 = true;
+                    break
+                };
+                if (!(_t1 < 10)) break 'l0;
+                _t0 = _t0 + 1;
+                _t3 = _t1;
+                _t4 = false;
+                'l2: loop {
+                    loop {
+                        if (_t4) {
+                            _t3 = _t3 + 1;
+                            break
+                        };
+                        _t4 = true;
+                        break
+                    };
+                    if (!(_t3 < 10)) continue 'l1;
+                    _t0 = _t0 + 1;
+                    _t5 = _t3;
+                    _t6 = false;
+                    loop {
+                        loop {
+                            if (_t6) {
+                                _t5 = _t5 + 1;
+                                break
+                            };
+                            _t6 = true;
+                            break
+                        };
+                        if (!(_t5 < 10)) continue 'l2;
+                        _t0 = _t0 + 1
+                    };
+                    break
                 };
                 break
             };
@@ -187,19 +268,22 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
-            _t0 = _t0 + 1;
-            _t2 = _t1;
-            if (_t1 > 10) break;
-            _t1 = _t1 + 1;
             'l1: loop {
                 _t0 = _t0 + 1;
-                _t3 = _t2;
-                if (_t2 > 10) continue 'l0;
-                _t2 = _t2 + 1;
-                loop {
+                _t2 = _t1;
+                if (_t1 > 10) break 'l0;
+                _t1 = _t1 + 1;
+                'l2: loop {
                     _t0 = _t0 + 1;
-                    if (_t3 > 10) continue 'l1;
-                    _t3 = _t3 + 1
+                    _t3 = _t2;
+                    if (_t2 > 10) continue 'l1;
+                    _t2 = _t2 + 1;
+                    loop {
+                        _t0 = _t0 + 1;
+                        if (_t3 > 10) continue 'l2;
+                        _t3 = _t3 + 1
+                    };
+                    break
                 };
                 break
             };
@@ -213,19 +297,23 @@ module 0x99::nested_loops {
         let _t0;
         _t0 = 0;
         _t1 = 0;
-        'l0: while (_t1 < 10) {
-            _t0 = _t0 + 1;
-            _t2 = _t1;
-            _t1 = _t1 + 1;
+        'l0: loop {
             'l1: loop {
-                if (!(_t2 < 10)) continue 'l0;
+                if (!(_t1 < 10)) break 'l0;
                 _t0 = _t0 + 1;
-                _t3 = _t2;
-                _t2 = _t2 + 1;
-                loop {
-                    if (!(_t3 < 10)) continue 'l1;
+                _t2 = _t1;
+                _t1 = _t1 + 1;
+                'l2: loop {
+                    if (!(_t2 < 10)) continue 'l1;
                     _t0 = _t0 + 1;
-                    _t3 = _t3 + 1
+                    _t3 = _t2;
+                    _t2 = _t2 + 1;
+                    loop {
+                        if (!(_t3 < 10)) continue 'l2;
+                        _t0 = _t0 + 1;
+                        _t3 = _t3 + 1
+                    };
+                    break
                 };
                 break
             };

--- a/third_party/move/tools/move-decompiler/tests/noexit_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/noexit_loops.exp
@@ -24,7 +24,14 @@ module 0x99::noexit_loops {
     }
     fun f13(cond: bool) {
         let _t2;
-        if (cond) _t2 = 0 else _t2 = 1;
+        loop {
+            if (cond) {
+                _t2 = 0;
+                break
+            };
+            _t2 = 1;
+            break
+        };
         loop continue
     }
     fun f14(p: bool, q: bool) {

--- a/third_party/move/tools/move-decompiler/tests/option.exp
+++ b/third_party/move/tools/move-decompiler/tests/option.exp
@@ -29,7 +29,14 @@ module 0x1::option {
         let _t3;
         let _t2;
         _t2 = &self.vec;
-        if (vector::is_empty<Element>(_t2)) _t3 = default_ref else _t3 = vector::borrow<Element>(_t2, 0);
+        loop {
+            if (vector::is_empty<Element>(_t2)) {
+                _t3 = default_ref;
+                break
+            };
+            _t3 = vector::borrow<Element>(_t2, 0);
+            break
+        };
         _t3
     }
     public fun destroy_none<Element>(self: Option<Element>) {
@@ -56,7 +63,14 @@ module 0x1::option {
         let _t5;
         Option<Element>{vec: _t5} = self;
         _t2 = _t5;
-        if (vector::is_empty<Element>(/*freeze*/&mut _t2)) _t3 = default else _t3 = vector::pop_back<Element>(&mut _t2);
+        loop {
+            if (vector::is_empty<Element>(/*freeze*/&mut _t2)) {
+                _t3 = default;
+                break
+            };
+            _t3 = vector::pop_back<Element>(&mut _t2);
+            break
+        };
         _t3
     }
     public fun extract<Element>(self: &mut Option<Element>): Element {
@@ -77,7 +91,14 @@ module 0x1::option {
         let _t3;
         let _t2;
         _t2 = &self.vec;
-        if (vector::is_empty<Element>(_t2)) _t3 = default else _t3 = *vector::borrow<Element>(_t2, 0);
+        loop {
+            if (vector::is_empty<Element>(_t2)) {
+                _t3 = default;
+                break
+            };
+            _t3 = *vector::borrow<Element>(_t2, 0);
+            break
+        };
         _t3
     }
     public fun none<Element>(): Option<Element> {
@@ -90,7 +111,14 @@ module 0x1::option {
         let _t3;
         let _t2;
         _t2 = &mut self.vec;
-        if (vector::is_empty<Element>(/*freeze*/_t2)) _t3 = none<Element>() else _t3 = some<Element>(vector::pop_back<Element>(_t2));
+        loop {
+            if (vector::is_empty<Element>(/*freeze*/_t2)) {
+                _t3 = none<Element>();
+                break
+            };
+            _t3 = some<Element>(vector::pop_back<Element>(_t2));
+            break
+        };
         vector::push_back<Element>(_t2, e);
         _t3
     }

--- a/third_party/move/tools/move-decompiler/tests/simple_map.exp
+++ b/third_party/move/tools/move-decompiler/tests/simple_map.exp
@@ -34,7 +34,14 @@ module 0x1::simple_map {
         let _t3;
         _t3 = 0;
         {
-            while (!(!(_t3 < vector::length<Element<Key, Value>>(&self.data)) || &vector::borrow<Element<Key, Value>>(&self.data, _t3).key == key)) _t3 = _t3 + 1;
+            'l0: loop {
+                loop {
+                    if (!(_t3 < vector::length<Element<Key, Value>>(&self.data))) break 'l0;
+                    if (&vector::borrow<Element<Key, Value>>(&self.data, _t3).key == key) break 'l0;
+                    _t3 = _t3 + 1
+                };
+                break
+            };
             return option::some<u64>(_t3)
         };
         option::none<u64>()
@@ -66,9 +73,13 @@ module 0x1::simple_map {
         _t6 = _t4;
         _t7 = vector::length<Key>(&_t5);
         if (!(_t7 == vector::length<Value>(&_t6))) abort 131074;
-        while (_t7 > 0) {
-            add<Key,Value>(self, vector::pop_back<Key>(&mut _t5), vector::pop_back<Value>(&mut _t6));
-            _t7 = _t7 - 1
+        'l0: loop {
+            loop {
+                if (!(_t7 > 0)) break 'l0;
+                add<Key,Value>(self, vector::pop_back<Key>(&mut _t5), vector::pop_back<Value>(&mut _t6));
+                _t7 = _t7 - 1
+            };
+            break
         };
         vector::destroy_empty<Key>(_t5);
         vector::destroy_empty<Value>(_t6);
@@ -80,9 +91,13 @@ module 0x1::simple_map {
         _t1 = &self.data;
         _t2 = vector::empty<Key>();
         _t3 = 0;
-        while (_t3 < vector::length<Element<Key, Value>>(_t1)) {
-            vector::push_back<Key>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).key);
-            _t3 = _t3 + 1
+        'l0: loop {
+            loop {
+                if (!(_t3 < vector::length<Element<Key, Value>>(_t1))) break 'l0;
+                vector::push_back<Key>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).key);
+                _t3 = _t3 + 1
+            };
+            break
         };
         _t2
     }
@@ -93,9 +108,13 @@ module 0x1::simple_map {
         _t1 = &self.data;
         _t2 = vector::empty<Value>();
         _t3 = 0;
-        while (_t3 < vector::length<Element<Key, Value>>(_t1)) {
-            vector::push_back<Value>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).value);
-            _t3 = _t3 + 1
+        'l0: loop {
+            loop {
+                if (!(_t3 < vector::length<Element<Key, Value>>(_t1))) break 'l0;
+                vector::push_back<Value>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).value);
+                _t3 = _t3 + 1
+            };
+            break
         };
         _t2
     }
@@ -130,11 +149,15 @@ module 0x1::simple_map {
         vector::reverse<Element<Key, Value>>(&mut _t3);
         _t4 = _t3;
         _t5 = vector::length<Element<Key, Value>>(&_t4);
-        while (_t5 > 0) {
-            Element<Key,Value>{key: _t21,value: _t22} = vector::pop_back<Element<Key, Value>>(&mut _t4);
-            vector::push_back<Key>(&mut _t1, _t21);
-            vector::push_back<Value>(&mut _t2, _t22);
-            _t5 = _t5 - 1
+        'l0: loop {
+            loop {
+                if (!(_t5 > 0)) break 'l0;
+                Element<Key,Value>{key: _t21,value: _t22} = vector::pop_back<Element<Key, Value>>(&mut _t4);
+                vector::push_back<Key>(&mut _t1, _t21);
+                vector::push_back<Value>(&mut _t2, _t22);
+                _t5 = _t5 - 1
+            };
+            break
         };
         vector::destroy_empty<Element<Key, Value>>(_t4);
         (_t1, _t2)
@@ -149,7 +172,14 @@ module 0x1::simple_map {
         _t4 = vector::length<Element<Key, Value>>(/*freeze*/_t3);
         _t5 = 0;
         {
-            while (!(!(_t5 < _t4) || &vector::borrow<Element<Key, Value>>(/*freeze*/_t3, _t5).key == &key)) _t5 = _t5 + 1;
+            'l0: loop {
+                loop {
+                    if (!(_t5 < _t4)) break 'l0;
+                    if (&vector::borrow<Element<Key, Value>>(/*freeze*/_t3, _t5).key == &key) break 'l0;
+                    _t5 = _t5 + 1
+                };
+                break
+            };
             vector::push_back<Element<Key, Value>>(_t3, Element<Key,Value>{key: key,value: value});
             vector::swap<Element<Key, Value>>(_t3, _t5, _t4);
             Element<Key,Value>{key: _t34,value: _t35} = vector::pop_back<Element<Key, Value>>(_t3);

--- a/third_party/move/tools/move-decompiler/tests/string.exp
+++ b/third_party/move/tools/move-decompiler/tests/string.exp
@@ -23,7 +23,14 @@ module 0x1::string {
         let _t4;
         let _t3;
         _t3 = &self.bytes;
-        if (at <= vector::length<u8>(_t3)) _t4 = internal_is_char_boundary(_t3, at) else _t4 = false;
+        loop {
+            if (at <= vector::length<u8>(_t3)) {
+                _t4 = internal_is_char_boundary(_t3, at);
+                break
+            };
+            _t4 = false;
+            break
+        };
         if (!_t4) abort 2;
         _t6 = sub_string(/*freeze*/self, 0, at);
         append(&mut _t6, o);
@@ -37,9 +44,30 @@ module 0x1::string {
         let _t5;
         let _t3;
         _t3 = &self.bytes;
-        if (j <= vector::length<u8>(_t3)) _t5 = i <= j else _t5 = false;
-        if (_t5) _t6 = internal_is_char_boundary(_t3, i) else _t6 = false;
-        if (_t6) _t7 = internal_is_char_boundary(_t3, j) else _t7 = false;
+        loop {
+            if (j <= vector::length<u8>(_t3)) {
+                _t5 = i <= j;
+                break
+            };
+            _t5 = false;
+            break
+        };
+        loop {
+            if (_t5) {
+                _t6 = internal_is_char_boundary(_t3, i);
+                break
+            };
+            _t6 = false;
+            break
+        };
+        loop {
+            if (_t6) {
+                _t7 = internal_is_char_boundary(_t3, j);
+                break
+            };
+            _t7 = false;
+            break
+        };
         if (!_t7) abort 2;
         String{bytes: internal_sub_string(_t3, i, j)}
     }
@@ -57,7 +85,14 @@ module 0x1::string {
     native fun internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8>;
     public fun try_utf8(bytes: vector<u8>): option::Option<String> {
         let _t1;
-        if (internal_check_utf8(&bytes)) _t1 = option::some<String>(String{bytes: bytes}) else _t1 = option::none<String>();
+        loop {
+            if (internal_check_utf8(&bytes)) {
+                _t1 = option::some<String>(String{bytes: bytes});
+                break
+            };
+            _t1 = option::none<String>();
+            break
+        };
         _t1
     }
 }

--- a/third_party/move/tools/move-decompiler/tests/vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/vector.exp
@@ -12,7 +12,14 @@ module 0x1::vector {
         let _t2;
         _t2 = 0;
         {
-            while (!(!(_t2 < length<Element>(self)) || borrow<Element>(self, _t2) == e)) _t2 = _t2 + 1;
+            'l0: loop {
+                loop {
+                    if (!(_t2 < length<Element>(self))) break 'l0;
+                    if (borrow<Element>(self, _t2) == e) break 'l0;
+                    _t2 = _t2 + 1
+                };
+                break
+            };
             return true
         };
         false
@@ -21,7 +28,14 @@ module 0x1::vector {
         let _t2;
         _t2 = 0;
         {
-            while (!(!(_t2 < length<Element>(self)) || borrow<Element>(self, _t2) == e)) _t2 = _t2 + 1;
+            'l0: loop {
+                loop {
+                    if (!(_t2 < length<Element>(self))) break 'l0;
+                    if (borrow<Element>(self, _t2) == e) break 'l0;
+                    _t2 = _t2 + 1
+                };
+                break
+            };
             return (true, _t2)
         };
         (false, 0)
@@ -33,9 +47,13 @@ module 0x1::vector {
         let _t3;
         if (!(step > 0)) abort 131075;
         _t3 = empty<u64>();
-        while (start < end) {
-            push_back<u64>(&mut _t3, start);
-            start = start + step
+        'l0: loop {
+            loop {
+                if (!(start < end)) break 'l0;
+                push_back<u64>(&mut _t3, start);
+                start = start + step
+            };
+            break
         };
         _t3
     }
@@ -49,9 +67,13 @@ module 0x1::vector {
     public fun reverse_append<Element>(self: &mut vector<Element>, other: vector<Element>) {
         let _t2;
         _t2 = length<Element>(&other);
-        while (_t2 > 0) {
-            push_back<Element>(self, pop_back<Element>(&mut other));
-            _t2 = _t2 - 1
+        'l0: loop {
+            loop {
+                if (!(_t2 > 0)) break 'l0;
+                push_back<Element>(self, pop_back<Element>(&mut other));
+                _t2 = _t2 - 1
+            };
+            break
         };
         destroy_empty<Element>(other);
     }
@@ -60,9 +82,13 @@ module 0x1::vector {
         _t3 = length<Element>(/*freeze*/self);
         if (!(i <= _t3)) abort 131072;
         push_back<Element>(self, e);
-        while (i < _t3) {
-            swap<Element>(self, i, _t3);
-            i = i + 1
+        'l0: loop {
+            loop {
+                if (!(i < _t3)) break 'l0;
+                swap<Element>(self, i, _t3);
+                i = i + 1
+            };
+            break
         };
     }
     public fun is_empty<Element>(self: &vector<Element>): bool {
@@ -72,9 +98,13 @@ module 0x1::vector {
         let _t2;
         _t2 = length<Element>(/*freeze*/self);
         if (i >= _t2) abort 131072;
-        while (i < _t2 - 1) {
-            i = i + 1;
-            swap<Element>(self, i, i)
+        'l0: loop {
+            loop {
+                if (!(i < _t2 - 1)) break 'l0;
+                i = i + 1;
+                swap<Element>(self, i, i)
+            };
+            break
         };
         pop_back<Element>(self)
     }
@@ -84,19 +114,25 @@ module 0x1::vector {
         let _t8;
         let _t7;
         (_t7,_t8) = index_of<Element>(/*freeze*/self, val);
-        if (_t7) {
-            _t12 = empty<Element>();
-            push_back<Element>(&mut _t12, remove<Element>(self, _t8));
-            _t3 = _t12
-        } else _t3 = empty<Element>();
+        loop {
+            if (_t7) {
+                _t12 = empty<Element>();
+                push_back<Element>(&mut _t12, remove<Element>(self, _t8));
+                _t3 = _t12;
+                break
+            };
+            _t3 = empty<Element>();
+            break
+        };
         _t3
     }
     public fun reverse_slice<Element>(self: &mut vector<Element>, left: u64, right: u64) {
         if (!(left <= right)) abort 131073;
-        {
+        'l0: loop {
             if (!(left == right)) {
                 right = right - 1;
-                while (left < right) {
+                loop {
+                    if (!(left < right)) break 'l0;
                     swap<Element>(self, left, right);
                     left = left + 1;
                     right = right - 1
@@ -123,12 +159,23 @@ module 0x1::vector {
     public fun slice<Element: copy>(self: &vector<Element>, start: u64, end: u64): vector<Element> {
         let _t4;
         let _t3;
-        if (start <= end) _t3 = end <= length<Element>(self) else _t3 = false;
+        loop {
+            if (start <= end) {
+                _t3 = end <= length<Element>(self);
+                break
+            };
+            _t3 = false;
+            break
+        };
         if (!_t3) abort 131076;
         _t4 = empty<Element>();
-        while (start < end) {
-            push_back<Element>(&mut _t4, *borrow<Element>(self, start));
-            start = start + 1
+        'l0: loop {
+            loop {
+                if (!(start < end)) break 'l0;
+                push_back<Element>(&mut _t4, *borrow<Element>(self, start));
+                start = start + 1
+            };
+            break
         };
         _t4
     }
@@ -149,9 +196,13 @@ module 0x1::vector {
         _t2 = length<Element>(/*freeze*/self);
         if (!(new_len <= _t2)) abort 131072;
         _t3 = empty<Element>();
-        while (new_len < _t2) {
-            push_back<Element>(&mut _t3, pop_back<Element>(self));
-            _t2 = _t2 - 1
+        'l0: loop {
+            loop {
+                if (!(new_len < _t2)) break 'l0;
+                push_back<Element>(&mut _t3, pop_back<Element>(self));
+                _t2 = _t2 - 1
+            };
+            break
         };
         _t3
     }


### PR DESCRIPTION
## Description
This PR fixes three issues.

#### 1. Disabling an unsafe optimization:
The `try_make_if_else` optimization transfers the following pattern
```Move
loop {
    loop { // no loop header
        ( if (c_i) break; )+
        <else-branch> // no reference to inner loop
        break[1]
    }
    <then-branch>
}
```
==>
```Move
if (c1 || .. || cn) {
    loop {
        <then-branch>
    }
}
else {
    loop {
        <else-branch> where loop_nest -= 1
    }
}
```

The transformation is not semantically equivalent:

- Let's assume `then-branch` does not have any `break`. In the original code, it can still break the outer loop via the `else-branch`. Yet, in the transformed code, `then-branch` will loop forever ...

- `c_1`, `c_2` etc. can be updated by `then-branch` and `else-branch` in each iteration in the original code, affecting how the loops work. Yet, in the optimized code, they become irrelevant once the loops are entered.

#### 2. Fixing a critical bug when converting a `Branch` stackless instruction into an `IfElse` ast expression. Basically, the PR makes changes to ensure that `break` expressions break out of the desired loop. 

#### 3. Fix a trivial bug inside the `cyclic_label_subst_detected` helper function.

## How Has This Been Tested?
- [New decompiler test cases](https://github.com/aptos-labs/aptos-core/blob/jun/fix-astfier-issues/third_party/move/tools/move-decompiler/tests/cfg_opt.move)

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (decompiler)
