### PR TITLE
[Decompiler] extend control flow optimizations

### DIFF
--- a/third_party/move/move-model/bytecode/src/astifier.rs
+++ b/third_party/move/move-model/bytecode/src/astifier.rs
@@ -94,6 +94,7 @@ use move_model::{
 use std::{
     cmp::Ordering,
     collections::{BTreeMap, BTreeSet},
+    vec,
 };
 use topological_sort::TopologicalSort;
 use try_match::match_ok;
@@ -1429,59 +1430,520 @@ struct IfElseTransformer<'a> {
 
 impl ExpRewriterFunctions for IfElseTransformer<'_> {
     fn rewrite_exp(&mut self, exp: Exp) -> Exp {
-        if let Some(result) = self.try_make_if(exp.clone()) {
-            self.rewrite_exp_descent(result)
-        } else {
-            self.rewrite_exp_descent(exp)
+        // Please maintain the order of the transformers.
+        let transforms: [fn(&Self, Exp) -> Option<Exp>; 4] = [
+            Self::try_remove_redundant_loop,
+            Self::try_make_if,
+            Self::try_make_if_else,
+            Self::try_remove_redundant_exp,
+        ];
+        let mut old_exp = exp;
+        // Recursively apply the transformers until a fixed point is reached.
+        loop {
+            let mut new_exp = None;
+            for transform in transforms {
+                if let Some(result) = transform(self, old_exp.clone()) {
+                    new_exp = Some(self.rewrite_exp_descent(result));
+                    break;
+                }
+            }
+            let new_exp = new_exp.unwrap_or_else(|| self.rewrite_exp_descent(old_exp.clone()));
+            if new_exp == old_exp {
+                return old_exp;
+            }
+            old_exp = new_exp;
         }
     }
 }
 
 impl IfElseTransformer<'_> {
-    /// Attempts to create an if-then (without else) from the given expression.
-    /// This recognizes the pattern below, as produced by the AST
-    /// generator:
+    /// Attempts to remove redundant loops introduced during control flow structuring
     ///
+    /// It identifies the following patterns (Pattern 1):
     /// ```move
     ///   loop { // no loop header
-    ///     ( if (c_i) break; )+
-    ///     <then-branch> // does not reference loop
-    ///     break|abort|return|continue
-    ///   }
-    ///
-    /// ==>
-    ///
-    ///   if (!(c1 || .. || cn)) {
-    ///     <then-branch> where loop_nest -= 1
+    ///     stms // no reference to current loop (via `break` or `continue`)
+    ///     break[*]|abort|return|continue[>0]
     ///   }
     /// ```
-    fn try_make_if(&self, exp: Exp) -> Option<Exp> {
-        let node_id = exp.node_id();
-        let default_loc = self.builder.env().get_node_loc(node_id);
-
-        // Match the pattern as described above
+    ///
+    /// If the above pattern does not match, it also checks for the following pattern (Pattern 2):
+    /// ```move
+    ///   'outer loop { // no loop header
+    ///     loop {
+    ///       stms // no `continue[1]` (i.e., does not continue to the 'outer loop)
+    ///     }
+    ///     break[0]
+    ///   }
+    /// ```
+    fn try_remove_redundant_loop(&self, exp: Exp) -> Option<Exp> {
         let (loop_id, body) = match_ok!(exp.as_ref(), ExpData::Loop(_0, _1))?;
-        let (cond, rest) = self.builder.match_if_break_list(body.clone())?;
-        let then_branch = self.builder.extract_terminated_prefix(
+        // Make sure this loop has no `continue` stmt
+        // Otherwise, it is not introduced by control flow structuring
+        self.check_no_loop_header(*loop_id)?;
+        let default_loc = self.builder.env().get_node_loc(*loop_id);
+
+        // Make sure this loop terminates (always exits)
+        // and extract the terminating prefix
+        let terminated_body = self.builder.extract_terminated_prefix(
             &default_loc,
-            rest,
+            body.clone(),
             0,
             /*allow_exit*/ true,
         )?;
 
-        // Check conditions
+        // match Pattern 1 (see doc above)
+        let branch_cond_1 = |loop_nest: usize, nest: usize, _: bool| nest == loop_nest;
+        if !terminated_body.customizable_branches_to(branch_cond_1) {
+            return Some(terminated_body.rewrite_loop_nest(-1));
+        }
+
+        // match Pattern 2 (see doc above)
+        let branch_cond_2 = |loop_nest: usize, nest: usize, cont: bool| cont && nest == loop_nest;
+        if matches!(terminated_body.as_ref(), ExpData::Loop(_, _))
+            && !terminated_body.customizable_branches_to(branch_cond_2)
+        {
+            return Some(terminated_body.rewrite_loop_nest(-1));
+        }
+        None
+    }
+
+    /// Attempts to create `if-then` from the given expression.
+    /// This transforms the pattern below
+    ///
+    /// ```move
+    ///   loop { // no loop header
+    ///     <begin_stmts> // no reference to current loop
+    ///     [ if (c_i) {
+    ///         break[*]|abort|return|continue[>0];
+    ///     }
+    ///     <then_branch_i> // no reference to current loop ]+
+    ///     <end_branch> // no reference to current loop
+    ///     break[*]|abort|return|continue[>0];
+    ///   } // end of loop
+    /// ==>
+    ///   <begin_stmts>
+    ///   if (!c_1) {
+    ///      <then_branch_1> where loop_nest -= 1
+    ///      if (!c_2){
+    ///         <then_branch_2> where loop_nest -= 1
+    ///         ...
+    ///         if (!c_n) {
+    ///            <end_branch> where loop_nest -= 1
+    ///         }
+    ///      }
+    ///   }
+    /// ```
+    fn try_make_if(&self, exp: Exp) -> Option<Exp> {
+        let (loop_id, body) = match_ok!(exp.as_ref(), ExpData::Loop(_0, _1))?;
         self.check_no_loop_header(*loop_id)?;
-        if then_branch.branches_to(0..1) {
+        let default_loc = self.builder.env().get_node_loc(*loop_id);
+
+        // Transform `if-else` where applicable (see doc of the function)
+        let body = self.try_unify_if_else(body.clone());
+
+        // Find the transformable pattern (see doc above)
+        // `if_cond_then_list` ALWAYS follows the format of [<begin_branch>, c_1, <then_branch_1>, c_2, <then_branch_2>, ..., c_n, <end_branch>],
+        let mut if_cond_then_list = self.builder.match_if_break_then_list(body.clone(), 0)?;
+        let end_branch = if_cond_then_list
+            .pop()
+            .expect("end branch should always be present");
+
+        // Make sure the <end_branch> always exits the loop
+        let end_branch = self.builder.extract_terminated_prefix(
+            &default_loc,
+            end_branch.clone(),
+            0,
+            /*allow_exit*/ true,
+        )?;
+        // Make sure the <end_branch> does not refer to the current loop
+        let branch_cond = |loop_nest: usize, nest: usize, _: bool| loop_nest == nest;
+        if end_branch.customizable_branches_to(branch_cond) {
             return None;
         }
 
-        // Construct result
-        let then_branch = then_branch.rewrite_loop_nest(-1);
-        Some(self.builder.if_else(
-            self.builder.not(cond),
-            then_branch,
-            self.builder.nop(&default_loc),
-        ))
+        // Recursively assemble a nested-if expression
+        //   - start from the <end_branch>
+        //     - put the <end_branch> as the true branch of `if(!c_n)`, forming `if(!c_n) { <end_branch> }`
+        //     - put the new `if` expression as the `new_body`
+        //   - continue with an upper-level branch, say `branch[n-1]`
+        //     - put the `branch[n-1]` together with the previous `new_body` as the true branch of `if(!c[n-1])`, forming `if(!c[n-1]) { <branch[n-1]>; new_body }`
+        //     - put the new `if` expression as the `new_body`
+        //   - repeat until we reach the <begin_stmts>
+        let mut cur_branch = end_branch.rewrite_loop_nest(-1);
+        let mut new_body = self.builder.nop(&default_loc);
+        while if_cond_then_list.len() > 1 {
+            let cond = if_cond_then_list.pop().expect("condition is expected");
+            new_body = self.builder.if_else(
+                self.builder.not(cond),
+                self.builder.seq(&default_loc, vec![cur_branch, new_body]),
+                self.builder.nop(&default_loc),
+            );
+            cur_branch = if_cond_then_list
+                .pop()
+                .expect("branch before if is expected");
+
+            // get the terminated prefix of `cur_branch` or fallback to the original
+            cur_branch = self
+                .builder
+                .extract_terminated_prefix(
+                    &default_loc,
+                    cur_branch.clone(),
+                    0,
+                    /*allow_exit*/ true,
+                )
+                .unwrap_or(cur_branch);
+
+            // Make sure the `cur-branch` does not refer to the current loop
+            if cur_branch.customizable_branches_to(branch_cond) {
+                return None;
+            }
+            cur_branch = cur_branch.rewrite_loop_nest(-1);
+        }
+        // Add the `begin_stmts` before the nested `if` expression
+        Some(self.builder.seq(&default_loc, vec![cur_branch, new_body]))
+    }
+
+    /// Attempts to create `if-then-else` from the given expression.
+    /// This transforms the pattern below
+    ///
+    /// ```move
+    ///   loop { // no loop header
+    ///    <begin_stmts> // no reference to current loop
+    ///     [ if (c_i) {
+    ///         then_branch_i // no reference to current loop
+    ///         break[*]|abort|return|continue[>0];
+    ///     }
+    ///     else_branch_i // no reference to current loop ]+
+    ///     break|abort|return|continue
+    /// ==>
+    ///   <begin_branch>
+    ///   if (c_1) {
+    ///      <then_branch_1>
+    ///   } else {
+    ///       <else_branch_1>
+    ///       if (c_2) {
+    ///           <then_branch_2>
+    ///       } else {
+    ///           <else_branch_2>
+    ///           ...
+    ///           if (c_n) {
+    ///              then_branch_n
+    ///           } else {
+    ///              <else_branch_n> where loop_nest -= 1
+    ///           }
+    ///       }
+    ///   }
+    /// ```
+    ///
+    fn try_make_if_else(&self, exp: Exp) -> Option<Exp> {
+        let (loop_id, body) = match_ok!(exp.as_ref(), ExpData::Loop(_0, _1))?;
+        self.check_no_loop_header(*loop_id)?;
+        let default_loc = self.builder.env().get_node_loc(*loop_id);
+
+        // Transform `if-else` where applicable (see doc of the function)
+        let body = self.try_unify_if_else(body.clone());
+
+        // Find the transformable pattern (see doc above)
+        // `if_else_list` ALWAYS follows the format of
+        //   <[seq(begin_stmts), c_1, seq(then_branch_1), seq(else_branch_1), c_2, seq(then_branch_2), seq(else_branch_2), ... c_n, seq(then_branch_n), seq(else_branch_n)]>
+        let mut if_else_list = self
+            .builder
+            .match_if_branch_break_branch_list(body.clone())?;
+        let end_branch = if_else_list
+            .pop()
+            .expect("end branch should always be present");
+
+        // Make sure the <end_branch> always exits the loop
+        let end_branch = self.builder.extract_terminated_prefix(
+            &default_loc,
+            end_branch.clone(),
+            0,
+            /*allow_exit*/ true,
+        )?;
+        // Make sure the <end_branch> does not refer to the current loop
+        let branch_cond = |loop_nest: usize, nest: usize, _: bool| nest == loop_nest;
+        if end_branch.customizable_branches_to(branch_cond) {
+            return None;
+        }
+
+        // recursively assemble a nested `if-else` expression
+        //   - start from the <end_branch>
+        //     - put the <end_branch> as the false branch of `if(c_n)` and <then_branch_n> as the true branch,
+        //       forming `if(c_n) { <then_branch_n> } else { <end_branch> }`
+        //     - put the new `if-else` expression as the `new_body`
+        //   - continue with an upper-level branch, say <then_branch_n-1> and <else_branch_n-1>
+        //     - put the <then_branch_n-1> as the true branch of `if(c_n-1)`
+        //            and <else_branch_n-1> together with `new_body` as the false branch,
+        //            forming `if(c_n-1) { <then_branch_n-1> } else { <else_branch_n-1>; new_body }`
+        //     - put the new `if-else` expression as the `new_body`
+        //   - repeat until we reach the <begin_stmts>
+        let mut else_branch = end_branch.rewrite_loop_nest(-1);
+        let mut new_body = self.builder.nop(&default_loc);
+
+        while if_else_list.len() > 2 {
+            let mut then_branch = if_else_list.pop().expect("then branch is expected");
+            // Make sure the <then_branch> always exits the loop
+            then_branch = self
+                .builder
+                .extract_terminated_prefix(
+                    &default_loc,
+                    then_branch.clone(),
+                    0,
+                    /*allow_exit*/ true,
+                )
+                .expect("then_branch must be terminated");
+
+            // Make sure the <then_branch> does not refer to the current loop
+            if then_branch.customizable_branches_to(branch_cond) {
+                return None;
+            }
+            then_branch = then_branch.rewrite_loop_nest(-1);
+            let cond = if_else_list.pop().expect("condition is expected");
+            new_body = self.builder.if_else(
+                cond,
+                then_branch,
+                self.builder.seq(&default_loc, vec![else_branch, new_body]),
+            );
+
+            else_branch = if_else_list.pop()?;
+            // get the terminated prefix of <else_branch> or fallback to the original
+            else_branch = self
+                .builder
+                .extract_terminated_prefix(
+                    &default_loc,
+                    else_branch.clone(),
+                    0,
+                    /*allow_exit*/ true,
+                )
+                .unwrap_or(else_branch);
+
+            // make sure the <else_branch> does not refer to the current loop
+            if else_branch.customizable_branches_to(branch_cond) {
+                return None;
+            }
+            // in case the <else_branch> branches to an outer loop
+            else_branch = else_branch.rewrite_loop_nest(-1);
+        }
+
+        // Add the <begin_stmts> to the top of the expression
+        Some(self.builder.seq(&default_loc, vec![else_branch, new_body]))
+    }
+
+    /// Attempts to remove redundant expressions generated during control flow transformations.
+    fn try_remove_redundant_exp(&self, mut exp: Exp) -> Option<Exp> {
+        let removers: [fn(&Self, Exp) -> Option<Exp>; 2] = [
+            Self::try_remove_redundant_seq,
+            Self::try_remove_redundant_code,
+        ];
+
+        let mut changed = false;
+        for remover in removers {
+            if let Some(new_exp) = remover(&self, exp.clone()) {
+                exp = new_exp;
+                changed = true;
+            }
+        }
+
+        if changed {
+            Some(exp)
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to remove dangling `seq` expressions produced by control flow transformations.
+    ///
+    /// It converts the following pattern
+    /// ```move
+    ///   seq {
+    ///     stmt1
+    ///     stmt2
+    ///     seq_1 {
+    ///       stmt3
+    ///       stmt4
+    ///     }
+    ///     seq_2 {
+    ///       stmt5
+    ///       stmt6
+    ///     }
+    ///     ...
+    ///   }
+    /// ==>
+    ///   seq {
+    ///     stmt1
+    ///     stmt2
+    ///     stmt3
+    ///     stmt4
+    ///     stmt5
+    ///     stmt6
+    ///     ...
+    ///   }
+    /// ```
+    fn try_remove_redundant_seq(&self, exp: Exp) -> Option<Exp> {
+        let mut new_stms = vec![];
+        let mut changed = false;
+        let (seq_id, stmts) = match_ok!(exp.as_ref(), ExpData::Sequence(_0, _1))?;
+        stmts.iter().for_each(|stmt| {
+            if let Some((_, inner_stmts)) = match_ok!(stmt.as_ref(), ExpData::Sequence(_0, _1)) {
+                new_stms.extend(inner_stmts.clone());
+                changed = true;
+            } else {
+                new_stms.push(stmt.clone());
+            }
+        });
+
+        if changed {
+            let default_loc = self.builder.env().get_node_loc(*seq_id);
+            Some(self.builder.seq(&default_loc, new_stms))
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to remove redundant code produced by control flow transformations.
+    ///
+    /// It converts the following pattern
+    /// ```move
+    ///   seq {
+    ///     stmt1
+    ///     stmt2
+    ///     break|continue|return|abort
+    ///     ...
+    ///   }
+    /// ==>
+    ///   seq {
+    ///     stmt1
+    ///     stmt2
+    ///     break|continue|return|abort
+    ///   }
+    /// ```
+    fn try_remove_redundant_code(&self, exp: Exp) -> Option<Exp> {
+        let (seq_id, stmts) = match_ok!(exp.as_ref(), ExpData::Sequence(_0, _1))?;
+
+        let terminating_prefix_idx = stmts
+            .iter()
+            .position(|stmt| {
+                matches!(
+                    stmt.as_ref(),
+                    ExpData::LoopCont(..)
+                        | ExpData::Return(..)
+                        | ExpData::Call(_, Operation::Abort, _)
+                )
+            })
+            .unwrap_or(stmts.len());
+
+        // We only return the prefix when the seq terminates early
+        if terminating_prefix_idx + 1 < stmts.len() {
+            let default_loc = self.builder.env().get_node_loc(*seq_id);
+            Some(
+                self.builder
+                    .seq(&default_loc, stmts[..=terminating_prefix_idx].to_vec()),
+            )
+        } else {
+            None
+        }
+    }
+
+    /// Attempts to unify 3 patterns of an `if-else` Exp or `if-else`s embedded in a Sequence Exp.
+    ///
+    /// Pattern 1
+    /// ```move
+    ///  if(c) {
+    ///     <then_branch>
+    ///   } else {
+    ///     <else_branch>
+    ///     break
+    ///   }
+    /// ```
+    ///  ==>
+    /// ```move
+    ///   if(!c) {
+    ///     <else_branch>
+    ///     break
+    ///   }
+    ///   <then_branch>
+    /// ```
+    ///
+    /// Pattern 2
+    /// ```move
+    ///  if(c) {
+    ///     <then_branch>
+    ///     break
+    ///   } else {
+    ///     <else_branch>
+    ///   }
+    /// ```
+    ///  ==>
+    /// ```move
+    ///   if(c) {
+    ///     <then_branch>
+    ///     break
+    ///   }
+    ///    <else_branch>
+    /// ```
+    ///
+    /// Pattern 3
+    /// ```move
+    ///  if(c_1) {
+    ///     if (c_2) {
+    ///       ...
+    ///       if (c_n) {
+    ///         stmts
+    ///         break
+    ///       }
+    ///     }
+    ///   }
+    /// ```
+    ///  ==>
+    /// ```move
+    ///   if(c_1 && c_2 && ... && c_n) {
+    ///     stmts
+    ///     break
+    ///   }
+    /// ```
+    fn try_unify_if_else(&self, mut exp: Exp) -> Exp {
+        let node_id = exp.node_id();
+        let default_loc = self.builder.env().get_node_loc(node_id);
+
+        let mut new_exp = vec![];
+        loop {
+            let (first, rest) = self.builder.extract_first(exp.clone());
+            if let Some((c, if_true, if_false)) = self.builder.match_if_else_break(first.clone()) {
+                // Pattern 1
+                let new_if = self.builder.if_else(
+                    self.builder.not(c),
+                    if_false,
+                    self.builder.nop(&default_loc),
+                );
+                new_exp.push(new_if);
+                new_exp.push(if_true);
+            } else if let Some((c, if_true, if_false)) =
+                self.builder.match_if_break_else(first.clone())
+            {
+                // Pattern 2
+                let new_if = self
+                    .builder
+                    .if_else(c, if_true, self.builder.nop(&default_loc));
+                new_exp.push(new_if);
+                new_exp.push(if_false);
+            } else if let Some((c, if_true)) = self.builder.match_nested_if_break(first.clone()) {
+                // Pattern 3
+                let new_if = self
+                    .builder
+                    .if_else(c, if_true, self.builder.nop(&default_loc));
+                new_exp.push(new_if);
+            } else {
+                // Not an if-branch, so we add it to the current sequence
+                new_exp.push(first);
+            };
+            // No more exps to process
+            if rest.is_empty() {
+                break;
+            }
+            exp = self.builder.seq(&default_loc, rest);
+        }
+        self.builder.seq(&default_loc, new_exp)
     }
 
     fn check_no_loop_header(&self, node_id: NodeId) -> Option<()> {

--- a/third_party/move/move-model/src/exp_builder.rs
+++ b/third_party/move/move-model/src/exp_builder.rs
@@ -11,7 +11,7 @@ use crate::{
     ty::Type,
 };
 use itertools::Itertools;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, vec};
 
 /// Represents an expression builder.
 pub struct ExpBuilder<'a> {
@@ -47,6 +47,20 @@ impl<'a> ExpBuilder<'a> {
             self.not(Call(id, Operation::And, vec![arg1, arg2]).into_exp())
         } else {
             Call(id, Operation::Or, vec![exp1, exp2]).into_exp()
+        }
+    }
+
+    pub fn and(&self, exp1: Exp, exp2: Exp) -> Exp {
+        use ExpData::*;
+        // Pull Not to the outside so it can be eliminated with if-else
+        let id = self.clone_node_id(exp1.node_id());
+        if let (Some(arg1), Some(arg2)) = (
+            self.extract_not(exp1.clone()),
+            self.extract_not(exp2.clone()),
+        ) {
+            self.not(Call(id, Operation::Or, vec![arg1, arg2]).into_exp())
+        } else {
+            Call(id, Operation::And, vec![exp1, exp2]).into_exp()
         }
     }
 
@@ -114,9 +128,14 @@ impl<'a> ExpBuilder<'a> {
     /// Constructs a loop, simplifying redundant loop.
     pub fn loop_(&self, body: Exp) -> Exp {
         let loc = self.env().get_node_loc(body.node_id());
+        // We can skip creating a loop if the loop body
+        //   - always terminates
+        //   - does not `continue` itself
+        //   - does not `break` itself
+        let branch_cond = |loop_nest: usize, nest: usize, _: bool| nest == loop_nest;
         if let Some(body_prefix) = self
             .extract_terminated_prefix(&loc, body.clone(), 0, true)
-            .filter(|prefix| !prefix.branches_to(0..1))
+            .filter(|prefix| !prefix.customizable_branches_to(branch_cond))
         {
             body_prefix.rewrite_loop_nest(-1)
         } else {
@@ -217,6 +236,70 @@ impl<'a> ExpBuilder<'a> {
         }
     }
 
+    pub fn match_if_then_break(&self, exp: Exp) -> Option<(Exp, Exp)> {
+        let node_id = exp.node_id();
+        let default_loc = self.env().get_node_loc(node_id);
+        match exp.as_ref() {
+            ExpData::IfElse(_, cond, if_true, if_false)
+                if if_false.is_unit_exp()
+                    && self
+                        .extract_terminated_prefix(&default_loc, if_true.clone(), 0, true)
+                        .is_some() =>
+            {
+                Some((cond.clone(), if_true.clone()))
+            },
+            _ => None,
+        }
+    }
+
+    pub fn match_if_else_break(&self, exp: Exp) -> Option<(Exp, Exp, Exp)> {
+        let node_id = exp.node_id();
+        let default_loc = self.env().get_node_loc(node_id);
+        match exp.as_ref() {
+            ExpData::IfElse(_, cond, if_true, if_false)
+            if self.extract_terminated_prefix(&default_loc, if_true.clone(), 0, true).is_none() // true branch does not break
+            && self.extract_terminated_prefix(&default_loc, if_false.clone(), 0, true).is_some() // false branch breaks
+            => {
+                Some((cond.clone(), if_true.clone(), if_false.clone()))
+            },
+            _ => None,
+        }
+    }
+
+    pub fn match_if_break_else(&self, exp: Exp) -> Option<(Exp, Exp, Exp)> {
+        let node_id = exp.node_id();
+        let default_loc = self.env().get_node_loc(node_id);
+        match exp.as_ref() {
+            ExpData::IfElse(_, cond, if_true, if_false)
+            if self.extract_terminated_prefix(&default_loc, if_true.clone(), 0, true).is_some() // true branch does not break
+            && self.extract_terminated_prefix(&default_loc, if_false.clone(), 0, true).is_none() // false branch breaks
+            => {
+                Some((cond.clone(), if_true.clone(), if_false.clone()))
+            },
+            _ => None,
+        }
+    }
+
+    pub fn match_nested_if_break(&self, mut exp: Exp) -> Option<(Exp, Exp)> {
+        let node_id = exp.node_id();
+        let default_loc = self.env().get_node_loc(node_id);
+        let mut cond = None;
+        loop {
+            let (c, if_true) = self.match_if(exp)?;
+            if self
+                .extract_terminated_prefix(&default_loc, if_true.clone(), 0, true)
+                .is_some()
+            {
+                return Some((cond.expect("condition must be present"), if_true));
+            }
+            match cond {
+                None => cond = Some(c),
+                Some(old) => cond = Some(self.and(old, c)),
+            }
+            exp = if_true;
+        }
+    }
+
     pub fn match_if_loop_cont(&self, exp: Exp, nest: usize, is_continue: bool) -> Option<Exp> {
         let (cond, if_true) = self.match_if(exp)?;
         if if_true.is_loop_cont(Some(nest), is_continue) {
@@ -251,6 +334,106 @@ impl<'a> ExpBuilder<'a> {
             exp = self.seq(&default_loc, rest)
         }
         cond.map(|c| (c, exp))
+    }
+
+    /// Attempts to extract a sequence of if-break-then
+    ///
+    /// ```move
+    /// branch_0
+    /// if (c_1) break;
+    /// branch_1
+    /// if (c_2) break;
+    /// branch_2
+    /// if (c_n) break;
+    /// branch_n
+    /// ```
+    ///
+    /// This will return the results as a vector <[seq(branch_0), c_1, seq(branch_1), c_2, seq(branch_2), ...]>
+    pub fn match_if_break_then_list(&self, mut exp: Exp, nest: usize) -> Option<Vec<Exp>> {
+        let default_loc = self.env.get_node_loc(exp.node_id());
+        // Global vector to track the if-break-then list
+        let mut if_branch_list = vec![];
+        // Local vector to track the current sequence of expressions that represent a branch
+        let mut cur_branch = vec![];
+
+        loop {
+            let (first, rest) = self.extract_first(exp.clone());
+            // Found a if-break
+            if let Some(c) = self.match_if_loop_cont(first.clone(), nest, false) {
+                let seq = self.seq(&default_loc, std::mem::take(&mut cur_branch));
+                // save the branch before the if-break
+                if_branch_list.push(seq);
+                // save the condition
+                if_branch_list.push(c);
+            } else {
+                cur_branch.push(first);
+            };
+            // No more exps to process
+            if rest.is_empty() {
+                break;
+            }
+            exp = self.seq(&default_loc, rest)
+        }
+
+        // Do not forget to add the last branch
+        let seq = self.seq(&default_loc, cur_branch.clone());
+        if_branch_list.push(seq);
+        Some(if_branch_list)
+    }
+
+    /// Attempts to extract a sequence of if-then-branch-else-branch
+    ///
+    /// ```move
+    /// <begin_stmts>
+    /// if (c_1) {
+    ///     <then_branch_1> where break[0+]
+    /// }
+    /// <else_branch_1>
+    /// if (c_2) {
+    ///     <then_branch_2> where break[0+]
+    /// }
+    /// <else_branch_2>
+    /// if (c_n) {
+    ///     <then_branch_n> where break[0+]
+    /// }
+    /// <else_branch_n>
+    /// ```
+    ///
+    /// This will return the results as a vector <[seq(begin_stmts), c_1, seq(then_branch_1), seq(else_branch_1), c_2, seq(then_branch_2), seq(else_branch_2), ...]>
+    pub fn match_if_branch_break_branch_list(&self, mut exp: Exp) -> Option<Vec<Exp>> {
+        let default_loc = self.env.get_node_loc(exp.node_id());
+        // Vector to track the global if-then-else list
+        let mut if_else_list = vec![];
+        // Vector to track the current sequence of expressions that represent the else-branch before an if-then
+        let mut cur_branch = vec![];
+
+        loop {
+            let (first, rest) = self.extract_first(exp.clone());
+            // Found a if-then
+            if let Some((c, if_true)) = self.match_if_then_break(first.clone()) {
+                // Save `cur_branch`
+                // Meanwhile clean up `cur_branch`
+                let seq = self.seq(&default_loc, std::mem::take(&mut cur_branch));
+                if_else_list.push(seq);
+                // Save the condition
+                if_else_list.push(c);
+                // Save the then-branch
+                if_else_list.push(if_true);
+            } else {
+                // Not an if-branch, so we add it to the current sequence
+                cur_branch.push(first);
+            };
+            // No more exps to process
+            if rest.is_empty() {
+                break;
+            }
+            exp = self.seq(&default_loc, rest)
+        }
+
+        // Do not forget to add the last sequence
+        let seq = self.seq(&default_loc, cur_branch.clone());
+        if_else_list.push(seq);
+        Some(if_else_list)
     }
 
     pub fn new_node_id(&self, loc: Loc, ty: Type) -> NodeId {

--- a/third_party/move/tools/move-decompiler/tests/bit_vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/bit_vector.exp
@@ -15,20 +15,7 @@ module 0x1::bit_vector {
         let _t2;
         if (!(start_index < *&self.length)) abort 131072;
         _t2 = start_index;
-        loop {
-            {
-                'l0: loop {
-                    loop {
-                        if (!(_t2 < *&self.length)) break 'l0;
-                        if (!is_index_set(self, _t2)) break 'l0;
-                        _t2 = _t2 + 1
-                    };
-                    break
-                };
-                break
-            };
-            break
-        };
+        while (_t2 < *&self.length && is_index_set(self, _t2)) _t2 = _t2 + 1;
         _t2 - start_index
     }
     public fun new(length: u64): BitVector {
@@ -38,13 +25,9 @@ module 0x1::bit_vector {
         if (!(length < 1024)) abort 131073;
         _t1 = 0;
         _t2 = 0x1::vector::empty<bool>();
-        'l0: loop {
-            loop {
-                if (!(_t1 < length)) break 'l0;
-                0x1::vector::push_back<bool>(&mut _t2, false);
-                _t1 = _t1 + 1
-            };
-            break
+        while (_t1 < length) {
+            0x1::vector::push_back<bool>(&mut _t2, false);
+            _t1 = _t1 + 1
         };
         BitVector{length: length,bit_field: _t2}
     }
@@ -56,53 +39,25 @@ module 0x1::bit_vector {
         let _t4;
         let _t3;
         let _t2;
-        'l2: loop {
-            'l0: loop {
-                loop {
-                    if (amount >= *&self.length) {
-                        _t2 = &mut self.bit_field;
-                        _t3 = 0;
-                        _t4 = 0x1::vector::length<bool>(/*freeze*/_t2);
-                        break
-                    };
-                    _t3 = amount;
-                    break 'l0
-                };
-                'l1: loop {
-                    loop {
-                        if (!(_t3 < _t4)) break 'l1;
-                        *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
-                        _t3 = _t3 + 1
-                    };
-                    break
-                };
-                break 'l2
-            };
-            'l3: loop {
-                loop {
-                    if (!(_t3 < *&self.length)) break 'l3;
-                    loop {
-                        if (is_index_set(/*freeze*/self, _t3)) {
-                            set(self, _t3 - amount);
-                            break
-                        };
-                        unset(self, _t3 - amount);
-                        break
-                    };
-                    _t3 = _t3 + 1
-                };
-                break
+        if (amount >= *&self.length) {
+            _t2 = &mut self.bit_field;
+            _t3 = 0;
+            _t4 = 0x1::vector::length<bool>(/*freeze*/_t2);
+            while (_t3 < _t4) {
+                *0x1::vector::borrow_mut<bool>(_t2, _t3) = false;
+                _t3 = _t3 + 1
+            }
+        } else {
+            _t3 = amount;
+            while (_t3 < *&self.length) {
+                if (is_index_set(/*freeze*/self, _t3)) set(self, _t3 - amount) else unset(self, _t3 - amount);
+                _t3 = _t3 + 1
             };
             _t3 = *&self.length - amount;
-            'l4: loop {
-                loop {
-                    if (!(_t3 < *&self.length)) break 'l4;
-                    unset(self, _t3);
-                    _t3 = _t3 + 1
-                };
-                break
-            };
-            break
+            while (_t3 < *&self.length) {
+                unset(self, _t3);
+                _t3 = _t3 + 1
+            }
         };
     }
     public fun unset(self: &mut BitVector, bit_index: u64) {

--- a/third_party/move/tools/move-decompiler/tests/cfg_opt.exp
+++ b/third_party/move/tools/move-decompiler/tests/cfg_opt.exp
@@ -22,44 +22,45 @@ module 0x99::cfg_opt_complex {
         let _t1;
         let _t2;
         let _t5;
-        'l2: loop {
-            while (!((self is Institution) && (&self.admin is Superuser))) {
-                'l0: loop {
-                    while (self is Institution) {
+        'l0: loop {
+            if (!(self is Institution)) {
+                loop {
+                    if (self is Institution) {
                         _t5 = &self.admin;
-                        if (!(_t5 is User)) break;
-                        _t2 = &_t5._0;
-                        if (*_t2 > 10) break 'l0;
-                        break
+                        if (_t5 is User) {
+                            _t2 = &_t5._0;
+                            if (*_t2 > 10) break
+                        }
                     };
-                    'l1: loop {
-                        while (self is Institution) {
+                    loop {
+                        if (self is Institution) {
                             _t5 = &self.admin;
-                            if (!(_t5 is User)) break;
-                            if (!(*&_t5._0 <= 10)) break;
-                            break 'l1
+                            if (_t5 is User) {
+                                if (*&_t5._0 <= 10) break}
                         };
                         _t1 = self;
-                        while (_t1 is Person) {
+                        if (_t1 is Person) {
                             _t2 = &_t1.id;
-                            if (!(*_t2 > 10)) break;
-                            _t3 = *_t2;
-                            break 'l2
+                            if (*_t2 > 10) {
+                                _t3 = *_t2;
+                                break 'l0
+                            }
                         };
                         if (_t1 is Institution) {
                             _t3 = *&_t1.id;
-                            break 'l2
+                            break 'l0
                         };
                         _t3 = 0;
-                        break 'l2
+                        break 'l0
                     };
                     _t1 = self;
-                    'l3: loop {
-                        while (_t1 is Person) {
+                    loop {
+                        if (_t1 is Person) {
                             _t2 = &_t1.id;
-                            if (!(*_t2 > 10)) break;
-                            _t6 = *_t2;
-                            break 'l3
+                            if (*_t2 > 10) {
+                                _t6 = *_t2;
+                                break
+                            }
                         };
                         if (_t1 is Institution) {
                             _t6 = *&_t1.id;
@@ -69,15 +70,16 @@ module 0x99::cfg_opt_complex {
                         break
                     };
                     _t3 = _t6 + 5;
-                    break 'l2
+                    break 'l0
                 };
                 _t1 = self;
-                'l4: loop {
-                    while (_t1 is Person) {
+                loop {
+                    if (_t1 is Person) {
                         _t2 = &_t1.id;
-                        if (!(*_t2 > 10)) break;
-                        _t6 = *_t2;
-                        break 'l4
+                        if (*_t2 > 10) {
+                            _t6 = *_t2;
+                            break
+                        }
                     };
                     if (_t1 is Institution) {
                         _t6 = *&_t1.id;
@@ -87,14 +89,15 @@ module 0x99::cfg_opt_complex {
                     break
                 };
                 _t3 = *_t2 + _t6;
-                break 'l2
+                break
             };
-            'l5: loop {
-                while (self is Person) {
+            loop {
+                if (self is Person) {
                     _t2 = &self.id;
-                    if (!(*_t2 > 10)) break;
-                    _t8 = *_t2;
-                    break 'l5
+                    if (*_t2 > 10) {
+                        _t8 = *_t2;
+                        break
+                    }
                 };
                 if (self is Institution) {
                     _t8 = *&self.id;
@@ -112,22 +115,18 @@ module 0x99::cfg_opt_complex {
 
 module 0x99::cfg_opt_simple {
     fun test1(x: u64, y: u64): u64 {
-        'l0: loop {
-            loop {
-                if (!(x > 1 || y > 2)) break 'l0;
-                y = y + 1
-            };
-            break
+        loop {
+            if (!(x > 1)) {
+                if (!(y > 2)) break};
+            y = y + 1
         };
         x + 1 + y
     }
     fun test2(x: u64, y: u64): u64 {
-        'l0: loop {
-            loop {
-                if (!(x > 1 || y > 2)) break 'l0;
-                y = y + 1
-            };
-            break
+        loop {
+            if (!(x > 1)) {
+                if (!(y > 2)) break};
+            y = y + 1
         };
         x + y
     }

--- a/third_party/move/tools/move-decompiler/tests/closure.exp
+++ b/third_party/move/tools/move-decompiler/tests/closure.exp
@@ -23,14 +23,7 @@ module 0x99::basic_struct {
     }
     fun test(f: &||(u64)): u64 {
         let _t1;
-        loop {
-            if (f == f) {
-                _t1 = 1;
-                break
-            };
-            _t1 = 2;
-            break
-        };
+        if (f == f) _t1 = 1 else _t1 = 2;
         _t1
     }
     public fun test_driver(acc: &signer) {

--- a/third_party/move/tools/move-decompiler/tests/enum.exp
+++ b/third_party/move/tools/move-decompiler/tests/enum.exp
@@ -1,0 +1,31 @@
+
+module 0x99::test_enum {
+    enum Shape {
+        Circle {
+            radius: u64,
+        }
+        Rectangle {
+            width: u64,
+            height: u64,
+        }
+    }
+    fun destroy_empty(self: Shape): bool {
+        let _t15;
+        let _t14;
+        let _t2;
+        let _t8;
+        let _t1;
+        _t1 = &self;
+        if (_t1 is Circle) {
+            Shape::Circle{radius: _t8} = self;
+            _t2 = true
+        } else if (_t1 is Rectangle) {
+            Shape::Rectangle{width: _t14,height: _t15} = self;
+            _t2 = false
+        } else abort 14566554180833181697;
+        _t2
+    }
+    fun example_destroy_shapes() {
+        ()
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/enum.move
+++ b/third_party/move/tools/move-decompiler/tests/enum.move
@@ -1,0 +1,21 @@
+module 0x99::test_enum {
+    // Note: `Shape` has no `drop` ability, so must be destroyed with explicit unpacking.
+    enum Shape {
+        Circle{radius: u64},
+        Rectangle{width: u64, height: u64}
+    }
+
+    fun destroy_empty(self: Shape) : bool {
+        match (self) {
+            Shape::Circle{radius} => true,
+            Shape::Rectangle{width, height: _} => false,
+        }
+    }
+
+    fun example_destroy_shapes() {
+        let c = Shape::Circle{radius: 0};
+        let r = Shape::Rectangle{width: 0, height: 0};
+        c.destroy_empty();
+        r.destroy_empty();
+    }
+}

--- a/third_party/move/tools/move-decompiler/tests/fixed_point32.exp
+++ b/third_party/move/tools/move-decompiler/tests/fixed_point32.exp
@@ -19,14 +19,7 @@ module 0x1::fixed_point32 {
         _t3 = (denominator as u128) << 32u8;
         if (!(_t3 != 0u128)) abort 65537;
         _t4 = ((numerator as u128) << 64u8) / _t3;
-        loop {
-            if (_t4 != 0u128) {
-                _t5 = true;
-                break
-            };
-            _t5 = numerator == 0;
-            break
-        };
+        if (_t4 != 0u128) _t5 = true else _t5 = numerator == 0;
         if (!_t5) abort 131077;
         if (!(_t4 <= 18446744073709551615u128)) abort 131077;
         FixedPoint32{value: _t4 as u64}
@@ -55,26 +48,12 @@ module 0x1::fixed_point32 {
     }
     public fun max(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
         let _t2;
-        loop {
-            if (*&(&num1).value > *&(&num2).value) {
-                _t2 = num1;
-                break
-            };
-            _t2 = num2;
-            break
-        };
+        if (*&(&num1).value > *&(&num2).value) _t2 = num1 else _t2 = num2;
         _t2
     }
     public fun min(num1: FixedPoint32, num2: FixedPoint32): FixedPoint32 {
         let _t2;
-        loop {
-            if (*&(&num1).value < *&(&num2).value) {
-                _t2 = num1;
-                break
-            };
-            _t2 = num2;
-            break
-        };
+        if (*&(&num1).value < *&(&num2).value) _t2 = num1 else _t2 = num2;
         _t2
     }
     public fun multiply_u64(val: u64, multiplier: FixedPoint32): u64 {
@@ -88,14 +67,7 @@ module 0x1::fixed_point32 {
         let _t1;
         _t1 = floor(self) << 32u8;
         _t2 = _t1 + 2147483648;
-        loop {
-            if (*&(&self).value < _t2) {
-                _t2 = _t1 >> 32u8;
-                break
-            };
-            _t2 = ceil(self);
-            break
-        };
+        if (*&(&self).value < _t2) _t2 = _t1 >> 32u8 else _t2 = ceil(self);
         _t2
     }
 }

--- a/third_party/move/tools/move-decompiler/tests/nested_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/nested_loops.exp
@@ -10,32 +10,15 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
-            'l1: loop {
-                loop {
-                    if (_t2) {
-                        _t1 = _t1 + 1;
-                        break
-                    };
-                    _t2 = true;
-                    break
-                };
-                if (!(_t1 < 10)) break 'l0;
-                _t0 = _t0 + 1;
-                _t3 = _t1;
-                _t4 = false;
-                loop {
-                    loop {
-                        if (_t4) {
-                            _t3 = _t3 + 1;
-                            break
-                        };
-                        _t4 = true;
-                        break
-                    };
-                    if (!(_t3 < 10)) continue 'l1;
-                    _t0 = _t0 + 1
-                };
-                break
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 10)) break;
+            _t0 = _t0 + 1;
+            _t3 = _t1;
+            _t4 = false;
+            loop {
+                if (_t4) _t3 = _t3 + 1 else _t4 = true;
+                if (!(_t3 < 10)) continue 'l0;
+                _t0 = _t0 + 1
             };
             break
         };
@@ -50,29 +33,19 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 5)) break;
+            _t0 = _t0 + 1;
+            _t3 = _t1;
             'l1: loop {
-                loop {
-                    if (_t2) {
-                        _t1 = _t1 + 1;
-                        break
-                    };
-                    _t2 = true;
-                    break
-                };
-                if (!(_t1 < 5)) break 'l0;
+                if (!(_t3 < 10)) continue 'l0;
                 _t0 = _t0 + 1;
-                _t3 = _t1;
-                'l2: loop {
-                    if (!(_t3 < 10)) continue 'l1;
+                _t4 = _t3;
+                _t3 = _t3 + 1;
+                loop {
                     _t0 = _t0 + 1;
-                    _t4 = _t3;
-                    _t3 = _t3 + 1;
-                    loop {
-                        _t0 = _t0 + 1;
-                        if (_t4 > 10) continue 'l2;
-                        _t4 = _t4 + 1
-                    };
-                    break
+                    if (_t4 > 10) continue 'l1;
+                    _t4 = _t4 + 1
                 };
                 break
             };
@@ -87,22 +60,12 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
-            'l1: loop {
-                loop {
-                    if (_t2) {
-                        _t1 = _t1 + 1;
-                        break
-                    };
-                    _t2 = true;
-                    break
-                };
-                if (!(_t1 < 5)) break 'l0;
-                _t0 = _t0 + 1;
-                loop {
-                    if (!(_t0 < 5)) continue 'l1;
-                    _t0 = _t0 + 10
-                };
-                break
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 5)) break;
+            _t0 = _t0 + 1;
+            loop {
+                if (!(_t0 < 5)) continue 'l0;
+                _t0 = _t0 + 10
             };
             break
         };
@@ -116,26 +79,16 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
-            'l1: loop {
-                _t0 = _t0 + 1;
-                _t2 = 0;
-                if (_t0 > 3) break 'l0;
-                _t3 = 0;
-                _t4 = false;
-                loop {
-                    loop {
-                        if (_t4) {
-                            _t3 = _t3 + 1;
-                            break
-                        };
-                        _t4 = true;
-                        break
-                    };
-                    if (!(_t3 < 5)) continue 'l1;
-                    _t2 = _t2 + 1;
-                    _t1 = _t1 + 1
-                };
-                break
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            if (_t0 > 3) break;
+            _t3 = 0;
+            _t4 = false;
+            loop {
+                if (_t4) _t3 = _t3 + 1 else _t4 = true;
+                if (!(_t3 < 5)) continue 'l0;
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1
             };
             break
         };
@@ -147,16 +100,13 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
-            'l1: loop {
-                _t0 = _t0 + 1;
-                _t2 = 0;
-                if (_t0 > 3) break 'l0;
-                loop {
-                    _t2 = _t2 + 1;
-                    _t1 = _t1 + 1;
-                    if (_t2 > 7) continue 'l1
-                };
-                break
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            if (_t0 > 3) break;
+            loop {
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1;
+                if (_t2 > 7) continue 'l0
             };
             break
         };
@@ -168,16 +118,13 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
-            'l1: loop {
-                _t0 = _t0 + 1;
-                _t2 = 0;
-                if (_t0 > 3) break 'l0;
-                loop {
-                    if (!(_t2 < 7)) continue 'l1;
-                    _t2 = _t2 + 1;
-                    _t1 = _t1 + 1
-                };
-                break
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            if (_t0 > 3) break;
+            loop {
+                if (!(_t2 < 7)) continue 'l0;
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1
             };
             break
         };
@@ -188,17 +135,13 @@ module 0x99::nested_loops {
         let _t0;
         _t0 = 0;
         _t1 = 0;
-        'l0: loop {
-            'l1: loop {
-                if (!(_t0 < 3)) break 'l0;
-                _t0 = _t0 + 1;
-                _t2 = 0;
-                loop {
-                    if (!(_t2 < 7)) continue 'l1;
-                    _t2 = _t2 + 1;
-                    _t1 = _t1 + 1
-                };
-                break
+        'l0: while (_t0 < 3) {
+            _t0 = _t0 + 1;
+            _t2 = 0;
+            loop {
+                if (!(_t2 < 7)) continue 'l0;
+                _t2 = _t2 + 1;
+                _t1 = _t1 + 1
             };
             break
         };
@@ -215,45 +158,21 @@ module 0x99::nested_loops {
         _t1 = 0;
         _t2 = false;
         'l0: loop {
+            if (_t2) _t1 = _t1 + 1 else _t2 = true;
+            if (!(_t1 < 10)) break;
+            _t0 = _t0 + 1;
+            _t3 = _t1;
+            _t4 = false;
             'l1: loop {
-                loop {
-                    if (_t2) {
-                        _t1 = _t1 + 1;
-                        break
-                    };
-                    _t2 = true;
-                    break
-                };
-                if (!(_t1 < 10)) break 'l0;
+                if (_t4) _t3 = _t3 + 1 else _t4 = true;
+                if (!(_t3 < 10)) continue 'l0;
                 _t0 = _t0 + 1;
-                _t3 = _t1;
-                _t4 = false;
-                'l2: loop {
-                    loop {
-                        if (_t4) {
-                            _t3 = _t3 + 1;
-                            break
-                        };
-                        _t4 = true;
-                        break
-                    };
-                    if (!(_t3 < 10)) continue 'l1;
-                    _t0 = _t0 + 1;
-                    _t5 = _t3;
-                    _t6 = false;
-                    loop {
-                        loop {
-                            if (_t6) {
-                                _t5 = _t5 + 1;
-                                break
-                            };
-                            _t6 = true;
-                            break
-                        };
-                        if (!(_t5 < 10)) continue 'l2;
-                        _t0 = _t0 + 1
-                    };
-                    break
+                _t5 = _t3;
+                _t6 = false;
+                loop {
+                    if (_t6) _t5 = _t5 + 1 else _t6 = true;
+                    if (!(_t5 < 10)) continue 'l1;
+                    _t0 = _t0 + 1
                 };
                 break
             };
@@ -268,22 +187,19 @@ module 0x99::nested_loops {
         _t0 = 0;
         _t1 = 0;
         'l0: loop {
+            _t0 = _t0 + 1;
+            _t2 = _t1;
+            if (_t1 > 10) break;
+            _t1 = _t1 + 1;
             'l1: loop {
                 _t0 = _t0 + 1;
-                _t2 = _t1;
-                if (_t1 > 10) break 'l0;
-                _t1 = _t1 + 1;
-                'l2: loop {
+                _t3 = _t2;
+                if (_t2 > 10) continue 'l0;
+                _t2 = _t2 + 1;
+                loop {
                     _t0 = _t0 + 1;
-                    _t3 = _t2;
-                    if (_t2 > 10) continue 'l1;
-                    _t2 = _t2 + 1;
-                    loop {
-                        _t0 = _t0 + 1;
-                        if (_t3 > 10) continue 'l2;
-                        _t3 = _t3 + 1
-                    };
-                    break
+                    if (_t3 > 10) continue 'l1;
+                    _t3 = _t3 + 1
                 };
                 break
             };
@@ -297,23 +213,19 @@ module 0x99::nested_loops {
         let _t0;
         _t0 = 0;
         _t1 = 0;
-        'l0: loop {
+        'l0: while (_t1 < 10) {
+            _t0 = _t0 + 1;
+            _t2 = _t1;
+            _t1 = _t1 + 1;
             'l1: loop {
-                if (!(_t1 < 10)) break 'l0;
+                if (!(_t2 < 10)) continue 'l0;
                 _t0 = _t0 + 1;
-                _t2 = _t1;
-                _t1 = _t1 + 1;
-                'l2: loop {
-                    if (!(_t2 < 10)) continue 'l1;
+                _t3 = _t2;
+                _t2 = _t2 + 1;
+                loop {
+                    if (!(_t3 < 10)) continue 'l1;
                     _t0 = _t0 + 1;
-                    _t3 = _t2;
-                    _t2 = _t2 + 1;
-                    loop {
-                        if (!(_t3 < 10)) continue 'l2;
-                        _t0 = _t0 + 1;
-                        _t3 = _t3 + 1
-                    };
-                    break
+                    _t3 = _t3 + 1
                 };
                 break
             };

--- a/third_party/move/tools/move-decompiler/tests/noexit_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/noexit_loops.exp
@@ -24,18 +24,12 @@ module 0x99::noexit_loops {
     }
     fun f13(cond: bool) {
         let _t2;
-        loop {
-            if (cond) {
-                _t2 = 0;
-                break
-            };
-            _t2 = 1;
-            break
-        };
+        if (cond) _t2 = 0 else _t2 = 1;
         loop continue
     }
     fun f14(p: bool, q: bool) {
-        if (p && q) loop continue;
+        if (p) {
+            if (q) loop continue};
     }
     fun f15() {
         let _t0;

--- a/third_party/move/tools/move-decompiler/tests/option.exp
+++ b/third_party/move/tools/move-decompiler/tests/option.exp
@@ -29,14 +29,7 @@ module 0x1::option {
         let _t3;
         let _t2;
         _t2 = &self.vec;
-        loop {
-            if (vector::is_empty<Element>(_t2)) {
-                _t3 = default_ref;
-                break
-            };
-            _t3 = vector::borrow<Element>(_t2, 0);
-            break
-        };
+        if (vector::is_empty<Element>(_t2)) _t3 = default_ref else _t3 = vector::borrow<Element>(_t2, 0);
         _t3
     }
     public fun destroy_none<Element>(self: Option<Element>) {
@@ -63,14 +56,7 @@ module 0x1::option {
         let _t5;
         Option<Element>{vec: _t5} = self;
         _t2 = _t5;
-        loop {
-            if (vector::is_empty<Element>(/*freeze*/&mut _t2)) {
-                _t3 = default;
-                break
-            };
-            _t3 = vector::pop_back<Element>(&mut _t2);
-            break
-        };
+        if (vector::is_empty<Element>(/*freeze*/&mut _t2)) _t3 = default else _t3 = vector::pop_back<Element>(&mut _t2);
         _t3
     }
     public fun extract<Element>(self: &mut Option<Element>): Element {
@@ -91,14 +77,7 @@ module 0x1::option {
         let _t3;
         let _t2;
         _t2 = &self.vec;
-        loop {
-            if (vector::is_empty<Element>(_t2)) {
-                _t3 = default;
-                break
-            };
-            _t3 = *vector::borrow<Element>(_t2, 0);
-            break
-        };
+        if (vector::is_empty<Element>(_t2)) _t3 = default else _t3 = *vector::borrow<Element>(_t2, 0);
         _t3
     }
     public fun none<Element>(): Option<Element> {
@@ -111,14 +90,7 @@ module 0x1::option {
         let _t3;
         let _t2;
         _t2 = &mut self.vec;
-        loop {
-            if (vector::is_empty<Element>(/*freeze*/_t2)) {
-                _t3 = none<Element>();
-                break
-            };
-            _t3 = some<Element>(vector::pop_back<Element>(_t2));
-            break
-        };
+        if (vector::is_empty<Element>(/*freeze*/_t2)) _t3 = none<Element>() else _t3 = some<Element>(vector::pop_back<Element>(_t2));
         vector::push_back<Element>(_t2, e);
         _t3
     }

--- a/third_party/move/tools/move-decompiler/tests/simple_map.exp
+++ b/third_party/move/tools/move-decompiler/tests/simple_map.exp
@@ -33,18 +33,8 @@ module 0x1::simple_map {
     fun find<Key: store, Value: store>(self: &SimpleMap<Key, Value>, key: &Key): option::Option<u64> {
         let _t3;
         _t3 = 0;
-        {
-            'l0: loop {
-                loop {
-                    if (!(_t3 < vector::length<Element<Key, Value>>(&self.data))) break 'l0;
-                    if (&vector::borrow<Element<Key, Value>>(&self.data, _t3).key == key) break 'l0;
-                    _t3 = _t3 + 1
-                };
-                break
-            };
-            return option::some<u64>(_t3)
-        };
-        option::none<u64>()
+        while (!(!(_t3 < vector::length<Element<Key, Value>>(&self.data)) || &vector::borrow<Element<Key, Value>>(&self.data, _t3).key == key)) _t3 = _t3 + 1;
+        option::some<u64>(_t3)
     }
     public fun remove<Key: store, Value: store>(self: &mut SimpleMap<Key, Value>, key: &Key): (Key, Value) {
         let _t19;
@@ -73,13 +63,9 @@ module 0x1::simple_map {
         _t6 = _t4;
         _t7 = vector::length<Key>(&_t5);
         if (!(_t7 == vector::length<Value>(&_t6))) abort 131074;
-        'l0: loop {
-            loop {
-                if (!(_t7 > 0)) break 'l0;
-                add<Key,Value>(self, vector::pop_back<Key>(&mut _t5), vector::pop_back<Value>(&mut _t6));
-                _t7 = _t7 - 1
-            };
-            break
+        while (_t7 > 0) {
+            add<Key,Value>(self, vector::pop_back<Key>(&mut _t5), vector::pop_back<Value>(&mut _t6));
+            _t7 = _t7 - 1
         };
         vector::destroy_empty<Key>(_t5);
         vector::destroy_empty<Value>(_t6);
@@ -91,13 +77,9 @@ module 0x1::simple_map {
         _t1 = &self.data;
         _t2 = vector::empty<Key>();
         _t3 = 0;
-        'l0: loop {
-            loop {
-                if (!(_t3 < vector::length<Element<Key, Value>>(_t1))) break 'l0;
-                vector::push_back<Key>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).key);
-                _t3 = _t3 + 1
-            };
-            break
+        while (_t3 < vector::length<Element<Key, Value>>(_t1)) {
+            vector::push_back<Key>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).key);
+            _t3 = _t3 + 1
         };
         _t2
     }
@@ -108,13 +90,9 @@ module 0x1::simple_map {
         _t1 = &self.data;
         _t2 = vector::empty<Value>();
         _t3 = 0;
-        'l0: loop {
-            loop {
-                if (!(_t3 < vector::length<Element<Key, Value>>(_t1))) break 'l0;
-                vector::push_back<Value>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).value);
-                _t3 = _t3 + 1
-            };
-            break
+        while (_t3 < vector::length<Element<Key, Value>>(_t1)) {
+            vector::push_back<Value>(&mut _t2, *&vector::borrow<Element<Key, Value>>(_t1, _t3).value);
+            _t3 = _t3 + 1
         };
         _t2
     }
@@ -149,15 +127,11 @@ module 0x1::simple_map {
         vector::reverse<Element<Key, Value>>(&mut _t3);
         _t4 = _t3;
         _t5 = vector::length<Element<Key, Value>>(&_t4);
-        'l0: loop {
-            loop {
-                if (!(_t5 > 0)) break 'l0;
-                Element<Key,Value>{key: _t21,value: _t22} = vector::pop_back<Element<Key, Value>>(&mut _t4);
-                vector::push_back<Key>(&mut _t1, _t21);
-                vector::push_back<Value>(&mut _t2, _t22);
-                _t5 = _t5 - 1
-            };
-            break
+        while (_t5 > 0) {
+            Element<Key,Value>{key: _t21,value: _t22} = vector::pop_back<Element<Key, Value>>(&mut _t4);
+            vector::push_back<Key>(&mut _t1, _t21);
+            vector::push_back<Value>(&mut _t2, _t22);
+            _t5 = _t5 - 1
         };
         vector::destroy_empty<Element<Key, Value>>(_t4);
         (_t1, _t2)
@@ -171,21 +145,10 @@ module 0x1::simple_map {
         _t3 = &mut self.data;
         _t4 = vector::length<Element<Key, Value>>(/*freeze*/_t3);
         _t5 = 0;
-        {
-            'l0: loop {
-                loop {
-                    if (!(_t5 < _t4)) break 'l0;
-                    if (&vector::borrow<Element<Key, Value>>(/*freeze*/_t3, _t5).key == &key) break 'l0;
-                    _t5 = _t5 + 1
-                };
-                break
-            };
-            vector::push_back<Element<Key, Value>>(_t3, Element<Key,Value>{key: key,value: value});
-            vector::swap<Element<Key, Value>>(_t3, _t5, _t4);
-            Element<Key,Value>{key: _t34,value: _t35} = vector::pop_back<Element<Key, Value>>(_t3);
-            return (option::some<Key>(_t34), option::some<Value>(_t35))
-        };
-        vector::push_back<Element<Key, Value>>(&mut self.data, Element<Key,Value>{key: key,value: value});
-        (option::none<Key>(), option::none<Value>())
+        while (!(!(_t5 < _t4) || &vector::borrow<Element<Key, Value>>(/*freeze*/_t3, _t5).key == &key)) _t5 = _t5 + 1;
+        vector::push_back<Element<Key, Value>>(_t3, Element<Key,Value>{key: key,value: value});
+        vector::swap<Element<Key, Value>>(_t3, _t5, _t4);
+        Element<Key,Value>{key: _t34,value: _t35} = vector::pop_back<Element<Key, Value>>(_t3);
+        (option::some<Key>(_t34), option::some<Value>(_t35))
     }
 }

--- a/third_party/move/tools/move-decompiler/tests/string.exp
+++ b/third_party/move/tools/move-decompiler/tests/string.exp
@@ -23,14 +23,7 @@ module 0x1::string {
         let _t4;
         let _t3;
         _t3 = &self.bytes;
-        loop {
-            if (at <= vector::length<u8>(_t3)) {
-                _t4 = internal_is_char_boundary(_t3, at);
-                break
-            };
-            _t4 = false;
-            break
-        };
+        if (at <= vector::length<u8>(_t3)) _t4 = internal_is_char_boundary(_t3, at) else _t4 = false;
         if (!_t4) abort 2;
         _t6 = sub_string(/*freeze*/self, 0, at);
         append(&mut _t6, o);
@@ -44,30 +37,9 @@ module 0x1::string {
         let _t5;
         let _t3;
         _t3 = &self.bytes;
-        loop {
-            if (j <= vector::length<u8>(_t3)) {
-                _t5 = i <= j;
-                break
-            };
-            _t5 = false;
-            break
-        };
-        loop {
-            if (_t5) {
-                _t6 = internal_is_char_boundary(_t3, i);
-                break
-            };
-            _t6 = false;
-            break
-        };
-        loop {
-            if (_t6) {
-                _t7 = internal_is_char_boundary(_t3, j);
-                break
-            };
-            _t7 = false;
-            break
-        };
+        if (j <= vector::length<u8>(_t3)) _t5 = i <= j else _t5 = false;
+        if (_t5) _t6 = internal_is_char_boundary(_t3, i) else _t6 = false;
+        if (_t6) _t7 = internal_is_char_boundary(_t3, j) else _t7 = false;
         if (!_t7) abort 2;
         String{bytes: internal_sub_string(_t3, i, j)}
     }
@@ -85,14 +57,7 @@ module 0x1::string {
     native fun internal_sub_string(v: &vector<u8>, i: u64, j: u64): vector<u8>;
     public fun try_utf8(bytes: vector<u8>): option::Option<String> {
         let _t1;
-        loop {
-            if (internal_check_utf8(&bytes)) {
-                _t1 = option::some<String>(String{bytes: bytes});
-                break
-            };
-            _t1 = option::none<String>();
-            break
-        };
+        if (internal_check_utf8(&bytes)) _t1 = option::some<String>(String{bytes: bytes}) else _t1 = option::none<String>();
         _t1
     }
 }

--- a/third_party/move/tools/move-decompiler/tests/vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/vector.exp
@@ -11,34 +11,14 @@ module 0x1::vector {
     public fun contains<Element>(self: &vector<Element>, e: &Element): bool {
         let _t2;
         _t2 = 0;
-        {
-            'l0: loop {
-                loop {
-                    if (!(_t2 < length<Element>(self))) break 'l0;
-                    if (borrow<Element>(self, _t2) == e) break 'l0;
-                    _t2 = _t2 + 1
-                };
-                break
-            };
-            return true
-        };
-        false
+        while (!(!(_t2 < length<Element>(self)) || borrow<Element>(self, _t2) == e)) _t2 = _t2 + 1;
+        true
     }
     public fun index_of<Element>(self: &vector<Element>, e: &Element): (bool, u64) {
         let _t2;
         _t2 = 0;
-        {
-            'l0: loop {
-                loop {
-                    if (!(_t2 < length<Element>(self))) break 'l0;
-                    if (borrow<Element>(self, _t2) == e) break 'l0;
-                    _t2 = _t2 + 1
-                };
-                break
-            };
-            return (true, _t2)
-        };
-        (false, 0)
+        while (!(!(_t2 < length<Element>(self)) || borrow<Element>(self, _t2) == e)) _t2 = _t2 + 1;
+        (true, _t2)
     }
     public fun range(start: u64, end: u64): vector<u64> {
         range_with_step(start, end, 1)
@@ -47,13 +27,9 @@ module 0x1::vector {
         let _t3;
         if (!(step > 0)) abort 131075;
         _t3 = empty<u64>();
-        'l0: loop {
-            loop {
-                if (!(start < end)) break 'l0;
-                push_back<u64>(&mut _t3, start);
-                start = start + step
-            };
-            break
+        while (start < end) {
+            push_back<u64>(&mut _t3, start);
+            start = start + step
         };
         _t3
     }
@@ -67,13 +43,9 @@ module 0x1::vector {
     public fun reverse_append<Element>(self: &mut vector<Element>, other: vector<Element>) {
         let _t2;
         _t2 = length<Element>(&other);
-        'l0: loop {
-            loop {
-                if (!(_t2 > 0)) break 'l0;
-                push_back<Element>(self, pop_back<Element>(&mut other));
-                _t2 = _t2 - 1
-            };
-            break
+        while (_t2 > 0) {
+            push_back<Element>(self, pop_back<Element>(&mut other));
+            _t2 = _t2 - 1
         };
         destroy_empty<Element>(other);
     }
@@ -82,13 +54,9 @@ module 0x1::vector {
         _t3 = length<Element>(/*freeze*/self);
         if (!(i <= _t3)) abort 131072;
         push_back<Element>(self, e);
-        'l0: loop {
-            loop {
-                if (!(i < _t3)) break 'l0;
-                swap<Element>(self, i, _t3);
-                i = i + 1
-            };
-            break
+        while (i < _t3) {
+            swap<Element>(self, i, _t3);
+            i = i + 1
         };
     }
     public fun is_empty<Element>(self: &vector<Element>): bool {
@@ -98,13 +66,9 @@ module 0x1::vector {
         let _t2;
         _t2 = length<Element>(/*freeze*/self);
         if (i >= _t2) abort 131072;
-        'l0: loop {
-            loop {
-                if (!(i < _t2 - 1)) break 'l0;
-                i = i + 1;
-                swap<Element>(self, i, i)
-            };
-            break
+        while (i < _t2 - 1) {
+            i = i + 1;
+            swap<Element>(self, i, i)
         };
         pop_back<Element>(self)
     }
@@ -114,16 +78,11 @@ module 0x1::vector {
         let _t8;
         let _t7;
         (_t7,_t8) = index_of<Element>(/*freeze*/self, val);
-        loop {
-            if (_t7) {
-                _t12 = empty<Element>();
-                push_back<Element>(&mut _t12, remove<Element>(self, _t8));
-                _t3 = _t12;
-                break
-            };
-            _t3 = empty<Element>();
-            break
-        };
+        if (_t7) {
+            _t12 = empty<Element>();
+            push_back<Element>(&mut _t12, remove<Element>(self, _t8));
+            _t3 = _t12
+        } else _t3 = empty<Element>();
         _t3
     }
     public fun reverse_slice<Element>(self: &mut vector<Element>, left: u64, right: u64) {
@@ -159,23 +118,12 @@ module 0x1::vector {
     public fun slice<Element: copy>(self: &vector<Element>, start: u64, end: u64): vector<Element> {
         let _t4;
         let _t3;
-        loop {
-            if (start <= end) {
-                _t3 = end <= length<Element>(self);
-                break
-            };
-            _t3 = false;
-            break
-        };
+        if (start <= end) _t3 = end <= length<Element>(self) else _t3 = false;
         if (!_t3) abort 131076;
         _t4 = empty<Element>();
-        'l0: loop {
-            loop {
-                if (!(start < end)) break 'l0;
-                push_back<Element>(&mut _t4, *borrow<Element>(self, start));
-                start = start + 1
-            };
-            break
+        while (start < end) {
+            push_back<Element>(&mut _t4, *borrow<Element>(self, start));
+            start = start + 1
         };
         _t4
     }
@@ -196,13 +144,9 @@ module 0x1::vector {
         _t2 = length<Element>(/*freeze*/self);
         if (!(new_len <= _t2)) abort 131072;
         _t3 = empty<Element>();
-        'l0: loop {
-            loop {
-                if (!(new_len < _t2)) break 'l0;
-                push_back<Element>(&mut _t3, pop_back<Element>(self));
-                _t2 = _t2 - 1
-            };
-            break
+        while (new_len < _t2) {
+            push_back<Element>(&mut _t3, pop_back<Element>(self));
+            _t2 = _t2 - 1
         };
         _t3
     }


### PR DESCRIPTION
## Description
This PR introduces four control flow optimizations to turn redundant loops into more human-friendly `if-else` expressions:
* `try_remove_redundant_loop`
* `try_make_if`
*  `try_make_if_else`
* `try_remove_redundant_exp`

close #17054 

## How Has This Been Tested?
* Existing test cases (results verified)
* Modules from mainnet (only tested for crashes/panics/timeout)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Move Decompiler)
