### PR TITLE
[Aptos Data Client] Add support for txn V2 data

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -395,6 +395,8 @@ impl Default for AptosLatencyFilteringConfig {
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct AptosDataClientConfig {
+    /// Whether transaction data v2 is enabled
+    pub enable_transaction_data_v2: bool,
     /// The aptos data poller config for the data client
     pub data_poller_config: AptosDataPollerConfig,
     /// The aptos data multi-fetch config for the data client
@@ -415,6 +417,8 @@ pub struct AptosDataClientConfig {
     pub max_num_output_reductions: u64,
     /// Maximum lag (in seconds) we'll tolerate when sending optimistic fetch requests
     pub max_optimistic_fetch_lag_secs: u64,
+    /// Maximum number of bytes to send in a single response
+    pub max_response_bytes: u64,
     /// Maximum timeout (in ms) when waiting for a response (after exponential increases)
     pub max_response_timeout_ms: u64,
     /// Maximum number of state keys and values per chunk
@@ -438,6 +442,7 @@ pub struct AptosDataClientConfig {
 impl Default for AptosDataClientConfig {
     fn default() -> Self {
         Self {
+            enable_transaction_data_v2: false, // TODO: flip this once V2 data is enabled
             data_poller_config: AptosDataPollerConfig::default(),
             data_multi_fetch_config: AptosDataMultiFetchConfig::default(),
             ignore_low_score_peers: true,
@@ -446,7 +451,8 @@ impl Default for AptosDataClientConfig {
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_num_output_reductions: 0,
             max_optimistic_fetch_lag_secs: 20, // 20 seconds
-            max_response_timeout_ms: 60_000,   // 60 seconds
+            max_response_bytes: MAX_MESSAGE_SIZE as u64,
+            max_response_timeout_ms: 60_000, // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
             max_subscription_lag_secs: 20, // 20 seconds
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -2,11 +2,17 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{error, error::Error, global_summary::GlobalDataSummary};
-use aptos_storage_service_types::{responses::TransactionOrOutputListWithProof, Epoch};
+use aptos_storage_service_types::{
+    responses::{TransactionOrOutputListWithProof, TransactionOrOutputListWithProofV2},
+    Epoch,
+};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValueChunkWithProof,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
+    transaction::{
+        TransactionListWithProof, TransactionListWithProofV2, TransactionOutputListWithProof,
+        TransactionOutputListWithProofV2, Version,
+    },
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -41,7 +47,7 @@ pub trait AptosDataClientInterface {
         known_version: Version,
         known_epoch: Epoch,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>>;
+    ) -> error::Result<Response<(TransactionOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 
     /// Fetches a new transaction list with proof. Versions start at
     /// `known_version + 1` and `known_epoch` (inclusive). The end version
@@ -53,7 +59,7 @@ pub trait AptosDataClientInterface {
         known_epoch: Epoch,
         include_events: bool,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>>;
+    ) -> error::Result<Response<(TransactionListWithProofV2, LedgerInfoWithSignatures)>>;
 
     /// Fetches a new transaction or output list with proof. Versions start at
     /// `known_version + 1` and `known_epoch` (inclusive). The end version
@@ -65,7 +71,7 @@ pub trait AptosDataClientInterface {
         known_epoch: Epoch,
         include_events: bool,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)>>;
+    ) -> error::Result<Response<(TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 
     /// Fetches the number of states at the specified version.
     async fn get_number_of_states(
@@ -98,7 +104,7 @@ pub trait AptosDataClientInterface {
         start_version: Version,
         end_version: Version,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<TransactionOutputListWithProof>>;
+    ) -> error::Result<Response<TransactionOutputListWithProofV2>>;
 
     /// Fetches a transaction list with proof, with transactions from
     /// start to end versions (inclusive). The proof is relative to the
@@ -113,7 +119,7 @@ pub trait AptosDataClientInterface {
         end_version: Version,
         include_events: bool,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<TransactionListWithProof>>;
+    ) -> error::Result<Response<TransactionListWithProofV2>>;
 
     /// Fetches a transaction or output list with proof, with data from
     /// start to end versions (inclusive). The proof is relative to the
@@ -128,7 +134,7 @@ pub trait AptosDataClientInterface {
         end_version: Version,
         include_events: bool,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<TransactionOrOutputListWithProof>>;
+    ) -> error::Result<Response<TransactionOrOutputListWithProofV2>>;
 
     /// Subscribes to new transaction output lists with proofs. Subscriptions
     /// start at `known_version + 1` and `known_epoch` (inclusive), as
@@ -139,7 +145,7 @@ pub trait AptosDataClientInterface {
         &self,
         subscription_request_metadata: SubscriptionRequestMetadata,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>>;
+    ) -> error::Result<Response<(TransactionOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 
     /// Subscribes to new transaction lists with proofs. Subscriptions start
     /// at `known_version + 1` and `known_epoch` (inclusive), as specified
@@ -152,7 +158,7 @@ pub trait AptosDataClientInterface {
         subscription_request_metadata: SubscriptionRequestMetadata,
         include_events: bool,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>>;
+    ) -> error::Result<Response<(TransactionListWithProofV2, LedgerInfoWithSignatures)>>;
 
     /// Subscribes to new transaction or output lists with proofs. Subscriptions
     /// start at `known_version + 1` and `known_epoch` (inclusive), as
@@ -165,7 +171,7 @@ pub trait AptosDataClientInterface {
         subscription_request_metadata: SubscriptionRequestMetadata,
         include_events: bool,
         request_timeout_ms: u64,
-    ) -> error::Result<Response<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)>>;
+    ) -> error::Result<Response<(TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 }
 
 /// Subscription stream metadata associated with each subscription request

--- a/state-sync/aptos-data-client/src/tests/advertise.rs
+++ b/state-sync/aptos-data-client/src/tests/advertise.rs
@@ -16,7 +16,7 @@ use aptos_storage_service_types::{
     responses::{CompleteDataRange, DataResponse, StorageServerSummary, StorageServiceResponse},
 };
 use aptos_time_service::MockTimeService;
-use aptos_types::transaction::{TransactionListWithProof, Version};
+use aptos_types::transaction::{TransactionListWithProofV2, Version};
 use claims::assert_matches;
 use std::time::Duration;
 use tokio::time::timeout;
@@ -90,7 +90,7 @@ async fn request_works_only_when_data_available() {
             .get_transactions_with_proof(100, 0, 100, false, request_timeout)
             .await
             .unwrap();
-        assert_eq!(response.payload, TransactionListWithProof::new_empty());
+        assert_eq!(response.payload, TransactionListWithProofV2::new_empty());
     }
 }
 

--- a/state-sync/aptos-data-client/src/tests/compression.rs
+++ b/state-sync/aptos-data-client/src/tests/compression.rs
@@ -14,7 +14,7 @@ use aptos_storage_service_types::{
     requests::{DataRequest, TransactionsWithProofRequest},
     responses::{CompleteDataRange, DataResponse, StorageServiceResponse},
 };
-use aptos_types::transaction::TransactionListWithProof;
+use aptos_types::transaction::TransactionListWithProofV2;
 use claims::assert_matches;
 
 #[tokio::test]
@@ -265,6 +265,6 @@ async fn disable_compression() {
             .get_transactions_with_proof(100, 50, 100, false, request_timeout)
             .await
             .unwrap();
-        assert_eq!(response.payload, TransactionListWithProof::new_empty());
+        assert_eq!(response.payload, TransactionListWithProofV2::new_empty());
     }
 }

--- a/state-sync/aptos-data-client/src/tests/mock.rs
+++ b/state-sync/aptos-data-client/src/tests/mock.rs
@@ -31,13 +31,13 @@ use aptos_storage_interface::DbReader;
 use aptos_storage_service_client::StorageServiceClient;
 use aptos_storage_service_server::network::{NetworkRequest, ResponseSender};
 use aptos_storage_service_types::{
-    responses::TransactionOrOutputListWithProof, Epoch, StorageServiceMessage,
+    responses::TransactionOrOutputListWithProofV2, Epoch, StorageServiceMessage,
 };
 use aptos_time_service::{MockTimeService, TimeService};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValueChunkWithProof,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
+    transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
     PeerId,
 };
 use async_trait::async_trait;
@@ -283,7 +283,7 @@ mock! {
             known_version: Version,
             known_epoch: Epoch,
             request_timeout_ms: u64,
-        ) -> Result<Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>>;
+        ) -> Result<Response<(TransactionOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 
         async fn get_new_transactions_with_proof(
             &self,
@@ -291,7 +291,7 @@ mock! {
             known_epoch: Epoch,
             include_events: bool,
             request_timeout_ms: u64,
-        ) -> Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>>;
+        ) -> Result<Response<(TransactionListWithProofV2, LedgerInfoWithSignatures)>>;
 
         async fn get_new_transactions_or_outputs_with_proof(
             &self,
@@ -299,7 +299,7 @@ mock! {
             known_epoch: Epoch,
             include_events: bool,
             request_timeout_ms: u64,
-        ) -> Result<Response<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)>>;
+        ) -> Result<Response<(TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 
         async fn get_number_of_states(
             &self,
@@ -321,7 +321,7 @@ mock! {
             start_version: Version,
             end_version: Version,
             request_timeout_ms: u64,
-        ) -> Result<Response<TransactionOutputListWithProof>>;
+        ) -> Result<Response<TransactionOutputListWithProofV2>>;
 
         async fn get_transactions_with_proof(
             &self,
@@ -330,7 +330,7 @@ mock! {
             end_version: Version,
             include_events: bool,
             request_timeout_ms: u64,
-        ) -> Result<Response<TransactionListWithProof>>;
+        ) -> Result<Response<TransactionListWithProofV2>>;
 
         async fn get_transactions_or_outputs_with_proof(
             &self,
@@ -339,27 +339,27 @@ mock! {
             end_version: Version,
             include_events: bool,
             request_timeout_ms: u64,
-        ) -> Result<Response<TransactionOrOutputListWithProof>>;
+        ) -> Result<Response<TransactionOrOutputListWithProofV2>>;
 
         async fn subscribe_to_transaction_outputs_with_proof(
             &self,
             subscription_request_metadata: SubscriptionRequestMetadata,
             request_timeout_ms: u64,
-        ) -> Result<Response<(TransactionOutputListWithProof, LedgerInfoWithSignatures)>>;
+        ) -> Result<Response<(TransactionOutputListWithProofV2, LedgerInfoWithSignatures)>>;
 
         async fn subscribe_to_transactions_with_proof(
             &self,
             subscription_request_metadata: SubscriptionRequestMetadata,
             include_events: bool,
             request_timeout_ms: u64,
-        ) -> Result<Response<(TransactionListWithProof, LedgerInfoWithSignatures)>>;
+        ) -> Result<Response<(TransactionListWithProofV2, LedgerInfoWithSignatures)>>;
 
         async fn subscribe_to_transactions_or_outputs_with_proof(
             &self,
             subscription_request_metadata: SubscriptionRequestMetadata,
             include_events: bool,
             request_timeout_ms: u64,
-        ) -> Result<Response<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)>>;
+        ) -> Result<Response<(TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures)>>;
     }
 }
 

