### PR TITLE
add benchmarks for field ops

### DIFF
--- a/crates/aptos-dkg/benches/crypto.rs
+++ b/crates/aptos-dkg/benches/crypto.rs
@@ -43,7 +43,7 @@ pub fn crypto_group(c: &mut Criterion) {
     field_additions(1_000_000, &mut group);
     field_multiplications(1_000_000, &mut group);
 
-    for thresh in [333, 666, 3_333, 6_6666] {
+    for thresh in [333, 666, 3_333, 6_666] {
         batch_evaluation_domain_new(thresh, &mut group);
         fft_assign_bench(thresh, &mut group);
 

--- a/crates/aptos-dkg/benches/crypto.rs
+++ b/crates/aptos-dkg/benches/crypto.rs
@@ -19,7 +19,7 @@ use aptos_dkg::{
     weighted_vuf::pinkas::MIN_MULTIPAIR_NUM_JOBS,
 };
 use aptos_runtimes::spawn_rayon_thread_pool;
-use blstrs::{G1Projective, G2Projective, Gt};
+use blstrs::{G1Projective, G2Projective, Gt, Scalar};
 use criterion::{
     criterion_group, criterion_main, measurement::Measurement, BenchmarkGroup, BenchmarkId,
     Criterion, Throughput,
@@ -40,8 +40,8 @@ pub const LARGE_SIZES: [usize; 3] = [8192, 16_384, 32_768];
 pub fn crypto_group(c: &mut Criterion) {
     let mut group = c.benchmark_group("crypto");
 
-    field_additions(1_000_000, &mut group);
-    field_multiplications(1_000_000, &mut group);
+    field_ops(1_000_000, &mut group, "field_additions", |a, b| a + b);
+    field_ops(1_000_000, &mut group, "field_multiplications", |a, b| a * b);
 
     for thresh in [333, 666, 3_333, 6_666] {
         batch_evaluation_domain_new(thresh, &mut group);
@@ -446,44 +446,25 @@ fn parallel_multipairing<M: Measurement>(n: usize, g: &mut BenchmarkGroup<M>, nu
     );
 }
 
-fn field_additions<M: Measurement>(n: usize, g: &mut BenchmarkGroup<M>) {
+fn field_ops<M: Measurement>(
+    n: usize,
+    g: &mut BenchmarkGroup<M>,
+    name: &str,
+    op: impl Fn(Scalar, Scalar) -> Scalar + Copy,
+) {
     let mut rng = thread_rng();
-
     g.throughput(Throughput::Elements(n as u64));
 
-    g.bench_function(BenchmarkId::new("field_additions", n), move |b| {
+    g.bench_function(BenchmarkId::new(name, n), move |b| {
         b.iter_with_setup(
             || {
                 let a = random_scalars(n, &mut rng);
                 let b = random_scalars(n, &mut rng);
-
                 (a, b)
             },
             |(a, b)| {
                 for i in 0..a.len() {
-                    let _c = a[i] + b[i];
-                }
-            },
-        )
-    });
-}
-
-fn field_multiplications<M: Measurement>(n: usize, g: &mut BenchmarkGroup<M>) {
-    let mut rng = thread_rng();
-
-    g.throughput(Throughput::Elements(n as u64));
-
-    g.bench_function(BenchmarkId::new("field_multiplication", n), move |b| {
-        b.iter_with_setup(
-            || {
-                let a = random_scalars(n, &mut rng);
-                let b = random_scalars(n, &mut rng);
-
-                (a, b)
-            },
-            |(a, b)| {
-                for i in 0..a.len() {
-                    let _c = a[i] * b[i];
+                    let _c = op(a[i], b[i]);
                 }
             },
         )


### PR DESCRIPTION
## Description

Just adding a few useful benchmarks to `aptos-dkg`.

## How Has This Been Tested?

No need; just benchmarks.

## Key Areas to Review

Nothing.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests/benchmarks

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
