### PR TITLE
WriteSet needs to contain both value and hotness

### DIFF
--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__create_account__create_account.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__create_account__create_account.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -14,7 +14,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("fungible_asset"), name: Identifier("Withdraw"), type_args: [] }), event_data: "b26af11b4f332a7794398554b6313a38c6a102c74c5ba9a12629ae3a492acb2f0100000000000000" },
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("fungible_asset"), name: Identifier("Deposit"), type_args: [] }), event_data: "3f4fc7462763e539d6c50356f9c1d14ffc32b567d038da6bdfa454b8618910670100000000000000" },

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_bad_sig_function_dep.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_bad_sig_function_dep.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_code_unverifiable.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_code_unverifiable.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_nested_type_argument_module_does_not_exist.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_nested_type_argument_module_does_not_exist.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_non_existing_function_dep.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_non_existing_function_dep.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_none_existing_module_dep.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_none_existing_module_dep.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_type_argument_module_does_not_exist.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__scripts__script_type_argument_module_does_not_exist.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__borrow_after_move.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__borrow_after_move.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -11,7 +11,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -30,8 +31,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -41,7 +42,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -56,8 +58,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -66,7 +68,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -81,8 +84,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -92,7 +95,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000020000000000000000000000000000000000000000000000" },
             ],
@@ -103,8 +107,8 @@ Ok(
             auxiliary_data: None,
         },
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -113,7 +117,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__change_after_move.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__change_after_move.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -11,7 +11,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -30,8 +31,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -41,7 +42,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -56,8 +58,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -66,7 +68,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -81,8 +84,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -92,7 +95,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000020000000000000000000000000000000000000000000000" },
             ],
@@ -103,8 +107,8 @@ Ok(
             auxiliary_data: None,
         },
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -113,7 +117,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -132,8 +137,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -142,7 +147,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__move_from_across_blocks.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__state_store__move_from_across_blocks.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -11,7 +11,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -30,8 +31,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -41,7 +42,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -56,8 +58,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -66,7 +68,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -81,8 +84,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -92,7 +95,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000020000000000000000000000000000000000000000000000" },
             ],
@@ -107,8 +111,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -117,7 +121,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -136,8 +141,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -146,7 +151,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -165,8 +171,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -176,7 +182,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],
@@ -191,8 +198,8 @@ Ok(
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -202,7 +209,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000020000000000000000000000000000000000000000000000" },
             ],
