### PR TITLE
[move package] implement new package resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ genesis_antithesis_*/
 
 # Ignore generated credentials from google-github-actions/auth
 gha-creds-*.json
+
+# Ignore cache for move-package-resolver tests
+third_party/move/tools/move-package-resolver/cache

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12418,6 +12418,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "move-package-resolver"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-rest-client",
+ "datatest-stable",
+ "either",
+ "git2 0.16.1",
+ "move-core-types",
+ "move-package-cache",
+ "move-package-manifest",
+ "move-prover-test-utils",
+ "petgraph 0.6.5",
+ "serde",
+ "tokio",
+ "toml 0.7.8",
+ "url",
+]
+
+[[package]]
 name = "move-prover"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,6 +251,7 @@ members = [
     "third_party/move/tools/move-package",
     "third_party/move/tools/move-package-cache",
     "third_party/move/tools/move-package-manifest",
+    "third_party/move/tools/move-package-resolver",
     "third_party/move/tools/move-resource-viewer",
     "third_party/move/tools/move-unit-test",
     "tools/calc-dep-sizes",

--- a/third_party/move/tools/move-package-cache/src/canonical.rs
+++ b/third_party/move/tools/move-package-cache/src/canonical.rs
@@ -2,7 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use anyhow::{anyhow, Result};
-use std::ops::Deref;
+use std::{
+    fmt::{self, Display},
+    ops::Deref,
+};
 use url::Url;
 
 /// Canonicalized identity of a git repository, derived from a [`Url`].
@@ -40,6 +43,12 @@ impl Deref for CanonicalGitIdentity {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Display for CanonicalGitIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 
@@ -105,6 +114,12 @@ impl Deref for CanonicalNodeIdentity {
 
     fn deref(&self) -> &Self::Target {
         &self.0
+    }
+}
+
+impl Display for CanonicalNodeIdentity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.0)
     }
 }
 

--- a/third_party/move/tools/move-package-cache/src/lib.rs
+++ b/third_party/move/tools/move-package-cache/src/lib.rs
@@ -44,5 +44,6 @@ mod file_lock;
 mod listener;
 mod package_cache;
 
+pub use canonical::{CanonicalGitIdentity, CanonicalNodeIdentity};
 pub use listener::{DebugPackageCacheListener, EmptyPackageCacheListener, PackageCacheListener};
 pub use package_cache::PackageCache;

