### PR TITLE
[spec]Update API description URL from spec.yaml to spec.json in documentation

### DIFF
--- a/api/doc/spec.html
+++ b/api/doc/spec.html
@@ -11,7 +11,7 @@
   </head>
   <body>
     <elements-api
-      apiDescriptionUrl="spec.yaml"
+      apiDescriptionUrl="spec.json"
       router="hash"
       layout="sidebar"
       hideInternal="true"


### PR DESCRIPTION
## Description

**Fix address fields being parsed as numbers in OpenAPI spec UI**

- This change ensures that address-type fields (such as authentication_key) are correctly interpreted as strings rather than numbers in the OpenAPI documentation.
- It addresses the issue where long hexadecimal values were incorrectly parsed due to YAML interpretation in Swagger UI.

Resolved: #17160 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
