### PR TITLE
[move-vm] Some fixes for runtime checks

### DIFF
--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -149,7 +149,7 @@ pub fn verify_pack_closure(
         AbilitySet::PRIVATE_FUNCTIONS
     };
     // Verify that captured arguments are assignable against types in the function
-    // signature.
+    // signature, and that they are no references.
     let expected_capture_tys = mask.extract(func.param_tys(), true);
 
     let given_capture_tys = operand_stack.popn_tys(expected_capture_tys.len() as u16)?;
@@ -157,6 +157,7 @@ pub fn verify_pack_closure(
         .into_iter()
         .zip(given_capture_tys.into_iter())
     {
+        expected.paranoid_check_is_no_ref("Captured argument type")?;
         with_instantiation(ty_builder, func, expected, |expected| {
             // Intersect the captured type with the accumulated abilities
             abilities = abilities.intersect(given.abilities()?);

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_local_num.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_local_num.baseline.exp
@@ -1,12 +1,12 @@
 processed 3 tasks
 
-task 2 'run'. lines 66-82:
+task 2 'run'. lines 43-62:
 Error: Script execution failed with VMError: {
     message: None,
     major_status: STLOC_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: script,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 1)],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
     exec_state: None,
 }

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_local_num.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_local_num.masm
@@ -1,37 +1,11 @@
 //# publish
 module 0x66::helpers
 
-// Uses pseudo captured structure to force a constructed
-// closure to have abilities. Note that declaration of
-// types (like return type) do not matter for paranoid
-// mode, rather it uses the actual type of the values
-// on the stack.
-
-struct CopyDropStore has copy+drop+store
-    dummy: bool
-struct Drop has drop
-    dummy: bool
-
 public fun f_copy_drop_store(): |u64|u32 has copy+drop+store
-    ld_true
-    pack CopyDropStore
-    pack_closure action_CopyDropStore, 1
+    pack_closure action, 0
     ret
 
-public fun f(): |u64|u32 has drop
-    ld_true
-    pack Drop
-    pack_closure action_Drop, 1
-    ret
-
-#[persistent] fun action_CopyDropStore(_s: CopyDropStore, x: u64): u32
-    move_loc x
-    cast_u32
-    ld_u32 20
-    add
-    ret
-
-#[persistent] fun action_Drop(_s: Drop, x: u64): u32
+#[persistent] fun action(x: u64): u32
     move_loc x
     cast_u32
     ld_u32 20
@@ -53,11 +27,14 @@ script
 use 0x66::helpers
 
 fun ok()
-    local f: |u64|u32 has copy+drop
+    local f1: |u64|u32 has copy+drop+store
+    local f2: |u64|u32 has copy+drop
     call helpers::f_copy_drop_store
-    st_loc f
+    st_loc f1
+    move_loc f1
+    st_loc f2 // valid type coercion
     ld_u64 5
-    move_loc f
+    move_loc f2
     call_closure<|u64|u32>
     ld_u32 25
     call helpers::assert_eq
@@ -68,14 +45,17 @@ script
 use 0x66::helpers
 
 fun not_assignable()
-    local f: |u64|u32 has copy+drop
-    call helpers::f
-    st_loc f            // ERROR
+    local f1: |u64|u32 has drop
+    local f2: |u64|u32 has copy+drop
+    call helpers::f_copy_drop_store
+    st_loc f1
+    move_loc f1
+    st_loc f2  // ERROR: invalid type coercion
     ld_u64 5
-    copy_loc f
+    copy_loc f2
     call_closure<|u64|u32>
     cast_u64
-    move_loc f
+    move_loc f2
     call_closure<|u64|u32>
     ld_u32 45
     call helpers::assert_eq

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_local_num.paranoid.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_local_num.paranoid.exp
@@ -1,12 +1,12 @@
 processed 3 tasks
 
-task 2 'run'. lines 66-82:
+task 2 'run'. lines 43-62:
 Error: Script execution failed with VMError: {
     message: Expected type |u64|u32 has copy + drop, got |u64|u32 has drop which is not assignable ,
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
     sub_status: Some(1),
     location: script,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 1)],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
     exec_state: Some(ExecutionState { stack_trace: [] }),
 }

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_pass.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_pass.baseline.exp
@@ -1,12 +1,12 @@
 processed 3 tasks
 
