### PR TITLE
[Hot State] Record read-only promotions in BlockEndInfo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4655,7 +4655,6 @@ dependencies = [
  "criterion",
  "dashmap 7.0.0-rc2",
  "derivative",
- "derive_more 0.99.17",
  "fixed",
  "fxhash",
  "hashbrown 0.14.3",

--- a/aptos-move/aptos-vm/src/block_executor/mod.rs
+++ b/aptos-move/aptos-vm/src/block_executor/mod.rs
@@ -30,7 +30,7 @@ use aptos_types::{
         signature_verified_transaction::SignatureVerifiedTransaction, BlockOutput,
         TransactionOutput, TransactionStatus,
     },
-    write_set::{HotStateOp, WriteOp},
+    write_set::WriteOp,
 };
 use aptos_vm_logging::{flush_speculative_logs, init_speculative_logs};
 use aptos_vm_types::{
@@ -553,28 +553,11 @@ impl<
         );
         match ret {
             Ok(block_output) => {
-                let (transaction_outputs, block_epilogue_txn, to_make_hot) =
-                    block_output.into_inner();
-                let mut output_vec: Vec<_> = transaction_outputs
+                let (transaction_outputs, block_epilogue_txn) = block_output.into_inner();
+                let output_vec: Vec<_> = transaction_outputs
                     .into_iter()
                     .map(|output| output.take_output())
                     .collect();
-                if block_epilogue_txn.is_some() {
-                    // Attach the hotness changes to block epilogue's output.
-                    let epilogue_output = output_vec
-                        .last_mut()
-                        .expect("transaction_outputs must be non-empty when epilogue exists");
-                    assert!(
-                        epilogue_output.status().is_kept(),
-                        "Block epilogue must be kept."
-                    );
-                    epilogue_output.add_hotness(
-                        to_make_hot
-                            .into_iter()
-                            .map(|(key, slot)| (key, HotStateOp::make_hot(slot)))
-                            .collect(),
-                    );
-                }
 
                 // Flush the speculative logs of the committed transactions.
                 let pos = output_vec.partition_point(|o| !o.status().is_retry());
@@ -585,11 +568,7 @@ impl<
                     flush_speculative_logs(pos);
                 }
 
-                Ok(BlockOutput::new(
-                    output_vec,
-                    block_epilogue_txn,
-                    BTreeMap::new(),
-                ))
+                Ok(BlockOutput::new(output_vec, block_epilogue_txn))
             },
             Err(BlockExecutionError::FatalBlockExecutorError(PanicError::CodeInvariantError(
                 err_msg,

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -292,10 +292,11 @@ impl<'s, T: Transaction, S: TStateView<Key = T::Key>> BlockGasLimitProcessor<'s,
             block_approx_output_size: self.get_accumulated_approx_output_size(),
         };
 
-        TBlockEndInfoExt::new(inner)
+        let to_make_hot = self.get_slots_to_make_hot();
+        TBlockEndInfoExt::new(inner, to_make_hot)
     }
 
-    pub(crate) fn get_slots_to_make_hot(&self) -> BTreeMap<T::Key, StateSlot> {
+    fn get_slots_to_make_hot(&self) -> BTreeMap<T::Key, StateSlot> {
         if self.hot_state_op_accumulator.is_none() {
             warn!("BlockHotStateOpAccumulator is not set.");
         }

--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -90,7 +90,7 @@ fn test_block_epilogue_happy_path() {
                 false,
             )
             .unwrap();
-        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
+        let (output, block_epilogue_txn) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -108,7 +108,7 @@ fn test_block_epilogue_happy_path() {
                 &mut guard,
             )
             .unwrap();
-        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
+        let (output, block_epilogue_txn) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -157,7 +157,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
                 false,
             )
             .unwrap();
-        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
+        let (output, block_epilogue_txn) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);
@@ -175,7 +175,7 @@ fn test_block_epilogue_block_gas_limit_reached() {
                 &mut guard,
             )
             .unwrap();
-        let (output, block_epilogue_txn, _to_make_hot) = result.into_inner();
+        let (output, block_epilogue_txn) = result.into_inner();
         assert!(block_epilogue_txn.is_some());
         assert_eq!(output.len(), 3);
         assert!(!output[0].skipped);

--- a/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
+++ b/execution/executor-benchmark/src/native/aptos_vm_uncoordinated.rs
@@ -22,7 +22,6 @@ use aptos_vm_environment::environment::AptosEnvironment;
 use aptos_vm_logging::log_schema::AdapterLogSchema;
 use aptos_vm_types::module_and_script_storage::AsAptosCodeStorage;
 use rayon::iter::{IndexedParallelIterator, IntoParallelRefIterator, ParallelIterator};
-use std::collections::BTreeMap;
 
 pub struct AptosVMParallelUncoordinatedBlockExecutor;
 
@@ -80,7 +79,6 @@ impl VMBlockExecutor for AptosVMParallelUncoordinatedBlockExecutor {
         Ok(BlockOutput::new(
             transaction_outputs,
             Some(block_epilogue_txn.into()),
-            BTreeMap::new(),
         ))
     }
 }

