### PR TITLE
[lint] Implemented no_op linter

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints.rs
@@ -18,6 +18,7 @@ mod needless_deref_ref;
 mod needless_ref_deref;
 mod needless_ref_in_field_access;
 mod needless_return;
+mod no_op;
 mod nonminimal_bool;
 mod self_assignment;
 mod simpler_bool_expression;
@@ -48,6 +49,7 @@ pub fn get_default_linter_pipeline(config: &BTreeMap<String, String>) -> Vec<Box
         Box::<needless_ref_in_field_access::NeedlessRefInFieldAccess>::default(),
         Box::<needless_return::NeedlessReturn>::default(),
         Box::<nonminimal_bool::NonminimalBool>::default(),
+        Box::<no_op::NoOp>::default(),
         Box::<self_assignment::SelfAssignment>::default(),
         Box::<simpler_bool_expression::SimplerBoolExpression>::default(),
         Box::<simpler_numeric_expression::SimplerNumericExpression>::default(),

--- a/third_party/move/tools/move-linter/src/model_ast_lints/no_op.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/no_op.rs
@@ -1,0 +1,424 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for statements that
+//! do nothing. In particular, it looks for three kinds of statements:
+//! First, assignments where the destination is an unused temporary:
+//!   *(&mut 0) = pure_expression;
+//!   *(&mut 1) = pure_expression;
+//!   *(&mut (x + 1)) = pure_expression;
+//! Second, statements consisting of a single expression that doesn't change any
+//! state:
+//!   0;
+//!   x;
+//!   x + 1;
+//!
+//! Of note, possible aborts caused by arithmetic errors are ignored by the
+//! linter. As such, the suggestions offered may not strictly preserve
+//! semantics. This is not a problem, as a statement that has no
+//! externally-observable effect other than implicitly aborting under certain
+//! states is almost certainly not the user's intention.
+
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{
+        Exp, ExpData,
+        Operation::{self, Borrow},
+        Pattern,
+    },
+    model::{FunctionEnv, NodeId},
+    ty::{ReferenceKind, Type},
+};
+use std::collections::HashSet;
+
+static NO_EFFECT_STMT: &str = "This statement has no effect and can be removed";
+static NO_EFFECT_OR_ABORT_STMT: &str = "This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed";
+static NO_EFFECT_ASSIGN: &str = "This assignment has no effect and can be removed";
+static NO_EFFECT_OR_ABORT_ASSIGN: &str = "This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed";
+
+#[derive(Default)]
+pub struct NoOp {
+    //Marks nodes to be skipped during visits.
+    skip: HashSet<NodeId>,
+}
+
+impl ExpChecker for NoOp {
+    fn get_name(&self) -> String {
+        "no_op".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
+        match expr {
+            ExpData::Sequence(_, _) => {
+                self.visit_subexpression(function, expr, false, 0);
+            },
+            ExpData::Block(_, _, _, _) => {
+                self.visit_subexpression(function, expr, false, 0);
+            },
+            _ => {},
+        }
+    }
+}
+
+impl NoOp {
+    fn visit_subexpression(
+        &mut self,
+        function: &FunctionEnv,
+        expr: &ExpData,
+        only_sequence: bool,
+        depth: u64,
+    ) {
+        if only_sequence && !matches!(expr, ExpData::Sequence(_, _)) {
+            return;
+        }
+
+        let exp_id = expr.node_id();
+        if !self.skip.insert(exp_id) {
+            return;
+        }
+        match expr {
+            ExpData::Value(id, _) | ExpData::Lambda(id, _, _, _, _) => {
+                let env = function.env();
+                self.report(env, &env.get_node_loc(*id), NO_EFFECT_STMT);
+            },
+            ExpData::Mutate(id, left, right) => {
+                if let Some(bitbucket) = Self::get_bitbucket_expression(left, function) {
+                    let mut analyzer = EffectsAnalyzer::new();
+                    if analyzer.classify_expression_purity(right, function) == EffectClass::Pure {
+                        let env = function.env();
+
+                        let msg = if Self::expression_is_trivial(bitbucket)
+                            && Self::expression_is_trivial(right)
+                        {
+                            NO_EFFECT_ASSIGN
+                        } else {
+                            NO_EFFECT_OR_ABORT_ASSIGN
+                        };
+
+                        self.report(env, &env.get_node_loc(*id), msg);
+                    }
+                }
+            },
+            ExpData::Block(id, _, _, block_expr) => {
+                self.visit_subexpression(function, block_expr, true, depth + 1);
+                let mut analyzer = EffectsAnalyzer::new();
+                if analyzer.classify_expression_purity(expr, function) == EffectClass::Pure {
+                    let env = function.env();
+                    if depth > 0 || env.get_node_type(*id) == Type::Tuple(vec![]) {
+                        self.report(env, &env.get_node_loc(*id), NO_EFFECT_OR_ABORT_STMT);
+                    }
+                }
+            },
+            ExpData::Sequence(id, seq) => {
+                for i in seq.iter().take(seq.len() - 1) {
+                    self.visit_subexpression(function, i, false, depth + 1);
+                }
+
+                let mut analyzer = EffectsAnalyzer::new();
+                if analyzer.classify_expression_purity(expr, function) == EffectClass::Pure {
+                    let env = function.env();
+                    if depth > 0 || env.get_node_type(*id) == Type::Tuple(vec![]) {
+                        self.report(env, &env.get_node_loc(*id), NO_EFFECT_OR_ABORT_STMT);
+                    }
+                }
+            },
+            ExpData::Loop(_, body) => {
+                self.visit_subexpression(function, body, true, depth + 1);
+            },
+            ExpData::LoopCont(_, _, _) => {},
+            ExpData::Assign(_, _, _) => {},
+            ExpData::SpecBlock(_, _) => {},
+            _ => {
+                if let ExpData::Call(_, Operation::Tuple, args) = expr {
+                    if args.is_empty() {
+                        return;
+                    }
+                }
+                let env = function.env();
+                let mut analyzer = EffectsAnalyzer::new();
+                if analyzer.classify_expression_purity(expr, function) == EffectClass::Pure {
+                    self.report(env, &env.get_node_loc(exp_id), NO_EFFECT_OR_ABORT_STMT);
+                }
+            },
+        }
+    }
+
+    // If the left side of an assignment is `*(&mut x)`, where `x` is any
+    // literal or the result of some operation, this function returns Some(x).
+    // Otherwise, it returns None.
+    fn get_bitbucket_expression<'a>(
+        left: &'a ExpData,
+        function: &FunctionEnv,
+    ) -> Option<&'a ExpData> {
+        if let ExpData::Call(_, op, args) = left {
+            if *op != Borrow(ReferenceKind::Mutable) || args.len() != 1 {
+                return None;
+            }
+            let e: &ExpData = args.first().unwrap();
+            match e {
+                ExpData::Value(_, _) => return Some(e),
+                ExpData::Call(_, op, _) => match op {
+                    Operation::Not
+                    | Operation::Add
+                    | Operation::Sub
+                    | Operation::Mul
+                    | Operation::Div
+                    | Operation::Mod
+                    | Operation::And
+                    | Operation::Or
+                    | Operation::BitAnd
+                    | Operation::BitOr
+                    | Operation::Xor
+                    | Operation::Shl
+                    | Operation::Shr
+                    | Operation::Eq
+                    | Operation::Neq
+                    | Operation::Lt
+                    | Operation::Gt
+                    | Operation::Ge
+                    | Operation::Le => return Some(e),
+                    _ => {},
+                },
+                _ => {},
+            }
+            let mut analyzer = EffectsAnalyzer::new();
+            if analyzer.classify_expression_purity(e, function) == EffectClass::Pure {
+                return Some(e);
+            }
+        }
+        None
+    }
+
+    fn expression_is_trivial(e: &ExpData) -> bool {
+        matches!(e, ExpData::Value(_, _))
+    }
+}
+
+//Represents the kind of effects an expression has on program state.
+#[derive(PartialEq, Clone, Debug)]
+enum EffectClass {
+    //The object could not be analyzed.
+    Unknown,
+    //The object has no side-effects.
+    Pure,
+    //The object causes state mutation side-effects.
+    Mutation,
+    //The object affects control flow in a non-sequential fashion.
+    ControlFlow(usize),
+    //The object affects both control flow and state.
+    Complex(usize),
+}
+
+fn combine_effects(left: EffectClass, right: EffectClass) -> EffectClass {
+    if left == EffectClass::Unknown || right == EffectClass::Unknown {
+        return EffectClass::Unknown;
+    }
+
+    //Neither is Unknown
+
+    if let EffectClass::Complex(left) = left {
+        if let EffectClass::Complex(right) = right {
+            return EffectClass::Complex(left.max(right));
+        }
+        return EffectClass::Complex(left);
+    }
+    if let EffectClass::Complex(_) = right {
+        return right;
+    }
+
+    //Neither is Unknown
+    //Neither is Complex(x)
+
+    if left == EffectClass::Pure {
+        return right;
+    }
+    if right == EffectClass::Pure {
+        return left;
+    }
+
+    //Neither is Unknown
+    //Neither is Complex(x)
+    //Neither is Pure
+
+    if left == right {
+        return left;
+    }
+
+    //Neither is Unknown
+    //Neither is Complex(x)
+    //Neither is Pure
+    //They're not equal
+    //Exactly one of these is true:
+    //* left == Mutation       && right == ControlFlow(x)
+    //* left == ControlFlow(x) && right == Mutation
+    //* left == ControlFlow(x) && right == ControlFlow(y) && x != y
+
+    if left == EffectClass::Mutation {
+        if let EffectClass::ControlFlow(right) = right {
+            return EffectClass::Complex(right);
+        }
+        unreachable!();
+    }
+
+    //Neither is Unknown
+    //Neither is Complex(x)
+    //Neither is Pure
+    //They're not equal
+    //Exactly one of these is true:
+    //* left == ControlFlow(x) && right == Mutation
+    //* left == ControlFlow(x) && right == ControlFlow(y) && x != y
+
+    if right == EffectClass::Mutation {
+        if let EffectClass::ControlFlow(left) = left {
+            return EffectClass::Complex(left);
+        }
+    }
+
+    //Neither is Unknown
+    //Neither is Complex(x)
+    //Neither is Pure
+    //They're not equal
+    //Exactly one of these is true:
+    //* left == ControlFlow(x) && right == ControlFlow(y) && x != y
+
+    if let EffectClass::ControlFlow(left) = left {
+        if let EffectClass::ControlFlow(right) = right {
+            return EffectClass::ControlFlow(left.max(right));
+        }
+    }
+
+    //Neither is Unknown
+    //Neither is Complex(x)
+    //Neither is Pure
+    //Neither is Mutation
+    //Neither is ControlFlow(x)
+
+    //Control flow can never reach this point.
+    unreachable!();
+}
+
+struct EffectsAnalyzer;
+
+impl EffectsAnalyzer {
+    pub fn new() -> EffectsAnalyzer {
+        EffectsAnalyzer {}
+    }
+
+    fn classify_unary_op(&mut self, args: &[Exp], function: &FunctionEnv) -> EffectClass {
+        if args.len() != 1 {
+            EffectClass::Unknown
+        } else {
+            self.classify_expression_purity(args.first().unwrap(), function)
+        }
+    }
+
+    fn classify_binary_op(&mut self, args: &[Exp], function: &FunctionEnv) -> EffectClass {
+        if args.len() != 2 {
+            EffectClass::Unknown
+        } else {
+            let left = args.first().unwrap();
+            let right = args.get(1).unwrap();
+            let left = self.classify_expression_purity(left, function);
+            let right = self.classify_expression_purity(right, function);
+            combine_effects(left, right)
+        }
+    }
+
+    fn classify_call(
+        &mut self,
+        op: &Operation,
+        args: &[Exp],
+        function: &FunctionEnv,
+    ) -> EffectClass {
+        match op {
+            Operation::Not => self.classify_unary_op(args, function),
+            Operation::Add
+            | Operation::Sub
+            | Operation::Mul
+            | Operation::Div
+            | Operation::Mod
+            | Operation::And
+            | Operation::Or
+            | Operation::BitAnd
+            | Operation::BitOr
+            | Operation::Xor
+            | Operation::Shl
+            | Operation::Shr
+            | Operation::Eq
+            | Operation::Neq
+            | Operation::Lt
+            | Operation::Gt
+            | Operation::Ge
+            | Operation::Le => self.classify_binary_op(args, function),
+            Operation::Borrow(_) => {
+                if args.len() != 1 {
+                    return EffectClass::Unknown;
+                }
+                self.classify_expression_purity(args.first().unwrap(), function)
+            },
+            Operation::BorrowGlobal(t) => match t {
+                ReferenceKind::Immutable => EffectClass::Pure,
+                ReferenceKind::Mutable => EffectClass::Mutation,
+            },
+            Operation::Select(_, _, _) | Operation::Vector => args
+                .iter()
+                .map(|x| self.classify_expression_purity(x, function))
+                .fold(EffectClass::Pure, combine_effects),
+            Operation::Deref => EffectClass::Pure,
+            Operation::Tuple => {
+                if args.is_empty() {
+                    EffectClass::Pure
+                } else {
+                    EffectClass::Unknown
+                }
+            },
+            _ => EffectClass::Unknown,
+        }
+    }
+
+    /// classify_expression_purity() returns the class of effects that `expr`
+    /// has. For example,
+    ///  (x + 1)          // EffectClass::Pure. The expression does not affect
+    ///                   // state.
+    ///  x = 1;           // EffectClass::Mutation. The expression mutates
+    ///                   // state.
+    ///  break;           // EffectClass::ControlFlow(x). The expression alters
+    ///                      control flow.
+    ///  if (foo){
+    ///      x = 1;
+    ///  }else{
+    ///      break;
+    ///  }                // EffectClass::Complex(x). The if expression may both
+    ///                   // mutate state as well as alter control flow.
+    ///  recursive_call() // EffectClass::Unknown. Some constructs are not
+    ///                   // analyzed. Recursive functions are among them.
+    pub fn classify_expression_purity(
+        &mut self,
+        expr: &ExpData,
+        function: &FunctionEnv,
+    ) -> EffectClass {
+        match expr {
+            ExpData::Value(_, _) => EffectClass::Pure,
+            ExpData::LocalVar(_, _) => EffectClass::Pure,
+            ExpData::Temporary(_, _) => EffectClass::Pure,
+            ExpData::Call(_, op, args) => self.classify_call(op, args, function),
+            ExpData::Assign(_, pattern, rhs) => {
+                let lhs = match pattern {
+                    Pattern::Var(_, _) => EffectClass::Mutation,
+                    _ => EffectClass::Unknown,
+                };
+                let rhs = self.classify_expression_purity(rhs, function);
+                combine_effects(lhs, rhs)
+            },
+            ExpData::Mutate(_, lhs, rhs) => {
+                let lhs = match lhs as &ExpData {
+                    ExpData::LocalVar(_, _) => EffectClass::Mutation,
+                    _ => EffectClass::Unknown,
+                };
+                let rhs = self.classify_expression_purity(rhs, function);
+                combine_effects(lhs, rhs)
+            },
+            _ => EffectClass::Unknown,
+        }
+    }
+}

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_deref_ref_warn.exp
@@ -9,6 +9,15 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
 
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:18:9
+   │
+18 │         *&mut r.x = 5;
+   │         ^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
 warning: [lint] Needless pair of `*` and `&` operators: consider removing them
    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:27:9
    │