--- a/state-sync/aptos-data-client/src/tests/mod.rs
+++ b/state-sync/aptos-data-client/src/tests/mod.rs
@@ -8,5 +8,6 @@ mod multi_fetch;
 mod peers;
 mod poller;
 mod priority;
+mod request_v2;
 mod utils;
 mod weighted_selection;

--- a/state-sync/aptos-data-client/src/tests/peers.rs
+++ b/state-sync/aptos-data-client/src/tests/peers.rs
@@ -20,7 +20,7 @@ use aptos_storage_service_types::{
     responses::{CompleteDataRange, DataResponse, StorageServerSummary, StorageServiceResponse},
     StorageServiceError,
 };
-use aptos_types::transaction::TransactionListWithProof;
+use aptos_types::transaction::{TransactionListWithProof, TransactionListWithProofV2};
 use claims::{assert_err, assert_matches, assert_ok};
 use maplit::hashset;
 use rand::{rngs::OsRng, Rng};
@@ -182,7 +182,7 @@ async fn bad_peer_is_eventually_banned_internal() {
             .get_transactions_with_proof(100, 50, 100, false, response_timeout_ms)
             .await
             .unwrap();
-        assert_eq!(response.payload, TransactionListWithProof::new_empty());
+        assert_eq!(response.payload, TransactionListWithProofV2::new_empty());
     }
 }
 

