### PR TITLE
Fix ordered_map::append_impl

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
@@ -1633,11 +1633,17 @@ to O(n).
 
 
 <pre><code><b>public</b>(<b>friend</b>) inline <b>fun</b> <a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>&lt;K: drop + <b>copy</b> + store, V: store&gt;(self: &<a href="big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">BigOrderedMap</a>&lt;K, V&gt;, f: |&K, &V|) {
-    self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_leaf_node_ref">for_each_leaf_node_ref</a>(|node| {
-        node.children.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>(|k: &K, v: &<a href="big_ordered_map.md#0x1_big_ordered_map_Child">Child</a>&lt;V&gt;| {
-            f(k, &v.value);
-        });
-    })
+    <b>let</b> iter = self.<a href="big_ordered_map.md#0x1_big_ordered_map_new_begin_iter">new_begin_iter</a>();
+    <b>while</b> (!iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_is_end">iter_is_end</a>(self)) {
+        f(iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_borrow_key">iter_borrow_key</a>(), iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_borrow">iter_borrow</a>(self));
+        iter = iter.<a href="big_ordered_map.md#0x1_big_ordered_map_iter_next">iter_next</a>(self);
+    };
+
+    // self.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_leaf_node_ref">for_each_leaf_node_ref</a>(|node| {
+    //     node.children.<a href="big_ordered_map.md#0x1_big_ordered_map_for_each_ref_friend">for_each_ref_friend</a>(|k: &K, v: &<a href="big_ordered_map.md#0x1_big_ordered_map_Child">Child</a>&lt;V&gt;| {
+    //         f(k, &v.value);
+    //     });
+    // })
 }
 </code></pre>
 

--- a/aptos-move/framework/aptos-framework/doc/ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/ordered_map.md
@@ -806,6 +806,16 @@ Takes all elements from <code>other</code> and adds them to <code>self</code>, r
             <b>if</b> (ord.is_eq()) {
                 // we skip the entries one, and below put in the result one from other.
                 overwritten.push_back(self.entries.<a href="ordered_map.md#0x1_ordered_map_pop_back">pop_back</a>());
+
+                <b>if</b> (cur_i == 0) {
+                    // make other_entries empty, and rest in entries.
+                    // TODO cannot <b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/mem.md#0x1_mem_swap">mem::swap</a> until it is <b>public</b>/released
+                    // <a href="../../aptos-stdlib/../move-stdlib/doc/mem.md#0x1_mem_swap">mem::swap</a>(&<b>mut</b> self.entries, &<b>mut</b> other_entries);
+                    self.entries.<a href="ordered_map.md#0x1_ordered_map_append">append</a>(other_entries);
+                    <b>break</b>;
+                } <b>else</b> {
+                    cur_i -= 1;
+                };
             };
 
             reverse_result.push_back(other_entries.<a href="ordered_map.md#0x1_ordered_map_pop_back">pop_back</a>());

--- a/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move
@@ -572,11 +572,17 @@ module aptos_std::big_ordered_map {
 
     // TODO: Temporary friend implementaiton, until for_each_ref can be made efficient.
     public(friend) inline fun for_each_ref_friend<K: drop + copy + store, V: store>(self: &BigOrderedMap<K, V>, f: |&K, &V|) {
-        self.for_each_leaf_node_ref(|node| {
-            node.children.for_each_ref_friend(|k: &K, v: &Child<V>| {
-                f(k, &v.value);
-            });
-        })
+        let iter = self.new_begin_iter();
+        while (!iter.iter_is_end(self)) {
+            f(iter.iter_borrow_key(), iter.iter_borrow(self));
+            iter = iter.iter_next(self);
+        };
+
+        // self.for_each_leaf_node_ref(|node| {
+        //     node.children.for_each_ref_friend(|k: &K, v: &Child<V>| {
+        //         f(k, &v.value);
+        //     });
+        // })
     }
 
     /// Apply the function to a mutable reference of each key-value pair in the map.

--- a/aptos-move/framework/aptos-framework/sources/datastructures/ordered_map.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/ordered_map.move
@@ -245,6 +245,16 @@ module aptos_std::ordered_map {
                 if (ord.is_eq()) {
                     // we skip the entries one, and below put in the result one from other.
                     overwritten.push_back(self.entries.pop_back());
+
+                    if (cur_i == 0) {
+                        // make other_entries empty, and rest in entries.
+                        // TODO cannot use mem::swap until it is public/released
+                        // mem::swap(&mut self.entries, &mut other_entries);
+                        self.entries.append(other_entries);
+                        break;
+                    } else {
+                        cur_i -= 1;
+                    };
                 };
 
                 reverse_result.push_back(other_entries.pop_back());
@@ -1225,6 +1235,30 @@ module aptos_std::ordered_map {
     public fun test_iter_add_abort_4() {
         let map = new_from(vector[1, 3, 5], vector[10, 30, 50]);
         map.new_begin_iter().iter_next(&map).iter_add(&mut map, 3, 25);
+    }
+
+    #[test]
+	public fun test_ordered_map_append_2() {
+        let map = new_from(vector[1, 2], vector[10, 20]);
+        let other = new_from(vector[1, 2], vector[100, 200]);
+        map.append(other);
+        assert!(map == new_from(vector[1, 2], vector[100, 200]));
+    }
+
+    #[test]
+	public fun test_ordered_map_append_3() {
+        let map = new_from(vector[1, 2, 3, 4, 5], vector[10, 20, 30, 40, 50]);
+        let other = new_from(vector[2, 4], vector[200, 400]);
+        map.append(other);
+        assert!(map == new_from(vector[1, 2, 3, 4, 5], vector[10, 200, 30, 400, 50]));
+    }
+
+    #[test]
+	public fun test_ordered_map_append_4() {
+        let map = new_from(vector[3, 4, 5, 6, 7], vector[30, 40, 50, 60, 70]);
+        let other = new_from(vector[1, 2, 4, 6], vector[100, 200, 400, 600]);
+        map.append(other);
+        assert!(map == new_from(vector[1, 2, 3, 4, 5, 6, 7], vector[100, 200, 30, 400, 50, 600, 70]));
     }
 
     #[test_only]


### PR DESCRIPTION
## Description

Fixing a bug in append_impl, where it would abort if there is overlap in the two maps being appended.

Found by OtterSec (@khokho), while reviewing a different feature - thanks!

It has no effect on BigOrderedMap, as it only uses append_disjoint - which aborts if there is overlap - so the effect is that abort is coming from a different place only.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
