### PR TITLE
[move-asm] Struct and enum related features

### DIFF
--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -439,8 +439,6 @@ pub trait MoveTestAdapter<'a>: Sized {
                     },
                     SyntaxChoice::ASM => {
                         // TODO(#16582): generate source info for .masm file
-                        self.compiled_state()
-                            .add_and_generate_interface_file(module);
                     },
                 };
                 Ok(merge_output(warnings_opt, output))

--- a/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/framework.rs
@@ -439,6 +439,8 @@ pub trait MoveTestAdapter<'a>: Sized {
                     },
                     SyntaxChoice::ASM => {
                         // TODO(#16582): generate source info for .masm file
+                        self.compiled_state()
+                            .add_without_source_file(named_addr_opt, module);
                     },
                 };
                 Ok(merge_output(warnings_opt, output))
@@ -684,6 +686,25 @@ impl<'a> CompiledState<'a> {
         let processed = ProcessedModule {
             module,
             source_file: Some(source_file),
+        };
+        self.modules.insert(id, processed);
+    }
+
+    pub fn add_without_source_file(
+        &mut self,
+        named_addr_opt: Option<Symbol>,
+        module: CompiledModule,
+    ) {
+        let id = module.self_id();
+        self.check_not_precompiled(&id);
+        if let Some(named_addr) = named_addr_opt {
+            self.compiled_module_named_address_mapping
+                .insert(id.clone(), named_addr);
+        }
+
+        let processed = ProcessedModule {
+            module,
+            source_file: None,
         };
         self.modules.insert(id, processed);
     }

--- a/third_party/move/tools/move-asm/src/assembler.rs
+++ b/third_party/move/tools/move-asm/src/assembler.rs
@@ -8,16 +8,19 @@ use crate::{
     module_builder::{ModuleBuilder, ModuleBuilderOptions},
     syntax,
     syntax::{
-        map_diag, Argument, AsmResult, Diag, Fun, Instruction, Loc, Local, Type, Unit, UnitId,
-        Value,
+        map_diag, Argument, AsmResult, Decl, Diag, Fun, Instruction, Loc, PartialIdent, Struct,
+        StructLayout, Type, Unit, UnitId, Value,
     },
     ModuleOrScript,
 };
 use either::Either;
 use move_binary_format::{
     file_format::{
-        Bytecode, CodeOffset, FunctionDefinitionIndex, FunctionHandleIndex, LocalIndex,
-        SignatureIndex, SignatureToken, TableIndex,
+        Bytecode, CodeOffset, FieldDefinition, FieldHandleIndex, FieldInstantiationIndex,
+        FunctionDefinitionIndex, FunctionHandleIndex, LocalIndex, SignatureIndex, SignatureToken,
+        StructDefInstantiationIndex, StructDefinitionIndex, StructFieldInformation,
+        StructVariantHandleIndex, StructVariantInstantiationIndex, TableIndex, TypeSignature,
+        VariantDefinition, VariantFieldHandleIndex, VariantFieldInstantiationIndex,
     },
     CompiledModule,
 };
@@ -28,10 +31,10 @@ struct Assembler<'a> {
     builder: ModuleBuilder<'a>,
     diags: Vec<Diag>,
     /// Context available during processing of a function.
-    fun_context: Option<FunctionContext>,
+    resolution_context: Option<ResolutionContext>,
 }
 