@@ -213,8 +221,8 @@ Ok(
             auxiliary_data: None,
         },
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -223,7 +231,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "04000000000000000300000000000000010000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_arbitrary_script_execution.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_arbitrary_script_execution.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_dependency_fails_verification.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_transitive_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_script_transitive_dependency_fails_verification.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_dependency_fails_verification.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_transitive_dependency_fails_verification.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__test_type_tag_transitive_dependency_fails_verification.exp
@@ -1,8 +1,8 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {
@@ -13,7 +13,8 @@ Ok(
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [
                 ModuleEvent { type: Struct(StructTag { address: 0000000000000000000000000000000000000000000000000000000000000001, module: Identifier("transaction_fee"), name: Identifier("FeeStatement"), type_args: [] }), event_data: "03000000000000000300000000000000000000000000000000000000000000000000000000000000" },
             ],

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_duplicate_secondary_signer.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_duplicate_secondary_signer.exp
@@ -1,15 +1,16 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {},
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [],
             gas_used: 0,
             status: Discard(

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_secondary_signature.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_secondary_signature.exp
@@ -1,15 +1,16 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {},
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [],
             gas_used: 0,
             status: Discard(

--- a/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_sender_signature.exp
+++ b/aptos-move/e2e-tests/goldens/language_e2e_testsuite__tests__verify_txn__verify_multi_agent_invalid_sender_signature.exp
@@ -1,15 +1,16 @@
 Ok(
     [
         TransactionOutput {
-            write_set: Value(
-                V0(
+            write_set: WriteSet {
+                value: V0(
                     WriteSetV0(
                         WriteSetMut {
                             write_set: {},
                         },
                     ),
                 ),
-            ),
+                hotness: {},
+            },
             events: [],
             gas_used: 0,
             status: Discard(

--- a/aptos-move/e2e-testsuite/src/tests/genesis.rs
+++ b/aptos-move/e2e-testsuite/src/tests/genesis.rs
@@ -15,7 +15,7 @@ fn no_deletion_in_genesis() {
     let genesis = GENESIS_CHANGE_SET_HEAD.clone();
     assert!(!genesis
         .write_set()
-        .expect_v0()
+        .as_v0()
         .iter()
         .any(|(_, op)| op.is_deletion()))
 }

--- a/aptos-move/vm-genesis/src/lib.rs
+++ b/aptos-move/vm-genesis/src/lib.rs
@@ -1730,7 +1730,7 @@ pub fn test_mainnet_end_to_end() {
         panic!("Invalid WriteSetPayload");
     };
 
-    let writeset = changeset.write_set().expect_v0();
+    let writeset = changeset.write_set().as_v0();
 
     let state_key = StateKey::on_chain_config::<ValidatorSet>().unwrap();
     let bytes = writeset

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -1,12 +1,7 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    state_store::{state_key::StateKey, state_slot::StateSlot},
-    transaction::TransactionOutput,
-    write_set::{HotStateOp, WriteSet},
-};
-use anyhow::Result;
+use crate::state_store::{state_key::StateKey, state_slot::StateSlot};
 use aptos_crypto::HashValue;
 use derive_more::Deref;
 #[cfg(any(test, feature = "fuzzing"))]
@@ -108,6 +103,7 @@ pub struct TBlockEndInfoExt<Key: Debug> {
     /// TODO(HotState): add evictions
     /// TODO(HotState): once hot state is deterministic across all nodes, add BlockEndInfo::V1 and
     ///                 serialize the promoted and evicted keys in the transaction.
+    #[allow(dead_code)]
     slots_to_make_hot: BTreeMap<Key, StateSlot>,
 }
 
@@ -130,18 +126,5 @@ impl<Key: Debug> TBlockEndInfoExt<Key> {
 
     pub fn to_persistent(&self) -> BlockEndInfo {
         self.inner.clone()
-    }
-}
-
-impl BlockEndInfoExt {
-    pub fn to_transaction_output(&self) -> Result<TransactionOutput> {
-        let write_ops = self
-            .slots_to_make_hot
-            .iter()
-            .map(|(key, slot)| Ok((key.clone(), HotStateOp::make_hot(slot.clone()))))
-            .collect::<Result<_>>()?;
-        Ok(TransactionOutput::new_success_with_write_set(
-            WriteSet::Hotness(write_ops),
-        ))
     }
 }

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -14,7 +14,7 @@ use anyhow::{bail, ensure, Result};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use ark_std::iterable::Iterable;
 use bytes::Bytes;
-use itertools::Either;
+use itertools::Itertools;
 use once_cell::sync::Lazy;
 use ref_cast::RefCast;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -560,17 +560,11 @@ impl Debug for HotStateOp {
     }
 }
 
-#[derive(BCSCryptoHash, Clone, CryptoHasher, Debug, Eq, PartialEq)]
-pub enum WriteSet {
-    Value(ValueWriteSet),
-    /// TODO(HotState): this variant silently serializes to an empty ValueWriteSet for now.
-    Hotness(BTreeMap<StateKey, HotStateOp>),
-}
-
-impl Default for WriteSet {
-    fn default() -> Self {
-        Self::Value(ValueWriteSet::default())
-    }
+#[derive(BCSCryptoHash, Clone, CryptoHasher, Debug, Default, Eq, PartialEq)]
+pub struct WriteSet {
+    value: ValueWriteSet,
+    /// TODO(HotState): this field is not serialized for now.
+    hotness: BTreeMap<StateKey, HotStateOp>,
 }
 
 impl Serialize for WriteSet {
@@ -578,10 +572,7 @@ impl Serialize for WriteSet {
     where
         S: Serializer,
     {
-        match self {
-            WriteSet::Value(ws) => ws.serialize(serializer),
-            WriteSet::Hotness(_hot_state_ops) => ValueWriteSet::default().serialize(serializer),
-        }
+        self.value.serialize(serializer)
     }
 }
 
@@ -590,38 +581,35 @@ impl<'de> Deserialize<'de> for WriteSet {
     where
         D: Deserializer<'de>,
     {
-        let ws = ValueWriteSet::deserialize(deserializer)?;
-        Ok(WriteSet::Value(ws))
+        let value = ValueWriteSet::deserialize(deserializer)?;
+        Ok(Self {
+            value,
+            hotness: BTreeMap::new(),
+        })
     }
 }
 
 impl WriteSet {
-    pub fn expect_into_v0(self) -> WriteSetV0 {
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => ws,
-            // TODO(HotState):
-            WriteSet::Hotness(_) => panic!("hot state ops touched unexpectedly"),
+    fn into_v0(self) -> WriteSetV0 {
+        match self.value {
+            ValueWriteSet::V0(ws) => ws,
         }
     }
 
-    pub fn expect_v0(&self) -> &WriteSetV0 {
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => ws,
-            // TODO(HotState):
-            WriteSet::Hotness(_) => panic!("hot state ops touched unexpectedly"),
+    pub fn as_v0(&self) -> &WriteSetV0 {
+        match &self.value {
+            ValueWriteSet::V0(ws) => ws,
         }
     }
 
-    pub fn expect_v0_mut(&mut self) -> &mut WriteSetV0 {
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => ws,
-            // TODO(HotState):
-            WriteSet::Hotness(_) => panic!("hot state ops touched unexpectedly"),
+    fn as_v0_mut(&mut self) -> &mut WriteSetV0 {
+        match &mut self.value {
+            ValueWriteSet::V0(ws) => ws,
         }
     }
 
     pub fn into_mut(self) -> WriteSetMut {
-        self.expect_into_v0().0
+        self.into_v0().0
     }
 
     pub fn new(write_ops: impl IntoIterator<Item = (StateKey, WriteOp)>) -> Result<Self> {
@@ -641,7 +629,7 @@ impl WriteSet {
     }
 
     pub fn state_update_refs(&self) -> impl Iterator<Item = (&StateKey, Option<&StateValue>)> + '_ {
-        self.expect_v0()
+        self.as_v0()
             .iter()
             .map(|(key, op)| (key, op.as_state_value_opt()))
     }
@@ -654,62 +642,48 @@ impl WriteSet {
     }
 
     pub fn update_total_supply(&mut self, value: u128) {
-        self.expect_v0_mut().update_total_supply(value);
+        self.as_v0_mut().update_total_supply(value);
     }
 
     pub fn get_write_op(&self, state_key: &StateKey) -> Option<&WriteOp> {
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => ws.get(state_key),
-            WriteSet::Hotness(_) => None,
-        }
+        self.as_v0().get(state_key)
     }
 
     pub fn get_total_supply(&self) -> Option<u128> {
-        self.expect_v0().get_total_supply()
+        self.as_v0().get_total_supply()
     }
 
     pub fn is_empty(&self) -> bool {
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => ws.is_empty(),
-            WriteSet::Hotness(ws) => ws.is_empty(),
-        }
+        self.as_v0().is_empty() && self.hotness.is_empty()
     }
 
     pub fn expect_into_write_op_iter(self) -> impl IntoIterator<Item = (StateKey, WriteOp)> {
-        self.expect_into_v0().0.write_set
+        self.into_v0().0.write_set
     }
 
     pub fn expect_write_op_iter(&self) -> impl Iterator<Item = (&StateKey, &WriteOp)> {
-        self.expect_v0().0.write_set.iter()
+        self.as_v0().0.write_set.iter()
     }
 
     pub fn write_op_iter(&self) -> impl Iterator<Item = (&StateKey, &WriteOp)> {
-        const EMPTY: &[(&StateKey, &WriteOp)] = &[];
-
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => Either::Left(ws.iter()),
-            WriteSet::Hotness(_) => Either::Right(EMPTY.iter().copied()),
-        }
+        self.as_v0().iter()
     }
 
     pub fn into_write_op_iter(self) -> impl Iterator<Item = (StateKey, WriteOp)> {
-        const EMPTY: &[(StateKey, WriteOp)] = &[];
-
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => Either::Left(ws.into_write_op_iter()),
-            WriteSet::Hotness(_) => Either::Right(EMPTY.iter().cloned()),
-        }
+        self.into_v0().into_write_op_iter()
     }
 
     pub fn base_op_iter(&self) -> impl Iterator<Item = (&StateKey, &BaseStateOp)> {
-        match self {
-            WriteSet::Value(ValueWriteSet::V0(ws)) => {
-                Either::Left(ws.iter().map(|(key, op)| (key, op.as_base_op())))
-            },
-            WriteSet::Hotness(ws) => {
-                Either::Right(ws.iter().map(|(key, op)| (key, op.as_base_op())))
-            },
-        }
+        self.as_v0()
+            .iter()
+            .map(|(key, op)| (key, op.as_base_op()))
+            .merge_by(
+                self.hotness.iter().map(|(key, op)| (key, op.as_base_op())),
+                |a, b| {
+                    assert_ne!(a.0, b.0, "key should not appear in both value and hotness");
+                    a.0 < b.0
+                },
+            )
     }
 }
 
@@ -809,7 +783,10 @@ impl WriteSetMut {
 
     pub fn freeze(self) -> Result<WriteSet> {
         // TODO: add structural validation
-        Ok(WriteSet::Value(ValueWriteSet::V0(WriteSetV0(self))))
+        Ok(WriteSet {
+            value: ValueWriteSet::V0(WriteSetV0(self)),
+            hotness: BTreeMap::new(),
+        })
     }
 
     pub fn get(&self, key: &StateKey) -> Option<&WriteOp> {


### PR DESCRIPTION

`WriteSet` was previously changed to an enum of `Value` and `Hotness`. The block
epilogue would generate `Hotness` only. However, after recent changes, it's
possible for the epilogue to generate both `Value` (from priority fee
implementation) and `Hotness` (from hot state promotions). So this change makes
`WriteSet` a struct instead. For serialization, it's still value-only.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/17113).
* #17114
* __->__ #17113