### PR TITLE
[gas] Add gas version for v1.35 and bump from 1.34 -> 1.35

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -72,7 +72,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_34;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_35;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -101,4 +101,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_32: u64 = 36;
     pub const RELEASE_V1_33: u64 = 37;
     pub const RELEASE_V1_34: u64 = 38;
+    pub const RELEASE_V1_35: u64 = 39;
 }


### PR DESCRIPTION
> [!CAUTION]
> Merge only after devnet v1.34 branch cut