--- a/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
+++ b/execution/executor-benchmark/src/native/parallel_uncoordinated_block_executor.rs
@@ -122,7 +122,6 @@ impl<E: RawTransactionExecutor + Sync + Send> VMBlockExecutor
         Ok(BlockOutput::new(
             transaction_outputs,
             Some(block_epilogue_txn.into()),
-            BTreeMap::new(),
         ))
     }
 }

--- a/execution/executor/src/fuzzing.rs
+++ b/execution/executor/src/fuzzing.rs
@@ -28,7 +28,7 @@ use aptos_vm::{
     sharded_block_executor::{executor_client::ExecutorClient, ShardedBlockExecutor},
     VMBlockExecutor,
 };
-use std::{collections::BTreeMap, sync::Arc};
+use std::sync::Arc;
 
 fn create_test_executor() -> BlockExecutor<FakeVM> {
     // setup fake db
@@ -83,7 +83,7 @@ impl VMBlockExecutor for FakeVM {
         _onchain_config: BlockExecutorConfigFromOnchain,
         _transaction_slice_metadata: TransactionSliceMetadata,
     ) -> Result<BlockOutput<SignatureVerifiedTransaction, TransactionOutput>, VMStatus> {
-        Ok(BlockOutput::new(vec![], None, BTreeMap::new()))
+        Ok(BlockOutput::new(vec![], None))
     }
 }
 

--- a/execution/executor/src/tests/mock_vm/mod.rs
+++ b/execution/executor/src/tests/mock_vm/mod.rs
@@ -36,10 +36,7 @@ use aptos_vm::{
 };
 use move_core_types::language_storage::TypeTag;
 use once_cell::sync::Lazy;
-use std::{
-    collections::{BTreeMap, HashMap},
-    sync::Arc,
-};
+use std::{collections::HashMap, sync::Arc};
 
 #[derive(Debug)]
 enum MockVMTransaction {
@@ -215,7 +212,6 @@ impl VMBlockExecutor for MockVM {
         Ok(BlockOutput::new(
             outputs,
             block_epilogue_txn.map(Into::into),
-            BTreeMap::new(),
         ))
     }
 

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -45,7 +45,7 @@ use aptos_types::{
         signature_verified_transaction::SignatureVerifiedTransaction, AuxiliaryInfo, BlockOutput,
         PersistedAuxiliaryInfo, Transaction, TransactionOutput, TransactionStatus, Version,
     },
-    write_set::{TransactionWrite, WriteSet},
+    write_set::{HotStateOp, TransactionWrite, WriteSet},
 };
 use aptos_vm::VMBlockExecutor;
 use itertools::Itertools;
@@ -117,7 +117,7 @@ impl DoGetExecutionOutput {
             onchain_config,
             transaction_slice_metadata,
         )?;
-        let (transaction_outputs, block_epilogue_txn, _) = block_output.into_inner();
+        let (mut transaction_outputs, block_epilogue_txn) = block_output.into_inner();
         let (transactions, mut auxiliary_info) = txn_provider.into_inner();
         let mut transactions = transactions
             .into_iter()
