### PR TITLE
[hot state] Populate hot state promotions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,6 +4125,7 @@ dependencies = [
  "anyhow",
  "aptos-crypto",
  "aptos-experimental-layered-map",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-secure-net",

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -67,7 +67,7 @@ use aptos_types::{
         TimedFeatureFlag, TimedFeatures,
     },
     randomness::Randomness,
-    state_store::{StateView, TStateView},
+    state_store::{state_key::StateKey, StateView, TStateView},
     transaction::{
         authenticator::{AbstractionAuthData, AnySignature, AuthenticationProof},
         block_epilogue::{BlockEpiloguePayload, FeeDistribution},
@@ -2759,7 +2759,7 @@ impl AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         fail_point!("aptos_vm_block_executor::execute_block_with_config", |_| {
             Err(VMStatus::error(
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
@@ -2807,7 +2807,7 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         let config = BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
                 blockstm_v2: false,

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -132,7 +132,7 @@ use aptos_types::{
         config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
         transaction_slice_metadata::TransactionSliceMetadata,
     },
-    state_store::StateView,
+    state_store::{state_key::StateKey, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, BlockOutput,
         SignedTransaction, TransactionOutput, VMValidatorResult,
@@ -173,7 +173,7 @@ pub trait VMBlockExecutor: Send + Sync {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus>;
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus>;
 
     /// Executes a block of transactions and returns output for each one of them, without applying
     /// any block limit.

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -79,7 +79,7 @@ use std::{
     },
 };
 
-struct SharedSyncParams<'a, T, E, S>
+struct SharedSyncParams<'a, 'b, T, E, S>
 where
     T: BlockExecutableTransaction,
     E: ExecutorTask<Txn = T>,
@@ -93,7 +93,7 @@ where
         &'a GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension>,
     last_input_output: &'a TxnLastInputOutput<T, E::Output, E::Error>,
     delayed_field_id_counter: &'a AtomicU32,
-    block_limit_processor: &'a ExplicitSyncWrapper<BlockGasLimitProcessor<'a, T, S>>,
+    block_limit_processor: &'a ExplicitSyncWrapper<BlockGasLimitProcessor<'b, T, S>>,
     final_results: &'a ExplicitSyncWrapper<Vec<E::Output>>,
 }
 
@@ -1344,7 +1344,7 @@ where
         // TODO: use worker id.
         _worker_id: u32,
         num_workers: u32,
-        shared_sync_params: &SharedSyncParams<'_, T, E, S>,
+        shared_sync_params: &SharedSyncParams<'_, '_, T, E, S>,
         start_delayed_field_id_counter: u32,
     ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
         let num_txns = block.num_txns() as u32;
@@ -1459,12 +1459,13 @@ where
         shared_maybe_error: &AtomicBool,
         has_remaining_commit_tasks: bool,
         final_results: ExplicitSyncWrapper<Vec<E::Output>>,
+        block_limit_processor: ExplicitSyncWrapper<BlockGasLimitProcessor<T, S>>,
         block_epilogue_txn: Option<Transaction>,
         mut versioned_cache: MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
         scheduler: impl Send + 'static,
         last_input_output: TxnLastInputOutput<T, E::Output, E::Error>,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<E::Output>, ()> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
         // Check for errors or remaining commit tasks before any side effects.
         let mut has_error = shared_maybe_error.load(Ordering::SeqCst);
         if !has_error && has_remaining_commit_tasks {
@@ -1493,9 +1494,11 @@ where
         DEFAULT_DROPPER.schedule_drop((last_input_output, scheduler, versioned_cache));
 
         // Return final result
+        let block_end_info = block_limit_processor.acquire().get_block_end_info();
         Ok(BlockOutput::new(
             final_results.into_inner(),
             block_epilogue_txn,
+            block_end_info.slots_to_make_hot,
         ))
     }
 
@@ -1505,7 +1508,7 @@ where
         signature_verified_block: &TP,
         base_view: &S,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<E::Output>, ()> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // BlockSTMv2 should have less restrictions on the number of workers but we
         // still sanity check that it is not instantiated w. concurrency level 1.
@@ -1517,7 +1520,7 @@ where
 
         let num_txns = signature_verified_block.num_txns();
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, BTreeMap::new()));
         }
 
         let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2) as u32;
@@ -1543,7 +1546,7 @@ where
         let versioned_cache = MVHashMap::new();
         let scheduler = SchedulerV2::new(num_txns, num_workers);
 
-        let shared_sync_params: SharedSyncParams<'_, T, E, S> = SharedSyncParams {
+        let shared_sync_params: SharedSyncParams<'_, '_, _, E, _> = SharedSyncParams {
             base_view,
             scheduler: &scheduler,
             versioned_cache: &versioned_cache,
@@ -1589,6 +1592,7 @@ where
             &shared_maybe_error,
             !scheduler.post_commit_processing_queue_is_empty(),
             final_results,
+            block_limit_processor,
             None, // BlockSTMv2 doesn't handle block epilogue yet.
             versioned_cache,
             scheduler,
@@ -1603,7 +1607,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<E::Output>, ()> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // Using parallel execution with 1 thread currently will not work as it
         // will only have a coordinator role but no workers for rolling commit.
@@ -1620,7 +1624,7 @@ where
 
         let num_txns = signature_verified_block.num_txns();
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, BTreeMap::new()));
         }
 
         let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2);
