### PR TITLE
[Specs] Add modifies clauses to certain function to allow them to be called by opaque spec functions. Also add a spec version of generate_signer_for_extending

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
@@ -37,6 +37,8 @@ See AIP-73 for further discussion
 -  [Function `dispatchable_derived_balance`](#0x1_dispatchable_fungible_asset_dispatchable_derived_balance)
 -  [Function `dispatchable_derived_supply`](#0x1_dispatchable_fungible_asset_dispatchable_derived_supply)
 -  [Specification](#@Specification_1)
+    -  [Function `withdraw`](#@Specification_1_withdraw)
+    -  [Function `deposit`](#@Specification_1_deposit)
     -  [Function `dispatchable_withdraw`](#@Specification_1_dispatchable_withdraw)
     -  [Function `dispatchable_deposit`](#@Specification_1_dispatchable_deposit)
     -  [Function `dispatchable_derived_balance`](#@Specification_1_dispatchable_derived_balance)
@@ -619,6 +621,41 @@ The semantics of supply will be governed by the function specified in DeriveSupp
 
 
 <pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_withdraw"></a>
+
+### Function `withdraw`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_withdraw">withdraw</a>&lt;T: key&gt;(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, amount: u64): <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">fungible_asset::FungibleAsset</a>
+</code></pre>
+
+
+
+
+<pre><code><b>modifies</b> <b>global</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">permissioned_signer::PermissionStorage</a>&gt;(<a href="permissioned_signer.md#0x1_permissioned_signer_spec_permission_address">permissioned_signer::spec_permission_address</a>(owner));
+<b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">fungible_asset::FungibleStore</a>&gt;(<a href="object.md#0x1_object_object_address">object::object_address</a>(store));
+<b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_ConcurrentFungibleBalance">fungible_asset::ConcurrentFungibleBalance</a>&gt;(<a href="object.md#0x1_object_object_address">object::object_address</a>(store));
+</code></pre>
+
+
+
+<a id="@Specification_1_deposit"></a>
+
+### Function `deposit`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_deposit">deposit</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, fa: <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">fungible_asset::FungibleAsset</a>)
+</code></pre>
+
+
+
+
+<pre><code><b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">fungible_asset::FungibleStore</a>&gt;(<a href="object.md#0x1_object_object_address">object::object_address</a>(store));
+<b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_ConcurrentFungibleBalance">fungible_asset::ConcurrentFungibleBalance</a>&gt;(<a href="object.md#0x1_object_object_address">object::object_address</a>(store));
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -130,6 +130,10 @@ metadata object can be any object that equipped with <code><a href="fungible_ass
 -  [Specification](#@Specification_1)
     -  [High-level Requirements](#high-level-req)
     -  [Module-level Specification](#module-level-spec)
+    -  [Function `withdraw_permission_check`](#@Specification_1_withdraw_permission_check)
+    -  [Function `deposit`](#@Specification_1_deposit)
+    -  [Function `unchecked_deposit`](#@Specification_1_unchecked_deposit)
+    -  [Function `unchecked_withdraw`](#@Specification_1_unchecked_withdraw)
 
 
 <pre><code><b>use</b> <a href="aggregator_v2.md#0x1_aggregator_v2">0x1::aggregator_v2</a>;
@@ -4612,7 +4616,74 @@ Removing permissions from permissioned signer.
 ### Module-level Specification
 
 
-<pre><code><b>pragma</b> verify=<b>false</b>;
+<pre><code><b>pragma</b> verify = <b>false</b>;
+</code></pre>
+
+
+
+<a id="@Specification_1_withdraw_permission_check"></a>
+
+### Function `withdraw_permission_check`
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_withdraw_permission_check">withdraw_permission_check</a>&lt;T: key&gt;(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, amount: u64)
+</code></pre>
+
+
+
+
+<pre><code><b>modifies</b> <b>global</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">permissioned_signer::PermissionStorage</a>&gt;(<a href="permissioned_signer.md#0x1_permissioned_signer_spec_permission_address">permissioned_signer::spec_permission_address</a>(owner));
+</code></pre>
+
+
+
+<a id="@Specification_1_deposit"></a>
+
+### Function `deposit`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_deposit">deposit</a>&lt;T: key&gt;(store: <a href="object.md#0x1_object_Object">object::Object</a>&lt;T&gt;, fa: <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">fungible_asset::FungibleAsset</a>)
+</code></pre>
+
+
+
+
+<pre><code><b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(<a href="object.md#0x1_object_object_address">object::object_address</a>(store));
+<b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_ConcurrentFungibleBalance">ConcurrentFungibleBalance</a>&gt;(<a href="object.md#0x1_object_object_address">object::object_address</a>(store));
+</code></pre>
+
+
+
+<a id="@Specification_1_unchecked_deposit"></a>
+
+### Function `unchecked_deposit`
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_unchecked_deposit">unchecked_deposit</a>(store_addr: <b>address</b>, fa: <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">fungible_asset::FungibleAsset</a>)
+</code></pre>
+
+
+
+
+<pre><code><b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr);
+<b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_ConcurrentFungibleBalance">ConcurrentFungibleBalance</a>&gt;(store_addr);
+</code></pre>
+
+
+
+<a id="@Specification_1_unchecked_withdraw"></a>
+
+### Function `unchecked_withdraw`
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_unchecked_withdraw">unchecked_withdraw</a>(store_addr: <b>address</b>, amount: u64): <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">fungible_asset::FungibleAsset</a>
+</code></pre>
+
+
+
+
+<pre><code><b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr);
+<b>modifies</b> <b>global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_ConcurrentFungibleBalance">ConcurrentFungibleBalance</a>&gt;(store_addr);
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -119,6 +119,7 @@ make it so that a reference to a global object can be returned from a function.
     -  [Function `new_event_handle`](#@Specification_1_new_event_handle)
     -  [Function `object_from_delete_ref`](#@Specification_1_object_from_delete_ref)
     -  [Function `delete`](#@Specification_1_delete)
+    -  [Function `generate_signer_for_extending`](#@Specification_1_generate_signer_for_extending)
     -  [Function `disable_ungated_transfer`](#@Specification_1_disable_ungated_transfer)
     -  [Function `set_untransferable`](#@Specification_1_set_untransferable)
     -  [Function `enable_ungated_transfer`](#@Specification_1_enable_ungated_transfer)
@@ -3173,6 +3174,23 @@ Grant a transfer permission to the permissioned signer using TransferRef.
 
 
 
+<a id="@Specification_1_generate_signer_for_extending"></a>
+
+### Function `generate_signer_for_extending`
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="object.md#0x1_object_generate_signer_for_extending">generate_signer_for_extending</a>(ref: &<a href="object.md#0x1_object_ExtendRef">object::ExtendRef</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+<b>ensures</b> result == <a href="object.md#0x1_object_spec_generate_signer_for_extending">spec_generate_signer_for_extending</a>(ref);
+</code></pre>
+
+
+
 <a id="@Specification_1_disable_ungated_transfer"></a>
 
 ### Function `disable_ungated_transfer`
@@ -3526,6 +3544,17 @@ Grant a transfer permission to the permissioned signer using TransferRef.
 
 
 <pre><code><b>fun</b> <a href="object.md#0x1_object_spec_create_guid_object_address">spec_create_guid_object_address</a>(source: <b>address</b>, creation_num: u64): <b>address</b>;
+</code></pre>
+
+
+
+
+<a id="0x1_object_spec_generate_signer_for_extending"></a>
+
+
+<pre><code><b>fun</b> <a href="object.md#0x1_object_spec_generate_signer_for_extending">spec_generate_signer_for_extending</a>(ref: &<a href="object.md#0x1_object_ExtendRef">ExtendRef</a>): <a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a> {
+   aptos_framework::create_signer::spec_create_signer(ref.self)
+}
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.spec.move
@@ -1,4 +1,5 @@
 spec aptos_framework::dispatchable_fungible_asset {
+    use aptos_framework::permissioned_signer;
     spec module {
         pragma verify = false;
     }
@@ -17,5 +18,16 @@ spec aptos_framework::dispatchable_fungible_asset {
 
     spec dispatchable_derived_supply{
         pragma opaque;
+    }
+
+    spec withdraw {
+        modifies global<permissioned_signer::PermissionStorage>(permissioned_signer::spec_permission_address(owner));
+        modifies global<fungible_asset::FungibleStore>(object::object_address(store));
+        modifies global<fungible_asset::ConcurrentFungibleBalance>(object::object_address(store));
+    }
+
+    spec deposit {
+        modifies global<fungible_asset::FungibleStore>(object::object_address(store));
+        modifies global<fungible_asset::ConcurrentFungibleBalance>(object::object_address(store));
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.spec.move
@@ -135,6 +135,25 @@ spec aptos_framework::fungible_asset {
     ///
     spec module {
         // TODO: verification disabled until this module is specified.
-        pragma verify=false;
+        pragma verify = false;
+    }
+
+    spec unchecked_withdraw {
+        modifies global<FungibleStore>(store_addr);
+        modifies global<ConcurrentFungibleBalance>(store_addr);
+    }
+
+    spec deposit {
+        modifies global<FungibleStore>(object::object_address(store));
+        modifies global<ConcurrentFungibleBalance>(object::object_address(store));
+    }
+
+    spec unchecked_deposit {
+        modifies global<FungibleStore>(store_addr);
+        modifies global<ConcurrentFungibleBalance>(store_addr);
+    }
+
+    spec withdraw_permission_check {
+        modifies global<permissioned_signer::PermissionStorage>(permissioned_signer::spec_permission_address(owner));
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/object.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/object.spec.move
@@ -394,6 +394,11 @@ spec aptos_framework::object {
         ensures !exists<ObjectCore>(ref.self);
     }
 
+    spec generate_signer_for_extending {
+        pragma opaque;
+        ensures result == spec_generate_signer_for_extending(ref);
+    }
+
     spec set_untransferable(ref: &ConstructorRef) {
         aborts_if !exists<ObjectCore>(ref.self);
         aborts_if exists<Untransferable>(ref.self);
@@ -569,4 +574,8 @@ spec aptos_framework::object {
     spec fun spec_create_user_derived_object_address(source: address, derive_from: address): address;
 
     spec fun spec_create_guid_object_address(source: address, creation_num: u64): address;
+
+    spec fun spec_generate_signer_for_extending(ref: &ExtendRef): signer {
+        aptos_framework::create_signer::spec_create_signer(ref.self)
+    }
 }


### PR DESCRIPTION
## Description
This adds modifies clauses for a handful of framework spec functions (thus allowing them to be called by opaque spec functions). This also adds a spec version of `generate_signer_for_extending`.

## How Has This Been Tested?
Manual testing


## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
