### PR TITLE
fix: update Move coding guidelines link to correct URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ For development environment setup and first build, see [Building Aptos From Sour
 
 ### Code Style, Hints, and Testing
 
-Refer to our Coding Guidelines for the [Move](https://aptos.dev/move/book/coding-conventions/) and [Rust](./RUST_CODING_STYLE.md) programming languages for detailed guidance about how to contribute to the project.
+Refer to our Coding Guidelines for the [Move](https://aptos.dev/build/smart-contracts/book/coding-conventions) and [Rust](./RUST_CODING_STYLE.md) programming languages for detailed guidance about how to contribute to the project.
 
 Also, please ensure you follow our [Secure Coding Guidelines](./RUST_SECURE_CODING.md) to contribute to Aptos securely. 
 


### PR DESCRIPTION
## Description
This change updates the documentation link for the Move programming language coding guidelines in the project CONTRIBUTING.md.
The previous link `https://aptos.dev/move/book/coding-conventions` returned a 404 .The link has been replaced with a correct working URL : `https://aptos.dev/build/smart-contracts/book/coding-conventions`  
No code functionality was changed; this is solely a documentation fix to ensure contributors can access the correct Move coding conventions page.

## How Has This Been Tested?
- Verified that the new Move coding guidelines link opens the intended documentation page in a browser.
- No code changes, so no application-level testing was required.

## Key Areas to Review
- Confirm that the updated URL is correct and functional.
- Ensure that there are no remaining references to the broken/old URL within the documentation.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ x ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ x ] Other (documentation)

## Checklist
- [ x ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ x ] I have performed a self-review of my own code
- [ x ] I have commented my code, particularly in hard-to-understand areas
- [ x ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ x ] I tested both happy and unhappy path of the functionality
- [ x ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