@@ -26,6 +35,15 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:44:9
+   │
+44 │         *&mut *x = 4;
+   │         ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
 
 warning: [lint] Needless pair of `*` and `&mut` operators: consider removing them
    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:60:9
@@ -126,6 +144,15 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
 
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:148:9
+    │
+148 │         *&mut x = 42;
+    │         ^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
 warning: [lint] Needless pair of `*` and `&mut` operators: consider removing them
     ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:153:9
     │
@@ -134,6 +161,15 @@ warning: [lint] Needless pair of `*` and `&mut` operators: consider removing the
     │
     = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_deref_ref)]`.
     = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_deref_ref.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+    ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:153:9
+    │
+153 │         *&mut x = 5;
+    │         ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
 
 warning: [lint] Needless pair of `*` and `&` operators: consider removing them
     ┌─ tests/model_ast_lints/needless_deref_ref_warn.move:170:26

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/needless_ref_deref_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/needless_ref_deref_warn.exp
@@ -9,6 +9,15 @@ warning: [lint] Needless pair of `&` and `*` operators: consider removing them
   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_ref_deref)]`.
   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_ref_deref.
 
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/needless_ref_deref_warn.move:31:9
+   │
+31 │         *&mut *x = 4;
+   │         ^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
 warning: [lint] Needless pair of `&` and `*` operators: consider removing them
    ┌─ tests/model_ast_lints/needless_ref_deref_warn.move:35:9
    │

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/no_op.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/no_op.exp
@@ -1,0 +1,631 @@
+
+Diagnostics:
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+  ┌─ tests/model_ast_lints/no_op.move:6:9
+  │
+6 │         x;
+  │         ^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect and can be removed
+  ┌─ tests/model_ast_lints/no_op.move:7:9
+  │
+7 │         42;
+  │         ^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect and can be removed
+  ┌─ tests/model_ast_lints/no_op.move:8:9
+  │
+8 │         b"hello";
+  │         ^^^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+  ┌─ tests/model_ast_lints/no_op.move:9:9
+  │
+9 │         vector<u64>[];
+  │         ^^^^^^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:10:9
+   │
+10 │         vector[0];
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:11:9
+   │
+11 │         vector[b"hello"];
+   │         ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:14:13
+   │
+14 │             x;
+   │             ^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect and can be removed
+   ┌─ tests/model_ast_lints/no_op.move:15:13
+   │
+15 │             42;
+   │             ^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect and can be removed
+   ┌─ tests/model_ast_lints/no_op.move:16:13
+   │
+16 │             b"hello";
+   │             ^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:17:13
+   │
+17 │             vector<u64>[];
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:18:13
+   │
+18 │             vector[0];
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:19:13
+   │
+19 │             vector[b"hello"];
+   │             ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:25:9
+   │
+25 │         *(&mut (x + 1)) = 1;
+   │         ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect and can be removed
+   ┌─ tests/model_ast_lints/no_op.move:26:9
+   │
+26 │         *(&mut 42) = 1;
+   │         ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:27:9
+   │
+27 │         *(&mut 42) = x;
+   │         ^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:28:9
+   │
+28 │         *(&mut 42) = x + 1;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:29:9
+   │
+29 │         *(&mut 42) = x + x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:30:9
+   │
+30 │         *(&mut 42) = x - 1;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:31:9
+   │
+31 │         *(&mut 42) = x - x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:32:9
+   │
+32 │         *(&mut 42) = x * 2;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:33:9
+   │
+33 │         *(&mut 42) = x * x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:34:9
+   │
+34 │         *(&mut 42) = x / 2;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `1`.
+   ┌─ tests/model_ast_lints/no_op.move:35:22
+   │
+35 │         *(&mut 42) = x / x;
+   │                      ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:35:9
+   │
+35 │         *(&mut 42) = x / x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to the same value: `x | x` and `x & x` can be simplified to `x`.
+   ┌─ tests/model_ast_lints/no_op.move:36:22
+   │
+36 │         *(&mut 42) = x & x;
+   │                      ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:36:9
+   │
+36 │         *(&mut 42) = x & x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to the same value: `x | x` and `x & x` can be simplified to `x`.
+   ┌─ tests/model_ast_lints/no_op.move:37:22
+   │
+37 │         *(&mut 42) = x | x;
+   │                      ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:37:9
+   │
+37 │         *(&mut 42) = x | x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `0`.
+   ┌─ tests/model_ast_lints/no_op.move:38:22
+   │
+38 │         *(&mut 42) = x ^ x;
+   │                      ^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:38:9
+   │
+38 │         *(&mut 42) = x ^ x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:39:9
+   │
+39 │         *(&mut 42) = x << x;
+   │         ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:40:9
+   │
+40 │         *(&mut 42) = x >> x;
+   │         ^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `true`.
+   ┌─ tests/model_ast_lints/no_op.move:41:26
+   │
+41 │         *(&mut 42) = if (x == x){ 1 }else{ 0 };
+   │                          ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This operation always evaluates to `false`.
+   ┌─ tests/model_ast_lints/no_op.move:42:26
+   │
+42 │         *(&mut 42) = if (x != x){ 1 }else{ 0 };
+   │                          ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This operation always evaluates to `false`.
+   ┌─ tests/model_ast_lints/no_op.move:43:26
+   │
+43 │         *(&mut 42) = if (x >  x){ 1 }else{ 0 };
+   │                          ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This operation always evaluates to `true`.
+   ┌─ tests/model_ast_lints/no_op.move:44:26
+   │
+44 │         *(&mut 42) = if (x >= x){ 1 }else{ 0 };
+   │                          ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This operation always evaluates to `false`.
+   ┌─ tests/model_ast_lints/no_op.move:45:26
+   │
+45 │         *(&mut 42) = if (x <  x){ 1 }else{ 0 };
+   │                          ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This operation always evaluates to `true`.
+   ┌─ tests/model_ast_lints/no_op.move:46:26
+   │
+46 │         *(&mut 42) = if (x <= x){ 1 }else{ 0 };
+   │                          ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This operation always evaluates to `true`.
+   ┌─ tests/model_ast_lints/no_op.move:47:28
+   │
+47 │         *(&mut 42) = { if (x <= x){ 1 }else{ 0 } };
+   │                            ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:52:9
+   │
+52 │         *(&mut true) = !x;
+   │         ^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This boolean expression can be simplified using double negation law (`!!a` is equivalent to `a`).
+   ┌─ tests/model_ast_lints/no_op.move:53:24
+   │
+53 │         *(&mut true) = !!x;
+   │                        ^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:53:9
+   │
+53 │         *(&mut true) = !!x;
+   │         ^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
+   ┌─ tests/model_ast_lints/no_op.move:54:24
+   │
+54 │         *(&mut true) = x && x;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:54:9
+   │
+54 │         *(&mut true) = x && x;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This boolean expression can be simplified using contradiction (`a && !a` is equivalent to `false`).
+   ┌─ tests/model_ast_lints/no_op.move:55:24
+   │
+55 │         *(&mut true) = x && !x;
+   │                        ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:55:9
+   │
+55 │         *(&mut true) = x && !x;
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
+   ┌─ tests/model_ast_lints/no_op.move:56:24
+   │
+56 │         *(&mut true) = x || x;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:56:9
+   │
+56 │         *(&mut true) = x || x;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This boolean expression can be simplified using tautology (`a || !a` is equivalent to `true`).
+   ┌─ tests/model_ast_lints/no_op.move:57:24
+   │
+57 │         *(&mut true) = x || !x;
+   │                        ^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:57:9
+   │
+57 │         *(&mut true) = x || !x;
+   │         ^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `true`.
+   ┌─ tests/model_ast_lints/no_op.move:59:24
+   │
+59 │         *(&mut true) = y == y;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:59:9
+   │
+59 │         *(&mut true) = y == y;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `false`.
+   ┌─ tests/model_ast_lints/no_op.move:60:24
+   │
+60 │         *(&mut true) = y != y;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:60:9
+   │
+60 │         *(&mut true) = y != y;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `false`.
+   ┌─ tests/model_ast_lints/no_op.move:61:24
+   │
+61 │         *(&mut true) = y >  y;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:61:9
+   │
+61 │         *(&mut true) = y >  y;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `true`.
+   ┌─ tests/model_ast_lints/no_op.move:62:24
+   │
+62 │         *(&mut true) = y >= y;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:62:9
+   │
+62 │         *(&mut true) = y >= y;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `false`.
+   ┌─ tests/model_ast_lints/no_op.move:63:24
+   │
+63 │         *(&mut true) = y <  y;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:63:9
+   │
+63 │         *(&mut true) = y <  y;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `true`.
+   ┌─ tests/model_ast_lints/no_op.move:64:24
+   │
+64 │         *(&mut true) = y <= y;
+   │                        ^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:64:9
+   │
+64 │         *(&mut true) = y <= y;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This assignment has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:68:9
+   │
+68 │         *(&mut vector<u64>[]) = vector[0_u64];
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:88:13
+   │
+88 │             x;
+   │             ^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:92:17
+   │
+92 │                 x;
+   │                 ^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:95:13
+   │
+95 │             x;
+   │             ^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This statement has no effect besides possibly aborting due to arithmetic errors and can be refactored or removed
+   ┌─ tests/model_ast_lints/no_op.move:97:13
+   │
+97 │             x;
+   │             ^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(no_op)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#no_op.
+
+warning: [lint] This operation always evaluates to `true`.
+    ┌─ tests/model_ast_lints/no_op.move:123:9
+    │
+123 │         x == x
+    │         ^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] This operation always evaluates to `true`.
+    ┌─ tests/model_ast_lints/no_op.move:143:9
+    │
+143 │         x == x
+    │         ^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(equal_operands_in_bin_op)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
+
+warning: [lint] Needless mutable reference or borrow: consider using immutable reference or borrow instead
+    ┌─ tests/model_ast_lints/no_op.move:155:24
+    │
+155 │     fun falsely_impure(x: &mut u64): u64{
+    │                        ^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(needless_mutable_reference)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#needless_mutable_reference.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/no_op.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/no_op.move
@@ -1,0 +1,158 @@
+module 0xc0ffee::m {
+    use std::signer;
+
+    public fun test1_warn(){
+        let x = 42;
+        x;
+        42;
+        b"hello";
+        vector<u64>[];
+        vector[0];
+        vector[b"hello"];
+        {
+            let x = 42;
+            x;
+            42;
+            b"hello";
+            vector<u64>[];
+            vector[0];
+            vector[b"hello"];
+        }
+    }
+
+    public fun test2_warn() {
+        let x = 42;
+        *(&mut (x + 1)) = 1;
+        *(&mut 42) = 1;
+        *(&mut 42) = x;
+        *(&mut 42) = x + 1;
+        *(&mut 42) = x + x;
+        *(&mut 42) = x - 1;
+        *(&mut 42) = x - x;
+        *(&mut 42) = x * 2;
+        *(&mut 42) = x * x;
+        *(&mut 42) = x / 2;
+        *(&mut 42) = x / x;
+        *(&mut 42) = x & x;
+        *(&mut 42) = x | x;
+        *(&mut 42) = x ^ x;
+        *(&mut 42) = x << x;
+        *(&mut 42) = x >> x;
+        *(&mut 42) = if (x == x){ 1 }else{ 0 };
+        *(&mut 42) = if (x != x){ 1 }else{ 0 };
+        *(&mut 42) = if (x >  x){ 1 }else{ 0 };
+        *(&mut 42) = if (x >= x){ 1 }else{ 0 };
+        *(&mut 42) = if (x <  x){ 1 }else{ 0 };
+        *(&mut 42) = if (x <= x){ 1 }else{ 0 };
+        *(&mut 42) = { if (x <= x){ 1 }else{ 0 } };
+    }
+
+    public fun test3_warn() {
+        let x = true;
+        *(&mut true) = !x;
+        *(&mut true) = !!x;
+        *(&mut true) = x && x;
+        *(&mut true) = x && !x;
+        *(&mut true) = x || x;
+        *(&mut true) = x || !x;
+        let y = 42;
+        *(&mut true) = y == y;
+        *(&mut true) = y != y;
+        *(&mut true) = y >  y;
+        *(&mut true) = y >= y;
+        *(&mut true) = y <  y;
+        *(&mut true) = y <= y;
+    }
+
+    public fun test4_warn() {
+        *(&mut vector<u64>[]) = vector[0_u64];
+    }
+
+    public fun test5_warn(account: signer) acquires S {
+        pure1();
+        pure2();
+        pure3(42);
+        pure4(&42);
+        pure5(signer::address_of(&account));
+        let x = true;
+        impure1(&mut x);
+        impure2(signer::address_of(&account));
+
+        let y: u64 = 64;
+        falsely_impure(&mut y);
+    }
+
+    public fun test6_warn(): bool {
+        let x = 42;
+        loop{
+            x;
+        };
+        if (true){
+            return {
+                x;
+                true
+            };
+            x;
+        }else{
+            x;
+        };
+        false
+    }
+
+    /*****************************************************/
+
+    /*public fun test1_no_warn(){
+        let x = 42;
+        vector[
+            {
+                x += 43;
+                x
+            },
+            x + 1
+        ];
+    }*/
+
+    /*****************************************************/
+
+    fun pure1(): bool{
+        true
+    }
+
+    fun pure2(): bool{
+        let x = 42;
+        x == x
+    }
+
+    fun pure3(x: u64): u64{
+        x = x * 2 + 1;
+        x
+    }
+
+    fun pure4(x: &u64): u64{
+        let x = *x * 2 + 1;
+        x
+    }
+
+    fun pure5(addr: address): u64 acquires S{
+        borrow_global<S>(addr).x
+    }
+
+    fun impure1(y: &mut bool): bool{
+        let x = 42;
+        *y = !*y;
+        x == x
+    }
+
+    struct S has key, drop {
+        x: u64,
+    }
+
+    fun impure2(addr: address): bool acquires S{
+        borrow_global_mut<S>(addr).x = 42;
+        true
+    }
+
+    fun falsely_impure(x: &mut u64): u64{
+        *x * 2
+    }
+}


### PR DESCRIPTION
The no_op linter finds statements that do nothing, such as `x;`, `*(&mut 0) = y;`

## Description
This PR implements bullet point
>Identify various side-effect free statements that can be removed

from https://github.com/aptos-labs/aptos-core/issues/15221

## How Has This Been Tested?
Positive and negative test cases have been added to the move lint unit tests.
Additionally, the linter has been run on the crates in the aptos-move/framework subdirectory, with the following results:
Crate | Result | Notes
-- | -- | --
aptos-experimental | 2 warnings in veiled_coin | 
aptos-framework | No warnings |
aptos-stdlib | No warnings |  
aptos-token | No warnings |  
aptos-token-objects | No warnings |  
move-stdlib | No warnings |  
## Key Areas to Review
The key change is to third_party/move/tools/move-linter/src/model_ast_lints/null_effects.rs

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Move Linter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a `no_op` linter to detect side-effect-free statements and assignments, wires it into the default pipeline, and adds/updates tests.
> 
> - **Move Linter**:
>   - **New Rule**: Introduce `no_op` linter (`model_ast_lints/no_op.rs`) to flag statements/assignments with no effect (e.g., `x;`, `42;`, `*(&mut 42) = y;`).
>   - **Pipeline**: Register `no_op` in `get_default_linter_pipeline`.
>   - **Analysis**: Implements an effects analyzer to classify expression purity and report no-op cases in sequences/blocks/loops and certain `Mutate` patterns.
> - **Tests**:
>   - Add `tests/model_ast_lints/no_op.move` and expected diagnostics `no_op.exp`.
>   - Update expected outputs in `needless_deref_ref_warn.exp` and `needless_ref_deref_warn.exp` to include `no_op` warnings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3a3b22168c3810128292e2d921beb87e9ce0fcc3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->