@@ -127,6 +127,32 @@ impl DoGetExecutionOutput {
             transactions.push(block_epilogue_txn.into_inner());
             // TODO(grao): Double check if we want to put anything into AuxiliaryInfo here.
             auxiliary_info.push(AuxiliaryInfo::new_empty());
+        }
+
+        // Manually create hotness write sets for block epilogue transaction(s), based on the block
+        // end info saved. Note that even if we are re-executing transactions during a state sync,
+        // the block end info is not re-computed and has to come from the previous execution.
+        //
+        // If the input transactions are from a normal block, the last one should be the epilogue.
+        // If they are from a chunk (i.e. we are re-executing transactions during state sync), then
+        // there could be zero or more block epilogue transactions, and we need to handle all of
+        // them.
+        //
+        // TODO(HotState): it might be better to do this in AptosVM::execute_single_transaction,
+        // but we need to figure out how to properly construct `VMOutput` from block end info.
+        for (transaction, output) in transactions.iter().zip_eq(transaction_outputs.iter_mut()) {
+            if let Transaction::BlockEpilogue(payload) = transaction {
+                assert!(output.status().is_kept(), "Block epilogue must be kept");
+                output.add_hotness(
+                    payload
+                        .try_get_slots_to_make_hot()
+                        .cloned()
+                        .unwrap_or_default()
+                        .into_iter()
+                        .map(|(key, slot)| (key, HotStateOp::make_hot(slot)))
+                        .collect(),
+                );
+            }
         }
 
         Parser::parse(

--- a/experimental/execution/ptx-executor/src/lib.rs
+++ b/experimental/execution/ptx-executor/src/lib.rs
@@ -41,10 +41,7 @@ use aptos_vm::{
     AptosVM, VMBlockExecutor,
 };
 use move_core_types::vm_status::VMStatus;
-use std::{
-    collections::BTreeMap,
-    sync::{mpsc::channel, Arc},
-};
+use std::sync::{mpsc::channel, Arc};
 
 pub struct PtxBlockExecutor;
 
@@ -109,7 +106,7 @@ impl VMBlockExecutor for PtxBlockExecutor {
             ret_clone.lock().replace(txn_outputs);
         });
         let ret = ret.lock().take().unwrap();
-        Ok(BlockOutput::new(ret, None, BTreeMap::new()))
+        Ok(BlockOutput::new(ret, None))
     }
 
     fn execute_block_sharded<S: StateView + Sync + Send + 'static, E: ExecutorClient<S>>(

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -34,7 +34,6 @@ chrono = { workspace = true }
 chrono-tz = { workspace = true }
 dashmap = { workspace = true }
 derivative = { workspace = true }
-derive_more = { workspace = true }
 fixed = { workspace = true }
 fxhash = { workspace = true }
 hashbrown = { workspace = true }

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -1,13 +1,14 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::state_store::state_key::StateKey;
+use crate::state_store::{state_key::StateKey, state_slot::StateSlot};
 use aptos_crypto::HashValue;
-use derive_more::Deref;
+#[cfg(any(test, feature = "fuzzing"))]
+use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug, marker::PhantomData};
+use std::{collections::BTreeMap, fmt::Debug};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -18,7 +19,7 @@ pub enum BlockEpiloguePayload {
     },
     V1 {
         block_id: HashValue,
-        block_end_info: BlockEndInfo,
+        block_end_info: BlockEndInfoExt,
         fee_distribution: FeeDistribution,
     },
 }
@@ -27,7 +28,14 @@ impl BlockEpiloguePayload {
     pub fn try_as_block_end_info(&self) -> Option<&BlockEndInfo> {
         match self {
             BlockEpiloguePayload::V0 { block_end_info, .. } => Some(block_end_info),
-            BlockEpiloguePayload::V1 { block_end_info, .. } => Some(block_end_info),
+            BlockEpiloguePayload::V1 { block_end_info, .. } => Some(&block_end_info.inner),
+        }
+    }
+
+    pub fn try_get_slots_to_make_hot(&self) -> Option<&BTreeMap<StateKey, StateSlot>> {
+        match self {
+            Self::V0 { .. } => None,
+            Self::V1 { block_end_info, .. } => Some(&block_end_info.to_make_hot),
         }
     }
 }
