### PR TITLE
[release-builder] generate metadata under versioned dir

### DIFF
--- a/aptos-move/aptos-release-builder/src/components/mod.rs
+++ b/aptos-move/aptos-release-builder/src/components/mod.rs
@@ -693,6 +693,7 @@ impl ReleaseConfig {
 
             let mut metadata_path = base_path.to_path_buf();
             metadata_path.push("metadata");
+            metadata_path.push(&self.name);
             metadata_path.push(proposal.name.as_str());
             metadata_path.set_extension("json");
 


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Minor fix to generate the metadata file under `metadata/vX.XX.X` instead of `metadata`. Existing way makes it tricky/hard to copy to mainnet proposals repo. 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Generated the proposal to make sure.