### PR TITLE
BlockSTMv2 PR [10.9/n] Improve TxnLastInputOutput and output traits

### DIFF
--- a/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
+++ b/aptos-move/block-executor/src/combinatorial_tests/mock_executor.rs
@@ -7,7 +7,10 @@ use crate::{
         DeltaTestKind, GroupSizeOrMetadata, MockIncarnation, MockTransaction, ValueType,
         RESERVED_TAG,
     },
-    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
+    task::{
+        AfterMaterializationOutput, BeforeMaterializationOutput, ExecutionStatus, ExecutorTask,
+        TransactionOutput,
+    },
     types::delayed_field_mock_serialization::{
         deserialize_to_delayed_field_id, serialize_from_delayed_field_id,
     },
@@ -25,7 +28,7 @@ use aptos_types::{
     executable::ModulePath,
     fee_statement::FeeStatement,
     state_store::{state_value::StateValueMetadata, TStateView},
-    transaction::{AuxiliaryInfo, BlockExecutableTransaction as Transaction},
+    transaction::AuxiliaryInfo,
     write_set::{TransactionWrite, WriteOp, WriteOpKind},
 };
 use aptos_vm_environment::environment::AptosEnvironment;
@@ -694,15 +697,12 @@ impl<K, E> MockOutput<K, E> {
     }
 }
 
-/// Wrapper that provides AsRef access to module write set without cloning.
-struct ModuleWriteSetRefWrapper<'a, K, V> {
-    writes: &'a BTreeMap<K, ModuleWrite<V>>,
-}
-
-impl<'a, K, V> AsRef<BTreeMap<K, ModuleWrite<V>>> for ModuleWriteSetRefWrapper<'a, K, V> {
-    fn as_ref(&self) -> &BTreeMap<K, ModuleWrite<V>> {
-        self.writes
-    }
+fn mock_fee_statement(total_gas: u64) -> FeeStatement {
+    // First argument is supposed to be total (not important for the test though).
+    // Next two arguments are different kinds of execution gas that are counted
+    // towards the block limit. We split the total into two pieces for these arguments.
+    // TODO: add variety to generating fee statement based on total gas.
+    FeeStatement::new(total_gas, total_gas / 2, (total_gas + 1) / 2, 0, 0)
 }
 
 impl<K, E> TransactionOutput for MockOutput<K, E>
@@ -710,11 +710,61 @@ where
     K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
     E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
 {
+    type AfterMaterializationGuard<'a> = &'a Self;
+    type BeforeMaterializationGuard<'a> = &'a Self;
     type Txn = MockTransaction<K, E>;
 
-    // TODO[agg_v2](tests): Assigning MoveTypeLayout as None for all the writes for now.
-    // That means, the resources do not have any DelayedFields embedded in them.
-    // Change it to test resources with DelayedFields as well.
+    fn skip_output() -> Self {
+        Self::skipped_output(None)
+    }
+
+    fn discard_output(discard_code: StatusCode) -> Self {
+        Self::with_discard_code(discard_code)
+    }
+
+    fn before_materialization(&self) -> Result<Self::BeforeMaterializationGuard<'_>, PanicError> {
+        Ok(self)
+    }
+
+    fn after_materialization(&self) -> Result<Self::AfterMaterializationGuard<'_>, PanicError> {
+        Ok(self)
+    }
+
+    fn legacy_sequential_materialize_agg_v1(&self, _view: &impl TAggregatorV1View<Identifier = K>) {
+        // TODO[agg_v2](tests): implement this method and compare
+        // against sequential execution results v. aggregator v1.
+    }
+
+    fn incorporate_materialized_txn_output(
+        &self,
+        aggregator_v1_writes: Vec<(K, WriteOp)>,
+        patched_resource_write_set: Vec<(K, ValueType)>,
+        _patched_events: Vec<E>,
+    ) -> Result<(), PanicError> {
+        assert_ok!(self
+            .patched_resource_write_set
+            .set(patched_resource_write_set.clone().into_iter().collect()));
+        assert_ok!(self.materialized_delta_writes.set(aggregator_v1_writes));
+        // TODO: Also test patched events.
+        Ok(())
+    }
+
+    fn set_txn_output_for_non_dynamic_change_set(&self) {
+        // No compatibility issues here since the move-vm doesn't use the dynamic flag.
+    }
+
+    fn is_materialized_and_success(&self) -> bool {
+        // TODO(BlockSTMv2): Actually test that materialize is called.
+        // A skipped transaction is not a success.
+        !self.skipped
+    }
+}
+
+impl<'a, K, E> BeforeMaterializationOutput<MockTransaction<K, E>> for &'a MockOutput<K, E>
+where
+    K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
+    E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
+{
     fn resource_write_set(&self) -> Vec<(K, Arc<ValueType>, Option<Arc<MoveTypeLayout>>)> {
         self.writes
             .iter()
@@ -724,14 +774,10 @@ where
             .collect()
     }
 
-    fn module_write_set(&self) -> impl AsRef<BTreeMap<K, ModuleWrite<ValueType>>> + '_ {
-        ModuleWriteSetRefWrapper {
-            writes: &self.module_writes,
-        }
+    fn module_write_set(&self) -> &BTreeMap<K, ModuleWrite<ValueType>> {
+        &self.module_writes
     }
 
-    // Aggregator v1 writes are included in resource_write_set for tests (writes are produced
-    // for all keys including ones for v1_aggregators without distinguishing).
     fn aggregator_v1_write_set(&self) -> BTreeMap<K, ValueType> {
         self.aggregator_v1_writes.clone().into_iter().collect()
     }
@@ -773,20 +819,14 @@ where
 
     fn reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        StateValueMetadata,
-        Arc<MoveTypeLayout>,
-    )> {
+    ) -> Vec<(K, StateValueMetadata, Arc<MoveTypeLayout>)> {
         self.reads_needing_exchange
             .iter()
             .map(|(key, (metadata, layout))| (key.clone(), metadata.clone(), layout.clone()))
             .collect()
     }
 
