### PR TITLE
[hot state] LRU updater for speculative state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4124,7 +4124,9 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "aptos-crypto",
+ "aptos-drop-helper",
  "aptos-experimental-layered-map",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-secure-net",
@@ -4134,6 +4136,7 @@ dependencies = [
  "dashmap 7.0.0-rc2",
  "derive_more 0.99.17",
  "itertools 0.13.0",
+ "maplit",
  "once_cell",
  "parking_lot 0.12.1",
  "proptest",

--- a/aptos-move/block-executor/src/hot_state_op_accumulator.rs
+++ b/aptos-move/block-executor/src/hot_state_op_accumulator.rs
@@ -17,6 +17,10 @@ pub struct BlockHotStateOpAccumulator<'base_view, Key, BaseView> {
     /// `hot_since_version` one is already hot but last refresh is far in the history) as the side
     /// effect of the block epilogue (subject to per block limit)
     to_make_hot: BTreeMap<Key, StateSlot>,
+    /// Keys to evict.
+    /// NOTE: oldest keys (the ones that are evicted first) are in the front.
+    to_evict: [Vec<Key>; 16],
+    num_free_slots: [usize; 16],
     /// Keep track of all the keys that are written to across the whole block, these keys are made
     /// hot (or have a refreshed `hot_since_version`) immediately at the version they got changed,
     /// so no need to issue separate HotStateOps to promote them to the hot state.
@@ -55,6 +59,8 @@ where
             first_version: base_view.next_version(),
             base_view,
             to_make_hot: BTreeMap::new(),
+            to_evict: [(); 16].map(|_| Vec::new()),
+            num_free_slots: base_view.num_free_hot_slots().unwrap(),
             writes: hashbrown::HashSet::new(),
             max_promotions_per_block,
             refresh_interval_versions,
@@ -68,7 +74,13 @@ where
     ) where
         Key: 'a,
     {
+        println!("BlockHotStateOpAccumulator::add_transaction start.");
         for key in writes {
+            println!("write key: {:?}", key);
+            if !self.writes.contains(key) && !self.base_view.hot_state_contains(key) {
+                self.maybe_evict(key);
+            }
+
             if self.to_make_hot.remove(key).is_some() {
                 COUNTER.inc_with(&["promotion_removed_by_write"]);
             }
@@ -76,6 +88,7 @@ where
         }
 
         for key in read_only {
+            println!("read_only key: {:?}", key);
             if self.to_make_hot.len() >= self.max_promotions_per_block {
                 COUNTER.inc_with(&["max_promotions_per_block_hit"]);
                 continue;
@@ -93,9 +106,12 @@ where
             let make_hot = match slot {
                 StateSlot::ColdVacant => {
                     COUNTER.inc_with(&["vacant_new"]);
+                    self.maybe_evict(key);
                     true
                 },
-                StateSlot::HotVacant { hot_since_version } => {
+                StateSlot::HotVacant {
+                    hot_since_version, ..
+                } => {
                     if self.should_refresh(hot_since_version) {
                         COUNTER.inc_with(&["vacant_refresh"]);
                         true
@@ -106,6 +122,7 @@ where
                 },
                 StateSlot::ColdOccupied { .. } => {
                     COUNTER.inc_with(&["occupied_new"]);
+                    self.maybe_evict(key);
                     true
                 },
                 StateSlot::HotOccupied {
@@ -123,6 +140,27 @@ where
             if make_hot {
                 self.to_make_hot.insert(key.clone(), slot);
             }
+        }
+        println!("BlockHotStateOpAccumulator::add_transaction end.");
+    }
+
+    fn maybe_evict(&mut self, key_added: &Key) {
+        let shard_id = self.base_view.get_shard_id(key_added);
+        if self.num_free_slots[shard_id] > 0 {
+            self.num_free_slots[shard_id] -= 1;
+            return;
+        }
+
+        // FIXME: let's say it's empty at the beginning, and the first block is really large. Then
+        // get_next_old_key would always return None, so nothing will be evicted. And the LRU would
+        // end up being larger than capacity.
+        // Next time when computing num_free_slots, it might overflow.
+
+        let last_evicted = self.to_evict[shard_id].last();
+        if let Some(k) = self.base_view.get_next_old_key(shard_id, last_evicted) {
+            // Unless the entire LRU is evicted (in that case `last_evicted` is already the newest
+            // key in the LRU and`get_next_old_key` would return `None`), evict the next key.
+            self.to_evict[shard_id].push(k);
         }
     }
 

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -42,6 +42,10 @@ impl<'s, T: Transaction, S: TStateView<Key = T::Key>> BlockGasLimitProcessor<'s,
         block_gas_limit_override: Option<u64>,
         init_size: usize,
     ) -> Self {
+        println!(
+            "BlockGasLimitProcessor::new. block_gas_limit_type: {:?}",
+            block_gas_limit_type
+        );
         let hot_state_op_accumulator = block_gas_limit_type
             .add_block_limit_outcome_onchain()
             .then(|| BlockHotStateOpAccumulator::new(base_view));
@@ -89,6 +93,8 @@ impl<'s, T: Transaction, S: TStateView<Key = T::Key>> BlockGasLimitProcessor<'s,
                 txn_read_write_summary.collapse_resource_group_conflicts()
             };
             if let Some(x) = &mut self.hot_state_op_accumulator {
+                // TODO(wqfish): probably need to order these to eliminate randomness.
+                // (These are `HashSet` right now.)
                 x.add_transaction(rw_summary.keys_written(), rw_summary.keys_read());
             }
             self.txn_read_write_summaries.push(rw_summary);

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -364,6 +364,7 @@ impl Parser {
         }
 
         let result_state = parent_state.update_with_memorized_reads(
+            Arc::clone(&base_state_view.hot),
             base_state_view.persisted_state(),
             to_commit.state_update_refs(),
             base_state_view.memorized_reads(),

--- a/storage/aptosdb/src/db/include/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_reader.rs
@@ -4,7 +4,10 @@
 use aptos_storage_interface::state_store::{
     state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
 };
-use aptos_types::{block_info::BlockHeight, transaction::IndexedTransactionSummary};
+use aptos_types::{
+    block_info::BlockHeight, state_store::state_slot::StateSlot,
+    transaction::IndexedTransactionSummary,
+};
 
 impl DbReader for AptosDB {
     fn get_persisted_state(&self) -> Result<(Arc<dyn HotStateView>, State)> {

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -9,31 +9,28 @@ use aptos_metrics_core::{IntCounterHelper, IntGaugeHelper, TimerHelper};
 use aptos_storage_interface::state_store::{
     state::State, state_view::hot_state_view::HotStateView, NUM_STATE_SHARDS,
 };
-use aptos_types::state_store::{hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot};
+use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot};
 use arr_macro::arr;
 use dashmap::{
     mapref::one::{Ref, RefMut},
     DashMap,
 };
-use std::sync::{
-    mpsc::{Receiver, SyncSender, TryRecvError},
-    Arc,
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{
+        mpsc::{Receiver, SyncSender, TryRecvError},
+        Arc,
+    },
 };
 
 const MAX_HOT_STATE_COMMIT_BACKLOG: usize = 10;
-
-#[derive(Debug)]
-struct Entry<K, V> {
-    data: V,
-    lru: LRUEntry<K>,
-}
 
 #[derive(Debug)]
 struct Shard<K, V>
 where
     K: Eq + std::hash::Hash,
 {
-    inner: DashMap<K, Entry<K, V>>,
+    inner: DashMap<K, V>,
 }
 
 impl<K, V> Shard<K, V>
@@ -50,20 +47,16 @@ where
         self.inner.contains_key(key)
     }
 
-    fn get(&self, key: &K) -> Option<Ref<K, Entry<K, V>>> {
+    fn get(&self, key: &K) -> Option<Ref<K, V>> {
         self.inner.get(key)
     }
 
-    fn get_mut(&self, key: &K) -> Option<RefMut<K, Entry<K, V>>> {
-        self.inner.get_mut(key)
+    fn insert(&self, key: K, value: V) {
+        self.inner.insert(key, value);
     }
 
-    fn insert(&self, key: K, entry: Entry<K, V>) {
-        self.inner.insert(key, entry);
-    }
-
-    fn remove(&self, key: &K) -> Option<(K, Entry<K, V>)> {
-        self.inner.remove(key)
+    fn remove(&self, key: &K) {
+        self.inner.remove(key);
     }
 
     fn len(&self) -> usize {
@@ -78,6 +71,7 @@ where
 {
     /// After committing a new batch to `inner`, items are evicted so that
     ///  1. total number of items doesn't exceed this number
+    #[allow(dead_code)] // TODO(HotState): not used for now
     max_items: usize,
     ///  2. total number of bytes, incl. both keys and values doesn't exceed this number
     #[allow(dead_code)] // TODO(HotState): not enforced for now
@@ -103,7 +97,7 @@ where
         }
     }
 
-    fn get_from_shard(&self, shard_id: usize, key: &K) -> Option<Ref<K, Entry<K, V>>> {
+    fn get_from_shard(&self, shard_id: usize, key: &K) -> Option<Ref<K, V>> {
         self.shards[shard_id].get(key)
     }
 
@@ -115,14 +109,7 @@ where
 impl HotStateView for HotStateBase<StateKey, StateSlot> {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
         let shard_id = state_key.get_shard_id();
-        self.get_from_shard(shard_id, state_key)
-            .map(|e| e.data.clone())
-    }
-
-    fn get_lru_entry(&self, state_key: &StateKey) -> Option<LRUEntry<StateKey>> {
-        let shard_id = state_key.get_shard_id();
-        self.get_from_shard(shard_id, state_key)
-            .map(|e| e.lru.clone())
+        self.get_from_shard(shard_id, state_key).map(|e| e.clone())
     }
 }
 
@@ -211,8 +198,25 @@ impl Committer {
         info!("HotState committer thread started.");
 
         while let Some(to_commit) = self.next_to_commit() {
+            info!(
+                "old hot state size: {:?}",
+                self.base
+                    .shards
+                    .as_slice()
+                    .iter()
+                    .map(|s| s.len())
+                    .collect::<Vec<_>>()
+            );
             self.commit(&to_commit);
-            self.evict();
+            info!(
+                "new hot state size: {:?}",
+                self.base
+                    .shards
+                    .as_slice()
+                    .iter()
+                    .map(|s| s.len())
+                    .collect::<Vec<_>>()
+            );
             *self.committed.lock() = to_commit;
 
             GAUGE.set_with(&["hot_state_items"], self.base.len() as i64);
@@ -260,269 +264,59 @@ impl Committer {
         let mut n_insert = 0;
 
         let delta = to_commit.make_delta(&self.committed.lock());
+
         for shard_id in 0..NUM_STATE_SHARDS {
-            let mut updates: Vec<_> = delta.shards[shard_id].iter().collect();
-            // We will update the LRU next. Here we put the deletions at the beginning, then the
-            // older updates, and the newest updates are at the end.
-            updates.sort_unstable_by_key(|(_key, slot)| {
-                slot.hot_since_version_opt().map_or(-1, |v| v as i64)
-            });
-
-            let mut updater = LRUUpdater::new(
-                &self.base.shards[shard_id],
-                &mut self.heads[shard_id],
-                &mut self.tails[shard_id],
-                self.base.max_items,
-            );
-
+            let updates: Vec<_> = delta.shards[shard_id].iter().collect();
             for (key, slot) in updates {
-                let has_old_entry = if let Some(old_slot) = self.base.get_state_slot(&key) {
-                    self.total_key_bytes -= key.size();
-                    self.total_value_bytes -= old_slot.size();
-                    true
+                let shard_id = key.get_shard_id();
+                if slot.is_hot() {
+                    self.base.shards[shard_id].insert(key, slot);
                 } else {
-                    false
-                };
-
-                if slot.is_cold() {
-                    // deletion
-                    if has_old_entry {
-                        n_delete += 1;
-                        updater.delete(&key);
-                    }
-                } else {
-                    if has_old_entry {
-                        n_update += 1;
-                    } else {
-                        n_insert += 1;
-                    };
-
-                    self.total_key_bytes += key.size();
-                    self.total_value_bytes += slot.size();
-
-                    updater.insert(key, slot);
+                    self.base.shards[shard_id].remove(&key);
                 }
             }
+            self.heads[shard_id] = delta.get_newest_key(shard_id);
+            self.tails[shard_id] = delta.get_oldest_key(shard_id);
+
+            self.validate_shard_debug_only(shard_id);
         }
 
-        COUNTER.inc_with_by(&["hot_state_delete"], n_delete);
-        COUNTER.inc_with_by(&["hot_state_too_large"], n_too_large);
-        COUNTER.inc_with_by(&["hot_state_update"], n_update);
-        COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
+        println!(
+            "Committed hot state. Head: {:?}. Tail: {:?}. Entries: {:?}",
+            self.heads, self.tails, self.base.shards
+        );
     }
 
-    fn evict(&mut self) {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hot_state_evict"]);
-        let mut num_evicted = 0;
+    fn validate_shard_debug_only(&self, shard_id: usize) {
+        let head = &self.heads[shard_id];
+        let tail = &self.tails[shard_id];
+        assert_eq!(head.is_some(), tail.is_some());
+        let shard = &self.base.shards[shard_id];
 
-        for shard_id in 0..NUM_STATE_SHARDS {
-            let mut updater = LRUUpdater::new(
-                &self.base.shards[shard_id],
-                &mut self.heads[shard_id],
-                &mut self.tails[shard_id],
-                self.base.max_items,
-            );
-            let evicted = updater.evict();
-            num_evicted += evicted.len();
-            for (key, slot) in &evicted {
-                self.total_key_bytes -= key.size();
-                self.total_value_bytes -= slot.size();
+        {
+            let mut visited = HashSet::new();
+            let mut current = head.clone();
+            while let Some(key) = current {
+                let entry = shard.get(&key).unwrap();
+                visited.insert(key);
+                assert!(visited.len() <= shard.len());
+                assert!(entry.is_hot());
+                current = entry.next().cloned();
             }
-        }
-        COUNTER.inc_with_by(&["hot_state_evict"], num_evicted as u64);
-    }
-}
-
-struct LRUUpdater<'a, K, V>
-where
-    K: Eq + std::hash::Hash,
-{
-    shard: &'a Shard<K, V>,
-    head: &'a mut Option<K>,
-    tail: &'a mut Option<K>,
-    max_items: usize,
-}
-
-impl<'a, K, V> LRUUpdater<'a, K, V>
-where
-    K: Clone + std::fmt::Debug + Eq + std::hash::Hash,
-    V: Clone + std::fmt::Debug,
-{
-    fn new(
-        shard: &'a Shard<K, V>,
-        head: &'a mut Option<K>,
-        tail: &'a mut Option<K>,
-        max_items: usize,
-    ) -> Self {
-        Self {
-            shard,
-            head,
-            tail,
-            max_items,
-        }
-    }
-
-    fn insert(&mut self, key: K, value: V) {
-        if self.shard.contains_key(&key) {
-            self.delete(&key);
-        }
-        self.insert_to_front(key, value);
-    }
-
-    /// Deletes and returns the oldest entry.
-    fn delete_lru(&mut self) -> Option<(K, V)> {
-        let key = match &self.tail {
-            Some(k) => k.clone(),
-            None => return None,
-        };
-        let value = self.delete(&key).expect("Tail must exist.");
-        Some((key, value))
-    }
-
-    fn delete(&mut self, key: &K) -> Option<V> {
-        let old_entry = match self.shard.remove(key) {
-            Some((_k, e)) => e,
-            None => return None,
-        };
-
-        match &old_entry.lru.prev {
-            Some(prev_key) => {
-                let mut prev_entry = self
-                    .shard
-                    .get_mut(prev_key)
-                    .expect("The previous key must exist");
-                prev_entry.lru.next = old_entry.lru.next.clone();
-            },
-            None => {
-                // There is no newer entry. The current key was the head.
-                *self.head = old_entry.lru.next.clone();
-            },
+            assert_eq!(visited.len(), shard.len());
         }
 
-        match &old_entry.lru.next {
-            Some(next_key) => {
-                let mut next_entry = self
-                    .shard
-                    .get_mut(next_key)
-                    .expect("The next key must exist.");
-                next_entry.lru.prev = old_entry.lru.prev;
-            },
-            None => {
-                // There is no older entry. The current key was the tail.
-                *self.tail = old_entry.lru.prev;
-            },
-        }
-
-        Some(old_entry.data)
-    }
-
-    fn insert_to_front(&mut self, key: K, value: V) {
-        assert_eq!(self.head.is_some(), self.tail.is_some());
-        match self.head.take() {
-            Some(head) => {
-                {
-                    // Release the reference to the old entry ASAP to avoid deadlock when inserting
-                    // the new entry below.
-                    let mut old_head_entry = self.shard.get_mut(&head).expect("Head must exist.");
-                    old_head_entry.lru.prev = Some(key.clone());
-                }
-                let entry = Entry {
-                    data: value,
-                    lru: LRUEntry {
-                        prev: None,
-                        next: Some(head),
-                    },
-                };
-                self.shard.insert(key.clone(), entry);
-                *self.head = Some(key);
-            },
-            None => {
-                let entry = Entry {
-                    data: value,
-                    lru: LRUEntry {
-                        prev: None,
-                        next: None,
-                    },
-                };
-                self.shard.insert(key.clone(), entry);
-                *self.head = Some(key.clone());
-                *self.tail = Some(key);
-            },
-        }
-    }
-
-    fn evict(&mut self) -> Vec<(K, V)> {
-        if !self.should_evict() {
-            return Vec::new();
-        }
-
-        let mut items = Vec::with_capacity(self.shard.len() - self.max_items);
-        while self.should_evict() {
-            items.push(self.delete_lru().unwrap());
-        }
-        items
-    }
-
-    fn should_evict(&self) -> bool {
-        self.shard.len() > self.max_items
-    }
-
-    #[cfg(test)]
-    fn collect_all(&self) -> Vec<(K, V)> {
-        assert_eq!(self.head.is_some(), self.tail.is_some());
-
-        let mut keys = Vec::new();
-        let mut values = Vec::new();
-
-        let mut current_key = self.head.clone();
-        while let Some(key) = current_key {
-            let entry = self.shard.get(&key).unwrap();
-            assert_eq!(entry.lru.prev, keys.last().cloned());
-            keys.push(key);
-            values.push(entry.data.clone());
-            current_key = entry.lru.next.clone();
-        }
-        itertools::zip_eq(keys, values).collect()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{LRUUpdater, Shard};
-    use lru::LruCache;
-    use proptest::{collection::vec, option, prelude::*};
-    use std::num::NonZeroUsize;
-
-    proptest! {
-        #[test]
-        fn test_hot_state_lru(
-            max_items in 1..10usize,
-            updates in vec((0..20u64, option::weighted(0.8, 0..1000u64)), 1..50),
-        ) {
-            let shard = Shard::new(max_items);
-            let mut head = None;
-            let mut tail = None;
-
-            let mut updater = LRUUpdater::new(&shard, &mut head, &mut tail, max_items);
-            let mut cache = LruCache::new(NonZeroUsize::new(max_items).unwrap());
-
-            for (key, value_opt) in updates {
-                match value_opt {
-                    Some(value) => {
-                        updater.insert(key, value);
-                        cache.put(key, value);
-                    }
-                    None => {
-                        updater.delete(&key);
-                        cache.pop(&key);
-                    }
-                }
-                updater.evict();
-
-                prop_assert_eq!(shard.len(), cache.len());
-                let items = updater.collect_all();
-                prop_assert_eq!(items, cache.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>());
+        {
+            let mut visited = HashSet::new();
+            let mut current = tail.clone();
+            while let Some(key) = current {
+                let entry = shard.get(&key).unwrap();
+                visited.insert(key);
+                assert!(visited.len() <= shard.len());
+                assert!(entry.is_hot());
+                current = entry.prev().cloned();
             }
+            assert_eq!(visited.len(), shard.len());
         }
     }
 }

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -9,6 +9,12 @@ use aptos_storage_interface::state_store::{
     state::State, state_summary::StateSummary, state_view::hot_state_view::HotStateView,
     state_with_summary::StateWithSummary,
 };
+use aptos_types::state_store::{
+    state_key::StateKey,
+    state_slot::{
+        StateSlot, HOT_STATE_MAX_BYTES, HOT_STATE_MAX_ITEMS, HOT_STATE_MAX_SINGLE_VALUE_BYTES,
+    },
+};
 use std::sync::Arc;
 
 #[derive(Clone)]
@@ -18,19 +24,13 @@ pub struct PersistedState {
 }
 
 impl PersistedState {
-    // 256 MiB per shard
-    const HOT_STATE_MAX_BYTES: usize = 256 * 1024 * 1024;
-    // 250k items per shard
-    const HOT_STATE_MAX_ITEMS: usize = 250_000;
-    // 10KB, worst case the hot state still caches 400K items
-    const HOT_STATE_MAX_SINGLE_VALUE_BYTES: usize = 10 * 1024;
     const MAX_PENDING_DROPS: usize = 8;
 
     pub fn new_empty() -> Self {
         Self::new_empty_with_config(
-            Self::HOT_STATE_MAX_ITEMS,
-            Self::HOT_STATE_MAX_BYTES,
-            Self::HOT_STATE_MAX_SINGLE_VALUE_BYTES,
+            HOT_STATE_MAX_ITEMS,
+            HOT_STATE_MAX_BYTES,
+            HOT_STATE_MAX_SINGLE_VALUE_BYTES,
         )
     }
 

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -29,11 +29,13 @@ use aptos_types::{
     write_set::{BaseStateOp, HotStateOp, WriteOp},
 };
 use itertools::Itertools;
+use lru::LruCache;
 use proptest::{collection::vec, prelude::*, sample::Index};
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Formatter},
+    num::NonZeroUsize,
     ops::Deref,
     sync::{
         mpsc::{channel, Receiver, Sender},
@@ -148,6 +150,7 @@ prop_compose! {
 #[derive(Clone)]
 struct VersionState {
     usage: StateStorageUsage,
+    hot_state: LruCache<StateKey, StateSlot>,
     state: HashMap<StateKey, (Version, StateValue)>,
     summary: NaiveSmt,
     next_version: Version,
@@ -157,6 +160,7 @@ impl VersionState {
     fn new_empty() -> Self {
         Self {
             usage: StateStorageUsage::zero(),
+            hot_state: LruCache::new(NonZeroUsize::new(HOT_STATE_MAX_ITEMS).unwrap()),
             state: HashMap::new(),
             summary: NaiveSmt::default(),
             next_version: 0,
@@ -170,16 +174,25 @@ impl VersionState {
     ) -> Self {
         assert_eq!(version, self.next_version);
 
+        let mut hot_state = self.hot_state.clone();
         let mut state = self.state.clone();
         let mut smt_updates = vec![];
 
         for (k, v_opt) in kvs.into_iter() {
             match v_opt {
                 None => {
+                    hot_state.put(k.clone(), StateSlot::HotVacant {
+                        hot_since_version: version,
+                    });
                     state.remove(k);
                     smt_updates.push((k.hash(), None));
                 },
                 Some(v) => {
+                    hot_state.put(k.clone(), StateSlot::HotOccupied {
+                        value_version: version,
+                        value: v.clone(),
+                        hot_since_version: version,
+                    });
                     state.insert(k.clone(), (version, v.clone()));
                     smt_updates.push((k.hash(), Some(v.hash())));
                 },
@@ -193,9 +206,10 @@ impl VersionState {
         let usage = StateStorageUsage::new(items, bytes);
 
         Self {
+            usage,
+            hot_state,
             state,
             summary,
-            usage,
             next_version: version + 1,
         }
     }
@@ -205,6 +219,9 @@ impl TStateView for VersionState {
     type Key = StateKey;
 
     fn get_state_slot(&self, key: &Self::Key) -> StateViewResult<StateSlot> {
+        if let Some(slot) = self.hot_state.peek(key) {
+            return Ok(slot.clone());
+        }
         Ok(StateSlot::from_db_get(self.state.get(key).cloned()))
     }
 
@@ -214,6 +231,25 @@ impl TStateView for VersionState {
 
     fn next_version(&self) -> Version {
         self.next_version
+    }
+
+    fn num_free_hot_slots(&self) -> Option<usize> {
+        println!("here");
+        Some(self.hot_state.cap().get() - self.hot_state.len())
+    }
+
+    fn hot_state_contains(&self, state_key: &Self::Key) -> bool {
+        self.hot_state.contains(state_key)
+    }
+
+    fn get_next_old_key(&self, state_key: Option<&Self::Key>) -> Option<Self::Key> {
+        match state_key {
+            Some(key) => {
+                let mut iter = self.hot_state.iter().skip_while(|x| x.0 != key).skip(1);
+                iter.next().map(|x| x.0.clone())
+            },
+            None => self.hot_state.peek_lru().map(|(k, _v)| k.clone()),
+        }
     }
 }
 
@@ -415,6 +451,7 @@ fn update_state(
         let memorized_reads = state_view.into_memorized_reads();
 
         let next_state = parent_state.update_with_memorized_reads(
+            hot_state.clone(),
             &persisted_state,
             block.update_refs(),
             &memorized_reads,
@@ -505,7 +542,7 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
     let mut state_by_version = StateByVersion::new_empty();
     let mut next_version: Version = 0;
     for (block_txns, append_epilogue) in blocks {
-        let base_view = state_by_version
+        let base_view: Arc<VersionState> = state_by_version
             .get_state(next_version.checked_sub(1))
             .clone();
         let mut op_accu =
@@ -625,7 +662,7 @@ fn replay_chunks_pipelined(chunks: Vec<Chunk>, state_by_version: Arc<StateByVers
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(100))]
+    #![proptest_config(ProptestConfig::with_cases(1))]
 
     #[test]
     fn test_speculative_state_workflow(

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -15,7 +15,9 @@ rust-version = { workspace = true }
 [dependencies]
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
+aptos-drop-helper = { workspace = true }
 aptos-experimental-layered-map = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-secure-net = { workspace = true }
@@ -36,6 +38,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }
+maplit = { workspace = true }
 
 [features]
 default = []

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -20,6 +20,7 @@ use aptos_types::{
     state_proof::StateProof,
     state_store::{
         state_key::StateKey,
+        state_slot::StateSlot,
         state_storage_usage::StateStorageUsage,
         state_value::{StateValue, StateValueChunkWithProof},
         table::{TableHandle, TableInfo},

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -1,0 +1,228 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::state_store::state_view::hot_state_view::HotStateView;
+use aptos_experimental_layered_map::LayeredMap;
+use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot};
+use std::{collections::HashMap, sync::Arc};
+
+pub(crate) struct HotStateLRU<'a> {
+    /// The entire hot state resulted from committed transactions.
+    committed: Arc<dyn HotStateView>,
+    /// Additional entries resulted from previous speculative execution.
+    overlay: &'a LayeredMap<StateKey, StateSlot>,
+    /// The new entries from the current execution.
+    pub pending: HashMap<StateKey, StateSlot>,
+    /// Points to the latest entry. `None` if empty.
+    pub head: Option<StateKey>,
+    /// Points to the oldest entry. `None` if empty.
+    pub tail: Option<StateKey>,
+    pub num_entries_changed: isize,
+}
+
+impl<'a> HotStateLRU<'a> {
+    pub fn new(
+        committed: Arc<dyn HotStateView>,
+        overlay: &'a LayeredMap<StateKey, StateSlot>,
+        head: Option<StateKey>,
+        tail: Option<StateKey>,
+    ) -> Self {
+        Self {
+            committed,
+            overlay,
+            pending: HashMap::new(),
+            head,
+            tail,
+            num_entries_changed: 0,
+        }
+    }
+
+    pub fn insert(&mut self, key: StateKey, slot: StateSlot) {
+        self.delete(&key);
+        self.insert_as_head(key, slot);
+    }
+
+    fn insert_as_head(&mut self, key: StateKey, mut slot: StateSlot) {
+        self.num_entries_changed += 1;
+        match self.head.take() {
+            Some(head) => {
+                let mut old_head_slot = self.expect_slot(&head);
+                old_head_slot.set_prev(Some(key.clone()));
+                slot.set_prev(None);
+                slot.set_next(Some(head.clone()));
+                self.pending.insert(head, old_head_slot);
+                self.pending.insert(key.clone(), slot);
+                self.head = Some(key);
+            },
+            None => {
+                slot.set_prev(None);
+                slot.set_next(None);
+                self.pending.insert(key.clone(), slot);
+                self.head = Some(key.clone());
+                self.tail = Some(key);
+            },
+        }
+    }
+
+    pub fn delete(&mut self, key: &StateKey) {
+        let old_entry = match self.get_slot(key) {
+            Some(e) => e,
+            None => return,
+        };
+        self.num_entries_changed -= 1;
+
+        match old_entry.prev() {
+            Some(prev_key) => {
+                let mut prev_entry = self.expect_slot(prev_key);
+                prev_entry.set_next(old_entry.next().cloned());
+                self.pending.insert(prev_key.clone(), prev_entry);
+            },
+            None => {
+                // There is no newer entry. The current key was the head.
+                self.head = old_entry.next().cloned();
+            },
+        }
+
+        match old_entry.next() {
+            Some(next_key) => {
+                let mut next_entry = self.expect_slot(next_key);
+                next_entry.set_prev(old_entry.prev().cloned());
+                self.pending.insert(next_key.clone(), next_entry);
+            },
+            None => {
+                // There is no older entry. The current key was the tail.
+                self.tail = old_entry.prev().cloned();
+            },
+        }
+
+        self.pending.insert(key.clone(), old_entry.to_cold());
+    }
+
+    fn get_slot(&self, key: &StateKey) -> Option<StateSlot> {
+        if let Some(entry) = self.pending.get(key) {
+            return Some(entry.clone());
+        }
+
+        if let Some(v) = self.overlay.get(key) {
+            return Some(v);
+        }
+
+        self.committed.get_state_slot(key)
+    }
+
+    fn expect_slot(&self, key: &StateKey) -> StateSlot {
+        self.get_slot(key).expect("Given key is expected to exist.")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::HotStateLRU;
+    use crate::state_store::state_view::hot_state_view::HotStateView;
+    use aptos_experimental_layered_map::MapLayer;
+    use aptos_types::state_store::{
+        hot_state::{LRUEntry, SpeculativeLRUEntry},
+        state_key::StateKey,
+        state_slot::StateSlot,
+    };
+    use maplit::hashmap;
+    use std::{collections::HashMap, sync::Arc};
+
+    #[derive(Debug)]
+    struct HotState {
+        inner: HashMap<StateKey, StateSlot>,
+        head: Option<StateKey>,
+        tail: Option<StateKey>,
+    }
+
+    impl HotStateView for HotState {
+        fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
+            self.inner.get(state_key).map(|v| v.clone())
+        }
+    }
+
+    struct LRUTest<'a> {
+        _hot_state: Arc<HotState>,
+        _base_layer: MapLayer<StateKey, StateSlot>,
+        _top_layer: MapLayer<StateKey, StateSlot>,
+        lru: HotStateLRU<'a>,
+    }
+
+    impl<'a> LRUTest<'a> {
+        fn new_empty() -> Self {
+            let hot_state = Arc::new(HotState {
+                inner: HashMap::new(),
+                head: None,
+                tail: None,
+            });
+            let base_layer = MapLayer::new_family("test");
+            let top_layer = base_layer.clone();
+            let overlay = Arc::new(base_layer.view_layers_after(&top_layer));
+
+            let lru = HotStateLRU::new(
+                Arc::clone(&hot_state) as Arc<dyn HotStateView<Key = u32, Value = ()>>,
+                overlay,
+                hot_state.head,
+                hot_state.tail,
+            );
+
+            Self {
+                _hot_state: hot_state,
+                _base_layer: base_layer,
+                _top_layer: top_layer,
+                lru,
+            }
+        }
+    }
+
+    #[test]
+    fn test_empty_overlay() {
+        let mut test_obj = LRUTest::new_empty();
+        let lru = &mut test_obj.lru;
+        assert_eq!(lru.head, None);
+        assert_eq!(lru.tail, None);
+        assert!(lru.pending.is_empty());
+
+        lru.insert(1);
+        assert_eq!(lru.head, Some(1));
+        assert_eq!(lru.tail, Some(1));
+        assert_eq!(
+            lru.pending,
+            hashmap! {1 => SpeculativeLRUEntry::Existing(LRUEntry { prev: None, next: None })}
+        );
+
+        lru.delete(&1);
+        assert_eq!(lru.head, None);
+        assert_eq!(lru.tail, None);
+        assert_eq!(lru.pending, hashmap! {1 => SpeculativeLRUEntry::Deleted});
+
+        lru.insert(1);
+        lru.insert(2);
+        lru.insert(3);
+        assert_eq!(lru.head, Some(3));
+        assert_eq!(lru.tail, Some(1));
+        assert_eq!(lru.pending, hashmap! {
+            1 => SpeculativeLRUEntry::Existing(LRUEntry { prev: Some(2), next: None }),
+            2 => SpeculativeLRUEntry::Existing(LRUEntry { prev: Some(3), next: Some(1) }),
+            3 => SpeculativeLRUEntry::Existing(LRUEntry { prev: None, next: Some(2) }),
+        });
+
+        lru.insert(2);
+        assert_eq!(lru.head, Some(2));
+        assert_eq!(lru.tail, Some(1));
+        assert_eq!(lru.pending, hashmap! {
+            1 => SpeculativeLRUEntry::Existing(LRUEntry { prev: Some(3), next: None }),
+            2 => SpeculativeLRUEntry::Existing(LRUEntry { prev: None, next: Some(3) }),
+            3 => SpeculativeLRUEntry::Existing(LRUEntry { prev: Some(2), next: Some(1) }),
+        });
+
+        lru.delete(&1);
+        assert_eq!(lru.head, Some(2));
+        assert_eq!(lru.tail, Some(3));
+        assert_eq!(lru.pending, hashmap! {
+            1 => SpeculativeLRUEntry::Deleted,
+            2 => SpeculativeLRUEntry::Existing(LRUEntry { prev: None, next: Some(3) }),
+            3 => SpeculativeLRUEntry::Existing(LRUEntry { prev: Some(2), next: None }),
+        });
+    }
+}

--- a/storage/storage-interface/src/state_store/mod.rs
+++ b/storage/storage-interface/src/state_store/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+mod hot_state;
 pub mod state;
 pub mod state_delta;
 pub mod state_summary;

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -4,6 +4,7 @@
 use crate::{
     metrics::TIMER,
     state_store::{
+        hot_state::HotStateLRU,
         state_delta::StateDelta,
         state_update_refs::{BatchedStateUpdateRefs, StateUpdateRefs},
         state_view::{
@@ -17,6 +18,7 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_experimental_layered_map::{LayeredMap, MapLayer};
+use aptos_logger::prelude::*;
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::{
@@ -24,12 +26,30 @@ use aptos_types::{
         StateViewId,
     },
     transaction::Version,
+    write_set::BaseStateOp,
 };
 use arr_macro::arr;
 use derive_more::Deref;
 use itertools::Itertools;
 use rayon::prelude::*;
 use std::{collections::HashMap, sync::Arc};
+
+#[derive(Clone, Debug)]
+pub struct HotStateMetadata {
+    pub latest: Option<StateKey>,
+    pub oldest: Option<StateKey>,
+    pub num_items: usize,
+}
+
+impl HotStateMetadata {
+    fn new() -> Self {
+        Self {
+            latest: None,
+            oldest: None,
+            num_items: 0,
+        }
+    }
+}
 
 /// Represents the blockchain state at a given version.
 /// n.b. the state can be either persisted or speculative.
@@ -42,6 +62,7 @@ pub struct State {
     ///       between this and a `base_version` to list the updates or create a
     ///       new `State` at a descendant version.
     shards: Arc<[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+    pub(crate) hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
     /// The total usage of the state at the current version.
     usage: StateStorageUsage,
 }
@@ -50,11 +71,13 @@ impl State {
     pub fn new_with_updates(
         version: Option<Version>,
         shards: Arc<[MapLayer<StateKey, StateSlot>; NUM_STATE_SHARDS]>,
+        hot_state_metadata: [HotStateMetadata; NUM_STATE_SHARDS],
         usage: StateStorageUsage,
     ) -> Self {
         Self {
             next_version: version.map_or(0, |v| v + 1),
             shards,
+            hot_state_metadata,
             usage,
         }
     }
@@ -63,6 +86,7 @@ impl State {
         Self::new_with_updates(
             version,
             Arc::new(arr![MapLayer::new_family("state"); 16]),
+            arr![HotStateMetadata::new(); 16],
             usage,
         )
     }
@@ -92,7 +116,7 @@ impl State {
         self.clone().into_delta(base.clone())
     }
 
-    pub fn into_delta(self, base: State) -> StateDelta {
+    pub(crate) fn into_delta(self, base: State) -> StateDelta {
         StateDelta::new(base, self)
     }
 
@@ -100,20 +124,24 @@ impl State {
         Arc::ptr_eq(&self.shards, &rhs.shards)
     }
 
-    pub fn is_descendant_of(&self, rhs: &State) -> bool {
+    pub(crate) fn is_descendant_of(&self, rhs: &State) -> bool {
         self.shards[0].is_descendant_of(&rhs.shards[0])
     }
 
-    pub fn update(
+    fn update<'kv>(
         &self,
+        persisted_hot_state: Arc<dyn HotStateView>,
         persisted: &State,
-        updates: &BatchedStateUpdateRefs,
+        batched_updates: &BatchedStateUpdateRefs,
+        per_version_updates: Vec<&[(&'kv StateKey, StateUpdateRef<'kv>)]>,
         state_cache: &ShardedStateCache,
     ) -> Self {
+        assert_eq!(per_version_updates.len(), NUM_STATE_SHARDS);
+
         let _timer = TIMER.timer_with(&["state__update"]);
 
         // 1. The update batch must begin at self.next_version().
-        assert_eq!(self.next_version(), updates.first_version);
+        assert_eq!(self.next_version(), batched_updates.first_version);
         // 2. The cache must be at a version equal or newer than `persisted`, otherwise
         //    updates between the cached version and the persisted version are potentially
         //    missed during the usage calculation.
@@ -128,29 +156,79 @@ impl State {
         assert!(self.next_version() >= state_cache.next_version());
 
         let overlay = self.make_delta(persisted);
-        let (shards, usage_delta_per_shard): (Vec<_>, Vec<_>) = (
+        let ((shards, new_metadata), usage_delta_per_shard): ((Vec<_>, Vec<_>), Vec<_>) = (
             state_cache.shards.as_slice(),
             overlay.shards.as_slice(),
-            updates.shards.as_slice(),
+            self.hot_state_metadata.as_slice(),
+            batched_updates.shards.as_slice(),
+            per_version_updates.as_slice(),
         )
             .into_par_iter()
-            .map(|(cache, overlay, updates)| {
-                let new_items = updates
-                    .iter()
-                    .map(|(k, u)| ((*k).clone(), u.to_result_slot()))
-                    .collect_vec();
+            .map(|(cache, overlay, hot_metadata, batched_updates, updates)| {
+                let head = hot_metadata.latest.clone();
+                let tail = hot_metadata.oldest.clone();
+                println!("head: {head:?}, tail: {tail:?}");
+
+                let mut lru =
+                    HotStateLRU::new(Arc::clone(&persisted_hot_state), overlay, head, tail);
+                for (key, update) in *updates {
+                    // We need to decide whether to put this update inside the LRU. It should go in
+                    // unless it's an eviction.
+                    match update.state_op {
+                        BaseStateOp::Creation(_)
+                        | BaseStateOp::Modification(_)
+                        | BaseStateOp::Deletion(_)
+                        | BaseStateOp::MakeHot { .. } => {
+                            // Construct the writes such that the key goes to the front of the LRU.
+                            lru.insert((*key).clone(), update.to_result_slot());
+                            // println!(
+                            //     "after insertion: head: {:?}, tail: {:?}, cache: {:?}",
+                            //     lru.head, lru.tail, lru.pending
+                            // );
+                        },
+                        BaseStateOp::Eviction { .. } => {
+                            // NOTE: once we actually populate the evictions here (currently it's
+                            // not populated because `to_evict` in `BlockHotStateOpAccumulator` is
+                            // never processed later), we want to double check inside the LRU that
+                            // these keys are indeed the oldest, i.e. we are not deleting some keys
+                            // in the middle.
+                            // This probably can be done by comparing the newest version of the
+                            // deleted key, with the tail of the LRU, or something similar.
+                            //
+                            // Construct the writes such that the key is removed from the LRU.
+                            // Maybe assert that this key is always around the tail.
+                            lru.delete(key);
+                            // println!(
+                            //     "after eviction: head: {:?}, tail: {:?}, cache: {:?}",
+                            //     lru.head, lru.tail, lru.pending
+                            // );
+                        },
+                    }
+                }
+
+                let new_items: Vec<_> = lru.pending.into_iter().collect();
+                println!(
+                    "new head: {:?}. new tail: {:?}. new_items: {:?}",
+                    lru.head, lru.tail, new_items
+                );
 
                 (
                     // TODO(aldenhu): change interface to take iter of ref
-                    overlay.new_layer(&new_items),
-                    Self::usage_delta_for_shard(cache, overlay, updates),
+                    (overlay.new_layer(&new_items), HotStateMetadata {
+                        latest: lru.head,
+                        oldest: lru.tail,
+                        num_items: (hot_metadata.num_items as isize + lru.num_entries_changed)
+                            as usize,
+                    }),
+                    Self::usage_delta_for_shard(cache, overlay, batched_updates),
                 )
             })
             .unzip();
         let shards = Arc::new(shards.try_into().expect("Known to be 16 shards."));
+        let new_metadata = new_metadata.try_into().expect("Known to be 16 shards.");
         let usage = self.update_usage(usage_delta_per_shard);
 
-        State::new_with_updates(updates.last_version(), shards, usage)
+        State::new_with_updates(batched_updates.last_version(), shards, new_metadata, usage)
     }
 
     fn update_usage(&self, usage_delta_per_shard: Vec<(i64, i64)>) -> StateStorageUsage {
@@ -234,14 +312,28 @@ impl LedgerState {
     /// have already been recorded.
     pub fn update_with_memorized_reads(
         &self,
+        persisted_hot_view: Arc<dyn HotStateView>,
         persisted_snapshot: &State,
         updates: &StateUpdateRefs,
         reads: &ShardedStateCache,
     ) -> LedgerState {
         let _timer = TIMER.timer_with(&["ledger_state__update"]);
 
-        let last_checkpoint = if let Some(updates) = &updates.for_last_checkpoint {
-            self.latest().update(persisted_snapshot, updates, reads)
+        let last_checkpoint = if let Some(u) = &updates.for_last_checkpoint {
+            let mut per_version = Vec::new();
+            for i in 0..NUM_STATE_SHARDS {
+                let s = &updates.per_version.shards[i];
+                let p = s.partition_point(|x| x.1.version < u.next_version());
+                println!("shard id: {i}. s.len(): {}. p: {p}", s.len());
+                per_version.push(&s[..p]);
+            }
+            self.latest().update(
+                Arc::clone(&persisted_hot_view),
+                persisted_snapshot,
+                u,
+                per_version,
+                reads,
+            )
         } else {
             self.last_checkpoint.clone()
         };
@@ -251,8 +343,20 @@ impl LedgerState {
         } else {
             &last_checkpoint
         };
-        let latest = if let Some(updates) = &updates.for_latest {
-            base_of_latest.update(persisted_snapshot, updates, reads)
+        let latest = if let Some(u) = &updates.for_latest {
+            let mut per_version = Vec::new();
+            for i in 0..NUM_STATE_SHARDS {
+                let s = &updates.per_version.shards[i];
+                let p = s.partition_point(|x| x.1.version < u.first_version());
+                per_version.push(&s[p..]);
+            }
+            base_of_latest.update(
+                persisted_hot_view,
+                persisted_snapshot,
+                u,
+                per_version,
+                reads,
+            )
         } else {
             base_of_latest.clone()
         };
@@ -272,13 +376,14 @@ impl LedgerState {
         let state_view = CachedStateView::new_impl(
             StateViewId::Miscellaneous,
             reader,
-            hot_state,
+            Arc::clone(&hot_state),
             persisted_snapshot.clone(),
             self.latest().clone(),
         );
         state_view.prime_cache(updates)?;
 
         let updated = self.update_with_memorized_reads(
+            hot_state,
             persisted_snapshot,
             updates,
             state_view.memorized_reads(),

--- a/storage/storage-interface/src/state_store/state_delta.rs
+++ b/storage/storage-interface/src/state_store/state_delta.rs
@@ -4,7 +4,10 @@
 use crate::state_store::{state::State, NUM_STATE_SHARDS};
 use aptos_experimental_layered_map::LayeredMap;
 use aptos_types::{
-    state_store::{state_key::StateKey, state_slot::StateSlot},
+    state_store::{
+        state_key::StateKey,
+        state_slot::{StateSlot, HOT_STATE_MAX_ITEMS},
+    },
     transaction::Version,
 };
 use itertools::Itertools;
@@ -58,5 +61,35 @@ impl StateDelta {
     /// `None` indicates the key is not updated in the delta.
     pub fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
         self.shards[state_key.get_shard_id()].get(state_key)
+    }
+
+    /*
+    pub fn num_hot_items(&self) -> usize {
+        self.current.hot_state_metadata.num_items
+    }
+    */
+
+    pub fn num_free_hot_slots(&self) -> [usize; NUM_STATE_SHARDS] {
+        let mut ret = [0; NUM_STATE_SHARDS];
+        for i in 0..NUM_STATE_SHARDS {
+            assert!(self.current.hot_state_metadata[i].num_items <= HOT_STATE_MAX_ITEMS);
+            ret[i] = HOT_STATE_MAX_ITEMS - self.current.hot_state_metadata[i].num_items
+        }
+        ret
+    }
+
+    pub fn hot_state_contains(&self, state_key: &StateKey) -> bool {
+        match self.get_state_slot(state_key) {
+            Some(slot) => slot.is_hot(),
+            None => false,
+        }
+    }
+
+    pub fn get_oldest_key(&self, shard_id: usize) -> Option<StateKey> {
+        self.current.hot_state_metadata[shard_id].oldest.clone()
+    }
+
+    pub fn get_newest_key(&self, shard_id: usize) -> Option<StateKey> {
+        self.current.hot_state_metadata[shard_id].latest.clone()
     }
 }

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -16,11 +16,15 @@ use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
 use std::collections::HashMap;
 
+#[derive(Debug)]
 pub struct PerVersionStateUpdateRefs<'kv> {
     pub first_version: Version,
     pub num_versions: usize,
     /// Converting to Vec to Box<[]> to release over-allocated memory during construction
     /// TODO(HotState): let WriteOp always carry StateSlot, so we can use &'kv StateSlot here
+    /// TODO(wqfish): check if this is deterministic, i.e. if the order within one
+    /// version/transaction is deterministic.
+    /// Note(wqfish): this is the flattened write sets.
     pub shards: [Box<[(&'kv StateKey, StateUpdateRef<'kv>)]>; NUM_STATE_SHARDS],
 }
 
@@ -97,6 +101,7 @@ impl BatchedStateUpdateRefs<'_> {
     }
 }
 
+#[derive(Debug)]
 pub struct StateUpdateRefs<'kv> {
     pub per_version: PerVersionStateUpdateRefs<'kv>,
     /// Batched updates (updates for the same keys are merged) from the

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -19,8 +19,12 @@ use anyhow::Result;
 use aptos_metrics_core::{IntCounterHelper, TimerHelper};
 use aptos_types::{
     state_store::{
-        state_key::StateKey, state_slot::StateSlot, state_storage_usage::StateStorageUsage,
-        state_value::StateValue, StateViewId, StateViewResult, TStateView,
+        hot_state::{LRUEntry, SpeculativeLRUEntry},
+        state_key::StateKey,
+        state_slot::StateSlot,
+        state_storage_usage::StateStorageUsage,
+        state_value::StateValue,
+        StateViewId, StateViewResult, TStateView,
     },
     transaction::Version,
 };
@@ -96,7 +100,7 @@ pub struct CachedStateView {
     speculative: StateDelta,
 
     /// Persisted hot state. To be fetched if a key isn't in `speculative`.
-    hot: Arc<dyn HotStateView>,
+    pub hot: Arc<dyn HotStateView>,
 
     /// Persisted base state. To be fetched if a key isn't in either `speculative` or `hot_state`.
     /// `self.speculative.base_version()` is targeted in db fetches.
@@ -249,6 +253,28 @@ impl CachedStateView {
     pub fn memorized_reads(&self) -> &ShardedStateCache {
         &self.memorized
     }
+
+    /*
+    pub(crate) fn get_hot_lru_entry_question(
+        &self,
+        state_key: &StateKey,
+    ) -> Option<LRUEntry<StateKey>> {
+        match self.speculative.get_lru_entry(state_key) {
+            Some(SpeculativeLRUEntry::Existing(entry)) => return Some(entry),
+            Some(SpeculativeLRUEntry::Deleted) => return None,
+            None => (),
+        }
+        self.hot.get_lru_entry(state_key)
+    }
+
+    pub(crate) fn get_lru_head(&self) -> Option<StateKey> {
+        self.speculative.get_newest_key()
+    }
+
+    pub(crate) fn get_lru_tail(&self) -> Option<StateKey> {
+        self.speculative.get_oldest_key()
+    }
+    */
 }
 
 impl TStateView for CachedStateView {
@@ -280,6 +306,42 @@ impl TStateView for CachedStateView {
 
     fn next_version(&self) -> Version {
         self.speculative.next_version()
+    }
+
+    fn num_free_hot_slots(&self) -> Option<[usize; NUM_STATE_SHARDS]> {
+        Some(self.speculative.num_free_hot_slots())
+    }
+
+    fn get_shard_id(&self, state_key: &StateKey) -> usize {
+        state_key.get_shard_id()
+    }
+
+    fn hot_state_contains(&self, state_key: &StateKey) -> bool {
+        if self.speculative.hot_state_contains(state_key) {
+            return true;
+        }
+
+        self.hot.get_state_slot(state_key).is_some()
+    }
+
+    fn get_next_old_key(&self, shard_id: usize, state_key: Option<&StateKey>) -> Option<StateKey> {
+        let key = match state_key {
+            Some(k) => {
+                assert_eq!(k.get_shard_id(), shard_id);
+                k
+            },
+            None => return self.speculative.get_oldest_key(shard_id),
+        };
+
+        let slot = if let Some(slot) = self.speculative.get_state_slot(key) {
+            slot
+        } else if let Some(slot) = self.hot.get_state_slot(key) {
+            slot
+        } else {
+            unreachable!();
+        };
+        assert!(slot.is_hot());
+        slot.next().cloned()
     }
 }
 

--- a/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
@@ -2,23 +2,17 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_types::state_store::{hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot};
+use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot};
 
 /// A view into the hot state store, whose content overlays on top of the cold state store content.
 pub trait HotStateView: Send + Sync {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot>;
-
-    fn get_lru_entry(&self, state_key: &StateKey) -> Option<LRUEntry<StateKey>>;
 }
 
 pub struct EmptyHotState;
 
 impl HotStateView for EmptyHotState {
     fn get_state_slot(&self, _state_key: &StateKey) -> Option<StateSlot> {
-        None
-    }
-
-    fn get_lru_entry(&self, _state_key: &StateKey) -> Option<LRUEntry<StateKey>> {
         None
     }
 }

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -1,10 +1,16 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LRUEntry<K> {
     /// The key that is slightly newer than the current entry. `None` for the newest entry.
     pub prev: Option<K>,
     /// The key that is slightly older than the current entry. `None` for the oldest entry.
     pub next: Option<K>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum SpeculativeLRUEntry<V> {
+    Existing(V),
+    Deleted,
 }

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -76,6 +76,30 @@ pub trait TStateView {
     fn contains_state_value(&self, state_key: &Self::Key) -> StateViewResult<bool> {
         self.get_state_value(state_key).map(|opt| opt.is_some())
     }
+
+    /// Number of free slots in hot state. `None` for views that do not implement hot state.
+    fn num_free_hot_slots(&self) -> Option<[usize; 16]> {
+        println!("default implementation");
+        None
+    }
+
+    fn get_shard_id(&self, _state_key: &Self::Key) -> usize {
+        unimplemented!();
+    }
+
+    fn hot_state_contains(&self, _state_key: &Self::Key) -> bool {
+        false
+    }
+
+    /// Returns the oldest key if `state_key` is `None`. Else returns the key that's just a little
+    /// bit newer, i.e. the next candidate for eviction.
+    fn get_next_old_key(
+        &self,
+        _shard_id: usize,
+        _state_key: Option<&Self::Key>,
+    ) -> Option<Self::Key> {
+        None
+    }
 }
 
 pub trait StateView: TStateView<Key = StateKey> {}
@@ -126,6 +150,26 @@ where
 
     fn get_state_value(&self, state_key: &K) -> StateViewResult<Option<StateValue>> {
         self.deref().get_state_value(state_key)
+    }
+
+    fn num_free_hot_slots(&self) -> Option<[usize; 16]> {
+        self.deref().num_free_hot_slots()
+    }
+
+    fn get_shard_id(&self, state_key: &K) -> usize {
+        self.deref().get_shard_id(state_key)
+    }
+
+    fn hot_state_contains(&self, state_key: &Self::Key) -> bool {
+        self.deref().hot_state_contains(state_key)
+    }
+
+    fn get_next_old_key(
+        &self,
+        shard_id: usize,
+        state_key: Option<&Self::Key>,
+    ) -> Option<Self::Key> {
+        self.deref().get_next_old_key(shard_id, state_key)
     }
 }
 

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    state_store::{state_key::StateKey, state_value::StateValue},
+    state_store::{hot_state::LRUEntry, state_key::StateKey, state_value::StateValue},
     transaction::Version,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -20,6 +20,7 @@ pub enum StateSlot {
     ColdVacant,
     HotVacant {
         hot_since_version: Version,
+        lru_info: LRUEntry<StateKey>,
     },
     ColdOccupied {
         value_version: Version,
@@ -29,6 +30,7 @@ pub enum StateSlot {
         value_version: Version,
         value: StateValue,
         hot_since_version: Version,
+        lru_info: LRUEntry<StateKey>,
     },
 }
 
@@ -36,7 +38,9 @@ impl StateSlot {
     fn maybe_update_cold_state(&self, min_version: Version) -> Option<Option<&StateValue>> {
         match self {
             ColdVacant => Some(None),
-            HotVacant { hot_since_version } => {
+            HotVacant {
+                hot_since_version, ..
+            } => {
                 if *hot_since_version >= min_version {
                     // TODO(HotState): revisit after the hot state is exclusive with the cold state
                     // Can't tell if there was a deletion to the cold state here, not much harm to
@@ -55,7 +59,7 @@ impl StateSlot {
             | HotOccupied {
                 value_version,
                 value,
-                hot_since_version: _,
+                ..
             } => {
                 if *value_version >= min_version {
                     // an update happened at or after min_version, need to update
@@ -108,6 +112,10 @@ impl StateSlot {
         }
     }
 
+    pub fn is_hot(&self) -> bool {
+        !self.is_cold()
+    }
+
     pub fn is_cold(&self) -> bool {
         match self {
             ColdVacant | ColdOccupied { .. } => true,
@@ -153,4 +161,57 @@ impl StateSlot {
             },
         }
     }
+
+    pub fn prev(&self) -> Option<&StateKey> {
+        match self {
+            HotVacant { lru_info, .. } | HotOccupied { lru_info, .. } => lru_info.prev.as_ref(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn next(&self) -> Option<&StateKey> {
+        match self {
+            HotVacant { lru_info, .. } | HotOccupied { lru_info, .. } => lru_info.next.as_ref(),
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn set_prev(&mut self, prev: Option<StateKey>) {
+        match self {
+            HotVacant { lru_info, .. } | HotOccupied { lru_info, .. } => lru_info.prev = prev,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn set_next(&mut self, next: Option<StateKey>) {
+        match self {
+            HotVacant { lru_info, .. } | HotOccupied { lru_info, .. } => lru_info.next = next,
+            _ => unreachable!(),
+        }
+    }
+
+    pub fn to_cold(self) -> Self {
+        assert!(self.is_hot());
+        match self {
+            HotVacant { .. } => ColdVacant,
+            HotOccupied {
+                value_version,
+                value,
+                ..
+            } => ColdOccupied {
+                value_version,
+                value,
+            },
+            _ => unreachable!(),
+        }
+    }
 }
+
+// 4 GiB
+pub const HOT_STATE_MAX_BYTES: usize = 4 * 1024 * 1024 * 1024;
+
+// 4 million items
+pub const HOT_STATE_MAX_ITEMS: usize = 1000; // 4_000_000;
+
+// 10KB, worst case the hot state still caches 400K items
+pub const HOT_STATE_MAX_SINGLE_VALUE_BYTES: usize = 10 * 1024;

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -178,10 +178,19 @@ impl PersistedStateValue {
     }
 }
 
-#[derive(BCSCryptoHash, Clone, CryptoHasher, Debug, Eq, PartialEq)]
+#[derive(BCSCryptoHash, Clone, CryptoHasher, Eq, PartialEq)]
 pub struct StateValue {
     data: Bytes,
     metadata: StateValueMetadata,
+}
+
+impl std::fmt::Debug for StateValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("StateValue")
+            .field("data", &"not shown(...)")
+            .field("metadata", &self.metadata)
+            .finish()
+    }
 }
 
 pub const ARB_STATE_VALUE_MAX_SIZE: usize = 100;

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -83,13 +83,26 @@ impl PersistedWriteOp {
 }
 
 /// Shared in memory representation between the (value) WriteOp and the (hotness) HotStateOp
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Eq, PartialEq)]
 pub enum BaseStateOp {
     Creation(StateValue),
     Modification(StateValue),
     Deletion(StateValueMetadata),
     MakeHot { prev_slot: StateSlot },
     Eviction { prev_slot: StateSlot },
+}
+
+impl std::fmt::Debug for BaseStateOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let var = match self {
+            Self::Creation(_) => "Creation(...)",
+            Self::Modification(_) => "Modification(...)",
+            Self::Deletion(_) => "Deletion(...)",
+            Self::MakeHot { .. } => "MakeHot",
+            Self::Eviction { .. } => "Eviction",
+        };
+        write!(f, "{}", var)
+    }
 }
 
 impl BaseStateOp {


### PR DESCRIPTION

This change implements an LRU updater that is similar to https://github.com/aptos-labs/aptos-core/blob/dd326acc00b5bd1d7e2fc45d5e36e90934a76fdc/storage/aptosdb/src/state_store/hot_state.rs#L286

The main difference is that this one works on speculative state. For example,
given the entire committed hot state (`committed`), and some blocks that have
been speculatively executed (`overlay`), this updater is able to compute the new
LRU entries when another block is added to the top.

The other one will later be deleted, because we have already computed the
updates to the LRU entries here, and `aptosdb/src/state_store/hot_state.rs` just
need to take and apply the updates instead of computing them again.

Only added a simple unit test for now. But we can add more later.

***
test (split later)