-task 2 'run'. lines 75-86:
+task 2 'run'. lines 49-63:
 Error: Script execution failed with VMError: {
     message: None,
     major_status: CALL_TYPE_MISMATCH_ERROR,
     sub_status: None,
     location: script,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 2)],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
     exec_state: None,
 }

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_pass.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_pass.masm
@@ -1,37 +1,11 @@
 //# publish
 module 0x66::helpers
 
-// Uses pseudo captured structure to force a constructed
-// closure to have abilities. Note that declaration of
-// types (like return type) do not matter for paranoid
-// mode, rather it uses the actual type of the values
-// on the stack.
-
-struct CopyDropStore has copy+drop+store
-    dummy: bool
-struct Drop has drop
-    dummy: bool
-
 public fun f_copy_drop_store(): |u64|u32 has copy+drop+store
-    ld_true
-    pack CopyDropStore
-    pack_closure action_CopyDropStore, 1
+    pack_closure action, 0
     ret
 
-public fun f(): |u64|u32 has drop
-    ld_true
-    pack Drop
-    pack_closure action_Drop, 1
-    ret
-
-#[persistent] fun action_CopyDropStore(_s: CopyDropStore, x: u64): u32
-    move_loc x
-    cast_u32
-    ld_u32 20
-    add
-    ret
-
-#[persistent] fun action_Drop(_s: Drop, x: u64): u32
+#[persistent] fun action(x: u64): u32
     move_loc x
     cast_u32
     ld_u32 20
@@ -78,7 +52,10 @@ script
 use 0x66::helpers as h
 
 fun error()
-    call h::f
+    local f: |u64|u32 has drop
+    call h::f_copy_drop_store
+    st_loc f
+    move_loc f
     ld_u64 5
     call h::exec_twice // f on stack has wrong type
     ld_u32 50

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_pass.paranoid.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_pass.paranoid.exp
@@ -1,6 +1,6 @@
 processed 3 tasks
 
