### PR TITLE
[lint] Added infinite_recursion security check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12545,6 +12545,7 @@ dependencies = [
  "move-prover-test-utils",
  "move-stackless-bytecode",
  "num 0.4.1",
+ "once_cell",
 ]
 
 [[package]]

--- a/third_party/move/tools/move-linter/Cargo.toml
+++ b/third_party/move/tools/move-linter/Cargo.toml
@@ -20,6 +20,7 @@ move-compiler-v2 = { workspace = true }
 move-model = { workspace = true }
 move-stackless-bytecode = { workspace = true }
 num = { workspace = true }
+once_cell = { workspace = true }
 
 [dev-dependencies]
 datatest-stable = { workspace = true }

--- a/third_party/move/tools/move-linter/src/stackless_bytecode_lints.rs
+++ b/third_party/move/tools/move-linter/src/stackless_bytecode_lints.rs
@@ -6,6 +6,7 @@
 //! The lint checks also assume that all the correctness checks have already been performed.
 
 mod avoid_copy_on_identity_comparison;
+mod infinite_recursion;
 mod needless_mutable_reference;
 
 use move_compiler_v2::external_checks::StacklessBytecodeChecker;
@@ -19,6 +20,7 @@ pub fn get_default_linter_pipeline(
     let checks: Vec<Box<dyn StacklessBytecodeChecker>> = vec![
         Box::new(avoid_copy_on_identity_comparison::AvoidCopyOnIdentityComparison {}),
         Box::new(needless_mutable_reference::NeedlessMutableReference {}),
+        Box::new(infinite_recursion::InfiniteRecursion {}),
     ];
     let checks_category = config.get("checks").map_or("default", |s| s.as_str());
     if checks_category == "strict" || checks_category == "experimental" {

--- a/third_party/move/tools/move-linter/src/stackless_bytecode_lints/infinite_recursion.rs
+++ b/third_party/move/tools/move-linter/src/stackless_bytecode_lints/infinite_recursion.rs
@@ -1,0 +1,412 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements a stackless-bytecode security check that looks for
+//! functions containing possible infinite recursion, either by themselves, or
+//! infinite recursive cycles with any number of other functions. I.e. f() calls
+//! g(), which calls h(), which calls i(), which calls f() again.
+
+use move_compiler_v2::external_checks::StacklessBytecodeChecker;
+use move_model::model::{FunId, GetNameString, GlobalEnv, Loc, ModuleId};
+use move_stackless_bytecode::{
+    function_target::FunctionTarget,
+    stackless_bytecode::{Bytecode, Operation},
+    stackless_control_flow_graph::{BlockContent, BlockId, StacklessControlFlowGraph},
+};
+use once_cell::sync::Lazy;
+use std::{
+    collections::{HashMap, HashSet},
+    hash::Hash,
+    sync::Mutex,
+};
+
+#[derive(Clone)]
+struct CallGraphNode {
+    //The set of functions that will be unconditionally called by the function.
+    callees: HashSet<Function>,
+    //Axiliary data.
+    visited: bool,
+}
+
+impl CallGraphNode {
+    fn new(callees: HashSet<Function>) -> CallGraphNode {
+        CallGraphNode {
+            callees,
+            visited: false,
+        }
+    }
+}
+
+//State persistent accross invocations of InfiniteRecursion::check().
+struct GlobalState {
+    functions: HashMap<Function, CallGraphNode>,
+}
+
+static GLOBAL_STATE: Lazy<Mutex<GlobalState>> = Lazy::new(|| Mutex::new(GlobalState::new()));
+
+pub struct InfiniteRecursion {}
+
+impl StacklessBytecodeChecker for InfiniteRecursion {
+    fn get_name(&self) -> String {
+        "infinite_recursion".to_string()
+    }
+
+    fn check(&self, target: &FunctionTarget) {
+        GlobalState::analyze_target(|e, l, m| self.report(e, l, m), target);
+    }
+}
+
+impl GlobalState {
+    pub fn new() -> GlobalState {
+        GlobalState {
+            functions: HashMap::new(),
+        }
+    }
+
+    //Analyzes a FunctionTarget and internally accumulates information about
+    //visited functions. When a cycle of functions that unconditionally call
+    //each other is found, it reports it using the provided `report` function.
+    pub fn analyze_target<F: Fn(&GlobalEnv, &Loc, &str)>(report: F, target: &FunctionTarget) {
+        let mut lock = GLOBAL_STATE.lock().unwrap();
+
+        let mut program = Program::new(target.get_bytecode());
+        //program.print();
+        let function = Function {
+            module: target.module_env().get_id(),
+            function: target.get_id(),
+        };
+        lock.functions.insert(
+            function.clone(),
+            CallGraphNode::new(program.get_unconditional_calls()),
+        );
+        lock.find_cycles(report, target, function);
+    }
+
+    //Entry function for recursive traverse_call_graph().
+    fn find_cycles<F: Fn(&GlobalEnv, &Loc, &str)>(
+        &mut self,
+        report: F,
+        target: &FunctionTarget,
+        initial: Function,
+    ) {
+        //Reset auxiliary data.
+        for v in self.functions.values_mut() {
+            v.visited = false;
+        }
+
+        let mut stack = Vec::new();
+        stack.push(initial.clone());
+        self.traverse_call_graph(&report, target, &mut stack);
+    }
+
+    //Traverses the call graph defined by GlobalState::functions looking for cycles.
+    fn traverse_call_graph<F: Fn(&GlobalEnv, &Loc, &str)>(
+        &mut self,
+        report: &F,
+        target: &FunctionTarget,
+        stack: &mut Vec<Function>,
+    ) {
+        if let Some(top) = stack.last().cloned() {
+            if let Some(node) = self.functions.get_mut(&top) {
+                if node.visited {
+                    let env = target.global_env();
+                    let cycle = Self::report_infinite_recursion(stack, env);
+                    report(
+                        env,
+                        &target.get_loc(),
+                        &format!("Unconditional infinite recursion detected: {}", cycle),
+                    );
+                    return;
+                }
+                node.visited = true;
+            }
+
+            if let Some(node) = self.functions.get(&top).cloned() {
+                for call in node.callees.iter() {
+                    stack.push(call.clone());
+                    self.traverse_call_graph(report, target, stack);
+                    stack.pop();
+                }
+            }
+
+            if let Some(node) = self.functions.get_mut(&top) {
+                node.visited = false;
+            }
+        }
+    }
+
+    fn report_infinite_recursion(stack: &[Function], env: &GlobalEnv) -> String {
+        debug_assert!(!stack.is_empty());
+        let mut ret = String::new();
+        if let Some(position) = stack.iter().position(|x| x == stack.last().unwrap()) {
+            let mut first = true;
+            for i in stack.iter().skip(position) {
+                if first {
+                    first = false;
+                } else {
+                    ret += " -> ";
+                }
+                ret += &i.get_name(env);
+            }
+        }
+        ret
+    }
+}
+
+//Represents a block. A "block" is a sequence of opcodes that does not have
+//any opcodes that affect control flow, except at the end.
+#[derive(Clone, Debug)]
+struct Block {
+    //The next blocks that may get executed after this one.
+    successors: Vec<BlockId>,
+    //These are the functions that are called (unconditionally) within the
+    //block.
+    calls: HashSet<Function>,
+    ends_in_ret: bool,
+
+    //Auxiliary data.
+    visited: bool,
+}
+
+//Uniquely represents a function by module and function ID.
+#[derive(Clone, Eq, PartialEq, Hash, Debug)]
+struct Function {
+    //Module ID.
+    pub module: ModuleId,
+    //Function ID.
+    pub function: FunId,
+}
+
+impl Function {
+    //Get the fully-qualified function name.
+    fn get_name(&self, env: &GlobalEnv) -> String {
+        self.module
+            .qualified(self.function)
+            .get_name_for_display(env)
+            .to_string()
+    }
+}
+
+#[derive(Debug)]
+enum StackAction {
+    WindUp(BlockId),
+    Backtrack(BlockId),
+}
+
+//A reduced representation of a program.
+struct Program {
+    //The program's `Segment`s by their `SegmentId`.
+    blocks_map: HashMap<BlockId, Block>,
+    //The program's entry point.
+    entry: BlockId,
+}
+
+impl Program {
+    pub fn new(code: &[Bytecode]) -> Program {
+        let cfg = StacklessControlFlowGraph::new_forward(code);
+        Program {
+            blocks_map: Self::construct_block_map(code, &cfg),
+            entry: cfg.entry_block(),
+        }
+    }
+
+    fn construct_block_map(
+        code: &[Bytecode],
+        cfg: &StacklessControlFlowGraph,
+    ) -> HashMap<BlockId, Block> {
+        let mut ret = HashMap::new();
+        let mut stack = vec![cfg.entry_block()];
+        let successors = cfg.get_successors_map();
+
+        while let Some(current) = stack.pop() {
+            if ret.contains_key(&current) {
+                continue;
+            }
+
+            let successors = if let Some(successors) = successors.get(&current) {
+                successors.clone()
+            } else {
+                vec![]
+            };
+            for i in successors.iter() {
+                stack.push(*i);
+            }
+
+            let (begin, end) = if let BlockContent::Basic { lower, upper } = cfg.content(current) {
+                (*lower as usize, (*upper as usize) + 1)
+            } else {
+                (0, 0)
+            };
+
+            let block = Block {
+                successors,
+                calls: Self::collect_calls(code, begin, end),
+                visited: false,
+                ends_in_ret: begin != end && matches!(code.get(end - 1), Some(Bytecode::Ret(_, _))),
+            };
+            ret.insert(current, block);
+        }
+
+        ret
+    }
+
+    fn collect_calls(code: &[Bytecode], begin: usize, end: usize) -> HashSet<Function> {
+        let mut ret = HashSet::new();
+        if end <= begin {
+            return ret;
+        }
+
+        for opcode in code.iter().skip(begin).take(end - begin) {
+            match opcode {
+                Bytecode::Call(_, _, Operation::Function(m, f, _), _, _)
+                | Bytecode::Call(_, _, Operation::Closure(m, f, _, _), _, _) => {
+                    ret.insert(Function {
+                        module: *m,
+                        function: *f,
+                    });
+                },
+                _ => {},
+            }
+        }
+        ret
+    }
+
+    //Find all control flow graph nodes that terminate in a return.
+    fn list_exits(&self) -> Vec<BlockId> {
+        self.blocks_map
+            .iter()
+            .filter(|(_, block)| block.ends_in_ret)
+            .map(|(id, _)| *id)
+            .collect()
+    }
+
+    //Use DFS to find any path through the control flow graph that connects two
+    //nodes, if any exists.
+    fn find_any_path(&mut self, from: &BlockId, to: &BlockId) -> Option<Vec<BlockId>> {
+        //Clear auxiliary data.
+        for block in self.blocks_map.values_mut() {
+            block.visited = false;
+        }
+
+        let mut ret = Vec::new();
+        let mut found = false;
+        let mut stack = vec![StackAction::WindUp(*from)];
+        while let Some(action) = stack.pop() {
+            let continue_looping = match action {
+                StackAction::WindUp(current) => {
+                    self.windup(&current, to, &mut stack, &mut found, &mut ret)
+                },
+                StackAction::Backtrack(current) => self.backtrack(&current, &mut ret),
+            };
+
+            if !continue_looping {
+                break;
+            }
+        }
+
+        if found {
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
+    fn windup(
+        &mut self,
+        current: &BlockId,
+        to: &BlockId,
+        stack: &mut Vec<StackAction>,
+        found: &mut bool,
+        accum: &mut Vec<BlockId>,
+    ) -> bool {
+        if let Some(data) = self.blocks_map.get_mut(current) {
+            if data.visited {
+                return true;
+            }
+            data.visited = true;
+            accum.push(*current);
+
+            if current == to {
+                *found = true;
+                return false;
+            }
+
+            stack.push(StackAction::Backtrack(*current));
+            if data.successors.is_empty() {
+                return true;
+            }
+
+            for next in data.successors.iter() {
+                stack.push(StackAction::WindUp(*next));
+            }
+        }
+
+        true
+    }
+
+    fn backtrack(&mut self, current: &BlockId, accum: &mut Vec<BlockId>) -> bool {
+        if let Some(data) = self.blocks_map.get_mut(current) {
+            data.visited = false;
+        }
+
+        let top = accum.pop();
+        debug_assert!(top == Some(*current));
+
+        true
+    }
+
+    //Get all unique functions that are called along a sequence of blocks.
+    fn get_calls_for_path(&self, path: &Option<Vec<BlockId>>) -> Option<HashSet<Function>> {
+        if let Some(path) = path {
+            let mut ret = HashSet::new();
+
+            for x in path.iter() {
+                if let Some(data) = self.blocks_map.get(x) {
+                    ret.extend(data.calls.iter().cloned());
+                }
+            }
+
+            Some(ret)
+        } else {
+            None
+        }
+    }
+
+    //Find the functions that are unconditionally called by the program.
+    //Algorithm:
+    // 1. Find all program segments that end in a return.
+    // 2. For each of those, find any path from the entry point to them.
+    // 3. For each of those paths, accumulate (through unions) a set of all
+    //    functions that are called.
+    // 4. The result for get_unconditional_calls() is the intersection of all
+    //    the sets found during step #3.
+    pub fn get_unconditional_calls(&mut self) -> HashSet<Function> {
+        let mut ret: Option<HashSet<Function>> = None;
+
+        for exit in self.list_exits() {
+            let path = self.find_any_path(&self.entry.clone(), &exit);
+            let ucs = self.get_calls_for_path(&path);
+
+            if let Some(ucs) = ucs {
+                ret = Some(
+                    if let Some(ret2) = ret {
+                        ret2.intersection(&ucs).cloned().collect::<HashSet<_>>()
+                    } else {
+                        ucs
+                    },
+                );
+            }
+        }
+
+        ret.unwrap_or_default()
+    }
+
+    #[allow(dead_code)]
+    fn print(&self) {
+        eprintln!("Program{{");
+        for (k, v) in self.blocks_map.iter() {
+            eprintln!("    [{:?}] = {:?},", k, v);
+        }
+        eprintln!("}}");
+    }
+}

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/infinite_recursion_01.exp
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/infinite_recursion_01.exp
@@ -1,0 +1,48 @@
+
+Diagnostics:
+warning: [lint] Unconditional infinite recursion detected: m::test1_warn -> m::test1_warn
+  ┌─ tests/stackless_bytecode_lints/infinite_recursion_01.move:2:5
+  │
+2 │ ╭     fun test1_warn() {
+3 │ │         test1_warn();
+4 │ │     }
+  │ ╰─────^
+  │
+  = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(infinite_recursion)]`.
+  = For more information, see https://aptos.dev/en/build/smart-contracts/linter#infinite_recursion.
+
+warning: [lint] Unconditional infinite recursion detected: m::test2_a_warn -> m::test2_b_warn -> m::test2_a_warn
+   ┌─ tests/stackless_bytecode_lints/infinite_recursion_01.move:8:5
+   │
+ 8 │ ╭     fun test2_a_warn() {
+ 9 │ │         test2_b_warn();
+10 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(infinite_recursion)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#infinite_recursion.
+
+warning: [lint] Unconditional infinite recursion detected: m::test3_a_warn -> m::test3_b_warn -> m::test3_c_warn -> m::test3_d_warn -> m::test3_a_warn
+   ┌─ tests/stackless_bytecode_lints/infinite_recursion_01.move:18:5
+   │
+18 │ ╭     fun test3_a_warn() {
+19 │ │         test3_b_warn();
+20 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(infinite_recursion)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#infinite_recursion.
+
+warning: [lint] Unconditional infinite recursion detected: m::test4_a_warn -> m::test4_a_warn
+   ┌─ tests/stackless_bytecode_lints/infinite_recursion_01.move:36:5
+   │
+36 │ ╭     fun test4_a_warn(x: u64, limit: u64) {
+37 │ │         if (limit < 1 || limit < 2) {
+38 │ │             abort 0
+39 │ │         };
+40 │ │         test4_a_warn(collatz(x), limit - 1);
+41 │ │     }
+   │ ╰─────^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(infinite_recursion)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#infinite_recursion.

--- a/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/infinite_recursion_01.move
+++ b/third_party/move/tools/move-linter/tests/stackless_bytecode_lints/infinite_recursion_01.move
@@ -1,0 +1,50 @@
+module 0xc0ffee::m {
+    fun test1_warn() {
+        test1_warn();
+    }
+
+
+
+    fun test2_a_warn() {
+        test2_b_warn();
+    }
+
+    fun test2_b_warn() {
+        test2_a_warn();
+    }
+
+
+
+    fun test3_a_warn() {
+        test3_b_warn();
+    }
+
+    fun test3_b_warn() {
+        test3_c_warn();
+    }
+
+    fun test3_c_warn() {
+        test3_d_warn();
+    }
+
+    fun test3_d_warn() {
+        test3_a_warn();
+    }
+
+
+
+    fun test4_a_warn(x: u64, limit: u64) {
+        if (limit < 1 || limit < 2) {
+            abort 0
+        };
+        test4_a_warn(collatz(x), limit - 1);
+    }
+
+    fun collatz(n: u64): u64 {
+        if (n % 2 == 0) {
+            n / 2
+        } else {
+            n * 3 + 1
+        }
+    }
+}


### PR DESCRIPTION
## Description
This security check finds cases of demonstrable infinite recursion, both of a function into itself and of mutual recursion between two or more functions.

## How Has This Been Tested?
Positive and negative test cases have been added to the move lint unit tests.
Additionally, the linter has been run on the crates in the aptos-move/framework subdirectory, with the following results:
Crate | Result | Notes
-- | -- | --
aptos-experimental | No warnings |
aptos-framework | No warnings |
aptos-stdlib | No warnings |  
aptos-token | No warnings |  
aptos-token-objects | No warnings |  
move-stdlib | No warnings |  

## Key Areas to Review
The key change is to aptos-move/aptos-move-linter/src/stackless_bytecode_lints/infinite_recursion.rs as well as to the entire aptos-move/aptos-move-linter subdirectory.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Move linter