@@ -94,33 +102,66 @@ impl BlockEndInfo {
 
 /// Wrapper type to temporarily host the hot_state_ops which will not serialize until
 /// the hot state is made entirely deterministic
-/// TODO(HotState): maybe get rid of this struct now that it doesn't have anything more than
-/// `BlockEndInfo`?
-#[derive(Debug, Deref)]
-pub struct TBlockEndInfoExt<Key: Debug> {
-    #[deref]
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct TBlockEndInfoExt<Key: Debug + Ord> {
     inner: BlockEndInfo,
-    _phantom: PhantomData<Key>,
+    to_make_hot: BTreeMap<Key, StateSlot>,
 }
 
 pub type BlockEndInfoExt = TBlockEndInfoExt<StateKey>;
 
-impl<Key: Debug> TBlockEndInfoExt<Key> {
+impl<Key: Debug + Ord> TBlockEndInfoExt<Key> {
     pub fn new_empty() -> Self {
         Self {
             inner: BlockEndInfo::new_empty(),
-            _phantom: PhantomData,
+            to_make_hot: BTreeMap::new(),
         }
     }
 
-    pub fn new(inner: BlockEndInfo) -> Self {
-        Self {
-            inner,
-            _phantom: PhantomData,
-        }
+    pub fn new(inner: BlockEndInfo, to_make_hot: BTreeMap<Key, StateSlot>) -> Self {
+        Self { inner, to_make_hot }
     }
 
     pub fn to_persistent(&self) -> BlockEndInfo {
         self.inner.clone()
+    }
+}
+
+impl<Key> Serialize for TBlockEndInfoExt<Key>
+where
+    Key: Debug + Ord,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        self.inner.serialize(serializer)
+    }
+}
+
+impl<'de, Key> Deserialize<'de> for TBlockEndInfoExt<Key>
+where
+    Key: Debug + Ord,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let inner = BlockEndInfo::deserialize(deserializer)?;
+        Ok(Self::new(inner, BTreeMap::new()))
+    }
+}
+
+#[cfg(any(test, feature = "fuzzing"))]
+impl<Key: Debug + Ord> Arbitrary for TBlockEndInfoExt<Key> {
+    type Parameters = ();
+    type Strategy = BoxedStrategy<Self>;
+
+    fn arbitrary_with(_args: Self::Parameters) -> Self::Strategy {
+        // TODO(HotState): it's used in db tests (encode/decode), so we need to make sure that
+        // serializing the data and then deserializing it reproduces the original value.
+        any::<BlockEndInfo>()
+            .prop_map(|inner| Self::new(inner, BTreeMap::new()))
+            .boxed()
     }
 }

--- a/types/src/transaction/block_output.rs
+++ b/types/src/transaction/block_output.rs
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::BlockExecutableTransaction;
-use crate::state_store::state_slot::StateSlot;
-use std::{collections::BTreeMap, fmt::Debug};
+use std::fmt::Debug;
 
 #[derive(Debug)]
 pub struct BlockOutput<T, Output>
@@ -15,7 +14,6 @@ where
     // A BlockEpilogueTxn might be appended to the block.
     // This field will be None iff the input is not a block, or an epoch change is triggered.
     block_epilogue_txn: Option<T>,
-    to_make_hot: BTreeMap<T::Key, StateSlot>,
 }
 
 impl<T, Output> BlockOutput<T, Output>
@@ -23,15 +21,10 @@ where
     T: BlockExecutableTransaction,
     Output: Debug,
 {
-    pub fn new(
-        transaction_outputs: Vec<Output>,
-        block_epilogue_txn: Option<T>,
-        to_make_hot: BTreeMap<T::Key, StateSlot>,
-    ) -> Self {
+    pub fn new(transaction_outputs: Vec<Output>, block_epilogue_txn: Option<T>) -> Self {
         Self {
             transaction_outputs,
             block_epilogue_txn,
-            to_make_hot,
         }
     }
 
@@ -39,12 +32,8 @@ where
         self.transaction_outputs
     }
 
-    pub fn into_inner(self) -> (Vec<Output>, Option<T>, BTreeMap<T::Key, StateSlot>) {
-        (
-            self.transaction_outputs,
-            self.block_epilogue_txn,
-            self.to_make_hot,
-        )
+    pub fn into_inner(self) -> (Vec<Output>, Option<T>) {
+        (self.transaction_outputs, self.block_epilogue_txn)
     }
 
     pub fn get_transaction_outputs_forced(&self) -> &[Output] {

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -2868,7 +2868,7 @@ impl Transaction {
     ) -> Self {
         Self::BlockEpilogue(BlockEpiloguePayload::V1 {
             block_id,
-            block_end_info: block_end_info.to_persistent(),
+            block_end_info,
             fee_distribution,
         })
     }


### PR DESCRIPTION

The previous approach in #17136 was to put `to_make_hot: Map<Key, Slot>` in `BlockOutput`, and let
`execute_block` compute and return this information.

It works for normal block execution. But if we are doing state sync and want to re-execute
transactions, it will not work, because it's hard to compute this information given a transaction
chunk. Therefore we still need to record this information in block epilogue transactions and simply
reuse them during re-execution.

For now it's in `TBlockEndInfoExt`, and it's not serialized or persisted until later.
