### PR TITLE
[consensus] keep retriving if block not found

### DIFF
--- a/consensus/consensus-types/src/block_retrieval.rs
+++ b/consensus/consensus-types/src/block_retrieval.rs
@@ -14,6 +14,7 @@ pub const NUM_RETRIES: usize = 5;
 pub const NUM_PEERS_PER_RETRY: usize = 3;
 pub const RETRY_INTERVAL_MSEC: u64 = 500;
 pub const RPC_TIMEOUT_MSEC: u64 = 5000;
+pub const MAX_NUM_PEERS_MISSING_BLOCK_ID: usize = 10;
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Eq)]
 pub enum BlockRetrievalRequest {

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -432,8 +432,7 @@ impl RoundManager {
             .push(new_round_event.reason.clone());
 
         // Process pending opt proposal for the new round.
-        // The existence of pending optimistic proposal and being the current proposer are mutually
-        // exclusive. Note that the opt proposal is checked for valid proposer before inserting into
+        // Note that the opt proposal is checked for valid proposer before inserting into
         // the pending queue.
         if let Some(opt_proposal) = self.pending_opt_proposals.remove(&new_round) {
             self.opt_proposal_loopback_tx
@@ -442,7 +441,8 @@ impl RoundManager {
                 .expect("Sending to a self loopback unbounded channel cannot fail");
         }
 
-        // If the current proposer is the leading, try to propose a regular block if not opt proposed already
+        // If the current proposer is the leading, try to propose a regular block if not opt
+        // proposed already
         if is_current_proposer
             && self
                 .proposal_generator


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Sometimes, the block retrieval requests are sent to a validator which haven't received the block themselves yet. This returns a `BlockIdNotFound` which short-circuits the block retrieval without trying additional validators. This PR fixes it such that retrieval tries a few more validators before giving up.