--- a/third_party/move/tools/move-package-cache/src/main.rs
+++ b/third_party/move/tools/move-package-cache/src/main.rs
@@ -25,7 +25,7 @@ async fn main() -> Result<()> {
 
     cache
         .fetch_on_chain_package(
-            Url::from_str("https://fullnode.mainnet.aptoslabs.com").unwrap(),
+            &Url::from_str("https://fullnode.mainnet.aptoslabs.com").unwrap(),
             3022354983,
             AccountAddress::ONE,
             "MoveStdlib",

--- a/third_party/move/tools/move-package-cache/src/package_cache.rs
+++ b/third_party/move/tools/move-package-cache/src/package_cache.rs
@@ -6,7 +6,7 @@ use crate::{
     file_lock::FileLock,
     listener::{EmptyPackageCacheListener, PackageCacheListener},
 };
-use anyhow::{bail, Result};
+use anyhow::{anyhow, bail, Result};
 use aptos_framework::natives::code::PackageRegistry;
 use futures::future;
 use git2::{
@@ -141,11 +141,16 @@ impl<L> PackageCache<L> {
             let repo = Repository::open_bare(&repo_path)?;
             {
                 let mut remote = repo.find_remote("origin")?;
-                remote.fetch(
-                    &["refs/heads/*:refs/remotes/origin/*"],
-                    Some(&mut fetch_options),
-                    None,
-                )?;
+                // Fetch all remote branches and map them to local remote-tracking branches
+                // - refs/heads/*: fetch all remote branches
+                // - refs/remotes/origin/*: store them as local remote-tracking branches under origin/
+                remote
+                    .fetch(
+                        &["refs/heads/*:refs/remotes/origin/*"],
+                        Some(&mut fetch_options),
+                        None,
+                    )
+                    .map_err(|err| anyhow!("Failed to update git repo at {}: {}", git_url, err))?;
             }
 
             self.listener.on_repo_update_complete(git_url.as_str());
@@ -158,7 +163,9 @@ impl<L> PackageCache<L> {
             repo_builder.bare(true);
 
             self.listener.on_repo_clone_start(git_url.as_str());
-            let repo = repo_builder.clone(git_url.as_str(), &repo_path)?;
+            let repo = repo_builder
+                .clone(git_url.as_str(), &repo_path)
+                .map_err(|err| anyhow!("Failed to clone git repo at {}: {}", git_url, err))?;
             self.listener.on_repo_clone_complete(git_url.as_str());
 
             repo
@@ -179,7 +186,16 @@ impl<L> PackageCache<L> {
     {
         let repo = self.clone_or_update_git_repo(git_url).await?;
 
-        let obj = repo.repo.revparse_single(&format!("origin/{}", rev))?;
+        let obj = repo
+            .repo
+            .revparse_single(&format!("origin/{}", rev))
+            .map_err(|_err| {
+                anyhow!(
+                    "Failed to resolve rev string \"{}\" in repo {}",
+                    rev,
+                    git_url
+                )
+            })?;
         let oid = obj.id();
 
         Ok(oid)
@@ -263,7 +279,7 @@ impl<L> PackageCache<L> {
     /// additional metadata in the future.
     pub async fn fetch_on_chain_package(
         &self,
-        fullnode_url: Url,
+        fullnode_url: &Url,
         network_version: u64,
         address: AccountAddress,
         package_name: &str,
@@ -273,7 +289,7 @@ impl<L> PackageCache<L> {
     {
         let on_chain_packages_path = self.root.join("on-chain");
 
-        let canonical_node_identity = CanonicalNodeIdentity::new(&fullnode_url)?;
+        let canonical_node_identity = CanonicalNodeIdentity::new(fullnode_url)?;
         let canonical_name = format!(
             "{}+{}+{}+{}",
             &*canonical_node_identity, network_version, address, package_name
@@ -383,11 +399,11 @@ impl<L> PackageCache<L> {
         future::try_join_all(fetch_futures).await?;
 
         remove_dir_if_exists(&cached_package_path)?;
-        fs::rename(temp.into_path(), cached_package_path)?;
+        fs::rename(temp.into_path(), &cached_package_path)?;
 
         self.listener
             .on_bytecode_package_download_complete(address, package_name);
 
-        Ok(PathBuf::new())
+        Ok(cached_package_path)
     }
 }

--- a/third_party/move/tools/move-package-manifest/src/manifest.rs
+++ b/third_party/move/tools/move-package-manifest/src/manifest.rs
@@ -119,7 +119,7 @@ pub struct Dependency {
     version: Option<Version>,
 
     /// Location of the dependency: local, git, or aptos (on-chain).
-    location: PackageLocation,
+    pub location: PackageLocation,
 }
 
 /// Location of a package dependency.
@@ -151,7 +151,7 @@ pub enum PackageLocation {
         node_url: String,
 
         /// Address of the published package.
-        package_addr: String,
+        package_addr: AccountAddress,
     },
 }
 
@@ -252,7 +252,7 @@ struct RawDependency {
     subdir: Option<String>,
 
     aptos: Option<String>,
-    address: Option<String>,
+    address: Option<AccountAddress>,
 }
 
 impl<'de> Deserialize<'de> for Dependency {

--- a/third_party/move/tools/move-package-manifest/tests/basic/everything.exp
+++ b/third_party/move/tools/move-package-manifest/tests/basic/everything.exp
@@ -39,7 +39,7 @@ PackageManifest {
             ),
             location: Aptos {
                 node_url: "mainnet",
-                package_addr: "0x1",
+                package_addr: 0000000000000000000000000000000000000000000000000000000000000001,
             },
         },
         "baz": Dependency {

--- a/third_party/move/tools/move-package-manifest/tests/dependencies/aptos.exp
+++ b/third_party/move/tools/move-package-manifest/tests/dependencies/aptos.exp
@@ -16,7 +16,7 @@ PackageManifest {
             version: None,
             location: Aptos {
                 node_url: "mainnet",
-                package_addr: "0x1",
+                package_addr: 0000000000000000000000000000000000000000000000000000000000000001,
             },
         },
     },

--- a/third_party/move/tools/move-package-resolver/Cargo.toml
+++ b/third_party/move/tools/move-package-resolver/Cargo.toml
@@ -1,0 +1,40 @@
+[package]
+name = "move-package-resolver"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+either = { workspace = true }
+git2 = { workspace = true }
+petgraph = { workspace = true }
+serde = { workspace = true }
+tokio = { workspace = true }
+toml = { workspace = true }
+url = { workspace = true }
+
+move-core-types = { workspace = true }
+move-package-cache = { workspace = true }
+move-package-manifest = { workspace = true }
+
+aptos-rest-client = { workspace = true }
+
+[dev-dependencies]
+datatest-stable = { workspace = true }
+move-prover-test-utils = { workspace = true }
+
+[[test]]
+name = "resolver_tests_offline"
+harness = false
+
+[[test]]
+name = "resolver_tests_online"
+harness = false

--- a/third_party/move/tools/move-package-resolver/src/graph.rs
+++ b/third_party/move/tools/move-package-resolver/src/graph.rs
@@ -1,0 +1,69 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::identity::PackageIdentity;
+use petgraph::{visit::EdgeRef, Graph};
+use std::{
+    collections::BTreeMap,
+    fmt::Write,
+    path::{Path, PathBuf},
+};
+
+/// Represents a node in the resolution graph, with metadata attached.
+#[derive(Debug)]
+pub struct Package {
+    pub identity: PackageIdentity,
+    pub local_path: PathBuf,
+}
+
+/// Represents an edge in the resolution graph -- a dependency between two packages.
+#[derive(Debug)]
+pub struct Dependency {}
+
+pub type ResolutionGraph = Graph<Package, Dependency>;
+
+/// Converts a [`ResolutionGraph`] into a Mermaid flowchart for visualization.
+pub fn graph_to_mermaid(graph: &ResolutionGraph, strip_root_path: Option<&Path>) -> String {
+    let mut mermaid = String::from("flowchart TD\n");
+    let mut node_map = BTreeMap::new();
+
+    let path_prefix = strip_root_path.unwrap_or_else(|| Path::new(""));
+
+    // Assign a simple identifier to each node
+    for node_idx in graph.node_indices() {
+        let id = format!("N{}", node_idx.index());
+        node_map.insert(node_idx, id.clone());
+
+        let package = &graph[node_idx];
+        let name = &package.identity.name;
+        let path = package
+            .local_path
+            .strip_prefix(path_prefix)
+            .unwrap()
+            .to_string_lossy();
+
+        let mut identity_str = String::new();
+        package
+            .identity
+            .location
+            .fmt_strip_root_path(&mut identity_str, Some(path_prefix))
+            .unwrap();
+        identity_str = identity_str.replace("://", "_");
+
+        writeln!(
+            &mut mermaid,
+            "    {}[\"{}<br><br>{}<br><br>{}\"]",
+            id, name, identity_str, path
+        )
+        .unwrap();
+    }
+
+    // Add edges
+    for edge in graph.edge_references() {
+        let source = node_map.get(&edge.source()).unwrap();
+        let target = node_map.get(&edge.target()).unwrap();
+        writeln!(&mut mermaid, "    {} --> {}", source, target).unwrap();
+    }
+
+    mermaid
+}

--- a/third_party/move/tools/move-package-resolver/src/identity.rs
+++ b/third_party/move/tools/move-package-resolver/src/identity.rs
@@ -1,0 +1,75 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::path::{CanonicalPath, NormalizedPath};
+use git2::Oid;
+use move_core_types::account_address::AccountAddress;
+use move_package_cache::{CanonicalGitIdentity, CanonicalNodeIdentity};
+use std::{
+    fmt::{self, Write},
+    path::Path,
+};
+
+/// Source location of a package, with canonicalized paths and URLs.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub enum SourceLocation {
+    Local {
+        path: CanonicalPath,
+    },
+    OnChain {
+        node: CanonicalNodeIdentity,
+        package_addr: AccountAddress,
+    },
+    Git {
+        repo: CanonicalGitIdentity,
+        commit_id: Oid,
+        subdir: NormalizedPath,
+    },
+}
+
+/// Unique identifier for a package.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct PackageIdentity {
+    pub name: String,
+    pub location: SourceLocation,
+}
+
+impl SourceLocation {
+    /// Formats the source location, stripping the root path if provided.
+    pub fn fmt_strip_root_path(
+        &self,
+        f: &mut impl Write,
+        strip_root_path: Option<&Path>,
+    ) -> fmt::Result {
+        match self {
+            SourceLocation::Local { path } => {
+                write!(f, "local:{}", match strip_root_path {
+                    Some(root_path) => {
+                        if let Ok(stripped) = path.strip_prefix(root_path) {
+                            stripped.display()
+                        } else {
+                            path.display()
+                        }
+                    },
+                    None => path.display(),
+                })
+            },
+            SourceLocation::OnChain { node, package_addr } => {
+                write!(f, "onchain:{}::{}", node, package_addr)
+            },
+            SourceLocation::Git {
+                repo,
+                commit_id,
+                subdir,
+            } => {
+                write!(f, "git:{}@{}/{}", repo, commit_id, subdir.display())
+            },
+        }
+    }
+}
+
+impl fmt::Display for SourceLocation {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.fmt_strip_root_path(f, None)
+    }
+}

--- a/third_party/move/tools/move-package-resolver/src/lib.rs
+++ b/third_party/move/tools/move-package-resolver/src/lib.rs
@@ -1,0 +1,38 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! # Move Package Resolver
+//!
+//! This crate implements the Move Package Resolver -- component that is responsible for
+//! traversing user-specified package manifests and constructing a fully resolved,
+//! reproducible dependency graph. During this process, all remote dependencies are fetched
+//! to the local file system for later use.
+//!
+//! ## High-level Architecture
+//!
+//! The resolver architecture centers around three main components:
+//!
+//! - **Package Cache** (external crate): Fetches and stores remote packages locally
+//! - **Package Lock**: Records resolved identities of git branches and blockchain versions
+//! - **Resolver**: Constructs the complete resolution graph and manages the `Move.lock` file
+//!
+//! ## Resolution Graph
+//!
+//! The resolver constructs a directed graph where:
+//!
+//! - **Nodes represent unique packages** identified by `(name, source_location)`
+//!   - **Source locations** can be:
+//!     - **Local**: Path to directory containing the package
+//!     - **Git**: Repository URL + commit + subdirectory
+//!     - **On-chain**: Network + address pair
+//! - **Edges represent dependencies** with optional metadata for address renaming.
+
+mod graph;
+mod identity;
+mod lock;
+mod path;
+mod resolver;
+
+pub use graph::{graph_to_mermaid, Dependency, Package, ResolutionGraph};
+pub use lock::PackageLock;
+pub use resolver::resolve;

--- a/third_party/move/tools/move-package-resolver/src/lock.rs
+++ b/third_party/move/tools/move-package-resolver/src/lock.rs
@@ -1,0 +1,107 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use git2::Oid;
+use move_package_cache::{
+    CanonicalGitIdentity, CanonicalNodeIdentity, PackageCache, PackageCacheListener,
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::{btree_map, BTreeMap},
+    fs,
+    path::Path,
+};
+use url::Url;
+
+/// Represents the package lock, which stores resolved identities of git branches and network versions.
+/// This ensures reproducible builds by pinning dependencies to specific commits or network versions.
+#[derive(Serialize, Deserialize)]
+pub struct PackageLock {
+    // git_identity (stringified) -> commit_id
+    git: BTreeMap<String, String>,
+
+    // node_identity (stringified) -> version
+    on_chain: BTreeMap<String, u64>,
+}
+
+impl PackageLock {
+    /// Creates a new, empty [`PackageLock`].
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        Self {
+            git: BTreeMap::new(),
+            on_chain: BTreeMap::new(),
+        }
+    }
+
+    /// Saves the current state of the package lock to a file in TOML format.
+    pub fn save_to_file(&self, path: impl AsRef<Path>) -> Result<()> {
+        let toml = toml::to_string_pretty(self)?;
+        fs::write(path, toml)?;
+        Ok(())
+    }
+
+    /// Loads the package lock from a file if it exists, or returns a new empty lock if not found.
+    pub fn load_from_file_or_empty(path: impl AsRef<Path>) -> Result<Self> {
+        match fs::read_to_string(path) {
+            Ok(contents) => Ok(toml::from_str(&contents)?),
+            Err(err) => match err.kind() {
+                std::io::ErrorKind::NotFound => Ok(Self::new()),
+                _ => Err(err.into()),
+            },
+        }
+    }
+
+    /// Resolves and pins a git revision.
+    ///
+    /// - If the given git URL and branch/rev combo is already recorded in the lock,
+    /// returns the pinned commit hash.
+    /// - Otherwise, queries the remote, records the result,
+    /// and returns the resolved commit hash.
+    pub async fn resolve_git_revision<L>(
+        &mut self,
+        package_cache: &PackageCache<L>,
+        git_url: &Url,
+        rev: &str,
+    ) -> Result<Oid>
+    where
+        L: PackageCacheListener,
+    {
+        let git_identity = CanonicalGitIdentity::new(git_url)?;
+
+        let repo_loc_and_rev = format!("{}@{}", git_identity, rev);
+
+        let res = match self.git.entry(repo_loc_and_rev) {
+            btree_map::Entry::Occupied(entry) => entry.get().clone(),
+            btree_map::Entry::Vacant(entry) => {
+                let oid = package_cache.resolve_git_revision(git_url, rev).await?;
+                entry.insert(oid.to_string()).clone()
+            },
+        };
+
+        Ok(Oid::from_str(&res)?)
+    }
+
+    /// Resolves and pins the network version for the given URL.
+    ///
+    /// - If the version is already recorded in the lock, returns the pinned version.
+    /// - Otherwise, queries the network, records the result in the lock, and returns the resolved version.
+    pub async fn resolve_network_version(&mut self, fullnode_url: &Url) -> Result<u64> {
+        let node_identity = CanonicalNodeIdentity::new(fullnode_url)?;
+
+        let res = match self.on_chain.entry(node_identity.to_string()) {
+            btree_map::Entry::Occupied(entry) => *entry.get(),
+            btree_map::Entry::Vacant(entry) => {
+                let client = aptos_rest_client::Client::new(fullnode_url.clone());
+                let version = client.get_ledger_information().await?.into_inner().version;
+
+                entry.insert(version);
+
+                version
+            },
+        };
+
+        Ok(res)
+    }
+}

--- a/third_party/move/tools/move-package-resolver/src/path.rs
+++ b/third_party/move/tools/move-package-resolver/src/path.rs
@@ -1,0 +1,134 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use std::{
+    ops::Deref,
+    path::{Component, Path, PathBuf},
+};
+
+/// Wrapper around [`PathBuf`] that represents a canonical path, which is not only normalized,
+/// but also absolute and have all symbolic links resolved.
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct CanonicalPath(PathBuf);
+
+impl Deref for CanonicalPath {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for CanonicalPath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl CanonicalPath {
+    pub fn new(path: impl AsRef<Path>) -> Result<Self> {
+        let path = path.as_ref().canonicalize()?;
+        Ok(Self(path))
+    }
+}
+
+/// Normalizes a path by removing all redundant `..` and `.` components.
+/// Accepts both relative and absolute paths as input.
+///
+/// Examples:
+/// - `./foo` -> `foo`
+/// - `a/b/../c` -> `a/c`
+/// - `/foo/../..` -> `/`
+/// - `a/../../b` -> `../b`
+fn normalize_path(path: impl AsRef<Path>) -> PathBuf {
+    let path = path.as_ref();
+    let mut stack = vec![];
+
+    for component in path.components() {
+        match &component {
+            Component::CurDir => (),
+            Component::ParentDir => match stack.last() {
+                Some(Component::Prefix(_) | Component::RootDir) => (),
+                Some(Component::Normal(_)) => {
+                    stack.pop();
+                },
+                Some(Component::ParentDir) | None => {
+                    stack.push(component);
+                },
+                Some(Component::CurDir) => unreachable!(),
+            },
+            Component::Prefix(_) | Component::RootDir | Component::Normal(_) => {
+                stack.push(component);
+            },
+        }
+    }
+
+    stack
+        .into_iter()
+        .map(|c| c.as_os_str())
+        .collect::<PathBuf>()
+}
+
+/// Wrapper around [`PathBuf`] that represents a normalized path, which is a path that
+/// does not contain any `..` or `.` components.
+#[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd)]
+pub struct NormalizedPath(PathBuf);
+
+impl NormalizedPath {
+    pub fn new(path: impl AsRef<Path>) -> Self {
+        Self(normalize_path(path))
+    }
+}
+
+impl Deref for NormalizedPath {
+    type Target = PathBuf;
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl AsRef<Path> for NormalizedPath {
+    fn as_ref(&self) -> &Path {
+        &self.0
+    }
+}
+
+#[test]
+fn test_normalize_path() {
+    for (path, expected) in [
+        // Relative paths
+        (".", ""),
+        ("..", ".."),
+        ("a", "a"),
+        ("a/", "a"),
+        ("a/b/c", "a/b/c"),
+        ("a/b/c/..", "a/b"),
+        ("a/b/../c", "a/c"),
+        ("a/b/../../c", "c"),
+        ("..", ".."),
+        ("a/../..", ".."),
+        ("../../..", "../../.."),
+        ("a/b/../../../c/d/../e", "../c/e"),
+        // Absolute paths
+        ("/", "/"),
+        ("/.", "/"),
+        ("/./", "/"),
+        ("/a", "/a"),
+        ("/a/", "/a"),
+        ("/a/b/..", "/a"),
+        ("/a/b/../..", "/"),
+        ("/a/b/../../..", "/"),
+        ("/a/./b/././c/..", "/a/b"),
+        ("/a//b///c", "/a/b/c"),
+        ("/..", "/"),
+        ("/../..", "/"),
+        ("/a/../../b", "/b"),
+        ("/a/../../../b", "/b"),
+        ("/a/b/c/../../../x/y/..", "/x"),
+        // TODO: Add tests for Windows
+    ] {
+        assert_eq!(normalize_path(Path::new(path)), PathBuf::from(expected));
+    }
+}

--- a/third_party/move/tools/move-package-resolver/src/resolver.rs
+++ b/third_party/move/tools/move-package-resolver/src/resolver.rs
@@ -1,0 +1,441 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    graph::{Dependency, Package, ResolutionGraph},
+    identity::{PackageIdentity, SourceLocation},
+    lock::PackageLock,
+    path::{CanonicalPath, NormalizedPath},
+};
+use anyhow::{anyhow, bail, Result};
+use either::Either;
+use move_package_cache::{
+    CanonicalGitIdentity, CanonicalNodeIdentity, PackageCache, PackageCacheListener,
+};
+use move_package_manifest::{self as manifest, PackageLocation, PackageName};
+use petgraph::{algo::kosaraju_scc, graph::NodeIndex, visit::EdgeRef};
+use std::{
+    collections::BTreeMap,
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
+use url::Url;
+
+// TODOs
+// - Addr subst
+// - Allow same package name
+// - Dep override
+// - Fetch transitive deps for on-chain packages
+// - Structured errors and error rendering
+// - (Low Priority) Symbolic links in git repos
+// - (Low Priority) Resolve deps in parallel
+
+/// Checks for cyclic dependencies in the given resolution graph.
+fn check_for_cyclic_dependencies(graph: &ResolutionGraph) -> Result<()> {
+    let format_scc = |scc: &[NodeIndex]| {
+        scc.iter()
+            .map(|node| {
+                format!(
+                    "{} @ {}",
+                    graph[*node].identity.name, graph[*node].identity.location
+                )
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    let sccs = kosaraju_scc(graph)
+        .into_iter()
+        .filter(|scc| scc.len() > 1)
+        .collect::<Vec<_>>();
+
+    if !sccs.is_empty() {
+        let sccs = sccs.iter().map(|scc| format_scc(scc)).collect::<Vec<_>>();
+        bail!("Cyclic dependencies found:\n{}", sccs.join("\n\n"));
+    }
+
+    Ok(())
+}
+
+/// Checks if any node has an edge to itself -- this is a special form of cyclic dependency.
+fn check_for_self_dependencies(graph: &ResolutionGraph) -> Result<()> {
+    let mut result = Vec::new();
+
+    for edge in graph.edge_references() {
+        if edge.source() == edge.target() {
+            result.push(edge.source());
+        }
+    }
+
+    result.sort_unstable();
+    result.dedup();
+
+    if !result.is_empty() {
+        bail!(
+            "Found packages with self-dependencies:\n{}",
+            result
+                .iter()
+                .map(|idx| format!(
+                    "{} @ {}",
+                    graph[*idx].identity.name, graph[*idx].identity.location
+                ))
+                .collect::<Vec<_>>()
+                .join("\n")
+        );
+    }
+
+    Ok(())
+}
+
+/// Checks if two different packages have the same name -- for now we forbid this, but
+/// plan to relax it in the future.
+fn check_for_name_conflicts(graph: &ResolutionGraph) -> Result<()> {
+    let mut name_location_map = BTreeMap::new();
+
+    for node in graph.node_indices() {
+        let identity = &graph[node].identity;
+
+        let locations = name_location_map
+            .entry(identity.name.as_str())
+            .or_insert_with(Vec::new);
+        locations.push(&identity.location);
+    }
+
+    let conflicts = name_location_map
+        .into_iter()
+        .filter(|(_name, locations)| locations.len() > 1)
+        .map(|(name, locations)| {
+            format!(
+                "Package name conflict: {}\n{}",
+                name,
+                locations
+                    .iter()
+                    .map(|l| format!("  {}", l))
+                    .collect::<Vec<_>>()
+                    .join("\n")
+            )
+        })
+        .collect::<Vec<_>>()
+        .join("\n\n");
+
+    if !conflicts.is_empty() {
+        bail!("{}", conflicts);
+    }
+
+    Ok(())
+}
+
+/// Resolves all transitive dependencies for the given root package.
+/// The results are returned as a [`ResolutionGraph`].
+///
+/// During resolution, remote dependencies are fetched and cached.
+///
+/// As of now, if dev_mode is set to true, dev dependencies are appended to the list of
+/// dependencies, after the regular ones.
+pub async fn resolve(
+    package_cache: &PackageCache<impl PackageCacheListener>,
+    package_lock: &mut PackageLock,
+    root_package_path: impl AsRef<Path>,
+    dev_mode: bool,
+) -> Result<ResolutionGraph> {
+    let mut graph = ResolutionGraph::new();
+    let mut resolved = BTreeMap::new();
+
+    let root_package_path = root_package_path.as_ref();
+
+    // TODO: Is there a way to avoid reading the manifest twice?
+    let root_package_manifest = move_package_manifest::parse_package_manifest(
+        &fs::read_to_string(root_package_path.join("Move.toml"))?,
+    )?;
+
+    let root_package_identity = PackageIdentity {
+        name: root_package_manifest.package.name.to_string(),
+        location: SourceLocation::Local {
+            path: CanonicalPath::new(root_package_path)?,
+        },
+    };
+
+    resolve_package(
+        package_cache,
+        package_lock,
+        &mut graph,
+        &mut resolved,
+        root_package_identity,
+        None,
+        dev_mode,
+    )
+    .await?;
+
+    check_for_name_conflicts(&graph)?;
+    check_for_self_dependencies(&graph)?;
+    check_for_cyclic_dependencies(&graph)?;
+
+    Ok(graph)
+}
+
+/// Returns the local path of the given package.
+/// - If the package is local, return the path as is.
+/// - If the package is remote, fetch it and return its local path within the package cache.
+async fn get_package_local_path(
+    package_cache: &PackageCache<impl PackageCacheListener>,
+    package_lock: &mut PackageLock,
+    identity: &PackageIdentity,
+    user_provided_url: Option<&Url>,
+) -> Result<PathBuf> {
+    Ok(match &identity.location {
+        SourceLocation::OnChain {
+            node: _,
+            package_addr,
+        } => {
+            let fullnode_url = user_provided_url.expect("must be specified for on-chain dep");
+
+            let network_version = package_lock.resolve_network_version(fullnode_url).await?;
+
+            package_cache
+                .fetch_on_chain_package(
+                    fullnode_url,
+                    network_version,
+                    *package_addr,
+                    &identity.name,
+                )
+                .await?
+        },
+        SourceLocation::Local { path } => (**path).clone(),
+        SourceLocation::Git {
+            repo: _,
+            commit_id,
+            subdir,
+        } => {
+            let git_url = user_provided_url.expect("must be specified for on-chain dep");
+
+            let checkout_path = package_cache.checkout_git_repo(git_url, *commit_id).await?;
+            checkout_path.join(subdir)
+        },
+    })
+}
+
+/// Resolves a package identified by the given identity and adds it to the resolution graph.
+async fn resolve_package(
+    package_cache: &PackageCache<impl PackageCacheListener>,
+    package_lock: &mut PackageLock,
+    graph: &mut ResolutionGraph,
+    resolved: &mut BTreeMap<PackageIdentity, NodeIndex>,
+    identity: PackageIdentity,
+    user_provided_url: Option<&Url>,
+    dev_mode: bool,
+) -> Result<NodeIndex> {
+    if let Some(idx) = resolved.get(&identity) {
+        return Ok(*idx);
+    }
+
+    let local_path =
+        get_package_local_path(package_cache, package_lock, &identity, user_provided_url).await?;
+
+    match &identity.location {
+        SourceLocation::OnChain { .. } => {
+            let node_idx = graph.add_node(Package {
+                identity: identity.clone(),
+                local_path,
+            });
+            resolved.insert(identity, node_idx);
+
+            // TODO: fetch transitive deps
+
+            Ok(node_idx)
+        },
+        SourceLocation::Local { .. } | SourceLocation::Git { .. } => {
+            // Read the package manifest
+            let manifest_path = local_path.join("Move.toml");
+            let contents = fs::read_to_string(&manifest_path).map_err(|err| {
+                anyhow!(
+                    "failed to read package manifest at {}: {}",
+                    manifest_path.display(),
+                    err
+                )
+            })?;
+            let package_manifest = move_package_manifest::parse_package_manifest(&contents)?;
+            if *package_manifest.package.name != identity.name {
+                bail!(
+                    "Package name mismatch -- expected {}, got {}",
+                    identity.name,
+                    package_manifest.package.name
+                );
+            }
+
+            // Add the package to the graph
+            let node_idx = graph.add_node(Package {
+                identity: identity.clone(),
+                local_path,
+            });
+            resolved.insert(identity.clone(), node_idx);
+
+            // Resolve all dependencies
+            let all_deps = if dev_mode {
+                Either::Left(
+                    package_manifest
+                        .dependencies
+                        .into_iter()
+                        .chain(package_manifest.dev_dependencies.into_iter()),
+                )
+            } else {
+                Either::Right(package_manifest.dependencies.into_iter())
+            };
+
+            for (dep_name, dep) in all_deps {
+                let dep_idx = Box::pin(resolve_dependency(
+                    package_cache,
+                    package_lock,
+                    graph,
+                    resolved,
+                    &identity,
+                    user_provided_url,
+                    &dep_name,
+                    dep,
+                    dev_mode,
+                ))
+                .await?;
+                graph.add_edge(node_idx, dep_idx, Dependency {});
+            }
+
+            Ok(node_idx)
+        },
+    }
+}
+
+/// Resolves a single dependency for a given package.
+///
+/// Note that in some cases, the child's identity needs to be derived from the parent's identity.
+async fn resolve_dependency(
+    package_cache: &PackageCache<impl PackageCacheListener>,
+    package_lock: &mut PackageLock,
+    graph: &mut ResolutionGraph,
+    resolved: &mut BTreeMap<PackageIdentity, NodeIndex>,
+    parent_identity: &PackageIdentity,
+    parent_url: Option<&Url>,
+    dep_name: &PackageName,
+    dep: manifest::Dependency,
+    dev_mode: bool,
+) -> Result<NodeIndex> {
+    // Declare this variable outside the match block to extend its lifetime to the end of the
+    // function.
+    let remote_url: Url;
+
+    let (package_identity, user_provided_url) = match dep.location {
+        PackageLocation::Local { path: local_path } => match &parent_identity.location {
+            SourceLocation::Local { path: parent_path } => {
+                // Both parent and child are local, so if the child's path is relative,
+                // it is relative to the parent's path.
+                let dep_manitest_path = if local_path.is_absolute() {
+                    local_path
+                } else {
+                    parent_path.join(local_path)
+                };
+                let canonical_path = CanonicalPath::new(&dep_manitest_path).map_err(|err| {
+                    anyhow!(
+                        "failed to find package at {}: {}",
+                        dep_manitest_path.display(),
+                        err
+                    )
+                })?;
+
+                let identity = PackageIdentity {
+                    name: dep_name.to_string(),
+                    location: SourceLocation::Local {
+                        path: canonical_path,
+                    },
+                };
+
+                (identity, None)
+            },
+            SourceLocation::Git {
+                repo,
+                commit_id,
+                subdir,
+            } => {
+                // Parent is a git dependency while child is local.
+                // This makes the child also a git dependency, with path relative to that of the
+                // parent's in the same git repo.
+                if local_path.is_absolute() {
+                    bail!(
+                        "local dependency in a git repo cannot be an absolute path: {}",
+                        local_path.display()
+                    );
+                }
+
+                let new_subdir = subdir.join(local_path);
+                let normalized_new_subdir = NormalizedPath::new(&new_subdir);
+                if let Some(std::path::Component::ParentDir) =
+                    normalized_new_subdir.components().next()
+                {
+                    bail!("subdir outside of repo root: {}", new_subdir.display());
+                }
+
+                let identity = PackageIdentity {
+                    name: dep_name.to_string(),
+                    location: SourceLocation::Git {
+                        repo: repo.clone(),
+                        commit_id: *commit_id,
+                        subdir: normalized_new_subdir,
+                    },
+                };
+
+                (identity, parent_url)
+            },
+            SourceLocation::OnChain { .. } => unreachable!(),
+        },
+        PackageLocation::Git { url, rev, subdir } => {
+            let commit_id = package_lock
+                .resolve_git_revision(package_cache, &url, &rev.unwrap())
+                .await?;
+
+            let subdir = PathBuf::from_str(&subdir.unwrap_or(String::new()))?;
+            if subdir.is_absolute() {
+                bail!("subdir cannot be an absolute path: {}", subdir.display());
+            }
+            let normalized_subdir = NormalizedPath::new(&subdir);
+            if let Some(std::path::Component::ParentDir) = normalized_subdir.components().next() {
+                bail!("subdir outside of repo root: {}", subdir.display());
+            }
+
+            let identity = PackageIdentity {
+                name: dep_name.to_string(),
+                location: SourceLocation::Git {
+                    repo: CanonicalGitIdentity::new(&url)?,
+                    commit_id,
+                    subdir: normalized_subdir,
+                },
+            };
+
+            remote_url = url;
+            (identity, Some(&remote_url))
+        },
+        PackageLocation::Aptos {
+            node_url,
+            package_addr,
+        } => {
+            remote_url = Url::from_str(&node_url)?;
+
+            let identity = PackageIdentity {
+                name: dep_name.to_string(),
+                location: SourceLocation::OnChain {
+                    node: CanonicalNodeIdentity::new(&remote_url)?,
+                    package_addr,
+                },
+            };
+
+            (identity, Some(&remote_url))
+        },
+    };
+
+    resolve_package(
+        package_cache,
+        package_lock,
+        graph,
+        resolved,
+        package_identity,
+        user_provided_url,
+        dev_mode,
+    )
+    .await
+}

--- a/third_party/move/tools/move-package-resolver/tests/resolver_tests_offline.rs
+++ b/third_party/move/tools/move-package-resolver/tests/resolver_tests_offline.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+mod runner;
+
+datatest_stable::harness!(
+    resolver_tests_offline,
+    "testsuite-offline",
+    r"^testsuite-offline/[^/]+/Move\.toml$"
+);
+
+fn resolver_tests_offline(manifest_path: &Path) -> datatest_stable::Result<()> {
+    runner::run_resolver_expected_output_tests(manifest_path)
+}

--- a/third_party/move/tools/move-package-resolver/tests/resolver_tests_online.rs
+++ b/third_party/move/tools/move-package-resolver/tests/resolver_tests_online.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use std::path::Path;
+
+mod runner;
+
+datatest_stable::harness!(
+    resolver_tests_online,
+    "testsuite-online",
+    r"^testsuite-online/[^/]+/Move\.toml$"
+);
+
+fn resolver_tests_online(manifest_path: &Path) -> datatest_stable::Result<()> {
+    runner::run_resolver_expected_output_tests(manifest_path)
+}

--- a/third_party/move/tools/move-package-resolver/tests/runner.rs
+++ b/third_party/move/tools/move-package-resolver/tests/runner.rs
@@ -1,0 +1,45 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use move_package_cache::{DebugPackageCacheListener, PackageCache};
+use move_package_resolver::{graph_to_mermaid, resolve, PackageLock};
+use move_prover_test_utils::baseline_test::verify_or_update_baseline;
+use std::{fmt::Write, path::Path};
+
+pub fn run_resolver_expected_output_tests(manifest_path: &Path) -> datatest_stable::Result<()> {
+    let package_path = manifest_path.parent().unwrap();
+
+    let crate_path = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let package_cache =
+        PackageCache::new_with_listener(crate_path.join("cache"), DebugPackageCacheListener)?;
+    let package_lock_path = package_path.join("Move.lock");
+    let mut package_lock = PackageLock::load_from_file_or_empty(&package_lock_path)?;
+
+    let res = tokio::runtime::Runtime::new()?
+        .block_on(async { resolve(&package_cache, &mut package_lock, package_path, true).await });
+
+    let mut output = String::new();
+    match res {
+        Ok(graph) => {
+            let mermaid = graph_to_mermaid(&graph, Some(crate_path));
+            writeln!(output, "success")?;
+            writeln!(output)?;
+            writeln!(output, "```mermaid")?;
+            writeln!(output, "{}", mermaid)?;
+            writeln!(output, "```")?;
+        },
+        Err(err) => {
+            writeln!(output, "error")?;
+            writeln!(output)?;
+            writeln!(output, "{}", err)?;
+        },
+    }
+    output = output.replace(&format!("{}/", crate_path.display()), "");
+
+    let toml = toml::to_string_pretty(&package_lock)?;
+
+    verify_or_update_baseline(&package_lock_path, &toml)?;
+    verify_or_update_baseline(&package_path.join("output.md"), &output)?;
+
+    Ok(())
+}

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+C1 = { local = "./c1" }
+C3 = { local = "c3" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c1/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c1/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C1"
+version = "0.1.2"
+
+[dependencies]
+C2 = { local = "../c2" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c2/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c2/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C2"
+version = "0.1.2"
+
+[dependencies]
+C1 = { local = "../c1" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c3/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c3/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C3"
+version = "0.1.2"
+
+[dependencies]
+C4 = { local = "../c4" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c4/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c4/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C4"
+version = "0.1.2"
+
+[dependencies]
+C5 = { local = "../c5" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c5/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/c5/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "C5"
+version = "0.1.2"
+
+[dependencies]
+C3 = { local = "../c3" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/cycle/output.md
@@ -1,0 +1,9 @@
+error
+
+Cyclic dependencies found:
+C3 @ local:testsuite-offline/cycle/c3
+C4 @ local:testsuite-offline/cycle/c4
+C5 @ local:testsuite-offline/cycle/c5
+
+C1 @ local:testsuite-offline/cycle/c1
+C2 @ local:testsuite-offline/cycle/c2

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/dep-directory-does-not-exist/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/dep-directory-does-not-exist/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/dep-directory-does-not-exist/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/dep-directory-does-not-exist/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+DoesNotExist = { local = "../deps/does-not-eixst" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/dep-directory-does-not-exist/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/dep-directory-does-not-exist/output.md
@@ -1,0 +1,3 @@
+error
+
+failed to find package at testsuite-offline/dep-directory-does-not-exist/../deps/does-not-eixst: No such file or directory (os error 2)

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+NoMoveToml = { local = "./no-move-toml" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/no-move-toml/Move.toml.bad
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/no-move-toml/Move.toml.bad
@@ -1,0 +1,8 @@
+# Intentionally misnamed to test missing Move.toml
+# Do not delete this file, as it ensures the directory exists!
+
+[package]
+name = "NoMoveToml"
+version = "0.1.2"
+
+[dependencies]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/dep-no-move-toml/output.md
@@ -1,0 +1,3 @@
+error
+
+failed to read package manifest at testsuite-offline/dep-no-move-toml/no-move-toml/Move.toml: No such file or directory (os error 2)

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/empty-package/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/empty-package/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/empty-package/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/empty-package/Move.toml
@@ -1,0 +1,3 @@
+[package]
+name = "Pack"
+version = "0.1.2"

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/empty-package/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/empty-package/output.md
@@ -1,0 +1,7 @@
+success
+
+```mermaid
+flowchart TD
+    N0["Pack<br><br>local:testsuite-offline/empty-package<br><br>testsuite-offline/empty-package"]
+
+```

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+Foo = { local = "./foo" }
+Bar = { local = "./bar" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/bar/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/bar/Move.toml
@@ -1,0 +1,5 @@
+[package]
+name = "Bar"
+version = "0.1.2"
+
+[dependencies]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/baz/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/baz/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Baz"
+version = "0.1.2"
+
+[dependencies]
+Bar = { local = "././../bar" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/foo/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/foo/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Foo"
+version = "0.1.2"
+
+[dependencies]
+Bar = { local = "../bar" }
+Baz = { local = "../baz" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/local-deps/output.md
@@ -1,0 +1,15 @@
+success
+
+```mermaid
+flowchart TD
+    N0["Pack<br><br>local:testsuite-offline/local-deps<br><br>testsuite-offline/local-deps"]
+    N1["Bar<br><br>local:testsuite-offline/local-deps/bar<br><br>testsuite-offline/local-deps/bar"]
+    N2["Foo<br><br>local:testsuite-offline/local-deps/foo<br><br>testsuite-offline/local-deps/foo"]
+    N3["Baz<br><br>local:testsuite-offline/local-deps/baz<br><br>testsuite-offline/local-deps/baz"]
+    N0 --> N1
+    N2 --> N1
+    N3 --> N1
+    N2 --> N3
+    N0 --> N2
+
+```

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/self-dep/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/self-dep/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/self-dep/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/self-dep/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+Pack = { local = "./" }

--- a/third_party/move/tools/move-package-resolver/testsuite-offline/self-dep/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-offline/self-dep/output.md
@@ -1,0 +1,4 @@
+error
+
+Found packages with self-dependencies:
+Pack @ local:testsuite-offline/self-dep

--- a/third_party/move/tools/move-package-resolver/testsuite-online/dep-same-name/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/dep-same-name/Move.lock
@@ -1,0 +1,5 @@
+[git]
+"github.com/aptos-labs/aptos-framework@main" = "fae5fee731d64e63e4028e27045792a053827dc5"
+"github.com/aptos-labs/aptos-framework@testnet" = "a232ffcf03e3f527bfed0448f0f92fedeba5c30f"
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-online/dep-same-name/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/dep-same-name/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+AptosStdlib = { git = "https://github.com/aptos-labs/aptos-framework", rev = "main", subdir = "aptos-stdlib" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-framework", rev = "testnet", subdir = "move-stdlib" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/dep-same-name/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/dep-same-name/output.md
@@ -1,0 +1,5 @@
+error
+
+Package name conflict: MoveStdlib
+  git:github.com/aptos-labs/aptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/move-stdlib
+  git:github.com/aptos-labs/aptos-framework@a232ffcf03e3f527bfed0448f0f92fedeba5c30f/move-stdlib

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-rev/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-rev/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-rev/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-rev/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-framework", rev = "bad-rev", subdir = "move-stdlib" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-rev/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-rev/output.md
@@ -1,0 +1,3 @@
+error
+
+Failed to resolve rev string "bad-rev" in repo https://github.com/aptos-labs/aptos-framework

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-subdir/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-subdir/Move.lock
@@ -1,0 +1,4 @@
+[git]
+"github.com/aptos-labs/aptos-framework@main" = "fae5fee731d64e63e4028e27045792a053827dc5"
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-subdir/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-subdir/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-framework", rev = "main", subdir = "does-not-exist" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-subdir/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-subdir/output.md
@@ -1,0 +1,3 @@
+error
+
+failed to read package manifest at cache/git/checkouts/github.com%2Faptos-labs%2Faptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/does-not-exist/Move.toml: No such file or directory (os error 2)

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-url/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-url/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-url/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-url/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+MoveStdlib = { git = "https://aptoslabs.com/does-not-exist", rev = "main", subdir = "move-stdlib" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-url/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git-bad-url/output.md
@@ -1,0 +1,3 @@
+error
+
+Failed to clone git repo at https://aptoslabs.com/does-not-exist: unexpected http status code: 404; class=Http (34)

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git/Move.lock
@@ -1,0 +1,4 @@
+[git]
+"github.com/aptos-labs/aptos-framework@main" = "fae5fee731d64e63e4028e27045792a053827dc5"
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+AptosFramework = { git = "https://github.com/aptos-labs/aptos-framework", rev = "main", subdir = "aptos-framework" }
+MoveStdlib = { git = "https://github.com/aptos-labs/aptos-framework", rev = "main", subdir = "move-stdlib" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/git/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/git/output.md
@@ -1,0 +1,15 @@
+success
+
+```mermaid
+flowchart TD
+    N0["Pack<br><br>local:testsuite-online/git<br><br>testsuite-online/git"]
+    N1["AptosFramework<br><br>git:github.com/aptos-labs/aptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/aptos-framework<br><br>cache/git/checkouts/github.com%2Faptos-labs%2Faptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/aptos-framework"]
+    N2["AptosStdlib<br><br>git:github.com/aptos-labs/aptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/aptos-stdlib<br><br>cache/git/checkouts/github.com%2Faptos-labs%2Faptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/aptos-stdlib"]
+    N3["MoveStdlib<br><br>git:github.com/aptos-labs/aptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/move-stdlib<br><br>cache/git/checkouts/github.com%2Faptos-labs%2Faptos-framework@fae5fee731d64e63e4028e27045792a053827dc5/move-stdlib"]
+    N2 --> N3
+    N1 --> N2
+    N1 --> N3
+    N0 --> N1
+    N0 --> N3
+
+```

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.lock
@@ -1,0 +1,4 @@
+[git]
+
+[on_chain]
+"fullnode.mainnet.aptoslabs.com" = 3152151156

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+MoveStdlib = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x10" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-addr/output.md
@@ -1,0 +1,3 @@
+error
+
+API error Error(ResourceNotFound): Resource not found by Address(0x10), Struct tag(0x1::code::PackageRegistry) and Ledger version(3152151156)

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.lock
@@ -1,0 +1,4 @@
+[git]
+
+[on_chain]
+"fullnode.mainnet.aptoslabs.com" = 3152151123

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+DoesNotExist = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x1" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-package-name/output.md
@@ -1,0 +1,3 @@
+error
+
+package not found: https://fullnode.mainnet.aptoslabs.com///0x1::DoesNotExist

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-url/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-url/Move.lock
@@ -1,0 +1,3 @@
+[git]
+
+[on_chain]

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-url/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-url/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+MoveStdlib = { aptos = "https://bad-network.mainnet.aptoslabs.com", address = "0x1" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-url/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain-bad-url/output.md
@@ -1,0 +1,3 @@
+error
+
+Unknown error error sending request for url (https://bad-network.mainnet.aptoslabs.com/v1/): error trying to connect: dns error: failed to lookup address information: Name or service not known

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.lock
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.lock
@@ -1,0 +1,4 @@
+[git]
+
+[on_chain]
+"fullnode.mainnet.aptoslabs.com" = 3152151123

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.toml
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/Move.toml
@@ -1,0 +1,7 @@
+[package]
+name = "Pack"
+version = "0.1.2"
+
+[dependencies]
+MoveStdlib = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x1" }
+AptosStdlib = { aptos = "https://fullnode.mainnet.aptoslabs.com", address = "0x1" }

--- a/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/output.md
+++ b/third_party/move/tools/move-package-resolver/testsuite-online/on-chain/output.md
@@ -1,0 +1,11 @@
+success
+
+```mermaid
+flowchart TD
+    N0["Pack<br><br>local:testsuite-online/on-chain<br><br>testsuite-online/on-chain"]
+    N1["AptosStdlib<br><br>onchain:fullnode.mainnet.aptoslabs.com::0x1<br><br>cache/on-chain/fullnode.mainnet.aptoslabs.com+3152151123+0x1+AptosStdlib"]
+    N2["MoveStdlib<br><br>onchain:fullnode.mainnet.aptoslabs.com::0x1<br><br>cache/on-chain/fullnode.mainnet.aptoslabs.com+3152151123+0x1+MoveStdlib"]
+    N0 --> N1
+    N0 --> N2
+
+```


### PR DESCRIPTION
This implements the Move Package Resolver, a component of the next-gen package system. 

It is responsible for traversing user-specified package manifests and constructing a fully resolved, reproducible dependency graph. During this process, all remote dependencies are fetched to the local file system for later use.

## Implementation Break-down
- `identity.rs`: defines the package identity  -- fundamental concept to distinguish one package from another
- `graph.rs`: defines the resolution graph + a helper function to covert to mermaid for visualization
- `path.rs`: canonicalization and normalization of paths
- `lock.rs`: the Package Lock implementation -- the pinning of resolved identities of remote git repos and networks
- `resolver.rs` recursive algorithm to construct the resolution graph

## Testing
Tests are split into two groups:
- `testsuite-offline`: tests that contain only local packages, can be run entirely offline
- `testsuite-online`: tests that contain remote dependencies, require internet to run

TODO: disable online tests in CI so they don't cause flakiness.

## Upcoming Changes
It should be noted that not all planned features have been implemented in this initial version. 

Particularly I'm leaving out the following features for now:
- Support for address substitution
- Allow identical package names (currently this is a hard error)
- Support package overrides for conflict resolution
- Fetching transitive deps for on-chain packages
- Structured errors and error rendering
- (Low Priority) Handling symbolic links in git repos
- (Low Priority) Parallel dependency resolution

These will be implemented and fine-tuned as I explore the next phase: the Build Executor.