### PR TITLE
[consensus] Enable Opt Proposal and increase execution target time

### DIFF
--- a/config/src/config/consensus_config.rs
+++ b/config/src/config/consensus_config.rs
@@ -147,6 +147,21 @@ pub struct ExecutionBackpressureTxnLimitConfig {
     pub min_calibrated_txns_per_block: u64,
 }
 
+impl Default for ExecutionBackpressureTxnLimitConfig {
+    fn default() -> Self {
+        Self {
+            lookback_config: ExecutionBackpressureLookbackConfig {
+                num_blocks_to_look_at: 18,
+                min_block_time_ms_to_activate: 50,
+                min_blocks_to_activate: 4,
+                metric: ExecutionBackpressureMetric::Percentile(0.5),
+                target_block_time_ms: 90,
+            },
+            min_calibrated_txns_per_block: 8,
+        }
+    }
+}
+
 /// Execution backpressure which handles gas/s variance,
 /// and adjusts gas limit to "recalibrate it" to wanted range.
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -154,6 +169,22 @@ pub struct ExecutionBackpressureGasLimitConfig {
     pub lookback_config: ExecutionBackpressureLookbackConfig,
     pub block_execution_overhead_ms: u64,
     pub min_calibrated_block_gas_limit: u64,
+}
+
+impl Default for ExecutionBackpressureGasLimitConfig {
+    fn default() -> Self {
+        Self {
+            lookback_config: ExecutionBackpressureLookbackConfig {
+                num_blocks_to_look_at: 30,
+                min_block_time_ms_to_activate: 10,
+                min_blocks_to_activate: 4,
+                metric: ExecutionBackpressureMetric::Mean,
+                target_block_time_ms: 90,
+            },
+            block_execution_overhead_ms: 10,
+            min_calibrated_block_gas_limit: 2000,
+        }
+    }
 }
 
 #[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
