### PR TITLE
Reduce resources for Forge runner

### DIFF
--- a/testsuite/forge-test-runner-template.yaml
+++ b/testsuite/forge-test-runner-template.yaml
@@ -25,12 +25,9 @@ spec:
           ulimit -n 1048576
           {FORGE_ARGS}
       resources:
-        limits:
-          cpu: 15.5
-          memory: 26Gi
         requests:
-          cpu: 15
-          memory: 26Gi
+          cpu: 8
+          memory: 20G
       env:
         - name: FORGE_TRIGGERED_BY
           value: {FORGE_TRIGGERED_BY}


### PR DESCRIPTION
## Description

Looking at the last 30 days of Forge, the runners maxed out at around 8 cores and 14G RAM, so reduce the minimum request and eliminate limits, to allow runners to burst if necessary.
