### PR TITLE
[storage] StateKey::get_shard_id should return usize

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -444,7 +444,7 @@ impl StorageDirPaths {
             .unwrap_or(&self.default_path)
     }
 
-    pub fn state_kv_db_shard_root_path(&self, shard_id: u8) -> &PathBuf {
+    pub fn state_kv_db_shard_root_path(&self, shard_id: usize) -> &PathBuf {
         self.state_kv_db_paths
             .shard_path(shard_id)
             .unwrap_or(&self.default_path)
@@ -456,13 +456,13 @@ impl StorageDirPaths {
             .unwrap_or(&self.default_path)
     }
 
-    pub fn state_merkle_db_shard_root_path(&self, shard_id: u8) -> &PathBuf {
+    pub fn state_merkle_db_shard_root_path(&self, shard_id: usize) -> &PathBuf {
         self.state_merkle_db_paths
             .shard_path(shard_id)
             .unwrap_or(&self.default_path)
     }
 
-    pub fn hot_state_kv_db_shard_root_path(&self, shard_id: u8) -> &PathBuf {
+    pub fn hot_state_kv_db_shard_root_path(&self, shard_id: usize) -> &PathBuf {
         self.hot_state_kv_db_paths
             .shard_path(shard_id)
             .unwrap_or(&self.default_path)
@@ -518,8 +518,8 @@ impl ShardedDbPaths {
         self.metadata_path.as_ref()
     }
 
-    fn shard_path(&self, shard_id: u8) -> Option<&PathBuf> {
-        self.shard_paths[shard_id as usize].as_ref()
+    fn shard_path(&self, shard_id: usize) -> Option<&PathBuf> {
+        self.shard_paths[shard_id].as_ref()
     }
 }
 

--- a/execution/executor/benches/data_collection.rs
+++ b/execution/executor/benches/data_collection.rs
@@ -154,7 +154,7 @@ fn collect_per_version_sharded_state_values(c: &mut Criterion, write_sets: &[Wri
                 .map(|write_set| {
                     let mut ret = empty_shards::<Vec<_>>();
                     for (k, v) in write_set.state_update_refs() {
-                        ret[k.get_shard_id() as usize].push((k, v));
+                        ret[k.get_shard_id()].push((k, v));
                     }
                     ret
                 })
@@ -170,7 +170,7 @@ fn collect_per_version_sharded_state_values(c: &mut Criterion, write_sets: &[Wri
                 .map(|write_set| {
                     let mut ret = empty_shards::<Vec<_>>();
                     for (k, v) in write_set.state_update_refs() {
-                        ret[k.get_shard_id() as usize].push((k, v));
+                        ret[k.get_shard_id()].push((k, v));
                     }
                     ret
                 })
@@ -185,7 +185,7 @@ fn collect_per_version_sharded_state_values(c: &mut Criterion, write_sets: &[Wri
                 .map(|write_set| {
                     let mut ret = empty_shards::<Vec<_>>();
                     for (k, v) in write_set.state_updates_cloned() {
-                        ret[k.get_shard_id() as usize].push((k, v));
+                        ret[k.get_shard_id()].push((k, v));
                     }
                     ret
                 })
@@ -201,7 +201,7 @@ fn collect_per_version_sharded_state_values(c: &mut Criterion, write_sets: &[Wri
                 .map(|write_set| {
                     let mut ret = empty_shards::<HashMap<_, _>>();
                     for (k, v) in write_set.state_update_refs() {
-                        ret[k.get_shard_id() as usize].insert(k, v);
+                        ret[k.get_shard_id()].insert(k, v);
                     }
                     ret
                 })
@@ -217,7 +217,7 @@ fn collect_per_version_sharded_state_values(c: &mut Criterion, write_sets: &[Wri
                 .map(|write_set| {
                     let mut ret = empty_shards::<HashMap<_, _>>();
                     for (k, v) in write_set.state_update_refs() {
-                        ret[k.get_shard_id() as usize].insert(k, v);
+                        ret[k.get_shard_id()].insert(k, v);
                     }
                     ret
                 })
@@ -236,7 +236,7 @@ fn collect_sharded_per_version_state_value_refs(c: &mut Criterion, write_sets: &
 
             write_sets.iter().enumerate().for_each(|(idx, write_set)| {
                 for (k, v) in write_set.state_update_refs() {
-                    ret[k.get_shard_id() as usize][idx].push((k, v));
+                    ret[k.get_shard_id()][idx].push((k, v));
                 }
             });
             ret
@@ -254,7 +254,7 @@ fn collect_sharded_per_version_state_value_refs(c: &mut Criterion, write_sets: &
                 .for_each(|(shard_id, shard)| {
                     write_sets.iter().enumerate().for_each(|(idx, write_set)| {
                         for (k, v) in write_set.state_update_refs() {
-                            if k.get_shard_id() == shard_id as u8 {
+                            if k.get_shard_id() == shard_id {
                                 shard[idx].push((k, v));
                             }
                         }
@@ -271,7 +271,7 @@ fn collect_sharded_per_version_state_value_refs(c: &mut Criterion, write_sets: &
 
             write_sets.iter().enumerate().for_each(|(idx, write_set)| {
                 for (k, v) in write_set.state_update_refs() {
-                    ret[k.get_shard_id() as usize][idx].insert(k, v);
+                    ret[k.get_shard_id()][idx].insert(k, v);
                 }
             });
             ret
@@ -289,7 +289,7 @@ fn collect_sharded_state_updates_with_version(c: &mut Criterion, write_sets: &[W
                 arr![Vec::with_capacity(write_sets.len()); 16];
             write_sets.iter().enumerate().for_each(|(idx, write_set)| {
                 for (k, v) in write_set.state_update_refs() {
-                    ret[k.get_shard_id() as usize].push((first_version + idx as Version, k, v));
+                    ret[k.get_shard_id()].push((first_version + idx as Version, k, v));
                 }
             });
 
@@ -420,7 +420,7 @@ fn collect_state_update_maps(c: &mut Criterion, write_sets: &[WriteSet]) {
         .map(|write_set| {
             let mut ret = empty_shards::<Vec<_>>();
             for (k, v) in write_set.state_update_refs() {
-                ret[k.get_shard_id() as usize].push((k, v));
+                ret[k.get_shard_id()].push((k, v));
             }
             ret
         })
@@ -467,7 +467,7 @@ fn collect_state_update_maps(c: &mut Criterion, write_sets: &[WriteSet]) {
         let mut ret = arr![Vec::with_capacity(write_sets.len()); 16];
         write_sets.iter().enumerate().for_each(|(idx, write_set)| {
             for (k, v) in write_set.state_update_refs() {
-                ret[k.get_shard_id() as usize].push((first_version + idx as Version, k, v));
+                ret[k.get_shard_id()].push((first_version + idx as Version, k, v));
             }
         });
         ret

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -338,7 +338,7 @@ mod test {
 
             if sharding_config.enable_storage_sharding {
                 let state_merkle_db = Arc::new(state_merkle_db);
-                for i in 0..NUM_STATE_SHARDS as u8 {
+                for i in 0..NUM_STATE_SHARDS {
                     let mut kv_shard_iter = state_kv_db.db_shard(i).iter::<StateValueByKeyHashSchema>().unwrap();
                     kv_shard_iter.seek_to_first();
                     for item in kv_shard_iter {

--- a/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/mod.rs
@@ -124,7 +124,7 @@ impl StateKvPruner {
 
         let shard_pruners = if state_kv_db.enabled_sharding() {
             let num_shards = state_kv_db.num_shards();
-            let mut shard_pruners = Vec::with_capacity(num_shards as usize);
+            let mut shard_pruners = Vec::with_capacity(num_shards);
             for shard_id in 0..num_shards {
                 shard_pruners.push(StateKvShardPruner::new(
                     shard_id,

--- a/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_kv_pruner/state_kv_shard_pruner.rs
@@ -17,19 +17,19 @@ use std::sync::Arc;
 
 // This pruner is only used when enable_sharding flag is true
 pub(in crate::pruner) struct StateKvShardPruner {
-    shard_id: u8,
+    shard_id: usize,
     db_shard: Arc<DB>,
 }
 
 impl StateKvShardPruner {
     pub(in crate::pruner) fn new(
-        shard_id: u8,
+        shard_id: usize,
         db_shard: Arc<DB>,
         metadata_progress: Version,
     ) -> Result<Self> {
         let progress = get_or_initialize_subpruner_progress(
             &db_shard,
-            &DbMetadataKey::StateKvShardPrunerProgress(shard_id as usize),
+            &DbMetadataKey::StateKvShardPrunerProgress(shard_id),
             metadata_progress,
         )?;
         let myself = Self { shard_id, db_shard };
@@ -64,14 +64,14 @@ impl StateKvShardPruner {
             batch.delete::<StateValueByKeyHashSchema>(&(index.state_key_hash, index.version))?;
         }
         batch.put::<DbMetadataSchema>(
-            &DbMetadataKey::StateKvShardPrunerProgress(self.shard_id as usize),
+            &DbMetadataKey::StateKvShardPrunerProgress(self.shard_id),
             &DbMetadataValue::Version(target_version),
         )?;
 
         self.db_shard.write_schemas(batch)
     }
 
-    pub(in crate::pruner) fn shard_id(&self) -> u8 {
+    pub(in crate::pruner) fn shard_id(&self) -> usize {
         self.shard_id
     }
 }

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/generics.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/generics.rs
@@ -12,14 +12,14 @@ pub trait StaleNodeIndexSchemaTrait: Schema<Key = StaleNodeIndex>
 where
     StaleNodeIndex: KeyCodec<Self>,
 {
-    fn progress_metadata_key(shard_id: Option<u8>) -> DbMetadataKey;
+    fn progress_metadata_key(shard_id: Option<usize>) -> DbMetadataKey;
     fn name() -> &'static str;
 }
 
 impl StaleNodeIndexSchemaTrait for StaleNodeIndexSchema {
-    fn progress_metadata_key(shard_id: Option<u8>) -> DbMetadataKey {
+    fn progress_metadata_key(shard_id: Option<usize>) -> DbMetadataKey {
         if let Some(shard_id) = shard_id {
-            DbMetadataKey::StateMerkleShardPrunerProgress(shard_id as usize)
+            DbMetadataKey::StateMerkleShardPrunerProgress(shard_id)
         } else {
             DbMetadataKey::StateMerklePrunerProgress
         }
@@ -31,9 +31,9 @@ impl StaleNodeIndexSchemaTrait for StaleNodeIndexSchema {
 }
 
 impl StaleNodeIndexSchemaTrait for StaleNodeIndexCrossEpochSchema {
-    fn progress_metadata_key(shard_id: Option<u8>) -> DbMetadataKey {
+    fn progress_metadata_key(shard_id: Option<usize>) -> DbMetadataKey {
         if let Some(shard_id) = shard_id {
-            DbMetadataKey::EpochEndingStateMerkleShardPrunerProgress(shard_id as usize)
+            DbMetadataKey::EpochEndingStateMerkleShardPrunerProgress(shard_id)
         } else {
             DbMetadataKey::EpochEndingStateMerklePrunerProgress
         }

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/mod.rs
@@ -135,7 +135,7 @@ where
 
         let shard_pruners = if state_merkle_db.sharding_enabled() {
             let num_shards = state_merkle_db.num_shards();
-            let mut shard_pruners = Vec::with_capacity(num_shards as usize);
+            let mut shard_pruners = Vec::with_capacity(num_shards);
             for shard_id in 0..num_shards {
                 shard_pruners.push(StateMerkleShardPruner::new(
                     shard_id,

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_shard_pruner.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/state_merkle_shard_pruner.rs
@@ -19,7 +19,7 @@ use aptos_types::transaction::Version;
 use std::{marker::PhantomData, sync::Arc};
 
 pub(in crate::pruner) struct StateMerkleShardPruner<S> {
-    shard_id: u8,
+    shard_id: usize,
     db_shard: Arc<DB>,
     _phantom: PhantomData<S>,
 }
@@ -29,7 +29,7 @@ where
     StaleNodeIndex: KeyCodec<S>,
 {
     pub(in crate::pruner) fn new(
-        shard_id: u8,
+        shard_id: usize,
         db_shard: Arc<DB>,
         metadata_progress: Version,
     ) -> Result<Self> {
@@ -97,7 +97,7 @@ where
         Ok(())
     }
 
-    pub(in crate::pruner) fn shard_id(&self) -> u8 {
+    pub(in crate::pruner) fn shard_id(&self) -> usize {
         self.shard_id
     }
 }

--- a/storage/aptosdb/src/pruner/state_merkle_pruner/test.rs
+++ b/storage/aptosdb/src/pruner/state_merkle_pruner/test.rs
@@ -234,7 +234,7 @@ fn test_state_store_pruner_partial_version() {
     );
 
     if aptos_db.state_merkle_db().sharding_enabled() {
-        for i in 0..NUM_STATE_SHARDS as u8 {
+        for i in 0..NUM_STATE_SHARDS {
             assert_eq!(
                 aptos_db
                     .state_merkle_db()

--- a/storage/aptosdb/src/rocksdb_property_reporter.rs
+++ b/storage/aptosdb/src/rocksdb_property_reporter.rs
@@ -143,7 +143,7 @@ fn update_rocksdb_properties(
             for cf in state_kv_db_new_key_column_families() {
                 set_property(cf, state_kv_db.metadata_db())?;
                 for shard in 0..NUM_STATE_SHARDS {
-                    set_shard_property(cf, state_kv_db.db_shard(shard as u8), shard)?;
+                    set_shard_property(cf, state_kv_db.db_shard(shard), shard)?;
                 }
             }
         }
@@ -157,7 +157,7 @@ fn update_rocksdb_properties(
         set_property(cf_name, state_merkle_db.metadata_db())?;
         if state_merkle_db.sharding_enabled() {
             for shard in 0..NUM_STATE_SHARDS {
-                set_shard_property(cf_name, state_merkle_db.db_shard(shard as u8), shard)?;
+                set_shard_property(cf_name, state_merkle_db.db_shard(shard), shard)?;
             }
         }
     }

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -96,10 +96,10 @@ impl StateKvDb {
         let state_kv_db_shards = (0..NUM_STATE_SHARDS)
             .into_par_iter()
             .map(|shard_id| {
-                let shard_root_path = db_paths.state_kv_db_shard_root_path(shard_id as u8);
+                let shard_root_path = db_paths.state_kv_db_shard_root_path(shard_id);
                 let db = Self::open_shard(
                     shard_root_path,
-                    shard_id as u8,
+                    shard_id,
                     &state_kv_db_config,
                     readonly,
                     /* is_hot = */ false,
@@ -120,11 +120,10 @@ impl StateKvDb {
                 (0..NUM_STATE_SHARDS)
                     .into_par_iter()
                     .map(|shard_id| {
-                        let shard_root_path =
-                            db_paths.hot_state_kv_db_shard_root_path(shard_id as u8);
+                        let shard_root_path = db_paths.hot_state_kv_db_shard_root_path(shard_id);
                         let db = Self::open_shard(
                             shard_root_path,
-                            shard_id as u8,
+                            shard_id,
                             &state_kv_db_config,
                             readonly,
                             /* is_hot = */ true,
@@ -158,7 +157,7 @@ impl StateKvDb {
 
     pub(crate) fn new_sharded_native_batches(&self) -> ShardedStateKvSchemaBatch {
         (0..NUM_STATE_SHARDS)
-            .map(|shard_id| self.db_shard(shard_id as u8).new_native_batch())
+            .map(|shard_id| self.db_shard(shard_id).new_native_batch())
             .collect_vec()
             .try_into()
             .expect("known to be 16 shards")
@@ -185,7 +184,7 @@ impl StateKvDb {
                         .expect("Not sufficient number of sharded state kv batches");
                     s.spawn(move |_| {
                         // TODO(grao): Consider propagating the error instead of panic, if necessary.
-                        self.commit_single_shard(version, shard_id as u8, state_kv_batch)
+                        self.commit_single_shard(version, shard_id, state_kv_batch)
                             .unwrap_or_else(|err| {
                                 panic!("Failed to commit shard {shard_id}: {err}.")
                             });
@@ -239,10 +238,10 @@ impl StateKvDb {
         // TODO(HotState): should handle hot state as well.
         for shard_id in 0..NUM_STATE_SHARDS {
             state_kv_db
-                .db_shard(shard_id as u8)
+                .db_shard(shard_id)
                 .create_checkpoint(Self::db_shard_path(
                     cp_root_path.as_ref(),
-                    shard_id as u8,
+                    shard_id,
                     /* is_hot = */ false,
                 ))?;
         }
@@ -258,20 +257,20 @@ impl StateKvDb {
         Arc::clone(&self.state_kv_metadata_db)
     }
 
-    pub(crate) fn db_shard(&self, shard_id: u8) -> &DB {
-        &self.state_kv_db_shards[shard_id as usize]
+    pub(crate) fn db_shard(&self, shard_id: usize) -> &DB {
+        &self.state_kv_db_shards[shard_id]
     }
 
-    pub(crate) fn db_shard_arc(&self, shard_id: u8) -> Arc<DB> {
-        Arc::clone(&self.state_kv_db_shards[shard_id as usize])
+    pub(crate) fn db_shard_arc(&self, shard_id: usize) -> Arc<DB> {
+        Arc::clone(&self.state_kv_db_shards[shard_id])
     }
 
     pub(crate) fn enabled_sharding(&self) -> bool {
         self.enabled_sharding
     }
 
-    pub(crate) fn num_shards(&self) -> u8 {
-        NUM_STATE_SHARDS as u8
+    pub(crate) fn num_shards(&self) -> usize {
+        NUM_STATE_SHARDS
     }
 
     pub(crate) fn hack_num_real_shards(&self) -> usize {
@@ -285,19 +284,19 @@ impl StateKvDb {
     pub(crate) fn commit_single_shard(
         &self,
         version: Version,
-        shard_id: u8,
+        shard_id: usize,
         mut batch: impl WriteBatch,
     ) -> Result<()> {
         batch.put::<DbMetadataSchema>(
-            &DbMetadataKey::StateKvShardCommitProgress(shard_id as usize),
+            &DbMetadataKey::StateKvShardCommitProgress(shard_id),
             &DbMetadataValue::Version(version),
         )?;
-        self.state_kv_db_shards[shard_id as usize].write_schemas(batch)
+        self.state_kv_db_shards[shard_id].write_schemas(batch)
     }
 
     fn open_shard<P: AsRef<Path>>(
         db_root_path: P,
-        shard_id: u8,
+        shard_id: usize,
         state_kv_db_config: &RocksdbConfig,
         readonly: bool,
         is_hot: bool,
@@ -338,7 +337,7 @@ impl StateKvDb {
         open_func(&rocksdb_opts, path, name, cfds)
     }
 
-    fn db_shard_path<P: AsRef<Path>>(db_root_path: P, shard_id: u8, is_hot: bool) -> PathBuf {
+    fn db_shard_path<P: AsRef<Path>>(db_root_path: P, shard_id: usize, is_hot: bool) -> PathBuf {
         let shard_sub_path = format!(
             "{}_{}",
             if is_hot { "hot_shard" } else { "shard" },

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -64,7 +64,7 @@ pub struct StateMerkleDb {
     state_merkle_db_shards: [Arc<DB>; NUM_STATE_SHARDS],
     enable_sharding: bool,
     // shard_id -> cache.
-    version_caches: HashMap<Option<u8>, VersionedNodeCache>,
+    version_caches: HashMap<Option<usize>, VersionedNodeCache>,
     // `None` means the cache is not enabled.
     lru_cache: Option<LruNodeCache>,
 }
@@ -83,7 +83,7 @@ impl StateMerkleDb {
         let mut version_caches = HashMap::with_capacity(NUM_STATE_SHARDS + 1);
         version_caches.insert(None, VersionedNodeCache::new());
         for i in 0..NUM_STATE_SHARDS {
-            version_caches.insert(Some(i as u8), VersionedNodeCache::new());
+            version_caches.insert(Some(i), VersionedNodeCache::new());
         }
         let lru_cache = NonZeroUsize::new(max_nodes_per_lru_cache_shard).map(LruNodeCache::new);
         if !sharding {
@@ -128,7 +128,7 @@ impl StateMerkleDb {
                 .into_par_iter()
                 .enumerate()
                 .for_each(|(shard_id, batch)| {
-                    self.db_shard(shard_id as u8)
+                    self.db_shard(shard_id)
                         .write_schemas(batch)
                         .unwrap_or_else(|err| {
                             panic!("Failed to commit state merkle shard {shard_id}: {err}")
@@ -190,11 +190,8 @@ impl StateMerkleDb {
         if sharding {
             for shard_id in 0..NUM_STATE_SHARDS {
                 state_merkle_db
-                    .db_shard(shard_id as u8)
-                    .create_checkpoint(Self::db_shard_path(
-                        cp_root_path.as_ref(),
-                        shard_id as u8,
-                    ))?;
+                    .db_shard(shard_id)
+                    .create_checkpoint(Self::db_shard_path(cp_root_path.as_ref(), shard_id))?;
             }
         }
 
@@ -209,15 +206,15 @@ impl StateMerkleDb {
         Arc::clone(&self.state_merkle_metadata_db)
     }
 
-    pub(crate) fn db_shard(&self, shard_id: u8) -> &DB {
-        &self.state_merkle_db_shards[shard_id as usize]
+    pub(crate) fn db_shard(&self, shard_id: usize) -> &DB {
+        &self.state_merkle_db_shards[shard_id]
     }
 
-    pub(crate) fn db_shard_arc(&self, shard_id: u8) -> Arc<DB> {
-        Arc::clone(&self.state_merkle_db_shards[shard_id as usize])
+    pub(crate) fn db_shard_arc(&self, shard_id: usize) -> Arc<DB> {
+        Arc::clone(&self.state_merkle_db_shards[shard_id])
     }
 
-    pub(crate) fn db(&self, shard_id: Option<u8>) -> &DB {
+    pub(crate) fn db(&self, shard_id: Option<usize>) -> &DB {
         if let Some(shard_id) = shard_id {
             self.db_shard(shard_id)
         } else {
@@ -264,14 +261,14 @@ impl StateMerkleDb {
 
     pub fn batch_put_value_set_for_shard(
         &self,
-        shard_id: u8,
+        shard_id: usize,
         value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         persisted_version: Option<Version>,
         version: Version,
     ) -> Result<(Node, TreeUpdateBatch<StateKey>)> {
         JellyfishMerkleTree::new(self).batch_put_value_set_for_shard(
-            shard_id,
+            shard_id as u8,
             value_set,
             node_hashes,
             persisted_version,
@@ -309,7 +306,7 @@ impl StateMerkleDb {
     fn create_jmt_commit_batch_for_shard(
         &self,
         version: Version,
-        shard_id: Option<u8>,
+        shard_id: Option<usize>,
         tree_update_batch: &TreeUpdateBatch<StateKey>,
         previous_epoch_ending_version: Option<Version>,
     ) -> Result<RawBatch> {
@@ -351,11 +348,11 @@ impl StateMerkleDb {
 
     pub(crate) fn put_progress(
         version: Option<Version>,
-        shard_id: Option<u8>,
+        shard_id: Option<usize>,
         batch: &mut impl WriteBatch,
     ) -> Result<()> {
         let key = if let Some(shard_id) = shard_id {
-            DbMetadataKey::StateMerkleShardCommitProgress(shard_id as usize)
+            DbMetadataKey::StateMerkleShardCommitProgress(shard_id)
         } else {
             DbMetadataKey::StateMerkleCommitProgress
         };
@@ -387,7 +384,7 @@ impl StateMerkleDb {
             .map(|shard_id| {
                 self.merklize_value_set_for_shard(
                     shard_id,
-                    sharded_value_set[shard_id as usize].clone(),
+                    sharded_value_set[shard_id].clone(),
                     /*node_hashes=*/ None,
                     version,
                     base_version,
@@ -415,7 +412,7 @@ impl StateMerkleDb {
     /// Assumes 16 shards in total for now.
     pub fn merklize_value_set_for_shard(
         &self,
-        shard_id: u8,
+        shard_id: usize,
         value_set: Vec<(HashValue, Option<&(HashValue, StateKey)>)>,
         node_hashes: Option<&HashMap<NibblePath, HashValue>>,
         version: Version,
@@ -518,7 +515,7 @@ impl StateMerkleDb {
         self.lru_cache.is_some()
     }
 
-    pub(crate) fn version_caches(&self) -> &HashMap<Option<u8>, VersionedNodeCache> {
+    pub(crate) fn version_caches(&self) -> &HashMap<Option<usize>, VersionedNodeCache> {
         &self.version_caches
     }
 
@@ -533,8 +530,8 @@ impl StateMerkleDb {
         )
     }
 
-    pub(crate) fn num_shards(&self) -> u8 {
-        NUM_STATE_SHARDS as u8
+    pub(crate) fn num_shards(&self) -> usize {
+        NUM_STATE_SHARDS
     }
 
     pub(crate) fn hack_num_real_shards(&self) -> usize {
@@ -557,7 +554,7 @@ impl StateMerkleDb {
         db_paths: &StorageDirPaths,
         state_merkle_db_config: RocksdbConfig,
         readonly: bool,
-        version_caches: HashMap<Option<u8>, VersionedNodeCache>,
+        version_caches: HashMap<Option<usize>, VersionedNodeCache>,
         lru_cache: Option<LruNodeCache>,
     ) -> Result<Self> {
         let state_merkle_metadata_db_path = Self::metadata_db_path(
@@ -580,16 +577,12 @@ impl StateMerkleDb {
         let state_merkle_db_shards = (0..NUM_STATE_SHARDS)
             .into_par_iter()
             .map(|shard_id| {
-                let shard_root_path = db_paths.state_merkle_db_shard_root_path(shard_id as u8);
-                let db = Self::open_shard(
-                    shard_root_path,
-                    shard_id as u8,
-                    &state_merkle_db_config,
-                    readonly,
-                )
-                .unwrap_or_else(|e| {
-                    panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
-                });
+                let shard_root_path = db_paths.state_merkle_db_shard_root_path(shard_id);
+                let db =
+                    Self::open_shard(shard_root_path, shard_id, &state_merkle_db_config, readonly)
+                        .unwrap_or_else(|e| {
+                            panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
+                        });
                 Arc::new(db)
             })
             .collect::<Vec<_>>()
@@ -620,7 +613,7 @@ impl StateMerkleDb {
 
     fn open_shard<P: AsRef<Path>>(
         db_root_path: P,
-        shard_id: u8,
+        shard_id: usize,
         state_merkle_db_config: &RocksdbConfig,
         readonly: bool,
     ) -> Result<DB> {
@@ -656,7 +649,7 @@ impl StateMerkleDb {
         })
     }
 
-    fn db_shard_path<P: AsRef<Path>>(db_root_path: P, shard_id: u8) -> PathBuf {
+    fn db_shard_path<P: AsRef<Path>>(db_root_path: P, shard_id: usize) -> PathBuf {
         let shard_sub_path = format!("shard_{}", shard_id);
         db_root_path
             .as_ref()
@@ -715,14 +708,14 @@ impl StateMerkleDb {
     fn get_rightmost_leaf_in_single_shard(
         &self,
         version: Version,
-        shard_id: u8,
+        shard_id: usize,
     ) -> Result<Option<(NodeKey, LeafNode)>> {
         assert!(
-            shard_id < NUM_STATE_SHARDS as u8,
+            shard_id < NUM_STATE_SHARDS,
             "Invalid shard_id: {}",
             shard_id
         );
-        let shard_db = self.state_merkle_db_shards[shard_id as usize].clone();
+        let shard_db = self.state_merkle_db_shards[shard_id].clone();
         // The encoding of key and value in DB looks like:
         //
         // | <-------------- key --------------> | <- value -> |
@@ -825,7 +818,7 @@ impl TreeReader<StateKey> for StateMerkleDb {
         // Search from right to left to find the first leaf node.
         for shard_id in shards.rev() {
             if let Some((node_key, leaf_node)) =
-                self.get_rightmost_leaf_in_single_shard(version, shard_id as u8)?
+                self.get_rightmost_leaf_in_single_shard(version, shard_id)?
             {
                 return Ok(Some((node_key, leaf_node)));
             }
@@ -846,8 +839,7 @@ impl TreeWriter<StateKey> for StateMerkleDb {
         jmt_shard_batches.resize_with(NUM_STATE_SHARDS, SchemaBatch::new);
         node_batch.iter().try_for_each(|(node_key, node)| {
             if let Some(shard_id) = node_key.get_shard_id() {
-                jmt_shard_batches[shard_id as usize]
-                    .put::<JellyfishMerkleNodeSchema>(node_key, node)
+                jmt_shard_batches[shard_id].put::<JellyfishMerkleNodeSchema>(node_key, node)
             } else {
                 top_level_batch.put::<JellyfishMerkleNodeSchema>(node_key, node)
             }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -958,7 +958,7 @@ impl StateStore {
         enable_sharding: bool,
     ) -> Result<()> {
         values.iter().for_each(|((key, version), value)| {
-            let shard_id = key.get_shard_id() as usize;
+            let shard_id = key.get_shard_id();
             assert!(
                 shard_id < NUM_STATE_SHARDS,
                 "Invalid shard id: {}",
@@ -1088,7 +1088,7 @@ impl StateStore {
         let mut keys: Vec<aptos_jellyfish_merkle::node_type::NodeKey> =
             all_rows.into_iter().map(|(k, _v)| k).collect();
         if self.state_merkle_db.sharding_enabled() {
-            for i in 0..NUM_STATE_SHARDS as u8 {
+            for i in 0..NUM_STATE_SHARDS {
                 let mut iter =
                     self.state_merkle_db
                         .db_shard(i)

--- a/storage/aptosdb/src/state_store/state_snapshot_committer.rs
+++ b/storage/aptosdb/src/state_store/state_snapshot_committer.rs
@@ -131,7 +131,7 @@ impl StateSnapshotCommitter {
                                     };
 
                                     self.state_db.state_merkle_db.merklize_value_set_for_shard(
-                                        shard_id as u8,
+                                        shard_id,
                                         jmt_update_refs(&updates),
                                         Some(&node_hashes),
                                         version,

--- a/storage/aptosdb/src/utils/truncation_helper.rs
+++ b/storage/aptosdb/src/utils/truncation_helper.rs
@@ -122,13 +122,13 @@ pub(crate) fn truncate_state_kv_db_shards(
     (0..state_kv_db.hack_num_real_shards())
         .into_par_iter()
         .try_for_each(|shard_id| {
-            truncate_state_kv_db_single_shard(state_kv_db, shard_id as u8, target_version)
+            truncate_state_kv_db_single_shard(state_kv_db, shard_id, target_version)
         })
 }
 
 pub(crate) fn truncate_state_kv_db_single_shard(
     state_kv_db: &StateKvDb,
-    shard_id: u8,
+    shard_id: usize,
     target_version: Version,
 ) -> Result<()> {
     let mut batch = SchemaBatch::new();
@@ -186,13 +186,13 @@ pub(crate) fn truncate_state_merkle_db_shards(
     (0..state_merkle_db.hack_num_real_shards())
         .into_par_iter()
         .try_for_each(|shard_id| {
-            truncate_state_merkle_db_single_shard(state_merkle_db, shard_id as u8, target_version)
+            truncate_state_merkle_db_single_shard(state_merkle_db, shard_id, target_version)
         })
 }
 
 pub(crate) fn truncate_state_merkle_db_single_shard(
     state_merkle_db: &StateMerkleDb,
-    shard_id: u8,
+    shard_id: usize,
     target_version: Version,
 ) -> Result<()> {
     let mut batch = SchemaBatch::new();
@@ -264,7 +264,7 @@ pub(crate) fn get_max_version_in_state_merkle_db(
     state_merkle_db: &StateMerkleDb,
 ) -> Result<Option<Version>> {
     let mut version = get_current_version_in_state_merkle_db(state_merkle_db)?;
-    let num_real_shards = state_merkle_db.hack_num_real_shards() as u8;
+    let num_real_shards = state_merkle_db.hack_num_real_shards();
     if num_real_shards > 1 {
         for shard_id in 0..num_real_shards {
             let shard_version = find_closest_node_version_at_or_before(
@@ -603,7 +603,7 @@ where
 fn delete_nodes_and_stale_indices_at_or_after_version(
     db: &DB,
     version: Version,
-    shard_id: Option<u8>,
+    shard_id: Option<usize>,
     batch: &mut SchemaBatch,
 ) -> Result<()> {
     delete_stale_node_index_at_or_after_version::<StaleNodeIndexSchema>(db, version, batch)?;

--- a/storage/jellyfish-merkle/src/node_type/mod.rs
+++ b/storage/jellyfish-merkle/src/node_type/mod.rs
@@ -146,7 +146,7 @@ impl NodeKey {
     }
 
     // Returns the shard_id of the NodeKey, or None if it is root.
-    pub fn get_shard_id(&self) -> Option<u8> {
+    pub fn get_shard_id(&self) -> Option<usize> {
         self.nibble_path().get_shard_id()
     }
 }

--- a/storage/storage-interface/src/state_store/state_delta.rs
+++ b/storage/storage-interface/src/state_store/state_delta.rs
@@ -57,6 +57,6 @@ impl StateDelta {
     /// Get the state update for a given state key.
     /// `None` indicates the key is not updated in the delta.
     pub fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
-        self.shards[state_key.get_shard_id() as usize].get(state_key)
+        self.shards[state_key.get_shard_id()].get(state_key)
     }
 }

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -44,7 +44,7 @@ impl<'kv> PerVersionStateUpdateRefs<'kv> {
             versions_seen += 1;
 
             for (key, write_op) in update_iter.into_iter() {
-                shards[key.get_shard_id() as usize].push((key, StateUpdateRef {
+                shards[key.get_shard_id()].push((key, StateUpdateRef {
                     version,
                     state_op: write_op,
                 }));

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -59,8 +59,8 @@ impl ShardedStateCache {
         }
     }
 
-    fn shard(&self, shard_id: u8) -> &StateCacheShard {
-        &self.shards[shard_id as usize]
+    fn shard(&self, shard_id: usize) -> &StateCacheShard {
+        &self.shards[shard_id]
     }
 
     pub fn get_cloned(&self, state_key: &StateKey) -> Option<StateSlot> {

--- a/types/src/nibble/mod.rs
+++ b/types/src/nibble/mod.rs
@@ -39,6 +39,12 @@ impl From<Nibble> for u8 {
     }
 }
 
+impl From<Nibble> for usize {
+    fn from(nibble: Nibble) -> Self {
+        Self::from(nibble.0)
+    }
+}
+
 impl fmt::LowerHex for Nibble {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{:x}", self.0)

--- a/types/src/nibble/nibble_path/mod.rs
+++ b/types/src/nibble/nibble_path/mod.rs
@@ -221,9 +221,9 @@ impl NibblePath {
     }
 
     // Returns the shard_id of the NibblePath, or None if it is root.
-    pub fn get_shard_id(&self) -> Option<u8> {
+    pub fn get_shard_id(&self) -> Option<usize> {
         if self.num_nibbles() > 0 {
-            Some(u8::from(self.get_nibble(0)))
+            Some(usize::from(self.get_nibble(0)))
         } else {
             None
         }

--- a/types/src/state_store/state_key/mod.rs
+++ b/types/src/state_store/state_key/mod.rs
@@ -214,8 +214,8 @@ impl StateKey {
         &self.0.deserialized
     }
 
-    pub fn get_shard_id(&self) -> u8 {
-        self.crypto_hash_ref().nibble(0)
+    pub fn get_shard_id(&self) -> usize {
+        usize::from(self.crypto_hash_ref().nibble(0))
     }
 
     pub fn is_aptos_code(&self) -> bool {

--- a/types/src/state_store/state_key/tests.rs
+++ b/types/src/state_store/state_key/tests.rs
@@ -98,8 +98,8 @@ proptest! {
         let shard1 = key1.get_shard_id();
         let shard2 = key2.get_shard_id();
 
-        assert_eq!(shard1, key1.crypto_hash_ref().nibble(0));
-        assert_eq!(shard2, key2.crypto_hash_ref().nibble(0));
+        assert_eq!(shard1, usize::from(key1.crypto_hash_ref().nibble(0)));
+        assert_eq!(shard2, usize::from(key2.crypto_hash_ref().nibble(0)));
 
         if shard1 != shard2 {
             assert_eq!(


### PR DESCRIPTION

Returning `usize` seems to eliminate unnecessary type conversion in a bunch of
places and simplify the code a bit.
