### PR TITLE
Run replay-verify on C3D instead of T2D

### DIFF
--- a/.github/workflows/replay-verify-mainnet.yaml
+++ b/.github/workflows/replay-verify-mainnet.yaml
@@ -3,17 +3,11 @@
 #
 # On PR, a single test case will run. On workflow_dispatch, you may specify the CHAIN_NAME to verify.
 
-name: "replay-verify-on-archive"
+name: "Replay-verify on archive: Mainnet"
 on:
   # Allow triggering manually
   workflow_dispatch:
     inputs:
-      NETWORK:
-        required: true
-        type: choice
-        options: [testnet, mainnet, all]
-        default: all
-        description: The chain name to test. If not specified, it will test both testnet and mainnet.
       IMAGE_TAG:
         required: false
         type: string
@@ -21,17 +15,17 @@ on:
       START_VERSION:
         required: false
         type: string
-        description: Optional version to start replaying. If not specified, replay-verify will determines start version itself.
+        description: Optional version to start replaying. If not specified, replay-verify will determine start version itself.
       END_VERSION:
         required: false
         type: string
-        description: Optional version to end replaying. If not specified, replay-verify will determines end version itself.
+        description: Optional version to end replaying. If not specified, replay-verify will determine end version itself.
   pull_request:
     paths:
-      - ".github/workflows/replay-verify.yaml"
+      - ".github/workflows/replay-verify-mainnet.yaml"
       - ".github/workflows/workflow-run-replay-verify-on-archive.yaml"
   schedule:
-    - cron: "0 8 * * 0,2,4" # The main branch cadence. This runs every Sun,Tues,Thurs UTC 08:00
+    - cron: "0 10 * * 0,2,4" # The main branch cadence. This runs every Sun,Tues,Thurs UTC 10:00
 
 permissions:
   contents: read
@@ -55,23 +49,9 @@ jobs:
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
-  replay-testnet:
+  replay:
     if: |
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' && (inputs.NETWORK == 'testnet' || inputs.NETWORK == 'all')
-    needs: determine-test-metadata
-    uses: ./.github/workflows/workflow-run-replay-verify-on-archive.yaml
-    secrets: inherit
-    with:
-      NETWORK: "testnet"
-      IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
-      START_VERSION: ${{ inputs.START_VERSION }}
-      END_VERSION: ${{ inputs.END_VERSION }}
-
-  replay-mainnet:
-    if: |
-      github.event_name == 'schedule' ||
-      github.event_name == 'workflow_dispatch' && (inputs.NETWORK == 'mainnet' || inputs.NETWORK == 'all' )
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: determine-test-metadata
     uses: ./.github/workflows/workflow-run-replay-verify-on-archive.yaml
     secrets: inherit

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -1,0 +1,62 @@
+# This defines a workflow to replay transactions on the given chain with the latest aptos node software.
+# In order to trigger it go to the Actions Tab of the Repo, click "replay-verify" and then "Run Workflow".
+#
+# On PR, a single test case will run. On workflow_dispatch, you may specify the CHAIN_NAME to verify.
+
+name: "Replay-verify on archive: Testnet"
+on:
+  # Allow triggering manually
+  workflow_dispatch:
+    inputs:
+      IMAGE_TAG:
+        required: false
+        type: string
+        description: The image tag of the feature branch to test, if not specified, it will use the latest commit on current branch.
+      START_VERSION:
+        required: false
+        type: string
+        description: Optional version to start replaying. If not specified, replay-verify will determine start version itself.
+      END_VERSION:
+        required: false
+        type: string
+        description: Optional version to end replaying. If not specified, replay-verify will determine end version itself.
+  pull_request:
+    paths:
+      - ".github/workflows/replay-verify-testnet.yaml"
+      - ".github/workflows/workflow-run-replay-verify-on-archive.yaml"
+  schedule:
+    - cron: "0 4 * * 0,2,4" # The main branch cadence. This runs every Sun,Tues,Thurs UTC 04:00
+
+permissions:
+  contents: read
+  id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
+  issues: read
+  pull-requests: read
+
+# cancel redundant builds
+concurrency:
+  # cancel redundant builds on PRs (only on PR, not on branches)
+  group: ${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.ref) || github.sha }}-${{ inputs.IMAGE_TAG || 'latest' }}
+  cancel-in-progress: true
+
+jobs:
+  determine-test-metadata:
+    runs-on: ubuntu-latest-32-core # consider  moving this to a smaller machine since the compute runs on GKE
+    steps:
+      # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/check-aptos-core
+        with:
+          cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
+
+  replay:
+    if: |
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+    needs: determine-test-metadata
+    uses: ./.github/workflows/workflow-run-replay-verify-on-archive.yaml
+    secrets: inherit
+    with:
+      NETWORK: "testnet"
+      IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
+      START_VERSION: ${{ inputs.START_VERSION }}
+      END_VERSION: ${{ inputs.END_VERSION }}

--- a/testsuite/replay-verify/replay-verify-worker-template.yaml
+++ b/testsuite/replay-verify/replay-verify-worker-template.yaml
@@ -23,11 +23,11 @@ spec:
           value: "info"
       resources:
         requests:
-          memory: "90Gi"
-          cpu: "30"
+          memory: "110Gi"
+          cpu: "28"
         limits:
-          memory: "90Gi"
-          cpu: "30"
+          memory: "110Gi"
+          cpu: "28"
   volumes:
     - name: archive
       persistentVolumeClaim:
@@ -40,4 +40,4 @@ spec:
               - key: cloud.google.com/machine-family
                 operator: In
                 values:
-                  - t2d
+                  - c3d


### PR DESCRIPTION
## Description

Switch instance type to C3D.
Split the workflow in two: separate testnet from mainnet and leave 6 hours between the runs, to avoid a peak of nearly 5k cores used when both run in parallel.