-task 2 'run'. lines 75-86:
+task 2 'run'. lines 49-63:
 Error: Script execution failed with VMError: {
     message: Expected type |u64|u32 has copy, got |u64|u32 has drop which is not assignable ,
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_return.baseline.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_return.baseline.exp
@@ -1,0 +1,24 @@
+processed 5 tasks
+
+task 2 'run'. lines 37-37:
+return values: 0x0000000000000000000000000000000000000000000000000000000000000066::helpers::action(..), 0x0000000000000000000000000000000000000000000000000000000000000066::helpers::action(..)
+
+task 3 'publish'. lines 39-49:
+Error: Unable to publish module '0000000000000000000000000000000000000000000000000000000000000066::not_ok'. Got VMError: {
+    major_status: RET_TYPE_MISMATCH_ERROR,
+    sub_status: None,
+    location: 0x66::not_ok,
+    indices: [(FunctionDefinition, 0)],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}
+
+task 4 'run'. lines 51-51:
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000066::not_ok doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_return.masm
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_return.masm
@@ -1,0 +1,51 @@
+//# publish
+module 0x66::helpers
+
+public fun f_copy_drop_store(): |u64|u32 has copy+drop+store
+    pack_closure action, 0
+    ret
+
+#[persistent] fun action(x: u64): u32
+    move_loc x
+    cast_u32
+    ld_u32 20
+    add
+    ret
+
+public fun assert_eq(x: u32, y:u32)
+    move_loc x
+    move_loc y
+    eq
+    br_true r
+    ld_u64 255
+    abort
+ r: ret
+
+
+//# publish
+module 0x66::ok
+use 0x66::helpers
+
+fun assignable(): (|u64|u32, |u64|u32 has copy+drop)
+    local f: |u64|u32
+    call helpers::f_copy_drop_store
+    st_loc f
+    move_loc f
+    call helpers::f_copy_drop_store
+    ret
+
+//# run --verbose 0x66::ok::assignable
+
+//# publish
+module 0x66::not_ok
+use 0x66::helpers
+
+fun assignable(): (|u64|u32, |u64|u32 has copy+drop)
+    local f: |u64|u32
+    call helpers::f_copy_drop_store
+    call helpers::f_copy_drop_store
+    st_loc f
+    move_loc f
+    ret
+
+//# run --verbose 0x66::not_ok::assignable

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_return.paranoid.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_assign_return.paranoid.exp
@@ -1,0 +1,15 @@
+processed 5 tasks
+
+task 2 'run'. lines 37-37:
+return values: 0x0000000000000000000000000000000000000000000000000000000000000066::helpers::action(..), 0x0000000000000000000000000000000000000000000000000000000000000066::helpers::action(..)
+
+task 4 'run'. lines 51-51:
+Error: Function execution failed with VMError: {
+    message: Expected type |u64|u32 has copy + drop, got |u64|u32 which is not assignable ,
+    major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
+    sub_status: Some(1),
+    location: 0x66::not_ok,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+    exec_state: None,
+}

--- a/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_captured_typing.paranoid.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/function_values_safety/closure_captured_typing.paranoid.exp
@@ -24,9 +24,9 @@ Error: Script execution failed with VMError: {
 
 task 5 'run'. lines 94-107:
 Error: Script execution failed with VMError: {
-    message: No type layout for Reference(U64),
+    message: Captured argument type `&u64` cannot be a reference,
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 3)],
@@ -35,9 +35,9 @@ Error: Script execution failed with VMError: {
 
 task 6 'run'. lines 109-122:
 Error: Script execution failed with VMError: {
-    message: No type layout for MutableReference(U64),
+    message: Captured argument type `&mut u64` cannot be a reference,
     major_status: UNKNOWN_INVARIANT_VIOLATION_ERROR,
-    sub_status: None,
+    sub_status: Some(1),
     location: script,
     indices: [],
     offsets: [(FunctionDefinitionIndex(0), 3)],

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -433,14 +433,6 @@ impl Type {
         }
     }
 
-    /// Returns true if the type is variant and can be subject of the assignability rule.
-    /// Currently, this is only the case for function types and immutable references to
-    /// function types.
-    pub fn is_variant(&self) -> bool {
-        matches!(self, Type::Function { .. })
-            || matches!(self, Type::Reference(bt) if matches!(bt.as_ref(), Type::Function{..}))
-    }
-
     pub fn paranoid_check_is_no_ref(&self, msg: &str) -> PartialVMResult<()> {
         if matches!(self, Type::Reference(_) | Type::MutableReference(_)) {
             let msg = format!("{} `{}` cannot be a reference", msg, self);

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -433,6 +433,22 @@ impl Type {
         }
     }
 
+    /// Returns true if the type is variant and can be subject of the assignability rule.
+    /// Currently, this is only the case for function types and immutable references to
+    /// function types.
+    pub fn is_variant(&self) -> bool {
+        matches!(self, Type::Function { .. })
+            || matches!(self, Type::Reference(bt) if matches!(bt.as_ref(), Type::Function{..}))
+    }
+
+    pub fn paranoid_check_is_no_ref(&self, msg: &str) -> PartialVMResult<()> {
+        if matches!(self, Type::Reference(_) | Type::MutableReference(_)) {
+            let msg = format!("{} `{}` cannot be a reference", msg, self);
+            return paranoid_failure!(msg);
+        }
+        Ok(())
+    }
+
     pub fn paranoid_check_is_bool_ty(&self) -> PartialVMResult<()> {
         if !matches!(self, Self::Bool) {
             let msg = format!("Expected boolean type, got {}", self);


### PR DESCRIPTION
## Description

- The captured argument types are now checked _before_ the LazyFunction is constructed, which requires to construct layouts. Thus a more descriptive error will be produced than failure in layout construction.
- Types of returned values of a function are checked explicitly. Before, those types would have been checked at some later point implicitly, when the returned values are used. Though the current behavior isn't wrong, the adjusted behavior is more aligned with what the bytecode verifier does.

Closes #17156

## How Has This Been Tested?

New tests, all tests change behavior

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [x] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

