### PR TITLE
Fix staking_rewards tracking in rosetta

### DIFF
--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -73,7 +73,7 @@ static SET_OPERATOR_EVENT_TAG: Lazy<TypeTag> =
 static UPDATE_VOTER_EVENT_TAG: Lazy<TypeTag> =
     Lazy::new(|| parse_type_tag("0x1::staking_contract::UpdateVoter").unwrap());
 static DISTRIBUTE_STAKING_REWARDS_TAG: Lazy<TypeTag> =
-    Lazy::new(|| parse_type_tag("0x1::stake::DistributeRewards").unwrap());
+    Lazy::new(|| parse_type_tag("0x1::staking_contract::Distribute").unwrap());
 static UPDATE_COMMISSION_TAG: Lazy<TypeTag> =
     Lazy::new(|| parse_type_tag("0x1::staking_contract::UpdateCommission").unwrap());
 


### PR DESCRIPTION
https://github.com/aptos-labs/aptos-core/commit/64f1810368640b3adfaf63f6c56d0340df476e8e assign DISTRIBUTE_STAKING_REWARDS_TAG with the wrong identifier.

## Description
Cherry pick of https://github.com/aptos-labs/aptos-core/pull/17044

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
