### PR TITLE
Fix incorrect read summary computation

### DIFF
--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -342,6 +342,11 @@ where
 {
     type Key = StateKey;
 
+    fn get_state_slot(&self, state_key: &Self::Key) -> StateViewResult<StateSlot> {
+        let value_opt = self.get_state_value(state_key)?.map(|value| (0, value));
+        Ok(StateSlot::from_db_get(value_opt))
+    }
+
     fn get_state_value(&self, state_key: &Self::Key) -> StateViewResult<Option<StateValue>> {
         if let Some(res) = self.states.read().get(state_key) {
             return Ok(res.clone());

--- a/aptos-move/block-executor/src/types.rs
+++ b/aptos-move/block-executor/src/types.rs
@@ -58,7 +58,7 @@ impl<T: Transaction> ReadWriteSummary<T> {
     }
 
     pub fn keys_read(&self) -> impl Iterator<Item = &T::Key> {
-        Self::keys_except_delayed_fields(self.writes.iter())
+        Self::keys_except_delayed_fields(self.reads.iter())
     }
 
     fn keys_except_delayed_fields<'a>(


### PR DESCRIPTION

While debugging the low hot state hit rate issue in devnet, I found that the
set of keys read reported from the VM is often much smaller than the set of keys
computed in `CachedStateView` (basically [memorized](https://github.com/aptos-labs/aptos-core/blob/66bef0fa48390d98f409f458b4379b4cadce03c8/storage/storage-interface/src/state_store/state_view/cached_state_view.rs#L105-L106)).

After more digging, it turns out that the code actually reports the writes as
reads...

With this change, the number of keys read from each transaction looks much more
reasonable now.
