### PR TITLE
Stack usage verifier early exit on error

### DIFF
--- a/third_party/move/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/third_party/move/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -60,10 +60,8 @@ impl<'a> StackUsageVerifier<'a> {
             if let Some(new_pushes) = u64::checked_add(overall_push, num_pushes) {
                 overall_push = new_pushes
             } else {
-                return Err(
-                    PartialVMError::new(StatusCode::VALUE_STACK_PUSH_OVERFLOW)
-                        .at_code_offset(self.current_function(), block_start),
-                );
+                return Err(PartialVMError::new(StatusCode::VALUE_STACK_PUSH_OVERFLOW)
+                    .at_code_offset(self.current_function(), block_start));
             };
 
             // Check that the accumulated pushes does not exceed a pre-defined max size

--- a/third_party/move/move-bytecode-verifier/src/stack_usage_verifier.rs
+++ b/third_party/move/move-bytecode-verifier/src/stack_usage_verifier.rs
@@ -59,6 +59,11 @@ impl<'a> StackUsageVerifier<'a> {
             let (num_pops, num_pushes) = self.instruction_effect(&code[i as usize])?;
             if let Some(new_pushes) = u64::checked_add(overall_push, num_pushes) {
                 overall_push = new_pushes
+            } else {
+                return Err(
+                    PartialVMError::new(StatusCode::VALUE_STACK_PUSH_OVERFLOW)
+                        .at_code_offset(self.current_function(), block_start),
+                );
             };
 
             // Check that the accumulated pushes does not exceed a pre-defined max size


### PR DESCRIPTION
## Description
Handle the unlikely case of `overall_push` overflow in `stack_usage_verifier`, which would cause `checked_add` to return `None`.
```
if let Some(new_pushes) = u64::checked_add(overall_push, num_pushes) {
    overall_push = new_pushes
}
```

## How Has This Been Tested?
Not necessary.

## Key Areas to Review


## Type of Change
- [ ] New feature
- [X] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [X] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [X] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
