### PR TITLE
Fix staking_rewards tracking in rosetta

### DIFF
--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -73,7 +73,7 @@ static SET_OPERATOR_EVENT_TAG: Lazy<TypeTag> =
 static UPDATE_VOTER_EVENT_TAG: Lazy<TypeTag> =
     Lazy::new(|| parse_type_tag("0x1::staking_contract::UpdateVoter").unwrap());
 static DISTRIBUTE_STAKING_REWARDS_TAG: Lazy<TypeTag> =
-    Lazy::new(|| parse_type_tag("0x1::stake::DistributeRewards").unwrap());
+    Lazy::new(|| parse_type_tag("0x1::staking_contract::Distribute").unwrap());
 static UPDATE_COMMISSION_TAG: Lazy<TypeTag> =
     Lazy::new(|| parse_type_tag("0x1::staking_contract::UpdateCommission").unwrap());
 


### PR DESCRIPTION
https://github.com/aptos-labs/aptos-core/commit/64f1810368640b3adfaf63f6c56d0340df476e8e assign DISTRIBUTE_STAKING_REWARDS_TAG with the wrong identifier.

## Description
This event is not "0x1::stake::DistributeRewards" but "0x1::staking_contract::Distribute". Coinbase team complains.


