### PR TITLE
[replay-verify] Try PD-BALANCED instead of PD-SSD

### DIFF
--- a/testsuite/replay-verify/archive-pvc-template.yaml
+++ b/testsuite/replay-verify/archive-pvc-template.yaml
@@ -12,7 +12,7 @@ spec:
   resources:
     requests:
       storage: 12Ti
-  storageClassName: ssd-data-xfs-immediate
+  storageClassName: pd-balanced-xfs-immediate
   volumeMode: Filesystem
   dataSourceRef:
     name: testnet-archive

--- a/testsuite/replay-verify/archive_disk_utils.py
+++ b/testsuite/replay-verify/archive_disk_utils.py
@@ -17,7 +17,7 @@ from typing import Tuple, List, Optional, Any
 
 # Constants
 DISK_COPIES = 1
-STORAGE_CLASS = "ssd-data-xfs-immediate"
+STORAGE_CLASS = "pd-balanced-xfs-immediate"
 
 # Logging configuration
 logging.basicConfig(level=logging.INFO)


### PR DESCRIPTION
## Description

Try using PD-BALANCED instead of PD-SSD for replay-verify, as it's 2x cheaper.