-    fn group_reads_needing_delayed_field_exchange(
-        &self,
-    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata)> {
+    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(K, StateValueMetadata)> {
         self.group_reads_needing_exchange
             .iter()
             .map(|(key, metadata)| (key.clone(), metadata.clone()))
@@ -819,90 +859,42 @@ where
         Ok(())
     }
 
-    fn skip_output() -> Self {
-        Self::skipped_output(None)
-    }
-
-    fn discard_output(discard_code: StatusCode) -> Self {
-        Self::with_discard_code(discard_code)
-    }
-
     fn output_approx_size(&self) -> u64 {
         // TODO add block output limit testing
         0
     }
 
-    fn get_write_summary(
-        &self,
-    ) -> HashSet<
-        crate::types::InputOutputKey<
-            <Self::Txn as Transaction>::Key,
-            <Self::Txn as Transaction>::Tag,
-        >,
-    > {
+    fn get_write_summary(&self) -> HashSet<crate::types::InputOutputKey<K, u32>> {
         _ = self.called_write_summary.set(());
         HashSet::new()
     }
 
-    fn legacy_sequential_materialize_agg_v1(
-        &self,
-        _view: &impl TAggregatorV1View<Identifier = <Self::Txn as Transaction>::Key>,
-    ) {
-        // TODO[agg_v2](tests): implement this method and compare
-        // against sequential execution results v. aggregator v1.
-    }
-
-    // TODO[agg_v2](tests): Currently, appending None to all events, which means none of the
-    // events have aggregators. Test it with aggregators as well.
     fn get_events(&self) -> Vec<(E, Option<MoveTypeLayout>)> {
         self.events.iter().map(|e| (e.clone(), None)).collect()
     }
 
-    fn incorporate_materialized_txn_output(
-        &self,
-        aggregator_v1_writes: Vec<(<Self::Txn as Transaction>::Key, WriteOp)>,
-        patched_resource_write_set: Vec<(
-            <Self::Txn as Transaction>::Key,
-            <Self::Txn as Transaction>::Value,
-        )>,
-        _patched_events: Vec<<Self::Txn as Transaction>::Event>,
-    ) -> Result<(), PanicError> {
-        assert_ok!(self
-            .patched_resource_write_set
-            .set(patched_resource_write_set.clone().into_iter().collect()));
-        assert_ok!(self.materialized_delta_writes.set(aggregator_v1_writes));
-        // TODO: Also test patched events.
-        Ok(())
-    }
-
-    fn set_txn_output_for_non_dynamic_change_set(&self) {
-        // No compatibility issues here since the move-vm doesn't use the dynamic flag.
-    }
-
     fn fee_statement(&self) -> FeeStatement {
-        // First argument is supposed to be total (not important for the test though).
-        // Next two arguments are different kinds of execution gas that are counted
-        // towards the block limit. We split the total into two pieces for these arguments.
-        // TODO: add variety to generating fee statement based on total gas.
-        FeeStatement::new(
-            self.total_gas,
-            self.total_gas / 2,
-            (self.total_gas + 1) / 2,
-            0,
-            0,
-        )
-    }
-
-    fn is_retry(&self) -> bool {
-        self.skipped
+        mock_fee_statement(self.total_gas)
     }
 
     fn has_new_epoch_event(&self) -> bool {
+        // For tests, it is ok to return false.
         false
     }
+}
 
-    fn is_success(&self) -> bool {
-        !self.skipped
+impl<'a, K, E> AfterMaterializationOutput<MockTransaction<K, E>> for &'a MockOutput<K, E>
+where
+    K: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + ModulePath + Debug + 'static,
+    E: Send + Sync + Debug + Clone + TransactionEvent + 'static,
+{
+    fn fee_statement(&self) -> FeeStatement {
+        mock_fee_statement(self.total_gas)
+    }
+
+    fn has_new_epoch_event(&self) -> bool {
+        // For tests, it is ok to return false.
+        false
     }
 }
 

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -18,7 +18,10 @@ use crate::{
     scheduler::{DependencyStatus, ExecutionTaskType, Scheduler, SchedulerTask, Wave},
     scheduler_v2::{AbortManager, SchedulerV2, TaskKind},
     scheduler_wrapper::SchedulerWrapper,
-    task::{ExecutionStatus, ExecutorTask, TransactionOutput},
+    task::{
+        AfterMaterializationOutput, BeforeMaterializationOutput, ExecutionStatus, ExecutorTask,
+        TransactionOutput,
+    },
     txn_commit_hook::TransactionCommitHook,
     txn_last_input_output::TxnLastInputOutput,
     txn_provider::TxnProvider,
@@ -176,8 +179,11 @@ where
         // previous tags.
         // TODO(BlockSTMv2): consider similar flow for resources.
 
-        let mut resource_group_write_set =
-            maybe_output.map_or(HashMap::new(), |output| output.resource_group_write_set());
+        let mut resource_group_write_set = maybe_output.map_or(Ok(HashMap::new()), |output| {
+            output
+                .before_materialization()
+                .map(|inner| inner.resource_group_write_set())
+        })?;
 
         last_input_output.for_each_resource_group_key_and_tags(
             idx_to_execute,
@@ -281,7 +287,8 @@ where
         // }
 
         if let Some(output) = maybe_output {
-            for (id, change) in output.delayed_field_change_set().into_iter() {
+            let output_before_guard = output.before_materialization()?;
+            for (id, change) in output_before_guard.delayed_field_change_set().into_iter() {
                 prev_modified_delayed_fields.remove(&id);
 
                 let entry = change.into_entry_no_additional_history();
@@ -389,10 +396,10 @@ where
             .map_or_else(HashSet::new, |keys| keys.collect());
 
         // TODO: BlockSTMv2: use estimates for delayed field reads? (see V1 update on abort).
-        let mut resource_write_set = vec![];
         if let Some(output) = maybe_output {
-            resource_write_set = output.resource_write_set();
-            for (key, value, maybe_layout) in resource_write_set.clone().into_iter() {
+            let output_before_guard = output.before_materialization()?;
+
+            for (key, value, maybe_layout) in output_before_guard.resource_write_set().into_iter() {
                 prev_modified_resource_keys.remove(&key);
                 abort_manager.invalidate_dependencies(
                     versioned_cache.data().write_v2::<false>(
@@ -408,7 +415,7 @@ where
             // Apply aggregator v1 writes and deltas, using versioned data's V1 (write/add_delta) APIs.
             // AggregatorV1 is not push-validated, but follows the same logic as delayed fields, i.e.
             // commit-time validation in BlockSTMv2.
-            for (key, value) in output.aggregator_v1_write_set().into_iter() {
+            for (key, value) in output_before_guard.aggregator_v1_write_set().into_iter() {
                 prev_modified_aggregator_v1_keys.remove(&key);
 
                 versioned_cache.data().write(
@@ -419,7 +426,7 @@ where
                     None,
                 );
             }
-            for (key, delta) in output.aggregator_v1_delta_set().into_iter() {
+            for (key, delta) in output_before_guard.aggregator_v1_delta_set().into_iter() {
                 prev_modified_aggregator_v1_keys.remove(&key);
                 versioned_cache.data().add_delta(key, idx_to_execute, delta);
             }
@@ -438,12 +445,7 @@ where
             versioned_cache.data().remove(&key, idx_to_execute);
         }
 
-        last_input_output.record(
-            idx_to_execute,
-            read_set,
-            execution_result,
-            resource_write_set,
-        );
+        last_input_output.record(idx_to_execute, read_set, execution_result);
 
         // It is important to call finish_execution after recording the input/output.
         if let Some(module_validation_requirements) = scheduler.finish_execution(abort_manager)? {
@@ -534,8 +536,9 @@ where
             Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>, // Cached resource writes
             PanicError,
         > {
+            let output_before_guard = output.before_materialization()?;
             for (group_key, (group_metadata_op, group_size, group_ops)) in
-                output.resource_group_write_set().into_iter()
+                output_before_guard.resource_group_write_set().into_iter()
             {
                 let prev_tags = prev_modified_group_keys
                     .remove(&group_key)
@@ -566,11 +569,11 @@ where
                 }
             }
 
-            let resource_write_set = output.resource_write_set();
+            let resource_write_set = output_before_guard.resource_write_set();
 
             // Then, process resource & aggregator_v1 writes.
             for (k, v, maybe_layout) in resource_write_set.clone().into_iter().chain(
-                output
+                output_before_guard
                     .aggregator_v1_write_set()
                     .into_iter()
                     .map(|(state_key, write_op)| (state_key, Arc::new(write_op), None)),
@@ -584,7 +587,7 @@ where
             }
 
             // Then, apply deltas.
-            for (k, d) in output.aggregator_v1_delta_set().into_iter() {
+            for (k, d) in output_before_guard.aggregator_v1_delta_set().into_iter() {
                 if !prev_modified_resource_keys.remove(&k) {
                     needs_suffix_validation = true;
                 }
@@ -594,10 +597,9 @@ where
             Ok(resource_write_set)
         };
 
-        let resource_write_set = match processed_output {
-            Some(output) => apply_updates(output)?,
-            None => vec![],
-        };
+        if let Some(output) = processed_output {
+            apply_updates(output)?;
+        }
 
         // Remove entries from previous write/delta set that were not overwritten.
         for k in prev_modified_resource_keys {
@@ -623,12 +625,7 @@ where
                 .remove(&k, idx_to_execute, tags);
         }
 
-        last_input_output.record(
-            idx_to_execute,
-            read_set,
-            execution_result,
-            resource_write_set,
-        );
+        last_input_output.record(idx_to_execute, read_set, execution_result);
         Ok(needs_suffix_validation)
     }
 
@@ -866,7 +863,7 @@ where
         executor: &E,
         block: &TP,
         num_workers: usize,
-    ) -> Result<(), PanicOr<ParallelBlockExecutionError>> {
+    ) -> Result<bool, PanicOr<ParallelBlockExecutionError>> {
         let block_limit_processor = &mut block_limit_processor.acquire();
         let mut side_effect_at_commit = false;
 
@@ -960,69 +957,15 @@ where
             scheduler.wake_dependencies_and_decrease_validation_idx(txn_idx)?;
         }
 
-        last_input_output
-            .check_fatal_vm_error(txn_idx)
-            .map_err(PanicOr::Or)?;
-        // Handle a potential vm error, then check invariants on the recorded outputs.
-        last_input_output.check_execution_status_during_commit(txn_idx)?;
-
-        if let Some(fee_statement) = last_input_output.fee_statement(txn_idx) {
-            let approx_output_size = block_gas_limit_type.block_output_limit().and_then(|_| {
-                last_input_output
-                    .output_approx_size(txn_idx)
-                    .map(|approx_output| {
-                        approx_output
-                            + if block_gas_limit_type.include_user_txn_size_in_block_output() {
-                                block.get_txn(txn_idx).user_txn_bytes_len()
-                            } else {
-                                0
-                            } as u64
-                    })
-            });
-            let txn_read_write_summary = block_gas_limit_type
-                .conflict_penalty_window()
-                .map(|_| last_input_output.get_txn_read_write_summary(txn_idx));
-
-            // For committed txns with Success status, calculate the accumulated gas costs.
-            block_limit_processor.accumulate_fee_statement(
-                fee_statement,
-                txn_read_write_summary,
-                approx_output_size,
-            );
-
-            if txn_idx < num_txns - 1 && block_limit_processor.should_end_block_parallel() {
-                // Set the execution output status to be SkipRest, to skip the rest of the txns.
-                last_input_output.update_to_skip_rest(txn_idx)?;
-            }
-        }
-
-        let skips = last_input_output.block_skips_rest_at_idx(txn_idx);
-
-        // Add before halt, so SchedulerV2 can organically observe and process post commit
-        // processing tasks even after it has halted.
-        scheduler.add_to_post_commit(txn_idx)?;
-
-        // While the above propagate errors and lead to eventually halting parallel execution,
-        // below we may halt the execution without an error in cases when:
-        // a) all transactions are scheduled for committing
-        // b) we skip_rest after a transaction
-        // Either all txn committed, or a committed txn caused an early halt.
-        if (txn_idx + 1 == num_txns || skips) && scheduler.halt() {
-            block_limit_processor.finish_parallel_update_counters_and_log_info(
-                txn_idx + 1,
-                num_txns,
-                num_workers,
-            );
-
-            // failpoint triggering error at the last committed transaction,
-            // to test that next transaction is handled correctly
-            fail_point!("commit-all-halt-err", |_| Err(code_invariant_error(
-                "fail points: Last committed transaction halted"
-            )
-            .into()));
-        }
-
-        Ok(())
+        last_input_output.commit(
+            txn_idx,
+            num_txns,
+            num_workers,
+            block.get_txn(txn_idx).user_txn_bytes_len() as u64,
+            block_gas_limit_type,
+            block_limit_processor,
+            &scheduler,
+        )
     }
 
     fn materialize_aggregator_v1_delta_writes(
@@ -1161,7 +1104,7 @@ where
                 code_invariant_error(format!("Panic error in serializing groups {e:?}"))
             })?;
 
-        let resource_write_set = last_input_output.take_resource_write_set(txn_idx);
+        let resource_write_set = last_input_output.resource_write_set(txn_idx)?;
         let resource_writes_to_materialize = resource_writes_to_materialize!(
             resource_write_set,
             last_input_output,
@@ -1248,6 +1191,7 @@ where
         shared_counter: &AtomicU32,
         block_limit_processor: &ExplicitSyncWrapper<BlockGasLimitProcessor<T, S>>,
         final_results: &ExplicitSyncWrapper<Vec<E::Output>>,
+        maybe_block_epilogue_txn_idx: &ExplicitSyncWrapper<Option<TxnIndex>>,
         block_epilogue_txn: &ExplicitSyncWrapper<Option<T>>,
         num_txns_materialized: &AtomicU32,
         total_txns_to_materialize: &AtomicU32,
@@ -1306,14 +1250,17 @@ where
                 }
 
                 let mut outputs = final_results.acquire();
-                let has_reconfig = outputs
-                    .iter()
-                    .rposition(|t| !t.is_retry())
-                    .map_or(false, |idx| outputs[idx].has_new_epoch_event());
 
                 // We don't have BlockEpilogue txn for epoch ending block, due to several
                 // historical reasons.
-                if !has_reconfig {
+                if let Some(block_epilogue_txn_idx) = maybe_block_epilogue_txn_idx.dereference() {
+                    if *block_epilogue_txn_idx != num_txns_materialized {
+                        return Err(code_invariant_error(format!(
+                            "block epilogue txn idx {} != num materialized txns {}",
+                            block_epilogue_txn_idx, num_txns_materialized
+                        )));
+                    }
+
                     // We only do this for block (when the block_id is returned). For other cases
                     // like state sync or replay, the BlockEpilogue txn should already in the input
                     // and we don't need to add one here.
@@ -1333,7 +1280,7 @@ where
                             outputs.dereference(),
                             block_limit_processor.acquire().get_block_end_info(),
                             environment.features(),
-                        );
+                        )?;
                         outputs.dereference_mut().push(E::Output::skip_output()); // placeholder
                                                                                   // Check if existing auxiliary infos are None to maintain consistency
                         let block_epilogue_aux_info = if num_txns > 0 {
@@ -1427,7 +1374,8 @@ where
                         )));
                     }
 
-                    self.prepare_and_queue_commit_ready_txn(
+                    // TODO: refactor block epilogue txn to happen after worker loop.
+                    if self.prepare_and_queue_commit_ready_txn(
                         txn_idx,
                         incarnation,
                         num_txns as u32,
@@ -1444,7 +1392,11 @@ where
                         &executor,
                         block,
                         num_workers,
-                    )?;
+                    )? {
+                        // We set the variable here and process after commit lock is released.
+                        *maybe_block_epilogue_txn_idx.acquire().dereference_mut() =
+                            Some(txn_idx + 1);
+                    }
                 }
                 scheduler.queueing_commits_mark_done();
             }
@@ -1553,7 +1505,8 @@ where
             while scheduler.commit_hooks_try_lock() {
                 // Perform sequential commit hooks.
                 while let Some((txn_idx, incarnation)) = scheduler.start_commit()? {
-                    self.prepare_and_queue_commit_ready_txn(
+                    // TODO: refactor block epilogue txn to happen after worker loop.
+                    let _ = self.prepare_and_queue_commit_ready_txn(
                         txn_idx,
                         incarnation,
                         num_txns,
@@ -1841,6 +1794,7 @@ where
                 .resize_with(num_txns, E::Output::skip_output);
         }
 
+        let block_epilogue_txn_idx = ExplicitSyncWrapper::new(None);
         let block_epilogue_txn = ExplicitSyncWrapper::new(None);
 
         let num_txns = num_txns as u32;
@@ -1871,6 +1825,7 @@ where
                         &shared_counter,
                         &block_limit_processor,
                         &final_results,
+                        &block_epilogue_txn_idx,
                         &block_epilogue_txn,
                         &num_txns_materialized,
                         &total_txns_to_materialize,
@@ -1912,7 +1867,7 @@ where
         outputs: &[E::Output],
         block_end_info: TBlockEndInfoExt<T::Key>,
         features: &Features,
-    ) -> T {
+    ) -> Result<T, PanicError> {
         // TODO(grao): Remove this check once AIP-88 is fully enabled.
         if !self
             .config
@@ -1920,10 +1875,13 @@ where
             .block_gas_limit_type
             .add_block_limit_outcome_onchain()
         {
-            return T::state_checkpoint(block_id);
+            return Ok(T::state_checkpoint(block_id));
         }
         if !features.is_calculate_transaction_fee_for_distribution_enabled() {
-            return T::block_epilogue_v0(block_id, block_end_info.to_persistent());
+            return Ok(T::block_epilogue_v0(
+                block_id,
+                block_end_info.to_persistent(),
+            ));
         }
 
         let mut amount = BTreeMap::new();
@@ -1946,16 +1904,17 @@ where
             // TODO(grao): Also include other transactions that is "Keep" if we are confident
             // that we successfully charge enough gas amount as it appears in the FeeStatement
             // for every corner cases.
-            if !output.is_success() {
+            if !output.is_materialized_and_success() {
                 continue;
             }
+            let output_after_guard = output.after_materialization()?;
             let txn = signature_verified_block.get_txn(i as TxnIndex);
             if let Some(user_txn) = txn.try_as_signed_user_txn() {
                 let auxiliary_info = signature_verified_block.get_auxiliary_info(i as TxnIndex);
                 let proposer_index = auxiliary_info.proposer_index();
                 if let Some(proposer_index) = proposer_index {
                     let gas_price = user_txn.gas_unit_price();
-                    let fee_statement = output.fee_statement();
+                    let fee_statement = output_after_guard.fee_statement();
                     let total_gas_unit = fee_statement.gas_used();
                     // Total gas unit here includes the storage fee (deposit), which is not
                     // available for distribution. Only the execution gas and IO gas are available
@@ -1978,7 +1937,11 @@ where
                 }
             }
         }
-        T::block_epilogue_v1(block_id, block_end_info, FeeDistribution::new(amount))
+        Ok(T::block_epilogue_v1(
+            block_id,
+            block_end_info,
+            FeeDistribution::new(amount),
+        ))
     }
 
     fn apply_output_sequential(
@@ -1991,7 +1954,7 @@ where
             AptosModuleExtension,
         >,
         unsync_map: &UnsyncMap<T::Key, T::Tag, T::Value, DelayedFieldID>,
-        output: &E::Output,
+        output_before_guard: &<E::Output as TransactionOutput>::BeforeMaterializationGuard<'_>,
         resource_write_set: Vec<(T::Key, Arc<T::Value>, Option<Arc<MoveTypeLayout>>)>,
     ) -> Result<(), SequentialBlockExecutionError<E::Error>> {
         for (key, write_op, layout) in resource_write_set.into_iter() {
@@ -1999,17 +1962,17 @@ where
         }
 
         for (group_key, (metadata_op, group_size, group_ops)) in
-            output.resource_group_write_set().into_iter()
+            output_before_guard.resource_group_write_set().into_iter()
         {
             unsync_map.insert_group_ops(&group_key, group_ops, group_size)?;
             unsync_map.write(group_key, Arc::new(metadata_op), None);
         }
 
-        for (key, write_op) in output.aggregator_v1_write_set().into_iter() {
+        for (key, write_op) in output_before_guard.aggregator_v1_write_set().into_iter() {
             unsync_map.write(key, Arc::new(write_op), None);
         }
 
-        for write in output.module_write_set().as_ref().values() {
+        for write in output_before_guard.module_write_set().values() {
             add_module_write_to_module_cache::<T>(
                 write,
                 txn_idx,
@@ -2021,7 +1984,7 @@ where
 
         let mut second_phase = Vec::new();
         let mut updates = HashMap::new();
-        for (id, change) in output.delayed_field_change_set().into_iter() {
+        for (id, change) in output_before_guard.delayed_field_change_set().into_iter() {
             match change {
                 DelayedChange::Create(value) => {
                     assert_none!(
@@ -2154,8 +2117,9 @@ where
                     ));
                 },
                 ExecutionStatus::Success(output) | ExecutionStatus::SkipRest(output) => {
+                    let output_before_guard = output.before_materialization()?;
                     // Calculating the accumulated gas costs of the committed txns.
-                    let fee_statement = output.fee_statement();
+                    let fee_statement = output_before_guard.fee_statement();
 
                     let approx_output_size = self
                         .config
@@ -2163,7 +2127,7 @@ where
                         .block_gas_limit_type
                         .block_output_limit()
                         .map(|_| {
-                            output.output_approx_size()
+                            output_before_guard.output_approx_size()
                                 + if self
                                     .config
                                     .onchain
@@ -2185,7 +2149,7 @@ where
                         .map(|_| {
                             ReadWriteSummary::new(
                                 sequential_reads.get_read_summary(),
-                                output.get_write_summary(),
+                                output_before_guard.get_write_summary(),
                             )
                         });
 
@@ -2195,9 +2159,13 @@ where
                         approx_output_size,
                     );
 
+                    // Drop to acquire a write lock, then re-assign the output_before_guard.
+                    drop(output_before_guard);
                     output.legacy_sequential_materialize_agg_v1(&latest_view);
+                    let output_before_guard = output.before_materialization()?;
+
                     assert_eq!(
-                        output.aggregator_v1_delta_set().len(),
+                        output_before_guard.aggregator_v1_delta_set().len(),
                         0,
                         "Sequential execution must materialize deltas"
                     );
@@ -2230,7 +2198,7 @@ where
                         };
 
                         // The IDs are not exchanged but it doesn't change the types (Bytes) or size.
-                        let serialization_error = output
+                        let serialization_error = output_before_guard
                             .group_reads_needing_delayed_field_exchange()
                             .iter()
                             .any(|(group_key, _)| {
@@ -2247,8 +2215,10 @@ where
                                     Err(_) => true,
                                 }
                             })
-                            || output.resource_group_write_set().into_iter().any(
-                                |(group_key, (_, output_group_size, group_ops))| {
+                            || output_before_guard
+                                .resource_group_write_set()
+                                .into_iter()
+                                .any(|(group_key, (_, output_group_size, group_ops))| {
                                     fail_point!("fail-point-resource-group-serialization", |_| {
                                         true
                                     });
@@ -2276,8 +2246,7 @@ where
                                         },
                                         Err(_) => true,
                                     }
-                                },
-                            );
+                                });
 
                         if serialization_error {
                             // The corresponding error / alert must already be triggered, the goal in sequential
@@ -2292,19 +2261,19 @@ where
                     };
 
                     // Apply the writes.
-                    let resource_write_set = output.resource_write_set();
+                    let resource_write_set = output_before_guard.resource_write_set();
                     Self::apply_output_sequential(
                         idx as TxnIndex,
                         runtime_environment,
                         module_cache_manager_guard.module_cache(),
                         &unsync_map,
-                        &output,
+                        &output_before_guard,
                         resource_write_set.clone(),
                     )?;
 
                     // If dynamic change set materialization part (indented for clarity/variable scope):
                     {
-                        let finalized_groups = groups_to_finalize!(output,)
+                        let finalized_groups = groups_to_finalize!(output_before_guard,)
                             .map(|((group_key, metadata_op), is_read_needing_exchange)| {
                                 let (group_ops_iter, group_size) =
                                     unsync_map.finalize_group(&group_key);
@@ -2326,7 +2295,7 @@ where
 
                         let resource_writes_to_materialize = resource_writes_to_materialize!(
                             resource_write_set,
-                            output,
+                            output_before_guard,
                             unsync_map,
                         )?;
                         // Replace delayed field id with values in resource write set and read set.
@@ -2337,9 +2306,12 @@ where
 
                         // Replace delayed field id with values in events
                         let materialized_events = map_id_to_values_events(
-                            Box::new(output.get_events().into_iter()),
+                            Box::new(output_before_guard.get_events().into_iter()),
                             &latest_view,
                         )?;
+                        // Output before guard holds a read lock, drop before incorporating materialized
+                        // output which needs a write lock.
+                        drop(output_before_guard);
 
                         output.incorporate_materialized_txn_output(
                             // No aggregator v1 delta writes are needed for sequential execution.
@@ -2378,7 +2350,7 @@ where
             if must_skip || block_limit_processor.should_end_block_sequential() || idx == num_txns {
                 let mut has_reconfig = false;
                 if let Some(last_output) = ret.last() {
-                    if last_output.has_new_epoch_event() {
+                    if last_output.after_materialization()?.has_new_epoch_event() {
                         has_reconfig = true;
                     }
                 }
@@ -2393,7 +2365,7 @@ where
                             &ret,
                             block_limit_processor.get_block_end_info(),
                             module_cache_manager_guard.environment().features(),
-                        ));
+                        )?);
                     } else {
                         info!("Reach epoch ending, do not append BlockEpilogue txn, block_id: {block_id:?}.");
                     }

--- a/aptos-move/block-executor/src/task.rs
+++ b/aptos-move/block-executor/src/task.rs
@@ -97,102 +97,94 @@ pub trait ExecutorTask {
     fn is_transaction_dynamic_change_set_capable(txn: &Self::Txn) -> bool;
 }
 
-/// Trait for execution result of a single transaction.
-pub trait TransactionOutput: Send + Sync + Debug {
-    /// Type of transaction and its associated key and value.
-    type Txn: Transaction;
+/// Traits for execution result of a single transaction.
+pub trait BeforeMaterializationOutput<Txn: Transaction> {
+    /// Get the writes of a transaction from its output, separately for resources,
+    /// modules and aggregator_v1.
+    fn resource_write_set(&self) -> Vec<(Txn::Key, Arc<Txn::Value>, Option<Arc<MoveTypeLayout>>)>;
 
-    /// Get the writes of a transaction from its output, separately for resources, modules and
-    /// aggregator_v1.
-    fn resource_write_set(
-        &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        Arc<<Self::Txn as Transaction>::Value>,
-        Option<Arc<MoveTypeLayout>>,
-    )>;
+    fn module_write_set(&self) -> &BTreeMap<Txn::Key, ModuleWrite<Txn::Value>>;
 
-    fn module_write_set(
-        &self,
-    ) -> impl AsRef<
-        BTreeMap<<Self::Txn as Transaction>::Key, ModuleWrite<<Self::Txn as Transaction>::Value>>,
-    > + '_;
-
-    fn aggregator_v1_write_set(
-        &self,
-    ) -> BTreeMap<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Value>;
+    fn aggregator_v1_write_set(&self) -> BTreeMap<Txn::Key, Txn::Value>;
 
     /// Get the aggregator V1 deltas of a transaction from its output.
-    fn aggregator_v1_delta_set(&self) -> BTreeMap<<Self::Txn as Transaction>::Key, DeltaOp>;
+    fn aggregator_v1_delta_set(&self) -> BTreeMap<Txn::Key, DeltaOp>;
 
     /// Get the delayed field changes of a transaction from its output.
     fn delayed_field_change_set(&self) -> BTreeMap<DelayedFieldID, DelayedChange<DelayedFieldID>>;
 
     fn reads_needing_delayed_field_exchange(
         &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        StateValueMetadata,
-        Arc<MoveTypeLayout>,
-    )>;
+    ) -> Vec<(Txn::Key, StateValueMetadata, Arc<MoveTypeLayout>)>;
 
-    fn group_reads_needing_delayed_field_exchange(
-        &self,
-    ) -> Vec<(<Self::Txn as Transaction>::Key, StateValueMetadata)>;
+    fn group_reads_needing_delayed_field_exchange(&self) -> Vec<(Txn::Key, StateValueMetadata)>;
 
     /// Get the events of a transaction from its output.
-    fn get_events(&self) -> Vec<(<Self::Txn as Transaction>::Event, Option<MoveTypeLayout>)>;
+    fn get_events(&self) -> Vec<(Txn::Event, Option<MoveTypeLayout>)>;
 
     fn resource_group_write_set(
         &self,
     ) -> HashMap<
-        <Self::Txn as Transaction>::Key,
+        Txn::Key,
         (
-            <Self::Txn as Transaction>::Value,
+            Txn::Value,
             ResourceGroupSize,
-            BTreeMap<
-                <Self::Txn as Transaction>::Tag,
-                (
-                    <Self::Txn as Transaction>::Value,
-                    Option<Arc<MoveTypeLayout>>,
-                ),
-            >,
+            BTreeMap<Txn::Tag, (Txn::Value, Option<Arc<MoveTypeLayout>>)>,
         ),
     >;
 
     fn for_each_resource_group_key_and_tags<F>(&self, callback: F) -> Result<(), PanicError>
     where
-        F: FnMut(
-            &<Self::Txn as Transaction>::Key,
-            HashSet<&<Self::Txn as Transaction>::Tag>,
-        ) -> Result<(), PanicError>;
+        F: FnMut(&Txn::Key, HashSet<&Txn::Tag>) -> Result<(), PanicError>;
 
     // For now, the below interfaces for keys and metada and keys and tags are provided
     // to avoid unnecessarily cloning the whole resource group write set.
     // TODO: get rid of these interfaces when we can have zero-copy access to the output.
-    fn resource_group_metadata_ops(
-        &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        <Self::Txn as Transaction>::Value,
-    )> {
+    fn resource_group_metadata_ops(&self) -> Vec<(Txn::Key, Txn::Value)> {
         self.resource_group_write_set()
             .into_iter()
             .map(|(key, (op, _, _))| (key, op))
             .collect()
     }
 
-    fn legacy_v1_resource_group_tags(
-        &self,
-    ) -> Vec<(
-        <Self::Txn as Transaction>::Key,
-        HashSet<<Self::Txn as Transaction>::Tag>,
-    )> {
+    fn legacy_v1_resource_group_tags(&self) -> Vec<(Txn::Key, HashSet<Txn::Tag>)> {
         self.resource_group_write_set()
             .into_iter()
             .map(|(key, (_, _, group_ops))| (key, group_ops.keys().cloned().collect()))
             .collect()
     }
+
+    /// Return the fee statement of the transaction.
+    fn fee_statement(&self) -> FeeStatement;
+
+    fn has_new_epoch_event(&self) -> bool;
+
+    /// Deterministic, but approximate size of the output, as
+    /// before creating actual TransactionOutput, we don't know the exact size of it.
+    ///
+    /// Sum of all sizes of writes (keys + write_ops) and events.
+    fn output_approx_size(&self) -> u64;
+
+    fn get_write_summary(&self) -> HashSet<InputOutputKey<Txn::Key, Txn::Tag>>;
+}
+
+pub trait AfterMaterializationOutput<Txn: Transaction> {
+    /// Return the fee statement of the transaction.
+    fn fee_statement(&self) -> FeeStatement;
+
+    /// Returns true iff it has a new epoch event.
+    fn has_new_epoch_event(&self) -> bool;
+}
+
+pub trait TransactionOutput: Send + Sync + Debug {
+    /// Type of transaction and its associated key and value.
+    type Txn: Transaction;
+    type BeforeMaterializationGuard<'a>: BeforeMaterializationOutput<Self::Txn> + 'a
+    where
+        Self: 'a;
+    type AfterMaterializationGuard<'a>: AfterMaterializationOutput<Self::Txn> + 'a
+    where
+        Self: 'a;
 
     /// Execution output for transactions that comes after SkipRest signal.
     fn skip_output() -> Self;
@@ -200,11 +192,24 @@ pub trait TransactionOutput: Send + Sync + Debug {
     /// Execution output for transactions that should be discarded.
     fn discard_output(discard_code: StatusCode) -> Self;
 
-    // !!![CAUTION]!!! This method should never be used in parallel execution.
-    fn legacy_sequential_materialize_agg_v1(
-        &self,
-        view: &impl TAggregatorV1View<Identifier = <Self::Txn as Transaction>::Key>,
-    );
+    // Materialization transforms the stored txn output, and may require the
+    // TransactionOutput implementation to have different processing for
+    // extracting data from the output. Hence, it is important to make the
+    // caller aware via the guard types and the chaining pattern in order to
+    // ensure the appropriate methods are called.
+    fn before_materialization<'a>(
+        &'a self,
+    ) -> Result<Self::BeforeMaterializationGuard<'a>, PanicError>;
+    fn after_materialization<'a>(
+        &'a self,
+    ) -> Result<Self::AfterMaterializationGuard<'a>, PanicError>;
+
+    /// Returns true iff the transaction status is Keep(Success).
+    fn is_materialized_and_success(&self) -> bool;
+
+    // Below methods perform various types of materialization. These may modify
+    // the stored output representation and hence must be carefully implemented
+    // to avoid data races with the accessor methods.
 
     /// Will be called once per transaction when the output is ready to be committed.
     /// Ensures that any writes corresponding to materialized deltas and group updates
@@ -223,25 +228,9 @@ pub trait TransactionOutput: Send + Sync + Debug {
 
     fn set_txn_output_for_non_dynamic_change_set(&self);
 
-    /// Return the fee statement of the transaction.
-    fn fee_statement(&self) -> FeeStatement;
-
-    /// Returns true iff the TransactionsStatus is Retry.
-    fn is_retry(&self) -> bool;
-
-    /// Returns true iff it has a new epoch event.
-    fn has_new_epoch_event(&self) -> bool;
-
-    /// Returns true iff the execution status is Keep(Success).
-    fn is_success(&self) -> bool;
-
-    /// Deterministic, but approximate size of the output, as
-    /// before creating actual TransactionOutput, we don't know the exact size of it.
-    ///
-    /// Sum of all sizes of writes (keys + write_ops) and events.
-    fn output_approx_size(&self) -> u64;
-
-    fn get_write_summary(
+    // !!![CAUTION]!!! These methods should never be used in parallel execution.
+    fn legacy_sequential_materialize_agg_v1(
         &self,
-    ) -> HashSet<InputOutputKey<<Self::Txn as Transaction>::Key, <Self::Txn as Transaction>::Tag>>;
+        view: &impl TAggregatorV1View<Identifier = <Self::Txn as Transaction>::Key>,
+    );
 }


### PR DESCRIPTION
- Implement a pattern with before_materialization / after_materialization chaining for accessing outputs, which should help ensure invariants are not broken by the caller as the internal output representation changes during materialization. The mapped guards also allow extending lifetime and sharing things with & - e.g. as we did for module writes, but without verbose AsRef overloading.
- Streamline TxnLastInputOutput storage with macros, relax load_full and having to reuse the result of load for multiple purposes when committing a txn. Get rid of separately stored resource writes.

pass existing tests & make sure execution performance passes