### PR TITLE
Adjust resources for replay-verify

### DIFF
--- a/testsuite/replay-verify/replay-verify-worker-template.yaml
+++ b/testsuite/replay-verify/replay-verify-worker-template.yaml
@@ -23,21 +23,26 @@ spec:
           value: "info"
       resources:
         requests:
-          memory: "110Gi"
-          cpu: "28"
-        limits:
-          memory: "110Gi"
+          memory: "100Gi"
           cpu: "28"
   volumes:
     - name: archive
       persistentVolumeClaim:
         claimName: testnet-archive-9
+  tolerations:
+  - key: aptos-workload
+    operator: Equal
+    value: "replay-verify"
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
         nodeSelectorTerms:
           - matchExpressions:
-              - key: cloud.google.com/machine-family
-                operator: In
-                values:
-                  - c3d
+            - key: cloud.google.com/machine-family
+              operator: In
+              values:
+              - "c3d"
+            - key: node-restriction.kubernetes.io/aptos-workload
+              operator: In
+              values:
+              - "replay-verify"


### PR DESCRIPTION
## Description

Remove resource limit to allow getting as much as possible if available on the instance.
Schedule on a dedicated node pool, and oversubscribe each instance to
take advantage of running without limits.
Increase the replay parallelism to be higher than core count.
Remove some noisy logging that caused the Github UI to freeze. 