--- a/state-sync/aptos-data-client/src/tests/request_v2.rs
+++ b/state-sync/aptos-data-client/src/tests/request_v2.rs
@@ -1,0 +1,1003 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    client::AptosDataClient,
+    interface::{AptosDataClientInterface, SubscriptionRequestMetadata},
+    priority::PeerPriority,
+    tests::{mock::MockNetwork, utils},
+};
+use aptos_config::{config::AptosDataClientConfig, network_id::NetworkId};
+use aptos_crypto::{ed25519::Ed25519PrivateKey, HashValue, PrivateKey, SigningKey, Uniform};
+use aptos_storage_service_types::{
+    requests::{DataRequest, TransactionData, TransactionDataRequestType, TransactionOrOutputData},
+    responses::{
+        DataResponse, NewTransactionDataWithProofResponse, StorageServiceResponse,
+        TransactionDataResponseType, TransactionDataWithProofResponse,
+    },
+};
+use aptos_types::{
+    account_address::AccountAddress,
+    aggregate_signature::AggregateSignature,
+    block_info::BlockInfo,
+    chain_id::ChainId,
+    ledger_info::{LedgerInfo, LedgerInfoWithSignatures},
+    transaction::{
+        ExecutionStatus, PersistedAuxiliaryInfo, RawTransaction, Script, SignedTransaction,
+        Transaction, TransactionAuxiliaryData, TransactionInfo, TransactionListWithAuxiliaryInfos,
+        TransactionListWithProof, TransactionListWithProofV2, TransactionOutput,
+        TransactionOutputListWithAuxiliaryInfos, TransactionOutputListWithProof,
+        TransactionOutputListWithProofV2, TransactionPayload, TransactionStatus,
+    },
+    write_set::WriteSet,
+};
+use claims::assert_matches;
+
+#[tokio::test]
+async fn test_get_transactions() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_transactions = 10;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::GetTransactionsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::GetTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionData(TransactionData {
+                                    include_events: true,
+                                })
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_list_with_proof =
+                            Some(create_transaction_list_with_proof_v2(num_transactions));
+                        DataResponse::TransactionDataWithProof(TransactionDataWithProofResponse {
+                            transaction_data_response_type:
+                                TransactionDataResponseType::TransactionData,
+                            transaction_list_with_proof,
+                            transaction_output_list_with_proof: None,
+                        })
+                    } else {
+                        let transaction_list_with_proof =
+                            create_transaction_list_with_proof(num_transactions);
+                        DataResponse::TransactionsWithProof(transaction_list_with_proof)
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let response = client
+            .get_transactions_with_proof(0, 0, 0, true, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let transaction_list_with_proof_v2 = response.payload;
+        verify_response_data(
+            Some(transaction_list_with_proof_v2),
+            None,
+            use_request_v2,
+            num_transactions,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_get_transaction_outputs() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_outputs = 15;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::GetTransactionOutputsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::GetTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionOutputData
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_output_list_with_proof =
+                            Some(create_transaction_output_list_with_proof_v2(num_outputs));
+                        DataResponse::TransactionDataWithProof(TransactionDataWithProofResponse {
+                            transaction_data_response_type:
+                                TransactionDataResponseType::TransactionOutputData,
+                            transaction_list_with_proof: None,
+                            transaction_output_list_with_proof,
+                        })
+                    } else {
+                        let output_list_with_proof =
+                            create_transaction_output_list_with_proof(num_outputs);
+                        DataResponse::TransactionOutputsWithProof(output_list_with_proof)
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let response = client
+            .get_transaction_outputs_with_proof(0, 0, 0, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let output_list_with_proof_v2 = response.payload;
+        verify_response_data(
+            None,
+            Some(output_list_with_proof_v2),
+            use_request_v2,
+            num_outputs,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_get_transactions_or_outputs() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_transactions_or_outputs = 20;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::GetTransactionsOrOutputsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::GetTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionOrOutputData(
+                                    TransactionOrOutputData {
+                                        include_events: false,
+                                    }
+                                )
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_list_with_proof = Some(
+                            create_transaction_list_with_proof_v2(num_transactions_or_outputs),
+                        );
+                        DataResponse::TransactionDataWithProof(TransactionDataWithProofResponse {
+                            transaction_data_response_type:
+                                TransactionDataResponseType::TransactionData,
+                            transaction_list_with_proof,
+                            transaction_output_list_with_proof: None,
+                        })
+                    } else {
+                        let transaction_list_with_proof = Some(create_transaction_list_with_proof(
+                            num_transactions_or_outputs,
+                        ));
+                        DataResponse::TransactionsOrOutputsWithProof((
+                            transaction_list_with_proof,
+                            None,
+                        ))
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let response = client
+            .get_transactions_or_outputs_with_proof(0, 0, 0, false, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let (transaction_list_with_proof_v2, output_list_with_proof_v2) = response.payload;
+        verify_response_data(
+            transaction_list_with_proof_v2,
+            output_list_with_proof_v2,
+            use_request_v2,
+            num_transactions_or_outputs,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_get_new_transactions() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_transactions = 34;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::GetNewTransactionsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::GetNewTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionData(TransactionData {
+                                    include_events: true,
+                                })
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_list_with_proof =
+                            Some(create_transaction_list_with_proof_v2(num_transactions));
+                        DataResponse::NewTransactionDataWithProof(
+                            NewTransactionDataWithProofResponse {
+                                transaction_data_response_type:
+                                    TransactionDataResponseType::TransactionData,
+                                transaction_list_with_proof,
+                                transaction_output_list_with_proof: None,
+                                ledger_info_with_signatures: create_ledger_info(),
+                            },
+                        )
+                    } else {
+                        let transaction_list_with_proof =
+                            create_transaction_list_with_proof(num_transactions);
+                        DataResponse::NewTransactionsWithProof((
+                            transaction_list_with_proof,
+                            create_ledger_info(),
+                        ))
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let response = client
+            .get_new_transactions_with_proof(0, 0, true, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let (transaction_list_with_proof_v2, _) = response.payload;
+        verify_response_data(
+            Some(transaction_list_with_proof_v2),
+            None,
+            use_request_v2,
+            num_transactions,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_get_new_transaction_outputs() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_outputs = 42;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::GetNewTransactionOutputsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::GetNewTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionOutputData
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_output_list_with_proof =
+                            Some(create_transaction_output_list_with_proof_v2(num_outputs));
+                        DataResponse::NewTransactionDataWithProof(
+                            NewTransactionDataWithProofResponse {
+                                transaction_data_response_type:
+                                    TransactionDataResponseType::TransactionOutputData,
+                                transaction_list_with_proof: None,
+                                transaction_output_list_with_proof,
+                                ledger_info_with_signatures: create_ledger_info(),
+                            },
+                        )
+                    } else {
+                        let output_list_with_proof =
+                            create_transaction_output_list_with_proof(num_outputs);
+                        DataResponse::NewTransactionOutputsWithProof((
+                            output_list_with_proof,
+                            create_ledger_info(),
+                        ))
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let response = client
+            .get_new_transaction_outputs_with_proof(0, 0, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let (output_list_with_proof_v2, _) = response.payload;
+        verify_response_data(
+            None,
+            Some(output_list_with_proof_v2),
+            use_request_v2,
+            num_outputs,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_get_new_transactions_or_outputs() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_transactions_or_outputs = 50;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::GetNewTransactionsOrOutputsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::GetNewTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionOrOutputData(
+                                    TransactionOrOutputData {
+                                        include_events: false,
+                                    }
+                                )
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_list_with_proof = Some(
+                            create_transaction_list_with_proof_v2(num_transactions_or_outputs),
+                        );
+                        DataResponse::NewTransactionDataWithProof(
+                            NewTransactionDataWithProofResponse {
+                                transaction_data_response_type:
+                                    TransactionDataResponseType::TransactionData,
+                                transaction_list_with_proof,
+                                transaction_output_list_with_proof: None,
+                                ledger_info_with_signatures: create_ledger_info(),
+                            },
+                        )
+                    } else {
+                        let transaction_list_with_proof =
+                            create_transaction_list_with_proof(num_transactions_or_outputs);
+                        let transaction_or_output_list_with_proof =
+                            (Some(transaction_list_with_proof), None);
+                        DataResponse::NewTransactionsOrOutputsWithProof((
+                            transaction_or_output_list_with_proof,
+                            create_ledger_info(),
+                        ))
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let response = client
+            .get_new_transactions_or_outputs_with_proof(0, 0, false, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let ((transaction_list_with_proof, output_list_with_proof), _) = response.payload;
+        verify_response_data(
+            transaction_list_with_proof,
+            output_list_with_proof,
+            use_request_v2,
+            num_transactions_or_outputs,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_subscribe_transactions() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_transactions = 5;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::SubscribeTransactionsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::SubscribeTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionData(TransactionData {
+                                    include_events: true,
+                                })
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_list_with_proof =
+                            Some(create_transaction_list_with_proof_v2(num_transactions));
+                        DataResponse::NewTransactionDataWithProof(
+                            NewTransactionDataWithProofResponse {
+                                transaction_data_response_type:
+                                    TransactionDataResponseType::TransactionData,
+                                transaction_list_with_proof,
+                                transaction_output_list_with_proof: None,
+                                ledger_info_with_signatures: create_ledger_info(),
+                            },
+                        )
+                    } else {
+                        let transaction_list_with_proof =
+                            create_transaction_list_with_proof(num_transactions);
+                        DataResponse::NewTransactionsWithProof((
+                            transaction_list_with_proof,
+                            create_ledger_info(),
+                        ))
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let subscription_request_metadata = create_subscription_request_metadata();
+        let response = client
+            .subscribe_to_transactions_with_proof(subscription_request_metadata, true, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let (transaction_list_with_proof_v2, _) = response.payload;
+        verify_response_data(
+            Some(transaction_list_with_proof_v2),
+            None,
+            use_request_v2,
+            num_transactions,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_subscribe_transaction_outputs() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_outputs = 7;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::SubscribeTransactionOutputsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::SubscribeTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionOutputData
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_output_list_with_proof =
+                            Some(create_transaction_output_list_with_proof_v2(num_outputs));
+                        DataResponse::NewTransactionDataWithProof(
+                            NewTransactionDataWithProofResponse {
+                                transaction_data_response_type:
+                                    TransactionDataResponseType::TransactionOutputData,
+                                transaction_list_with_proof: None,
+                                transaction_output_list_with_proof,
+                                ledger_info_with_signatures: create_ledger_info(),
+                            },
+                        )
+                    } else {
+                        let output_list_with_proof =
+                            create_transaction_output_list_with_proof(num_outputs);
+                        DataResponse::NewTransactionOutputsWithProof((
+                            output_list_with_proof,
+                            create_ledger_info(),
+                        ))
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let subscription_request_metadata = create_subscription_request_metadata();
+        let response = client
+            .subscribe_to_transaction_outputs_with_proof(subscription_request_metadata, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let (output_list_with_proof_v2, _) = response.payload;
+        verify_response_data(
+            None,
+            Some(output_list_with_proof_v2),
+            use_request_v2,
+            num_outputs,
+        );
+    }
+}
+
+#[tokio::test]
+async fn test_subscribe_transactions_or_outputs() {
+    // Test both v1 and v2 requests
+    for use_request_v2 in [false, true] {
+        // Create the data client with a connected peer
+        let (mut mock_network, client, network_id) = create_client_with_peer(use_request_v2);
+
+        // Spawn a handler for the peer to respond to the request
+        let num_transactions_or_outputs = 12;
+        tokio::spawn(async move {
+            while let Some(network_request) = mock_network.next_request(network_id).await {
+                tokio::spawn(async move {
+                    // Verify the network request
+                    match network_request.storage_service_request.data_request {
+                        DataRequest::SubscribeTransactionsOrOutputsWithProof(_) => {
+                            assert!(!use_request_v2)
+                        },
+                        DataRequest::SubscribeTransactionDataWithProof(request) => {
+                            assert!(use_request_v2);
+                            assert_matches!(
+                                request.transaction_data_request_type,
+                                TransactionDataRequestType::TransactionOrOutputData(
+                                    TransactionOrOutputData {
+                                        include_events: true,
+                                    }
+                                )
+                            );
+                        },
+                        _ => panic!(
+                            "Unexpected data request type: {:?}",
+                            network_request.storage_service_request.data_request
+                        ),
+                    }
+
+                    // Create the storage service response
+                    let data_response = if use_request_v2 {
+                        let transaction_output_list_with_proof =
+                            Some(create_transaction_output_list_with_proof_v2(
+                                num_transactions_or_outputs,
+                            ));
+                        DataResponse::NewTransactionDataWithProof(
+                            NewTransactionDataWithProofResponse {
+                                transaction_data_response_type:
+                                    TransactionDataResponseType::TransactionData,
+                                transaction_list_with_proof: None,
+                                transaction_output_list_with_proof,
+                                ledger_info_with_signatures: create_ledger_info(),
+                            },
+                        )
+                    } else {
+                        let output_list_with_proof =
+                            create_transaction_output_list_with_proof(num_transactions_or_outputs);
+                        let transaction_or_output_list_with_proof =
+                            (None, Some(output_list_with_proof));
+                        DataResponse::NewTransactionsOrOutputsWithProof((
+                            transaction_or_output_list_with_proof,
+                            create_ledger_info(),
+                        ))
+                    };
+                    let storage_service_response =
+                        StorageServiceResponse::new(data_response, true).unwrap();
+
+                    // Send the response
+                    network_request
+                        .response_sender
+                        .send(Ok(storage_service_response));
+                });
+            }
+        });
+
+        // Send the request and wait for the response
+        let subscription_request_metadata = create_subscription_request_metadata();
+        let response = client
+            .subscribe_to_transactions_or_outputs_with_proof(subscription_request_metadata, true, 0)
+            .await
+            .unwrap();
+
+        // Verify the response
+        let ((transaction_list_with_proof, output_list_with_proof), _) = response.payload;
+        verify_response_data(
+            transaction_list_with_proof,
+            output_list_with_proof,
+            use_request_v2,
+            num_transactions_or_outputs,
+        );
+    }
+}
+
+/// Creates a data client config with the specified request v2 flag
+fn create_aptos_data_client(use_request_v2: bool) -> AptosDataClientConfig {
+    AptosDataClientConfig {
+        enable_transaction_data_v2: use_request_v2,
+        ..Default::default()
+    }
+}
+
+/// Creates a data client with a connected peer for testing
+fn create_client_with_peer(use_request_v2: bool) -> (MockNetwork, AptosDataClient, NetworkId) {
+    // Create a base config for a fullnode
+    let base_config = utils::create_fullnode_base_config();
+
+    // Create a data client config with request v2 set appropriately
+    let data_client_config = create_aptos_data_client(use_request_v2);
+
+    // Create the mock network and client
+    let (mut mock_network, _, client, _) =
+        MockNetwork::new(Some(base_config), Some(data_client_config), None);
+
+    // Add a peer to the network
+    let (peer_network_id, network_id) =
+        utils::add_peer_to_network(PeerPriority::HighPriority, &mut mock_network);
+
+    // Advertise transaction data for the peer
+    let storage_summary = utils::create_storage_summary(1000);
+    client.update_peer_storage_summary(peer_network_id, storage_summary.clone());
+    client.update_global_summary_cache().unwrap();
+    (mock_network, client, network_id)
+}
+
+/// Creates a new ledger info
+fn create_ledger_info() -> LedgerInfoWithSignatures {
+    LedgerInfoWithSignatures::new(
+        LedgerInfo::new(BlockInfo::random_with_epoch(10, 10), HashValue::random()),
+        AggregateSignature::empty(),
+    )
+}
+
+/// Creates a subscription request metadata with default values
+fn create_subscription_request_metadata() -> SubscriptionRequestMetadata {
+    SubscriptionRequestMetadata {
+        known_version_at_stream_start: 0,
+        known_epoch_at_stream_start: 0,
+        subscription_stream_index: 0,
+        subscription_stream_id: 0,
+    }
+}
+
+/// Creates a test transaction
+fn create_transaction() -> Transaction {
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+
+    let transaction_payload = TransactionPayload::Script(Script::new(vec![], vec![], vec![]));
+    let raw_transaction = RawTransaction::new(
+        AccountAddress::random(),
+        0,
+        transaction_payload,
+        0,
+        0,
+        0,
+        ChainId::new(10),
+    );
+    let signature = private_key.sign(&raw_transaction).unwrap();
+    let signed_transaction = SignedTransaction::new(raw_transaction, public_key, signature);
+
+    Transaction::UserTransaction(signed_transaction)
+}
+
+/// Creates a test transaction info
+fn create_transaction_info() -> TransactionInfo {
+    TransactionInfo::new(
+        HashValue::random(),
+        HashValue::random(),
+        HashValue::random(),
+        Some(HashValue::random()),
+        0,
+        ExecutionStatus::Success,
+        Some(HashValue::random()),
+    )
+}
+
+/// Creates a transaction list with proof (with the specified number of transactions)
+fn create_transaction_list_with_proof(num_transactions: usize) -> TransactionListWithProof {
+    // Create the requested transactions
+    let mut transactions = vec![];
+    for _ in 0..num_transactions {
+        transactions.push(create_transaction());
+    }
+
+    // Create the transaction infos
+    let mut transaction_infos = vec![];
+    for _ in 0..num_transactions {
+        transaction_infos.push(create_transaction_info());
+    }
+
+    // Create the transaction list with proof
+    let mut transaction_list_with_proof = TransactionListWithProof::new_empty();
+    transaction_list_with_proof.transactions = transactions;
+    transaction_list_with_proof.proof.transaction_infos = transaction_infos;
+
+    transaction_list_with_proof
+}
+
+/// Creates a transaction list with proof v2 (with the specified number of transactions)
+fn create_transaction_list_with_proof_v2(num_transactions: usize) -> TransactionListWithProofV2 {
+    // Create the transaction list with proof
+    let transaction_list_with_proof = create_transaction_list_with_proof(num_transactions);
+
+    // Create the auxiliary infos
+    let mut persisted_auxiliary_infos = vec![];
+    for index in 0..num_transactions {
+        persisted_auxiliary_infos.push(PersistedAuxiliaryInfo::V1 {
+            transaction_index: index as u32,
+        });
+    }
+
+    // Create the transaction list with proof v2
+    let transaction_list_with_auxiliary_infos = TransactionListWithAuxiliaryInfos::new(
+        transaction_list_with_proof,
+        persisted_auxiliary_infos,
+    );
+    TransactionListWithProofV2::new(transaction_list_with_auxiliary_infos)
+}
+
+/// Creates a single test transaction output
+fn create_transaction_output() -> TransactionOutput {
+    TransactionOutput::new(
+        WriteSet::default(),
+        vec![],
+        0,
+        TransactionStatus::Keep(ExecutionStatus::Success),
+        TransactionAuxiliaryData::default(),
+    )
+}
+
+/// Creates a transaction output list with proof (with the specified number of outputs)
+fn create_transaction_output_list_with_proof(num_outputs: usize) -> TransactionOutputListWithProof {
+    // Create the transactions and outputs
+    let transaction_list_with_proof = create_transaction_list_with_proof(num_outputs);
+    let transactions_and_outputs = transaction_list_with_proof
+        .transactions
+        .iter()
+        .map(|txn| (txn.clone(), create_transaction_output()))
+        .collect();
+
+    // Create the transaction infos
+    let mut transaction_infos = vec![];
+    for _ in 0..num_outputs {
+        transaction_infos.push(create_transaction_info());
+    }
+
+    // Create the transaction output list with proof
+    let mut output_list_with_proof = TransactionOutputListWithProof::new_empty();
+    output_list_with_proof.transactions_and_outputs = transactions_and_outputs;
+    output_list_with_proof.proof.transaction_infos = transaction_infos;
+
+    output_list_with_proof
+}
+
+/// Creates a transaction output list with proof v2 (with the specified number of outputs)
+fn create_transaction_output_list_with_proof_v2(
+    num_outputs: usize,
+) -> TransactionOutputListWithProofV2 {
+    // Create the transaction output list with proof
+    let transaction_output_list_with_proof = create_transaction_output_list_with_proof(num_outputs);
+
+    // Create the auxiliary infos
+    let mut persisted_auxiliary_infos = vec![];
+    for index in 0..num_outputs {
+        persisted_auxiliary_infos.push(PersistedAuxiliaryInfo::V1 {
+            transaction_index: index as u32,
+        });
+    }
+
+    // Create the transaction output list with proof v2
+    let output_list_with_auxiliary_infos = TransactionOutputListWithAuxiliaryInfos::new(
+        transaction_output_list_with_proof,
+        persisted_auxiliary_infos,
+    );
+    TransactionOutputListWithProofV2::new(output_list_with_auxiliary_infos)
+}
+
+/// Verifies that the persisted auxiliary infos are populated correctly
+fn verify_persisted_auxiliary_infos(
+    use_request_v2: bool,
+    persisted_auxiliary_infos: &[PersistedAuxiliaryInfo],
+    expected_length: usize,
+) {
+    // Verify the length of the auxiliary infos
+    assert_eq!(persisted_auxiliary_infos.len(), expected_length);
+
+    // Verify the contents of the auxiliary infos
+    for auxiliary_info in persisted_auxiliary_infos {
+        if use_request_v2 {
+            assert_matches!(auxiliary_info, PersistedAuxiliaryInfo::V1 { .. });
+        } else {
+            assert_eq!(auxiliary_info, &PersistedAuxiliaryInfo::None);
+        }
+    }
+}
+
+/// Verifies the response data for any given transaction or output list.
+/// Also verifies the persisted auxiliary infos (if applicable).
+fn verify_response_data(
+    transaction_list_with_proof_v2: Option<TransactionListWithProofV2>,
+    output_list_with_proof_v2: Option<TransactionOutputListWithProofV2>,
+    use_request_v2: bool,
+    expected_count: usize,
+) {
+    // Verify the transaction data
+    if let Some(transaction_list_with_proof_v2) = transaction_list_with_proof_v2 {
+        // Verify the number of transactions
+        let transaction_list_with_proof =
+            transaction_list_with_proof_v2.get_transaction_list_with_proof();
+        let num_transactions = transaction_list_with_proof.transactions.len();
+        assert_eq!(num_transactions, expected_count);
+
+        // Verify the persisted auxiliary infos
+        verify_persisted_auxiliary_infos(
+            use_request_v2,
+            transaction_list_with_proof_v2.get_persisted_auxiliary_infos(),
+            expected_count,
+        );
+    }
+
+    // Verify the output data
+    if let Some(output_list_with_proof_v2) = output_list_with_proof_v2 {
+        // Verify the number of outputs
+        let output_list_with_proof = output_list_with_proof_v2.get_output_list_with_proof();
+        let num_outputs = output_list_with_proof.transactions_and_outputs.len();
+        assert_eq!(num_outputs, expected_count);
+
+        // Verify the persisted auxiliary infos
+        verify_persisted_auxiliary_infos(
+            use_request_v2,
+            output_list_with_proof_v2.get_persisted_auxiliary_infos(),
+            expected_count,
+        );
+    }
+}

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -2186,7 +2186,7 @@ fn create_data_notification(
             StreamEngine::ContinuousTransactionStreamEngine(_) => {
                 DataPayload::ContinuousTransactionOutputsWithProof(
                     target_ledger_info,
-                    transactions_output_chunk,
+                    transactions_output_chunk.clone(),
                 )
             },
             _ => invalid_response_type!(client_response_type),

--- a/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transaction_outputs.rs
@@ -7,8 +7,7 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_storage_service_types::requests::{
-    DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionOutputsWithProofRequest,
-    StorageServiceRequest, TransactionDataRequestType,
+    DataRequest, NewTransactionOutputsWithProofRequest, StorageServiceRequest,
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
@@ -419,13 +418,7 @@ async fn get_new_outputs_with_proof_for_peer(
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
     let data_request = if use_request_v2 {
-        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
-        DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
-            transaction_data_request_type,
-            known_version,
-            known_epoch,
-            max_response_bytes: 0,
-        })
+        DataRequest::get_new_transaction_output_data_with_proof(known_version, known_epoch, 0)
     } else {
         DataRequest::GetNewTransactionOutputsWithProof(NewTransactionOutputsWithProofRequest {
             known_version,

--- a/state-sync/storage-service/server/src/tests/new_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions.rs
@@ -7,8 +7,7 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_storage_service_types::requests::{
-    DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionsWithProofRequest,
-    StorageServiceRequest, TransactionData, TransactionDataRequestType,
+    DataRequest, NewTransactionsWithProofRequest, StorageServiceRequest,
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
@@ -456,14 +455,12 @@ async fn get_new_transactions_with_proof_for_peer(
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
     let data_request = if use_request_v2 {
-        let transaction_data_request_type =
-            TransactionDataRequestType::TransactionData(TransactionData { include_events });
-        DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::get_new_transaction_data_with_proof(
             known_version,
             known_epoch,
-            max_response_bytes: 0,
-        })
+            include_events,
+            0,
+        )
     } else {
         DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
             known_version,

--- a/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
@@ -7,8 +7,7 @@ use aptos_config::{
     network_id::{NetworkId, PeerNetworkId},
 };
 use aptos_storage_service_types::requests::{
-    DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionsOrOutputsWithProofRequest,
-    StorageServiceRequest, TransactionDataRequestType, TransactionOrOutputData,
+    DataRequest, NewTransactionsOrOutputsWithProofRequest, StorageServiceRequest,
 };
 use aptos_types::{epoch_change::EpochChangeProof, PeerId};
 use claims::assert_none;
@@ -617,16 +616,12 @@ async fn get_new_transactions_or_outputs_with_proof_for_peer(
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
     let data_request = if use_request_v2 {
-        let transaction_data_request_type =
-            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
-                include_events,
-            });
-        DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::get_new_transaction_or_output_data_with_proof(
             known_version,
             known_epoch,
-            max_response_bytes: 0,
-        })
+            include_events,
+            0,
+        )
     } else {
         DataRequest::GetNewTransactionsOrOutputsWithProof(
             NewTransactionsOrOutputsWithProofRequest {

--- a/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
+++ b/state-sync/storage-service/server/src/tests/optimistic_fetch.rs
@@ -15,10 +15,9 @@ use aptos_config::{
 };
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, GetNewTransactionDataWithProofRequest, NewTransactionOutputsWithProofRequest,
+        DataRequest, NewTransactionOutputsWithProofRequest,
         NewTransactionsOrOutputsWithProofRequest, NewTransactionsWithProofRequest,
-        StorageServiceRequest, TransactionData, TransactionDataRequestType,
-        TransactionOrOutputData,
+        StorageServiceRequest,
     },
     responses::StorageServerSummary,
 };
@@ -426,16 +425,12 @@ fn create_optimistic_fetch_data_request(
     match random_number % 3 {
         0 => {
             if use_request_v2 {
-                let transaction_data_request_type =
-                    TransactionDataRequestType::TransactionData(TransactionData {
-                        include_events: true,
-                    });
-                DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
-                    transaction_data_request_type,
+                DataRequest::get_new_transaction_data_with_proof(
                     known_version,
                     known_epoch,
-                    max_response_bytes: 0,
-                })
+                    true,
+                    0,
+                )
             } else {
                 DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {
                     known_version,
@@ -446,14 +441,11 @@ fn create_optimistic_fetch_data_request(
         },
         1 => {
             if use_request_v2 {
-                let transaction_data_request_type =
-                    TransactionDataRequestType::TransactionOutputData;
-                DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
-                    transaction_data_request_type,
+                DataRequest::get_new_transaction_output_data_with_proof(
                     known_version,
                     known_epoch,
-                    max_response_bytes: 0,
-                })
+                    0,
+                )
             } else {
                 DataRequest::GetNewTransactionOutputsWithProof(
                     NewTransactionOutputsWithProofRequest {
@@ -465,16 +457,12 @@ fn create_optimistic_fetch_data_request(
         },
         2 => {
             if use_request_v2 {
-                let transaction_data_request_type =
-                    TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
-                        include_events: true,
-                    });
-                DataRequest::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
-                    transaction_data_request_type,
+                DataRequest::get_new_transaction_or_output_data_with_proof(
                     known_version,
                     known_epoch,
-                    max_response_bytes: 0,
-                })
+                    true,
+                    0,
+                )
             } else {
                 DataRequest::GetNewTransactionsOrOutputsWithProof(
                     NewTransactionsOrOutputsWithProofRequest {

--- a/state-sync/storage-service/server/src/tests/subscription.rs
+++ b/state-sync/storage-service/server/src/tests/subscription.rs
@@ -16,11 +16,9 @@ use aptos_config::{
 };
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, StorageServiceRequest, SubscribeTransactionDataWithProofRequest,
-        SubscribeTransactionOutputsWithProofRequest,
+        DataRequest, StorageServiceRequest, SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
-        SubscriptionStreamMetadata, TransactionData, TransactionDataRequestType,
-        TransactionOrOutputData,
+        SubscriptionStreamMetadata,
     },
     responses::StorageServerSummary,
     StorageServiceError,
@@ -1087,17 +1085,11 @@ fn create_subscription_data_request(
     match random_number % 3 {
         0 => {
             if use_request_v2 {
-                let transaction_data_request_type =
-                    TransactionDataRequestType::TransactionData(TransactionData {
-                        include_events: true,
-                    });
-                DataRequest::SubscribeTransactionDataWithProof(
-                    SubscribeTransactionDataWithProofRequest {
-                        transaction_data_request_type,
-                        subscription_stream_metadata,
-                        subscription_stream_index,
-                        max_response_bytes: 0,
-                    },
+                DataRequest::subscribe_transaction_data_with_proof(
+                    subscription_stream_metadata,
+                    subscription_stream_index,
+                    true,
+                    0,
                 )
             } else {
                 DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
@@ -1109,15 +1101,10 @@ fn create_subscription_data_request(
         },
         1 => {
             if use_request_v2 {
-                let transaction_data_request_type =
-                    TransactionDataRequestType::TransactionOutputData;
-                DataRequest::SubscribeTransactionDataWithProof(
-                    SubscribeTransactionDataWithProofRequest {
-                        transaction_data_request_type,
-                        subscription_stream_metadata,
-                        subscription_stream_index,
-                        max_response_bytes: 0,
-                    },
+                DataRequest::subscribe_transaction_output_data_with_proof(
+                    subscription_stream_metadata,
+                    subscription_stream_index,
+                    0,
                 )
             } else {
                 DataRequest::SubscribeTransactionOutputsWithProof(
@@ -1130,17 +1117,11 @@ fn create_subscription_data_request(
         },
         2 => {
             if use_request_v2 {
-                let transaction_data_request_type =
-                    TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
-                        include_events: true,
-                    });
-                DataRequest::SubscribeTransactionDataWithProof(
-                    SubscribeTransactionDataWithProofRequest {
-                        transaction_data_request_type,
-                        subscription_stream_metadata,
-                        subscription_stream_index,
-                        max_response_bytes: 0,
-                    },
+                DataRequest::subscribe_transaction_or_output_data_with_proof(
+                    subscription_stream_metadata,
+                    subscription_stream_index,
+                    true,
+                    0,
                 )
             } else {
                 DataRequest::SubscribeTransactionsOrOutputsWithProof(

--- a/state-sync/storage-service/server/src/tests/transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transaction_outputs.rs
@@ -4,10 +4,7 @@
 use crate::tests::{mock, mock::MockClient, utils};
 use aptos_config::config::StorageServiceConfig;
 use aptos_storage_service_types::{
-    requests::{
-        DataRequest, GetTransactionDataWithProofRequest, TransactionDataRequestType,
-        TransactionOutputsWithProofRequest,
-    },
+    requests::{DataRequest, TransactionOutputsWithProofRequest},
     responses::{DataResponse, StorageServiceResponse, TransactionDataResponseType},
     StorageServiceError,
 };
@@ -239,14 +236,12 @@ async fn get_outputs_with_proof(
     use_request_v2: bool,
 ) -> Result<StorageServiceResponse, StorageServiceError> {
     let data_request = if use_request_v2 {
-        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
-        DataRequest::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::get_transaction_output_data_with_proof(
             proof_version,
             start_version,
             end_version,
-            max_response_bytes: 0,
-        })
+            0,
+        )
     } else {
         DataRequest::GetTransactionOutputsWithProof(TransactionOutputsWithProofRequest {
             proof_version,

--- a/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
@@ -4,10 +4,7 @@
 use crate::tests::{mock, mock::MockClient, utils};
 use aptos_config::config::StorageServiceConfig;
 use aptos_storage_service_types::{
-    requests::{
-        DataRequest, GetTransactionDataWithProofRequest, TransactionDataRequestType,
-        TransactionOrOutputData, TransactionsOrOutputsWithProofRequest,
-    },
+    requests::{DataRequest, TransactionsOrOutputsWithProofRequest},
     responses::{DataResponse, StorageServiceResponse, TransactionDataResponseType},
     StorageServiceError,
 };
@@ -321,17 +318,13 @@ async fn get_transactions_or_outputs_with_proof(
     use_request_v2: bool,
 ) -> Result<StorageServiceResponse, StorageServiceError> {
     let data_request = if use_request_v2 {
-        let transaction_data_request_type =
-            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
-                include_events,
-            });
-        DataRequest::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::get_transaction_or_output_data_with_proof(
             proof_version,
             start_version,
             end_version,
-            max_response_bytes: 0,
-        })
+            include_events,
+            0,
+        )
     } else {
         DataRequest::GetTransactionsOrOutputsWithProof(TransactionsOrOutputsWithProofRequest {
             proof_version,

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -23,12 +23,10 @@ use aptos_storage_service_notifications::{
 };
 use aptos_storage_service_types::{
     requests::{
-        DataRequest, GetTransactionDataWithProofRequest, StateValuesWithProofRequest,
-        StorageServiceRequest, SubscribeTransactionDataWithProofRequest,
+        DataRequest, StateValuesWithProofRequest, StorageServiceRequest,
         SubscribeTransactionOutputsWithProofRequest,
         SubscribeTransactionsOrOutputsWithProofRequest, SubscribeTransactionsWithProofRequest,
-        SubscriptionStreamMetadata, TransactionData, TransactionDataRequestType,
-        TransactionOrOutputData, TransactionsWithProofRequest,
+        SubscriptionStreamMetadata, TransactionsWithProofRequest,
     },
     responses::{
         CompleteDataRange, DataResponse, StorageServerSummary, StorageServiceResponse,
@@ -585,15 +583,13 @@ pub async fn get_transactions_with_proof(
     use_request_v2: bool,
 ) -> Result<StorageServiceResponse, StorageServiceError> {
     let data_request = if use_request_v2 {
-        let transaction_data_request_type =
-            TransactionDataRequestType::TransactionData(TransactionData { include_events });
-        DataRequest::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::get_transaction_data_with_proof(
             proof_version,
             start_version,
             end_version,
-            max_response_bytes: 0,
-        })
+            include_events,
+            0,
+        )
     } else {
         DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
             proof_version,
@@ -705,16 +701,12 @@ pub async fn subscribe_to_transactions_or_outputs_for_peer(
         subscription_stream_id,
     };
     let data_request = if use_request_v2 {
-        let transaction_data_request_type =
-            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
-                include_events,
-            });
-        DataRequest::SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::subscribe_transaction_or_output_data_with_proof(
             subscription_stream_metadata,
             subscription_stream_index,
-            max_response_bytes: 0,
-        })
+            include_events,
+            0,
+        )
     } else {
         DataRequest::SubscribeTransactionsOrOutputsWithProof(
             SubscribeTransactionsOrOutputsWithProofRequest {
@@ -772,13 +764,11 @@ pub async fn subscribe_to_transaction_outputs_for_peer(
         subscription_stream_id,
     };
     let data_request = if use_request_v2 {
-        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
-        DataRequest::SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::subscribe_transaction_output_data_with_proof(
             subscription_stream_metadata,
             subscription_stream_index,
-            max_response_bytes: 0,
-        })
+            0,
+        )
     } else {
         DataRequest::SubscribeTransactionOutputsWithProof(
             SubscribeTransactionOutputsWithProofRequest {
@@ -837,14 +827,12 @@ pub async fn subscribe_to_transactions_for_peer(
         subscription_stream_id,
     };
     let data_request = if use_request_v2 {
-        let transaction_data_request_type =
-            TransactionDataRequestType::TransactionData(TransactionData { include_events });
-        DataRequest::SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest {
-            transaction_data_request_type,
+        DataRequest::subscribe_transaction_data_with_proof(
             subscription_stream_metadata,
             subscription_stream_index,
-            max_response_bytes: 0,
-        })
+            include_events,
+            0,
+        )
     } else {
         DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {
             subscription_stream_metadata,

--- a/state-sync/storage-service/types/src/requests.rs
+++ b/state-sync/storage-service/types/src/requests.rs
@@ -121,6 +121,7 @@ impl DataRequest {
         }
     }
 
+    /// Returns true iff the request is an optimistic fetch request
     pub fn is_optimistic_fetch(&self) -> bool {
         matches!(self, &Self::GetNewTransactionOutputsWithProof(_))
             || matches!(self, &Self::GetNewTransactionsWithProof(_))
@@ -128,14 +129,17 @@ impl DataRequest {
             || matches!(self, &Self::GetNewTransactionDataWithProof(_))
     }
 
+    /// Returns true iff the request is a protocol version request
     pub fn is_protocol_version_request(&self) -> bool {
         matches!(self, &Self::GetServerProtocolVersion)
     }
 
+    /// Returns true iff the request is a storage summary request
     pub fn is_storage_summary_request(&self) -> bool {
         matches!(self, &Self::GetStorageServerSummary)
     }
 
+    /// Returns true iff the request is a subscription request
     pub fn is_subscription_request(&self) -> bool {
         matches!(self, &Self::SubscribeTransactionOutputsWithProof(_))
             || matches!(self, &Self::SubscribeTransactionsWithProof(_))
@@ -143,10 +147,170 @@ impl DataRequest {
             || matches!(self, Self::SubscribeTransactionDataWithProof(_))
     }
 
+    /// Returns true iff the request is a transaction data v2 request
     pub fn is_transaction_data_v2_request(&self) -> bool {
         matches!(self, &Self::GetTransactionDataWithProof(_))
             || matches!(self, &Self::GetNewTransactionDataWithProof(_))
             || matches!(self, &Self::SubscribeTransactionDataWithProof(_))
+    }
+
+    /// Creates and returns a request to get transaction data with a proof
+    pub fn get_transaction_data_with_proof(
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+        include_events: bool,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionData(TransactionData { include_events });
+        Self::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            proof_version,
+            start_version,
+            end_version,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to get new transaction output data with a proof
+    pub fn get_transaction_output_data_with_proof(
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
+        Self::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            proof_version,
+            start_version,
+            end_version,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to get new transaction or output data with a proof
+    pub fn get_transaction_or_output_data_with_proof(
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+        include_events: bool,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+                include_events,
+            });
+        Self::GetTransactionDataWithProof(GetTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            proof_version,
+            start_version,
+            end_version,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to get new transaction data with a proof
+    pub fn get_new_transaction_data_with_proof(
+        known_version: u64,
+        known_epoch: u64,
+        include_events: bool,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionData(TransactionData { include_events });
+        Self::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            known_version,
+            known_epoch,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to get new transaction output data with a proof
+    pub fn get_new_transaction_output_data_with_proof(
+        known_version: u64,
+        known_epoch: u64,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
+        Self::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            known_version,
+            known_epoch,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to get new transaction or output data with a proof
+    pub fn get_new_transaction_or_output_data_with_proof(
+        known_version: u64,
+        known_epoch: u64,
+        include_events: bool,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+                include_events,
+            });
+        Self::GetNewTransactionDataWithProof(GetNewTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            known_version,
+            known_epoch,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to subscribe to transaction with a proof
+    pub fn subscribe_transaction_data_with_proof(
+        subscription_stream_metadata: SubscriptionStreamMetadata,
+        subscription_stream_index: u64,
+        include_events: bool,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionData(TransactionData { include_events });
+        Self::SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            subscription_stream_metadata,
+            subscription_stream_index,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to subscribe to transaction output with a proof
+    pub fn subscribe_transaction_output_data_with_proof(
+        subscription_stream_metadata: SubscriptionStreamMetadata,
+        subscription_stream_index: u64,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type = TransactionDataRequestType::TransactionOutputData;
+        Self::SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            subscription_stream_metadata,
+            subscription_stream_index,
+            max_response_bytes,
+        })
+    }
+
+    /// Creates and returns a request to subscribe to transaction or output with a proof
+    pub fn subscribe_transaction_or_output_data_with_proof(
+        subscription_stream_metadata: SubscriptionStreamMetadata,
+        subscription_stream_index: u64,
+        include_events: bool,
+        max_response_bytes: u64,
+    ) -> Self {
+        let transaction_data_request_type =
+            TransactionDataRequestType::TransactionOrOutputData(TransactionOrOutputData {
+                include_events,
+            });
+        Self::SubscribeTransactionDataWithProof(SubscribeTransactionDataWithProofRequest {
+            transaction_data_request_type,
+            subscription_stream_metadata,
+            subscription_stream_index,
+            max_response_bytes,
+        })
     }
 }
 

--- a/state-sync/storage-service/types/src/responses.rs
+++ b/state-sync/storage-service/types/src/responses.rs
@@ -132,6 +132,12 @@ pub type TransactionOrOutputListWithProof = (
     Option<TransactionOutputListWithProof>,
 );
 
+/// A useful type to hold optional transaction data v2
+pub type TransactionOrOutputListWithProofV2 = (
+    Option<TransactionListWithProofV2>,
+    Option<TransactionOutputListWithProofV2>,
+);
+
 /// A single data response.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[allow(clippy::large_enum_variant)]
@@ -263,14 +269,37 @@ impl TryFrom<StorageServiceResponse> for EpochChangeProof {
 }
 
 impl TryFrom<StorageServiceResponse>
-    for (TransactionOutputListWithProof, LedgerInfoWithSignatures)
+    for (TransactionOutputListWithProofV2, LedgerInfoWithSignatures)
 {
     type Error = crate::responses::Error;
 
     fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
         let data_response = response.get_data_response()?;
         match data_response {
-            DataResponse::NewTransactionOutputsWithProof(inner) => Ok(inner),
+            DataResponse::NewTransactionOutputsWithProof((
+                output_list_with_proof,
+                ledger_info_with_signatures,
+            )) => Ok((
+                TransactionOutputListWithProofV2::new_from_v1(output_list_with_proof),
+                ledger_info_with_signatures,
+            )),
+            DataResponse::NewTransactionDataWithProof(response) => {
+                if let TransactionDataResponseType::TransactionOutputData =
+                    response.transaction_data_response_type
+                {
+                    if let Some(output_list_with_proof_v2) =
+                        response.transaction_output_list_with_proof
+                    {
+                        return Ok((
+                            output_list_with_proof_v2,
+                            response.ledger_info_with_signatures,
+                        ));
+                    }
+                }
+                Err(Error::UnexpectedResponseError(
+                    "new_transaction_output_list_with_proof is empty".into(),
+                ))
+            },
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected new_transaction_outputs_with_proof, found {}",
                 data_response.get_label()
@@ -279,13 +308,36 @@ impl TryFrom<StorageServiceResponse>
     }
 }
 
-impl TryFrom<StorageServiceResponse> for (TransactionListWithProof, LedgerInfoWithSignatures) {
+impl TryFrom<StorageServiceResponse> for (TransactionListWithProofV2, LedgerInfoWithSignatures) {
     type Error = crate::responses::Error;
 
     fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
         let data_response = response.get_data_response()?;
         match data_response {
-            DataResponse::NewTransactionsWithProof(inner) => Ok(inner),
+            DataResponse::NewTransactionsWithProof((
+                transaction_list_with_proof,
+                ledger_info_with_signatures,
+            )) => Ok((
+                TransactionListWithProofV2::new_from_v1(transaction_list_with_proof),
+                ledger_info_with_signatures,
+            )),
+            DataResponse::NewTransactionDataWithProof(response) => {
+                if let TransactionDataResponseType::TransactionData =
+                    response.transaction_data_response_type
+                {
+                    if let Some(transaction_list_with_proof_v2) =
+                        response.transaction_list_with_proof
+                    {
+                        return Ok((
+                            transaction_list_with_proof_v2,
+                            response.ledger_info_with_signatures,
+                        ));
+                    }
+                }
+                Err(Error::UnexpectedResponseError(
+                    "new_transaction_list_with_proof is empty".into(),
+                ))
+            },
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected new_transactions_with_proof, found {}",
                 data_response.get_label()
@@ -339,13 +391,29 @@ impl TryFrom<StorageServiceResponse> for StorageServerSummary {
     }
 }
 
-impl TryFrom<StorageServiceResponse> for TransactionOutputListWithProof {
+impl TryFrom<StorageServiceResponse> for TransactionOutputListWithProofV2 {
     type Error = crate::responses::Error;
 
     fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
         let data_response = response.get_data_response()?;
         match data_response {
-            DataResponse::TransactionOutputsWithProof(inner) => Ok(inner),
+            DataResponse::TransactionOutputsWithProof(output_list_with_proof) => Ok(
+                TransactionOutputListWithProofV2::new_from_v1(output_list_with_proof),
+            ),
+            DataResponse::TransactionDataWithProof(response) => {
+                if let TransactionDataResponseType::TransactionOutputData =
+                    response.transaction_data_response_type
+                {
+                    if let Some(output_list_with_proof_v2) =
+                        response.transaction_output_list_with_proof
+                    {
+                        return Ok(output_list_with_proof_v2);
+                    }
+                }
+                Err(Error::UnexpectedResponseError(
+                    "transaction_output_list_with_proof is empty".into(),
+                ))
+            },
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected transaction_outputs_with_proof, found {}",
                 data_response.get_label()
@@ -354,13 +422,29 @@ impl TryFrom<StorageServiceResponse> for TransactionOutputListWithProof {
     }
 }
 
-impl TryFrom<StorageServiceResponse> for TransactionListWithProof {
+impl TryFrom<StorageServiceResponse> for TransactionListWithProofV2 {
     type Error = crate::responses::Error;
 
     fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
         let data_response = response.get_data_response()?;
         match data_response {
-            DataResponse::TransactionsWithProof(inner) => Ok(inner),
+            DataResponse::TransactionsWithProof(transaction_list_with_proof) => Ok(
+                TransactionListWithProofV2::new_from_v1(transaction_list_with_proof),
+            ),
+            DataResponse::TransactionDataWithProof(response) => {
+                if let TransactionDataResponseType::TransactionData =
+                    response.transaction_data_response_type
+                {
+                    if let Some(transaction_list_with_proof_v2) =
+                        response.transaction_list_with_proof
+                    {
+                        return Ok(transaction_list_with_proof_v2);
+                    }
+                }
+                Err(Error::UnexpectedResponseError(
+                    "transaction_list_with_proof is empty".into(),
+                ))
+            },
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected transactions_with_proof, found {}",
                 data_response.get_label()
@@ -370,14 +454,33 @@ impl TryFrom<StorageServiceResponse> for TransactionListWithProof {
 }
 
 impl TryFrom<StorageServiceResponse>
-    for (TransactionOrOutputListWithProof, LedgerInfoWithSignatures)
+    for (TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures)
 {
     type Error = crate::responses::Error;
 
     fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
         let data_response = response.get_data_response()?;
         match data_response {
-            DataResponse::NewTransactionsOrOutputsWithProof(inner) => Ok(inner),
+            DataResponse::NewTransactionsOrOutputsWithProof((
+                (transaction_list_with_proof, output_list_with_proof),
+                ledger_info_with_signatures,
+            )) => Ok((
+                (
+                    transaction_list_with_proof.map(TransactionListWithProofV2::new_from_v1),
+                    output_list_with_proof.map(TransactionOutputListWithProofV2::new_from_v1),
+                ),
+                ledger_info_with_signatures,
+            )),
+            DataResponse::NewTransactionDataWithProof(response) => {
+                let transaction_or_output_list_with_proof = (
+                    response.transaction_list_with_proof,
+                    response.transaction_output_list_with_proof,
+                );
+                Ok((
+                    transaction_or_output_list_with_proof,
+                    response.ledger_info_with_signatures,
+                ))
+            },
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected new_transactions_or_outputs_with_proof, found {}",
                 data_response.get_label()
@@ -386,13 +489,23 @@ impl TryFrom<StorageServiceResponse>
     }
 }
 
-impl TryFrom<StorageServiceResponse> for TransactionOrOutputListWithProof {
+impl TryFrom<StorageServiceResponse> for TransactionOrOutputListWithProofV2 {
     type Error = crate::responses::Error;
 
     fn try_from(response: StorageServiceResponse) -> crate::Result<Self, Self::Error> {
         let data_response = response.get_data_response()?;
         match data_response {
-            DataResponse::TransactionsOrOutputsWithProof(inner) => Ok(inner),
+            DataResponse::TransactionsOrOutputsWithProof((
+                transaction_list_with_proof,
+                output_list_with_proof,
+            )) => Ok((
+                transaction_list_with_proof.map(TransactionListWithProofV2::new_from_v1),
+                output_list_with_proof.map(TransactionOutputListWithProofV2::new_from_v1),
+            )),
+            DataResponse::TransactionDataWithProof(response) => Ok((
+                response.transaction_list_with_proof,
+                response.transaction_output_list_with_proof,
+            )),
             _ => Err(Error::UnexpectedResponseError(format!(
                 "expected transactions_or_outputs_with_proof, found {}",
                 data_response.get_label()

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2249,7 +2249,7 @@ impl TransactionListWithProofV2 {
         }
     }
 
-    /// Splits the transaction list with proof v2 into its components
+    /// Splits the transaction list with proof v2 into its components.
     pub fn into_parts(self) -> (TransactionListWithProof, Vec<PersistedAuxiliaryInfo>) {
         match self {
             Self::TransactionListWithAuxiliaryInfos(txn_list_with_auxiliary_infos) => (
@@ -2502,7 +2502,7 @@ impl TransactionOutputListWithProofV2 {
         }
     }
 
-    /// Splits the transaction output list with proof v2 into its components
+    /// Splits the transaction output list with proof v2 into its components.
     pub fn into_parts(self) -> (TransactionOutputListWithProof, Vec<PersistedAuxiliaryInfo>) {
         match self {
             Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => (

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2231,18 +2231,6 @@ impl TransactionListWithProofV2 {
         ))
     }
 
-    pub fn verify(
-        &self,
-        ledger_info: &LedgerInfo,
-        first_transaction_output_version: Option<Version>,
-    ) -> Result<()> {
-        match self {
-            Self::TransactionListWithAuxiliaryInfos(inner) => {
-                inner.verify(ledger_info, first_transaction_output_version)
-            },
-        }
-    }
-
     /// Returns a reference to the inner transaction list with proof
     pub fn get_transaction_list_with_proof(&self) -> &TransactionListWithProof {
         match self {
@@ -2261,12 +2249,26 @@ impl TransactionListWithProofV2 {
         }
     }
 
+    /// Splits the transaction list with proof v2 into its components
     pub fn into_parts(self) -> (TransactionListWithProof, Vec<PersistedAuxiliaryInfo>) {
         match self {
             Self::TransactionListWithAuxiliaryInfos(txn_list_with_auxiliary_infos) => (
                 txn_list_with_auxiliary_infos.transaction_list_with_proof,
                 txn_list_with_auxiliary_infos.persisted_auxiliary_infos,
             ),
+        }
+    }
+
+    /// Verifies the transaction list with proof v2 against the given ledger info.
+    pub fn verify(
+        &self,
+        ledger_info: &LedgerInfo,
+        first_transaction_output_version: Option<Version>,
+    ) -> Result<()> {
+        match self {
+            Self::TransactionListWithAuxiliaryInfos(inner) => {
+                inner.verify(ledger_info, first_transaction_output_version)
+            },
         }
     }
 }
@@ -2482,18 +2484,6 @@ impl TransactionOutputListWithProofV2 {
         )
     }
 
-    pub fn verify(
-        &self,
-        ledger_info: &LedgerInfo,
-        first_transaction_output_version: Option<Version>,
-    ) -> Result<()> {
-        match self {
-            Self::TransactionOutputListWithAuxiliaryInfos(inner) => {
-                inner.verify(ledger_info, first_transaction_output_version)
-            },
-        }
-    }
-
     /// Returns a reference to the inner transaction output list with proof
     pub fn get_output_list_with_proof(&self) -> &TransactionOutputListWithProof {
         match self {
@@ -2512,12 +2502,26 @@ impl TransactionOutputListWithProofV2 {
         }
     }
 
+    /// Splits the transaction output list with proof v2 into its components
     pub fn into_parts(self) -> (TransactionOutputListWithProof, Vec<PersistedAuxiliaryInfo>) {
         match self {
             Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => (
                 output_list_with_auxiliary_infos.transaction_output_list_with_proof,
                 output_list_with_auxiliary_infos.persisted_auxiliary_infos,
             ),
+        }
+    }
+
+    /// Verifies the transaction output list with proof v2 against the given ledger info.
+    pub fn verify(
+        &self,
+        ledger_info: &LedgerInfo,
+        first_transaction_output_version: Option<Version>,
+    ) -> Result<()> {
+        match self {
+            Self::TransactionOutputListWithAuxiliaryInfos(inner) => {
+                inner.verify(ledger_info, first_transaction_output_version)
+            },
         }
     }
 }
@@ -2546,7 +2550,7 @@ impl TransactionOutputListWithAuxiliaryInfos {
 
     /// A convenience function to create a v2 output list from a
     /// v1 list. In this case, all auxiliary infos are set to None.
-    pub fn new_from_v1(transaction_output_list_with_proof: TransactionOutputListWithProof) -> Self {
+    fn new_from_v1(transaction_output_list_with_proof: TransactionOutputListWithProof) -> Self {
         let num_transaction_infos = transaction_output_list_with_proof
             .proof
             .transaction_infos


### PR DESCRIPTION
Notes:
- This PR is mostly just new unit tests 😄 

## Description
This PR updates the Aptos data client to support transaction v2 data in state sync. It offers the following commits:
1. Refactor: Add helper methods for request creation.
2. Aptos Data Client: Add support for fetching transaction v2 data. If v2 support is disabled (via the config flag), the client will only fetch v1 data (without aux infos), and populate the aux info responses with `None` results. 
    - Note: the aux infos are currently dropped by the data streaming service. In the next PR, we'll avoid this.
4. Tests: Add tests to the data client (to verify the new feature and flag).

## Testing Plan
New and existing test infrastructure.