### PR TITLE
fix decompiler assignment optimization issue #17008

### DIFF
--- a/third_party/move/tools/move-decompiler/tests/control-flow-recovery/noexit_loops.exp
+++ b/third_party/move/tools/move-decompiler/tests/control-flow-recovery/noexit_loops.exp
@@ -24,6 +24,7 @@ module 0x99::noexit_loops {
     fun f13(cond: bool) {
         let _t2;
         if (cond) _t2 = 0 else _t2 = 1;
+        1 + (_t2 + 2);
         loop continue
     }
     fun f14(p: bool, q: bool) {
@@ -33,6 +34,7 @@ module 0x99::noexit_loops {
     fun f15() {
         let _t0;
         _t0 = 0;
+        _t0 + 1;
     }
     fun f16() {
         loop continue
@@ -73,19 +75,19 @@ module 0x99::noexit_loops {
 --- unable to recompile the decompiled code:
 exiting with context checking errors
 error: cannot return nothing from a function with result type `R`
-   ┌─ noexit_loops.move:54:9
+   ┌─ noexit_loops.move:56:9
    │
-54 │         loop continue
+56 │         loop continue
    │         ^^^^^^^^^^^^^
 
 error: cannot return nothing from a function with result type `u64`
-   ┌─ noexit_loops.move:57:9
+   ┌─ noexit_loops.move:59:9
    │
-57 │         loop continue
+59 │         loop continue
    │         ^^^^^^^^^^^^^
 
 error: cannot return nothing from a function with result type `R`
-   ┌─ noexit_loops.move:63:9
+   ┌─ noexit_loops.move:65:9
    │
-63 │         loop continue
+65 │         loop continue
    │         ^^^^^^^^^^^^^

--- a/third_party/move/tools/move-decompiler/tests/move-v2-features/closure.exp
+++ b/third_party/move/tools/move-decompiler/tests/move-v2-features/closure.exp
@@ -101,7 +101,7 @@ module 0x99::lambda_generics {
         self
     }
     fun inlined<T: drop>(f: |S<T>|(S<T>), s: S<T>) {
-        ()
+        f(s);
     }
     fun test_receiver_inference(s: S<u64>) {
         inlined<u64>(|arg0| id(arg0), s);

--- a/third_party/move/tools/move-decompiler/tests/move-v2-features/enum.exp
+++ b/third_party/move/tools/move-decompiler/tests/move-v2-features/enum.exp
@@ -139,7 +139,8 @@ module 0x99::enum_simple {
         _t2
     }
     fun example_destroy_shapes() {
-        ()
+        destroy_empty(Shape::Circle{radius: 0});
+        destroy_empty(Shape::Rectangle{width: 0,height: 0});
     }
 }
 


### PR DESCRIPTION
## Description
The decompiler optimizes the following pattern
```Move
t1 = rhs;
...
use(t1)
```
===>
```Move
...
use(rhs)
```

If `t1` is never used (i.e., `use(t1)` does not exist), the decompiler will eliminate `t1 = rhs` entirely. This is not safe as `rhs` can have side effects (e.g., `rhs` being a function call). This PR fixes this issue by checking if `rhs` carries potential side effects. Currently, it only checks if `rhs` is a `Call(Operation::MoveFunction)` or `Invoke`. 

Close issue #17008.

## How Has This Been Tested?
- Existing decompiler test cases

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Move Decompiler)