### PR TITLE
Use BlockEndInfoExt to construct epilogue transaction (V1)

### DIFF
--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -68,7 +68,7 @@ use aptos_types::{
         TimedFeatureFlag, TimedFeatures,
     },
     randomness::Randomness,
-    state_store::{state_key::StateKey, StateView, TStateView},
+    state_store::{StateView, TStateView},
     transaction::{
         authenticator::{AbstractionAuthData, AnySignature, AuthenticationProof},
         block_epilogue::{BlockEpiloguePayload, FeeDistribution},
@@ -2895,7 +2895,7 @@ impl AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         fail_point!("aptos_vm_block_executor::execute_block_with_config", |_| {
             Err(VMStatus::error(
                 StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR,
@@ -2943,7 +2943,7 @@ impl VMBlockExecutor for AptosVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         let config = BlockExecutorConfig {
             local: BlockExecutorLocalConfig {
                 blockstm_v2: false,

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -521,7 +521,7 @@ impl<
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
         transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<S::Key, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         let _timer = BLOCK_EXECUTOR_EXECUTE_BLOCK_SECONDS.start_timer();
 
         let num_txns = signature_verified_block.num_txns();
@@ -614,7 +614,7 @@ impl<
         config: BlockExecutorConfig,
         transaction_slice_metadata: TransactionSliceMetadata,
         transaction_commit_listener: Option<L>,
-    ) -> Result<BlockOutput<S::Key, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         Self::execute_block_on_thread_pool::<S, L, TP>(
             Arc::clone(&RAYON_EXEC_POOL),
             signature_verified_block,

--- a/aptos-move/aptos-vm/src/lib.rs
+++ b/aptos-move/aptos-vm/src/lib.rs
@@ -132,7 +132,7 @@ use aptos_types::{
         config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
         transaction_slice_metadata::TransactionSliceMetadata,
     },
-    state_store::{state_key::StateKey, StateView},
+    state_store::StateView,
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, BlockOutput,
         SignedTransaction, TransactionOutput, VMValidatorResult,
@@ -173,7 +173,7 @@ pub trait VMBlockExecutor: Send + Sync {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus>;
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus>;
 
     /// Executes a block of transactions and returns output for each one of them, without applying
     /// any block limit.

--- a/aptos-move/block-executor/src/combinatorial_tests/baseline.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/baseline.rs
@@ -19,8 +19,9 @@ use crate::{
 use aptos_aggregator::delta_change_set::{serialize, DeltaOp};
 use aptos_mvhashmap::types::TxnIndex;
 use aptos_types::{
-    contract_event::TransactionEvent, state_store::state_value::StateValueMetadata,
-    transaction::BlockOutput, write_set::TransactionWrite,
+    contract_event::TransactionEvent, executable::ModulePath,
+    state_store::state_value::StateValueMetadata, transaction::BlockOutput,
+    write_set::TransactionWrite,
 };
 use aptos_vm_types::{
     module_write_set::ModuleWrite, resolver::ResourceGroupSize,
@@ -526,7 +527,10 @@ impl<K: Clone + Debug + Eq + Hash> BaselineOutputBuilder<K> {
     }
 }
 
-impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
+impl<K> BaselineOutput<K>
+where
+    K: Debug + Hash + Clone + Ord + Send + Sync + ModulePath + 'static,
+{
     /// Must be invoked after parallel execution to have incarnation information set and
     /// work with dynamic read/writes.
     pub(crate) fn generate<E: Debug + Clone + TransactionEvent>(
@@ -588,6 +592,7 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
                     }
                 },
                 MockTransaction::InterruptRequested => unreachable!("Not tested with outputs"),
+                MockTransaction::StateCheckpoint => unreachable!("Not used as test input"),
             }
         }
 
@@ -640,7 +645,10 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
         self.insert_or_verify_delayed_field_id(baseline_key.clone(), id);
     }
 
-    fn assert_success<E: Debug>(&self, block_output: &BlockOutput<K, MockOutput<K, E>>) {
+    fn assert_success<E: Clone + Debug + Send + Sync + TransactionEvent + 'static>(
+        &self,
+        block_output: &BlockOutput<MockTransaction<K, E>, MockOutput<K, E>>,
+    ) {
         let mut group_world = HashMap::new();
         let mut group_metadata: HashMap<K, Option<StateValueMetadata>> = HashMap::new();
 
@@ -1031,9 +1039,9 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
 
     // Used for testing, hence the function asserts the correctness conditions within
     // itself to be easily traceable in case of an error.
-    pub(crate) fn assert_output<E: Debug>(
+    pub(crate) fn assert_output<E: Clone + Debug + Send + Sync + TransactionEvent + 'static>(
         &self,
-        results: &BlockExecutionResult<BlockOutput<K, MockOutput<K, E>>, usize>,
+        results: &BlockExecutionResult<BlockOutput<MockTransaction<K, E>, MockOutput<K, E>>, usize>,
     ) {
         match results {
             Ok(block_output) => {
@@ -1050,9 +1058,11 @@ impl<K: Debug + Hash + Clone + Eq> BaselineOutput<K> {
         }
     }
 
-    pub(crate) fn assert_parallel_output<E: Debug>(
+    pub(crate) fn assert_parallel_output<
+        E: Clone + Debug + Send + Sync + TransactionEvent + 'static,
+    >(
         &self,
-        results: &Result<BlockOutput<K, MockOutput<K, E>>, ()>,
+        results: &Result<BlockOutput<MockTransaction<K, E>, MockOutput<K, E>>, ()>,
     ) {
         match results {
             Ok(block_output) => {

--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -636,6 +636,29 @@ impl<K: Clone + Debug + Eq + PartialEq + Hash, E: Clone> MockOutputBuilder<K, E>
 }
 
 impl<K, E> MockOutput<K, E> {
+    fn empty_success_output() -> Self {
+        Self {
+            writes: vec![],
+            aggregator_v1_writes: vec![],
+            group_writes: vec![],
+            module_writes: vec![],
+            deltas: vec![],
+            events: vec![],
+            read_results: vec![],
+            delayed_field_reads: vec![],
+            module_read_results: vec![],
+            read_group_size_or_metadata: vec![],
+            materialized_delta_writes: OnceCell::new(),
+            patched_resource_write_set: OnceCell::new(),
+            total_gas: 0,
+            called_write_summary: OnceCell::new(),
+            skipped: false,
+            maybe_error_msg: None,
+            reads_needing_exchange: HashMap::new(),
+            group_reads_needing_exchange: HashMap::new(),
+        }
+    }
+
     // Helper method to create an empty MockOutput with common settings
     pub(crate) fn skipped_output(error_msg: Option<String>) -> Self {
         Self {
@@ -985,6 +1008,9 @@ where
             MockTransaction::InterruptRequested => {
                 while !view.interrupt_requested() {}
                 ExecutionStatus::SkipRest(MockOutput::skip_output())
+            },
+            MockTransaction::StateCheckpoint => {
+                ExecutionStatus::Success(MockOutput::empty_success_output())
             },
         }
     }

--- a/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/resource_tests.rs
@@ -104,7 +104,7 @@ pub(crate) fn execute_block_parallel<TxnType, ViewType, Provider>(
     data_view: &ViewType,
     all_module_ids: Option<&[ModuleId]>,
     block_stm_v2: bool,
-) -> Result<BlockOutput<ViewType::Key, MockOutput<KeyType<[u8; 32]>, MockEvent>>, ()>
+) -> Result<BlockOutput<TxnType, MockOutput<KeyType<[u8; 32]>, MockEvent>>, ()>
 where
     TxnType: Transaction<Key = KeyType<[u8; 32]>> + Debug + Clone + Send + Sync + 'static,
     ViewType: TStateView<Key = TxnType::Key> + Sync + 'static,

--- a/aptos-move/block-executor/src/combinatorial_tests/types.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/types.rs
@@ -4,6 +4,7 @@
 
 use crate::types::delayed_field_mock_serialization::serialize_delayed_field_tuple;
 use aptos_aggregator::delta_change_set::{delta_add, delta_sub, serialize, DeltaOp};
+use aptos_crypto::HashValue;
 use aptos_types::{
     account_address::AccountAddress,
     contract_event::TransactionEvent,
@@ -423,6 +424,7 @@ pub(crate) enum MockTransaction<K, E> {
     SkipRest(u64),
     /// Abort the execution.
     Abort,
+    StateCheckpoint,
 }
 
 impl<K, E> MockTransaction<K, E> {
@@ -473,6 +475,9 @@ impl<K, E> MockTransaction<K, E> {
             Self::InterruptRequested => {
                 unreachable!("InterruptRequested does not contain incarnation behaviors")
             },
+            Self::StateCheckpoint => {
+                unreachable!("StateCheckpoint does not contain incarnation behaviors")
+            },
         }
     }
 }
@@ -491,15 +496,8 @@ impl<
         0
     }
 
-    fn from_txn(txn: aptos_types::transaction::Transaction) -> Self {
-        match txn {
-            aptos_types::transaction::Transaction::StateCheckpoint(_)
-            | aptos_types::transaction::Transaction::BlockEpilogue(_) => {
-                let behaivor = MockIncarnation::new(vec![], vec![], vec![], vec![], 0);
-                Self::from_behavior(behaivor)
-            },
-            _ => unreachable!(),
-        }
+    fn state_checkpoint(_block_id: HashValue) -> Self {
+        Self::StateCheckpoint
     }
 }
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -47,7 +47,6 @@ use aptos_types::{
     state_store::{state_value::StateValue, TStateView},
     transaction::{
         block_epilogue::TBlockEndInfoExt, BlockExecutableTransaction, BlockOutput, FeeDistribution,
-        Transaction,
     },
     vm::modules::AptosModuleExtension,
     write_set::{TransactionWrite, WriteOp},
@@ -1281,7 +1280,7 @@ where
         shared_counter: &AtomicU32,
         block_limit_processor: &ExplicitSyncWrapper<BlockGasLimitProcessor<T, S>>,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
-        block_epilogue_txn: &ExplicitSyncWrapper<Option<Transaction>>,
+        block_epilogue_txn: &ExplicitSyncWrapper<Option<T>>,
         num_txns_materialized: &AtomicU32,
         total_txns_to_materialize: &AtomicU32,
         num_running_workers: &AtomicU32,
@@ -1371,7 +1370,7 @@ where
                         if Self::execute(
                             num_txns as u32,
                             0,
-                            &T::from_txn(txn.clone()),
+                            &txn,
                             last_input_output,
                             versioned_cache,
                             &executor,
@@ -1669,12 +1668,12 @@ where
         has_remaining_commit_tasks: bool,
         final_results: ExplicitSyncWrapper<Vec<E::Output>>,
         block_limit_processor: ExplicitSyncWrapper<BlockGasLimitProcessor<T, S>>,
-        block_epilogue_txn: Option<Transaction>,
+        block_epilogue_txn: Option<T>,
         mut versioned_cache: MVHashMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
         scheduler: impl Send + 'static,
         last_input_output: TxnLastInputOutput<T, E::Output, E::Error>,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
+    ) -> Result<BlockOutput<T, E::Output>, ()> {
         // Check for errors or remaining commit tasks before any side effects.
         let mut has_error = shared_maybe_error.load(Ordering::SeqCst);
         if !has_error && has_remaining_commit_tasks {
@@ -1721,7 +1720,7 @@ where
         signature_verified_block: &TP,
         base_view: &S,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
+    ) -> Result<BlockOutput<T, E::Output>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // BlockSTMv2 should have less restrictions on the number of workers but we
         // still sanity check that it is not instantiated w. concurrency level 1.
@@ -1820,7 +1819,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> Result<BlockOutput<T::Key, E::Output>, ()> {
+    ) -> Result<BlockOutput<T, E::Output>, ()> {
         let _timer = PARALLEL_EXECUTION_SECONDS.start_timer();
         // Using parallel execution with 1 thread currently will not work as it
         // will only have a coordinator role but no workers for rolling commit.
@@ -1929,7 +1928,7 @@ where
         outputs: &[E::Output],
         block_end_info: TBlockEndInfoExt<T::Key>,
         features: &Features,
-    ) -> Transaction {
+    ) -> T {
         // TODO(grao): Remove this check once AIP-88 is fully enabled.
         if !self
             .config
@@ -1937,10 +1936,10 @@ where
             .block_gas_limit_type
             .add_block_limit_outcome_onchain()
         {
-            return Transaction::StateCheckpoint(block_id);
+            return T::state_checkpoint(block_id);
         }
         if !features.is_calculate_transaction_fee_for_distribution_enabled() {
-            return Transaction::block_epilogue_v0(block_id, block_end_info.to_persistent());
+            return T::block_epilogue_v0(block_id, block_end_info.to_persistent());
         }
 
         let mut amount = BTreeMap::new();
@@ -1995,11 +1994,7 @@ where
                 }
             }
         }
-        Transaction::block_epilogue_v1(
-            block_id,
-            block_end_info.to_persistent(),
-            FeeDistribution::new(amount),
-        )
+        T::block_epilogue_v1(block_id, block_end_info, FeeDistribution::new(amount))
     }
 
     /// Converts module write into cached module representation, and adds it to the module cache.
@@ -2148,7 +2143,7 @@ where
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
         resource_group_bcs_fallback: bool,
-    ) -> Result<BlockOutput<T::Key, E::Output>, SequentialBlockExecutionError<E::Error>> {
+    ) -> Result<BlockOutput<T, E::Output>, SequentialBlockExecutionError<E::Error>> {
         let num_txns = signature_verified_block.num_txns();
 
         if num_txns == 0 {
@@ -2173,14 +2168,12 @@ where
         );
 
         let mut block_epilogue_txn = None;
-        let mut block_epilogue_txn_to_execute;
         let mut idx = 0;
         while idx <= num_txns {
             let txn = if idx != num_txns {
                 signature_verified_block.get_txn(idx as TxnIndex)
             } else if block_epilogue_txn.is_some() {
-                block_epilogue_txn_to_execute = T::from_txn(block_epilogue_txn.clone().unwrap());
-                &block_epilogue_txn_to_execute
+                block_epilogue_txn.as_ref().unwrap()
             } else {
                 break;
             };
@@ -2495,7 +2488,7 @@ where
         base_view: &S,
         transaction_slice_metadata: &TransactionSliceMetadata,
         module_cache_manager_guard: &mut AptosModuleCacheManagerGuard,
-    ) -> BlockExecutionResult<BlockOutput<T::Key, E::Output>, E::Error> {
+    ) -> BlockExecutionResult<BlockOutput<T, E::Output>, E::Error> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         if self.config.local.concurrency_level > 1 {

--- a/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
+++ b/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
@@ -10,7 +10,7 @@ use aptos_types::{
         config::BlockExecutorConfigFromOnchain,
         transaction_slice_metadata::TransactionSliceMetadata,
     },
-    state_store::{state_key::StateKey, StateView},
+    state_store::StateView,
     transaction::{
         block_epilogue::BlockEndInfo, signature_verified_transaction::SignatureVerifiedTransaction,
         BlockOutput, Transaction, TransactionOutput,
@@ -37,7 +37,7 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         let _timer = BLOCK_EXECUTOR_INNER_EXECUTE_BLOCK.start_timer();
 
         // let features = Features::fetch_config(&state_view).unwrap_or_default();
@@ -79,7 +79,7 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
 
         Ok(BlockOutput::new(
             transaction_outputs,
-            Some(block_epilogue_txn),
+            Some(block_epilogue_txn.into()),
             BTreeMap::new(),
         ))
     }

--- a/execution/executor-benchmark/src/native/native_vm.rs
+++ b/execution/executor-benchmark/src/native/native_vm.rs
@@ -90,7 +90,7 @@ impl VMBlockExecutor for NativeVMBlockExecutor {
         state_view: &(impl StateView + Sync),
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         AptosBlockExecutorWrapper::<NativeVMExecutorTask>::execute_block_on_thread_pool::<
             _,
             NoOpTransactionCommitHook<AptosTransactionOutput, VMStatus>,

--- a/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
+++ b/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
@@ -84,7 +84,7 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         let block_epilogue_txn = Transaction::block_epilogue_v0(
             transaction_slice_metadata
                 .append_state_checkpoint_to_block()
@@ -121,7 +121,7 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
 
         Ok(BlockOutput::new(
             transaction_outputs,
-            Some(block_epilogue_txn),
+            Some(block_epilogue_txn.into()),
             BTreeMap::new(),
         ))
     }

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -14,7 +14,7 @@ use aptos_types::{
         transaction_slice_metadata::TransactionSliceMetadata,
     },
     ledger_info::LedgerInfoWithSignatures,
-    state_store::{state_key::StateKey, StateView},
+    state_store::StateView,
     test_helpers::transaction_test_helpers::TEST_BLOCK_EXECUTOR_ONCHAIN_CONFIG,
     transaction::{
         signature_verified_transaction::{
@@ -82,7 +82,7 @@ impl VMBlockExecutor for FakeVM {
         _state_view: &impl StateView,
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         Ok(BlockOutput::new(vec![], None, BTreeMap::new()))
     }
 }

--- a/execution/executor/src/tests/mock_vm/mod.rs
+++ b/execution/executor/src/tests/mock_vm/mod.rs
@@ -75,7 +75,7 @@ impl VMBlockExecutor for MockVM {
         state_view: &impl StateView,
         _onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         // output_cache is used to store the output of transactions so they are visible to later
         // transactions.
         let mut output_cache = HashMap::new();
@@ -214,7 +214,7 @@ impl VMBlockExecutor for MockVM {
 
         Ok(BlockOutput::new(
             outputs,
-            block_epilogue_txn,
+            block_epilogue_txn.map(Into::into),
             BTreeMap::new(),
         ))
     }

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -124,7 +124,7 @@ impl DoGetExecutionOutput {
             .map(|t| t.into_inner())
             .collect_vec();
         if let Some(block_epilogue_txn) = block_epilogue_txn {
-            transactions.push(block_epilogue_txn);
+            transactions.push(block_epilogue_txn.into_inner());
             // TODO(grao): Double check if we want to put anything into AuxiliaryInfo here.
             auxiliary_info.push(AuxiliaryInfo::new_empty());
         }
@@ -242,7 +242,7 @@ impl DoGetExecutionOutput {
         state_view: &CachedStateView,
         onchain_config: BlockExecutorConfigFromOnchain,
         transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>> {
         let _timer = OTHER_TIMERS.timer_with(&["vm_execute_block"]);
         Ok(executor.execute_block(
             txn_provider,

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -30,7 +30,7 @@ use aptos_types::{
         config::BlockExecutorConfigFromOnchain, partitioner::PartitionedTransactions,
         transaction_slice_metadata::TransactionSliceMetadata,
     },
-    state_store::{state_key::StateKey, StateView},
+    state_store::StateView,
     transaction::{
         signature_verified_transaction::SignatureVerifiedTransaction, BlockOutput,
         TransactionOutput,
@@ -59,7 +59,7 @@ impl VMBlockExecutor for PtxBlockExecutor {
         state_view: &(impl StateView + Sync),
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
-    ) -> Result<BlockOutput<StateKey, TransactionOutput>, VMStatus> {
+    ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
         let _timer = TIMER.timer_with(&["block_total"]);
 
         let concurrency_level = AptosVM::get_concurrency_level();

--- a/types/src/transaction/block_output.rs
+++ b/types/src/transaction/block_output.rs
@@ -1,24 +1,32 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use super::Transaction;
+use super::BlockExecutableTransaction;
 use crate::state_store::state_slot::StateSlot;
 use std::{collections::BTreeMap, fmt::Debug};
 
 #[derive(Debug)]
-pub struct BlockOutput<Key, Output: Debug> {
+pub struct BlockOutput<T, Output>
+where
+    T: BlockExecutableTransaction,
+    Output: Debug,
+{
     transaction_outputs: Vec<Output>,
     // A BlockEpilogueTxn might be appended to the block.
     // This field will be None iff the input is not a block, or an epoch change is triggered.
-    block_epilogue_txn: Option<Transaction>,
-    to_make_hot: BTreeMap<Key, StateSlot>,
+    block_epilogue_txn: Option<T>,
+    to_make_hot: BTreeMap<T::Key, StateSlot>,
 }
 
-impl<Key, Output: Debug> BlockOutput<Key, Output> {
+impl<T, Output> BlockOutput<T, Output>
+where
+    T: BlockExecutableTransaction,
+    Output: Debug,
+{
     pub fn new(
         transaction_outputs: Vec<Output>,
-        block_epilogue_txn: Option<Transaction>,
-        to_make_hot: BTreeMap<Key, StateSlot>,
+        block_epilogue_txn: Option<T>,
+        to_make_hot: BTreeMap<T::Key, StateSlot>,
     ) -> Self {
         Self {
             transaction_outputs,
@@ -31,7 +39,7 @@ impl<Key, Output: Debug> BlockOutput<Key, Output> {
         self.transaction_outputs
     }
 
-    pub fn into_inner(self) -> (Vec<Output>, Option<Transaction>, BTreeMap<Key, StateSlot>) {
+    pub fn into_inner(self) -> (Vec<Output>, Option<T>, BTreeMap<T::Key, StateSlot>) {
         (
             self.transaction_outputs,
             self.block_epilogue_txn,

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -54,7 +54,9 @@ pub mod use_case;
 pub mod user_transaction_context;
 pub mod webauthn;
 
-pub use self::block_epilogue::{BlockEndInfo, BlockEpiloguePayload, FeeDistribution};
+pub use self::block_epilogue::{
+    BlockEndInfo, BlockEndInfoExt, BlockEpiloguePayload, FeeDistribution, TBlockEndInfoExt,
+};
 use crate::{
     block_metadata_ext::BlockMetadataExt,
     contract_event::TransactionEvent,
@@ -2861,12 +2863,12 @@ impl Transaction {
 
     pub fn block_epilogue_v1(
         block_id: HashValue,
-        block_end_info: BlockEndInfo,
+        block_end_info: BlockEndInfoExt,
         fee_distribution: FeeDistribution,
     ) -> Self {
         Self::BlockEpilogue(BlockEpiloguePayload::V1 {
             block_id,
-            block_end_info,
+            block_end_info: block_end_info.to_persistent(),
             fee_distribution,
         })
     }
@@ -2979,7 +2981,19 @@ pub trait BlockExecutableTransaction: Sync + Send + Clone + 'static {
         None
     }
 
-    fn from_txn(_txn: Transaction) -> Self {
+    fn state_checkpoint(_block_id: HashValue) -> Self {
+        unimplemented!()
+    }
+
+    fn block_epilogue_v0(_block_id: HashValue, _block_end_info: BlockEndInfo) -> Self {
+        unimplemented!()
+    }
+
+    fn block_epilogue_v1(
+        _block_id: HashValue,
+        _block_end_info: TBlockEndInfoExt<Self::Key>,
+        _fee_distribution: FeeDistribution,
+    ) -> Self {
         unimplemented!()
     }
 }

--- a/types/src/transaction/signature_verified_transaction.rs
+++ b/types/src/transaction/signature_verified_transaction.rs
@@ -4,7 +4,10 @@
 use crate::{
     contract_event::ContractEvent,
     state_store::state_key::StateKey,
-    transaction::{BlockExecutableTransaction, SignedTransaction, Transaction},
+    transaction::{
+        BlockEndInfo, BlockExecutableTransaction, FeeDistribution, SignedTransaction,
+        TBlockEndInfoExt, Transaction,
+    },
     write_set::WriteOp,
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
@@ -106,8 +109,20 @@ impl BlockExecutableTransaction for SignatureVerifiedTransaction {
         }
     }
 
-    fn from_txn(txn: Transaction) -> Self {
-        txn.into()
+    fn state_checkpoint(block_id: HashValue) -> Self {
+        Transaction::StateCheckpoint(block_id).into()
+    }
+
+    fn block_epilogue_v0(block_id: HashValue, block_end_info: BlockEndInfo) -> Self {
+        Transaction::block_epilogue_v0(block_id, block_end_info).into()
+    }
+
+    fn block_epilogue_v1(
+        block_id: HashValue,
+        block_end_info: TBlockEndInfoExt<Self::Key>,
+        fee_distribution: FeeDistribution,
+    ) -> Self {
+        Transaction::block_epilogue_v1(block_id, block_end_info, fee_distribution).into()
     }
 }
 


### PR DESCRIPTION

For hot state, later we need to save the promoted / evicted keys inside the
epilogue transaction, in order to use them during state sync. So the first step
is that we pass BlockEndInfoExt when constructing block epilogue.