-struct FunctionContext {
+struct ResolutionContext {
     ty_param_map: BTreeMap<String, u16>,
     local_map: BTreeMap<String, (LocalIndex, SignatureToken)>,
 }
@@ -44,7 +47,7 @@ pub(crate) fn compile<'a>(
     let mut compiler = Assembler {
         builder: ModuleBuilder::new(options, context_modules, ast.name.module_opt()),
         diags: vec![],
-        fun_context: None,
+        resolution_context: None,
     };
     compiler.unit(&ast);
     if compiler.diags.is_empty() {
@@ -63,6 +66,7 @@ impl<'a> Assembler<'a> {
             name: _,
             address_aliases,
             module_aliases,
+            structs,
             functions,
         } = ast;
         // Register aliases
@@ -75,17 +79,77 @@ impl<'a> Assembler<'a> {
             self.add_diags(Loc::new(0, 0), res);
         }
 
+        // Declare structs
+        for str in structs {
+            self.declare_struct(str)
+        }
+
         // Declare functions
         for fun in functions {
             self.declare_fun(fun);
         }
 
-        // Define code for functions
         if self.diags.is_empty() {
+            // Define layout for structs
+            for (pos, str) in structs.iter().enumerate() {
+                self.define_struct(StructDefinitionIndex::new(pos as TableIndex), str)
+            }
+
+            // Define code for functions
             for (pos, fun) in functions.iter().enumerate() {
                 self.define_fun(FunctionDefinitionIndex::new(pos as TableIndex), fun)
             }
         }
+    }
+
+    fn declare_struct(&mut self, str: &Struct) {
+        self.setup_struct(str);
+        let res = self.builder.declare_struct(
+            str.name.clone(),
+            str.type_params
+                .iter()
+                .map(|(_, constraints, is_phantom)| (*constraints, *is_phantom))
+                .collect(),
+            str.abilities,
+        );
+        self.add_diags(str.loc, res);
+    }
+
+    fn define_struct(&mut self, idx: StructDefinitionIndex, str: &Struct) {
+        self.setup_struct(str);
+        let layout = match &str.layout {
+            StructLayout::Singleton(fields) => {
+                StructFieldInformation::Declared(self.translate_fields(fields))
+            },
+            StructLayout::Variants(variants) => {
+                let mut result = vec![];
+                for (loc, name, fields) in variants {
+                    let name_res = self.builder.name_index(name.clone());
+                    if let Some(name) = self.add_diags(*loc, name_res) {
+                        result.push(VariantDefinition {
+                            name,
+                            fields: self.translate_fields(fields),
+                        })
+                    }
+                }
+                StructFieldInformation::DeclaredVariants(result)
+            },
+        };
+        self.builder.define_struct_layout(idx, layout)
+    }
+
+    fn translate_fields(&mut self, fields: &[Decl]) -> Vec<FieldDefinition> {
+        let mut result = vec![];
+        for field in fields {
+            let name_res = self.builder.name_index(field.name.clone());
+            if let Some(name) = self.add_diags(field.loc, name_res) {
+                result.push(FieldDefinition {
+                    name,
+                    signature: TypeSignature(self.build_type(field.loc, &field.ty)),
+                })
+            }
+        }
+        result
     }
 
     fn declare_fun(&mut self, fun: &Fun) {
@@ -104,8 +168,10 @@ impl<'a> Assembler<'a> {
             .collect();
         let res = self.builder.signature_index(result_tys);
         let result_sign = self.add_diags(fun.loc, res).unwrap_or_default();
+        let acquires_res = self.acquires(fun.acquires.iter());
+        let acquires = self.add_diags(fun.loc, acquires_res).unwrap_or_default();
         let res = self.builder.declare_fun(
-            false, // TODO(#16582): entry
+            fun.is_entry,
             fun.name.clone(),
             fun.visibility,
             param_sign,
@@ -114,35 +180,52 @@ impl<'a> Assembler<'a> {
                 .iter()
                 .map(|(_, abilities)| *abilities)
                 .collect(),
+            acquires,
         );
         self.add_diags(fun.loc, res);
     }
 
+    fn acquires<'b>(
+        &mut self,
+        ids: impl Iterator<Item = &'b Identifier>,
+    ) -> anyhow::Result<Vec<StructDefinitionIndex>> {
+        ids.map(|id| self.builder.resolve_struct_def(id.as_ident_str()))
+            .collect::<anyhow::Result<Vec<_>>>()
+    }
+
     fn setup_fun(&mut self, fun: &Fun) {
-        let ty_param_map = fun
-            .type_params
-            .iter()
-            .enumerate()
-            .map(|(pos, (id, _))| (id.to_string(), pos as u16))
-            .collect();
-        self.fun_context = Some(FunctionContext {
-            ty_param_map, // This is needed for build_type called below
-            local_map: Default::default(),
-        });
-        self.fun_context.as_mut().unwrap().local_map = fun
+        self.setup_type_params(fun.type_params.iter().map(|(id, _)| id));
+        self.resolution_context.as_mut().unwrap().local_map = fun
             .params
             .iter()
             .chain(fun.locals.iter())
             .enumerate()
-            .map(|(pos, Local { loc, name, ty })| {
+            .map(|(pos, Decl { loc, name, ty })| {
                 let ty = self.build_type(*loc, ty);
                 (name.to_string(), (pos as LocalIndex, ty))
             })
             .collect();
     }
 
-    fn require_fun(&self) -> &FunctionContext {
-        self.fun_context.as_ref().expect("function context")
+    fn setup_struct(&mut self, str: &Struct) {
+        self.setup_type_params(str.type_params.iter().map(|(name, _, _)| name))
+    }
+
+    fn setup_type_params<'b>(&mut self, params: impl Iterator<Item = &'b Identifier>) {
+        let ty_param_map = params
+            .enumerate()
+            .map(|(pos, id)| (id.to_string(), pos as u16))
+            .collect();
+        self.resolution_context = Some(ResolutionContext {
+            ty_param_map,
+            local_map: Default::default(),
+        });
+    }
+
+    fn require_resolution_context(&self) -> &ResolutionContext {
+        self.resolution_context
+            .as_ref()
+            .expect("resolution context")
     }
 
     fn define_fun(&mut self, def_idx: FunctionDefinitionIndex, fun: &Fun) {
@@ -185,7 +268,7 @@ impl<'a> Assembler<'a> {
                 // Define locals signature.
                 let locals_start = fun.params.len();
                 let mut locals: Vec<(LocalIndex, SignatureToken)> = self
-                    .require_fun()
+                    .require_resolution_context()
                     .local_map
                     .clone()
                     .into_iter()
@@ -232,12 +315,31 @@ impl<'a> Assembler<'a> {
         let tr_inst = |comp: &mut Self, inst: Option<&Vec<Type>>| -> Option<Vec<SignatureToken>> {
             inst.map(|tys| tys.iter().map(|t| comp.build_type(loc, t)).collect())
         };
+        let tr_named =
+            |comp: &mut Self, name: &PartialIdent, inst: Option<&Vec<Type>>| -> SignatureToken {
+                let res = comp.builder.resolve_struct(&name.address, &name.id_parts);
+                if let Some(shdl_idx) = comp.add_diags(loc, res) {
+                    match tr_inst(comp, inst) {
+                        Some(tys) => SignatureToken::StructInstantiation(shdl_idx, tys),
+                        None => SignatureToken::Struct(shdl_idx),
+                    }
+                } else {
+                    // error reported
+                    SignatureToken::Bool
+                }
+            };
         match ty {
             Type::Named(partial_id, opt_inst) => {
                 if partial_id.address.is_none() && partial_id.id_parts.len() == 1 {
                     match partial_id.id_parts[0].as_str() {
-                        s if self.require_fun().ty_param_map.contains_key(s) => {
-                            SignatureToken::TypeParameter(self.require_fun().ty_param_map[s])
+                        s if self
+                            .require_resolution_context()
+                            .ty_param_map
+                            .contains_key(s) =>
+                        {
+                            SignatureToken::TypeParameter(
+                                self.require_resolution_context().ty_param_map[s],
+                            )
                         },
                         "u8" => {
                             ck_inst(self, None, opt_inst.as_ref());
@@ -285,14 +387,10 @@ impl<'a> Assembler<'a> {
                                 SignatureToken::Bool
                             }
                         },
-                        _ => {
-                            self.error(loc, "structs NYI");
-                            SignatureToken::Bool
-                        },
+                        _ => tr_named(self, partial_id, opt_inst.as_ref()),
                     }
                 } else {
-                    self.error(loc, "structs NYI type");
-                    SignatureToken::Bool
+                    tr_named(self, partial_id, opt_inst.as_ref())
                 }
             },
             Type::Ref(is_mut, ty) => {
@@ -337,7 +435,7 @@ impl<'a> Assembler<'a> {
                     _ => unreachable!(),
                 };
                 let arg = self.args1(instr)?;
-                let label = self.simple_id(instr, arg)?;
+                let label = self.simple_id(instr, arg, " for label")?;
                 if let Some(label_offs) = label_defs.get(&label) {
                     mk_instr(*label_offs)
                 } else {
@@ -376,7 +474,6 @@ impl<'a> Assembler<'a> {
                 let num = self.number(instr, arg, U256::max_value())?;
                 LdU256(num)
             },
-
             "cast_u8" => {
                 self.args0(instr)?;
                 CastU8
@@ -457,7 +554,7 @@ impl<'a> Assembler<'a> {
                 let arg = self.args1(instr)?;
                 MutBorrowLoc(self.local(instr, arg)?)
             },
-            "imm_borrow_loc" => {
+            "borrow_loc" => {
                 let arg = self.args1(instr)?;
                 ImmBorrowLoc(self.local(instr, arg)?)
             },
@@ -608,6 +705,175 @@ impl<'a> Assembler<'a> {
                 let sign_idx = self.type_index(instr, arg)?;
                 CallClosure(sign_idx)
             },
+            "pack" | "unpack" => {
+                let (gen_op, op): (
+                    fn(StructDefInstantiationIndex) -> Bytecode,
+                    fn(StructDefinitionIndex) -> Bytecode,
+                ) = match instr_name.as_str() {
+                    "pack" => (PackGeneric, Pack),
+                    "unpack" => (UnpackGeneric, Unpack),
+                    _ => unreachable!(),
+                };
+                let arg = self.args1(instr)?;
+                let (def_idx, targs_opt) = self.struct_ref(instr, arg)?;
+                if let Some(targs) = targs_opt {
+                    let res = self.builder.struct_def_inst_index(def_idx, targs);
+                    let inst_idx = self.add_diags(instr.loc, res)?;
+                    gen_op(inst_idx)
+                } else {
+                    op(def_idx)
+                }
+            },
+            "pack_variant" | "unpack_variant" | "test_variant" => {
+                let (gen_op, op): (
+                    fn(StructVariantInstantiationIndex) -> Bytecode,
+                    fn(StructVariantHandleIndex) -> Bytecode,
+                ) = match instr_name.as_str() {
+                    "pack_variant" => (PackVariantGeneric, PackVariant),
+                    "unpack_variant" => (UnpackVariantGeneric, UnpackVariant),
+                    "test_variant" => (TestVariantGeneric, TestVariant),
+                    _ => unreachable!(),
+                };
+                let [arg1, arg2] = self.args2(instr)?;
+                let (def_idx, targs_opt) = self.struct_ref(instr, arg1)?;
+                let variant_idx = self.struct_variant(instr, def_idx, arg2)?;
+                if let Some(targs) = targs_opt {
+                    let inst_idx = self.add_diags(
+                        instr.loc,
+                        self.builder.variant_inst_index(variant_idx, targs),
+                    )?;
+                    gen_op(inst_idx)
+                } else {
+                    op(variant_idx)
+                }
+            },
+            "borrow_field" | "mut_borrow_field" => {
+                let (gen_op, op): (
+                    fn(FieldInstantiationIndex) -> Bytecode,
+                    fn(FieldHandleIndex) -> Bytecode,
+                ) = match instr_name.as_str() {
+                    "borrow_field" => (ImmBorrowFieldGeneric, ImmBorrowField),
+                    "mut_borrow_field" => (MutBorrowFieldGeneric, MutBorrowField),
+                    _ => unreachable!(),
+                };
+                let [arg1, arg2] = self.args2(instr)?;
+                let (def_idx, targs_opt) = self.struct_ref(instr, arg1)?;
+                let field_name = self.simple_id(instr, arg2, " for field")?;
+                let field_offs = self.add_diags(
+                    instr.loc,
+                    self.builder
+                        .resolve_field(def_idx, None, field_name.as_ident_str()),
+                )?;
+                let hdl_idx =
+                    self.add_diags(instr.loc, self.builder.field_index(def_idx, field_offs))?;
+                if let Some(targs) = targs_opt {
+                    let inst_idx =
+                        self.add_diags(instr.loc, self.builder.field_inst_index(hdl_idx, targs))?;
+                    gen_op(inst_idx)
+                } else {
+                    op(hdl_idx)
+                }
+            },
+            "borrow_variant_field" | "mut_borrow_variant_field" => {
+                let (gen_op, op): (
+                    fn(VariantFieldInstantiationIndex) -> Bytecode,
+                    fn(VariantFieldHandleIndex) -> Bytecode,
+                ) = match instr_name.as_str() {
+                    "borrow_variant_field" => (ImmBorrowVariantFieldGeneric, ImmBorrowVariantField),
+                    "mut_borrow_variant_field" => {
+                        (MutBorrowVariantFieldGeneric, MutBorrowVariantField)
+                    },
+                    _ => unreachable!(),
+                };
+                if instr.args.len() < 2 {
+                    self.error(
+                        instr.loc,
+                        "expected at least 2 arguments for variant field borrow",
+                    );
+                    return None;
+                }
+                let (def_idx, targs_opt) = self.struct_ref(instr, &instr.args[0])?;
+
+                let mut variants = vec![];
+                let mut field_offs = None;
+                for field in &instr.args[1..] {
+                    match field {
+                        Argument::Id(
+                            PartialIdent {
+                                address: None,
+                                id_parts,
+                            },
+                            None,
+                        ) if id_parts.len() == 2 => {
+                            let variant_idx = self.add_diags(
+                                instr.loc,
+                                self.builder
+                                    .resolve_variant(def_idx, id_parts[0].as_ident_str()),
+                            )?;
+                            variants.push(variant_idx);
+                            let offs = self.add_diags(
+                                instr.loc,
+                                self.builder.resolve_field(
+                                    def_idx,
+                                    Some(variant_idx),
+                                    id_parts[1].as_ident_str(),
+                                ),
+                            )?;
+                            if field_offs.map(|cur| cur == offs).unwrap_or(true) {
+                                field_offs = Some(offs)
+                            } else {
+                                self.error(instr.loc, format!("variants of fields must be at some position, previous was {} while this is {}", field_offs.unwrap(), offs));
+                                return None;
+                            }
+                        },
+                        _ => {
+                            self.error(
+                                instr.loc,
+                                "expected `<variant>::<field>` to describe field of variant",
+                            );
+                            return None;
+                        },
+                    }
+                }
+                let hdl_idx = self.add_diags(
+                    instr.loc,
+                    self.builder
+                        .variant_field_index(def_idx, variants, field_offs.unwrap()),
+                )?;
+                if let Some(targs) = targs_opt {
+                    let inst_idx = self.add_diags(
+                        instr.loc,
+                        self.builder.variant_field_inst_index(hdl_idx, targs),
+                    )?;
+                    gen_op(inst_idx)
+                } else {
+                    op(hdl_idx)
+                }
+            },
+            "borrow_global" | "mut_borrow_global" | "exists" | "move_from" | "move_to" => {
+                let (gen_op, op): (
+                    fn(StructDefInstantiationIndex) -> Bytecode,
+                    fn(StructDefinitionIndex) -> Bytecode,
+                ) = match instr_name.as_str() {
+                    "borrow_global" => (ImmBorrowGlobalGeneric, ImmBorrowGlobal),
+                    "mut_borrow_global" => (MutBorrowGlobalGeneric, MutBorrowGlobal),
+                    "exists" => (ExistsGeneric, Exists),
+                    "move_from" => (MoveFromGeneric, MoveFrom),
+                    "move_to" => (MoveToGeneric, MoveTo),
+                    _ => unreachable!(),
+                };
+                let arg = self.args1(instr)?;
+                let (def_idx, targs_opt) = self.struct_ref(instr, arg)?;
+                if let Some(targs) = targs_opt {
+                    let inst_idx = self.add_diags(
+                        instr.loc,
+                        self.builder.struct_def_inst_index(def_idx, targs),
+                    )?;
+                    gen_op(inst_idx)
+                } else {
+                    op(def_idx)
+                }
+            },
             _ => {
                 self.error(instr.loc, format!("unknown instruction `{}`", instr.name));
                 return None;
@@ -616,13 +882,13 @@ impl<'a> Assembler<'a> {
         Some(instr)
     }
 
-    fn simple_id(&mut self, instr: &Instruction, arg: &Argument) -> Option<Identifier> {
+    fn simple_id(&mut self, instr: &Instruction, arg: &Argument, ctx: &str) -> Option<Identifier> {
         match arg {
             Argument::Id(pid, None) if pid.address.is_none() && pid.id_parts.len() == 1 => {
                 Some(pid.id_parts[0].clone())
             },
             _ => {
-                self.error(instr.loc, "expected simple identifier");
+                self.error(instr.loc, format!("expected simple identifier{}", ctx));
                 None
             },
         }
@@ -648,9 +914,54 @@ impl<'a> Assembler<'a> {
         }
     }
 
+    fn struct_ref(
+        &mut self,
+        instr: &Instruction,
+        arg: &Argument,
+    ) -> Option<(StructDefinitionIndex, Option<Vec<SignatureToken>>)> {
+        match arg {
+            Argument::Id(
+                PartialIdent {
+                    address: None,
+                    id_parts,
+                },
+                targs,
+            ) if id_parts.len() == 1 => {
+                let res = self.builder.resolve_struct_def(&id_parts[0]);
+                let idx = self.add_diags(instr.loc, res)?;
+                let targs = targs.as_ref().map(|tys| {
+                    tys.iter()
+                        .map(|ty| self.build_type(instr.loc, ty))
+                        .collect()
+                });
+                Some((idx, targs))
+            },
+            _ => {
+                self.error(
+                    instr.loc,
+                    "expected simple struct name with optional type instantiation",
+                );
+                None
+            },
+        }
+    }
+
+    fn struct_variant(
+        &mut self,
+        instr: &Instruction,
+        def_idx: StructDefinitionIndex,
+        variant: &Argument,
+    ) -> Option<StructVariantHandleIndex> {
+        let name = self.simple_id(instr, variant, " for variant")?;
+        let res = self.builder.resolve_variant(def_idx, name.as_ident_str());
+        let variant_idx = self.add_diags(instr.loc, res)?;
+        let res = self.builder.variant_index(def_idx, variant_idx);
+        self.add_diags(instr.loc, res)
+    }
+
     fn local(&mut self, instr: &Instruction, arg: &Argument) -> Option<LocalIndex> {
-        let id = self.simple_id(instr, arg)?;
-        if let Some((idx, _)) = self.require_fun().local_map.get(id.as_str()) {
+        let id = self.simple_id(instr, arg, " for local")?;
+        if let Some((idx, _)) = self.require_resolution_context().local_map.get(id.as_str()) {
             Some(*idx)
         } else {
             self.error(instr.loc, format!("unknown local `{}`", id));

--- a/third_party/move/tools/move-asm/src/module_builder.rs
+++ b/third_party/move/tools/move-asm/src/module_builder.rs
@@ -17,21 +17,31 @@ use move_binary_format::{
     access::ModuleAccess,
     file_format::{
         AddressIdentifierIndex, Bytecode, CodeUnit, CompiledScript, Constant, ConstantPoolIndex,
-        FunctionDefinition, FunctionDefinitionIndex, FunctionHandle, FunctionHandleIndex,
-        FunctionInstantiation, FunctionInstantiationIndex, IdentifierIndex, ModuleHandle,
-        ModuleHandleIndex, Signature, SignatureIndex, SignatureToken, StructHandle,
-        StructHandleIndex, TableIndex, Visibility,
+        FieldDefinition, FieldHandle, FieldHandleIndex, FieldInstantiation,
+        FieldInstantiationIndex, FunctionDefinition, FunctionDefinitionIndex, FunctionHandle,
+        FunctionHandleIndex, FunctionInstantiation, FunctionInstantiationIndex, IdentifierIndex,
+        MemberCount, ModuleHandle, ModuleHandleIndex, Signature, SignatureIndex, SignatureToken,
+        StructDefInstantiation, StructDefInstantiationIndex, StructDefinition,
+        StructDefinitionIndex, StructFieldInformation, StructHandle, StructHandleIndex,
+        StructTypeParameter, StructVariantHandle, StructVariantHandleIndex,
+        StructVariantInstantiation, StructVariantInstantiationIndex, TableIndex,
+        VariantFieldHandle, VariantFieldHandleIndex, VariantFieldInstantiation,
+        VariantFieldInstantiationIndex, VariantIndex, Visibility,
     },
     file_format_common::VERSION_DEFAULT,
     internals::ModuleIndex,
     module_to_script::convert_module_to_script,
     views::{
-        FunctionDefinitionView, FunctionHandleView, ModuleHandleView, ModuleView, StructHandleView,
+        FunctionDefinitionView, FunctionHandleView, ModuleHandleView, ModuleView,
+        StructDefinitionView, StructHandleView,
     },
     CompiledModule,
 };
 use move_core_types::{
-    ability::AbilitySet, account_address::AccountAddress, identifier::Identifier, language_storage,
+    ability::AbilitySet,
+    account_address::AccountAddress,
+    identifier::{IdentStr, Identifier},
+    language_storage,
     language_storage::ModuleId,
 };
 use std::{
@@ -96,6 +106,29 @@ pub struct ModuleBuilder<'a> {
     signature_to_idx: RefCell<BTreeMap<Signature, SignatureIndex>>,
     /// A mapping for constants.
     cons_to_idx: RefCell<BTreeMap<(Vec<u8>, SignatureToken), ConstantPoolIndex>>,
+    /// A mapping from struct instantiations to indices.
+    struct_def_inst_to_idx:
+        RefCell<BTreeMap<(StructDefinitionIndex, SignatureIndex), StructDefInstantiationIndex>>,
+    /// A mapping from fields to indices.
+    field_to_idx: RefCell<BTreeMap<(StructDefinitionIndex, MemberCount), FieldHandleIndex>>,
+    /// A mapping from generic fields to indices.
+    field_inst_to_idx:
+        RefCell<BTreeMap<(FieldHandleIndex, SignatureIndex), FieldInstantiationIndex>>,
+    /// A mapping from fields with applicable variants and offset to index.
+    variant_field_to_idx: RefCell<
+        BTreeMap<(StructDefinitionIndex, Vec<VariantIndex>, MemberCount), VariantFieldHandleIndex>,
+    >,
+    /// A mapping from field instantiations with applicable variants and offset to index.
+    variant_field_inst_to_idx: RefCell<
+        BTreeMap<(VariantFieldHandleIndex, SignatureIndex), VariantFieldInstantiationIndex>,
+    >,
+    /// A mapping from variants to index.
+    struct_variant_to_idx:
+        RefCell<BTreeMap<(StructDefinitionIndex, VariantIndex), StructVariantHandleIndex>>,
+    /// A mapping from variant instantiations to index.
+    struct_variant_inst_to_idx: RefCell<
+        BTreeMap<(StructVariantHandleIndex, SignatureIndex), StructVariantInstantiationIndex>,
+    >,
 }
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
@@ -218,6 +251,68 @@ impl<'a> ModuleBuilder<'a> {
         }
     }
 
+    /// Declares a struct and adds it to the builder. The struct initially does not have any
+    /// layout associated.
+    pub fn declare_struct(
+        &mut self,
+        name: Identifier,
+        type_parameters: Vec<(AbilitySet, bool)>,
+        abilities: AbilitySet,
+    ) -> Result<StructDefinitionIndex> {
+        if self.is_script() {
+            bail!("script cannot have struct definitions")
+        }
+        if self.options.validate {
+            let module_ref = self.module.borrow();
+            let module = &*module_ref;
+            for sdef in &module.struct_defs {
+                let view = StructDefinitionView::new(module, sdef);
+                if view.name() == name.as_ref() {
+                    bail!("duplicate struct definition `{}`", name);
+                }
+            }
+        }
+        let full_name = self.this_module_id(name.clone());
+        let name_idx = self.name_index(name.clone())?;
+        let shdl = StructHandle {
+            module: self.this_module_idx,
+            name: name_idx,
+            abilities,
+            type_parameters: type_parameters
+                .into_iter()
+                .map(|(constraints, is_phantom)| StructTypeParameter {
+                    constraints,
+                    is_phantom,
+                })
+                .collect(),
+        };
+        let shdl_idx = self.index(
+            &mut self.module.borrow_mut().struct_handles,
+            &mut self.struct_to_idx.borrow_mut(),
+            full_name,
+            shdl,
+            StructHandleIndex,
+            "struct handle",
+        )?;
+        let sdef = StructDefinition {
+            struct_handle: shdl_idx,
+            field_information: StructFieldInformation::Native,
+        };
+        let new_idx = self.module.borrow().struct_defs.len();
+        self.bounds_check(new_idx, TableIndex::MAX, "struct definition index")?;
+        let sidx = StructDefinitionIndex(new_idx as TableIndex);
+        self.module.borrow_mut().struct_defs.push(sdef);
+        Ok(sidx)
+    }
+
+    pub fn define_struct_layout(
+        &self,
+        def_idx: StructDefinitionIndex,
+        layout: StructFieldInformation,
+    ) {
+        self.module.borrow_mut().struct_defs[def_idx.0 as usize].field_information = layout
+    }
+
     /// Declares a function and adds it to the builder. The function
     /// initially does not have any code associated.
     /// TODO(#16582): attributes and access specifiers
@@ -229,6 +324,7 @@ impl<'a> ModuleBuilder<'a> {
         parameters: SignatureIndex,
         return_: SignatureIndex,
         type_parameters: Vec<AbilitySet>,
+        acquires_global_resources: Vec<StructDefinitionIndex>,
     ) -> Result<FunctionDefinitionIndex> {
         if self.options.validate {
             let module_ref = self.module.borrow();
@@ -268,7 +364,7 @@ impl<'a> ModuleBuilder<'a> {
             function: fhdl_idx,
             visibility,
             is_entry,
-            acquires_global_resources: vec![],
+            acquires_global_resources,
             code: None,
         };
         let new_idx = self.module.borrow().function_defs.len();
@@ -322,6 +418,9 @@ impl<'a> ModuleBuilder<'a> {
 
     // ==========================================================================================
     // Resolving Names
+
+    // TODO(#16582): The resolution algorithms here use linear search over tables. If better
+    //   performance is a requirement, we should introduce lookup maps to speed this up.
 
     /// Resolves a module name, where the name is specified to some extent.
     /// - If an address is given, one further name part needs to be present
@@ -390,6 +489,107 @@ impl<'a> ModuleBuilder<'a> {
                 module_id,
                 id: name_parts[name_parts.len() - 1].clone(),
             })
+        }
+    }
+
+    /// Same as `resolve_fun` but for structs.
+    pub fn resolve_struct(
+        &self,
+        address_opt: &Option<AccountAddress>,
+        name_parts: &[Identifier],
+    ) -> Result<StructHandleIndex> {
+        if address_opt.is_none() && name_parts.len() == 1 {
+            // A simple name can only be resolved into a struct within this module.
+            let module = self.module.borrow();
+            for sdef in &module.struct_defs {
+                let view = StructDefinitionView::new(&*module, sdef);
+                if view.name() == name_parts[0].as_ref() {
+                    return self.struct_index(QualifiedId {
+                        module_id: self.this_module(),
+                        id: name_parts[0].clone(),
+                    });
+                }
+            }
+            bail!(
+                "undeclared struct `{}` in `{}`",
+                name_parts[0],
+                self.this_module()
+            )
+        } else {
+            // Pass address and name prefix to resolve_module.
+            let module_id =
+                self.resolve_module(address_opt, &name_parts[0..name_parts.len() - 1])?;
+            self.struct_index(QualifiedId {
+                module_id,
+                id: name_parts[name_parts.len() - 1].clone(),
+            })
+        }
+    }
+
+    /// Resolves a struct definition in the current module from a simple name.
+    pub fn resolve_struct_def(&self, name: &IdentStr) -> Result<StructDefinitionIndex> {
+        let module = self.module.borrow();
+        for (pos, sdef) in module.struct_defs.iter().enumerate() {
+            let view = StructDefinitionView::new(&*module, sdef);
+            if view.name() == name {
+                return Ok(StructDefinitionIndex(pos as TableIndex));
+            }
+        }
+        Err(anyhow!("undeclared struct `{}` in current module", name))
+    }
+
+    /// Resolves variant name into variant index.
+    pub fn resolve_variant(
+        &self,
+        struct_def: StructDefinitionIndex,
+        variant_name: &IdentStr,
+    ) -> Result<VariantIndex> {
+        let module = self.module.borrow();
+        if let StructFieldInformation::DeclaredVariants(variants) =
+            &module.struct_defs[struct_def.into_index()].field_information
+        {
+            for (pos, variant) in variants.iter().enumerate() {
+                let name = module.identifier_at(variant.name);
+                if name == variant_name {
+                    return Ok(pos as VariantIndex);
+                }
+            }
+        }
+        Err(anyhow!("undeclared variant `{}`", variant_name))
+    }
+
+    pub fn resolve_field(
+        &self,
+        struct_def: StructDefinitionIndex,
+        variant_opt: Option<VariantIndex>,
+        field_name: &IdentStr,
+    ) -> Result<MemberCount> {
+        let module_ref = self.module.borrow();
+        let module = &*module_ref;
+        let find_field = |fields: &[FieldDefinition]| -> Result<MemberCount> {
+            for (pos, field) in fields.iter().enumerate() {
+                let name = module.identifier_at(field.name);
+                if name == field_name {
+                    return Ok(pos as MemberCount);
+                }
+            }
+            Err(anyhow!("undeclared field `{}`", field_name))
+        };
+        match (
+            &module.struct_defs[struct_def.into_index()].field_information,
+            variant_opt,
+        ) {
+            (StructFieldInformation::Declared(fields), None) => find_field(fields),
+            (StructFieldInformation::DeclaredVariants(variants), Some(n))
+                if (n as usize) < variants.len() =>
+            {
+                find_field(&variants[n as usize].fields)
+            },
+            _ => Err(if variant_opt.is_some() {
+                anyhow!("need variant for field selection of enum")
+            } else {
+                anyhow!("invalid variant for field selection of struct")
+            }),
         }
     }
 }
@@ -469,8 +669,8 @@ impl<'a> ModuleBuilder<'a> {
             return Ok(idx);
         }
         if id.module_id == self.this_module() {
-            // All functions in this module should be already in fun_to_idx via
-            // declare_fun; so this is known to be undefined.
+            // All functions in this module should be already in struct_to_idx via
+            // declare_struct; so this is known to be undefined.
             bail!("unknown struct `{}` in the current module", id.id)
         }
         let hdl = self.import_struct_handle(&id)?;
@@ -481,6 +681,142 @@ impl<'a> ModuleBuilder<'a> {
             hdl,
             StructHandleIndex,
             "struct handle",
+        )
+    }
+
+    pub fn struct_def_inst_index(
+        &self,
+        def: StructDefinitionIndex,
+        targs: Vec<SignatureToken>,
+    ) -> Result<StructDefInstantiationIndex> {
+        let type_parameters = self.signature_index(targs)?;
+        let entry = StructDefInstantiation {
+            def,
+            type_parameters,
+        };
+        self.index(
+            &mut self.module.borrow_mut().struct_def_instantiations,
+            &mut self.struct_def_inst_to_idx.borrow_mut(),
+            (def, type_parameters),
+            entry,
+            StructDefInstantiationIndex,
+            "struct handle",
+        )
+    }
+
+    pub fn field_index(
+        &self,
+        owner: StructDefinitionIndex,
+        field: MemberCount,
+    ) -> Result<FieldHandleIndex> {
+        let entry = FieldHandle { owner, field };
+        self.index(
+            &mut self.module.borrow_mut().field_handles,
+            &mut self.field_to_idx.borrow_mut(),
+            (owner, field),
+            entry,
+            FieldHandleIndex,
+            "field handle",
+        )
+    }
+
+    pub fn field_inst_index(
+        &self,
+        handle: FieldHandleIndex,
+        type_parameters: Vec<SignatureToken>,
+    ) -> Result<FieldInstantiationIndex> {
+        let type_parameters = self.signature_index(type_parameters)?;
+        let entry = FieldInstantiation {
+            handle,
+            type_parameters,
+        };
+        self.index(
+            &mut self.module.borrow_mut().field_instantiations,
+            &mut self.field_inst_to_idx.borrow_mut(),
+            (handle, type_parameters),
+            entry,
+            FieldInstantiationIndex,
+            "generic field handle",
+        )
+    }
+
+    pub fn variant_field_index(
+        &self,
+        struct_index: StructDefinitionIndex,
+        variants: Vec<VariantIndex>,
+        field: MemberCount,
+    ) -> Result<VariantFieldHandleIndex> {
+        let entry = VariantFieldHandle {
+            struct_index,
+            variants: variants.clone(),
+            field,
+        };
+        self.index(
+            &mut self.module.borrow_mut().variant_field_handles,
+            &mut self.variant_field_to_idx.borrow_mut(),
+            (struct_index, variants, field),
+            entry,
+            VariantFieldHandleIndex,
+            "variant field handle",
+        )
+    }
+
+    pub fn variant_field_inst_index(
+        &self,
+        handle: VariantFieldHandleIndex,
+        type_parameters: Vec<SignatureToken>,
+    ) -> Result<VariantFieldInstantiationIndex> {
+        let type_parameters = self.signature_index(type_parameters)?;
+        let entry = VariantFieldInstantiation {
+            handle,
+            type_parameters,
+        };
+        self.index(
+            &mut self.module.borrow_mut().variant_field_instantiations,
+            &mut self.variant_field_inst_to_idx.borrow_mut(),
+            (handle, type_parameters),
+            entry,
+            VariantFieldInstantiationIndex,
+            "generic variant field handle",
+        )
+    }
+
+    pub fn variant_index(
+        &self,
+        struct_index: StructDefinitionIndex,
+        variant: VariantIndex,
+    ) -> Result<StructVariantHandleIndex> {
+        let entry = StructVariantHandle {
+            struct_index,
+            variant,
+        };
+        self.index(
+            &mut self.module.borrow_mut().struct_variant_handles,
+            &mut self.struct_variant_to_idx.borrow_mut(),
+            (struct_index, variant),
+            entry,
+            StructVariantHandleIndex,
+            "struct variant handle",
+        )
+    }
+
+    pub fn variant_inst_index(
+        &self,
+        handle: StructVariantHandleIndex,
+        type_parameters: Vec<SignatureToken>,
+    ) -> Result<StructVariantInstantiationIndex> {
+        let type_parameters = self.signature_index(type_parameters)?;
+        let entry = StructVariantInstantiation {
+            handle,
+            type_parameters,
+        };
+        self.index(
+            &mut self.module.borrow_mut().struct_variant_instantiations,
+            &mut self.struct_variant_inst_to_idx.borrow_mut(),
+            (handle, type_parameters),
+            entry,
+            StructVariantInstantiationIndex,
+            "generic struct variant handle",
         )
     }
 

--- a/third_party/move/tools/move-asm/tests/assembler/call_different_module.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/call_different_module.exp
@@ -1,0 +1,35 @@
+processed 2 tasks
+
+task 0 'publish'. lines 1-6:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test1 {
+
+
+public f(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+}
+== END Bytecode ==
+
+task 1 'publish'. lines 9-16:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test2 {
+use 0000000000000000000000000000000000000000000000000000000000000066::test1;
+
+
+
+
+g(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(10)
+	1: Call test1::f(u64): u64
+	2: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/call_different_module.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/call_different_module.masm
@@ -1,0 +1,16 @@
+//# publish --print-bytecode
+module 0x66::test1
+
+public fun f(x: u64): u64
+    move_loc x
+    ret
+
+
+//# publish --print-bytecode
+module 0x66::test2
+use 0x66::test1 as tm
+
+fun g(): u64
+    ld_u64 10
+    call tm::f
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/declare_entry_fun.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/declare_entry_fun.exp
@@ -1,0 +1,16 @@
+processed 1 task
+
+task 0 'publish'. lines 1-6:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test {
+
+
+entry public f(Arg0: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: u64)
+	1: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/declare_entry_fun.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/declare_entry_fun.masm
@@ -1,0 +1,6 @@
+//# publish --print-bytecode
+module 0x66::test
+
+entry public fun f(x: u64): u64
+    move_loc x
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/enum.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/enum.exp
@@ -1,0 +1,43 @@
+processed 1 task
+
+task 0 'publish'. lines 1-30:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test {
+enum E has drop {
+ V1{
+	_1: u64,
+	_2: u8
+ },
+ V2{
+	_1: u64,
+	_2: u32
+ }
+}
+
+pack_and_select(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU8(2)
+	2: PackVariant[0](E/V1)
+	3: Call select(E): u64
+	4: Ret
+}
+select(Arg0: E): u64 /* def_idx: 1 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: E)
+	1: ImmBorrowVariantField[0](V1._1|V2._1: u64)
+	2: ReadRef
+	3: Ret
+}
+pack_and_unpack(): u64 * u32 /* def_idx: 2 */ {
+B0:
+	0: LdU64(1)
+	1: LdU8(2)
+	2: PackVariant[0](E/V1)
+	3: UnpackVariant[1](E/V2)
+	4: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/enum.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/enum.masm
@@ -1,0 +1,30 @@
+//# publish --print-bytecode
+module 0x66::test
+
+enum E has drop
+  V1
+    _1: u64
+    _2: u8
+  V2
+    _1: u64
+    _2: u32
+
+fun pack_and_select(): u64
+    ld_u64 1
+    ld_u8 2
+    pack_variant E, V1
+    call select
+    ret
+
+fun select(x: E): u64
+    borrow_loc x
+    borrow_variant_field E, V1::_1, V2::_1
+    read_ref
+    ret
+
+fun pack_and_unpack(): (u64, u32)
+    ld_u64 1
+    ld_u8 2
+    pack_variant E, V1
+    unpack_variant E, V2
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/enum_generic.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/enum_generic.exp
@@ -1,0 +1,43 @@
+processed 1 task
+
+task 0 'publish'. lines 1-30:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test {
+enum E<Ty0> has drop {
+ V1{
+	_1: Ty0,
+	_2: u8
+ },
+ V2{
+	_1: Ty0,
+	_2: u32
+ }
+}
+
+pack_and_select(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(1)
+	1: LdU8(2)
+	2: PackVariantGeneric[0](E/V1<u64>)
+	3: Call select(E<u64>): u64
+	4: Ret
+}
+select(Arg0: E<u64>): u64 /* def_idx: 1 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: E<u64>)
+	1: ImmBorrowVariantFieldGeneric[0](V1._1|V2._1: Ty0)
+	2: ReadRef
+	3: Ret
+}
+pack_and_unpack(): u64 * u32 /* def_idx: 2 */ {
+B0:
+	0: LdU64(1)
+	1: LdU8(2)
+	2: PackVariantGeneric[0](E/V1<u64>)
+	3: UnpackVariantGeneric[1](E/V2<u64>)
+	4: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/enum_generic.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/enum_generic.masm
@@ -1,0 +1,30 @@
+//# publish --print-bytecode
+module 0x66::test
+
+enum E<A> has drop
+  V1
+    _1: A
+    _2: u8
+  V2
+    _1: A
+    _2: u32
+
+fun pack_and_select(): u64
+    ld_u64 1
+    ld_u8 2
+    pack_variant E<u64>, V1
+    call select
+    ret
+
+fun select(x: E<u64>): u64
+    borrow_loc x
+    borrow_variant_field E<u64>, V1::_1, V2::_1
+    read_ref
+    ret
+
+fun pack_and_unpack(): (u64, u32)
+    ld_u64 1
+    ld_u8 2
+    pack_variant E<u64>, V1
+    unpack_variant E<u64>, V2
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/resource.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/resource.exp
@@ -1,0 +1,29 @@
+processed 1 task
+
+task 0 'publish'. lines 1-19:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test {
+struct S has drop, key {
+	x: u64
+}
+
+move_to(Arg0: &signer) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &signer)
+	1: LdU64(3)
+	2: Pack[0](S)
+	3: MoveTo[0](S)
+	4: Ret
+}
+borrow(Arg0: address): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: address)
+	1: ImmBorrowGlobal[0](S)
+	2: ImmBorrowField[0](S.x: u64)
+	3: ReadRef
+	4: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/resource.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/resource.masm
@@ -1,0 +1,19 @@
+//# publish --print-bytecode --verbose
+module 0x66::test
+
+struct S has key+drop
+  x: u64
+
+fun move_to(s: &signer)
+    move_loc s
+    ld_u64 3
+    pack S
+    move_to S
+    ret
+
+fun borrow(a: address): u64 acquires S
+    move_loc a
+    borrow_global S
+    borrow_field S, x
+    read_ref
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/resource_generic.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/resource_generic.exp
@@ -1,0 +1,29 @@
+processed 1 task
+
+task 0 'publish'. lines 1-19:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test {
+struct S<Ty0> has drop, key {
+	x: Ty0
+}
+
+move_to(Arg0: &signer) /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](Arg0: &signer)
+	1: LdU64(3)
+	2: PackGeneric[0](S<u64>)
+	3: MoveToGeneric[0](S<u64>)
+	4: Ret
+}
+borrow(Arg0: address): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](Arg0: address)
+	1: ImmBorrowGlobalGeneric[0](S<u64>)
+	2: ImmBorrowFieldGeneric[0](S.x: Ty0)
+	3: ReadRef
+	4: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/resource_generic.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/resource_generic.masm
@@ -1,0 +1,19 @@
+//# publish --print-bytecode --verbose
+module 0x66::test
+
+struct S<A> has key+drop
+  x: A
+
+fun move_to(s: &signer)
+    move_loc s
+    ld_u64 3
+    pack S<u64>
+    move_to S<u64>
+    ret
+
+fun borrow(a: address): u64 acquires S
+    move_loc a
+    borrow_global S<u64>
+    borrow_field S<u64>, x
+    read_ref
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/struct.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/struct.exp
@@ -1,0 +1,37 @@
+processed 1 task
+
+task 0 'publish'. lines 1-26:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test {
+struct S has drop {
+	_1: u64,
+	_2: u8
+}
+
+pack_and_select(): u8 /* def_idx: 0 */ {
+B0:
+	0: LdU64(3)
+	1: LdU8(2)
+	2: Pack[0](S)
+	3: Call select(S): u8
+	4: Ret
+}
+select(Arg0: S): u8 /* def_idx: 1 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: S)
+	1: ImmBorrowField[0](S._2: u8)
+	2: ReadRef
+	3: Ret
+}
+pack_and_unpack(): u64 * u8 /* def_idx: 2 */ {
+B0:
+	0: LdU64(3)
+	1: LdU8(2)
+	2: Pack[0](S)
+	3: Unpack[0](S)
+	4: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/struct.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/struct.masm
@@ -1,0 +1,26 @@
+//# publish --print-bytecode
+module 0x66::test
+
+struct S has drop
+  _1: u64
+  _2: u8
+
+fun pack_and_select(): u8
+    ld_u64 3
+    ld_u8 2
+    pack S
+    call select
+    ret
+
+fun select(x: S): u8
+    borrow_loc x
+    borrow_field S, _2
+    read_ref
+    ret
+
+fun pack_and_unpack(): (u64, u8)
+    ld_u64 3
+    ld_u8 2
+    pack S
+    unpack S
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/struct_generic.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/struct_generic.exp
@@ -1,0 +1,37 @@
+processed 1 task
+
+task 0 'publish'. lines 1-26:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test {
+struct S<Ty0> has drop {
+	_1: u64,
+	_2: Ty0
+}
+
+pack_and_select(): u8 /* def_idx: 0 */ {
+B0:
+	0: LdU64(3)
+	1: LdU8(2)
+	2: PackGeneric[0](S<u8>)
+	3: Call select(S<u8>): u8
+	4: Ret
+}
+select(Arg0: S<u8>): u8 /* def_idx: 1 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: S<u8>)
+	1: ImmBorrowFieldGeneric[0](S._2: Ty0)
+	2: ReadRef
+	3: Ret
+}
+pack_and_unpack(): u64 * u8 /* def_idx: 2 */ {
+B0:
+	0: LdU64(3)
+	1: LdU8(2)
+	2: PackGeneric[0](S<u8>)
+	3: UnpackGeneric[0](S<u8>)
+	4: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/struct_generic.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/struct_generic.masm
@@ -1,0 +1,26 @@
+//# publish --print-bytecode
+module 0x66::test
+
+struct S<A> has drop
+  _1: u64
+  _2: A
+
+fun pack_and_select(): u8
+    ld_u64 3
+    ld_u8 2
+    pack S<u8>
+    call select
+    ret
+
+fun select(x: S<u8>): u8
+    borrow_loc x
+    borrow_field S<u8>, _2
+    read_ref
+    ret
+
+fun pack_and_unpack(): (u64, u8)
+    ld_u64 3
+    ld_u8 2
+    pack S<u8>
+    unpack S<u8>
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/struct_use.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/struct_use.exp
@@ -1,0 +1,37 @@
+processed 2 tasks
+
+task 0 'publish'. lines 1-6:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test1 {
+struct S has copy, drop {
+	_1: u64,
+	_2: u8
+}
+
+
+}
+== END Bytecode ==
+
+task 1 'publish'. lines 8-19:
+
+== BEGIN Bytecode ==
+// Move bytecode v7
+module 66.test2 {
+use 0000000000000000000000000000000000000000000000000000000000000066::test1;
+
+
+struct T has drop {
+	_1: S
+}
+
+get(Arg0: T): S /* def_idx: 0 */ {
+B0:
+	0: ImmBorrowLoc[0](Arg0: T)
+	1: ImmBorrowField[0](T._1: S)
+	2: ReadRef
+	3: Ret
+}
+}
+== END Bytecode ==

--- a/third_party/move/tools/move-asm/tests/assembler/struct_use.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/struct_use.masm
@@ -1,0 +1,19 @@
+//# publish --print-bytecode
+module 0x66::test1
+
+struct S has drop+copy
+  _1: u64
+  _2: u8
+
+//# publish --print-bytecode
+module 0x66::test2
+use 0x66::test1
+
+struct T has drop
+  _1: 0x66::test1::S
+
+fun get(x: T): test1::S
+    borrow_loc x
+    borrow_field T, _1
+    read_ref
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/unknown_field.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/unknown_field.exp
@@ -1,0 +1,10 @@
+processed 1 task
+
+task 0 'publish'. lines 1-11:
+Error: error: undeclared field `bad`
+  ┌─ test:7:5
+  │
+7 │     borrow_field S, bad
+  │     ^^^^^^^^^^^^^^^^^^^
+
+

--- a/third_party/move/tools/move-asm/tests/assembler/unknown_field.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/unknown_field.masm
@@ -1,0 +1,11 @@
+//# publish --print-bytecode
+module 0x66::test
+
+struct S has drop
+  x: u64
+
+fun select(x: S): u64
+    borrow_loc x
+    borrow_field S, bad
+    read_ref
+    ret

--- a/third_party/move/tools/move-asm/tests/assembler/unknown_variant.exp
+++ b/third_party/move/tools/move-asm/tests/assembler/unknown_variant.exp
@@ -1,0 +1,10 @@
+processed 1 task
+
+task 0 'publish'. lines 1-12:
+Error: error: undeclared variant `V2`
+  ┌─ test:8:5
+  │
+8 │     borrow_variant_field E, V2::y
+  │     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+

--- a/third_party/move/tools/move-asm/tests/assembler/unknown_variant.masm
+++ b/third_party/move/tools/move-asm/tests/assembler/unknown_variant.masm
@@ -1,0 +1,12 @@
+//# publish --print-bytecode
+module 0x66::test
+
+enum E has drop
+  V1
+    x: u64
+
+fun select(x: E): u64
+    borrow_loc x
+    borrow_variant_field E, V2::y
+    read_ref
+    ret


### PR DESCRIPTION
## Description

This implements declaration of structs and enums as well as the related bytecodes, and completes most of the assembler functionality. There are still things missing (like string constants for byte vectors) but otherwise should be fairly complete, or can be easily extended self-service style.

## How Has This Been Tested?

New tests

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

