### PR TITLE
[Data Streaming Service] Add support for transaction data v2.

### DIFF
--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -842,7 +842,7 @@ impl Context {
             .0;
 
         let txn_start_version = data
-            .first_transaction_output_version
+            .get_first_output_version()
             .ok_or_else(|| format_err!("no start version from database"))?;
         ensure!(
             txn_start_version == start_version,

--- a/api/src/context.rs
+++ b/api/src/context.rs
@@ -838,8 +838,7 @@ impl Context {
         let data = self
             .db
             .get_transaction_outputs(start_version, limit as u64, ledger_version)?
-            .into_parts()
-            .0;
+            .consume_output_list_with_proof();
 
         let txn_start_version = data
             .get_first_output_version()
@@ -1077,8 +1076,7 @@ impl Context {
         let (_, txn_output) = &self
             .db
             .get_transaction_outputs(txn.version, 1, txn.version)?
-            .into_parts()
-            .0
+            .consume_output_list_with_proof()
             .transactions_and_outputs[0];
         self.get_accumulator_root_hash(txn.version)
             .map(|h| (txn, h, txn_output).into())

--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -182,7 +182,7 @@ pub struct StorageServiceConfig {
 impl Default for StorageServiceConfig {
     fn default() -> Self {
         Self {
-            enable_transaction_data_v2: false, // TODO: flip this once V2 data is enabled
+            enable_transaction_data_v2: true,
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_invalid_requests_per_peer: 500,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB

--- a/execution/executor/src/chunk_executor/mod.rs
+++ b/execution/executor/src/chunk_executor/mod.rs
@@ -128,9 +128,7 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
         if !cfg!(feature = "consensus-only-perf-test") {
             txn_list_with_proof.verify(
                 verified_target_li.ledger_info(),
-                txn_list_with_proof
-                    .get_transaction_list_with_proof()
-                    .first_transaction_version,
+                txn_list_with_proof.get_first_transaction_version(),
             )?;
         }
 
@@ -172,9 +170,7 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
             let _timer = CHUNK_OTHER_TIMERS.timer_with(&["apply_chunk__verify"]);
             txn_output_list_with_proof.verify(
                 verified_target_li.ledger_info(),
-                txn_output_list_with_proof
-                    .get_output_list_with_proof()
-                    .first_transaction_output_version,
+                txn_output_list_with_proof.get_first_output_version(),
             )
         })?;
 

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -301,10 +301,10 @@ impl ResponsePayload {
                 epoch_ending_ledger_infos.len()
             },
             Self::NewTransactionOutputsWithProof((outputs_with_proof, _)) => {
-                outputs_with_proof.transactions_and_outputs.len()
+                outputs_with_proof.get_num_outputs()
             },
             Self::NewTransactionsWithProof((transactions_with_proof, _)) => {
-                transactions_with_proof.transactions.len()
+                transactions_with_proof.get_num_transactions()
             },
             Self::NumberOfStates(_) => {
                 1 // The number of states is a single u64
@@ -313,10 +313,10 @@ impl ResponsePayload {
                 state_values_with_proof.raw_values.len()
             },
             Self::TransactionOutputsWithProof(outputs_with_proof) => {
-                outputs_with_proof.transactions_and_outputs.len()
+                outputs_with_proof.get_num_outputs()
             },
             Self::TransactionsWithProof(transactions_with_proof) => {
-                transactions_with_proof.transactions.len()
+                transactions_with_proof.get_num_transactions()
             },
         }
     }

--- a/state-sync/aptos-data-client/src/interface.rs
+++ b/state-sync/aptos-data-client/src/interface.rs
@@ -2,17 +2,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{error, error::Error, global_summary::GlobalDataSummary};
-use aptos_storage_service_types::{
-    responses::{TransactionOrOutputListWithProof, TransactionOrOutputListWithProofV2},
-    Epoch,
-};
+use aptos_storage_service_types::{responses::TransactionOrOutputListWithProofV2, Epoch};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValueChunkWithProof,
-    transaction::{
-        TransactionListWithProof, TransactionListWithProofV2, TransactionOutputListWithProof,
-        TransactionOutputListWithProofV2, Version,
-    },
+    transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use async_trait::async_trait;
 use serde::{Deserialize, Serialize};
@@ -270,12 +264,12 @@ impl<T> Response<T> {
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum ResponsePayload {
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
-    NewTransactionOutputsWithProof((TransactionOutputListWithProof, LedgerInfoWithSignatures)),
-    NewTransactionsWithProof((TransactionListWithProof, LedgerInfoWithSignatures)),
+    NewTransactionOutputsWithProof((TransactionOutputListWithProofV2, LedgerInfoWithSignatures)),
+    NewTransactionsWithProof((TransactionListWithProofV2, LedgerInfoWithSignatures)),
     NumberOfStates(u64),
     StateValuesWithProof(StateValueChunkWithProof),
-    TransactionOutputsWithProof(TransactionOutputListWithProof),
-    TransactionsWithProof(TransactionListWithProof),
+    TransactionOutputsWithProof(TransactionOutputListWithProofV2),
+    TransactionsWithProof(TransactionListWithProofV2),
 }
 
 impl ResponsePayload {
@@ -334,23 +328,23 @@ impl From<Vec<LedgerInfoWithSignatures>> for ResponsePayload {
     }
 }
 
-impl From<(TransactionOutputListWithProof, LedgerInfoWithSignatures)> for ResponsePayload {
-    fn from(inner: (TransactionOutputListWithProof, LedgerInfoWithSignatures)) -> Self {
+impl From<(TransactionOutputListWithProofV2, LedgerInfoWithSignatures)> for ResponsePayload {
+    fn from(inner: (TransactionOutputListWithProofV2, LedgerInfoWithSignatures)) -> Self {
         Self::NewTransactionOutputsWithProof(inner)
     }
 }
 
-impl From<(TransactionListWithProof, LedgerInfoWithSignatures)> for ResponsePayload {
-    fn from(inner: (TransactionListWithProof, LedgerInfoWithSignatures)) -> Self {
+impl From<(TransactionListWithProofV2, LedgerInfoWithSignatures)> for ResponsePayload {
+    fn from(inner: (TransactionListWithProofV2, LedgerInfoWithSignatures)) -> Self {
         Self::NewTransactionsWithProof(inner)
     }
 }
 
-impl TryFrom<(TransactionOrOutputListWithProof, LedgerInfoWithSignatures)> for ResponsePayload {
+impl TryFrom<(TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures)> for ResponsePayload {
     type Error = Error;
 
     fn try_from(
-        inner: (TransactionOrOutputListWithProof, LedgerInfoWithSignatures),
+        inner: (TransactionOrOutputListWithProofV2, LedgerInfoWithSignatures),
     ) -> error::Result<Self, Error> {
         let ((transaction_list, output_list), ledger_info) = inner;
         if let Some(transaction_list) = transaction_list {
@@ -377,22 +371,22 @@ impl From<u64> for ResponsePayload {
     }
 }
 
-impl From<TransactionOutputListWithProof> for ResponsePayload {
-    fn from(inner: TransactionOutputListWithProof) -> Self {
+impl From<TransactionOutputListWithProofV2> for ResponsePayload {
+    fn from(inner: TransactionOutputListWithProofV2) -> Self {
         Self::TransactionOutputsWithProof(inner)
     }
 }
 
-impl From<TransactionListWithProof> for ResponsePayload {
-    fn from(inner: TransactionListWithProof) -> Self {
+impl From<TransactionListWithProofV2> for ResponsePayload {
+    fn from(inner: TransactionListWithProofV2) -> Self {
         Self::TransactionsWithProof(inner)
     }
 }
 
-impl TryFrom<TransactionOrOutputListWithProof> for ResponsePayload {
+impl TryFrom<TransactionOrOutputListWithProofV2> for ResponsePayload {
     type Error = Error;
 
-    fn try_from(inner: TransactionOrOutputListWithProof) -> error::Result<Self, Error> {
+    fn try_from(inner: TransactionOrOutputListWithProofV2) -> error::Result<Self, Error> {
         let (transaction_list, output_list) = inner;
         if let Some(transaction_list) = transaction_list {
             Ok(Self::TransactionsWithProof(transaction_list))

--- a/state-sync/aptos-data-client/src/tests/request_v2.rs
+++ b/state-sync/aptos-data-client/src/tests/request_v2.rs
@@ -975,7 +975,7 @@ fn verify_response_data(
         // Verify the number of transactions
         let transaction_list_with_proof =
             transaction_list_with_proof_v2.get_transaction_list_with_proof();
-        let num_transactions = transaction_list_with_proof.transactions.len();
+        let num_transactions = transaction_list_with_proof.get_num_transactions();
         assert_eq!(num_transactions, expected_count);
 
         // Verify the persisted auxiliary infos
@@ -990,7 +990,7 @@ fn verify_response_data(
     if let Some(output_list_with_proof_v2) = output_list_with_proof_v2 {
         // Verify the number of outputs
         let output_list_with_proof = output_list_with_proof_v2.get_output_list_with_proof();
-        let num_outputs = output_list_with_proof.transactions_and_outputs.len();
+        let num_outputs = output_list_with_proof.get_num_outputs();
         assert_eq!(num_outputs, expected_count);
 
         // Verify the persisted auxiliary infos

--- a/state-sync/data-streaming-service/src/data_notification.rs
+++ b/state-sync/data-streaming-service/src/data_notification.rs
@@ -7,7 +7,7 @@ use aptos_data_client::interface::{Response, ResponsePayload};
 use aptos_types::{
     ledger_info::LedgerInfoWithSignatures,
     state_store::state_value::StateValueChunkWithProof,
-    transaction::{TransactionListWithProof, TransactionOutputListWithProof, Version},
+    transaction::{TransactionListWithProofV2, TransactionOutputListWithProofV2, Version},
 };
 use std::{
     fmt::{Debug, Formatter},
@@ -39,13 +39,16 @@ impl DataNotification {
 #[allow(clippy::large_enum_variant)]
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub enum DataPayload {
-    ContinuousTransactionOutputsWithProof(LedgerInfoWithSignatures, TransactionOutputListWithProof),
-    ContinuousTransactionsWithProof(LedgerInfoWithSignatures, TransactionListWithProof),
+    ContinuousTransactionOutputsWithProof(
+        LedgerInfoWithSignatures,
+        TransactionOutputListWithProofV2,
+    ),
+    ContinuousTransactionsWithProof(LedgerInfoWithSignatures, TransactionListWithProofV2),
     EpochEndingLedgerInfos(Vec<LedgerInfoWithSignatures>),
     EndOfStream,
     StateValuesWithProof(StateValueChunkWithProof),
-    TransactionOutputsWithProof(TransactionOutputListWithProof),
-    TransactionsWithProof(TransactionListWithProof),
+    TransactionOutputsWithProof(TransactionOutputListWithProofV2),
+    TransactionsWithProof(TransactionListWithProofV2),
 }
 
 /// A request that has been sent to the Aptos data client.

--- a/state-sync/data-streaming-service/src/data_stream.rs
+++ b/state-sync/data-streaming-service/src/data_stream.rs
@@ -1507,8 +1507,6 @@ fn spawn_request_task<T: AptosDataClientInterface + Send + Clone + 'static>(
     })
 }
 
-// TODO: don't drop the v2 response info!
-
 async fn get_states_values_with_proof<T: AptosDataClientInterface + Send + Clone + 'static>(
     aptos_data_client: T,
     request: StateValuesWithProofRequest,
@@ -1552,16 +1550,9 @@ async fn get_new_transaction_outputs_with_proof<
         request.known_epoch,
         request_timeout_ms,
     );
-    client_response.await.map(|response| {
-        let (context, (output_list_with_proof_v2, ledger_info_with_signatures)) =
-            response.into_parts();
-        let output_list_with_proof = output_list_with_proof_v2.get_output_list_with_proof();
-        let response_v1 = Response::new(
-            context,
-            (output_list_with_proof.clone(), ledger_info_with_signatures),
-        );
-        response_v1.map(ResponsePayload::from)
-    })
+    client_response
+        .await
+        .map(|response| response.map(ResponsePayload::from))
 }
 
 async fn get_new_transactions_with_proof<T: AptosDataClientInterface + Send + Clone + 'static>(
@@ -1575,20 +1566,9 @@ async fn get_new_transactions_with_proof<T: AptosDataClientInterface + Send + Cl
         request.include_events,
         request_timeout_ms,
     );
-    client_response.await.map(|response| {
-        let (context, (transaction_list_with_proof_v2, ledger_info_with_signatures)) =
-            response.into_parts();
-        let transaction_list_with_proof =
-            transaction_list_with_proof_v2.get_transaction_list_with_proof();
-        let response_v1 = Response::new(
-            context,
-            (
-                transaction_list_with_proof.clone(),
-                ledger_info_with_signatures,
-            ),
-        );
-        response_v1.map(ResponsePayload::from)
-    })
+    client_response
+        .await
+        .map(|response| response.map(ResponsePayload::from))
 }
 
 async fn get_new_transactions_or_outputs_with_proof<
@@ -1604,22 +1584,8 @@ async fn get_new_transactions_or_outputs_with_proof<
         request.include_events,
         request_timeout_ms,
     );
-    let (
-        context,
-        ((transaction_list_with_proof_v2, output_list_with_proof_v2), ledger_info_with_signatures),
-    ) = client_response.await?.into_parts();
-    let transaction_or_output_list_with_proof = (
-        transaction_list_with_proof_v2.map(|t| t.get_transaction_list_with_proof().clone()),
-        output_list_with_proof_v2.map(|o| o.get_output_list_with_proof().clone()),
-    );
-    let payload_v1 = (
-        transaction_or_output_list_with_proof,
-        ledger_info_with_signatures,
-    );
-    Ok(Response::new(
-        context,
-        ResponsePayload::try_from(payload_v1)?,
-    ))
+    let (context, payload) = client_response.await?.into_parts();
+    Ok(Response::new(context, ResponsePayload::try_from(payload)?))
 }
 
 async fn get_number_of_states<T: AptosDataClientInterface + Send + Clone + 'static>(
@@ -1647,12 +1613,9 @@ async fn get_transaction_outputs_with_proof<
         request.end_version,
         request_timeout_ms,
     );
-    client_response.await.map(|response| {
-        let (context, output_list_with_proof_v2) = response.into_parts();
-        let output_list_with_proof = output_list_with_proof_v2.get_output_list_with_proof();
-        let response_v1 = Response::new(context, output_list_with_proof.clone());
-        response_v1.map(ResponsePayload::from)
-    })
+    client_response
+        .await
+        .map(|response| response.map(ResponsePayload::from))
 }
 
 async fn get_transactions_with_proof<T: AptosDataClientInterface + Send + Clone + 'static>(
@@ -1667,13 +1630,9 @@ async fn get_transactions_with_proof<T: AptosDataClientInterface + Send + Clone 
         request.include_events,
         request_timeout_ms,
     );
-    client_response.await.map(|response| {
-        let (context, transaction_list_with_proof_v2) = response.into_parts();
-        let transaction_list_with_proof =
-            transaction_list_with_proof_v2.get_transaction_list_with_proof();
-        let response_v1 = Response::new(context, transaction_list_with_proof.clone());
-        response_v1.map(ResponsePayload::from)
-    })
+    client_response
+        .await
+        .map(|response| response.map(ResponsePayload::from))
 }
 
 async fn get_transactions_or_outputs_with_proof<
@@ -1690,16 +1649,8 @@ async fn get_transactions_or_outputs_with_proof<
         request.include_events,
         request_timeout_ms,
     );
-    let (context, (transaction_list_with_proof_v2, output_list_with_proof_v2)) =
-        client_response.await?.into_parts();
-    let payload_v1 = (
-        transaction_list_with_proof_v2.map(|t| t.get_transaction_list_with_proof().clone()),
-        output_list_with_proof_v2.map(|o| o.get_output_list_with_proof().clone()),
-    );
-    Ok(Response::new(
-        context,
-        ResponsePayload::try_from(payload_v1)?,
-    ))
+    let (context, payload) = client_response.await?.into_parts();
+    Ok(Response::new(context, ResponsePayload::try_from(payload)?))
 }
 
 async fn subscribe_to_transactions_with_proof<
@@ -1720,20 +1671,9 @@ async fn subscribe_to_transactions_with_proof<
         request.include_events,
         request_timeout_ms,
     );
-    client_response.await.map(|response| {
-        let (context, (transaction_list_with_proof_v2, ledger_info_with_signatures)) =
-            response.into_parts();
-        let transaction_list_with_proof =
-            transaction_list_with_proof_v2.get_transaction_list_with_proof();
-        let response_v1 = Response::new(
-            context,
-            (
-                transaction_list_with_proof.clone(),
-                ledger_info_with_signatures,
-            ),
-        );
-        response_v1.map(ResponsePayload::from)
-    })
+    client_response
+        .await
+        .map(|response| response.map(ResponsePayload::from))
 }
 
 async fn subscribe_to_transaction_outputs_with_proof<
@@ -1753,16 +1693,9 @@ async fn subscribe_to_transaction_outputs_with_proof<
         subscription_request_metadata,
         request_timeout_ms,
     );
-    client_response.await.map(|response| {
-        let (context, (output_list_with_proof_v2, ledger_info_with_signatures)) =
-            response.into_parts();
-        let output_list_with_proof = output_list_with_proof_v2.get_output_list_with_proof();
-        let response_v1 = Response::new(
-            context,
-            (output_list_with_proof.clone(), ledger_info_with_signatures),
-        );
-        response_v1.map(ResponsePayload::from)
-    })
+    client_response
+        .await
+        .map(|response| response.map(ResponsePayload::from))
 }
 
 async fn subscribe_to_transactions_or_outputs_with_proof<
@@ -1783,22 +1716,8 @@ async fn subscribe_to_transactions_or_outputs_with_proof<
         request.include_events,
         request_timeout_ms,
     );
-    let (
-        context,
-        ((transaction_list_with_proof_v2, output_list_with_proof_v2), ledger_info_with_signatures),
-    ) = client_response.await?.into_parts();
-    let transaction_or_output_list_with_proof = (
-        transaction_list_with_proof_v2.map(|t| t.get_transaction_list_with_proof().clone()),
-        output_list_with_proof_v2.map(|o| o.get_output_list_with_proof().clone()),
-    );
-    let payload_v1 = (
-        transaction_or_output_list_with_proof,
-        ledger_info_with_signatures,
-    );
-    Ok(Response::new(
-        context,
-        ResponsePayload::try_from(payload_v1)?,
-    ))
+    let (context, payload) = client_response.await?.into_parts();
+    Ok(Response::new(context, ResponsePayload::try_from(payload)?))
 }
 
 #[cfg(test)]

--- a/state-sync/data-streaming-service/src/stream_engine.rs
+++ b/state-sync/data-streaming-service/src/stream_engine.rs
@@ -518,10 +518,10 @@ impl ContinuousTransactionStreamEngine {
         // Check the number of received versions
         let num_received_versions = match &client_response_payload {
             ResponsePayload::TransactionsWithProof(transactions_with_proof) => {
-                transactions_with_proof.transactions.len()
+                transactions_with_proof.get_num_transactions()
             },
             ResponsePayload::TransactionOutputsWithProof(outputs_with_proof) => {
-                outputs_with_proof.transactions_and_outputs.len()
+                outputs_with_proof.get_num_outputs()
             },
             _ => invalid_response_type!(client_response_payload),
         };
@@ -1674,10 +1674,10 @@ impl TransactionStreamEngine {
         // Check the number of received versions
         let num_received_versions = match client_response_payload {
             ResponsePayload::TransactionsWithProof(transactions_with_proof) => {
-                transactions_with_proof.transactions.len()
+                transactions_with_proof.get_num_transactions()
             },
             ResponsePayload::TransactionOutputsWithProof(outputs_with_proof) => {
-                outputs_with_proof.transactions_and_outputs.len()
+                outputs_with_proof.get_num_outputs()
             },
             _ => invalid_response_type!(client_response_payload),
         };
@@ -2243,14 +2243,14 @@ fn extract_new_versions_and_target(
             transactions_with_proof,
             target_ledger_info,
         )) => (
-            transactions_with_proof.transactions.len(),
+            transactions_with_proof.get_num_transactions(),
             target_ledger_info.clone(),
         ),
         ResponsePayload::NewTransactionOutputsWithProof((
             outputs_with_proof,
             target_ledger_info,
         )) => (
-            outputs_with_proof.transactions_and_outputs.len(),
+            outputs_with_proof.get_num_outputs(),
             target_ledger_info.clone(),
         ),
         response_payload => {

--- a/state-sync/data-streaming-service/src/tests/missing_data.rs
+++ b/state-sync/data-streaming-service/src/tests/missing_data.rs
@@ -17,7 +17,7 @@ use crate::{
         ContinuouslyStreamTransactionOutputsRequest, GetAllEpochEndingLedgerInfosRequest,
         GetAllStatesRequest, GetAllTransactionsRequest, StreamRequest,
     },
-    tests::utils::{create_ledger_info, create_transaction_list_with_proof},
+    tests::{utils, utils::create_ledger_info},
 };
 use aptos_config::config::DataStreamingServiceConfig;
 use aptos_crypto::HashValue;
@@ -31,8 +31,9 @@ use aptos_types::{
         state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
-        Transaction, TransactionAuxiliaryData, TransactionListWithProof, TransactionOutput,
-        TransactionOutputListWithProof, TransactionStatus,
+        Transaction, TransactionAuxiliaryData, TransactionListWithProof,
+        TransactionListWithProofV2, TransactionOutput, TransactionOutputListWithProof,
+        TransactionOutputListWithProofV2, TransactionStatus, Version,
     },
     write_set::WriteSet,
 };
@@ -233,12 +234,9 @@ fn create_missing_data_request_transactions() {
     let transactions = (start_version..last_response_version + 1)
         .map(|_| create_test_transaction())
         .collect::<Vec<_>>();
-    let response_payload = ResponsePayload::TransactionsWithProof(TransactionListWithProof {
-        transactions,
-        events: None,
-        first_transaction_version: Some(start_version),
-        proof: TransactionInfoListWithProof::new_empty(),
-    });
+    let transaction_list_with_proof =
+        create_transaction_list_with_proof(start_version, transactions);
+    let response_payload = ResponsePayload::TransactionsWithProof(transaction_list_with_proof);
 
     // Create the missing data request and verify that it's valid
     let missing_data_request =
@@ -257,12 +255,9 @@ fn create_missing_data_request_transactions() {
     let transactions = (start_version..last_response_version + 1)
         .map(|_| create_test_transaction())
         .collect::<Vec<_>>();
-    let response_payload = ResponsePayload::TransactionsWithProof(TransactionListWithProof {
-        transactions,
-        events: None,
-        first_transaction_version: Some(start_version),
-        proof: TransactionInfoListWithProof::new_empty(),
-    });
+    let transaction_list_with_proof =
+        create_transaction_list_with_proof(start_version, transactions);
+    let response_payload = ResponsePayload::TransactionsWithProof(transaction_list_with_proof);
 
     // Create the missing data request and verify that it's empty
     let missing_data_request =
@@ -287,12 +282,9 @@ fn create_missing_data_request_transaction_outputs() {
     let transactions_and_outputs = (start_version..last_response_version + 1)
         .map(|_| (create_test_transaction(), create_test_transaction_output()))
         .collect::<Vec<_>>();
-    let response_payload =
-        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
-            transactions_and_outputs,
-            proof: TransactionInfoListWithProof::new_empty(),
-            first_transaction_output_version: Some(start_version),
-        });
+    let output_list_with_proof =
+        create_output_list_with_proof(start_version, transactions_and_outputs);
+    let response_payload = ResponsePayload::TransactionOutputsWithProof(output_list_with_proof);
 
     // Create the missing data request and verify that it's valid
     let missing_data_request =
@@ -310,12 +302,9 @@ fn create_missing_data_request_transaction_outputs() {
     let transactions_and_outputs = (start_version..last_response_version + 1)
         .map(|_| (create_test_transaction(), create_test_transaction_output()))
         .collect::<Vec<_>>();
-    let response_payload =
-        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
-            transactions_and_outputs,
-            proof: TransactionInfoListWithProof::new_empty(),
-            first_transaction_output_version: Some(start_version),
-        });
+    let output_list_with_proof =
+        create_output_list_with_proof(start_version, transactions_and_outputs);
+    let response_payload = ResponsePayload::TransactionOutputsWithProof(output_list_with_proof);
 
     // Create the missing data request and verify that it's empty
     let missing_data_request =
@@ -341,24 +330,19 @@ fn create_missing_data_request_transactions_or_outputs() {
     let transactions = (start_version..last_response_version + 1)
         .map(|_| create_test_transaction())
         .collect::<Vec<_>>();
+    let transaction_list_with_proof =
+        create_transaction_list_with_proof(start_version, transactions);
     let response_payload_with_transactions =
-        ResponsePayload::TransactionsWithProof(TransactionListWithProof {
-            transactions,
-            events: None,
-            first_transaction_version: Some(start_version),
-            proof: TransactionInfoListWithProof::new_empty(),
-        });
+        ResponsePayload::TransactionsWithProof(transaction_list_with_proof);
 
     // Create a partial response payload with transaction outputs
     let transactions_and_outputs = (start_version..last_response_version + 1)
         .map(|_| (create_test_transaction(), create_test_transaction_output()))
         .collect::<Vec<_>>();
+    let output_list_with_proof =
+        create_output_list_with_proof(start_version, transactions_and_outputs);
     let response_payload_with_transaction_outputs =
-        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
-            transactions_and_outputs,
-            proof: TransactionInfoListWithProof::new_empty(),
-            first_transaction_output_version: Some(start_version),
-        });
+        ResponsePayload::TransactionOutputsWithProof(output_list_with_proof);
 
     // Create the missing data requests and verify that they are valid
     for response_payload in [
@@ -383,24 +367,19 @@ fn create_missing_data_request_transactions_or_outputs() {
     let transactions = (start_version..last_response_version + 1)
         .map(|_| create_test_transaction())
         .collect::<Vec<_>>();
+    let transaction_list_with_proof =
+        create_transaction_list_with_proof(start_version, transactions);
     let response_payload_with_transactions =
-        ResponsePayload::TransactionsWithProof(TransactionListWithProof {
-            transactions,
-            events: None,
-            first_transaction_version: Some(start_version),
-            proof: TransactionInfoListWithProof::new_empty(),
-        });
+        ResponsePayload::TransactionsWithProof(transaction_list_with_proof);
 
     // Create a complete response payload with transaction outputs
     let transactions_and_outputs = (start_version..last_response_version + 1)
         .map(|_| (create_test_transaction(), create_test_transaction_output()))
         .collect::<Vec<_>>();
+    let output_list_with_proof =
+        create_output_list_with_proof(start_version, transactions_and_outputs);
     let response_payload_with_transaction_outputs =
-        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof {
-            transactions_and_outputs,
-            proof: TransactionInfoListWithProof::new_empty(),
-            first_transaction_output_version: Some(start_version),
-        });
+        ResponsePayload::TransactionOutputsWithProof(output_list_with_proof);
 
     // Create the missing data requests and verify that they are empty
     for response_payload in [
@@ -699,7 +678,7 @@ fn transform_transactions_stream_notifications() {
 
     // Create an empty client response
     let client_response_payload =
-        ResponsePayload::TransactionsWithProof(TransactionListWithProof::new_empty());
+        ResponsePayload::TransactionsWithProof(TransactionListWithProofV2::new_empty());
 
     // Transform the client response into a notification and verify an error is returned
     let _ = stream_engine
@@ -713,7 +692,7 @@ fn transform_transactions_stream_notifications() {
     // Create a partial client response
     let last_version = end_version - 50;
     let transactions_with_proof =
-        create_transaction_list_with_proof(start_version, last_version, true);
+        utils::create_transaction_list_with_proof(start_version, last_version, true);
     let client_response_payload =
         ResponsePayload::TransactionsWithProof(transactions_with_proof.clone());
 
@@ -806,7 +785,7 @@ fn transform_continuous_outputs_stream_notifications() {
 
     // Create an empty client response
     let client_response_payload =
-        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProof::new_empty());
+        ResponsePayload::TransactionOutputsWithProof(TransactionOutputListWithProofV2::new_empty());
 
     // Transform the client response into a notification and verify an error is returned
     let _ = stream_engine
@@ -822,13 +801,10 @@ fn transform_continuous_outputs_stream_notifications() {
     let transactions_and_outputs = (known_version..last_version + 1)
         .map(|_| (create_test_transaction(), create_test_transaction_output()))
         .collect::<Vec<_>>();
-    let transaction_outputs_with_proof = TransactionOutputListWithProof {
-        transactions_and_outputs,
-        proof: TransactionInfoListWithProof::new_empty(),
-        first_transaction_output_version: Some(known_version),
-    };
+    let output_list_with_proof =
+        create_output_list_with_proof(known_version, transactions_and_outputs);
     let client_response_payload =
-        ResponsePayload::TransactionOutputsWithProof(transaction_outputs_with_proof.clone());
+        ResponsePayload::TransactionOutputsWithProof(output_list_with_proof);
 
     // Transform the client response into a notification
     let data_client_request =
@@ -859,6 +835,19 @@ fn transform_continuous_outputs_stream_notifications() {
 /// Returns a simple notification ID generator for testing purposes
 fn create_notification_id_generator() -> Arc<U64IdGenerator> {
     Arc::new(U64IdGenerator::new())
+}
+
+/// Creates an output list with proof for testing purposes
+fn create_output_list_with_proof(
+    start_version: Version,
+    transactions_and_outputs: Vec<(Transaction, TransactionOutput)>,
+) -> TransactionOutputListWithProofV2 {
+    let output_list_with_proof = TransactionOutputListWithProof {
+        transactions_and_outputs,
+        proof: TransactionInfoListWithProof::new_empty(),
+        first_transaction_output_version: Some(start_version),
+    };
+    TransactionOutputListWithProofV2::new_from_v1(output_list_with_proof)
 }
 
 /// Returns a state value chunk with proof for testing purposes
@@ -898,4 +887,18 @@ fn create_test_transaction_output() -> TransactionOutput {
         TransactionStatus::Retry,
         TransactionAuxiliaryData::default(),
     )
+}
+
+/// Creates a transaction list with proof for testing purposes
+fn create_transaction_list_with_proof(
+    start_version: Version,
+    transactions: Vec<Transaction>,
+) -> TransactionListWithProofV2 {
+    let transaction_list_with_proof = TransactionListWithProof {
+        transactions,
+        events: None,
+        first_transaction_version: Some(start_version),
+        proof: TransactionInfoListWithProof::new_empty(),
+    };
+    TransactionListWithProofV2::new_from_v1(transaction_list_with_proof)
 }

--- a/state-sync/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_service.rs
@@ -576,12 +576,9 @@ async fn test_notifications_continuous_transactions_or_outputs_target() {
 
         // Update the next expected version
         let num_transactions = if transactions_with_proof.is_some() {
-            transactions_with_proof
-                .clone()
-                .unwrap()
-                .get_num_transactions() as u64
+            transactions_with_proof.unwrap().get_num_transactions() as u64
         } else {
-            outputs_with_proof.clone().unwrap().get_num_outputs() as u64
+            outputs_with_proof.unwrap().get_num_outputs() as u64
         };
         next_expected_version += num_transactions;
 
@@ -646,12 +643,9 @@ async fn test_notifications_continuous_transactions_or_outputs_multiple_streams(
 
         // Update the next expected version
         let num_transactions = if transactions_with_proof.is_some() {
-            transactions_with_proof
-                .clone()
-                .unwrap()
-                .get_num_transactions() as u64
+            transactions_with_proof.unwrap().get_num_transactions() as u64
         } else {
-            outputs_with_proof.clone().unwrap().get_num_outputs() as u64
+            outputs_with_proof.unwrap().get_num_outputs() as u64
         };
         next_expected_version += num_transactions;
 

--- a/state-sync/data-streaming-service/src/tests/streaming_service.rs
+++ b/state-sync/data-streaming-service/src/tests/streaming_service.rs
@@ -186,11 +186,11 @@ async fn test_notifications_continuous_outputs_target() {
                 assert_eq!(ledger_info.epoch(), next_expected_epoch);
 
                 // Verify the output start version matches the expected version
-                let first_output_version = outputs_with_proofs.first_transaction_output_version;
+                let first_output_version = outputs_with_proofs.get_first_output_version();
                 assert_eq!(Some(next_expected_version), first_output_version);
 
                 // Update the next expected version
-                let num_outputs = outputs_with_proofs.transactions_and_outputs.len() as u64;
+                let num_outputs = outputs_with_proofs.get_num_outputs() as u64;
                 next_expected_version += num_outputs;
 
                 // Update epochs if we've hit the epoch end
@@ -234,11 +234,11 @@ async fn test_notifications_continuous_outputs_multiple_streams() {
                 outputs_with_proofs,
             ) => {
                 // Verify the first output version
-                let first_output_version = outputs_with_proofs.first_transaction_output_version;
+                let first_output_version = outputs_with_proofs.get_first_output_version();
                 assert_eq!(Some(next_expected_version), first_output_version);
 
                 // Update the next expected version
-                let num_outputs = outputs_with_proofs.transactions_and_outputs.len() as u64;
+                let num_outputs = outputs_with_proofs.get_num_outputs() as u64;
                 next_expected_version += num_outputs;
 
                 // Update the next expected epoch if we've hit the epoch end
@@ -356,14 +356,15 @@ async fn test_notifications_continuous_transactions_target() {
                 assert_eq!(ledger_info.epoch(), next_expected_epoch);
 
                 // Verify the transaction start version matches the expected version
-                let first_transaction_version = transactions_with_proof.first_transaction_version;
+                let first_transaction_version =
+                    transactions_with_proof.get_first_transaction_version();
                 assert_eq!(Some(next_expected_version), first_transaction_version);
 
                 // Verify the payload contains events
-                assert_some!(transactions_with_proof.events);
+                assert!(transactions_with_proof.events.is_some());
 
                 // Update the next expected version
-                let num_transactions = transactions_with_proof.transactions.len() as u64;
+                let num_transactions = transactions_with_proof.get_num_transactions() as u64;
                 next_expected_version += num_transactions;
 
                 // Update epochs if we've hit the epoch end
@@ -409,11 +410,12 @@ async fn test_notifications_continuous_transactions_multiple_streams() {
                 transactions_with_proofs,
             ) => {
                 // Verify the first transaction version
-                let first_transaction_version = transactions_with_proofs.first_transaction_version;
+                let first_transaction_version =
+                    transactions_with_proofs.get_first_transaction_version();
                 assert_eq!(Some(next_expected_version), first_transaction_version);
 
                 // Update the next expected version
-                let num_transactions = transactions_with_proofs.transactions.len() as u64;
+                let num_transactions = transactions_with_proofs.get_num_transactions() as u64;
                 next_expected_version += num_transactions;
 
                 // Update the next expected epoch if we've hit the epoch end
@@ -550,12 +552,12 @@ async fn test_notifications_continuous_transactions_or_outputs_target() {
             transactions_with_proof
                 .clone()
                 .unwrap()
-                .first_transaction_version
+                .get_first_transaction_version()
         } else {
             outputs_with_proof
                 .clone()
                 .unwrap()
-                .first_transaction_output_version
+                .get_first_output_version()
         };
         assert_eq!(Some(next_expected_version), first_version);
 
@@ -566,13 +568,12 @@ async fn test_notifications_continuous_transactions_or_outputs_target() {
 
         // Update the next expected version
         let num_transactions = if transactions_with_proof.is_some() {
-            transactions_with_proof.clone().unwrap().transactions.len() as u64
-        } else {
-            outputs_with_proof
+            transactions_with_proof
                 .clone()
                 .unwrap()
-                .transactions_and_outputs
-                .len() as u64
+                .get_num_transactions() as u64
+        } else {
+            outputs_with_proof.clone().unwrap().get_num_outputs() as u64
         };
         next_expected_version += num_transactions;
 
@@ -626,24 +627,23 @@ async fn test_notifications_continuous_transactions_or_outputs_multiple_streams(
             transactions_with_proof
                 .clone()
                 .unwrap()
-                .first_transaction_version
+                .get_first_transaction_version()
         } else {
             outputs_with_proof
                 .clone()
                 .unwrap()
-                .first_transaction_output_version
+                .get_first_output_version()
         };
         assert_eq!(Some(next_expected_version), first_version);
 
         // Update the next expected version
         let num_transactions = if transactions_with_proof.is_some() {
-            transactions_with_proof.clone().unwrap().transactions.len() as u64
-        } else {
-            outputs_with_proof
+            transactions_with_proof
                 .clone()
                 .unwrap()
-                .transactions_and_outputs
-                .len() as u64
+                .get_num_transactions() as u64
+        } else {
+            outputs_with_proof.clone().unwrap().get_num_outputs() as u64
         };
         next_expected_version += num_transactions;
 
@@ -1083,11 +1083,11 @@ async fn test_notifications_transaction_outputs_multiple_streams() {
         match data_notification.data_payload {
             DataPayload::TransactionOutputsWithProof(outputs_with_proof) => {
                 // Verify the first transaction output version
-                let first_output_version = outputs_with_proof.first_transaction_output_version;
+                let first_output_version = outputs_with_proof.get_first_output_version();
                 assert_eq!(Some(next_expected_version), first_output_version);
 
                 // Update the next expected version
-                next_expected_version += outputs_with_proof.transactions_and_outputs.len() as u64;
+                next_expected_version += outputs_with_proof.get_num_outputs() as u64;
 
                 // Terminate the stream if we haven't reached the end
                 if next_expected_version < MAX_ADVERTISED_TRANSACTION_OUTPUT {
@@ -1196,11 +1196,12 @@ async fn test_notifications_transactions_multiple_streams() {
         match data_notification.data_payload {
             DataPayload::TransactionsWithProof(transactions_with_proof) => {
                 // Verify the first transaction version
-                let first_transaction_version = transactions_with_proof.first_transaction_version;
+                let first_transaction_version =
+                    transactions_with_proof.get_first_transaction_version();
                 assert_eq!(Some(next_expected_version), first_transaction_version);
 
                 // Update the next expected version
-                next_expected_version += transactions_with_proof.transactions.len() as u64;
+                next_expected_version += transactions_with_proof.get_num_transactions() as u64;
 
                 // Terminate the stream if we haven't reached the end
                 if next_expected_version < MAX_ADVERTISED_TRANSACTION {
@@ -1911,16 +1912,13 @@ fn verify_continuous_outputs_with_proof(
     assert_eq!(ledger_info.epoch(), expected_epoch);
 
     // Verify the output start version matches the expected version
-    let first_output_version = outputs_with_proofs
-        .get_output_list_with_proof()
-        .first_transaction_output_version;
+    let first_output_version = outputs_with_proofs.get_first_output_version();
     assert_eq!(Some(expected_version), first_output_version);
 
     // Calculate the next expected version
     let num_outputs = outputs_with_proofs
         .get_output_list_with_proof()
-        .transactions_and_outputs
-        .len() as u64;
+        .get_num_outputs() as u64;
     let next_expected_version = expected_version + num_outputs;
 
     // Update epochs if we've hit the epoch end
@@ -1949,11 +1947,11 @@ fn verify_continuous_transactions_with_proof(
     assert_eq!(ledger_info.epoch(), expected_epoch);
 
     // Verify the transaction start version matches the expected version
-    let first_transaction_version = transactions_with_proofs.first_transaction_version;
+    let first_transaction_version = transactions_with_proofs.get_first_transaction_version();
     assert_eq!(Some(expected_version), first_transaction_version);
 
     // Calculate the next expected version
-    let num_transactions = transactions_with_proofs.transactions.len() as u64;
+    let num_transactions = transactions_with_proofs.get_num_transactions() as u64;
     let next_expected_version = expected_version + num_transactions;
 
     // Update epochs if we've hit the epoch end
@@ -1984,11 +1982,11 @@ async fn verify_output_notifications(
         match data_notification.data_payload {
             DataPayload::TransactionOutputsWithProof(outputs_with_proof) => {
                 // Verify the transaction output start version matches the expected version
-                let first_output_version = outputs_with_proof.first_transaction_output_version;
+                let first_output_version = outputs_with_proof.get_first_output_version();
                 assert_eq!(Some(next_expected_version), first_output_version);
 
                 // Calculate the next expected version
-                let num_outputs = outputs_with_proof.transactions_and_outputs.len();
+                let num_outputs = outputs_with_proof.get_num_outputs();
                 next_expected_version += num_outputs as u64;
             },
             DataPayload::EndOfStream => {
@@ -2014,11 +2012,12 @@ async fn verify_transaction_notifications(
         match data_notification.data_payload {
             DataPayload::TransactionsWithProof(transactions_with_proof) => {
                 // Verify the transaction start version matches the expected version
-                let first_transaction_version = transactions_with_proof.first_transaction_version;
+                let first_transaction_version =
+                    transactions_with_proof.get_first_transaction_version();
                 assert_eq!(Some(next_expected_version), first_transaction_version);
 
                 // Calculate the next expected version
-                let num_transactions = transactions_with_proof.transactions.len();
+                let num_transactions = transactions_with_proof.get_num_transactions();
                 next_expected_version += num_transactions as u64;
             },
             DataPayload::EndOfStream => {

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -619,7 +619,6 @@ impl<
                     )
                     .await?;
                 },
-                // TODO(joshlind): Update to V2 type.
                 DataPayload::TransactionsWithProof(transactions_with_proof) => {
                     let payload_start_version =
                         transactions_with_proof.get_first_transaction_version();
@@ -629,15 +628,12 @@ impl<
                     );
                     self.process_transaction_or_output_payload(
                         notification_metadata,
-                        Some(TransactionListWithProofV2::new_from_v1(
-                            transactions_with_proof,
-                        )),
+                        Some(transactions_with_proof),
                         None,
                         payload_start_version,
                     )
                     .await?;
                 },
-                // TODO(joshlind): Update to V2 type.
                 DataPayload::TransactionOutputsWithProof(transaction_outputs_with_proof) => {
                     let payload_start_version =
                         transaction_outputs_with_proof.get_first_output_version();
@@ -648,9 +644,7 @@ impl<
                     self.process_transaction_or_output_payload(
                         notification_metadata,
                         None,
-                        Some(TransactionOutputListWithProofV2::new_from_v1(
-                            transaction_outputs_with_proof,
-                        )),
+                        Some(transaction_outputs_with_proof),
                         payload_start_version,
                     )
                     .await?;

--- a/state-sync/state-sync-driver/src/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/bootstrapper.rs
@@ -621,7 +621,8 @@ impl<
                 },
                 // TODO(joshlind): Update to V2 type.
                 DataPayload::TransactionsWithProof(transactions_with_proof) => {
-                    let payload_start_version = transactions_with_proof.first_transaction_version;
+                    let payload_start_version =
+                        transactions_with_proof.get_first_transaction_version();
                     let notification_metadata = NotificationMetadata::new(
                         data_notification.creation_time,
                         data_notification.notification_id,
@@ -639,7 +640,7 @@ impl<
                 // TODO(joshlind): Update to V2 type.
                 DataPayload::TransactionOutputsWithProof(transaction_outputs_with_proof) => {
                     let payload_start_version =
-                        transaction_outputs_with_proof.first_transaction_output_version;
+                        transaction_outputs_with_proof.get_first_output_version();
                     let notification_metadata = NotificationMetadata::new(
                         data_notification.creation_time,
                         data_notification.notification_id,
@@ -1388,10 +1389,7 @@ impl<
         let num_versions = match self.get_bootstrapping_mode() {
             BootstrappingMode::ApplyTransactionOutputsFromGenesis => {
                 if let Some(transaction_outputs_with_proof) = transaction_outputs_with_proof {
-                    transaction_outputs_with_proof
-                        .get_output_list_with_proof()
-                        .transactions_and_outputs
-                        .len()
+                    transaction_outputs_with_proof.get_num_outputs()
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(
                         notification_id,
@@ -1405,10 +1403,7 @@ impl<
             },
             BootstrappingMode::ExecuteTransactionsFromGenesis => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
-                    transaction_list_with_proof
-                        .get_transaction_list_with_proof()
-                        .transactions
-                        .len()
+                    transaction_list_with_proof.get_num_transactions()
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(
                         notification_id,
@@ -1422,15 +1417,9 @@ impl<
             },
             BootstrappingMode::ExecuteOrApplyFromGenesis => {
                 if let Some(transaction_list_with_proof) = transaction_list_with_proof {
-                    transaction_list_with_proof
-                        .get_transaction_list_with_proof()
-                        .transactions
-                        .len()
+                    transaction_list_with_proof.get_num_transactions()
                 } else if let Some(output_list_with_proof) = transaction_outputs_with_proof {
-                    output_list_with_proof
-                        .get_output_list_with_proof()
-                        .transactions_and_outputs
-                        .len()
+                    output_list_with_proof.get_num_outputs()
                 } else {
                     self.reset_active_stream(Some(NotificationAndFeedback::new(
                         notification_id,

--- a/state-sync/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/continuous_syncer.rs
@@ -208,7 +208,6 @@ impl<
             // Fetch and process any data notifications
             let data_notification = self.fetch_next_data_notification().await?;
             match data_notification.data_payload {
-                // TODO(joshlind): Update to V2 type.
                 DataPayload::ContinuousTransactionOutputsWithProof(
                     ledger_info_with_sigs,
                     transaction_outputs_with_proof,
@@ -224,9 +223,7 @@ impl<
                         notification_metadata,
                         ledger_info_with_sigs,
                         None,
-                        Some(TransactionOutputListWithProofV2::new_from_v1(
-                            transaction_outputs_with_proof,
-                        )),
+                        Some(transaction_outputs_with_proof),
                         payload_start_version,
                     )
                     .await?;
@@ -246,9 +243,7 @@ impl<
                         consensus_sync_request.clone(),
                         notification_metadata,
                         ledger_info_with_sigs,
-                        Some(TransactionListWithProofV2::new_from_v1(
-                            transactions_with_proof,
-                        )),
+                        Some(transactions_with_proof),
                         None,
                         payload_start_version,
                     )

--- a/state-sync/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/continuous_syncer.rs
@@ -228,7 +228,6 @@ impl<
                     )
                     .await?;
                 },
-                // TODO(joshlind): Update to V2 type.
                 DataPayload::ContinuousTransactionsWithProof(
                     ledger_info_with_sigs,
                     transactions_with_proof,

--- a/state-sync/state-sync-driver/src/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/continuous_syncer.rs
@@ -214,7 +214,7 @@ impl<
                     transaction_outputs_with_proof,
                 ) => {
                     let payload_start_version =
-                        transaction_outputs_with_proof.first_transaction_output_version;
+                        transaction_outputs_with_proof.get_first_output_version();
                     let notification_metadata = NotificationMetadata::new(
                         data_notification.creation_time,
                         data_notification.notification_id,
@@ -236,7 +236,8 @@ impl<
                     ledger_info_with_sigs,
                     transactions_with_proof,
                 ) => {
-                    let payload_start_version = transactions_with_proof.first_transaction_version;
+                    let payload_start_version =
+                        transactions_with_proof.get_first_transaction_version();
                     let notification_metadata = NotificationMetadata::new(
                         data_notification.creation_time,
                         data_notification.notification_id,

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -991,10 +991,7 @@ async fn apply_output_chunk<ChunkExecutor: ChunkExecutorTrait + 'static>(
     end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
 ) -> anyhow::Result<()> {
     // Apply the output chunk
-    let num_outputs = outputs_with_proof
-        .get_output_list_with_proof()
-        .transactions_and_outputs
-        .len();
+    let num_outputs = outputs_with_proof.get_num_outputs();
     let result = tokio::task::spawn_blocking(move || {
         chunk_executor.enqueue_chunk_by_transaction_outputs(
             outputs_with_proof,

--- a/state-sync/state-sync-driver/src/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/storage_synchronizer.rs
@@ -1190,8 +1190,7 @@ fn create_commit_notification(
 ) -> CommitNotification {
     let (transactions, outputs): (Vec<Transaction>, Vec<TransactionOutput>) =
         target_output_with_proof
-            .into_parts()
-            .0
+            .consume_output_list_with_proof()
             .transactions_and_outputs
             .into_iter()
             .unzip();

--- a/state-sync/state-sync-driver/src/tests/bootstrapper.rs
+++ b/state-sync/state-sync-driver/src/tests/bootstrapper.rs
@@ -28,7 +28,7 @@ use aptos_data_streaming_service::{
 };
 use aptos_time_service::TimeService;
 use aptos_types::{
-    transaction::{TransactionOutputListWithProof, Version},
+    transaction::{TransactionOutputListWithProofV2, Version},
     waypoint::Waypoint,
 };
 use claims::{assert_matches, assert_none, assert_ok};
@@ -401,7 +401,7 @@ async fn test_data_stream_state_values() {
     // Send an invalid output along the stream
     let data_notification = DataNotification::new(
         notification_id,
-        DataPayload::TransactionOutputsWithProof(create_output_list_with_proof().into_parts().0),
+        DataPayload::TransactionOutputsWithProof(create_output_list_with_proof()),
     );
     notification_sender_1.send(data_notification).await.unwrap();
 
@@ -473,7 +473,7 @@ async fn test_data_stream_transactions() {
     // Send an invalid output along the stream
     let data_notification = DataNotification::new(
         notification_id,
-        DataPayload::TransactionsWithProof(create_transaction_list_with_proof().into_parts().0),
+        DataPayload::TransactionsWithProof(create_transaction_list_with_proof()),
     );
     notification_sender_1.send(data_notification).await.unwrap();
 
@@ -545,7 +545,7 @@ async fn test_data_stream_transaction_outputs() {
     // Send an invalid output along the stream
     let data_notification = DataNotification::new(
         notification_id,
-        DataPayload::TransactionOutputsWithProof(TransactionOutputListWithProof::new_empty()),
+        DataPayload::TransactionOutputsWithProof(TransactionOutputListWithProofV2::new_empty()),
     );
     notification_sender_1.send(data_notification).await.unwrap();
 
@@ -1230,7 +1230,7 @@ async fn test_snapshot_sync_existing_state() {
     // Send an invalid notification (incorrect data type)
     let data_notification = DataNotification::new(
         notification_id,
-        DataPayload::TransactionOutputsWithProof(create_output_list_with_proof().into_parts().0),
+        DataPayload::TransactionOutputsWithProof(create_output_list_with_proof()),
     );
     notification_sender_1.send(data_notification).await.unwrap();
 

--- a/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
+++ b/state-sync/state-sync-driver/src/tests/continuous_syncer.rs
@@ -29,7 +29,9 @@ use aptos_data_streaming_service::{
 use aptos_infallible::Mutex;
 use aptos_storage_service_types::Epoch;
 use aptos_time_service::TimeService;
-use aptos_types::transaction::{TransactionOutputListWithProof, Version};
+use aptos_types::transaction::{
+    TransactionOutputListWithProof, TransactionOutputListWithProofV2, Version,
+};
 use claims::assert_matches;
 use futures::SinkExt;
 use mockall::{predicate::eq, Sequence};
@@ -181,7 +183,7 @@ async fn test_data_stream_transactions_with_sync_duration() {
         notification_id,
         DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
-            TransactionOutputListWithProof::new_empty(),
+            TransactionOutputListWithProofV2::new_empty(),
         ),
     );
     notification_sender_1.send(data_notification).await.unwrap();
@@ -262,7 +264,7 @@ async fn test_data_stream_transactions_with_sync_target() {
         notification_id,
         DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
-            TransactionOutputListWithProof::new_empty(),
+            TransactionOutputListWithProofV2::new_empty(),
         ),
     );
     notification_sender_1.send(data_notification).await.unwrap();
@@ -341,7 +343,7 @@ async fn test_data_stream_transaction_outputs() {
         notification_id,
         DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
-            transaction_output_with_proof,
+            TransactionOutputListWithProofV2::new_from_v1(transaction_output_with_proof),
         ),
     );
     notification_sender_1.send(data_notification).await.unwrap();
@@ -423,7 +425,7 @@ async fn test_data_stream_transactions_or_outputs_with_sync_duration() {
         notification_id,
         DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
-            TransactionOutputListWithProof::new_empty(),
+            TransactionOutputListWithProofV2::new_empty(),
         ),
     );
     notification_sender_1.send(data_notification).await.unwrap();
@@ -504,7 +506,7 @@ async fn test_data_stream_transactions_or_outputs_with_sync_target() {
         notification_id,
         DataPayload::ContinuousTransactionOutputsWithProof(
             create_epoch_ending_ledger_info(),
-            TransactionOutputListWithProof::new_empty(),
+            TransactionOutputListWithProofV2::new_empty(),
         ),
     );
     notification_sender_1.send(data_notification).await.unwrap();

--- a/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
+++ b/state-sync/state-sync-driver/src/tests/storage_synchronizer.rs
@@ -626,7 +626,8 @@ async fn test_execute_transactions_commit_send_error() {
 #[should_panic]
 async fn test_initialize_state_synchronizer_missing_info() {
     // Create test data that is missing transaction infos
-    let (mut output_list_with_proof, _) = create_output_list_with_proof().into_parts();
+    let mut output_list_with_proof =
+        create_output_list_with_proof().consume_output_list_with_proof();
     output_list_with_proof.proof.transaction_infos = vec![]; // This is invalid!
     let output_list_with_proof =
         TransactionOutputListWithProofV2::new_from_v1(output_list_with_proof);

--- a/state-sync/state-sync-driver/src/utils.rs
+++ b/state-sync/state-sync-driver/src/utils.rs
@@ -436,10 +436,7 @@ pub async fn execute_transactions<StorageSyncer: StorageSynchronizerInterface>(
     end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     transaction_list_with_proof: TransactionListWithProofV2,
 ) -> Result<usize, Error> {
-    let num_transactions = transaction_list_with_proof
-        .get_transaction_list_with_proof()
-        .transactions
-        .len();
+    let num_transactions = transaction_list_with_proof.get_num_transactions();
     storage_synchronizer
         .execute_transactions(
             notification_metadata,
@@ -460,10 +457,7 @@ pub async fn apply_transaction_outputs<StorageSyncer: StorageSynchronizerInterfa
     end_of_epoch_ledger_info: Option<LedgerInfoWithSignatures>,
     transaction_outputs_with_proof: TransactionOutputListWithProofV2,
 ) -> Result<usize, Error> {
-    let num_transaction_outputs = transaction_outputs_with_proof
-        .get_output_list_with_proof()
-        .transactions_and_outputs
-        .len();
+    let num_transaction_outputs = transaction_outputs_with_proof.get_num_outputs();
     storage_synchronizer
         .apply_transaction_outputs(
             notification_metadata,

--- a/state-sync/storage-service/server/src/handler.rs
+++ b/state-sync/storage-service/server/src/handler.rs
@@ -521,8 +521,7 @@ impl<T: StorageReaderInterface> Handler<T> {
             response
                 .transaction_output_list_with_proof
                 .unwrap()
-                .into_parts()
-                .0,
+                .consume_output_list_with_proof(),
         ))
     }
 
@@ -538,7 +537,10 @@ impl<T: StorageReaderInterface> Handler<T> {
         )?;
 
         Ok(DataResponse::TransactionsWithProof(
-            response.transaction_list_with_proof.unwrap().into_parts().0,
+            response
+                .transaction_list_with_proof
+                .unwrap()
+                .consume_transaction_list_with_proof(),
         ))
     }
 
@@ -557,10 +559,10 @@ impl<T: StorageReaderInterface> Handler<T> {
         Ok(DataResponse::TransactionsOrOutputsWithProof((
             response
                 .transaction_list_with_proof
-                .map(|t| t.into_parts().0),
+                .map(|t| t.consume_transaction_list_with_proof()),
             response
                 .transaction_output_list_with_proof
-                .map(|t| t.into_parts().0),
+                .map(|t| t.consume_output_list_with_proof()),
         )))
     }
 

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -272,8 +272,9 @@ impl StorageReaderInterface for StorageReader {
             }
 
             // Attempt to divide up the request if it overflows the message size
+            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
             let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&response, self.config.max_network_chunk_bytes)?;
+                check_overflow_network_frame(&response, max_network_chunk_bytes)?;
             if !overflow_frame {
                 return Ok(response);
             } else {
@@ -281,8 +282,8 @@ impl StorageReaderInterface for StorageReader {
                     DataResponse::TransactionDataWithProof(response).get_label(),
                 );
                 let new_num_transactions_to_fetch = num_transactions_to_fetch / 2;
-                debug!("The request for {:?} transactions was too large (num bytes: {:?}). Retrying with {:?}.",
-                    num_transactions_to_fetch, num_bytes, new_num_transactions_to_fetch);
+                debug!("The request for {:?} transactions was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_transactions_to_fetch, num_bytes, max_network_chunk_bytes, new_num_transactions_to_fetch);
                 num_transactions_to_fetch = new_num_transactions_to_fetch; // Try again with half the amount of data
             }
         }
@@ -323,10 +324,9 @@ impl StorageReaderInterface for StorageReader {
             }
 
             // Attempt to divide up the request if it overflows the message size
-            let (overflow_frame, num_bytes) = check_overflow_network_frame(
-                &epoch_change_proof,
-                self.config.max_network_chunk_bytes,
-            )?;
+            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
+            let (overflow_frame, num_bytes) =
+                check_overflow_network_frame(&epoch_change_proof, max_network_chunk_bytes)?;
             if !overflow_frame {
                 return Ok(epoch_change_proof);
             } else {
@@ -334,8 +334,8 @@ impl StorageReaderInterface for StorageReader {
                     DataResponse::EpochEndingLedgerInfos(epoch_change_proof).get_label(),
                 );
                 let new_num_ledger_infos_to_fetch = num_ledger_infos_to_fetch / 2;
-                debug!("The request for {:?} ledger infos was too large (num bytes: {:?}). Retrying with {:?}.",
-                    num_ledger_infos_to_fetch, num_bytes, new_num_ledger_infos_to_fetch);
+                debug!("The request for {:?} ledger infos was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_ledger_infos_to_fetch, num_bytes, max_network_chunk_bytes, new_num_ledger_infos_to_fetch);
                 num_ledger_infos_to_fetch = new_num_ledger_infos_to_fetch; // Try again with half the amount of data
             }
         }
@@ -374,8 +374,9 @@ impl StorageReaderInterface for StorageReader {
             }
 
             // Attempt to divide up the request if it overflows the message size
+            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
             let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&response, self.config.max_network_chunk_bytes)?;
+                check_overflow_network_frame(&response, max_network_chunk_bytes)?;
             if !overflow_frame {
                 return Ok(response);
             } else {
@@ -383,8 +384,8 @@ impl StorageReaderInterface for StorageReader {
                     DataResponse::TransactionDataWithProof(response).get_label(),
                 );
                 let new_num_outputs_to_fetch = num_outputs_to_fetch / 2;
-                debug!("The request for {:?} outputs was too large (num bytes: {:?}). Retrying with {:?}.",
-                    num_outputs_to_fetch, num_bytes, new_num_outputs_to_fetch);
+                debug!("The request for {:?} outputs was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_outputs_to_fetch, num_bytes, max_network_chunk_bytes, new_num_outputs_to_fetch);
                 num_outputs_to_fetch = new_num_outputs_to_fetch; // Try again with half the amount of data
             }
         }
@@ -423,8 +424,10 @@ impl StorageReaderInterface for StorageReader {
                 transaction_list_with_proof: None,
                 transaction_output_list_with_proof: Some(output_list_with_proof),
             };
+
+            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
             let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&response, self.config.max_network_chunk_bytes)?;
+                check_overflow_network_frame(&response, max_network_chunk_bytes)?;
 
             if !overflow_frame {
                 return Ok(response);
@@ -435,8 +438,8 @@ impl StorageReaderInterface for StorageReader {
                     DataResponse::TransactionDataWithProof(response).get_label(),
                 );
                 let new_num_outputs_to_fetch = num_outputs_to_fetch / 2;
-                debug!("The request for {:?} outputs was too large (num bytes: {:?}). Current number of data reductions: {:?}",
-                    num_outputs_to_fetch, num_bytes, num_output_reductions);
+                debug!("The request for {:?} outputs was too large (num bytes: {:?}, limit: {:?}). Current number of data reductions: {:?}",
+                    num_outputs_to_fetch, num_bytes, max_network_chunk_bytes, num_output_reductions);
                 num_outputs_to_fetch = new_num_outputs_to_fetch; // Try again with half the amount of data
                 num_output_reductions += 1;
             }
@@ -530,9 +533,10 @@ impl StorageReaderInterface for StorageReader {
             }
 
             // Attempt to divide up the request if it overflows the message size
+            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
             let (overflow_frame, num_bytes) = check_overflow_network_frame(
                 &state_value_chunk_with_proof,
-                self.config.max_network_chunk_bytes,
+                max_network_chunk_bytes,
             )?;
             if !overflow_frame {
                 return Ok(state_value_chunk_with_proof);
@@ -542,8 +546,8 @@ impl StorageReaderInterface for StorageReader {
                         .get_label(),
                 );
                 let new_num_state_values_to_fetch = num_state_values_to_fetch / 2;
-                debug!("The request for {:?} state values was too large (num bytes: {:?}). Retrying with {:?}.",
-                    num_state_values_to_fetch, num_bytes, new_num_state_values_to_fetch);
+                debug!("The request for {:?} state values was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_state_values_to_fetch, num_bytes, max_network_chunk_bytes, new_num_state_values_to_fetch);
                 num_state_values_to_fetch = new_num_state_values_to_fetch; // Try again with half the amount of data
             }
         }

--- a/state-sync/storage-service/server/src/subscription.rs
+++ b/state-sync/storage-service/server/src/subscription.rs
@@ -473,21 +473,21 @@ impl SubscriptionStreamRequests {
                 transaction_output_list,
                 target_ledger_info,
             )) => (
-                transaction_output_list.transactions_and_outputs.len(),
+                transaction_output_list.get_num_outputs(),
                 target_ledger_info,
             ),
             DataResponse::NewTransactionsWithProof((transaction_list, target_ledger_info)) => {
-                (transaction_list.transactions.len(), target_ledger_info)
+                (transaction_list.get_num_transactions(), target_ledger_info)
             },
             DataResponse::NewTransactionsOrOutputsWithProof((
                 (transaction_list, transaction_output_list),
                 target_ledger_info,
             )) => {
                 if let Some(transaction_list) = transaction_list {
-                    (transaction_list.transactions.len(), target_ledger_info)
+                    (transaction_list.get_num_transactions(), target_ledger_info)
                 } else if let Some(transaction_output_list) = transaction_output_list {
                     (
-                        transaction_output_list.transactions_and_outputs.len(),
+                        transaction_output_list.get_num_outputs(),
                         target_ledger_info,
                     )
                 } else {
@@ -505,8 +505,7 @@ impl SubscriptionStreamRequests {
                         {
                             transaction_list_with_proof_v2
                                 .get_transaction_list_with_proof()
-                                .transactions
-                                .len()
+                                .get_num_transactions()
                         } else {
                             return Err(Error::UnexpectedErrorEncountered(format!(
                                 "Transaction data response is missing transaction list: {:?}",
@@ -520,8 +519,7 @@ impl SubscriptionStreamRequests {
                         {
                             output_list_with_proof_v2
                                 .get_output_list_with_proof()
-                                .transactions_and_outputs
-                                .len()
+                                .get_num_outputs()
                         } else {
                             return Err(Error::UnexpectedErrorEncountered(format!(
                                 "Transaction output data response is missing output list: {:?}",

--- a/state-sync/storage-service/server/src/tests/subscribe_transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transaction_outputs.rs
@@ -554,8 +554,7 @@ async fn test_subscribe_transaction_outputs_streaming_epoch_change() {
         for stream_request_index in 0..max_num_active_subscriptions {
             // Determine the target ledger info for the response
             let first_output_version = output_lists_with_proofs[stream_request_index as usize]
-                .get_output_list_with_proof()
-                .first_transaction_output_version
+                .get_first_output_version()
                 .unwrap();
             let target_ledger_info = if first_output_version > epoch_change_version {
                 highest_ledger_info.clone()

--- a/state-sync/storage-service/server/src/tests/subscribe_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transactions.rs
@@ -587,8 +587,7 @@ async fn test_subscribe_transactions_streaming_epoch_change() {
         for stream_request_index in 0..max_num_active_subscriptions {
             // Determine the target ledger info for the response
             let first_output_version = transaction_lists_with_proofs[stream_request_index as usize]
-                .get_transaction_list_with_proof()
-                .first_transaction_version
+                .get_first_transaction_version()
                 .unwrap();
             let target_ledger_info = if first_output_version > epoch_change_version {
                 highest_ledger_info.clone()

--- a/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
@@ -787,8 +787,7 @@ async fn test_subscribe_transactions_or_outputs_streaming_epoch_change() {
             for stream_request_index in 0..max_num_active_subscriptions {
                 // Determine the target ledger info for the response
                 let first_version = output_lists_with_proofs[stream_request_index as usize]
-                    .get_output_list_with_proof()
-                    .first_transaction_output_version
+                    .get_first_output_version()
                     .unwrap();
                 let target_ledger_info = if first_version > epoch_change_version {
                     highest_ledger_info.clone()

--- a/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
@@ -19,8 +19,6 @@ use futures::channel::oneshot::Receiver;
 use std::collections::HashMap;
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
-// TODO(joshlind): Fix test.
 async fn test_subscribe_transactions_or_outputs_different_network() {
     // Test both v1 and v2 data requests
     for use_request_v2 in [false, true] {
@@ -479,8 +477,6 @@ async fn test_subscribe_transactions_or_outputs_max_chunk() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
-// TODO(joshlind): Fix test.
 async fn test_subscribe_transaction_or_outputs_streaming() {
     // Test both v1 and v2 data requests
     for use_request_v2 in [false, true] {
@@ -635,8 +631,6 @@ async fn test_subscribe_transaction_or_outputs_streaming() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
-// TODO(joshlind): Fix test.
 async fn test_subscribe_transactions_or_outputs_streaming_epoch_change() {
     // Test both v1 and v2 data requests
     for use_request_v2 in [false, true] {
@@ -825,8 +819,6 @@ async fn test_subscribe_transactions_or_outputs_streaming_epoch_change() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
-#[ignore]
-// TODO(joshlind): Fix test.
 async fn test_subscribe_transaction_or_outputs_streaming_loop() {
     // Test both v1 and v2 data requests
     for use_request_v2 in [false, true] {

--- a/state-sync/storage-service/server/src/tests/transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transaction_outputs.rs
@@ -314,16 +314,13 @@ async fn get_outputs_with_proof_network_limit(network_limit_bytes: u64, use_requ
         let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
         let num_outputs = match response.get_data_response().unwrap() {
             DataResponse::TransactionOutputsWithProof(outputs_with_proof) => {
-                outputs_with_proof.transactions_and_outputs.len() as u64
+                outputs_with_proof.get_num_outputs() as u64
             },
             DataResponse::TransactionDataWithProof(transaction_data_with_proof) => {
                 let output_list_with_proof_v2 = transaction_data_with_proof
                     .transaction_output_list_with_proof
                     .unwrap();
-                output_list_with_proof_v2
-                    .get_output_list_with_proof()
-                    .transactions_and_outputs
-                    .len() as u64
+                output_list_with_proof_v2.get_num_outputs() as u64
             },
             _ => panic!("Expected outputs with proof but got: {:?}", response),
         };

--- a/state-sync/storage-service/server/src/tests/transactions.rs
+++ b/state-sync/storage-service/server/src/tests/transactions.rs
@@ -315,16 +315,13 @@ async fn get_transactions_with_proof_network_limit(network_limit_bytes: u64, use
             let num_response_bytes = bcs::serialized_size(&response).unwrap() as u64;
             let num_transactions = match response.get_data_response().unwrap() {
                 DataResponse::TransactionsWithProof(transactions_with_proof) => {
-                    transactions_with_proof.transactions.len() as u64
+                    transactions_with_proof.get_num_transactions() as u64
                 },
                 DataResponse::TransactionDataWithProof(transaction_data_with_proof) => {
                     let transaction_list_with_proof_v2 = transaction_data_with_proof
                         .transaction_list_with_proof
                         .unwrap();
-                    transaction_list_with_proof_v2
-                        .get_transaction_list_with_proof()
-                        .transactions
-                        .len() as u64
+                    transaction_list_with_proof_v2.get_num_transactions() as u64
                 },
                 _ => panic!("Expected transactions with proof but got: {:?}", response),
             };

--- a/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/transactions_or_outputs.rs
@@ -493,7 +493,7 @@ fn check_output_response_bytes(
     outputs_with_proof: &TransactionOutputListWithProof,
 ) {
     let num_response_bytes = bcs::serialized_size(&outputs_with_proof).unwrap() as u64;
-    let num_outputs = outputs_with_proof.transactions_and_outputs.len() as u64;
+    let num_outputs = outputs_with_proof.get_num_outputs() as u64;
 
     if num_response_bytes > network_limit_bytes {
         assert_eq!(num_outputs, 1); // Data cannot be reduced more than a single item
@@ -510,7 +510,7 @@ fn check_transaction_response_bytes(
     transactions_with_proof: &TransactionListWithProof,
 ) {
     let num_response_bytes = bcs::serialized_size(&transactions_with_proof).unwrap() as u64;
-    let num_transactions = transactions_with_proof.transactions.len() as u64;
+    let num_transactions = transactions_with_proof.get_num_transactions() as u64;
 
     if num_response_bytes > network_limit_bytes {
         assert_eq!(num_transactions, 1); // Data cannot be reduced more than a single item

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -5,10 +5,7 @@ use crate::{
     optimistic_fetch::OptimisticFetchRequest,
     storage::StorageReader,
     subscription::SubscriptionStreamRequests,
-    tests::{
-        mock::{MockClient, MockDatabaseReader},
-        utils,
-    },
+    tests::mock::{MockClient, MockDatabaseReader},
     StorageServiceServer,
 };
 use aptos_config::{
@@ -210,7 +207,7 @@ pub fn create_persisted_auxiliary_infos(
     // Create a list of auxiliary infos
     let mut persisted_auxiliary_infos = vec![];
     for i in 0..num_auxiliary_infos {
-        let persisted_auxiliary_info = if utils::get_random_u64() % 2 == 0 && use_request_v2 {
+        let persisted_auxiliary_info = if use_request_v2 {
             PersistedAuxiliaryInfo::V1 {
                 transaction_index: i as u32,
             }
@@ -315,9 +312,13 @@ pub fn create_transaction_list_using_sizes(
     transaction_list_with_proof.events = events;
     transaction_list_with_proof.transactions = transactions;
 
+    // Create the auxiliary infos
+    let auxiliary_infos =
+        create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
+
     TransactionListWithProofV2::new(TransactionListWithAuxiliaryInfos::new(
         transaction_list_with_proof,
-        create_persisted_auxiliary_infos(start_version, end_version, use_request_v2),
+        auxiliary_infos,
     ))
 }
 
@@ -344,9 +345,13 @@ pub fn create_transaction_list_with_proof(
     transaction_list_with_proof.events = events;
     transaction_list_with_proof.transactions = transactions;
 
+    // Create the auxiliary infos
+    let auxiliary_infos =
+        create_persisted_auxiliary_infos(start_version, end_version, use_request_v2);
+
     TransactionListWithProofV2::new(TransactionListWithAuxiliaryInfos::new(
         transaction_list_with_proof,
-        create_persisted_auxiliary_infos(start_version, end_version, use_request_v2),
+        auxiliary_infos,
     ))
 }
 

--- a/storage/aptosdb/src/db/fake_aptosdb.rs
+++ b/storage/aptosdb/src/db/fake_aptosdb.rs
@@ -1184,21 +1184,20 @@ mod tests {
     ) -> Result<()> {
         // Verify the first transaction/output versions match
         ensure!(
-            txn_outputs_with_proof.first_transaction_output_version
-                == first_transaction_output_version,
+            txn_outputs_with_proof.get_first_output_version() == first_transaction_output_version,
             "First transaction and output version ({:?}) doesn't match given version ({:?}).",
-            txn_outputs_with_proof.first_transaction_output_version,
+            txn_outputs_with_proof.get_first_output_version(),
             first_transaction_output_version,
         );
 
         // Verify the lengths of the transaction(output)s and transaction infos match
         ensure!(
             txn_outputs_with_proof.proof.transaction_infos.len()
-                == txn_outputs_with_proof.transactions_and_outputs.len(),
+                == txn_outputs_with_proof.get_num_outputs(),
             "The number of TransactionInfo objects ({}) does not match the number of \
              transactions and outputs ({}).",
             txn_outputs_with_proof.proof.transaction_infos.len(),
-            txn_outputs_with_proof.transactions_and_outputs.len(),
+            txn_outputs_with_proof.get_num_outputs(),
         );
 
         // Verify the events, status, gas used and transaction hashes.
@@ -1247,19 +1246,19 @@ mod tests {
     ) -> Result<()> {
         // Verify the first transaction versions match
         ensure!(
-            txn_list.first_transaction_version == first_transaction_version,
+            txn_list.get_first_transaction_version() == first_transaction_version,
             "First transaction version ({:?}) doesn't match given version ({:?}).",
-            txn_list.first_transaction_version,
+            txn_list.get_first_transaction_version(),
             first_transaction_version,
         );
 
         // Verify the lengths of the transactions and transaction infos match
         ensure!(
-            txn_list.proof.transaction_infos.len() == txn_list.transactions.len(),
+            txn_list.proof.transaction_infos.len() == txn_list.get_num_transactions(),
             "The number of TransactionInfo objects ({}) does not match the number of \
              transactions ({}).",
             txn_list.proof.transaction_infos.len(),
-            txn_list.transactions.len(),
+            txn_list.get_num_transactions(),
         );
 
         // Verify the transaction hashes match those of the transaction infos

--- a/storage/aptosdb/src/db/include/aptosdb_writer.rs
+++ b/storage/aptosdb/src/db/include/aptosdb_writer.rs
@@ -95,7 +95,7 @@ impl DbWriter for AptosDB {
         let (output_with_proof, persisted_aux_info) = output_with_proof.into_parts();
         gauged_api("finalize_state_snapshot", || {
             // Ensure the output with proof only contains a single transaction output and info
-            let num_transaction_outputs = output_with_proof.transactions_and_outputs.len();
+            let num_transaction_outputs = output_with_proof.get_num_outputs();
             let num_transaction_infos = output_with_proof.proof.transaction_infos.len();
             ensure!(
                 num_transaction_outputs == 1,

--- a/storage/aptosdb/src/db/test_helper.rs
+++ b/storage/aptosdb/src/db/test_helper.rs
@@ -897,13 +897,7 @@ pub fn verify_committed_transactions(
             txn_list_with_proof
                 .verify(ledger_info, Some(cur_ver))
                 .unwrap();
-            assert_eq!(
-                txn_list_with_proof
-                    .get_transaction_list_with_proof()
-                    .transactions
-                    .len(),
-                1
-            );
+            assert_eq!(txn_list_with_proof.get_num_transactions(), 1);
 
             let txn_output_list_with_proof = db
                 .get_transaction_outputs(cur_ver, 1, ledger_version)
@@ -911,13 +905,7 @@ pub fn verify_committed_transactions(
             txn_output_list_with_proof
                 .verify(ledger_info, Some(cur_ver))
                 .unwrap();
-            assert_eq!(
-                txn_output_list_with_proof
-                    .get_output_list_with_proof()
-                    .transactions_and_outputs
-                    .len(),
-                1
-            );
+            assert_eq!(txn_output_list_with_proof.get_num_outputs(), 1);
         }
         cur_ver += 1;
     }

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -229,8 +229,8 @@ mod test {
 
             let txn_list_with_proof = db.get_transactions(0, db_version + 1, db_version, true).unwrap().into_parts().0;
             prop_assert_eq!(txn_list_with_proof.transactions.len() as u64, db_version + 1);
-            prop_assert_eq!(txn_list_with_proof.events.unwrap().len() as u64, db_version + 1);
-            prop_assert_eq!(txn_list_with_proof.first_transaction_version, Some(0));
+            prop_assert_eq!(txn_list_with_proof.clone().events.unwrap().len() as u64, db_version + 1);
+            prop_assert_eq!(txn_list_with_proof.get_first_transaction_version(), Some(0));
 
             let state_checkpoint_version = db.get_latest_state_checkpoint_version().unwrap().unwrap();
             let state_leaf_count = db.get_state_item_count(state_checkpoint_version).unwrap();

--- a/storage/aptosdb/src/db_debugger/validation.rs
+++ b/storage/aptosdb/src/db_debugger/validation.rs
@@ -105,10 +105,7 @@ pub fn validate_db_data(
             .unwrap();
         verify_batch_txn_events(&txns, &internal_db, start)
             .unwrap_or_else(|_| panic!("{}, {} failed to verify", start, end));
-        assert_eq!(
-            txns.get_transaction_list_with_proof().transactions.len() as u64,
-            num_of_txns
-        );
+        assert_eq!(txns.get_num_transactions() as u64, num_of_txns);
     });
 
     Ok(())

--- a/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/state_snapshot/tests.rs
@@ -46,8 +46,7 @@ fn end_to_end() {
     let state_root_hash = src_db
         .get_transactions(version, 1, version, false)
         .unwrap()
-        .into_parts()
-        .0
+        .consume_transaction_list_with_proof()
         .proof
         .transaction_infos
         .pop()

--- a/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
+++ b/storage/backup/backup-cli/src/backup_types/transaction/tests.rs
@@ -129,8 +129,7 @@ fn end_to_end() {
     let ouptputlist = tgt_db
         .get_transaction_outputs(0, target_version, target_version)
         .unwrap()
-        .into_parts()
-        .0;
+        .consume_output_list_with_proof();
 
     for (restore_ws, org_ws) in zip_eq(
         ouptputlist
@@ -148,7 +147,7 @@ fn end_to_end() {
 
     assert_eq!(tgt_db.expect_synced_version(), target_version);
     // TODO(grao): Test PersistedAuxiliaryInfo here.
-    let (recovered_transactions, _) = tgt_db
+    let recovered_transactions = tgt_db
         .get_transactions(
             0,
             target_version,
@@ -156,7 +155,7 @@ fn end_to_end() {
             true, /* fetch_events */
         )
         .unwrap()
-        .into_parts();
+        .consume_transaction_list_with_proof();
 
     assert_eq!(
         recovered_transactions.transactions,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2139,6 +2139,16 @@ impl TransactionListWithProof {
         )
     }
 
+    /// Returns the first version in the transaction list
+    pub fn get_first_transaction_version(&self) -> Option<Version> {
+        self.first_transaction_version
+    }
+
+    /// Returns the number of transactions in the transaction list
+    pub fn get_num_transactions(&self) -> usize {
+        self.transactions.len()
+    }
+
     /// Verifies the transaction list with proof using the given `ledger_info`.
     /// This method will ensure:
     /// 1. All transactions exist on the given `ledger_info`.
@@ -2153,19 +2163,19 @@ impl TransactionListWithProof {
     ) -> Result<()> {
         // Verify the first transaction versions match
         ensure!(
-            self.first_transaction_version == first_transaction_version,
+            self.get_first_transaction_version() == first_transaction_version,
             "First transaction version ({:?}) doesn't match given version ({:?}).",
-            self.first_transaction_version,
+            self.get_first_transaction_version(),
             first_transaction_version,
         );
 
         // Verify the lengths of the transactions and transaction infos match
         ensure!(
-            self.proof.transaction_infos.len() == self.transactions.len(),
+            self.proof.transaction_infos.len() == self.get_num_transactions(),
             "The number of TransactionInfo objects ({}) does not match the number of \
              transactions ({}).",
             self.proof.transaction_infos.len(),
-            self.transactions.len(),
+            self.get_num_transactions(),
         );
 
         // Verify the transaction hashes match those of the transaction infos
@@ -2187,15 +2197,15 @@ impl TransactionListWithProof {
 
         // Verify the transaction infos are proven by the ledger info.
         self.proof
-            .verify(ledger_info, self.first_transaction_version)?;
+            .verify(ledger_info, self.get_first_transaction_version())?;
 
         // Verify the events if they exist.
         if let Some(event_lists) = &self.events {
             ensure!(
-                event_lists.len() == self.transactions.len(),
+                event_lists.len() == self.get_num_transactions(),
                 "The length of event_lists ({}) does not match the number of transactions ({}).",
                 event_lists.len(),
-                self.transactions.len(),
+                self.get_num_transactions(),
             );
             event_lists
                 .into_par_iter()
@@ -2229,6 +2239,28 @@ impl TransactionListWithProofV2 {
         Self::TransactionListWithAuxiliaryInfos(TransactionListWithAuxiliaryInfos::new_from_v1(
             transaction_list_with_proof,
         ))
+    }
+
+    /// Returns the first version in the transaction list
+    pub fn get_first_transaction_version(&self) -> Option<Version> {
+        match self {
+            Self::TransactionListWithAuxiliaryInfos(transaction_list_with_auxiliary_infos) => {
+                transaction_list_with_auxiliary_infos
+                    .transaction_list_with_proof
+                    .get_first_transaction_version()
+            },
+        }
+    }
+
+    /// Returns the number of transactions in the transaction list
+    pub fn get_num_transactions(&self) -> usize {
+        match self {
+            Self::TransactionListWithAuxiliaryInfos(transaction_list_with_auxiliary_infos) => {
+                transaction_list_with_auxiliary_infos
+                    .transaction_list_with_proof
+                    .get_num_transactions()
+            },
+        }
     }
 
     /// Returns a reference to the inner transaction list with proof
@@ -2352,6 +2384,16 @@ impl TransactionOutputListWithProof {
         Self::new(vec![], None, TransactionInfoListWithProof::new_empty())
     }
 
+    /// Returns the first version in the transaction output list
+    pub fn get_first_output_version(&self) -> Option<Version> {
+        self.first_transaction_output_version
+    }
+
+    /// Returns the number of outputs in the transaction output list
+    pub fn get_num_outputs(&self) -> usize {
+        self.transactions_and_outputs.len()
+    }
+
     /// Verifies the transaction output list with proof using the given `ledger_info`.
     /// This method will ensure:
     /// 1. All transaction infos exist on the given `ledger_info`.
@@ -2367,19 +2409,19 @@ impl TransactionOutputListWithProof {
     ) -> Result<()> {
         // Verify the first transaction output versions match
         ensure!(
-            self.first_transaction_output_version == first_transaction_output_version,
+            self.get_first_output_version() == first_transaction_output_version,
             "First transaction and output version ({:?}) doesn't match given version ({:?}).",
-            self.first_transaction_output_version,
+            self.get_first_output_version(),
             first_transaction_output_version,
         );
 
         // Verify the lengths of the transactions and outputs match the transaction infos
         ensure!(
-            self.proof.transaction_infos.len() == self.transactions_and_outputs.len(),
+            self.proof.transaction_infos.len() == self.get_num_outputs(),
             "The number of TransactionInfo objects ({}) does not match the number of \
              transactions and outputs ({}).",
             self.proof.transaction_infos.len(),
-            self.transactions_and_outputs.len(),
+            self.get_num_outputs(),
         );
 
         // Verify the events, write set, status, gas used and transaction hashes.
@@ -2431,7 +2473,7 @@ impl TransactionOutputListWithProof {
 
         // Verify the transaction infos are proven by the ledger info.
         self.proof
-            .verify(ledger_info, self.first_transaction_output_version)?;
+            .verify(ledger_info, self.get_first_output_version())?;
 
         Ok(())
     }
@@ -2482,6 +2524,28 @@ impl TransactionOutputListWithProofV2 {
                 transaction_output_list_with_proof,
             ),
         )
+    }
+
+    /// Returns the first version in the transaction output list
+    pub fn get_first_output_version(&self) -> Option<Version> {
+        match self {
+            Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
+                output_list_with_auxiliary_infos
+                    .transaction_output_list_with_proof
+                    .get_first_output_version()
+            },
+        }
+    }
+
+    /// Returns the number of outputs in the transaction output list
+    pub fn get_num_outputs(&self) -> usize {
+        match self {
+            Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
+                output_list_with_auxiliary_infos
+                    .transaction_output_list_with_proof
+                    .get_num_outputs()
+            },
+        }
     }
 
     /// Returns a reference to the inner transaction output list with proof

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2234,11 +2234,20 @@ impl TransactionListWithProofV2 {
         Self::TransactionListWithAuxiliaryInfos(TransactionListWithAuxiliaryInfos::new_empty())
     }
 
-    /// A convenience function to create a v2 list from a v1 list.
+    /// A convenience function to create a v2 list from a v1 list
     pub fn new_from_v1(transaction_list_with_proof: TransactionListWithProof) -> Self {
         Self::TransactionListWithAuxiliaryInfos(TransactionListWithAuxiliaryInfos::new_from_v1(
             transaction_list_with_proof,
         ))
+    }
+
+    /// Consumes and returns the inner transaction list with proof
+    pub fn consume_transaction_list_with_proof(self) -> TransactionListWithProof {
+        match self {
+            Self::TransactionListWithAuxiliaryInfos(transaction_list_with_auxiliary_infos) => {
+                transaction_list_with_auxiliary_infos.transaction_list_with_proof
+            },
+        }
     }
 
     /// Returns the first version in the transaction list
@@ -2281,7 +2290,7 @@ impl TransactionListWithProofV2 {
         }
     }
 
-    /// Splits the transaction list with proof v2 into its components.
+    /// Splits the transaction list with proof v2 into its components
     pub fn into_parts(self) -> (TransactionListWithProof, Vec<PersistedAuxiliaryInfo>) {
         match self {
             Self::TransactionListWithAuxiliaryInfos(txn_list_with_auxiliary_infos) => (
@@ -2291,7 +2300,7 @@ impl TransactionListWithProofV2 {
         }
     }
 
-    /// Verifies the transaction list with proof v2 against the given ledger info.
+    /// Verifies the transaction list with proof v2 against the given ledger info
     pub fn verify(
         &self,
         ledger_info: &LedgerInfo,
@@ -2517,13 +2526,22 @@ impl TransactionOutputListWithProofV2 {
         )
     }
 
-    /// A convenience function to create a v2 output list from a v1 list.
+    /// A convenience function to create a v2 output list from a v1 list
     pub fn new_from_v1(transaction_output_list_with_proof: TransactionOutputListWithProof) -> Self {
         Self::TransactionOutputListWithAuxiliaryInfos(
             TransactionOutputListWithAuxiliaryInfos::new_from_v1(
                 transaction_output_list_with_proof,
             ),
         )
+    }
+
+    /// Consumes and returns the inner transaction output list
+    pub fn consume_output_list_with_proof(self) -> TransactionOutputListWithProof {
+        match self {
+            Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => {
+                output_list_with_auxiliary_infos.transaction_output_list_with_proof
+            },
+        }
     }
 
     /// Returns the first version in the transaction output list
@@ -2566,7 +2584,7 @@ impl TransactionOutputListWithProofV2 {
         }
     }
 
-    /// Splits the transaction output list with proof v2 into its components.
+    /// Splits the transaction output list with proof v2 into its components
     pub fn into_parts(self) -> (TransactionOutputListWithProof, Vec<PersistedAuxiliaryInfo>) {
         match self {
             Self::TransactionOutputListWithAuxiliaryInfos(output_list_with_auxiliary_infos) => (
@@ -2576,7 +2594,7 @@ impl TransactionOutputListWithProofV2 {
         }
     }
 
-    /// Verifies the transaction output list with proof v2 against the given ledger info.
+    /// Verifies the transaction output list with proof v2 against the given ledger info
     pub fn verify(
         &self,
         ledger_info: &LedgerInfo,


### PR DESCRIPTION
## Description
This PR updates the data streaming service to support transaction auxiliary data. Instead of dropping it, we now propagate it to the state sync driver.

The PR offers the following commits:
1. [Refactor] Expose and use new helper methods for transaction lists.
2. [Data Streaming Service] Support transaction data v2.
3. [Storage Service] Fix previously failing tests.
4. [Storage Service] Allow transaction data v2 requests.

## Testing Plan
Existing test infrastructure.
