### PR TITLE
[hot state] Put lru pointers inside StateSlot

### DIFF
--- a/aptos-move/block-executor/src/hot_state_op_accumulator.rs
+++ b/aptos-move/block-executor/src/hot_state_op_accumulator.rs
@@ -95,7 +95,9 @@ where
                     COUNTER.inc_with(&["vacant_new"]);
                     true
                 },
-                StateSlot::HotVacant { hot_since_version } => {
+                StateSlot::HotVacant {
+                    hot_since_version, ..
+                } => {
                     if self.should_refresh(hot_since_version) {
                         COUNTER.inc_with(&["vacant_refresh"]);
                         true

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -9,7 +9,9 @@ use aptos_metrics_core::{IntCounterHelper, IntGaugeHelper, TimerHelper};
 use aptos_storage_interface::state_store::{
     state::State, state_view::hot_state_view::HotStateView, NUM_STATE_SHARDS,
 };
-use aptos_types::state_store::{hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot};
+use aptos_types::state_store::{
+    hot_state::THotStateSlot, state_key::StateKey, state_slot::StateSlot,
+};
 use arr_macro::arr;
 use dashmap::{
     mapref::one::{Ref, RefMut},
@@ -23,17 +25,11 @@ use std::sync::{
 const MAX_HOT_STATE_COMMIT_BACKLOG: usize = 10;
 
 #[derive(Debug)]
-struct Entry<K, V> {
-    data: V,
-    lru: LRUEntry<K>,
-}
-
-#[derive(Debug)]
 struct Shard<K, V>
 where
     K: Eq + std::hash::Hash,
 {
-    inner: DashMap<K, Entry<K, V>>,
+    inner: DashMap<K, V>,
 }
 
 impl<K, V> Shard<K, V>
@@ -50,19 +46,19 @@ where
         self.inner.contains_key(key)
     }
 
-    fn get(&self, key: &K) -> Option<Ref<K, Entry<K, V>>> {
+    fn get(&self, key: &K) -> Option<Ref<K, V>> {
         self.inner.get(key)
     }
 
-    fn get_mut(&self, key: &K) -> Option<RefMut<K, Entry<K, V>>> {
+    fn get_mut(&self, key: &K) -> Option<RefMut<K, V>> {
         self.inner.get_mut(key)
     }
 
-    fn insert(&self, key: K, entry: Entry<K, V>) {
-        self.inner.insert(key, entry);
+    fn insert(&self, key: K, value: V) {
+        self.inner.insert(key, value);
     }
 
-    fn remove(&self, key: &K) -> Option<(K, Entry<K, V>)> {
+    fn remove(&self, key: &K) -> Option<(K, V)> {
         self.inner.remove(key)
     }
 
@@ -103,7 +99,7 @@ where
         }
     }
 
-    fn get_from_shard(&self, shard_id: usize, key: &K) -> Option<Ref<K, Entry<K, V>>> {
+    fn get_from_shard(&self, shard_id: usize, key: &K) -> Option<Ref<K, V>> {
         self.shards[shard_id].get(key)
     }
 
@@ -115,14 +111,7 @@ where
 impl HotStateView for HotStateBase<StateKey, StateSlot> {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot> {
         let shard_id = state_key.get_shard_id();
-        self.get_from_shard(shard_id, state_key)
-            .map(|e| e.data.clone())
-    }
-
-    fn get_lru_entry(&self, state_key: &StateKey) -> Option<LRUEntry<StateKey>> {
-        let shard_id = state_key.get_shard_id();
-        self.get_from_shard(shard_id, state_key)
-            .map(|e| e.lru.clone())
+        self.get_from_shard(shard_id, state_key).map(|v| v.clone())
     }
 }
 
@@ -346,7 +335,7 @@ where
 impl<'a, K, V> LRUUpdater<'a, K, V>
 where
     K: Clone + std::fmt::Debug + Eq + std::hash::Hash,
-    V: Clone + std::fmt::Debug,
+    V: Clone + std::fmt::Debug + THotStateSlot<Key = K>,
 {
     fn new(
         shard: &'a Shard<K, V>,
@@ -385,38 +374,38 @@ where
             None => return None,
         };
 
-        match &old_entry.lru.prev {
+        match old_entry.prev() {
             Some(prev_key) => {
                 let mut prev_entry = self
                     .shard
                     .get_mut(prev_key)
                     .expect("The previous key must exist");
-                prev_entry.lru.next = old_entry.lru.next.clone();
+                prev_entry.set_next(old_entry.next().cloned());
             },
             None => {
                 // There is no newer entry. The current key was the head.
-                *self.head = old_entry.lru.next.clone();
+                *self.head = old_entry.next().cloned();
             },
         }
 
-        match &old_entry.lru.next {
+        match old_entry.next() {
             Some(next_key) => {
                 let mut next_entry = self
                     .shard
                     .get_mut(next_key)
                     .expect("The next key must exist.");
-                next_entry.lru.prev = old_entry.lru.prev;
+                next_entry.set_prev(old_entry.prev().cloned());
             },
             None => {
                 // There is no older entry. The current key was the tail.
-                *self.tail = old_entry.lru.prev;
+                *self.tail = old_entry.prev().cloned();
             },
         }
 
-        Some(old_entry.data)
+        Some(old_entry)
     }
 
-    fn insert_to_front(&mut self, key: K, value: V) {
+    fn insert_to_front(&mut self, key: K, mut value: V) {
         assert_eq!(self.head.is_some(), self.tail.is_some());
         match self.head.take() {
             Some(head) => {
@@ -424,27 +413,17 @@ where
                     // Release the reference to the old entry ASAP to avoid deadlock when inserting
                     // the new entry below.
                     let mut old_head_entry = self.shard.get_mut(&head).expect("Head must exist.");
-                    old_head_entry.lru.prev = Some(key.clone());
+                    old_head_entry.set_prev(Some(key.clone()));
                 }
-                let entry = Entry {
-                    data: value,
-                    lru: LRUEntry {
-                        prev: None,
-                        next: Some(head),
-                    },
-                };
-                self.shard.insert(key.clone(), entry);
+                value.set_prev(None);
+                value.set_next(Some(head));
+                self.shard.insert(key.clone(), value);
                 *self.head = Some(key);
             },
             None => {
-                let entry = Entry {
-                    data: value,
-                    lru: LRUEntry {
-                        prev: None,
-                        next: None,
-                    },
-                };
-                self.shard.insert(key.clone(), entry);
+                value.set_prev(None);
+                value.set_next(None);
+                self.shard.insert(key.clone(), value);
                 *self.head = Some(key.clone());
                 *self.tail = Some(key);
             },
@@ -477,10 +456,10 @@ where
         let mut current_key = self.head.clone();
         while let Some(key) = current_key {
             let entry = self.shard.get(&key).unwrap();
-            assert_eq!(entry.lru.prev, keys.last().cloned());
+            assert_eq!(entry.prev(), keys.last());
             keys.push(key);
-            values.push(entry.data.clone());
-            current_key = entry.lru.next.clone();
+            values.push(entry.clone());
+            current_key = entry.next().cloned();
         }
         itertools::zip_eq(keys, values).collect()
     }
@@ -488,16 +467,53 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::{LRUUpdater, Shard};
+    use super::{LRUUpdater, Shard, THotStateSlot};
     use lru::LruCache;
     use proptest::{collection::vec, option, prelude::*};
     use std::num::NonZeroUsize;
+
+    #[derive(Clone, Debug)]
+    struct TestSlot {
+        num: u64,
+        prev: Option<u32>,
+        next: Option<u32>,
+    }
+
+    impl TestSlot {
+        fn new(num: u64) -> Self {
+            Self {
+                num,
+                prev: None,
+                next: None,
+            }
+        }
+    }
+
+    impl THotStateSlot for TestSlot {
+        type Key = u32;
+
+        fn prev(&self) -> Option<&Self::Key> {
+            self.prev.as_ref()
+        }
+
+        fn next(&self) -> Option<&Self::Key> {
+            self.next.as_ref()
+        }
+
+        fn set_prev(&mut self, prev: Option<Self::Key>) {
+            self.prev = prev;
+        }
+
+        fn set_next(&mut self, next: Option<Self::Key>) {
+            self.next = next;
+        }
+    }
 
     proptest! {
         #[test]
         fn test_hot_state_lru(
             max_items in 1..10usize,
-            updates in vec((0..20u64, option::weighted(0.8, 0..1000u64)), 1..50),
+            updates in vec((0..20u32, option::weighted(0.8, 0..1000u64)), 1..50),
         ) {
             let shard = Shard::new(max_items);
             let mut head = None;
@@ -509,7 +525,7 @@ mod tests {
             for (key, value_opt) in updates {
                 match value_opt {
                     Some(value) => {
-                        updater.insert(key, value);
+                        updater.insert(key, TestSlot::new(value));
                         cache.put(key, value);
                     }
                     None => {
@@ -521,7 +537,10 @@ mod tests {
 
                 prop_assert_eq!(shard.len(), cache.len());
                 let items = updater.collect_all();
-                prop_assert_eq!(items, cache.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>());
+                prop_assert_eq!(
+                    items.into_iter().map(|(k, v)| (k, v.num)).collect::<Vec<_>>(),
+                    cache.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
+                );
             }
         }
     }

--- a/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/hot_state_view.rs
@@ -2,23 +2,17 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_types::state_store::{hot_state::LRUEntry, state_key::StateKey, state_slot::StateSlot};
+use aptos_types::state_store::{state_key::StateKey, state_slot::StateSlot};
 
 /// A view into the hot state store, whose content overlays on top of the cold state store content.
 pub trait HotStateView: Send + Sync {
     fn get_state_slot(&self, state_key: &StateKey) -> Option<StateSlot>;
-
-    fn get_lru_entry(&self, state_key: &StateKey) -> Option<LRUEntry<StateKey>>;
 }
 
 pub struct EmptyHotState;
 
 impl HotStateView for EmptyHotState {
     fn get_state_slot(&self, _state_key: &StateKey) -> Option<StateSlot> {
-        None
-    }
-
-    fn get_lru_entry(&self, _state_key: &StateKey) -> Option<LRUEntry<StateKey>> {
         None
     }
 }

--- a/storage/storage-interface/src/state_store/versioned_state_value.rs
+++ b/storage/storage-interface/src/state_store/versioned_state_value.rs
@@ -3,7 +3,9 @@
 
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_types::{
-    state_store::state_slot::StateSlot, transaction::Version, write_set::BaseStateOp,
+    state_store::{hot_state::LRUEntry, state_slot::StateSlot},
+    transaction::Version,
+    write_set::BaseStateOp,
 };
 
 #[derive(Clone, Debug)]
@@ -14,6 +16,7 @@ pub struct StateUpdateRef<'kv> {
 }
 
 impl StateUpdateRef<'_> {
+    /// NOTE: the lru_info in the result is not initialized yet.
     pub fn to_result_slot(&self) -> StateSlot {
         match self.state_op.clone() {
             BaseStateOp::Creation(value) | BaseStateOp::Modification(value) => {
@@ -21,19 +24,21 @@ impl StateUpdateRef<'_> {
                     value_version: self.version,
                     value,
                     hot_since_version: self.version,
+                    lru_info: LRUEntry::uninitialized(),
                 }
             },
             BaseStateOp::Deletion(_) => StateSlot::HotVacant {
                 hot_since_version: self.version,
+                lru_info: LRUEntry::uninitialized(),
             },
             BaseStateOp::MakeHot { prev_slot } => match prev_slot {
                 StateSlot::ColdVacant => StateSlot::HotVacant {
                     hot_since_version: self.version,
+                    lru_info: LRUEntry::uninitialized(),
                 },
-                StateSlot::HotVacant {
-                    hot_since_version: _,
-                } => StateSlot::HotVacant {
+                StateSlot::HotVacant { .. } => StateSlot::HotVacant {
                     hot_since_version: self.version,
+                    lru_info: LRUEntry::uninitialized(),
                 },
                 StateSlot::ColdOccupied {
                     value_version,
@@ -42,11 +47,12 @@ impl StateUpdateRef<'_> {
                 | StateSlot::HotOccupied {
                     value_version,
                     value,
-                    hot_since_version: _,
+                    ..
                 } => StateSlot::HotOccupied {
                     value_version,
                     value,
                     hot_since_version: self.version,
+                    lru_info: LRUEntry::uninitialized(),
                 },
             },
             BaseStateOp::Eviction { prev_slot } => match prev_slot {

--- a/types/src/state_store/hot_state.rs
+++ b/types/src/state_store/hot_state.rs
@@ -1,10 +1,31 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Eq, PartialEq)]
 pub struct LRUEntry<K> {
     /// The key that is slightly newer than the current entry. `None` for the newest entry.
     pub prev: Option<K>,
     /// The key that is slightly older than the current entry. `None` for the oldest entry.
     pub next: Option<K>,
+}
+
+impl<K> LRUEntry<K> {
+    pub fn uninitialized() -> Self {
+        Self {
+            prev: None,
+            next: None,
+        }
+    }
+}
+
+pub trait THotStateSlot {
+    type Key;
+
+    /// Returns the key that is slightly newer in the hot state.
+    fn prev(&self) -> Option<&Self::Key>;
+    /// Returns the key that is slightly older in the hot state.
+    fn next(&self) -> Option<&Self::Key>;
+
+    fn set_prev(&mut self, prev: Option<Self::Key>);
+    fn set_next(&mut self, next: Option<Self::Key>);
 }

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -2,7 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    state_store::{state_key::StateKey, state_value::StateValue},
+    state_store::{
+        hot_state::{LRUEntry, THotStateSlot},
+        state_key::StateKey,
+        state_value::StateValue,
+    },
     transaction::Version,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -20,6 +24,7 @@ pub enum StateSlot {
     ColdVacant,
     HotVacant {
         hot_since_version: Version,
+        lru_info: LRUEntry<StateKey>,
     },
     ColdOccupied {
         value_version: Version,
@@ -29,6 +34,7 @@ pub enum StateSlot {
         value_version: Version,
         value: StateValue,
         hot_since_version: Version,
+        lru_info: LRUEntry<StateKey>,
     },
 }
 
@@ -36,7 +42,9 @@ impl StateSlot {
     fn maybe_update_cold_state(&self, min_version: Version) -> Option<Option<&StateValue>> {
         match self {
             ColdVacant => Some(None),
-            HotVacant { hot_since_version } => {
+            HotVacant {
+                hot_since_version, ..
+            } => {
                 if *hot_since_version >= min_version {
                     // TODO(HotState): revisit after the hot state is exclusive with the cold state
                     // Can't tell if there was a deletion to the cold state here, not much harm to
@@ -55,7 +63,7 @@ impl StateSlot {
             | HotOccupied {
                 value_version,
                 value,
-                hot_since_version: _,
+                ..
             } => {
                 if *value_version >= min_version {
                     // an update happened at or after min_version, need to update
@@ -108,6 +116,10 @@ impl StateSlot {
         }
     }
 
+    pub fn is_hot(&self) -> bool {
+        !self.is_cold()
+    }
+
     pub fn is_cold(&self) -> bool {
         match self {
             ColdVacant | ColdOccupied { .. } => true,
@@ -151,6 +163,38 @@ impl StateSlot {
             ColdOccupied { value_version, .. } | HotOccupied { value_version, .. } => {
                 *value_version
             },
+        }
+    }
+}
+
+impl THotStateSlot for StateSlot {
+    type Key = StateKey;
+
+    fn prev(&self) -> Option<&Self::Key> {
+        match self {
+            HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.prev.as_ref(),
+            _ => panic!("Should not be called on cold slots."),
+        }
+    }
+
+    fn next(&self) -> Option<&Self::Key> {
+        match self {
+            HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.next.as_ref(),
+            _ => panic!("Should not be called on cold slots."),
+        }
+    }
+
+    fn set_prev(&mut self, prev: Option<Self::Key>) {
+        match self {
+            HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.prev = prev,
+            _ => panic!("Should not be called on cold slots."),
+        }
+    }
+
+    fn set_next(&mut self, next: Option<Self::Key>) {
+        match self {
+            HotOccupied { lru_info, .. } | HotVacant { lru_info, .. } => lru_info.next = next,
+            _ => panic!("Should not be called on cold slots."),
         }
     }
 }


### PR DESCRIPTION

The type of the speculative state is `Map<StateKey, StateSlot>`, having these
pointers inside `StateSlot` means that we do not need to change the current type
of the speculative state, or create a separate speculative state.
