### PR TITLE
[hot state] Populate hot state promotions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4125,6 +4125,7 @@ dependencies = [
  "anyhow",
  "aptos-crypto",
  "aptos-experimental-layered-map",
+ "aptos-logger",
  "aptos-metrics-core",
  "aptos-scratchpad",
  "aptos-secure-net",

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -67,7 +67,7 @@ use aptos_types::{
         TimedFeatureFlag, TimedFeatures,
     },
     randomness::Randomness,
-    state_store::{StateView, TStateView},
+    state_store::{state_key::StateKey, StateView, TStateView},
     transaction::{
         authenticator::{AbstractionAuthData, AnySignature, AuthenticationProof},
         block_epilogue::{BlockEpiloguePayload, FeeDistribution},
@@ -2759,7 +2759,7 @@ impl AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         fail_point!("aptos_vm_block_executor::execute_block_with_config", |_| {
             Err(VMStatus::error(
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
@@ -2807,7 +2807,7 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         let config = BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
                 blockstm_v2: false,

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -30,7 +30,7 @@ use aptos_types::{
         signature_verified_transaction::SignatureVerifiedTransaction, BlockOutput,
         TransactionOutput, TransactionStatus,
     },
-    write_set::WriteOp,
+    write_set::{HotStateOp, WriteOp},
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::{
@@ -523,7 +523,7 @@ impl<
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
         transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<S::Key, TransactionOutput>, VMStatus> {
         let _timer = BLOCK_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
 
         let num_txns = signature_verified_block.num_txns();
@@ -555,11 +555,28 @@ impl<
         );
         match ret {
             Ok(block_output) => {
-                let (transaction_outputs, block_epilogue_txn) = block_output.into_inner();
-                let output_vec: Vec<_> = transaction_outputs
+                let (transaction_outputs, block_epilogue_txn, to_make_hot) =
+                    block_output.into_inner();
+                let mut output_vec: Vec<_> = transaction_outputs
                     .into_iter()
                     .map(|output| output.take_output())
                     .collect();
+                if block_epilogue_txn.is_some() {
+                    // Attach the hotness changes to block epilogue's output.
+                    let epilogue_output = output_vec
+                        .last_mut()
+                        .expect("transaction_outputs must be non-empty when epilogue exists");
+                    assert!(
+                        epilogue_output.status().is_kept(),
+                        "Block epilogue must be kept."
+                    );
+                    epilogue_output.add_hotness(
+                        to_make_hot
+                            .into_iter()
+                            .map(|(key, slot)| (key, HotStateOp::make_hot(slot)))
+                            .collect(),
+                    );
+                }
 
                 // Flush the speculative logs of the committed transactions.
                 let pos = output_vec.partition_point(|o| !o.status().is_retry());
@@ -570,7 +587,11 @@ impl<
                     flush_speculative_logs(pos);
                 }
 
-                Ok(BlockOutput::new(output_vec, block_epilogue_txn))
+                Ok(BlockOutput::new(
+                    output_vec,
+                    block_epilogue_txn,
+                    BTreeMap::new(),
+                ))
             },
             Err(BlockExecutionError::FatalBlockExecutorError(PanicError::CodeInvariantError(
                 err_msg,
@@ -595,7 +616,7 @@ impl<
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
         transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<S::Key, TransactionOutput>, VMStatus> {
         Self::execute_block_on_thread_pool::<S, L, TP>(
             Arc::clone(&RAYON_EXEC_POOL),
             signature_verified_block,

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -132,7 +132,7 @@ use aptos_types::{
         config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
         transaction_slice_metadata::TransactionSliceMetadata,
     },
-    state_store::StateView,
+    state_store::{state_key::StateKey, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, BlockOutput,
         SignedTransaction, TransactionOutput, VMValidatorResult,
@@ -173,7 +173,7 @@ pub trait VMBlockExecutor: Send + Sync {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus>;
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus>;
 
     /// Executes a block of transactions and returns output for each one of them, without applying
     /// any block limit.

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -79,7 +79,7 @@ use std::{
     },
 };
 
-struct SharedSyncParams<'a, T, E, S>
+struct SharedSyncParams<'a, 'b, T, E, S>
 where
     T: BlockExecutableTransaction,
     E: ExecutorTask<Txn = T>,
@@ -93,7 +93,7 @@ where
         &'a GlobalModuleCache<ModuleId, CompiledModule, Module, AptosModuleExtension>,
     last_input_output: &'a TxnLastInputOutput<T, E::Output, E::Error>,
     delayed_field_id_counter: &'a AtomicU32,
-    block_limit_processor: &'a ExplicitSyncWrapper<BlockGasLimitProcessor<'a, T, S>>,
+    block_limit_processor: &'a ExplicitSyncWrapper<BlockGasLimitProcessor<'b, T, S>>,
     final_results: &'a ExplicitSyncWrapper<Vec<E::Output>>,
 }
 
@@ -1344,7 +1344,7 @@ where
         // TODO: use worker id.
         _worker_id: u32,
         num_workers: u32,
-        shared_sync_params: &SharedSyncParams<'_, T, E, S>,
+        shared_sync_params: &SharedSyncParams<'_, '_, T, E, S>,
         start_delayed_field_id_counter: u32,
     ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
         let num_txns = block.num_txns() as u32;
@@ -1459,12 +1459,13 @@ where
         shared_maybe_error: &AtomicBool,
         has_remaining_commit_tasks: bool,
         final_results: ExplicitSyncWrapper<Vec<E::Output>>,
+        block_limit_processor: ExplicitSyncWrapper<BlockGasLimitProcessor<T, S>>,
         block_epilogue_txn: Option<Transaction>,
         mut versioned_cache: MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
         scheduler: impl Send + 'static,
         last_input_output: TxnLastInputOutput<T, E::Output, E::Error>,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<E::Output>, ()> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
         // Check for errors or remaining commit tasks before any side effects.
         let mut has_error = shared_maybe_error.load(Ordering::SeqCst);
         if !has_error && has_remaining_commit_tasks {
@@ -1492,10 +1493,16 @@ where
         // Explicit async drops
         DEFAULT_DROPPER.schedule_drop((last_input_output, scheduler, versioned_cache));
 
+        let to_make_hot = block_epilogue_txn
+            .is_some()
+            .then(|| block_limit_processor.acquire().get_slots_to_make_hot())
+            .unwrap_or_default();
+
         // Return final result
         Ok(BlockOutput::new(
             final_results.into_inner(),
             block_epilogue_txn,
+            to_make_hot,
         ))
     }
 
@@ -1505,7 +1512,7 @@ where
         signature_verified_block: &TP,
         base_view: &S,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<E::Output>, ()> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // BlockSTMv2 should have less restrictions on the number of workers but we
         // still sanity check that it is not instantiated w. concurrency level 1.
@@ -1517,7 +1524,7 @@ where
 
         let num_txns = signature_verified_block.num_txns();
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, BTreeMap::new()));
         }
 
         let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2) as u32;
@@ -1543,7 +1550,7 @@ where
         let versioned_cache = MVHashMap::new();
         let scheduler = SchedulerV2::new(num_txns, num_workers);
 
-        let shared_sync_params: SharedSyncParams<'_, T, E, S> = SharedSyncParams {
+        let shared_sync_params: SharedSyncParams<'_, '_, T, E, S> = SharedSyncParams {
             base_view,
             scheduler: &scheduler,
             versioned_cache: &versioned_cache,
@@ -1589,6 +1596,7 @@ where
             &shared_maybe_error,
             !scheduler.post_commit_processing_queue_is_empty(),
             final_results,
+            block_limit_processor,
             None, // BlockSTMv2 doesn't handle block epilogue yet.
             versioned_cache,
             scheduler,
@@ -1603,7 +1611,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<E::Output>, ()> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // Using parallel execution with 1 thread currently will not work as it
         // will only have a coordinator role but no workers for rolling commit.
@@ -1620,7 +1628,7 @@ where
 
         let num_txns = signature_verified_block.num_txns();
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, BTreeMap::new()));
         }
 
         let num_workers = self.config.local.concurrency_level.min(num_txns / 2).max(2);
@@ -1696,6 +1704,7 @@ where
             &shared_maybe_error,
             scheduler.pop_from_commit_queue().is_ok(),
             final_results,
+            block_limit_processor,
             block_epilogue_txn.into_inner(),
             versioned_cache,
             scheduler,
@@ -1930,11 +1939,11 @@ where
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
         resource_group_bcs_fallback: bool,
-    ) -> Result<BlockOutput<E::Output>, SequentialBlockExecutionError<E::Error>> {
+    ) -> Result<BlockOutput<T::Key, E::Output>, SequentialBlockExecutionError<E::Error>> {
         let num_txns = signature_verified_block.num_txns();
 
         if num_txns == 0 {
-            return Ok(BlockOutput::new(vec![], None));
+            return Ok(BlockOutput::new(vec![], None, BTreeMap::new()));
         }
 
         let init_timer = VM_INIT_SECONDS.start_timer();
@@ -2264,7 +2273,11 @@ where
             .module_cache_mut()
             .insert_verified(unsync_map.into_modules_iter())?;
 
-        Ok(BlockOutput::new(ret, block_epilogue_txn))
+        let to_make_hot = block_epilogue_txn
+            .is_some()
+            .then(|| block_limit_processor.get_slots_to_make_hot())
+            .unwrap_or_default();
+        Ok(BlockOutput::new(ret, block_epilogue_txn, to_make_hot))
     }
 
     pub fn execute_block(
@@ -2273,7 +2286,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> BlockExecutionResult<BlockOutput<E::Output>, E::Error> {
+    ) -> BlockExecutionResult<BlockOutput<T::Key, E::Output>, E::Error> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         if self.config.local.concurrency_level > 1 {
@@ -2379,7 +2392,7 @@ where
             let ret = (0..signature_verified_block.num_txns())
                 .map(|_| E::Output::discard_output(error_code))
                 .collect();
-            return Ok(BlockOutput::new(ret, None));
+            return Ok(BlockOutput::new(ret, None, BTreeMap::new()));
         }
 
         Err(sequential_error)

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -8,7 +8,7 @@ use aptos_logger::{info, warn};
 use aptos_types::{
     fee_statement::FeeStatement,
     on_chain_config::BlockGasLimitType,
-    state_store::TStateView,
+    state_store::{state_slot::StateSlot, TStateView},
     transaction::{
         block_epilogue::{BlockEndInfo, TBlockEndInfoExt},
         BlockExecutableTransaction as Transaction,
@@ -291,14 +291,19 @@ impl<'s, T: Transaction, S: TStateView<Key = T::Key>> BlockGasLimitProcessor<'s,
             block_effective_block_gas_units: self.get_effective_accumulated_block_gas(),
             block_approx_output_size: self.get_accumulated_approx_output_size(),
         };
-        let slots_to_make_hot = if let Some(x) = &self.hot_state_op_accumulator {
-            x.get_slots_to_make_hot()
-        } else {
-            warn!("BlockHotStateOpAccumulator is not set.");
-            BTreeMap::new()
-        };
 
-        TBlockEndInfoExt::new(inner, slots_to_make_hot)
+        TBlockEndInfoExt::new(inner)
+    }
+
+    pub(crate) fn get_slots_to_make_hot(&self) -> BTreeMap<T::Key, StateSlot> {
+        if self.hot_state_op_accumulator.is_none() {
+            warn!("BlockHotStateOpAccumulator is not set.");
+        }
+
+        self.hot_state_op_accumulator
+            .as_ref()
+            .map(|x| x.get_slots_to_make_hot())
+            .unwrap_or_default()
     }
 }
 

--- a/aptos-move/block-executor/src/proptest_types/baseline.rs
+++ b/aptos-move/block-executor/src/proptest_types/baseline.rs
@@ -637,7 +637,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
         self.insert_or_verify_delayed_field_id(baseline_key.clone(), id);
     }
 
-    fn assert_success<E: Debug>(&self, block_output: &BlockOutput<MockOutput<K, E>>) {
+    fn assert_success<E: Debug>(&self, block_output: &BlockOutput<K, MockOutput<K, E>>) {
         let mut group_world = HashMap::new();
         let mut group_metadata: HashMap<K, Option<StateValueMetadata>> = HashMap::new();
 
@@ -1030,7 +1030,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
     // itself to be easily traceable in case of an error.
     pub(crate) fn assert_output<E: Debug>(
         &self,
-        results: &BlockExecutionResult<BlockOutput<MockOutput<K, E>>, usize>,
+        results: &BlockExecutionResult<BlockOutput<K, MockOutput<K, E>>, usize>,
     ) {
         match results {
             Ok(block_output) => {
@@ -1049,7 +1049,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
 
     pub(crate) fn assert_parallel_output<E: Debug>(
         &self,
-        results: &Result<BlockOutput<MockOutput<K, E>>, ()>,
+        results: &Result<BlockOutput<K, MockOutput<K, E>>, ()>,
     ) {
         match results {
             Ok(block_output) => {

--- a/aptos-move/block-executor/src/proptest_types/resource_tests.rs
+++ b/aptos-move/block-executor/src/proptest_types/resource_tests.rs
@@ -105,7 +105,7 @@ pub(crate) fn execute_block_parallel<TxnType, ViewType, Provider>(
     data_view: &ViewType,
     all_module_ids: Option<&[ModuleId]>,
     block_stm_v2: bool,
-) -> Result<BlockOutput<MockOutput<KeyType<[u8; 32]>, MockEvent>>, ()>
+) -> Result<BlockOutput<ViewType::Key, MockOutput<KeyType<[u8; 32]>, MockEvent>>, ()>
 where
     TxnType: Transaction<Key = KeyType<[u8; 32]>> + Debug + Clone + Send + Sync + 'static,
     ViewType: TStateView<Key = TxnType::Key> + Sync + 'static,

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -90,7 +90,7 @@ fn test_block_epilogue_happy_path() {
                 false,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -108,7 +108,7 @@ fn test_block_epilogue_happy_path() {
                 &mut guard,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -157,7 +157,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
                 false,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -175,7 +175,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
                 &mut guard,
             )
             .unwrap();
-        let (output, block_epilogue_txn) = result.into_inner();
+        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -660,7 +660,7 @@ mod tests {
         state_store::state_key::inner::StateKeyInner,
         transaction::{
             signature_verified_transaction::into_signature_verified_block, Transaction,
-            TransactionPayload,
+            TransactionOutput, TransactionPayload,
         },
     };
     use aptos_vm::{aptos_vm::AptosVMBlockExecutor, AptosVM, VMBlockExecutor};
@@ -806,7 +806,7 @@ mod tests {
         let other_txn_output = &other_to_commit.transaction_outputs[0];
         let other_cp_txn_output = &other_to_commit.transaction_outputs[1];
 
-        assert_eq!(vm_cp_txn_output, other_cp_txn_output);
+        assert_equal_transaction_outputs(vm_cp_txn_output, other_cp_txn_output);
 
         let vm_event_types = vm_txn_output
             .events()
@@ -879,6 +879,16 @@ mod tests {
         if values_match {
             assert_eq!(vm_txn_output, other_txn_output);
         }
+    }
+
+    // TODO(HotState): hotness computation not implemented in all VMs, so their hotness part of the
+    // write set might be different.
+    fn assert_equal_transaction_outputs(output1: &TransactionOutput, output2: &TransactionOutput) {
+        assert_eq!(output1.write_set().as_v0(), output2.write_set().as_v0());
+        assert_eq!(output1.events(), output2.events());
+        assert_eq!(output1.gas_used(), output2.gas_used());
+        assert_eq!(output1.status(), output2.status());
+        assert_eq!(output1.auxiliary_data(), output2.auxiliary_data());
     }
 
     fn test_generic_benchmark<E>(

--- a/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
+++ b/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
@@ -10,7 +10,7 @@ use aptos_types::{
         config::BlockExecutorConfigFromOnchain,
         transaction_slice_metadata::TransactionSliceMetadata,
     },
-    state_store::StateView,
+    state_store::{state_key::StateKey, StateView},
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
         BlockOutput, Transaction, TransactionOutput,
@@ -22,6 +22,7 @@ use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use aptos_vm_types::module_and_script_storage::AsAptosCodeStorage;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
+use std::collections::BTreeMap;
 
 pub struct AptosVMParallelUncoordinatedBlockExecutor;
 
@@ -36,7 +37,7 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         // let features = Features::fetch_config(&state_view).unwrap_or_default();
@@ -79,6 +80,7 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
         Ok(BlockOutput::new(
             transaction_outputs,
             Some(block_epilogue_txn),
+            BTreeMap::new(),
         ))
     }
 }

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -90,7 +90,7 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block_on_thread_pool::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,

--- a/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
+++ b/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
@@ -84,7 +84,7 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         let block_epilogue_txn = Transaction::block_epilogue_v0(
             transaction_slice_metadata
                 .append_state_checkpoint_to_block()
@@ -122,6 +122,7 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
         Ok(BlockOutput::new(
             transaction_outputs,
             Some(block_epilogue_txn),
+            BTreeMap::new(),
         ))
     }
 }

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -14,7 +14,7 @@ use aptos_types::{
         transaction_slice_metadata::TransactionSliceMetadata,
     },
     ledger_info::LedgerInfoWithSignatures,
-    state_store::StateView,
+    state_store::{state_key::StateKey, StateView},
     test_helpers::transaction_test_helpers::TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
     transaction::{
         signature_verified_transaction::{
@@ -28,7 +28,7 @@ use aptos_vm::{
     sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor},
     VMBlockExecutor,
 };
-use std::sync::Arc;
+use std::{collections::BTreeMap, sync::Arc};
 
 fn create_test_executor() -> BlockExecutor<FakeVM> {
     // setup fake db
@@ -82,8 +82,8 @@ impl VMBlockExecutor for FakeVM {
         _state_view: &impl StateView,
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
-        Ok(BlockOutput::new(vec![], None))
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+        Ok(BlockOutput::new(vec![], None, BTreeMap::new()))
     }
 }
 

--- a/execution/executor/src/tests/mock_vm/mod.rs
+++ b/execution/executor/src/tests/mock_vm/mod.rs
@@ -36,7 +36,10 @@ use aptos_vm::{
 };
 use move_core_types::language_storage::TypeTag;
 use once_cell::sync::Lazy;
-use std::{collections::HashMap, sync::Arc};
+use std::{
+    collections::{BTreeMap, HashMap},
+    sync::Arc,
+};
 
 #[derive(Debug)]
 enum MockVMTransaction {
@@ -72,7 +75,7 @@ impl VMBlockExecutor for MockVM {
         state_view: &impl StateView,
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         // output_cache is used to store the output of transactions so they are visible to later
         // transactions.
         let mut output_cache = HashMap::new();
@@ -209,7 +212,11 @@ impl VMBlockExecutor for MockVM {
             }
         }
 
-        Ok(BlockOutput::new(outputs, block_epilogue_txn))
+        Ok(BlockOutput::new(
+            outputs,
+            block_epilogue_txn,
+            BTreeMap::new(),
+        ))
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -117,7 +117,7 @@ impl DoGetExecutionOutput {
             onchain_config,
             transaction_slice_metadata,
         )?;
-        let (transaction_outputs, block_epilogue_txn) = block_output.into_inner();
+        let (transaction_outputs, block_epilogue_txn, _) = block_output.into_inner();
         let (transactions, mut auxiliary_info) = txn_provider.into_inner();
         let mut transactions = transactions
             .into_iter()
@@ -242,7 +242,7 @@ impl DoGetExecutionOutput {
         state_view: &CachedStateView,
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>> {
         let _timer = OTHER_TIMERS.timer_with(&["vm_execute_block"]);
         Ok(executor.execute_block(
             txn_provider,

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -30,7 +30,7 @@ use aptos_types::{
         config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
         transaction_slice_metadata::TransactionSliceMetadata,
     },
-    state_store::StateView,
+    state_store::{state_key::StateKey, StateView},
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, BlockOutput,
         TransactionOutput,
@@ -41,7 +41,10 @@ use aptos_vm::{
     AptosVM, VMBlockExecutor,
 };
 use move_core_types::vm_status::VMStatus;
-use std::sync::{mpsc::channel, Arc};
+use std::{
+    collections::BTreeMap,
+    sync::{mpsc::channel, Arc},
+};
 
 pub struct PtxBlockExecutor;
 
@@ -56,7 +59,7 @@ impl VMBlockExecutor for PtxBlockExecutor {
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
         let _timer = TIMER.timer_with(&["block_total"]);
 
         let concurrency_level = AptosVM::get_concurrency_level();
@@ -106,7 +109,7 @@ impl VMBlockExecutor for PtxBlockExecutor {
             ret_clone.lock().replace(txn_outputs);
         });
         let ret = ret.lock().take().unwrap();
-        Ok(BlockOutput::new(ret, None))
+        Ok(BlockOutput::new(ret, None, BTreeMap::new()))
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -16,6 +16,7 @@ rust-version = { workspace = true }
 anyhow = { workspace = true }
 aptos-crypto = { workspace = true }
 aptos-experimental-layered-map = { workspace = true }
+aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-scratchpad = { workspace = true }
 aptos-secure-net = { workspace = true }

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{metrics::TIMER, state_store::versioned_state_value::StateUpdateRef};
+use aptos_logger::{sample, sample::SampleRate, warn};
 use aptos_metrics_core::TimerHelper;
 use aptos_types::{
     state_store::{state_key::StateKey, NUM_STATE_SHARDS},
@@ -11,8 +12,12 @@ use aptos_types::{
 use arr_macro::arr;
 use itertools::Itertools;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
-use std::collections::HashMap;
+use std::{
+    collections::{hash_map::Entry, HashMap},
+    time::Duration,
+};
 
+#[derive(Debug)]
 pub struct PerVersionStateUpdateRefs<'kv> {
     pub first_version: Version,
     pub num_versions: usize,
@@ -94,6 +99,7 @@ impl BatchedStateUpdateRefs<'_> {
     }
 }
 
+#[derive(Debug)]
 pub struct StateUpdateRefs<'kv> {
     pub per_version: PerVersionStateUpdateRefs<'kv>,
     /// Batched updates (updates for the same keys are merged) from the
@@ -204,11 +210,43 @@ impl<'kv> StateUpdateRefs<'kv> {
             .par_iter_mut()
             .zip_eq(ret.shards.par_iter_mut())
             .for_each(|(shard_iter, dedupped)| {
-                dedupped.extend(
-                    shard_iter
-                        // n.b. take_while_ref so that in the next step we can process the rest of the entries from the iters.
-                        .take_while_ref(|(_k, u)| u.version < end_version),
-                )
+                // n.b. take_while_ref so that in the next step we can process the rest of the
+                // entries from the iters.
+                for (k, u) in shard_iter.take_while_ref(|(_k, u)| u.version < end_version) {
+                    // If it's a value write op (Creation/Modification/Deletion), just insert and
+                    // overwrite the previous op.
+                    if u.state_op.is_value_write_op() {
+                        dedupped.insert(k, u);
+                        continue;
+                    }
+
+                    // If we see a hotness op, we check if there is a value write op with the same
+                    // key before. This is unlikely, but if it does happen (e.g. if the write
+                    // summary used to compute MakeHot is missing keys), we must discard the
+                    // hotness op to avoid overwriting the value write op.
+                    // TODO(HotState): also double check this logic for state sync later. For now
+                    // we do not output hotness ops for state sync.
+                    match dedupped.entry(k) {
+                        Entry::Occupied(mut entry) => {
+                            let prev_op = &entry.get().state_op;
+                            sample!(
+                                SampleRate::Duration(Duration::from_secs(10)),
+                                warn!(
+                                    "Key: {:?}. Previous write op: {}. Current write op: {}",
+                                    k,
+                                    prev_op.as_ref(),
+                                    u.state_op.as_ref()
+                                )
+                            );
+                            if !prev_op.is_value_write_op() {
+                                entry.insert(u);
+                            }
+                        },
+                        Entry::Vacant(entry) => {
+                            entry.insert(u);
+                        },
+                    }
+                }
             });
         ret
     }

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -1,13 +1,13 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::state_store::{state_key::StateKey, state_slot::StateSlot};
+use crate::state_store::state_key::StateKey;
 use aptos_crypto::HashValue;
 use derive_more::Deref;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug};
+use std::{collections::BTreeMap, fmt::Debug, marker::PhantomData};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -93,18 +93,13 @@ impl BlockEndInfo {
 
 /// Wrapper type to temporarily host the hot_state_ops which will not serialize until
 /// the hot state is made entirely deterministic
+/// TODO(HotState): maybe get rid of this struct now that it doesn't have anything more than
+/// `BlockEndInfo`?
 #[derive(Debug, Deref)]
 pub struct TBlockEndInfoExt<Key: Debug> {
     #[deref]
     inner: BlockEndInfo,
-    /// TODO(HotState): remove
-    /// Changes to the hot state.
-    /// n.b. only involves keys that are not written to by the user transactions.
-    /// TODO(HotState): add evictions
-    /// TODO(HotState): once hot state is deterministic across all nodes, add BlockEndInfo::V1 and
-    ///                 serialize the promoted and evicted keys in the transaction.
-    #[allow(dead_code)]
-    slots_to_make_hot: BTreeMap<Key, StateSlot>,
+    _phantom: PhantomData<Key>,
 }
 
 pub type BlockEndInfoExt = TBlockEndInfoExt<StateKey>;
@@ -113,14 +108,14 @@ impl<Key: Debug> TBlockEndInfoExt<Key> {
     pub fn new_empty() -> Self {
         Self {
             inner: BlockEndInfo::new_empty(),
-            slots_to_make_hot: BTreeMap::new(),
+            _phantom: PhantomData,
         }
     }
 
-    pub fn new(inner: BlockEndInfo, slots_to_make_hot: BTreeMap<Key, StateSlot>) -> Self {
+    pub fn new(inner: BlockEndInfo) -> Self {
         Self {
             inner,
-            slots_to_make_hot,
+            _phantom: PhantomData,
         }
     }
 

--- a/types/src/transaction/block_output.rs
+++ b/types/src/transaction/block_output.rs
@@ -2,21 +2,28 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::Transaction;
-use std::fmt::Debug;
+use crate::state_store::state_slot::StateSlot;
+use std::{collections::BTreeMap, fmt::Debug};
 
 #[derive(Debug)]
-pub struct BlockOutput<Output: Debug> {
+pub struct BlockOutput<Key, Output: Debug> {
     transaction_outputs: Vec<Output>,
     // A BlockEpilogueTxn might be appended to the block.
     // This field will be None iff the input is not a block, or an epoch change is triggered.
     block_epilogue_txn: Option<Transaction>,
+    to_make_hot: BTreeMap<Key, StateSlot>,
 }
 
-impl<Output: Debug> BlockOutput<Output> {
-    pub fn new(transaction_outputs: Vec<Output>, block_epilogue_txn: Option<Transaction>) -> Self {
+impl<Key, Output: Debug> BlockOutput<Key, Output> {
+    pub fn new(
+        transaction_outputs: Vec<Output>,
+        block_epilogue_txn: Option<Transaction>,
+        to_make_hot: BTreeMap<Key, StateSlot>,
+    ) -> Self {
         Self {
             transaction_outputs,
             block_epilogue_txn,
+            to_make_hot,
         }
     }
 
@@ -24,8 +31,12 @@ impl<Output: Debug> BlockOutput<Output> {
         self.transaction_outputs
     }
 
-    pub fn into_inner(self) -> (Vec<Output>, Option<Transaction>) {
-        (self.transaction_outputs, self.block_epilogue_txn)
+    pub fn into_inner(self) -> (Vec<Output>, Option<Transaction>, BTreeMap<Key, StateSlot>) {
+        (
+            self.transaction_outputs,
+            self.block_epilogue_txn,
+            self.to_make_hot,
+        )
     }
 
     pub fn get_transaction_outputs_forced(&self) -> &[Output] {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -17,7 +17,7 @@ use crate::{
         TransactionAuthenticator,
     },
     vm_status::{DiscardedVMStatus, KeptVMStatus, StatusCode, StatusType, VMStatus},
-    write_set::WriteSet,
+    write_set::{HotStateOp, WriteSet},
 };
 use anyhow::{ensure, format_err, Context, Error, Result};
 use aptos_crypto::{
@@ -36,6 +36,7 @@ use rayon::prelude::*;
 use serde::{Deserialize, Serialize};
 use std::{
     borrow::Cow,
+    collections::BTreeMap,
     convert::TryFrom,
     fmt::{self, Debug, Display, Formatter},
 };
@@ -1477,6 +1478,10 @@ impl TransactionStatus {
         }
     }
 
+    pub fn is_kept(&self) -> bool {
+        !self.is_discarded()
+    }
+
     pub fn is_retry(&self) -> bool {
         matches!(self, Self::Retry)
     }
@@ -1806,6 +1811,10 @@ impl TransactionOutput {
 
     pub fn state_update_refs(&self) -> impl Iterator<Item = (&StateKey, Option<&StateValue>)> + '_ {
         self.write_set.state_update_refs()
+    }
+
+    pub fn add_hotness(&mut self, hotness: BTreeMap<StateKey, HotStateOp>) {
+        self.write_set.add_hotness(hotness);
     }
 }
 


### PR DESCRIPTION

This was originally done in #16485. However, subsequent changes (mostly priority
fee implementation) undid some of the changes, so while
`BlockHotStateOpAccumulator` still computes `slots_to_make_hot`, the result is
never populated to the hot state storage. Therefore, the read-only keys are
never cached.

This change populates the information again by putting it inside `BlockOutput`,
and eventually merge it with the epilogue's write set.

One tricky thing is that the read write summary can sometimes be inaccurate. For
example, occasionally a key is written to, but it's not in the write summary,
then the code would generate both a `Modification` op and a `MakeHot` op for the
same key. To be defensive, if `Creation`/`Modification`/`Deletion` is followed
by `MakeHot` on the same key when computing `BatchedStateUpdateRefs`, we have to
discard the `MakeHot`.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/17136).
* #17169
* __->__ #17136 (2 commits)