### PR TITLE
Fix another control flow structuring bug

### DIFF
--- a/third_party/move/tools/move-decompiler/tests/control-flow-recovery/cfg_bugs.exp
+++ b/third_party/move/tools/move-decompiler/tests/control-flow-recovery/cfg_bugs.exp
@@ -4,11 +4,17 @@ module 0x99::return_test {
         let _t2;
         _t2 = 0;
         _t4 = false;
-        while (!(!(_t2 < 0x1::vector::length<u64>(&v)) || 0x1::vector::borrow<u64>(&v, _t2) == &e)) _t2 = _t2 + 1;
-        _t4 = true;
+        'l0: loop {
+            loop {
+                if (!(_t2 < 0x1::vector::length<u64>(&v))) break 'l0;
+                if (0x1::vector::borrow<u64>(&v, _t2) == &e) break;
+                _t2 = _t2 + 1
+            };
+            _t4 = true;
+            break
+        };
         _t4
     }
 }
-
 
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/control-flow-recovery/cfg_opt.exp
+++ b/third_party/move/tools/move-decompiler/tests/control-flow-recovery/cfg_opt.exp
@@ -17,5 +17,4 @@ module 0x99::cfg_opt_simple {
     }
 }
 
-
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/control-flow-recovery/nested_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/control-flow-recovery/nested_loops.exp
@@ -233,5 +233,4 @@ module 0x99::nested_loops {
     }
 }
 
-
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/bit_vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/bit_vector.exp
@@ -65,5 +65,4 @@ module 0x1::bit_vector {
     }
 }
 
-
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/error.exp
+++ b/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/error.exp
@@ -40,5 +40,4 @@ module 0x1::error {
     }
 }
 
-
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/multi_module.exp
+++ b/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/multi_module.exp
@@ -11,5 +11,4 @@ module 0xc0ffee::n {
     }
 }
 
-
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/simple_map.exp
+++ b/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/simple_map.exp
@@ -32,8 +32,15 @@ module 0x1::simple_map {
     fun find<Key: store, Value: store>(self: &SimpleMap<Key, Value>, key: &Key): option::Option<u64> {
         let _t3;
         _t3 = 0;
-        while (!(!(_t3 < vector::length<Element<Key, Value>>(&self.data)) || &vector::borrow<Element<Key, Value>>(&self.data, _t3).key == key)) _t3 = _t3 + 1;
-        option::some<u64>(_t3)
+        'l0: loop {
+            loop {
+                if (!(_t3 < vector::length<Element<Key, Value>>(&self.data))) break 'l0;
+                if (&vector::borrow<Element<Key, Value>>(&self.data, _t3).key == key) break;
+                _t3 = _t3 + 1
+            };
+            return option::some<u64>(_t3)
+        };
+        option::none<u64>()
     }
     public fun remove<Key: store, Value: store>(self: &mut SimpleMap<Key, Value>, key: &Key): (Key, Value) {
         let _t19;
@@ -144,13 +151,20 @@ module 0x1::simple_map {
         _t3 = &mut self.data;
         _t4 = vector::length<Element<Key, Value>>(/*freeze*/_t3);
         _t5 = 0;
-        while (!(!(_t5 < _t4) || &vector::borrow<Element<Key, Value>>(/*freeze*/_t3, _t5).key == &key)) _t5 = _t5 + 1;
-        vector::push_back<Element<Key, Value>>(_t3, Element<Key,Value>{key: key,value: value});
-        vector::swap<Element<Key, Value>>(_t3, _t5, _t4);
-        Element<Key,Value>{key: _t34,value: _t35} = vector::pop_back<Element<Key, Value>>(_t3);
-        (option::some<Key>(_t34), option::some<Value>(_t35))
+        'l0: loop {
+            loop {
+                if (!(_t5 < _t4)) break 'l0;
+                if (&vector::borrow<Element<Key, Value>>(/*freeze*/_t3, _t5).key == &key) break;
+                _t5 = _t5 + 1
+            };
+            vector::push_back<Element<Key, Value>>(_t3, Element<Key,Value>{key: key,value: value});
+            vector::swap<Element<Key, Value>>(_t3, _t5, _t4);
+            Element<Key,Value>{key: _t34,value: _t35} = vector::pop_back<Element<Key, Value>>(_t3);
+            return (option::some<Key>(_t34), option::some<Value>(_t35))
+        };
+        vector::push_back<Element<Key, Value>>(&mut self.data, Element<Key,Value>{key: key,value: value});
+        (option::none<Key>(), option::none<Value>())
     }
 }