@@ -1696,6 +1700,7 @@ where
             &shared_maybe_error,
             scheduler.pop_from_commit_queue().is_ok(),
             final_results,
+            block_limit_processor,
             block_epilogue_txn.into_inner(),
             versioned_cache,
             scheduler,
@@ -1930,11 +1935,11 @@ where
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
         resource_group_bcs_fallback: bool,
-    ) -> Result<BlockOutput<E::Output>, SequentialBlockExecutionError<E::Error>> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, SequentialBlockExecutionError<E::Error>> {
         let num_txns = signature_verified_block.num_txns();
 
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, BTreeMap::new()));
         }
 
         let init_timer = VM_INIT_SECONDS.start_timer();
@@ -2264,7 +2269,17 @@ where
             .module_cache_mut()
             .insert_verified(unsync_map.into_modules_iter())?;
 
-        Ok(BlockOutput::new(ret, block_epilogue_txn))
+        let block_end_info = block_limit_processor.get_block_end_info();
+        info!(
+            "epilogue output: {:?}, block end info: {:?}",
+            ret.last(),
+            block_end_info
+        );
+        Ok(BlockOutput::new(
+            ret,
+            block_epilogue_txn,
+            block_end_info.slots_to_make_hot,
+        ))
     }
 
     pub fn execute_block(
@@ -2273,7 +2288,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> BlockExecutionResult<BlockOutput<E::Output>, E::Error> {
+    ) -> BlockExecutionResult<BlockOutput<T::Key, E::Output>, E::Error> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         if self.config.local.concurrency_level > 1 {
@@ -2379,7 +2394,7 @@ where
             let ret = (0..signature_verified_block.num_txns())
                 .map(|_| E::Output::discard_output(error_code))
                 .collect();
-            return Ok(BlockOutput::new(ret, None));
+            return Ok(BlockOutput::new(ret, None, BTreeMap::new()));
         }
 
         Err(sequential_error)

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -117,8 +117,16 @@ impl DoGetExecutionOutput {
             onchain_config,
             transaction_slice_metadata,
         )?;
-        let (transaction_outputs, block_epilogue_txn) = block_output.into_inner();
+        let (mut transaction_outputs, block_epilogue_txn, slots_to_make_hot) =
+            block_output.into_inner();
+        info!("slots_to_make_hot: {:?}", slots_to_make_hot);
         let (transactions, mut auxiliary_info) = txn_provider.into_inner();
+        info!(
+            "outputs.len(): {}, transactions.len(): {}. auxiliary_info.len(): {}",
+            transaction_outputs.len(),
+            transactions.len(),
+            auxiliary_info.len(),
+        );
         let mut transactions = transactions
             .into_iter()
             .map(|t| t.into_inner())
@@ -127,6 +135,8 @@ impl DoGetExecutionOutput {
             transactions.push(block_epilogue_txn);
             // TODO(grao): Double check if we want to put anything into AuxiliaryInfo here.
             auxiliary_info.push(AuxiliaryInfo::new_empty());
+            // let o = transaction_outputs.last_mut().unwrap();
+            // info!("o: {o:?}");
         }
 
         Parser::parse(
@@ -242,7 +252,7 @@ impl DoGetExecutionOutput {
         state_view: &CachedStateView,
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>> {
         let _timer = OTHER_TIMERS.timer_with(&["vm_execute_block"]);
         Ok(executor.execute_block(
             txn_provider,
@@ -345,12 +355,19 @@ impl Parser {
         // The rest is to be committed, attach block epilogue as needed and optionally get next EpochState.
         let to_commit = {
             let _timer = OTHER_TIMERS.timer_with(&["parse_raw_output__to_commit"]);
+            info!("raw output: {:?}", transaction_outputs);
             let to_commit = TransactionsWithOutput::new(
                 transactions,
                 transaction_outputs,
                 persisted_auxiliary_info,
             );
-            TransactionsToKeep::index(first_version, to_commit, has_reconfig)
+            let tc = TransactionsToKeep::index(first_version, to_commit, has_reconfig);
+            info!(
+                "indexed output: {:?}",
+                tc.state_update_refs().for_last_checkpoint
+            );
+            info!("indexed output: {:?}", tc.state_update_refs().for_latest);
+            tc
         };
         let next_epoch_state = {
             let _timer = OTHER_TIMERS.timer_with(&["parse_raw_output__next_epoch_state"]);

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-experimental-layered-map = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-secure-net = { workspace = true }

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{metrics::TIMER, state_store::versioned_state_value::StateUpdateRef};
+use aptos_logger::{sample, sample::SampleRate, warn};
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::{state_key::StateKey, NUM_STATE_SHARDS},
@@ -11,8 +12,12 @@ use aptos_types::{
 use arr_macro::arr;
 use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
-use std::collections::HashMap;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    time::Duration,
+};
 
+#[derive(Debug)]
 pub struct PerVersionStateUpdateRefs<'kv> {
     pub first_version: Version,
     pub num_versions: usize,
@@ -94,6 +99,7 @@ impl BatchedStateUpdateRefs<'_> {
     }
 }
 
+#[derive(Debug)]
 pub struct StateUpdateRefs<'kv> {
     pub per_version: PerVersionStateUpdateRefs<'kv>,
     /// Batched updates (updates for the same keys are merged) from the
@@ -204,11 +210,41 @@ impl<'kv> StateUpdateRefs<'kv> {
             .par_iter_mut()
             .zip_eq(ret.shards.par_iter_mut())
             .for_each(|(shard_iter, dedupped)| {
-                dedupped.extend(
-                    shard_iter
-                        // n.b. take_while_ref so that in the next step we can process the rest of the entries from the iters.
-                        .take_while_ref(|(_k, u)| u.version < end_version),
-                )
+                // n.b. take_while_ref so that in the next step we can process the rest of the
+                // entries from the iters.
+                for (k, u) in shard_iter.take_while_ref(|(_k, u)| u.version < end_version) {
+                    // If it's a value write op (Creation/Modification/Deletion), just insert and
+                    // overwrite the previous op.
+                    if u.state_op.is_value_write_op() {
+                        dedupped.insert(k, u);
+                        continue;
+                    }
+
+                    // If we see a hotness op, we check if there is a value write op with the same
+                    // key before. This is unlikely, but if it does happen (e.g. if the write
+                    // summary used to compute MakeHot is missing keys), we do not want the hot
+                    // state promotion to overwrite the write.
+                    match dedupped.entry(k) {
+                        Entry::Occupied(mut entry) => {
+                            let prev_op = &entry.get().state_op;
+                            sample!(
+                                SampleRate::Duration(Duration::from_secs(10)),
+                                warn!(
+                                    "Key: {:?}. Previous write op: {}. Current write op: {}",
+                                    k,
+                                    prev_op.as_ref(),
+                                    u.state_op.as_ref()
+                                )
+                            );
+                            if !prev_op.is_value_write_op() {
+                                entry.insert(u);
+                            }
+                        },
+                        Entry::Vacant(entry) => {
+                            entry.insert(u);
+                        },
+                    }
+                }
             });
         ret
     }

--- a/types/src/state_store/state_value.rs
+++ b/types/src/state_store/state_value.rs
@@ -178,10 +178,16 @@ impl PersistedStateValue {
     }
 }
 
-#[derive(BCSCryptoHash, Clone, CryptoHasher, Debug, Eq, PartialEq)]
+#[derive(BCSCryptoHash, Clone, CryptoHasher, Eq, PartialEq)]
 pub struct StateValue {
     data: Bytes,
     metadata: StateValueMetadata,
+}
+
+impl std::fmt::Debug for StateValue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "StateValue(...)")
+    }
 }
 
 pub const ARB_STATE_VALUE_MAX_SIZE: usize = 100;

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -103,8 +103,7 @@ pub struct TBlockEndInfoExt<Key: Debug> {
     /// TODO(HotState): add evictions
     /// TODO(HotState): once hot state is deterministic across all nodes, add BlockEndInfo::V1 and
     ///                 serialize the promoted and evicted keys in the transaction.
-    #[allow(dead_code)]
-    slots_to_make_hot: BTreeMap<Key, StateSlot>,
+    pub slots_to_make_hot: BTreeMap<Key, StateSlot>,
 }
 
 pub type BlockEndInfoExt = TBlockEndInfoExt<StateKey>;

--- a/types/src/transaction/block_output.rs
+++ b/types/src/transaction/block_output.rs
@@ -2,21 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Transaction;
-use std::fmt::Debug;
+use crate::state_store::state_slot::StateSlot;
+use std::{collections::BTreeMap, fmt::Debug};
 
 #[derive(Debug)]
-pub struct BlockOutput<Output: Debug> {
+pub struct BlockOutput<Key, Output: Debug> {
     transaction_outputs: Vec<Output>,
     // A BlockEpilogueTxn might be appended to the block.
     // This field will be None iff the input is not a block, or an epoch change is triggered.
     block_epilogue_txn: Option<Transaction>,
+    to_make_hot: BTreeMap<Key, StateSlot>,
 }
 
-impl<Output: Debug> BlockOutput<Output> {
-    pub fn new(transaction_outputs: Vec<Output>, block_epilogue_txn: Option<Transaction>) -> Self {
+impl<Key, Output: Debug> BlockOutput<Key, Output> {
+    pub fn new(
+        transaction_outputs: Vec<Output>,
+        block_epilogue_txn: Option<Transaction>,
+        to_make_hot: BTreeMap<Key, StateSlot>,
+    ) -> Self {
         Self {
             transaction_outputs,
             block_epilogue_txn,
+            to_make_hot,
         }
     }
 
@@ -24,8 +31,12 @@ impl<Output: Debug> BlockOutput<Output> {
         self.transaction_outputs
     }
 
-    pub fn into_inner(self) -> (Vec<Output>, Option<Transaction>) {
-        (self.transaction_outputs, self.block_epilogue_txn)
+    pub fn into_inner(self) -> (Vec<Output>, Option<Transaction>, BTreeMap<Key, StateSlot>) {
+        (
+            self.transaction_outputs,
+            self.block_epilogue_txn,
+            self.to_make_hot,
+        )
     }
 
     pub fn get_transaction_outputs_forced(&self) -> &[Output] {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         TransactionAuthenticator,
     },
     vm_status::{DiscardedVMStatus, KeptVMStatus, StatusCode, StatusType, VMStatus},
-    write_set::WriteSet,
+    write_set::{HotStateOp, WriteSet},
 };
 use anyhow::{ensure, format_err, Context, Error, Result};
 use aptos_crypto::{
@@ -36,6 +36,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
+    collections::BTreeMap,
     convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
 };
@@ -1478,6 +1479,13 @@ impl TransactionStatus {
         }
     }
 
+    pub fn is_keep(&self) -> bool {
+        match self {
+            TransactionStatus::Keep(_) => true,
+            _ => false,
+        }
+    }
+
     pub fn is_retry(&self) -> bool {
         match self {
             TransactionStatus::Discard(_) => false,
@@ -1811,6 +1819,10 @@ impl TransactionOutput {
 
     pub fn state_update_refs(&self) -> impl Iterator<Item = (&StateKey, Option<&StateValue>)> + '_ {
         self.write_set.state_update_refs()
+    }
+
+    pub fn add_hotness(&mut self, hotness: BTreeMap<StateKey, HotStateOp>) {
+        self.write_set.add_hotness(hotness);
     }
 }
 

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -14,7 +14,7 @@ use anyhow::{bail, ensure, Result};
 use aptos_crypto_derive::{BCSCryptoHash, CryptoHasher};
 use ark_std::iterable::Iterable;
 use bytes::Bytes;
-use itertools::Itertools;
+use itertools::{EitherOrBoth, Itertools};
 use once_cell::sync::Lazy;
 use ref_cast::RefCast;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -22,6 +22,7 @@ use std::{
     collections::{btree_map, BTreeMap},
     fmt::{Debug, Formatter},
 };
+use strum_macros::AsRefStr;
 
 // Note: in case this changes in the future, it doesn't have to be a constant, and can be read from
 // genesis directly if necessary.
@@ -83,7 +84,7 @@ impl PersistedWriteOp {
 }
 
 /// Shared in memory representation between the (value) WriteOp and the (hotness) HotStateOp
-#[derive(Clone, Debug, Eq, PartialEq)]
+#[derive(Clone, Debug, Eq, PartialEq, AsRefStr)]
 pub enum BaseStateOp {
     Creation(StateValue),
     Modification(StateValue),
@@ -485,27 +486,9 @@ impl Debug for WriteOp {
         use BaseStateOp::*;
 
         match &self.0 {
-            Creation(v) => write!(
-                f,
-                "Creation({}, metadata:{:?})",
-                v.bytes()
-                    .iter()
-                    .map(|byte| format!("{:02x}", byte))
-                    .collect::<String>(),
-                v.metadata(),
-            ),
-            Modification(v) => write!(
-                f,
-                "Modification({}, metadata:{:?})",
-                v.bytes()
-                    .iter()
-                    .map(|byte| format!("{:02x}", byte))
-                    .collect::<String>(),
-                v.metadata(),
-            ),
-            Deletion(metadata) => {
-                write!(f, "Deletion(metadata:{:?})", metadata,)
-            },
+            Creation(_) => write!(f, "Creation(...)"),
+            Modification(_) => write!(f, "Modification(...)"),
+            Deletion(_) => write!(f, "Deletion(...)"),
             MakeHot { .. } | Eviction { .. } => unreachable!("malformed write op"),
         }
     }
@@ -677,13 +660,27 @@ impl WriteSet {
         self.as_v0()
             .iter()
             .map(|(key, op)| (key, op.as_base_op()))
-            .merge_by(
+            .merge_join_by(
                 self.hotness.iter().map(|(key, op)| (key, op.as_base_op())),
-                |a, b| {
-                    assert_ne!(a.0, b.0, "key should not appear in both value and hotness");
-                    a.0 < b.0
-                },
+                |a, b| a.0.cmp(b.0),
             )
+            .map(|entry| {
+                // It seems like it's possible to have a key that is both in `value` and `hotness`
+                // (because of inaccurate read write summary). If this happens we discard the
+                // hotness change, and the recently written keys will be made hot anyway.
+                match entry {
+                    EitherOrBoth::Left(e) | EitherOrBoth::Right(e) => e,
+                    EitherOrBoth::Both(e, _) => e,
+                }
+            })
+    }
+
+    pub fn add_hotness(&mut self, hotness: BTreeMap<StateKey, HotStateOp>) {
+        assert!(
+            self.hotness.is_empty(),
+            "hotness should only be initialized once."
+        );
+        self.hotness = hotness;
     }
 }
 


### PR DESCRIPTION

This was originally done in #16485. However, subsequent changes (mostly priority
fee implementation) undid some of the changes, so while
`BlockHotStateOpAccumulator` still computes `slots_to_make_hot`, the result is
never populated to the hot state storage. Therefore, the read-only keys are
never cached.

This change poluates the infomation again by putting it inside `BlockOutput`.
