### PR TITLE
[new move package] implement package cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12371,6 +12371,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-package-cache"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-framework",
+ "aptos-rest-client",
+ "fs2",
+ "futures",
+ "git2 0.16.1",
+ "hex",
+ "move-core-types",
+ "percent-encoding",
+ "tempfile",
+ "tokio",
+ "url",
+]
+
+[[package]]
 name = "move-package-manifest"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,7 @@ members = [
     "third_party/move/tools/move-disassembler",
     "third_party/move/tools/move-linter",
     "third_party/move/tools/move-package",
+    "third_party/move/tools/move-package-cache",
     "third_party/move/tools/move-package-manifest",
     "third_party/move/tools/move-resource-viewer",
     "third_party/move/tools/move-unit-test",
@@ -611,6 +612,7 @@ futures-channel = "0.3.29"
 futures-core = "0.3.29"
 futures-util = "0.3.29"
 fxhash = "0.2.1"
+fs2 = "0.4.3"
 getrandom = "0.2.2"
 gcp-bigquery-client = "0.16.8"
 get_if_addrs = "0.5.3"
@@ -861,6 +863,7 @@ move-ir-to-bytecode = { path = "third_party/move/move-ir-compiler/move-ir-to-byt
 move-linter = { path = "third_party/move/tools/move-linter" }
 move-model = { path = "third_party/move/move-model" }
 move-package = { path = "third_party/move/tools/move-package" }
+move-package-cache = { path = "third_party/move/tools/move-package-cache" }
 move-package-manifest = { path = "third_party/move/tools/move-package-manifest" }
 move-prover = { path = "third_party/move/move-prover" }
 move-prover-boogie-backend = { path = "third_party/move/move-prover/boogie-backend" }

--- a/third_party/move/tools/move-package-cache/Cargo.toml
+++ b/third_party/move/tools/move-package-cache/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "move-package-cache"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+fs2 = { workspace = true }
+futures = { workspace = true }
+git2 = { workspace = true }
+hex = { workspace = true }
+percent-encoding = { workspace = true }
+tempfile = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+
+move-core-types = { workspace = true }
+
+aptos-framework = { workspace = true }
+aptos-rest-client = { workspace = true }

--- a/third_party/move/tools/move-package-cache/src/canonical.rs
+++ b/third_party/move/tools/move-package-cache/src/canonical.rs
@@ -1,0 +1,129 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{anyhow, Result};
+use std::ops::Deref;
+use url::Url;
+
+/// Canonicalized identity of a git repository, derived from a [`Url`].
+/// - Ignores the scheme
+/// - Converts host & path to lowercase
+/// - Keeps port, but only if it is non-default
+/// - Trims trailing slashes and `.git` suffix
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct CanonicalGitIdentity(String);
+
+impl CanonicalGitIdentity {
+    pub fn new(git_url: &Url) -> Result<Self> {
+        let host = git_url
+            .host_str()
+            .ok_or_else(|| anyhow!("invalid git URL, unable to extract host: {}", git_url))?
+            .to_ascii_lowercase();
+
+        let port = match git_url.port() {
+            Some(port) => match (git_url.scheme(), port) {
+                ("http", 80) | ("https", 443) | ("ssh", 22) => "".to_string(),
+                _ => format!(":{}", port),
+            },
+            None => "".to_string(),
+        };
+
+        let path = git_url.path().to_ascii_lowercase();
+        let path = path.trim_end_matches("/").trim_end_matches(".git");
+
+        Ok(Self(format!("{}{}{}", host, port, path)))
+    }
+}
+
+impl Deref for CanonicalGitIdentity {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[test]
+fn test_canonical_git_identity() {
+    let canonical = "github.com/foo/bar";
+
+    for url in [
+        "https://github.com/foo/bar.git",
+        "https://github.com/foo/bar/",
+        "https://github.com/foo/bar.git/",
+        "https://GITHUB.com/foo/bar",
+        "https://github.com/Foo/bar",
+        "ssh://github.com/Foo/bar",
+    ] {
+        assert_eq!(
+            &*CanonicalGitIdentity::new(&Url::parse(url).unwrap()).unwrap(),
+            canonical
+        );
+    }
+
+    #[allow(clippy::single_element_loop)]
+    for url in ["https://github.com/foo/bar.git/abc"] {
+        assert_ne!(
+            &*CanonicalGitIdentity::new(&Url::parse(url).unwrap()).unwrap(),
+            canonical
+        );
+    }
+}
+
+/// Canonicalized identity of a node, derived from a [`Url`].
+/// - Ignores the scheme
+/// - Converts host & path to lowercase
+/// - Keeps port, but only if it is non-default
+/// - Trims trailing slashes
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct CanonicalNodeIdentity(String);
+
+impl CanonicalNodeIdentity {
+    pub fn new(node_url: &Url) -> Result<Self> {
+        let host = node_url
+            .host_str()
+            .ok_or_else(|| anyhow!("invalid node URL, unable to extract host: {}", node_url))?
+            .to_ascii_lowercase();
+
+        let port = match node_url.port() {
+            Some(port) => match (node_url.scheme(), port) {
+                ("http", 80) | ("https", 443) => "".to_string(),
+                _ => format!(":{}", port),
+            },
+            None => "".to_string(),
+        };
+
+        let path = node_url.path().to_ascii_lowercase();
+        let path = path.trim_end_matches("/");
+
+        Ok(Self(format!("{}{}{}", host, port, path)))
+    }
+}
+
+impl Deref for CanonicalNodeIdentity {
+    type Target = str;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+#[test]
+fn test_canonical_node_url() {
+    let canonical = "node.com";
+
+    for url in ["https://node.com", "https://node.com/", "https://nOdE.com"] {
+        assert_eq!(
+            &*CanonicalNodeIdentity::new(&Url::parse(url).unwrap()).unwrap(),
+            canonical
+        );
+    }
+
+    let canonical = "node.com:1234/foo";
+    for url in ["https://NODE.com:1234/foo", "https://node.com:1234/foo/"] {
+        assert_eq!(
+            &*CanonicalNodeIdentity::new(&Url::parse(url).unwrap()).unwrap(),
+            canonical
+        );
+    }
+}

--- a/third_party/move/tools/move-package-cache/src/file_lock.rs
+++ b/third_party/move/tools/move-package-cache/src/file_lock.rs
@@ -1,0 +1,77 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use fs2::FileExt;
+use futures::FutureExt;
+use std::{
+    fs::{self, File},
+    mem,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tokio::{pin, select, task};
+
+/// A file-based lock to ensure exclusive access to certain resources.
+///
+/// This is used by the package cache to ensure only one process can mutate a cached repo, checkout,
+/// or on-chain package at a time.
+pub struct FileLock {
+    file: Option<File>,
+    path: PathBuf,
+}
+
+impl FileLock {
+    /// Attempts to acquire an exclusive `FileLock`, with an optional alert callback.
+    ///
+    /// If the lock cannot be acquired within `alert_timeout`, the `alert_on_wait` callback
+    /// is executed to notify the caller.
+    pub async fn lock_with_alert_on_wait<P, F>(
+        lock_path: P,
+        alert_timeout: Duration,
+        alert_on_wait: F,
+    ) -> Result<Self>
+    where
+        P: AsRef<Path>,
+        F: FnOnce(),
+    {
+        let lock_path = lock_path.as_ref().to_owned();
+
+        let lock_fut = {
+            let lock_path = lock_path.clone();
+
+            task::spawn_blocking(move || -> Result<File> {
+                let lock_file = File::create(&lock_path)?;
+                lock_file.lock_exclusive()?;
+                Ok(lock_file)
+            })
+        };
+
+        let timeout = tokio::time::sleep(alert_timeout).fuse();
+
+        pin!(lock_fut, timeout);
+
+        let lock_file = select! {
+            _ = &mut timeout => {
+                alert_on_wait();
+                lock_fut.await??
+            },
+            res = &mut lock_fut => res??,
+        };
+
+        Ok(Self {
+            file: Some(lock_file),
+            path: lock_path,
+        })
+    }
+}
+
+impl Drop for FileLock {
+    /// Automatically releases the lock and removes the lock file when dropped.
+    /// This makes the lock easy to use -- exclusive access is guaranteed as long as the lock is alive.
+    fn drop(&mut self) {
+        let file = self.file.take().expect("this should always succeed");
+        mem::drop(file);
+        _ = fs::remove_file(&self.path); // Best effort
+    }
+}

--- a/third_party/move/tools/move-package-cache/src/lib.rs
+++ b/third_party/move/tools/move-package-cache/src/lib.rs
@@ -1,0 +1,48 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Move Package Cache
+//!
+//! The Package Cache is a component of the Move package system, responsible for downloading,
+//! indexing, and storing all remote dependencies (Git repositories and on-chain packages) in a local,
+//! globally accessible directory.
+//!
+//! It is implemented as a modular library and is intended to be used by other tools in the
+//! Move ecosystem, such as the package resolver.
+//!
+//! ## Storage Layout
+//!
+//! The package cache manages two types of dependencies:
+//! - **Git repositories** (`git/`): Full Git repositories and immutable checkouts at specific commits
+//! - **On-chain packages** (`on-chain/`): Bytecode packages from the blockchain
+//!
+//! ```plaintext
+//! .
+//! ├── git
+//! │   ├── checkouts/     # Immutable snapshots at specific commits
+//! │   └── repos/         # Full Git repositories
+//! └── on-chain/          # Fetched bytecode packages
+//! ```
+//!
+//! ## Concurrency & Safety
+//!
+//! The package cache is designed to allow safe concurrent access:
+//! - **File-based locking** for each repository, checkout, and package
+//! - **Atomic directory renaming** to prevent visibility of incomplete data
+//! - **Async operations** for high concurrency and non-blocking I/O
+//!
+//! ## Event Notifications
+//!
+//! Listener APIs are provided to allow clients to subscribe to events for progress tracking,
+//! such as file lock acquisition, repository cloning and package downloads.
+//
+//! This is particularly useful for CLI tools to provide visual feedback and reassure users
+//! that the tool is still actively progressing.
+
+mod canonical;
+mod file_lock;
+mod listener;
+mod package_cache;
+
+pub use listener::{DebugPackageCacheListener, EmptyPackageCacheListener, PackageCacheListener};
+pub use package_cache::PackageCache;

--- a/third_party/move/tools/move-package-cache/src/listener.rs
+++ b/third_party/move/tools/move-package-cache/src/listener.rs
@@ -1,0 +1,130 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_framework::natives::code::PackageMetadata;
+use move_core_types::account_address::AccountAddress;
+use std::path::Path;
+
+/// Trait for subscribing to package cache events.
+///
+/// This allows clients to receive notifications about various operations happening
+/// in the package cache, such as repository cloning, package downloads, and file
+/// lock acquisitions. Useful for providing visual feedback to users, debugging,
+/// and collecting telemetry data.
+///
+/// Visual feedback is particularly important to reassure users that the tool is
+/// actively working and not stalled during long-running operations.
+#[allow(unused_variables)]
+pub trait PackageCacheListener: Sync {
+    fn on_file_lock_wait(&self, lock_path: &Path) {}
+    fn on_file_lock_acquired(&self, lock_path: &Path) {}
+
+    fn on_repo_update_start(&self, repo_url: &str) {}
+    fn on_repo_update_complete(&self, repo_url: &str) {}
+    fn on_repo_clone_start(&self, repo_url: &str) {}
+    fn on_repo_clone_complete(&self, repo_url: &str) {}
+    fn on_repo_receive_object(&self, repo_url: &str, received: usize, total: usize) {}
+
+    fn on_repo_checkout(&self, repo_url: &str, commit_id: &[u8]) {}
+
+    fn on_bytecode_package_download_start(&self, address: AccountAddress, package_name: &str) {}
+    fn on_bytecode_package_receive_metadata(
+        &self,
+        address: AccountAddress,
+        package_metadata: &PackageMetadata,
+    ) {
+    }
+    fn on_bytecode_package_receive_module(
+        &self,
+        address: AccountAddress,
+        package_name: &str,
+        module_name: &str,
+    ) {
+    }
+    fn on_bytecode_package_download_complete(&self, address: AccountAddress, package_name: &str) {}
+}
+
+/// A no-op implementation of `PackageCacheListener`.
+///
+/// This can be used when no event notifications are needed.
+pub struct EmptyPackageCacheListener;
+
+impl PackageCacheListener for EmptyPackageCacheListener {}
+
+/// A debug implementation of `PackageCacheListener` that prints all events to stdout,
+/// used mainly for debugging and development.
+pub struct DebugPackageCacheListener;
+
+impl PackageCacheListener for DebugPackageCacheListener {
+    fn on_file_lock_wait(&self, lock_path: &Path) {
+        println!("waiting for repo lock {}", lock_path.display())
+    }
+
+    fn on_file_lock_acquired(&self, lock_path: &Path) {
+        println!("lock acquired {}", lock_path.display())
+    }
+
+    fn on_repo_clone_start(&self, repo_url: &str) {
+        println!("cloning {}", repo_url)
+    }
+
+    fn on_repo_clone_complete(&self, repo_url: &str) {
+        println!("cloned {}", repo_url)
+    }
+
+    fn on_repo_update_start(&self, repo_url: &str) {
+        println!("updating {}", repo_url)
+    }
+
+    fn on_repo_update_complete(&self, repo_url: &str) {
+        println!("updated {}", repo_url)
+    }
+
+    fn on_repo_receive_object(&self, repo_url: &str, received: usize, total: usize) {
+        println!("repo {}, received {}/{} objects", repo_url, received, total);
+    }
+
+    fn on_repo_checkout(&self, repo_url: &str, commit_id: &[u8]) {
+        println!("checking out {}@{}", repo_url, hex::encode(commit_id))
+    }
+
+    fn on_bytecode_package_download_start(&self, address: AccountAddress, package_name: &str) {
+        println!("downloading bytecode package {}::{}", address, package_name)
+    }
+
+    fn on_bytecode_package_receive_metadata(
+        &self,
+        address: AccountAddress,
+        package_metadata: &PackageMetadata,
+    ) {
+        println!(
+            "received metadata for package {}::{}",
+            address, package_metadata.name
+        );
+        println!("  upgrade number: {}", package_metadata.upgrade_number);
+        println!(
+            "  upgrade policy: {}",
+            package_metadata.upgrade_policy.policy
+        );
+        println!("  modules:");
+        for module in &package_metadata.modules {
+            println!("    {}", module.name);
+        }
+    }
+
+    fn on_bytecode_package_receive_module(
+        &self,
+        address: AccountAddress,
+        package_name: &str,
+        module_name: &str,
+    ) {
+        println!(
+            "downloaded bytecode module {}::{}::{}",
+            address, package_name, module_name
+        )
+    }
+
+    fn on_bytecode_package_download_complete(&self, address: AccountAddress, package_name: &str) {
+        println!("downloaded bytecode package {}::{}", address, package_name)
+    }
+}

--- a/third_party/move/tools/move-package-cache/src/main.rs
+++ b/third_party/move/tools/move-package-cache/src/main.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use move_core_types::account_address::AccountAddress;
+use move_package_cache::{DebugPackageCacheListener, PackageCache};
+use std::str::FromStr;
+use url::Url;
+
+// Note: this is just sample workflow demonstrating how the package cache can be used as a library.
+// It will likely be removed later as the package cache is intended to be integrated into
+// other tools rather than used as a standalone executable.
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let cache = PackageCache::new_with_listener("./data", DebugPackageCacheListener).unwrap();
+
+    let aptos_framework_url =
+        Url::from_str("https://github.com/aptos-labs/aptos-framework").unwrap();
+
+    let oid = cache
+        .resolve_git_revision(&aptos_framework_url, "main")
+        .await?;
+    cache.checkout_git_repo(&aptos_framework_url, oid).await?;
+
+    cache
+        .fetch_on_chain_package(
+            Url::from_str("https://fullnode.mainnet.aptoslabs.com").unwrap(),
+            3022354983,
+            AccountAddress::ONE,
+            "MoveStdlib",
+        )
+        .await?;
+
+    Ok(())
+}

--- a/third_party/move/tools/move-package-cache/src/package_cache.rs
+++ b/third_party/move/tools/move-package-cache/src/package_cache.rs
@@ -1,0 +1,393 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    canonical::{CanonicalGitIdentity, CanonicalNodeIdentity},
+    file_lock::FileLock,
+    listener::{EmptyPackageCacheListener, PackageCacheListener},
+};
+use anyhow::{bail, Result};
+use aptos_framework::natives::code::PackageRegistry;
+use futures::future;
+use git2::{
+    build::RepoBuilder, FetchOptions, ObjectType, Oid, RemoteCallbacks, Repository, TreeWalkResult,
+};
+use move_core_types::account_address::AccountAddress;
+use percent_encoding::{AsciiSet, CONTROLS};
+use std::{
+    fs::{self, File},
+    io::Write,
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use url::Url;
+
+/// Removes a directory if it exists, ignoring "directory not found" errors.
+fn remove_dir_if_exists(path: &Path) -> std::io::Result<()> {
+    match fs::remove_dir_all(path) {
+        Ok(()) => Ok(()),
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(err) => Err(err),
+    }
+}
+
+/// A Move package cache that manages Git repositories and on-chain packages.
+///
+/// The cache provides async APIs for fetching and storing remote dependencies.
+/// Safe concurrent access is provided through file-based locking.
+pub struct PackageCache<L> {
+    root: PathBuf,
+    listener: L,
+}
+
+/// An opened Git repository with an active file lock.
+///
+/// This serves two purposes:
+/// 1. Provides access to the contents of an opened repo
+/// 2. Holds a file lock that prevents other package cache instances from accessing
+///    the repository while this `ActiveRepository` is still alive
+pub struct ActiveRepository {
+    repo: Repository,
+
+    #[allow(dead_code)]
+    lock: FileLock,
+}
+
+impl PackageCache<EmptyPackageCacheListener> {
+    /// Creates a new package cache with a no-op listener.
+    pub fn new(root: impl AsRef<Path>) -> Result<Self> {
+        Self::new_with_listener(root, EmptyPackageCacheListener)
+    }
+}
+
+fn percent_encode_for_filename(s: &str) -> String {
+    const ASCII_SET: AsciiSet = CONTROLS
+        .add(b'<')
+        .add(b'>')
+        .add(b':')
+        .add(b'"')
+        .add(b'/')
+        .add(b'\\')
+        .add(b'/')
+        .add(b'|')
+        .add(b'?')
+        .add(b'*');
+
+    percent_encoding::utf8_percent_encode(s, &ASCII_SET).to_string()
+}
+
+impl<L> PackageCache<L> {
+    /// Creates a new package cache with a custom listener.
+    pub fn new_with_listener(root: impl AsRef<Path>, listener: L) -> Result<Self> {
+        let root = root.as_ref().to_owned();
+
+        fs::create_dir_all(&root)?;
+
+        Ok(PackageCache { root, listener })
+    }
+
+    /// Clones or updates a Git repository, ensuring it is available locally with up-to-date data.
+    ///
+    /// Returns an `ActiveRepository` object. This can be used to access the contents of the repo, and while
+    /// is still alive, a lock is held to prevent other package cache instances to access the repo.
+    async fn clone_or_update_git_repo(&self, git_url: &Url) -> Result<ActiveRepository>
+    where
+        L: PackageCacheListener,
+    {
+        let repo_dir_name = percent_encode_for_filename(&CanonicalGitIdentity::new(git_url)?);
+        let repos_path = self.root.join("git").join("repos");
+        let repo_path = repos_path.join(&repo_dir_name);
+
+        println!("{}", repo_path.display());
+
+        // First, acquire a file lock to ensure exclusive write access to the cached repo.
+        let lock_path = repo_path.with_extension("lock");
+
+        fs::create_dir_all(&repos_path)?;
+        let file_lock =
+            FileLock::lock_with_alert_on_wait(&lock_path, Duration::from_millis(1000), || {
+                self.listener.on_file_lock_wait(&lock_path);
+            })
+            .await?;
+
+        // Next, ensure that we have an up-to-date clone of the repo locally.
+        //
+        // Before performing the actual operation, we need to configure the fetch options
+        // (shared by both clone and update).
+        let mut cbs = RemoteCallbacks::new();
+        let mut received = 0;
+        cbs.transfer_progress(move |stats| {
+            let received_new = stats.received_objects();
+
+            if received_new != received {
+                received = received_new;
+
+                self.listener.on_repo_receive_object(
+                    git_url.as_str(),
+                    stats.received_objects(),
+                    stats.total_objects(),
+                );
+            }
+
+            true
+        });
+        let mut fetch_options = FetchOptions::new();
+        fetch_options.remote_callbacks(cbs);
+
+        let repo = if repo_path.exists() {
+            // If the repo already exists, update it.
+            self.listener.on_repo_update_start(git_url.as_str());
+
+            let repo = Repository::open_bare(&repo_path)?;
+            {
+                let mut remote = repo.find_remote("origin")?;
+                remote.fetch(
+                    &["refs/heads/*:refs/remotes/origin/*"],
+                    Some(&mut fetch_options),
+                    None,
+                )?;
+            }
+
+            self.listener.on_repo_update_complete(git_url.as_str());
+
+            repo
+        } else {
+            // If the repo does not exist, clone it.
+            let mut repo_builder = RepoBuilder::new();
+            repo_builder.fetch_options(fetch_options);
+            repo_builder.bare(true);
+
+            self.listener.on_repo_clone_start(git_url.as_str());
+            let repo = repo_builder.clone(git_url.as_str(), &repo_path)?;
+            self.listener.on_repo_clone_complete(git_url.as_str());
+
+            repo
+        };
+
+        Ok(ActiveRepository {
+            repo,
+            lock: file_lock,
+        })
+    }
+
+    /// Resolves a Git revision string to a specific commit id.
+    ///
+    /// This will clone the repo if it is not already cached, or update it if it is.
+    pub async fn resolve_git_revision(&self, git_url: &Url, rev: &str) -> Result<Oid>
+    where
+        L: PackageCacheListener,
+    {
+        let repo = self.clone_or_update_git_repo(git_url).await?;
+
+        let obj = repo.repo.revparse_single(&format!("origin/{}", rev))?;
+        let oid = obj.id();
+
+        Ok(oid)
+    }
+
+    /// Checks out a commit of a Git repository and returns the path to the checkout.
+    ///
+    /// A checkout is an immutable snapshot of a repository at a specific commit.
+    /// If a checkout already exists, the existing path is returned.
+    pub async fn checkout_git_repo(&self, git_url: &Url, oid: Oid) -> Result<PathBuf>
+    where
+        L: PackageCacheListener,
+    {
+        let repo_dir_name = percent_encode_for_filename(&CanonicalGitIdentity::new(git_url)?);
+        let checkouts_path = self.root.join("git").join("checkouts");
+
+        // Check if a checkout already exists for this commit.
+        let checkout_path = checkouts_path.join(format!("{}@{}", repo_dir_name, oid));
+        if checkout_path.exists() {
+            return Ok(checkout_path);
+        }
+
+        // Checkout does not exist -- need to create one.
+        //
+        // However before we do that, we need to make sure the repo is cloned to the local
+        // file system and updated.
+        let repo = self.clone_or_update_git_repo(git_url).await?;
+
+        // Acquire a file lock to ensure exclusive write access to the checkout.
+        let lock_path = checkout_path.with_extension("lock");
+
+        fs::create_dir_all(&checkouts_path)?;
+        let _file_lock =
+            FileLock::lock_with_alert_on_wait(&lock_path, Duration::from_millis(1000), || {
+                self.listener.on_file_lock_wait(&lock_path);
+            })
+            .await?;
+
+        self.listener
+            .on_repo_checkout(git_url.as_str(), oid.as_bytes());
+
+        // Create the files from the commit.
+        //
+        // The files stored into a temporary directory, and then the temporary directory
+        // is atomically renamed/moved to the destination.
+        //
+        // This is to ensure we only expose complete checkouts.
+        let temp = tempfile::tempdir_in(&checkouts_path)?;
+
+        let commit = repo.repo.find_commit(oid)?;
+        let tree = commit.tree()?;
+
+        tree.walk(git2::TreeWalkMode::PreOrder, |root, entry| {
+            let name = entry.name().unwrap_or("");
+            let full_path = temp.path().join(format!("{}{}", root, name));
+
+            match entry.kind() {
+                Some(ObjectType::Blob) => {
+                    let blob = repo.repo.find_blob(entry.id()).unwrap();
+                    fs::create_dir_all(full_path.parent().unwrap()).unwrap();
+                    let mut file = File::create(&full_path).unwrap();
+                    file.write_all(blob.content()).unwrap();
+                },
+                Some(ObjectType::Tree) => (),
+                _ => {},
+            }
+
+            TreeWalkResult::Ok
+        })?;
+
+        remove_dir_if_exists(&checkout_path)?;
+        fs::rename(temp.into_path(), &checkout_path)?;
+
+        Ok(checkout_path)
+    }
+
+    /// Fetches an on-chain package from the specified network and version and stores it locally.
+    /// Returns the path to the cached package.
+    ///
+    /// The cached package currently only contains the bytecode modules, but may be extended with
+    /// additional metadata in the future.
+    pub async fn fetch_on_chain_package(
+        &self,
+        fullnode_url: Url,
+        network_version: u64,
+        address: AccountAddress,
+        package_name: &str,
+    ) -> Result<PathBuf>
+    where
+        L: PackageCacheListener,
+    {
+        let on_chain_packages_path = self.root.join("on-chain");
+
+        let canonical_node_identity = CanonicalNodeIdentity::new(&fullnode_url)?;
+        let canonical_name = format!(
+            "{}+{}+{}+{}",
+            &*canonical_node_identity, network_version, address, package_name
+        );
+
+        let cached_package_path = on_chain_packages_path.join(&canonical_name);
+
+        // If the package directory already exists, assume it has been cached.
+        if cached_package_path.exists() {
+            // TODO: In the future, consider verifying data integrity,
+            //       e.g. hash of metadata or full contents.
+            return Ok(cached_package_path);
+        }
+
+        // Package directory does not exist -- need to download the package and cache it.
+        //
+        // First, acquire a lock to ensure exclusive write access to this package.
+        let lock_path = cached_package_path.with_extension("lock");
+
+        fs::create_dir_all(&on_chain_packages_path)?;
+        let _file_lock =
+            FileLock::lock_with_alert_on_wait(&lock_path, Duration::from_millis(1000), || {
+                self.listener.on_file_lock_wait(&lock_path);
+            })
+            .await?;
+
+        self.listener.on_file_lock_acquired(&lock_path);
+
+        // After acquiring the lock, re-check if the package was already cached by another process.
+        if cached_package_path.exists() {
+            return Ok(cached_package_path);
+        }
+
+        // Fetch the on-chain package registry at the specified ledger version and look-up the
+        // package by name.
+        self.listener
+            .on_bytecode_package_download_start(address, package_name);
+
+        let client = aptos_rest_client::Client::new(fullnode_url.clone());
+
+        let package_registry = client
+            .get_account_resource_at_version_bcs::<PackageRegistry>(
+                address,
+                "0x1::code::PackageRegistry",
+                network_version,
+            )
+            .await?
+            .into_inner();
+
+        let package = match package_registry
+            .packages
+            .iter()
+            .find(|package_metadata| package_metadata.name == package_name)
+        {
+            Some(package) => package,
+            None => bail!(
+                "package not found: {}//{}::{}",
+                fullnode_url,
+                address,
+                package_name
+            ),
+        };
+
+        self.listener
+            .on_bytecode_package_receive_metadata(address, package);
+
+        // Download all modules of the package concurrently.
+        //
+        // The downloaded files are first saved into a temporary directory, and then
+        // the temporary directory is atomically renamed/moved to the destination.
+        // This is to ensure we only expose complete downloads.
+        let temp = tempfile::tempdir_in(&on_chain_packages_path)?;
+
+        let fetch_futures = package.modules.iter().map(|module| {
+            let client = client.clone();
+            let temp_path = temp.path().to_owned();
+            let package_name = package_name.to_string();
+            let module_name = module.name.clone();
+
+            async move {
+                let module_bytes = client
+                    .get_account_module_bcs_at_version(address, &module_name, network_version)
+                    .await?
+                    .into_inner();
+
+                let module_file_path = temp_path.join(&module_name).with_extension("mv");
+
+                // Use blocking file write in spawn_blocking to avoid blocking the async runtime
+                tokio::task::spawn_blocking(move || {
+                    fs::create_dir_all(module_file_path.parent().unwrap())?;
+                    let mut file = File::create(&module_file_path)?;
+                    file.write_all(&module_bytes)?;
+                    Ok::<(), std::io::Error>(())
+                })
+                .await??;
+
+                // Notify listener after writing
+                self.listener.on_bytecode_package_receive_module(
+                    address,
+                    &package_name,
+                    &module_name,
+                );
+                Ok::<(), anyhow::Error>(())
+            }
+        });
+
+        future::try_join_all(fetch_futures).await?;
+
+        remove_dir_if_exists(&cached_package_path)?;
+        fs::rename(temp.into_path(), cached_package_path)?;
+
+        self.listener
+            .on_bytecode_package_download_complete(address, package_name);
+
+        Ok(PathBuf::new())
+    }
+}


### PR DESCRIPTION
This implements the Move Package Cache, a component of the next-gen package system.

It is responsible for downloading, indexing, and storing all remote dependencies (Git repositories and on-chain packages) in a local globally accessible directory.

The package cache is implemented as a modular library and is intended to be used by other tools in the Move ecosystem, such as the package resolver.

## Storage Layout

The package cache manages two types of dependencies:
- **Git repositories** (`git/`): Full Git repositories and immutable checkouts at specific commits
- **On-chain packages** (`on-chain/`): Bytecode packages from the blockchain

```
.
├── git
│   ├── checkouts/     # Immutable snapshots at specific commits
│   └── repos/         # Full Git repositories
└── on-chain/          # Fetched bytecode packages
```

## Concurrency & Safety

The package cache is designed to allow safe concurrent access:
- **File-based locking** for each repository, checkout, and package
- **Atomic directory renaming** to prevent visibility of incomplete data
- **Async operations** for high concurrency and non-blocking I/O

## Event Notifications

Listener APIs are provided to allow clients to subscribe to events for progress tracking, such as file lock acquisition, repository cloning and package downloads.

This is particularly useful for CLI tools to provide visual feedback and reassure users that the tool is still actively progressing.