-
 
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/string.exp
+++ b/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/string.exp
@@ -61,5 +61,4 @@ module 0x1::string {
     }
 }
 
-
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/vector.exp
+++ b/third_party/move/tools/move-decompiler/tests/legacy-move-stdlib/vector.exp
@@ -10,14 +10,28 @@ module 0x1::vector {
     public fun contains<Element>(self: &vector<Element>, e: &Element): bool {
         let _t2;
         _t2 = 0;
-        while (!(!(_t2 < length<Element>(self)) || borrow<Element>(self, _t2) == e)) _t2 = _t2 + 1;
-        true
+        'l0: loop {
+            loop {
+                if (!(_t2 < length<Element>(self))) break 'l0;
+                if (borrow<Element>(self, _t2) == e) break;
+                _t2 = _t2 + 1
+            };
+            return true
+        };
+        false
     }
     public fun index_of<Element>(self: &vector<Element>, e: &Element): (bool, u64) {
         let _t2;
         _t2 = 0;
-        while (!(!(_t2 < length<Element>(self)) || borrow<Element>(self, _t2) == e)) _t2 = _t2 + 1;
-        (true, _t2)
+        'l0: loop {
+            loop {
+                if (!(_t2 < length<Element>(self))) break 'l0;
+                if (borrow<Element>(self, _t2) == e) break;
+                _t2 = _t2 + 1
+            };
+            return (true, _t2)
+        };
+        (false, 0)
     }
     public fun range(start: u64, end: u64): vector<u64> {
         range_with_step(start, end, 1)
@@ -154,9 +168,9 @@ module 0x1::vector {
 --- unable to recompile the decompiled code:
 exiting with stackless-bytecode checks failed
 error: cannot freeze value which is still mutably borrowed
-   ┌─ vector.move:40:67
+   ┌─ vector.move:54:67
    │
-40 │         reverse_slice<Element>(self, 0, length<Element>(/*freeze*/self));
+54 │         reverse_slice<Element>(self, 0, length<Element>(/*freeze*/self));
    │         ----------------------------------------------------------^^^^--
    │         │                      │                                  │
    │         │                      │                                  implicitly frozen here
@@ -164,9 +178,9 @@ error: cannot freeze value which is still mutably borrowed
    │         conflicting reference used here
 
 error: cannot freeze value which is still mutably borrowed
-    ┌─ vector.move:103:71
+    ┌─ vector.move:117:71
     │
-103 │         rotate_slice<Element>(self, 0, rot, length<Element>(/*freeze*/self))
+117 │         rotate_slice<Element>(self, 0, rot, length<Element>(/*freeze*/self))
     │         --------------------------------------------------------------^^^^--
     │         │                     │                                       │
     │         │                     │                                       implicitly frozen here
@@ -174,9 +188,9 @@ error: cannot freeze value which is still mutably borrowed
     │         conflicting reference used here
 
 error: cannot freeze value which is still mutably borrowed
-    ┌─ vector.move:131:58
+    ┌─ vector.move:145:58
     │
-131 │         swap<Element>(self, i, length<Element>(/*freeze*/self) - 1);
+145 │         swap<Element>(self, i, length<Element>(/*freeze*/self) - 1);
     │         -------------------------------------------------^^^^------
     │         │             │                                  │
     │         │             │                                  implicitly frozen here

--- a/third_party/move/tools/move-decompiler/tests/move-v2-features/enum.exp
+++ b/third_party/move/tools/move-decompiler/tests/move-v2-features/enum.exp
@@ -143,5 +143,4 @@ module 0x99::enum_simple {
     }
 }
 
-
 ============ recompilation succeeded ========

--- a/third_party/move/tools/move-decompiler/tests/testsuite.rs
+++ b/third_party/move/tools/move-decompiler/tests/testsuite.rs
@@ -321,7 +321,7 @@ fn recompile_decompiled_code(
         .collect();
 
     run_move_compiler_for_analysis(error_writer, compiler_options)?;
-    Ok("\n============ recompilation succeeded ========\n".to_string())
+    Ok("============ recompilation succeeded ========\n".to_string())
 }
 
 /// Get a list of dependencies that exclude the target file itself


### PR DESCRIPTION
## Description
The decompiler, during control flow structuring, does not consider the impacts of newly inserted loops on previously generated `LoopCont` expressions. See #17087 for an example. This PR fixes this issue.

Close #17087.

## How Has This Been Tested?
- Existing decompiler test cases

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Move Decompiler)
