### PR TITLE
[Storage Service] Respect max response sizes for v2 requests.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -11,7 +11,11 @@ use serde::{Deserialize, Serialize};
 use serde_yaml::Value;
 
 // The maximum message size per state sync message
-const MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024; /* 10 MiB */
+const SERVER_MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
+
+// The maximum message size per state sync message (for v2 data requests)
+const CLIENT_MAX_MESSAGE_SIZE_V2: usize = 15 * 1024 * 1024; // 15 MiB (used for v2 data requests)
+const SERVER_MAX_MESSAGE_SIZE_V2: usize = 40 * 1024 * 1024; // 40 MiB (used for v2 data requests)
 
 // The maximum chunk sizes for data client requests and response
 const MAX_EPOCH_CHUNK_SIZE: u64 = 200;
@@ -159,6 +163,8 @@ pub struct StorageServiceConfig {
     pub max_network_channel_size: u64,
     /// Maximum number of bytes to send per network message
     pub max_network_chunk_bytes: u64,
+    /// Maximum number of bytes to send per network message (for v2 data)
+    pub max_network_chunk_bytes_v2: u64,
     /// Maximum number of active subscriptions (per peer)
     pub max_num_active_subscriptions: u64,
     /// Maximum period (ms) of pending optimistic fetch requests
@@ -187,7 +193,8 @@ impl Default for StorageServiceConfig {
             max_invalid_requests_per_peer: 500,
             max_lru_cache_size: 500, // At ~0.6MiB per chunk, this should take no more than 0.5GiB
             max_network_channel_size: 4000,
-            max_network_chunk_bytes: MAX_MESSAGE_SIZE as u64,
+            max_network_chunk_bytes: SERVER_MAX_MESSAGE_SIZE as u64,
+            max_network_chunk_bytes_v2: SERVER_MAX_MESSAGE_SIZE_V2 as u64,
             max_num_active_subscriptions: 30,
             max_optimistic_fetch_period_ms: 5000, // 5 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
@@ -451,7 +458,7 @@ impl Default for AptosDataClientConfig {
             max_epoch_chunk_size: MAX_EPOCH_CHUNK_SIZE,
             max_num_output_reductions: 0,
             max_optimistic_fetch_lag_secs: 20, // 20 seconds
-            max_response_bytes: MAX_MESSAGE_SIZE as u64,
+            max_response_bytes: CLIENT_MAX_MESSAGE_SIZE_V2 as u64,
             max_response_timeout_ms: 60_000, // 60 seconds
             max_state_chunk_size: MAX_STATE_CHUNK_SIZE,
             max_subscription_lag_secs: 20, // 20 seconds

--- a/state-sync/storage-service/server/src/storage.rs
+++ b/state-sync/storage-service/server/src/storage.rs
@@ -194,6 +194,277 @@ impl StorageReader {
             Ok(None)
         }
     }
+
+    /// Returns an epoch ending ledger info response (bound by the max response size in bytes)
+    fn get_epoch_ending_ledger_infos_by_size(
+        &self,
+        start_epoch: u64,
+        expected_end_epoch: u64,
+        max_response_size: u64,
+    ) -> Result<EpochChangeProof, Error> {
+        // Calculate the number of ledger infos to fetch
+        let expected_num_ledger_infos = inclusive_range_len(start_epoch, expected_end_epoch)?;
+        let max_num_ledger_infos = self.config.max_epoch_chunk_size;
+        let mut num_ledger_infos_to_fetch = min(expected_num_ledger_infos, max_num_ledger_infos);
+
+        // Attempt to serve the request
+        while num_ledger_infos_to_fetch >= 1 {
+            // The DbReader interface returns the epochs up to: `end_epoch - 1`.
+            // However, we wish to fetch epoch endings up to end_epoch (inclusive).
+            let end_epoch = start_epoch
+                .checked_add(num_ledger_infos_to_fetch)
+                .ok_or_else(|| {
+                    Error::UnexpectedErrorEncountered("End epoch has overflown!".into())
+                })?;
+            let epoch_change_proof = self
+                .storage
+                .get_epoch_ending_ledger_infos(start_epoch, end_epoch)
+                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            if num_ledger_infos_to_fetch == 1 {
+                return Ok(epoch_change_proof); // We cannot return less than a single item
+            }
+
+            // Attempt to divide up the request if it overflows the message size
+            let (overflow_frame, num_bytes) =
+                check_overflow_network_frame(&epoch_change_proof, max_response_size)?;
+            if !overflow_frame {
+                return Ok(epoch_change_proof);
+            } else {
+                increment_network_frame_overflow(
+                    DataResponse::EpochEndingLedgerInfos(epoch_change_proof).get_label(),
+                );
+                let new_num_ledger_infos_to_fetch = num_ledger_infos_to_fetch / 2;
+                debug!("The request for {:?} ledger infos was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_ledger_infos_to_fetch, num_bytes, max_response_size, new_num_ledger_infos_to_fetch);
+                num_ledger_infos_to_fetch = new_num_ledger_infos_to_fetch; // Try again with half the amount of data
+            }
+        }
+
+        Err(Error::UnexpectedErrorEncountered(format!(
+            "Unable to serve the get_epoch_ending_ledger_infos request! Start epoch: {:?}, \
+            expected end epoch: {:?}. The data cannot fit into a single network frame!",
+            start_epoch, expected_end_epoch
+        )))
+    }
+
+    /// Returns a transaction with proof response (bound by the max response size in bytes)
+    fn get_transactions_with_proof_by_size(
+        &self,
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+        include_events: bool,
+        max_response_size: u64,
+    ) -> Result<TransactionDataWithProofResponse, Error> {
+        // Calculate the number of transactions to fetch
+        let expected_num_transactions = inclusive_range_len(start_version, end_version)?;
+        let max_num_transactions = self.config.max_transaction_chunk_size;
+        let mut num_transactions_to_fetch = min(expected_num_transactions, max_num_transactions);
+
+        // Attempt to serve the request
+        while num_transactions_to_fetch >= 1 {
+            let transaction_list_with_proof = self
+                .storage
+                .get_transactions(
+                    start_version,
+                    num_transactions_to_fetch,
+                    proof_version,
+                    include_events,
+                )
+                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            let response = TransactionDataWithProofResponse {
+                transaction_data_response_type: TransactionDataResponseType::TransactionData,
+                transaction_list_with_proof: Some(transaction_list_with_proof),
+                transaction_output_list_with_proof: None,
+            };
+            if num_transactions_to_fetch == 1 {
+                return Ok(response); // We cannot return less than a single item
+            }
+
+            // Attempt to divide up the request if it overflows the message size
+            let (overflow_frame, num_bytes) =
+                check_overflow_network_frame(&response, max_response_size)?;
+            if !overflow_frame {
+                return Ok(response);
+            } else {
+                increment_network_frame_overflow(
+                    DataResponse::TransactionDataWithProof(response).get_label(),
+                );
+                let new_num_transactions_to_fetch = num_transactions_to_fetch / 2;
+                debug!("The request for {:?} transactions was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_transactions_to_fetch, num_bytes, max_response_size, new_num_transactions_to_fetch);
+                num_transactions_to_fetch = new_num_transactions_to_fetch; // Try again with half the amount of data
+            }
+        }
+
+        Err(Error::UnexpectedErrorEncountered(format!(
+            "Unable to serve the get_transactions_with_proof request! Proof version: {:?}, \
+            start version: {:?}, end version: {:?}, include events: {:?}. The data cannot fit into \
+            a single network frame!",
+            proof_version, start_version, end_version, include_events,
+        )))
+    }
+
+    /// Returns a transaction output with proof response (bound by the max response size in bytes)
+    fn get_transaction_outputs_with_proof_by_size(
+        &self,
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+        max_response_size: u64,
+    ) -> Result<TransactionDataWithProofResponse, Error> {
+        // Calculate the number of transaction outputs to fetch
+        let expected_num_outputs = inclusive_range_len(start_version, end_version)?;
+        let max_num_outputs = self.config.max_transaction_output_chunk_size;
+        let mut num_outputs_to_fetch = min(expected_num_outputs, max_num_outputs);
+
+        // Attempt to serve the request
+        while num_outputs_to_fetch >= 1 {
+            let output_list_with_proof = self
+                .storage
+                .get_transaction_outputs(start_version, num_outputs_to_fetch, proof_version)
+                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            let response = TransactionDataWithProofResponse {
+                transaction_data_response_type: TransactionDataResponseType::TransactionOutputData,
+                transaction_list_with_proof: None,
+                transaction_output_list_with_proof: Some(output_list_with_proof),
+            };
+            if num_outputs_to_fetch == 1 {
+                return Ok(response); // We cannot return less than a single item
+            }
+
+            // Attempt to divide up the request if it overflows the message size
+            let (overflow_frame, num_bytes) =
+                check_overflow_network_frame(&response, max_response_size)?;
+            if !overflow_frame {
+                return Ok(response);
+            } else {
+                increment_network_frame_overflow(
+                    DataResponse::TransactionDataWithProof(response).get_label(),
+                );
+                let new_num_outputs_to_fetch = num_outputs_to_fetch / 2;
+                debug!("The request for {:?} outputs was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_outputs_to_fetch, num_bytes, max_response_size, new_num_outputs_to_fetch);
+                num_outputs_to_fetch = new_num_outputs_to_fetch; // Try again with half the amount of data
+            }
+        }
+
+        Err(Error::UnexpectedErrorEncountered(format!(
+            "Unable to serve the get_transaction_outputs_with_proof request! Proof version: {:?}, \
+            start version: {:?}, end version: {:?}. The data cannot fit into a single network frame!",
+            proof_version, start_version, end_version
+        )))
+    }
+
+    /// Returns a transaction or output with proof response (bound by the max response size in bytes)
+    fn get_transactions_or_outputs_with_proof_by_size(
+        &self,
+        proof_version: u64,
+        start_version: u64,
+        end_version: u64,
+        include_events: bool,
+        max_num_output_reductions: u64,
+        max_response_size: u64,
+    ) -> Result<TransactionDataWithProofResponse, Error> {
+        // Calculate the number of transaction outputs to fetch
+        let expected_num_outputs = inclusive_range_len(start_version, end_version)?;
+        let max_num_outputs = self.config.max_transaction_output_chunk_size;
+        let mut num_outputs_to_fetch = min(expected_num_outputs, max_num_outputs);
+
+        // Attempt to serve the outputs. Halve the data only as many
+        // times as the fallback count allows. If the data still
+        // doesn't fit, return a transaction chunk instead.
+        let mut num_output_reductions = 0;
+        while num_output_reductions <= max_num_output_reductions {
+            let output_list_with_proof = self
+                .storage
+                .get_transaction_outputs(start_version, num_outputs_to_fetch, proof_version)
+                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            let response = TransactionDataWithProofResponse {
+                transaction_data_response_type: TransactionDataResponseType::TransactionOutputData,
+                transaction_list_with_proof: None,
+                transaction_output_list_with_proof: Some(output_list_with_proof),
+            };
+
+            let (overflow_frame, num_bytes) =
+                check_overflow_network_frame(&response, max_response_size)?;
+
+            if !overflow_frame {
+                return Ok(response);
+            } else if num_outputs_to_fetch == 1 {
+                break; // We cannot return less than a single item. Fallback to transactions
+            } else {
+                increment_network_frame_overflow(
+                    DataResponse::TransactionDataWithProof(response).get_label(),
+                );
+                let new_num_outputs_to_fetch = num_outputs_to_fetch / 2;
+                debug!("The request for {:?} outputs was too large (num bytes: {:?}, limit: {:?}). Current number of data reductions: {:?}",
+                    num_outputs_to_fetch, num_bytes, max_response_size, num_output_reductions);
+                num_outputs_to_fetch = new_num_outputs_to_fetch; // Try again with half the amount of data
+                num_output_reductions += 1;
+            }
+        }
+
+        // Return transactions only
+        self.get_transactions_with_proof_by_size(
+            proof_version,
+            start_version,
+            end_version,
+            include_events,
+            max_response_size,
+        )
+    }
+
+    /// Returns a state value chunk with proof response (bound by the max response size in bytes)
+    fn get_state_value_chunk_with_proof_by_size(
+        &self,
+        version: u64,
+        start_index: u64,
+        end_index: u64,
+        max_response_size: u64,
+    ) -> Result<StateValueChunkWithProof, Error> {
+        // Calculate the number of state values to fetch
+        let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
+        let max_num_state_values = self.config.max_state_chunk_size;
+        let mut num_state_values_to_fetch = min(expected_num_state_values, max_num_state_values);
+
+        // Attempt to serve the request
+        while num_state_values_to_fetch >= 1 {
+            let state_value_chunk_with_proof = self
+                .storage
+                .get_state_value_chunk_with_proof(
+                    version,
+                    start_index as usize,
+                    num_state_values_to_fetch as usize,
+                )
+                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
+            if num_state_values_to_fetch == 1 {
+                return Ok(state_value_chunk_with_proof); // We cannot return less than a single item
+            }
+
+            // Attempt to divide up the request if it overflows the message size
+            let (overflow_frame, num_bytes) =
+                check_overflow_network_frame(&state_value_chunk_with_proof, max_response_size)?;
+            if !overflow_frame {
+                return Ok(state_value_chunk_with_proof);
+            } else {
+                increment_network_frame_overflow(
+                    DataResponse::StateValueChunkWithProof(state_value_chunk_with_proof)
+                        .get_label(),
+                );
+                let new_num_state_values_to_fetch = num_state_values_to_fetch / 2;
+                debug!("The request for {:?} state values was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
+                    num_state_values_to_fetch, num_bytes, max_response_size, new_num_state_values_to_fetch);
+                num_state_values_to_fetch = new_num_state_values_to_fetch; // Try again with half the amount of data
+            }
+        }
+
+        Err(Error::UnexpectedErrorEncountered(format!(
+            "Unable to serve the get_state_value_chunk_with_proof request! Version: {:?}, \
+            start index: {:?}, end index: {:?}. The data cannot fit into a single network frame!",
+            version, start_index, end_index
+        )))
+    }
 }
 
 impl StorageReaderInterface for StorageReader {
@@ -246,54 +517,13 @@ impl StorageReaderInterface for StorageReader {
         end_version: u64,
         include_events: bool,
     ) -> aptos_storage_service_types::Result<TransactionDataWithProofResponse, Error> {
-        // Calculate the number of transactions to fetch
-        let expected_num_transactions = inclusive_range_len(start_version, end_version)?;
-        let max_num_transactions = self.config.max_transaction_chunk_size;
-        let mut num_transactions_to_fetch = min(expected_num_transactions, max_num_transactions);
-
-        // Attempt to serve the request
-        while num_transactions_to_fetch >= 1 {
-            let transaction_list_with_proof = self
-                .storage
-                .get_transactions(
-                    start_version,
-                    num_transactions_to_fetch,
-                    proof_version,
-                    include_events,
-                )
-                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
-            let response = TransactionDataWithProofResponse {
-                transaction_data_response_type: TransactionDataResponseType::TransactionData,
-                transaction_list_with_proof: Some(transaction_list_with_proof),
-                transaction_output_list_with_proof: None,
-            };
-            if num_transactions_to_fetch == 1 {
-                return Ok(response); // We cannot return less than a single item
-            }
-
-            // Attempt to divide up the request if it overflows the message size
-            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
-            let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&response, max_network_chunk_bytes)?;
-            if !overflow_frame {
-                return Ok(response);
-            } else {
-                increment_network_frame_overflow(
-                    DataResponse::TransactionDataWithProof(response).get_label(),
-                );
-                let new_num_transactions_to_fetch = num_transactions_to_fetch / 2;
-                debug!("The request for {:?} transactions was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
-                    num_transactions_to_fetch, num_bytes, max_network_chunk_bytes, new_num_transactions_to_fetch);
-                num_transactions_to_fetch = new_num_transactions_to_fetch; // Try again with half the amount of data
-            }
-        }
-
-        Err(Error::UnexpectedErrorEncountered(format!(
-            "Unable to serve the get_transactions_with_proof request! Proof version: {:?}, \
-            start version: {:?}, end version: {:?}, include events: {:?}. The data cannot fit into \
-            a single network frame!",
-            proof_version, start_version, end_version, include_events,
-        )))
+        self.get_transactions_with_proof_by_size(
+            proof_version,
+            start_version,
+            end_version,
+            include_events,
+            self.config.max_network_chunk_bytes,
+        )
     }
 
     fn get_epoch_ending_ledger_infos(
@@ -301,50 +531,11 @@ impl StorageReaderInterface for StorageReader {
         start_epoch: u64,
         expected_end_epoch: u64,
     ) -> aptos_storage_service_types::Result<EpochChangeProof, Error> {
-        // Calculate the number of ledger infos to fetch
-        let expected_num_ledger_infos = inclusive_range_len(start_epoch, expected_end_epoch)?;
-        let max_num_ledger_infos = self.config.max_epoch_chunk_size;
-        let mut num_ledger_infos_to_fetch = min(expected_num_ledger_infos, max_num_ledger_infos);
-
-        // Attempt to serve the request
-        while num_ledger_infos_to_fetch >= 1 {
-            // The DbReader interface returns the epochs up to: `end_epoch - 1`.
-            // However, we wish to fetch epoch endings up to end_epoch (inclusive).
-            let end_epoch = start_epoch
-                .checked_add(num_ledger_infos_to_fetch)
-                .ok_or_else(|| {
-                    Error::UnexpectedErrorEncountered("End epoch has overflown!".into())
-                })?;
-            let epoch_change_proof = self
-                .storage
-                .get_epoch_ending_ledger_infos(start_epoch, end_epoch)
-                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
-            if num_ledger_infos_to_fetch == 1 {
-                return Ok(epoch_change_proof); // We cannot return less than a single item
-            }
-
-            // Attempt to divide up the request if it overflows the message size
-            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
-            let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&epoch_change_proof, max_network_chunk_bytes)?;
-            if !overflow_frame {
-                return Ok(epoch_change_proof);
-            } else {
-                increment_network_frame_overflow(
-                    DataResponse::EpochEndingLedgerInfos(epoch_change_proof).get_label(),
-                );
-                let new_num_ledger_infos_to_fetch = num_ledger_infos_to_fetch / 2;
-                debug!("The request for {:?} ledger infos was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
-                    num_ledger_infos_to_fetch, num_bytes, max_network_chunk_bytes, new_num_ledger_infos_to_fetch);
-                num_ledger_infos_to_fetch = new_num_ledger_infos_to_fetch; // Try again with half the amount of data
-            }
-        }
-
-        Err(Error::UnexpectedErrorEncountered(format!(
-            "Unable to serve the get_epoch_ending_ledger_infos request! Start epoch: {:?}, \
-            expected end epoch: {:?}. The data cannot fit into a single network frame!",
-            start_epoch, expected_end_epoch
-        )))
+        self.get_epoch_ending_ledger_infos_by_size(
+            start_epoch,
+            expected_end_epoch,
+            self.config.max_network_chunk_bytes,
+        )
     }
 
     fn get_transaction_outputs_with_proof(
@@ -353,48 +544,12 @@ impl StorageReaderInterface for StorageReader {
         start_version: u64,
         end_version: u64,
     ) -> aptos_storage_service_types::Result<TransactionDataWithProofResponse, Error> {
-        // Calculate the number of transaction outputs to fetch
-        let expected_num_outputs = inclusive_range_len(start_version, end_version)?;
-        let max_num_outputs = self.config.max_transaction_output_chunk_size;
-        let mut num_outputs_to_fetch = min(expected_num_outputs, max_num_outputs);
-
-        // Attempt to serve the request
-        while num_outputs_to_fetch >= 1 {
-            let output_list_with_proof = self
-                .storage
-                .get_transaction_outputs(start_version, num_outputs_to_fetch, proof_version)
-                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
-            let response = TransactionDataWithProofResponse {
-                transaction_data_response_type: TransactionDataResponseType::TransactionOutputData,
-                transaction_list_with_proof: None,
-                transaction_output_list_with_proof: Some(output_list_with_proof),
-            };
-            if num_outputs_to_fetch == 1 {
-                return Ok(response); // We cannot return less than a single item
-            }
-
-            // Attempt to divide up the request if it overflows the message size
-            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
-            let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&response, max_network_chunk_bytes)?;
-            if !overflow_frame {
-                return Ok(response);
-            } else {
-                increment_network_frame_overflow(
-                    DataResponse::TransactionDataWithProof(response).get_label(),
-                );
-                let new_num_outputs_to_fetch = num_outputs_to_fetch / 2;
-                debug!("The request for {:?} outputs was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
-                    num_outputs_to_fetch, num_bytes, max_network_chunk_bytes, new_num_outputs_to_fetch);
-                num_outputs_to_fetch = new_num_outputs_to_fetch; // Try again with half the amount of data
-            }
-        }
-
-        Err(Error::UnexpectedErrorEncountered(format!(
-            "Unable to serve the get_transaction_outputs_with_proof request! Proof version: {:?}, \
-            start version: {:?}, end version: {:?}. The data cannot fit into a single network frame!",
-            proof_version, start_version, end_version
-        )))
+        self.get_transaction_outputs_with_proof_by_size(
+            proof_version,
+            start_version,
+            end_version,
+            self.config.max_network_chunk_bytes,
+        )
     }
 
     fn get_transactions_or_outputs_with_proof(
@@ -405,60 +560,16 @@ impl StorageReaderInterface for StorageReader {
         include_events: bool,
         max_num_output_reductions: u64,
     ) -> aptos_storage_service_types::Result<TransactionDataWithProofResponse, Error> {
-        // Calculate the number of transaction outputs to fetch
-        let expected_num_outputs = inclusive_range_len(start_version, end_version)?;
-        let max_num_outputs = self.config.max_transaction_output_chunk_size;
-        let mut num_outputs_to_fetch = min(expected_num_outputs, max_num_outputs);
-
-        // Attempt to serve the outputs. Halve the data only as many
-        // times as the fallback count allows. If the data still
-        // doesn't fit, return a transaction chunk instead.
-        let mut num_output_reductions = 0;
-        while num_output_reductions <= max_num_output_reductions {
-            let output_list_with_proof = self
-                .storage
-                .get_transaction_outputs(start_version, num_outputs_to_fetch, proof_version)
-                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
-            let response = TransactionDataWithProofResponse {
-                transaction_data_response_type: TransactionDataResponseType::TransactionOutputData,
-                transaction_list_with_proof: None,
-                transaction_output_list_with_proof: Some(output_list_with_proof),
-            };
-
-            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
-            let (overflow_frame, num_bytes) =
-                check_overflow_network_frame(&response, max_network_chunk_bytes)?;
-
-            if !overflow_frame {
-                return Ok(response);
-            } else if num_outputs_to_fetch == 1 {
-                break; // We cannot return less than a single item. Fallback to transactions
-            } else {
-                increment_network_frame_overflow(
-                    DataResponse::TransactionDataWithProof(response).get_label(),
-                );
-                let new_num_outputs_to_fetch = num_outputs_to_fetch / 2;
-                debug!("The request for {:?} outputs was too large (num bytes: {:?}, limit: {:?}). Current number of data reductions: {:?}",
-                    num_outputs_to_fetch, num_bytes, max_network_chunk_bytes, num_output_reductions);
-                num_outputs_to_fetch = new_num_outputs_to_fetch; // Try again with half the amount of data
-                num_output_reductions += 1;
-            }
-        }
-
-        // Return transactions only
-        self.get_transactions_with_proof(proof_version, start_version, end_version, include_events)
+        self.get_transactions_or_outputs_with_proof_by_size(
+            proof_version,
+            start_version,
+            end_version,
+            include_events,
+            max_num_output_reductions,
+            self.config.max_network_chunk_bytes,
+        )
     }
 
-    // TODOs:
-    // 1. Make this function respect the `max_network_chunk_bytes` limit. It's
-    //    currently not respected because the auxiliary information is not
-    //    size checked. However, this is okay for now because the limit is not
-    //    a hard limit, and auxiliary information is still quite small (e.g., u32
-    //    per transaction). However, we should address this.
-    // 2. Make this function respect the `max_response_bytes` limit in each request.
-    //    It's currently not respected because we only consider the
-    //    `max_network_chunk_bytes` limit as defined by the storage service config.
-    //    We should also address this.
     fn get_transaction_data_with_proof(
         &self,
         transaction_data_with_proof_request: &GetTransactionDataWithProofRequest,
@@ -468,29 +579,42 @@ impl StorageReaderInterface for StorageReader {
         let start_version = transaction_data_with_proof_request.start_version;
         let end_version = transaction_data_with_proof_request.end_version;
 
+        // Calculate the max response size to use
+        let max_response_bytes = min(
+            transaction_data_with_proof_request.max_response_bytes,
+            self.config.max_network_chunk_bytes_v2,
+        );
+
         // Fetch the transaction data based on the request type
         match transaction_data_with_proof_request.transaction_data_request_type {
             TransactionDataRequestType::TransactionData(request) => {
                 // Get the transaction list with proof
-                self.get_transactions_with_proof(
+                self.get_transactions_with_proof_by_size(
                     proof_version,
                     start_version,
                     end_version,
                     request.include_events,
+                    max_response_bytes,
                 )
             },
             TransactionDataRequestType::TransactionOutputData => {
                 // Get the transaction output list with proof
-                self.get_transaction_outputs_with_proof(proof_version, start_version, end_version)
+                self.get_transaction_outputs_with_proof_by_size(
+                    proof_version,
+                    start_version,
+                    end_version,
+                    max_response_bytes,
+                )
             },
             TransactionDataRequestType::TransactionOrOutputData(request) => {
                 // Get the transaction or output list with proof
-                self.get_transactions_or_outputs_with_proof(
+                self.get_transactions_or_outputs_with_proof_by_size(
                     proof_version,
                     start_version,
                     end_version,
                     request.include_events,
                     0, // Fetch all outputs, or return transactions
+                    max_response_bytes,
                 )
             },
         }
@@ -513,50 +637,12 @@ impl StorageReaderInterface for StorageReader {
         start_index: u64,
         end_index: u64,
     ) -> aptos_storage_service_types::Result<StateValueChunkWithProof, Error> {
-        // Calculate the number of state values to fetch
-        let expected_num_state_values = inclusive_range_len(start_index, end_index)?;
-        let max_num_state_values = self.config.max_state_chunk_size;
-        let mut num_state_values_to_fetch = min(expected_num_state_values, max_num_state_values);
-
-        // Attempt to serve the request
-        while num_state_values_to_fetch >= 1 {
-            let state_value_chunk_with_proof = self
-                .storage
-                .get_state_value_chunk_with_proof(
-                    version,
-                    start_index as usize,
-                    num_state_values_to_fetch as usize,
-                )
-                .map_err(|error| Error::StorageErrorEncountered(error.to_string()))?;
-            if num_state_values_to_fetch == 1 {
-                return Ok(state_value_chunk_with_proof); // We cannot return less than a single item
-            }
-
-            // Attempt to divide up the request if it overflows the message size
-            let max_network_chunk_bytes = self.config.max_network_chunk_bytes;
-            let (overflow_frame, num_bytes) = check_overflow_network_frame(
-                &state_value_chunk_with_proof,
-                max_network_chunk_bytes,
-            )?;
-            if !overflow_frame {
-                return Ok(state_value_chunk_with_proof);
-            } else {
-                increment_network_frame_overflow(
-                    DataResponse::StateValueChunkWithProof(state_value_chunk_with_proof)
-                        .get_label(),
-                );
-                let new_num_state_values_to_fetch = num_state_values_to_fetch / 2;
-                debug!("The request for {:?} state values was too large (num bytes: {:?}, limit: {:?}). Retrying with {:?}.",
-                    num_state_values_to_fetch, num_bytes, max_network_chunk_bytes, new_num_state_values_to_fetch);
-                num_state_values_to_fetch = new_num_state_values_to_fetch; // Try again with half the amount of data
-            }
-        }
-
-        Err(Error::UnexpectedErrorEncountered(format!(
-            "Unable to serve the get_state_value_chunk_with_proof request! Version: {:?}, \
-            start index: {:?}, end index: {:?}. The data cannot fit into a single network frame!",
-            version, start_index, end_index
-        )))
+        self.get_state_value_chunk_with_proof_by_size(
+            version,
+            start_index,
+            end_index,
+            self.config.max_network_chunk_bytes,
+        )
     }
 }
 

--- a/state-sync/storage-service/server/src/tests/cache.rs
+++ b/state-sync/storage-service/server/src/tests/cache.rs
@@ -68,6 +68,7 @@ async fn test_cachable_requests_compression() {
                     include_events,
                     *use_compression,
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await
                 .unwrap();
@@ -139,6 +140,7 @@ async fn test_cachable_requests_data_versions() {
                     include_events,
                     true,
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await
                 .unwrap();

--- a/state-sync/storage-service/server/src/tests/new_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions.rs
@@ -67,6 +67,7 @@ async fn test_get_new_transactions() {
                     highest_epoch,
                     include_events,
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -172,6 +173,7 @@ async fn test_get_new_transactions_different_networks() {
                     include_events,
                     Some(peer_network_1),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -184,6 +186,7 @@ async fn test_get_new_transactions_different_networks() {
                     include_events,
                     Some(peer_network_2),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -243,6 +246,7 @@ async fn test_get_new_transactions_disable_v2() {
         0,
         true,
         true, // use_request_v2
+        0,
     )
     .await;
 
@@ -314,6 +318,7 @@ async fn test_get_new_transactions_epoch_change() {
                 peer_epoch,
                 include_events,
                 use_request_v2,
+                storage_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -398,6 +403,7 @@ async fn test_get_new_transactions_max_chunk() {
                 highest_epoch,
                 include_events,
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -432,6 +438,7 @@ async fn get_new_transactions_with_proof(
     known_epoch: u64,
     include_events: bool,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     get_new_transactions_with_proof_for_peer(
         mock_client,
@@ -440,6 +447,7 @@ async fn get_new_transactions_with_proof(
         include_events,
         None,
         use_request_v2,
+        max_response_bytes_v2,
     )
     .await
 }
@@ -452,6 +460,7 @@ async fn get_new_transactions_with_proof_for_peer(
     include_events: bool,
     peer_network_id: Option<PeerNetworkId>,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
     let data_request = if use_request_v2 {
@@ -459,7 +468,7 @@ async fn get_new_transactions_with_proof_for_peer(
             known_version,
             known_epoch,
             include_events,
-            0,
+            max_response_bytes_v2,
         )
     } else {
         DataRequest::GetNewTransactionsWithProof(NewTransactionsWithProofRequest {

--- a/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/new_transactions_or_outputs.rs
@@ -87,6 +87,7 @@ async fn test_get_new_transactions_or_outputs() {
                     false,
                     0, // Outputs cannot be reduced and will fallback to transactions
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -238,6 +239,7 @@ async fn test_get_new_transactions_or_outputs_different_network() {
                     0, // Outputs cannot be reduced and will fallback to transactions
                     Some(peer_network_1),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -251,6 +253,7 @@ async fn test_get_new_transactions_or_outputs_different_network() {
                     0, // Outputs cannot be reduced and will fallback to transactions
                     Some(peer_network_2),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -334,6 +337,7 @@ async fn test_get_new_transactions_or_outputs_disable_v2() {
         true,
         0,
         true, // use_request_v2
+        storage_config.max_network_chunk_bytes_v2,
     )
     .await;
 
@@ -424,6 +428,7 @@ async fn test_get_new_transactions_or_outputs_epoch_change() {
                 false,
                 5,
                 use_request_v2,
+                storage_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -543,6 +548,7 @@ async fn test_get_new_transactions_or_outputs_max_chunk() {
                 false,
                 max_num_output_reductions,
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -591,6 +597,7 @@ async fn get_new_transactions_or_outputs_with_proof(
     include_events: bool,
     max_num_output_reductions: u64,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     get_new_transactions_or_outputs_with_proof_for_peer(
         mock_client,
@@ -600,6 +607,7 @@ async fn get_new_transactions_or_outputs_with_proof(
         max_num_output_reductions,
         None,
         use_request_v2,
+        max_response_bytes_v2,
     )
     .await
 }
@@ -613,6 +621,7 @@ async fn get_new_transactions_or_outputs_with_proof_for_peer(
     max_num_output_reductions: u64,
     peer_network_id: Option<PeerNetworkId>,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     // Create the data request
     let data_request = if use_request_v2 {
@@ -620,7 +629,7 @@ async fn get_new_transactions_or_outputs_with_proof_for_peer(
             known_version,
             known_epoch,
             include_events,
-            0,
+            max_response_bytes_v2,
         )
     } else {
         DataRequest::GetNewTransactionsOrOutputsWithProof(

--- a/state-sync/storage-service/server/src/tests/subscribe_transaction_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transaction_outputs.rs
@@ -79,6 +79,7 @@ async fn test_subscribe_transaction_outputs_different_networks() {
                 0,
                 Some(peer_network_1),
                 use_request_v2,
+                storage_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -92,6 +93,7 @@ async fn test_subscribe_transaction_outputs_different_networks() {
                 0,
                 Some(peer_network_2),
                 use_request_v2,
+                storage_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -150,6 +152,7 @@ async fn test_subscribe_transaction_outputs_disable_v2() {
         0,
         0,
         true, // Use transaction v2
+        0,
     )
     .await;
 
@@ -218,6 +221,7 @@ async fn test_subscribe_transaction_outputs_epoch_change() {
             utils::get_random_u64(),
             0,
             use_request_v2,
+            storage_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -296,6 +300,7 @@ async fn test_subscribe_transaction_outputs_max_chunk() {
             utils::get_random_u64(),
             0,
             use_request_v2,
+            storage_service_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -398,6 +403,7 @@ async fn test_subscribe_transaction_outputs_streaming() {
                 peer_version,
                 highest_epoch,
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -531,6 +537,7 @@ async fn test_subscribe_transaction_outputs_streaming_epoch_change() {
             peer_version,
             peer_epoch,
             use_request_v2,
+            storage_service_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -645,6 +652,7 @@ async fn test_subscribe_transaction_outputs_streaming_loop() {
             peer_version,
             highest_epoch,
             use_request_v2,
+            storage_service_config.max_network_chunk_bytes_v2,
         )
         .await;
 

--- a/state-sync/storage-service/server/src/tests/subscribe_transactions.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transactions.rs
@@ -92,6 +92,7 @@ async fn test_subscribe_transactions_different_networks() {
                     0,
                     Some(peer_network_1),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -106,6 +107,7 @@ async fn test_subscribe_transactions_different_networks() {
                     0,
                     Some(peer_network_2),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -166,6 +168,7 @@ async fn test_subscribe_transactions_disable_v2() {
         0,
         0,
         true, // Use transaction v2
+        storage_config.max_network_chunk_bytes_v2,
     )
     .await;
 
@@ -239,6 +242,7 @@ async fn test_subscribe_transactions_epoch_change() {
                 utils::get_random_u64(),
                 0,
                 use_request_v2,
+                storage_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -325,6 +329,7 @@ async fn test_subscribe_transactions_max_chunk() {
                 utils::get_random_u64(),
                 0,
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -429,6 +434,7 @@ async fn test_subscribe_transactions_streaming() {
                 peer_version,
                 highest_epoch,
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -564,6 +570,7 @@ async fn test_subscribe_transactions_streaming_epoch_change() {
             peer_version,
             peer_epoch,
             use_request_v2,
+            storage_service_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -679,6 +686,7 @@ async fn test_subscribe_transactions_streaming_loop() {
             peer_version,
             highest_epoch,
             use_request_v2,
+            storage_service_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -734,6 +742,7 @@ async fn send_transaction_subscription_request_batch(
     peer_version: u64,
     peer_epoch: u64,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> HashMap<u64, Receiver<Result<Bytes, RpcError>>> {
     // Shuffle the stream request indices to emulate out of order requests
     let stream_request_indices =
@@ -752,6 +761,7 @@ async fn send_transaction_subscription_request_batch(
             stream_request_index,
             Some(peer_network_id),
             use_request_v2,
+            max_response_bytes_v2,
         )
         .await;
 

--- a/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
+++ b/state-sync/storage-service/server/src/tests/subscribe_transactions_or_outputs.rs
@@ -127,6 +127,7 @@ async fn test_subscribe_transactions_or_outputs_different_network() {
                     0,
                     Some(peer_network_1),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -142,6 +143,7 @@ async fn test_subscribe_transactions_or_outputs_different_network() {
                     0,
                     Some(peer_network_2),
                     use_request_v2,
+                    storage_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -226,6 +228,7 @@ async fn test_subscribe_transactions_or_outputs_disable_v2() {
         0,
         0,
         true, // Use transaction v2
+        0,
     )
     .await;
 
@@ -318,6 +321,7 @@ async fn test_subscribe_transactions_or_outputs_epoch_change() {
                 utils::get_random_u64(),
                 0,
                 use_request_v2,
+                storage_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -436,6 +440,7 @@ async fn test_subscribe_transactions_or_outputs_max_chunk() {
                 utils::get_random_u64(),
                 0,
                 use_request_v2,
+                storage_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -589,6 +594,7 @@ async fn test_subscribe_transaction_or_outputs_streaming() {
                     peer_version,
                     highest_epoch,
                     use_request_v2,
+                    storage_service_config.max_network_chunk_bytes_v2,
                 )
                 .await;
 
@@ -758,6 +764,7 @@ async fn test_subscribe_transactions_or_outputs_streaming_epoch_change() {
                 peer_version,
                 peer_epoch,
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -924,6 +931,7 @@ async fn test_subscribe_transaction_or_outputs_streaming_loop() {
                 peer_version,
                 highest_epoch,
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -993,6 +1001,7 @@ async fn send_transaction_or_output_subscription_request_batch(
     peer_version: u64,
     peer_epoch: u64,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> HashMap<u64, Receiver<Result<Bytes, RpcError>>> {
     // Shuffle the stream request indices to emulate out of order requests
     let stream_request_indices =
@@ -1012,6 +1021,7 @@ async fn send_transaction_or_output_subscription_request_batch(
             stream_request_index,
             Some(peer_network_id),
             use_request_v2,
+            max_response_bytes_v2,
         )
         .await;
 

--- a/state-sync/storage-service/server/src/tests/subscription.rs
+++ b/state-sync/storage-service/server/src/tests/subscription.rs
@@ -777,6 +777,7 @@ async fn test_subscription_max_pending_requests() {
             peer_version,
             highest_epoch,
             use_request_v2,
+            storage_service_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -800,6 +801,7 @@ async fn test_subscription_max_pending_requests() {
                 stream_request_index,
                 Some(peer_network_id),
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -852,6 +854,7 @@ async fn test_subscription_max_pending_requests() {
             peer_version,
             highest_epoch,
             use_request_v2,
+            storage_service_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -877,6 +880,7 @@ async fn test_subscription_max_pending_requests() {
                 stream_request_index,
                 Some(peer_network_id),
                 use_request_v2,
+                storage_service_config.max_network_chunk_bytes_v2,
             )
             .await;
 
@@ -967,6 +971,7 @@ async fn test_subscription_overwrite_streams() {
             peer_version,
             highest_epoch,
             use_request_v2,
+            storage_config.max_network_chunk_bytes_v2,
         )
         .await;
 
@@ -1011,6 +1016,7 @@ async fn test_subscription_overwrite_streams() {
             0,
             Some(peer_network_id),
             use_request_v2,
+            storage_config.max_network_chunk_bytes_v2,
         )
         .await;
 

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -395,6 +395,7 @@ pub fn configure_network_chunk_limit(
     StorageServiceConfig {
         max_network_chunk_bytes,
         enable_transaction_data_v2,
+        max_network_chunk_bytes_v2: max_network_chunk_bytes, // Use the same limit for v2
         ..Default::default()
     }
 }
@@ -586,6 +587,7 @@ pub async fn get_transactions_with_proof(
     include_events: bool,
     use_compression: bool,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Result<StorageServiceResponse, StorageServiceError> {
     let data_request = if use_request_v2 {
         DataRequest::get_transaction_data_with_proof(
@@ -593,7 +595,7 @@ pub async fn get_transactions_with_proof(
             start_version,
             end_version,
             include_events,
-            0,
+            max_response_bytes_v2,
         )
     } else {
         DataRequest::GetTransactionsWithProof(TransactionsWithProofRequest {
@@ -625,6 +627,7 @@ pub async fn send_output_subscription_request_batch(
     peer_version: u64,
     peer_epoch: u64,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> HashMap<u64, Receiver<Result<Bytes, RpcError>>> {
     // Shuffle the stream request indices to emulate out of order requests
     let stream_request_indices =
@@ -642,6 +645,7 @@ pub async fn send_output_subscription_request_batch(
             stream_request_index,
             Some(peer_network_id),
             use_request_v2,
+            max_response_bytes_v2,
         )
         .await;
 
@@ -672,6 +676,7 @@ pub async fn subscribe_to_transactions_or_outputs(
     stream_id: u64,
     stream_index: u64,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<bytes::Bytes, aptos_network::protocols::network::RpcError>> {
     subscribe_to_transactions_or_outputs_for_peer(
         mock_client,
@@ -683,6 +688,7 @@ pub async fn subscribe_to_transactions_or_outputs(
         stream_index,
         None,
         use_request_v2,
+        max_response_bytes_v2,
     )
     .await
 }
@@ -698,6 +704,7 @@ pub async fn subscribe_to_transactions_or_outputs_for_peer(
     subscription_stream_index: u64,
     peer_network_id: Option<PeerNetworkId>,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<Bytes, RpcError>> {
     // Create the data request
     let subscription_stream_metadata = SubscriptionStreamMetadata {
@@ -710,7 +717,7 @@ pub async fn subscribe_to_transactions_or_outputs_for_peer(
             subscription_stream_metadata,
             subscription_stream_index,
             include_events,
-            0,
+            max_response_bytes_v2,
         )
     } else {
         DataRequest::SubscribeTransactionsOrOutputsWithProof(
@@ -739,6 +746,7 @@ pub async fn subscribe_to_transaction_outputs(
     stream_id: u64,
     stream_index: u64,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<Bytes, RpcError>> {
     subscribe_to_transaction_outputs_for_peer(
         mock_client,
@@ -748,6 +756,7 @@ pub async fn subscribe_to_transaction_outputs(
         stream_index,
         None,
         use_request_v2,
+        max_response_bytes_v2,
     )
     .await
 }
@@ -761,6 +770,7 @@ pub async fn subscribe_to_transaction_outputs_for_peer(
     subscription_stream_index: u64,
     peer_network_id: Option<PeerNetworkId>,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<Bytes, RpcError>> {
     // Create the data request
     let subscription_stream_metadata = SubscriptionStreamMetadata {
@@ -772,7 +782,7 @@ pub async fn subscribe_to_transaction_outputs_for_peer(
         DataRequest::subscribe_transaction_output_data_with_proof(
             subscription_stream_metadata,
             subscription_stream_index,
-            0,
+            max_response_bytes_v2,
         )
     } else {
         DataRequest::SubscribeTransactionOutputsWithProof(
@@ -800,6 +810,7 @@ pub async fn subscribe_to_transactions(
     stream_id: u64,
     stream_index: u64,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<Bytes, RpcError>> {
     subscribe_to_transactions_for_peer(
         mock_client,
@@ -810,6 +821,7 @@ pub async fn subscribe_to_transactions(
         stream_index,
         None,
         use_request_v2,
+        max_response_bytes_v2,
     )
     .await
 }
@@ -824,6 +836,7 @@ pub async fn subscribe_to_transactions_for_peer(
     subscription_stream_index: u64,
     peer_network_id: Option<PeerNetworkId>,
     use_request_v2: bool,
+    max_response_bytes_v2: u64,
 ) -> Receiver<Result<Bytes, RpcError>> {
     // Create the data request
     let subscription_stream_metadata = SubscriptionStreamMetadata {
@@ -836,7 +849,7 @@ pub async fn subscribe_to_transactions_for_peer(
             subscription_stream_metadata,
             subscription_stream_index,
             include_events,
-            0,
+            max_response_bytes_v2,
         )
     } else {
         DataRequest::SubscribeTransactionsWithProof(SubscribeTransactionsWithProofRequest {


### PR DESCRIPTION
## Description
This PR updates the storage service to respect the max response sizes specified by clients when making requests for v2 transaction data. Now, the storage service will use the client specified size, or the local storage config maximum, whichever is smaller (to avoid excessive data sizes). The PR also increases the default max response size from 10MB -> 15MB (to help favor output syncing).

The PR offers the following commits:
1. Update the storage service to respect the max response sizes.
2. Update the tests to verify the new functionality.

## Testing Plan
New and existing test infrastructure.