@@ -226,27 +257,8 @@ impl Default for ConsensusConfig {
             vote_back_pressure_limit: 12,
             min_max_txns_in_block_after_filtering_from_backpressure: MIN_BLOCK_TXNS_AFTER_FILTERING,
             execution_backpressure: Some(ExecutionBackpressureConfig {
-                txn_limit: Some(ExecutionBackpressureTxnLimitConfig {
-                    lookback_config: ExecutionBackpressureLookbackConfig {
-                        num_blocks_to_look_at: 18,
-                        min_block_time_ms_to_activate: 50,
-                        min_blocks_to_activate: 4,
-                        metric: ExecutionBackpressureMetric::Percentile(0.5),
-                        target_block_time_ms: 60,
-                    },
-                    min_calibrated_txns_per_block: 8,
-                }),
-                gas_limit: Some(ExecutionBackpressureGasLimitConfig {
-                    lookback_config: ExecutionBackpressureLookbackConfig {
-                        num_blocks_to_look_at: 30,
-                        min_block_time_ms_to_activate: 10,
-                        min_blocks_to_activate: 4,
-                        metric: ExecutionBackpressureMetric::Mean,
-                        target_block_time_ms: 60,
-                    },
-                    block_execution_overhead_ms: 10,
-                    min_calibrated_block_gas_limit: 2000,
-                }),
+                txn_limit: Some(ExecutionBackpressureTxnLimitConfig::default()),
+                gas_limit: Some(ExecutionBackpressureGasLimitConfig::default()),
             }),
             pipeline_backpressure: vec![
                 PipelineBackpressureValues {

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -347,7 +347,7 @@ pub(crate) fn realistic_env_max_load_test(
     }
 
     // Create the test
-    let mempool_backlog = if ha_proxy { 30000 } else { 40000 };
+    let mempool_backlog = if ha_proxy { 28000 } else { 38000 };
     ForgeConfig::default()
         .with_initial_validator_count(NonZeroUsize::new(num_validators).unwrap())
         .with_initial_fullnode_count(num_fullnodes)

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -378,9 +378,6 @@ pub(crate) fn realistic_env_max_load_test(
                 serde_yaml::to_value(OnChainExecutionConfig::default_for_genesis())
                     .expect("must serialize");
         }))
-        .with_validator_override_node_config_fn(Arc::new(|config, _| {
-            config.consensus.enable_optimistic_proposal_tx = true;
-        }))
         .with_fullnode_override_node_config_fn(Arc::new(|config, _| {
             // Increase the consensus observer fallback thresholds
             config

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -7,8 +7,7 @@ use crate::{
     *,
 };
 use aptos_config::config::{
-    ExecutionBackpressureGasLimitConfig, ExecutionBackpressureLookbackConfig,
-    ExecutionBackpressureMetric, ExecutionBackpressureTxnLimitConfig, NodeConfig,
+    ExecutionBackpressureGasLimitConfig, ExecutionBackpressureTxnLimitConfig, NodeConfig,
     OverrideNodeConfig,
 };
 use aptos_framework::ReleaseBundle;
@@ -257,8 +256,8 @@ impl ForgeConfig {
             gas_limit_backpressure.lookback_config.target_block_time_ms = 63;
             helm_values["validator"]["config"]["consensus"]["execution_backpressure"]
                 ["txn_limit"] = serde_yaml::to_value(&txn_limit_backpressure).unwrap();
-            helm_values["validator"]["config"]["consensus"]["execution_backpressure"]["gas_limit"] =
-                serde_yaml::to_value(&gas_limit_backpressure).unwrap();
+            helm_values["validator"]["config"]["consensus"]["execution_backpressure"]
+                ["gas_limit"] = serde_yaml::to_value(&gas_limit_backpressure).unwrap();
         }))
     }
 

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -252,9 +252,9 @@ impl ForgeConfig {
                 true.into();
 
             let mut txn_limit_backpressure = ExecutionBackpressureTxnLimitConfig::default();
-            txn_limit_backpressure.lookback_config.target_block_time_ms = 60;
+            txn_limit_backpressure.lookback_config.target_block_time_ms = 63;
             let mut gas_limit_backpressure = ExecutionBackpressureGasLimitConfig::default();
-            gas_limit_backpressure.lookback_config.target_block_time_ms = 60;
+            gas_limit_backpressure.lookback_config.target_block_time_ms = 63;
             helm_values["validator"]["config"]["consensus"]["execution_backpressure"]
                 ["txn_limit"] = serde_yaml::to_value(&txn_limit_backpressure).unwrap();
             helm_values["validator"]["config"]["consensus"]["execution_backpressure"]["gas_limit"] =

--- a/testsuite/forge/src/config.rs
+++ b/testsuite/forge/src/config.rs
@@ -6,7 +6,11 @@ use crate::{
     success_criteria::{MetricsThreshold, SuccessCriteria, SystemMetricsThreshold},
     *,
 };
-use aptos_config::config::{NodeConfig, OverrideNodeConfig};
+use aptos_config::config::{
+    ExecutionBackpressureGasLimitConfig, ExecutionBackpressureLookbackConfig,
+    ExecutionBackpressureMetric, ExecutionBackpressureTxnLimitConfig, NodeConfig,
+    OverrideNodeConfig,
+};
 use aptos_framework::ReleaseBundle;
 use std::{num::NonZeroUsize, sync::Arc};
 
@@ -244,9 +248,17 @@ impl ForgeConfig {
                 ["subscription_peer_change_interval_ms"] = 5_000.into();
 
             // enable opt proposal
-            // TODO(ibalajiarun):
-            // helm_values["validator"]["config"]["consensus"]["enable_optimistic_proposal_tx"] =
-            //     true.into();
+            helm_values["validator"]["config"]["consensus"]["enable_optimistic_proposal_tx"] =
+                true.into();
+
+            let mut txn_limit_backpressure = ExecutionBackpressureTxnLimitConfig::default();
+            txn_limit_backpressure.lookback_config.target_block_time_ms = 60;
+            let mut gas_limit_backpressure = ExecutionBackpressureGasLimitConfig::default();
+            gas_limit_backpressure.lookback_config.target_block_time_ms = 60;
+            helm_values["validator"]["config"]["consensus"]["execution_backpressure"]
+                ["txn_limit"] = serde_yaml::to_value(&txn_limit_backpressure).unwrap();
+            helm_values["validator"]["config"]["consensus"]["execution_backpressure"]["gas_limit"] =
+                serde_yaml::to_value(&gas_limit_backpressure).unwrap();
         }))
     }
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR enabled Opt Proposal in forge by default for all runs. Further, it increases  the target block time to 90 ms in main. Only force is tuned for 15 blocks per second with 60ms target block time.