### PR TITLE
BlockSTMv2 PR [10.5/n]: Retrospective comments, v2 flag, simple refactors

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -2810,6 +2810,7 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
     ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
         let config = BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
+                blockstm_v2: false,
                 concurrency_level: AptosVM::get_concurrency_level(),
                 allow_fallback: true,
                 discard_failed_blocks: AptosVM::get_discard_failed_blocks(),

--- a/aptos-move/block-executor/src/scheduler_status.rs
+++ b/aptos-move/block-executor/src/scheduler_status.rs
@@ -654,6 +654,7 @@ impl ExecutionStatuses {
     /// This can be called during an ongoing execution to determine if the
     /// execution has been concurrently aborted. This allows the executor
     /// to return early and to discard the results.
+    #[inline]
     pub(crate) fn already_started_abort(
         &self,
         txn_idx: TxnIndex,

--- a/aptos-move/block-executor/src/view.rs
+++ b/aptos-move/block-executor/src/view.rs
@@ -616,9 +616,9 @@ impl<T: Transaction> ResourceState<T> for ParallelState<'_, T> {
             let data = if self.scheduler.is_v2() {
                 self.versioned_map
                     .data()
-                    .fetch_data_v2(key, txn_idx, self.incarnation)
+                    .fetch_data_and_record(key, txn_idx, self.incarnation)
             } else {
-                self.versioned_map.data().fetch_data(key, txn_idx)
+                self.versioned_map.data().fetch_data_no_record(key, txn_idx)
             };
 
             match data {
@@ -3185,7 +3185,7 @@ mod test {
             holder
                 .versioned_map
                 .data()
-                .fetch_data(&KeyType::<u32>(3), 1)
+                .fetch_data_no_record(&KeyType::<u32>(3), 1)
         );
 
         let patched_value = create_struct_value(create_aggregator_value_u64(id.as_u64(), 30));

--- a/aptos-move/e2e-tests/src/executor.rs
+++ b/aptos-move/e2e-tests/src/executor.rs
@@ -736,6 +736,7 @@ impl FakeExecutor {
     ) -> Result<Vec<TransactionOutput>, VMStatus> {
         let config = BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
+                blockstm_v2: false,
                 concurrency_level: if sequential {
                     1
                 } else {

--- a/aptos-move/mvhashmap/src/unit_tests/dependencies.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/dependencies.rs
@@ -148,7 +148,9 @@ fn test_dependencies(
                                     ));
                                     sleep(Duration::from_millis(sleep_millis));
                                     process_deps(
-                                        map.data().remove_v2::<_, false>(&key, idx as TxnIndex),
+                                        map.data()
+                                            .remove_v2::<_, false>(&key, idx as TxnIndex)
+                                            .unwrap(),
                                     );
                                     None
                                 },
@@ -170,7 +172,7 @@ fn test_dependencies(
                     if let Some((key, txn_idx, incarnation)) = maybe_perform_read {
                         let speculative_read_value =
                             map.data()
-                                .fetch_data_v2(&KeyType(key), txn_idx, incarnation);
+                                .fetch_data_and_record(&KeyType(key), txn_idx, incarnation);
                         let correct = match speculative_read_value {
                             Ok(MVDataOutput::Versioned(_version, value)) => {
                                 let correct = baseline

--- a/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
+++ b/aptos-move/mvhashmap/src/unit_tests/proptest_types.rs
@@ -314,7 +314,7 @@ where
                             } else {
                                 match map
                                     .data()
-                                    .fetch_data(&KeyType(key.clone()), idx as TxnIndex)
+                                    .fetch_data_no_record(&KeyType(key.clone()), idx as TxnIndex)
                                 {
                                     Ok(Versioned(_, v)) => {
                                         assert_value(v);

--- a/aptos-move/mvhashmap/src/versioned_group_data.rs
+++ b/aptos-move/mvhashmap/src/versioned_group_data.rs
@@ -309,7 +309,7 @@ impl<
         let key_ref = GroupKeyRef { group_key, tag };
         let initialized = self.group_sizes.contains_key(group_key);
 
-        match self.values.fetch_data(&key_ref, txn_idx) {
+        match self.values.fetch_data_no_record(&key_ref, txn_idx) {
             Ok(MVDataOutput::Versioned(version, value)) => Ok((version, value)),
             Err(MVDataError::Uninitialized) => Err(if initialized {
                 MVGroupError::TagNotFound

--- a/aptos-move/replay-benchmark/src/execution.rs
+++ b/aptos-move/replay-benchmark/src/execution.rs
@@ -22,6 +22,7 @@ pub(crate) fn execute_workload(
 ) -> Vec<TransactionOutput> {
     let config = BlockExecutorConfig {
         local: BlockExecutorLocalConfig {
+            blockstm_v2: false,
             concurrency_level,
             allow_fallback: true,
             discard_failed_blocks: false,

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -35,6 +35,8 @@ impl Default for BlockExecutorModuleCacheLocalConfig {
 /// Local, per-node configuration.
 #[derive(Clone, Debug)]
 pub struct BlockExecutorLocalConfig {
+    // If enabled, uses BlockSTMv2 algorithm / scheduler for parallel execution.
+    pub blockstm_v2: bool,
     pub concurrency_level: usize,
     // If specified, parallel execution fallbacks to sequential, if issue occurs.
     // Otherwise, if there is an error in either of the execution, we will panic.
@@ -52,6 +54,7 @@ impl BlockExecutorLocalConfig {
     ///   - Default module cache configs.
     pub fn default_with_concurrency_level(concurrency_level: usize) -> Self {
         Self {
+            blockstm_v2: false,
             concurrency_level,
             allow_fallback: true,
             discard_failed_blocks: false,


### PR DESCRIPTION
- Address comments on landed PRs, incl. a fix to early return to fallback on errors properly (before side effects).
- Add a local config flag, set to false.
- Refactor docs.