### PR TITLE
chore: update `base-branch` to `main` for `bump-homebrew-formula-action`

### DIFF
--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -189,7 +189,7 @@ jobs:
         with:
           formula-name: aptos
           tag-name: "${{ format('aptos-cli-v{0}', inputs.release_version) }}"
-          base-branch: master
+          base-branch: main
           create-pullrequest: true
           commit-message: |
             {{formulaName}} {{version}}


### PR DESCRIPTION
chore: update `base-branch` to `main` for `bump-homebrew-formula-action`

---

relates to https://github.com/Homebrew/homebrew-core/pull/230936