### PR TITLE
[ci] build images automatically if not present

### DIFF
--- a/.github/actions/wait-images-ci/action.yaml
+++ b/.github/actions/wait-images-ci/action.yaml
@@ -11,8 +11,16 @@ inputs:
     description: "The number of seconds to wait for the images to be available"
     required: false
     default: "1800" # a sane default based on the longest observed build time on the main branch
-  RELEASE_DEFAULT_ONLY:
-    description: "If true, only wait for the release default images to be available"
+  RELEASE_DEFAULT:
+    description: "If true, wait for the release default images to be available."
+    required: false
+    default: false
+  PERF:
+    description: "If true, wait for the performance images to be available."
+    required: false
+    default: false
+  FAILPOINTS:
+    description: "If true, wait for the failpoints images to be available."
     required: false
     default: false
 runs:
@@ -27,5 +35,5 @@ runs:
     # The source code must be checkout out by the workflow that invokes this action.
     - name: Run wait-images-ci
       run: |
-        GCP_DOCKER_ARTIFACT_REPO=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }} GIT_SHA=${{ inputs.GIT_SHA }} RELEASE_DEFAULT_ONLY=${{ inputs.RELEASE_DEFAULT_ONLY }} ./docker/wait-images-ci.mjs --wait-for-image-seconds=${{ inputs.WAIT_FOR_IMAGE_SECONDS }}
+        GCP_DOCKER_ARTIFACT_REPO=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }} GIT_SHA=${{ inputs.GIT_SHA }} RELEASE_DEFAULT=${{ inputs.RELEASE_DEFAULT }} PERF=${{ inputs.PERF }} FAILPOINTS=${{ inputs.FAILPOINTS }} ./docker/wait-images-ci.mjs --wait-for-image-seconds=${{ inputs.WAIT_FOR_IMAGE_SECONDS }}
       shell: bash

--- a/.github/actions/wait-images-ci/action.yaml
+++ b/.github/actions/wait-images-ci/action.yaml
@@ -11,6 +11,10 @@ inputs:
     description: "The number of seconds to wait for the images to be available"
     required: false
     default: "1800" # a sane default based on the longest observed build time on the main branch
+  RELEASE_DEFAULT_ONLY:
+    description: "If true, only wait for the release default images to be available"
+    required: false
+    default: false
 runs:
   using: composite
   steps:
@@ -23,5 +27,5 @@ runs:
     # The source code must be checkout out by the workflow that invokes this action.
     - name: Run wait-images-ci
       run: |
-        GCP_DOCKER_ARTIFACT_REPO=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }} GIT_SHA=${{ inputs.GIT_SHA }} ./docker/wait-images-ci.mjs --wait-for-image-seconds=${{ inputs.WAIT_FOR_IMAGE_SECONDS }}
+        GCP_DOCKER_ARTIFACT_REPO=${{ inputs.GCP_DOCKER_ARTIFACT_REPO }} GIT_SHA=${{ inputs.GIT_SHA }} RELEASE_DEFAULT_ONLY=${{ inputs.RELEASE_DEFAULT_ONLY }} ./docker/wait-images-ci.mjs --wait-for-image-seconds=${{ inputs.WAIT_FOR_IMAGE_SECONDS }}
       shell: bash

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -148,6 +148,7 @@ jobs:
       PROFILE: release
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
+      RELEASE_DEFAULT_CHECK: true
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
@@ -164,6 +165,7 @@ jobs:
       FEATURES: failpoints
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
+      FAILPOINTS_CHECK: true
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
@@ -179,6 +181,7 @@ jobs:
       PROFILE: performance
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
+      PERF_CHECK: true
 
   rust-images-consensus-only-perf-test:
     needs: [permission-check, determine-docker-build-metadata]

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -140,7 +140,7 @@ jobs:
   # This is a PR required job.
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: revert
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -151,7 +151,7 @@ jobs:
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: revert
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
@@ -167,7 +167,7 @@ jobs:
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: revert
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -148,7 +148,7 @@ jobs:
       PROFILE: release
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
-      RELEASE_DEFAULT_CHECK: true
+      WAIT_FOR_RELEASE_IMAGES: true
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
@@ -165,7 +165,7 @@ jobs:
       FEATURES: failpoints
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
-      FAILPOINTS_CHECK: true
+      WAIT_FOR_FAILPOINTS_IMAGES: true
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
@@ -181,7 +181,7 @@ jobs:
       PROFILE: performance
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
-      PERF_CHECK: true
+      WAIT_FOR_PERF_IMAGES: true
 
   rust-images-consensus-only-perf-test:
     needs: [permission-check, determine-docker-build-metadata]

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -148,7 +148,6 @@ jobs:
       PROFILE: release
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
-      WAIT_FOR_RELEASE_IMAGES: true
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
@@ -165,7 +164,6 @@ jobs:
       FEATURES: failpoints
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
-      WAIT_FOR_FAILPOINTS_IMAGES: true
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
@@ -181,7 +179,6 @@ jobs:
       PROFILE: performance
       BUILD_ADDL_TESTING_IMAGES: true
       TARGET_REGISTRY: ${{ needs.determine-docker-build-metadata.outputs.targetRegistry }}
-      WAIT_FOR_PERF_IMAGES: true
 
   rust-images-consensus-only-perf-test:
     needs: [permission-check, determine-docker-build-metadata]

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -140,7 +140,7 @@ jobs:
   # This is a PR required job.
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -152,7 +152,7 @@ jobs:
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
@@ -169,7 +169,7 @@ jobs:
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -140,7 +140,7 @@ jobs:
   # This is a PR required job.
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -140,7 +140,7 @@ jobs:
   # This is a PR required job.
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -140,7 +140,7 @@ jobs:
   # This is a PR required job.
   rust-images:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     secrets: inherit
     with:
       GIT_SHA: ${{ needs.determine-docker-build-metadata.outputs.gitSha }}
@@ -152,7 +152,7 @@ jobs:
 
   rust-images-failpoints:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
@@ -169,7 +169,7 @@ jobs:
 
   rust-images-performance:
     needs: [permission-check, determine-docker-build-metadata]
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     if: |
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||

--- a/.github/workflows/replay-verify-mainnet.yaml
+++ b/.github/workflows/replay-verify-mainnet.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         description: Optional version to end replaying. If not specified, replay-verify will determine end version itself.
+      DRY_RUN: 
+        required: false
+        type: boolean
+        description: If true, the workflow will not run replay verify.
+        default: false
   pull_request:
     paths:
       - ".github/workflows/replay-verify-mainnet.yaml"
@@ -60,3 +65,4 @@ jobs:
       IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
       START_VERSION: ${{ inputs.START_VERSION }}
       END_VERSION: ${{ inputs.END_VERSION }}
+      DRY_RUN: ${{ inputs.DRY_RUN }}

--- a/.github/workflows/replay-verify-mainnet.yaml
+++ b/.github/workflows/replay-verify-mainnet.yaml
@@ -23,7 +23,7 @@ on:
       DRY_RUN: 
         required: false
         type: boolean
-        description: If true, the workflow will not run replay verify.
+        description: If true, the workflow will not run replay verify nor build images.
         default: false
   pull_request:
     paths:

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -23,7 +23,7 @@ on:
       DRY_RUN: 
         required: false
         type: boolean
-        description: If true, the workflow will not run replay verify.
+        description: If true, the workflow will not run replay verify nor build images.
         default: false
   pull_request:
     paths:

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -20,6 +20,11 @@ on:
         required: false
         type: string
         description: Optional version to end replaying. If not specified, replay-verify will determine end version itself.
+      DRY_RUN: 
+        required: false
+        type: boolean
+        description: If true, the workflow will not run replay verify.
+        default: false
   pull_request:
     paths:
       - ".github/workflows/replay-verify-testnet.yaml"
@@ -61,3 +66,4 @@ jobs:
       IMAGE_TAG: ${{ inputs.IMAGE_TAG }}
       START_VERSION: ${{ inputs.START_VERSION }}
       END_VERSION: ${{ inputs.END_VERSION }}
+      DRY_RUN: ${{ inputs.DRY_RUN }}

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -54,7 +54,6 @@ jobs:
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
-  # TODO: Remove pull_request from the if statement after testing
   replay:
     if: |
       github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -49,9 +49,10 @@ jobs:
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork
 
+  # TODO: Remove pull_request from the if statement after testing
   replay:
     if: |
-      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
     needs: determine-test-metadata
     uses: ./.github/workflows/workflow-run-replay-verify-on-archive.yaml
     secrets: inherit

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -52,7 +52,7 @@ jobs:
   # TODO: Remove pull_request from the if statement after testing
   replay:
     if: |
-      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' || github.event_name == 'pull_request'
+      github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
     needs: determine-test-metadata
     uses: ./.github/workflows/workflow-run-replay-verify-on-archive.yaml
     secrets: inherit

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -30,17 +30,17 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      RELEASE_DEFAULT_CHECK:
+      WAIT_FOR_RELEASE_IMAGES:
         required: false
         type: boolean
         description: If true, wait for the release default images to be available
         default: false
-      PERF_CHECK:
+      WAIT_FOR_PERF_IMAGES:
         required: false
         type: boolean
         description: If true, wait for the performance images to be available
         default: false
-      FAILPOINTS_CHECK:
+      WAIT_FOR_FAILPOINTS_IMAGES:
         required: false
         type: boolean
         description: If true, wait for the failpoints images to be available
@@ -76,17 +76,17 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      RELEASE_DEFAULT_CHECK:
+      WAIT_FOR_RELEASE_IMAGES:
         required: false
         type: boolean
         description: If true, wait for the release default images to be available
         default: false
-      PERF_CHECK:
+      WAIT_FOR_PERF_IMAGES:
         required: false
         type: boolean
         description: If true, wait for the performance images to be available
         default: false
-      FAILPOINTS_CHECK:
+      WAIT_FOR_FAILPOINTS_IMAGES:
         required: false
         type: boolean
         description: If true, wait for the failpoints images to be available
@@ -152,9 +152,9 @@ jobs:
           GIT_SHA: ${{ env.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
           WAIT_FOR_IMAGE_SECONDS: 1
-          RELEASE_DEFAULT: ${{ inputs.RELEASE_DEFAULT_CHECK }}
-          PERF: ${{ inputs.PERF_CHECK }}
-          FAILPOINTS: ${{ inputs.FAILPOINTS_CHECK }}
+          RELEASE_DEFAULT: ${{ inputs.WAIT_FOR_RELEASE_IMAGES }}
+          PERF: ${{ inputs.WAIT_FOR_PERF_IMAGES }}
+          FAILPOINTS: ${{ inputs.WAIT_FOR_FAILPOINTS_IMAGES }}
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -82,14 +82,14 @@ jobs:
         with:
           ref: ${{ env.GIT_SHA }}
 
-      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: "google-github-actions/auth@v2"
         with:
-          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
-          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          export_environment_variables: false
+          create_credentials_file: true
 
       - name: Check if docker images already exist
         id: check-images

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Check if docker images already exist
         id: check-images
-        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
         continue-on-error: true
         with:
           GIT_SHA: ${{ env.GIT_SHA }}
@@ -161,8 +161,7 @@ jobs:
           fi
 
       - name: Build and Push Rust images
-        # if: ${{ inputs.DRY_RUN == false }} TODO: re-enable this after testing
-        if: ${{ steps.check-images.outcome == 'failure' }}
+        if: ${{ steps.check-images.outcome == 'failure' && inputs.DRY_RUN == false }}
         run: docker/builder/docker-bake-rust-all.sh
         env:
           PROFILE: ${{ env.PROFILE }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -131,6 +131,7 @@ jobs:
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
       
       - name: Lock Check and Creation
+        id: lock
         run: |
           set +e
           gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
@@ -166,7 +167,7 @@ jobs:
           fi
       
       - name: Post-run Lock Cleanup 
-        if: always()
+        if: ${{ always() && steps.lock.outcome == 'success' }}
         run: | 
           gcloud storage rm gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${GIT_SHA}.txt || true
           echo "Docker Build unlocked"

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -30,17 +30,17 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      RELEASE_DEFAULT:
+      RELEASE_DEFAULT_CHECK:
         required: false
         type: boolean
         description: If true, wait for the release default images to be available
         default: false
-      PERF:
+      PERF_CHECK:
         required: false
         type: boolean
         description: If true, wait for the performance images to be available
         default: false
-      FAILPOINTS:
+      FAILPOINTS_CHECK:
         required: false
         type: boolean
         description: If true, wait for the failpoints images to be available
@@ -76,17 +76,17 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      RELEASE_DEFAULT:
+      RELEASE_DEFAULT_CHECK:
         required: false
         type: boolean
         description: If true, wait for the release default images to be available
         default: false
-      PERF:
+      PERF_CHECK:
         required: false
         type: boolean
         description: If true, wait for the performance images to be available
         default: false
-      FAILPOINTS:
+      FAILPOINTS_CHECK:
         required: false
         type: boolean
         description: If true, wait for the failpoints images to be available
@@ -146,15 +146,15 @@ jobs:
 
       - name: Check if docker images already exist
         id: check-images
-        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@jkao97/verify-and-build-images-for-workflows #TODO: revert
         continue-on-error: true
         with:
           GIT_SHA: ${{ env.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
           WAIT_FOR_IMAGE_SECONDS: 1
-          RELEASE_DEFAULT: ${{ inputs.RELEASE_DEFAULT }}
-          PERF: ${{ inputs.PERF }}
-          FAILPOINTS: ${{ inputs.FAILPOINTS }}
+          RELEASE_DEFAULT: ${{ inputs.RELEASE_DEFAULT_CHECK }}
+          PERF: ${{ inputs.PERF_CHECK }}
+          FAILPOINTS: ${{ inputs.FAILPOINTS_CHECK }}
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -93,7 +93,6 @@ jobs:
 
       - name: Set output
         id: set-output
-        needs: check-images
         run: |
           if [ "${{ steps.check-images.outcome }}" = "success" ]; then
             echo "image-exist=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -178,7 +178,7 @@ jobs:
           fi
       
       - name: Post-run Lock Cleanup 
-        if: ${{ always() }}
+        if: ${{ always() && steps.lock.outcome == 'success' }}
         run: | 
           gcloud storage rm gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${GIT_SHA}.txt || true
           echo "Docker Build unlocked"

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -141,14 +141,18 @@ jobs:
         if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
         run: |
           set +e
-          gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+          output=$(gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt)
           result=$?
           set -e
-          if [ $result -eq 0 ]; then
-            echo "Lock file exists: Current workflow building: " | tee -a $GITHUB_STEP_SUMMARY
-            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt | tee -a $GITHUB_STEP_SUMMARY
-            echo "Rerun again when the image is finished building" | tee -a $GITHUB_STEP_SUMMARY
-            exit 1
+          if [[ $result -eq 0 ]]; then
+            if [[ "$output" != *"${{ github.run_id }}"* ]]; then
+              echo "Lock file for current workflow exists. Continuing ..."
+            else
+              echo "Lock file exists: Current workflow building: " | tee -a $GITHUB_STEP_SUMMARY
+              gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt | tee -a $GITHUB_STEP_SUMMARY
+              echo "Rerun again when the image is finished building" | tee -a $GITHUB_STEP_SUMMARY
+              exit 1
+            fi
           else
             echo "Lock file does not exist"
             echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${{ env.GIT_SHA }}.txt

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -145,9 +145,9 @@ jobs:
           result=$?
           set -e
           if [ $result -eq 0 ]; then
-            echo "Lock file exists: Current workflow building: " >> $GITHUB_STEP_SUMMARY
-            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt >> $GITHUB_STEP_SUMMARY
-            echo "Rerun again when the image is finished building" >> $GITHUB_STEP_SUMMARY
+            echo "Lock file exists: Current workflow building: " | tee -a $GITHUB_STEP_SUMMARY
+            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt | tee -a $GITHUB_STEP_SUMMARY
+            echo "Rerun again when the image is finished building" | tee -a $GITHUB_STEP_SUMMARY
             exit 1
           else
             echo "Lock file does not exist"

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -112,11 +112,6 @@ jobs:
           GIT_SHA: ${{ env.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
           WAIT_FOR_IMAGE_SECONDS: 1
-      
-      - name: Setup GCloud
-        uses: google-github-actions/setup-gcloud@v2
-        with:
-          install_components: 'gcloud'
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -124,33 +119,39 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-
-      - name: Configure GCloud
-        run: |
-          gcloud config set project aptos-ci
-
-      - name: Lock File Check and Lock if not exists
+      
+      - name: Check if lock file exists
         id: check-lock
         if: steps.check-images.outcome == 'failure'
-        run:  |
-          echo "Checking lock file"
+        run: |
           set +e
           gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
-          result=$?
-          set -e
-          if [ $result -eq 0 ]; then
-            echo "Lock file exists: Current workflow building: "
-            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
-            echo "Rerun again when the image is finished building" && exit 1
+          if [ $? -eq 0 ]; then
+            echo "lock-exists=true" >> $GITHUB_OUTPUT
           else
-            echo "Lock file does not exist"
-            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
-            gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
-            echo "Docker Build locked"
+            echo "lock-exists=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Show lock file content
+        if: steps.check-lock.outputs.lock-exists == 'true'
+        run: |
+          echo "Lock file exists: Current workflow building: "
+          gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+          echo "Rerun again when the image is finished building"
+          exit 1
+
+      - name: Create and upload lock file
+        id: create-lock
+        if: steps.check-lock.outputs.lock-exists == 'false'
+        run: |
+          echo "Lock file does not exist"
+          echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
+          gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
+          echo "Docker Build locked"
 
       - name: Build and Push Rust images
         run: docker/builder/docker-bake-rust-all.sh
+        if: steps.create-lock.outcome == 'success'
         env:
           PROFILE: ${{ env.PROFILE }}
           FEATURES: ${{ env.FEATURES }}
@@ -159,6 +160,7 @@ jobs:
           TARGET_REGISTRY: ${{ env.TARGET_REGISTRY }}
       
       - name: Prepare Docker for Caching
+        if: steps.create-lock.outcome == 'success'
         run: |
           if [ ! -f /home/runner/docker-cache.tzst ]; then
             sudo systemctl stop docker

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -66,14 +66,64 @@ env:
   AWS_ECR_ACCOUNT_NUM: ${{ secrets.ENV_ECR_AWS_ACCOUNT_NUM }}
   GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
   TARGET_REGISTRY: ${{ inputs.TARGET_REGISTRY }}
+  GCP_DOCKER_BUILD_LOCK_BUCKET: "aptos-docker-build-lock-bucket"
 
 permissions:
   contents: read
   id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
 
 jobs:
+  pre-build-validation:
+    outputs: 
+      image-exist: ${{ steps.set-output.outputs.image-exist }}
+    runs-on: runs-on,cpu=4,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=small
+    steps:       
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_SHA }}
+
+      - name: Check if docker images already exist
+        id: check-images
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
+        continue-on-error: true
+        with:
+          GIT_SHA: ${{ env.GIT_SHA }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
+          WAIT_FOR_IMAGE_SECONDS: 1
+
+      - name: Set output
+        id: set-output
+        depends-on: check-images
+        run: |
+          if [ "${{ steps.check-images.outcome }}" = "success" ]; then
+            echo "image-exist=true" >> $GITHUB_OUTPUT
+          else
+            echo "image-exist=false" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Lock File Check and Lock if not exists
+        id: check-lock
+        if: steps.check-images.outcome == 'failure'
+        run:  |
+          set +e
+          gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+          result=$?
+          set -e
+          if [ $result -eq 0 ]; then
+            echo "Lock file exists: Current workflow building: "
+            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+            echo "Rerun again when the image is finished building" && exit 1
+          else
+            echo "Lock file does not exist"
+            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
+            gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
+            echo "Docker Build locked"
+          fi
+
   rust-all:
     runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=large
+    needs: pre-build-validation
+    if: needs.pre-build-validation.outputs.image-exist == 'false'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -118,4 +168,9 @@ jobs:
             sudo systemctl stop docker
             sudo tar --posix -cf /home/runner/docker-cache.tzst -P -C /var/lib/docker --use-compress-program zstdmt .
           fi
-
+      
+      - name: Post-run Lock Cleanup 
+        if: always()
+        run: | 
+          gcloud storage rm gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${GIT_SHA}.txt || true
+          echo "Docker Build unlocked"

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -113,11 +113,26 @@ jobs:
           GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
           WAIT_FOR_IMAGE_SECONDS: 1
       
+      - name: Setup GCloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          install_components: 'gcloud'
+
+      - name: Authenticate to Google Cloud
+        id: auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+
+      - name: Configure GCloud
+        run: |
+          gcloud config set project aptos-ci
+
       - name: Lock File Check and Lock if not exists
         id: check-lock
         if: steps.check-images.outcome == 'failure'
         run:  |
-          gcloud config set account aptos-ci
           echo "Checking lock file"
           set +e
           gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -143,13 +143,13 @@ jobs:
             exit 1
           else
             echo "Lock file does not exist"
-            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
-            gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
+            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${{ env.GIT_SHA }}.txt
+            gcloud storage cp ${{ env.GIT_SHA }}.txt gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
             echo "Docker Build locked"
           fi
 
       - name: Build and Push Rust images
-        if: ${{ inputs.DRY_RUN == false }}
+        # if: ${{ inputs.DRY_RUN == false }} TODO: re-enable this after testing
         run: docker/builder/docker-bake-rust-all.sh
         env:
           PROFILE: ${{ env.PROFILE }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -141,7 +141,7 @@ jobs:
         if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
         run: |
           set +e
-          output=$(gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt)
+          output=$(gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt)
           result=$?
           set -e
           if [[ $result -eq 0 ]]; then
@@ -149,7 +149,7 @@ jobs:
               echo "Lock file for current workflow exists. Continuing ..."
             else
               echo "Lock file exists: Current workflow building: " | tee -a $GITHUB_STEP_SUMMARY
-              gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt | tee -a $GITHUB_STEP_SUMMARY
+              echo "$output" | tee -a $GITHUB_STEP_SUMMARY
               echo "Rerun again when the image is finished building" | tee -a $GITHUB_STEP_SUMMARY
               exit 1
             fi

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -183,7 +183,7 @@ jobs:
           fi
 
       - name: Build and Push Rust images
-        if: ${{ steps.check-images.outcome == 'failure' && inputs.DRY_RUN == false }}
+        if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
         run: docker/builder/docker-bake-rust-all.sh
         env:
           PROFILE: ${{ env.PROFILE }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -162,6 +162,7 @@ jobs:
 
       - name: Build and Push Rust images
         # if: ${{ inputs.DRY_RUN == false }} TODO: re-enable this after testing
+        if: ${{ steps.check-images.outcome == 'failure' }}
         run: docker/builder/docker-bake-rust-all.sh
         env:
           PROFILE: ${{ env.PROFILE }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -145,7 +145,7 @@ jobs:
           result=$?
           set -e
           if [[ $result -eq 0 ]]; then
-            if [[ "$output" != *"${{ github.run_id }}"* ]]; then
+            if [[ "$output" == *"${{ github.run_id }}"* ]]; then
               echo "Lock file for current workflow exists. Continuing ..."
             else
               echo "Lock file exists: Current workflow building: " | tee -a $GITHUB_STEP_SUMMARY

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -30,21 +30,6 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      WAIT_FOR_RELEASE_IMAGES:
-        required: false
-        type: boolean
-        description: If true, wait for the release default images to be available
-        default: false
-      WAIT_FOR_PERF_IMAGES:
-        required: false
-        type: boolean
-        description: If true, wait for the performance images to be available
-        default: false
-      WAIT_FOR_FAILPOINTS_IMAGES:
-        required: false
-        type: boolean
-        description: If true, wait for the failpoints images to be available
-        default: false
       DRY_RUN: 
         required: false
         type: boolean
@@ -76,21 +61,6 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      WAIT_FOR_RELEASE_IMAGES:
-        required: false
-        type: boolean
-        description: If true, wait for the release default images to be available
-        default: false
-      WAIT_FOR_PERF_IMAGES:
-        required: false
-        type: boolean
-        description: If true, wait for the performance images to be available
-        default: false
-      WAIT_FOR_FAILPOINTS_IMAGES:
-        required: false
-        type: boolean
-        description: If true, wait for the failpoints images to be available
-        default: false
       DRY_RUN: 
         required: false
         type: boolean
@@ -107,6 +77,9 @@ env:
   GCP_DOCKER_ARTIFACT_REPO: ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}
   TARGET_REGISTRY: ${{ inputs.TARGET_REGISTRY }}
   GCP_DOCKER_BUILD_LOCK_BUCKET: "aptos-docker-build-lock-bucket"
+  RELEASE_DEFAULT: ${{ inputs.PROFILE == 'release' && inputs.FEATURES == '' }}
+  PERF: ${{ inputs.PROFILE == 'performance' }}
+  FAILPOINTS: ${{ inputs.FEATURES == 'failpoints' }}
 
 permissions:
   contents: read
@@ -152,9 +125,9 @@ jobs:
           GIT_SHA: ${{ env.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
           WAIT_FOR_IMAGE_SECONDS: 1
-          RELEASE_DEFAULT: ${{ inputs.WAIT_FOR_RELEASE_IMAGES }}
-          PERF: ${{ inputs.WAIT_FOR_PERF_IMAGES }}
-          FAILPOINTS: ${{ inputs.WAIT_FOR_FAILPOINTS_IMAGES }}
+          RELEASE_DEFAULT: ${{ env.RELEASE_DEFAULT }}
+          PERF: ${{ env.PERF }}
+          FAILPOINTS: ${{ env.FAILPOINTS }}
 
       - name: Authenticate to Google Cloud
         id: auth
@@ -172,9 +145,9 @@ jobs:
           result=$?
           set -e
           if [ $result -eq 0 ]; then
-            echo "Lock file exists: Current workflow building: "
-            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
-            echo "Rerun again when the image is finished building"
+            echo "Lock file exists: Current workflow building: " >> $GITHUB_STEP_SUMMARY
+            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt >> $GITHUB_STEP_SUMMARY
+            echo "Rerun again when the image is finished building" >> $GITHUB_STEP_SUMMARY
             exit 1
           else
             echo "Lock file does not exist"
@@ -201,7 +174,7 @@ jobs:
           fi
       
       - name: Post-run Lock Cleanup 
-        if: ${{ always() && steps.lock.outcome == 'success' }}
+        if: ${{ always() }}
         run: | 
           gcloud storage rm gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${GIT_SHA}.txt || true
           echo "Docker Build unlocked"

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -82,6 +82,15 @@ jobs:
         with:
           ref: ${{ env.GIT_SHA }}
 
+      - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
+        with:
+          GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          GCP_SERVICE_ACCOUNT_EMAIL: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
+          GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
       - name: Check if docker images already exist
         id: check-images
         uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -146,7 +146,7 @@ jobs:
 
       - name: Check if docker images already exist
         id: check-images
-        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@jkao97/verify-and-build-images-for-workflows #TODO: revert
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
         continue-on-error: true
         with:
           GIT_SHA: ${{ env.GIT_SHA }}
@@ -165,7 +165,7 @@ jobs:
       
       - name: Lock Check and Creation
         id: lock
-        if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
+        if: ${{ steps.check-images.outcome == 'failure' && inputs.DRY_RUN == false }}
         run: |
           set +e
           gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
@@ -184,7 +184,7 @@ jobs:
           fi
 
       - name: Build and Push Rust images
-        if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
+        if: ${{ steps.check-images.outcome == 'failure' && inputs.DRY_RUN == false }}
         run: docker/builder/docker-bake-rust-all.sh
         env:
           PROFILE: ${{ env.PROFILE }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Set output
         id: set-output
-        depends-on: check-images
+        needs: check-images
         run: |
           if [ "${{ steps.check-images.outcome }}" = "success" ]; then
             echo "image-exist=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
+      RELEASE_DEFAULT_ONLY:
+        required: false
+        type: boolean
+        description: If true, only wait for the release default images to be available
+        default: false
       DRY_RUN: 
         required: false
         type: boolean
@@ -61,6 +66,11 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
+      RELEASE_DEFAULT_ONLY:
+        required: false
+        type: boolean
+        description: If true, only wait for the release default images to be available
+        default: false
       DRY_RUN: 
         required: false
         type: boolean
@@ -122,6 +132,7 @@ jobs:
           GIT_SHA: ${{ env.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
           WAIT_FOR_IMAGE_SECONDS: 1
+          RELEASE_DEFAULT_ONLY: ${{ inputs.RELEASE_DEFAULT_ONLY }}
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -30,10 +30,20 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      RELEASE_DEFAULT_ONLY:
+      RELEASE_DEFAULT:
         required: false
         type: boolean
-        description: If true, only wait for the release default images to be available
+        description: If true, wait for the release default images to be available
+        default: false
+      PERF:
+        required: false
+        type: boolean
+        description: If true, wait for the performance images to be available
+        default: false
+      FAILPOINTS:
+        required: false
+        type: boolean
+        description: If true, wait for the failpoints images to be available
         default: false
       DRY_RUN: 
         required: false
@@ -66,10 +76,20 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
-      RELEASE_DEFAULT_ONLY:
+      RELEASE_DEFAULT:
         required: false
         type: boolean
-        description: If true, only wait for the release default images to be available
+        description: If true, wait for the release default images to be available
+        default: false
+      PERF:
+        required: false
+        type: boolean
+        description: If true, wait for the performance images to be available
+        default: false
+      FAILPOINTS:
+        required: false
+        type: boolean
+        description: If true, wait for the failpoints images to be available
         default: false
       DRY_RUN: 
         required: false
@@ -132,7 +152,9 @@ jobs:
           GIT_SHA: ${{ env.GIT_SHA }}
           GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
           WAIT_FOR_IMAGE_SECONDS: 1
-          RELEASE_DEFAULT_ONLY: ${{ inputs.RELEASE_DEFAULT_ONLY }}
+          RELEASE_DEFAULT: ${{ inputs.RELEASE_DEFAULT }}
+          PERF: ${{ inputs.PERF }}
+          FAILPOINTS: ${{ inputs.FAILPOINTS }}
 
       - name: Authenticate to Google Cloud
         id: auth

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -165,6 +165,7 @@ jobs:
       
       - name: Lock Check and Creation
         id: lock
+        if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
         run: |
           set +e
           gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -73,65 +73,8 @@ permissions:
   id-token: write #required for GCP Workload Identity federation which we use to login into Google Artifact Registry
 
 jobs:
-  pre-build-validation:
-    outputs: 
-      image-exist: ${{ steps.set-output.outputs.image-exist }}
-    runs-on: runs-on,cpu=4,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=small
-    steps:       
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ env.GIT_SHA }}
-
-      - name: Authenticate to Google Cloud
-        id: auth
-        uses: "google-github-actions/auth@v2"
-        with:
-          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
-          export_environment_variables: false
-          create_credentials_file: true
-
-      - name: Check if docker images already exist
-        id: check-images
-        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
-        continue-on-error: true
-        with:
-          GIT_SHA: ${{ env.GIT_SHA }}
-          GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
-          WAIT_FOR_IMAGE_SECONDS: 1
-
-      - name: Set output
-        id: set-output
-        run: |
-          if [ "${{ steps.check-images.outcome }}" = "success" ]; then
-            echo "image-exist=true" >> $GITHUB_OUTPUT
-          else
-            echo "image-exist=false" >> $GITHUB_OUTPUT
-          fi
-      
-      - name: Lock File Check and Lock if not exists
-        id: check-lock
-        if: steps.check-images.outcome == 'failure'
-        run:  |
-          set +e
-          gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
-          result=$?
-          set -e
-          if [ $result -eq 0 ]; then
-            echo "Lock file exists: Current workflow building: "
-            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
-            echo "Rerun again when the image is finished building" && exit 1
-          else
-            echo "Lock file does not exist"
-            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
-            gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
-            echo "Docker Build locked"
-          fi
-
   rust-all:
     runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=large
-    needs: pre-build-validation
-    if: needs.pre-build-validation.outputs.image-exist == 'false'
     steps:
       - uses: actions/checkout@v4
         with:
@@ -160,6 +103,34 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           AWS_DOCKER_ARTIFACT_REPO: ${{ secrets.AWS_DOCKER_ARTIFACT_REPO }}
           GIT_CREDENTIALS: ${{ secrets.GIT_CREDENTIALS }}
+
+      - name: Check if docker images already exist
+        id: check-images
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
+        continue-on-error: true
+        with:
+          GIT_SHA: ${{ env.GIT_SHA }}
+          GCP_DOCKER_ARTIFACT_REPO: ${{ env.GCP_DOCKER_ARTIFACT_REPO }}
+          WAIT_FOR_IMAGE_SECONDS: 1
+      
+      - name: Lock File Check and Lock if not exists
+        id: check-lock
+        if: steps.check-images.outcome == 'failure'
+        run:  |
+          set +e
+          gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+          result=$?
+          set -e
+          if [ $result -eq 0 ]; then
+            echo "Lock file exists: Current workflow building: "
+            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+            echo "Rerun again when the image is finished building" && exit 1
+          else
+            echo "Lock file does not exist"
+            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
+            gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
+            echo "Docker Build locked"
+          fi
 
       - name: Build and Push Rust images
         run: docker/builder/docker-bake-rust-all.sh

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -30,6 +30,11 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
+      DRY_RUN: 
+        required: false
+        type: boolean
+        description: If true, the workflow will not build and push images.
+        default: false
 
   workflow_dispatch:
     inputs:
@@ -56,6 +61,11 @@ on:
         required: false
         type: string
         description: The target docker registry to push to
+      DRY_RUN: 
+        required: false
+        type: boolean
+        description: If true, the workflow will not build and push images.
+        default: false
 
 env:
   GIT_SHA: ${{ inputs.GIT_SHA }}
@@ -139,6 +149,7 @@ jobs:
           fi
 
       - name: Build and Push Rust images
+        if: ${{ inputs.DRY_RUN == false }}
         run: docker/builder/docker-bake-rust-all.sh
         env:
           PROFILE: ${{ env.PROFILE }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -117,6 +117,8 @@ jobs:
         id: check-lock
         if: steps.check-images.outcome == 'failure'
         run:  |
+          gcloud config set account aptos-ci
+          echo "Checking lock file"
           set +e
           gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
           result=$?

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -119,7 +119,7 @@ jobs:
 
       - name: Check if docker images already exist
         id: check-images
-        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@jkao97/verify-and-build-images-for-workflows # TODO: revert
         continue-on-error: true
         with:
           GIT_SHA: ${{ env.GIT_SHA }}
@@ -138,7 +138,7 @@ jobs:
       
       - name: Lock Check and Creation
         id: lock
-        if: ${{ steps.check-images.outcome == 'failure' && inputs.DRY_RUN == false }}
+        if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
         run: |
           set +e
           gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
@@ -157,7 +157,7 @@ jobs:
           fi
 
       - name: Build and Push Rust images
-        if: ${{ steps.check-images.outcome == 'failure' && inputs.DRY_RUN == false }}
+        if: ${{ steps.check-images.outcome == 'failure' }} #&& inputs.DRY_RUN == false }} TODO: revert
         run: docker/builder/docker-bake-rust-all.sh
         env:
           PROFILE: ${{ env.PROFILE }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -122,14 +122,20 @@ jobs:
       
       - name: Lock Check and Creation
         run: |
-          echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
-          if gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt --if-not-exists; then
-            echo "Lock created successfully"
-          else
-            echo "Lock already exists"
-            echo "Checkback when the following workflow is finished building images: "
-            gcloud storage cat gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
+          set +e
+          gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+          result=$?
+          set -e
+          if [ $result -eq 0 ]; then
+            echo "Lock file exists: Current workflow building: "
+            gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
+            echo "Rerun again when the image is finished building"
             exit 1
+          else
+            echo "Lock file does not exist"
+            echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
+            gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
+            echo "Docker Build locked"
           fi
 
       - name: Build and Push Rust images

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Check if docker images already exist
         id: check-images
-        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@main
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@jkao97/wait-images-ci-release-default-only # TODO: change back to main
         continue-on-error: true
         with:
           GIT_SHA: ${{ env.GIT_SHA }}

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -120,38 +120,20 @@ jobs:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT_EMAIL }}
       
-      - name: Check if lock file exists
-        id: check-lock
-        if: steps.check-images.outcome == 'failure'
+      - name: Lock Check and Creation
         run: |
-          set +e
-          gcloud storage ls gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
-          if [ $? -eq 0 ]; then
-            echo "lock-exists=true" >> $GITHUB_OUTPUT
-          else
-            echo "lock-exists=false" >> $GITHUB_OUTPUT
-          fi
-
-      - name: Show lock file content
-        if: steps.check-lock.outputs.lock-exists == 'true'
-        run: |
-          echo "Lock file exists: Current workflow building: "
-          gcloud storage cat gs://${{ env.GCP_DOCKER_BUILD_LOCK_BUCKET }}/${{ env.GIT_SHA }}.txt
-          echo "Rerun again when the image is finished building"
-          exit 1
-
-      - name: Create and upload lock file
-        id: create-lock
-        if: steps.check-lock.outputs.lock-exists == 'false'
-        run: |
-          echo "Lock file does not exist"
           echo "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" > ${GIT_SHA}.txt
-          gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
-          echo "Docker Build locked"
+          if gcloud storage cp ${GIT_SHA}.txt gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt --if-not-exists; then
+            echo "Lock created successfully"
+          else
+            echo "Lock already exists"
+            echo "Checkback when the following workflow is finished building images: "
+            gcloud storage cat gs://${GCP_DOCKER_BUILD_LOCK_BUCKET}/${GIT_SHA}.txt
+            exit 1
+          fi
 
       - name: Build and Push Rust images
         run: docker/builder/docker-bake-rust-all.sh
-        if: steps.create-lock.outcome == 'success'
         env:
           PROFILE: ${{ env.PROFILE }}
           FEATURES: ${{ env.FEATURES }}
@@ -160,7 +142,6 @@ jobs:
           TARGET_REGISTRY: ${{ env.TARGET_REGISTRY }}
       
       - name: Prepare Docker for Caching
-        if: steps.create-lock.outcome == 'success'
         run: |
           if [ ! -f /home/runner/docker-cache.tzst ]; then
             sudo systemctl stop docker

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Check if docker images already exist
         id: check-images
-        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@jkao97/wait-images-ci-release-default-only # TODO: change back to main
+        uses: aptos-labs/aptos-core/.github/actions/wait-images-ci@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
         continue-on-error: true
         with:
           GIT_SHA: ${{ env.GIT_SHA }}

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -40,9 +40,17 @@ on:
         type: string
         description: The end version to use for the backup. If not specified, it will use the latest version.
 jobs:
+
+  build-images:
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
+    with:
+      GIT_SHA: ${{ env.GIT_SHA }}
+      TARGET_CACHE_ID: ${{ github.ref_name }}
+
   run-replay-verify:
     runs-on: ubuntu-latest-32-core # consider moving this to a smaller machien since the compute runs on GKE
     timeout-minutes: 420 # 7 hours
+    needs: build-images
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -51,12 +59,6 @@ jobs:
           # get the last 10 commits to find images that have been built
           # we can optionally use the IMAGE_TAG to find the exact commit to checkout
           fetch-depth: 10
-
-      - name: Build Docker images
-        uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
-        with:
-          GIT_SHA: ${{ env.IMAGE_TAG }}
-          TARGET_CACHE_ID: ${{ github.ref_name }}
       
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         id: docker-setup

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -52,7 +52,7 @@ on:
 jobs:
   build-images:
     secrets: inherit
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -131,10 +131,9 @@ jobs:
         timeout-minutes: 420 # 7 hours
       # This is in case user manually cancel the step above, we still want to cleanup the resources
       - name: Post-run cleanup
-        if: ${{ inputs.DRY_RUN == false }}
         env:
           GOOGLE_CLOUD_PROJECT: aptos-devinfra-0
-        if: ${{ always() }}  
+        if: ${{ always() && inputs.DRY_RUN != false}}  
         run: |
           cd testsuite/replay-verify
           CMD="poetry run python main.py --network ${{ inputs.NETWORK }} --cleanup"  

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -51,10 +51,12 @@ on:
         default: false
 jobs:
   build-images:
+    secrets: inherit
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
+      DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:
     runs-on: ubuntu-latest-32-core # consider moving this to a smaller machien since the compute runs on GKE
@@ -133,7 +135,7 @@ jobs:
       - name: Post-run cleanup
         env:
           GOOGLE_CLOUD_PROJECT: aptos-devinfra-0
-        if: ${{ always() && inputs.DRY_RUN != false}}  
+        if: ${{ always() && inputs.DRY_RUN == false}}  
         run: |
           cd testsuite/replay-verify
           CMD="poetry run python main.py --network ${{ inputs.NETWORK }} --cleanup"  

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -20,7 +20,12 @@ on:
         required: false
         type: string
         description: Optional version to end replaying. If not specified, replay-verify will determines end version itself.
-    
+      DRY_RUN: 
+        required: false
+        type: boolean
+        description: If true, the workflow will not run replay verify.
+        default: false
+
   workflow_dispatch:
     inputs:
       NETWORK:
@@ -39,11 +44,15 @@ on:
         required: false
         type: string
         description: The end version to use for the backup. If not specified, it will use the latest version.
+      DRY_RUN: 
+        required: false
+        type: boolean
+        description: If true, the workflow will not run replay verify.
+        default: false
 jobs:
 
   # Should only build images if IMAGE_TAG is provided; otherwise, we will find and use the latest image 
   build-images:
-    if: inputs.IMAGE_TAG != ''
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG }}
@@ -53,7 +62,7 @@ jobs:
     runs-on: ubuntu-latest-32-core # consider moving this to a smaller machien since the compute runs on GKE
     timeout-minutes: 420 # 7 hours
     needs: build-images
-    if: needs.build-images.result == 'success' || needs.build-images.result == 'skipped'
+    if: ${{ inputs.DRY_RUN == false }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -56,7 +56,6 @@ jobs:
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
-      WAIT_FOR_RELEASE_IMAGES: true
       DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -52,7 +52,7 @@ on:
 jobs:
   build-images:
     secrets: inherit
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: revert
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -56,7 +56,7 @@ jobs:
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
-      RELEASE_DEFAULT_CHECK: true
+      WAIT_FOR_RELEASE_IMAGES: true
       DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -50,19 +50,16 @@ on:
         description: If true, the workflow will not run replay verify.
         default: false
 jobs:
-
-  # Should only build images if IMAGE_TAG is provided; otherwise, we will find and use the latest image 
   build-images:
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
     with:
-      GIT_SHA: ${{ inputs.IMAGE_TAG }}
-      TARGET_CACHE_ID: ${{ github.ref_name }}
+      GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
+      TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
 
   run-replay-verify:
     runs-on: ubuntu-latest-32-core # consider moving this to a smaller machien since the compute runs on GKE
     timeout-minutes: 420 # 7 hours
     needs: build-images
-    if: ${{ inputs.DRY_RUN == false }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -113,6 +110,7 @@ jobs:
           pyproject_directory: testsuite/replay-verify
 
       - name: Schedule replay verify
+        if: ${{ inputs.DRY_RUN == false }}
         env:
           GOOGLE_CLOUD_PROJECT: aptos-devinfra-0
         run: | 
@@ -133,6 +131,7 @@ jobs:
         timeout-minutes: 420 # 7 hours
       # This is in case user manually cancel the step above, we still want to cleanup the resources
       - name: Post-run cleanup
+        if: ${{ inputs.DRY_RUN == false }}
         env:
           GOOGLE_CLOUD_PROJECT: aptos-devinfra-0
         if: ${{ always() }}  

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -53,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest-32-core # consider moving this to a smaller machien since the compute runs on GKE
     timeout-minutes: 420 # 7 hours
     needs: build-images
+    if: needs.build-images.result == 'success' || needs.build-images.result == 'skipped'
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -56,7 +56,7 @@ jobs:
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
-      RELEASE_DEFAULT_ONLY: true
+      RELEASE_DEFAULT: true
       DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -56,6 +56,7 @@ jobs:
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
+      RELEASE_DEFAULT_ONLY: true
       DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -52,7 +52,7 @@ on:
 jobs:
   build-images:
     secrets: inherit
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows #TODO: revert
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -52,6 +52,12 @@ jobs:
           # we can optionally use the IMAGE_TAG to find the exact commit to checkout
           fetch-depth: 10
 
+      - name: Build Docker images
+        uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
+        with:
+          GIT_SHA: ${{ env.IMAGE_TAG }}
+          TARGET_CACHE_ID: ${{ github.ref_name }}
+      
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         id: docker-setup
         with:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -52,7 +52,7 @@ on:
 jobs:
   build-images:
     secrets: inherit
-    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
+    uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@main
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -56,7 +56,7 @@ jobs:
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
-      RELEASE_DEFAULT: true
+      RELEASE_DEFAULT_CHECK: true
       DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -41,10 +41,12 @@ on:
         description: The end version to use for the backup. If not specified, it will use the latest version.
 jobs:
 
+  # Should only build images if IMAGE_TAG is provided; otherwise, we will find and use the latest image 
   build-images:
+    if: inputs.IMAGE_TAG != ''
     uses: aptos-labs/aptos-core/.github/workflows/workflow-run-docker-rust-build.yaml@jkao97/verify-and-build-images-for-workflows # TODO: change back to main
     with:
-      GIT_SHA: ${{ env.GIT_SHA }}
+      GIT_SHA: ${{ inputs.IMAGE_TAG }}
       TARGET_CACHE_ID: ${{ github.ref_name }}
 
   run-replay-verify:

--- a/docker/image-helpers.js
+++ b/docker/image-helpers.js
@@ -124,11 +124,11 @@ export const CargoBuildProfiles = {
 
 export function getImagesToWaitFor(releaseDefaultOnly) {
   const perfImages = ["validator", "validator-testing"];
-  const images = ["indexer-grpc", "forge", "tools"];
+  const images = ["forge", "tools", "indexer-grpc"];
   const imagesToWaitFor = {};
-  for (const image of images) {
+  for (const image of [...perfImages, ...images]) {
     imagesToWaitFor[image] = {
-      [CargoBuildProfiles.Release]: releaseDefaultOnly && !perfImages.includes(image) ? [
+      [CargoBuildProfiles.Release]: releaseDefaultOnly || !perfImages.includes(image) ? [
         CargoBuildFeatures.Default,
       ] : [
         CargoBuildFeatures.Default,

--- a/docker/wait-images-ci.mjs
+++ b/docker/wait-images-ci.mjs
@@ -4,7 +4,7 @@
 // These images are typically built on push to the main branch or on a PR, from the "docker-build-test.yaml" workflow.
 
 // Try it out:
-// GCP_DOCKER_ARTIFACT_REPO=us-docker.pkg.dev/aptos-registry/docker GIT_SHA=$(git fetch && git rev-parse origin/main) ./docker/wait-images-ci.mjs --wait-for-image-seconds=3600 --release-default-only
+// GCP_DOCKER_ARTIFACT_REPO=us-docker.pkg.dev/aptos-registry/docker GIT_SHA=$(git fetch && git rev-parse origin/main) RELEASE_DEFAULT_ONLY=true ./docker/wait-images-ci.mjs --wait-for-image-seconds=3600
 import {
   assertExecutingInRepoRoot,
   CargoBuildFeatures,
@@ -27,8 +27,6 @@ async function main() {
 
   await assertExecutingInRepoRoot();
   await installCrane();
-
-  const GCP_ARTIFACT_REPO = parsedArgs.GCP_DOCKER_ARTIFACT_REPO;
 
   const imagesToWaitFor = getImagesToWaitFor(parsedArgs.RELEASE_DEFAULT_ONLY);
   

--- a/docker/wait-images-ci.mjs
+++ b/docker/wait-images-ci.mjs
@@ -4,7 +4,7 @@
 // These images are typically built on push to the main branch or on a PR, from the "docker-build-test.yaml" workflow.
 
 // Try it out:
-// GCP_DOCKER_ARTIFACT_REPO=us-docker.pkg.dev/aptos-registry/docker GIT_SHA=$(git fetch && git rev-parse origin/main) ./docker/wait-images-ci.mjs --wait-for-image-seconds=3600
+// GCP_DOCKER_ARTIFACT_REPO=us-docker.pkg.dev/aptos-registry/docker GIT_SHA=$(git fetch && git rev-parse origin/main) ./docker/wait-images-ci.mjs --wait-for-image-seconds=3600 --release-only
 import {
   assertExecutingInRepoRoot,
   CargoBuildFeatures,
@@ -57,8 +57,9 @@ const IMAGES_TO_WAIT_FOR = {
 async function main() {
   const REQUIRED_ARGS = ["GIT_SHA", "GCP_DOCKER_ARTIFACT_REPO"];
   const OPTIONAL_ARGS = ["WAIT_FOR_IMAGE_SECONDS"];
+  const BOOLEAN_ARGS = ["RELEASE_ONLY"];
 
-  const parsedArgs = parseArgsFromFlagOrEnv(REQUIRED_ARGS, OPTIONAL_ARGS);
+  const parsedArgs = parseArgsFromFlagOrEnv(REQUIRED_ARGS, OPTIONAL_ARGS, BOOLEAN_ARGS);
 
   await assertExecutingInRepoRoot();
   await installCrane();

--- a/docker/wait-images-ci.mjs
+++ b/docker/wait-images-ci.mjs
@@ -4,7 +4,7 @@
 // These images are typically built on push to the main branch or on a PR, from the "docker-build-test.yaml" workflow.
 
 // Try it out:
-// GCP_DOCKER_ARTIFACT_REPO=us-docker.pkg.dev/aptos-registry/docker GIT_SHA=$(git fetch && git rev-parse origin/main) RELEASE_DEFAULT_ONLY=true ./docker/wait-images-ci.mjs --wait-for-image-seconds=3600
+// GCP_DOCKER_ARTIFACT_REPO=us-docker.pkg.dev/aptos-registry/docker GIT_SHA=$(git fetch && git rev-parse origin/main) ./docker/wait-images-ci.mjs --wait-for-image-seconds=3600
 import {
   assertExecutingInRepoRoot,
   CargoBuildFeatures,
@@ -21,14 +21,19 @@ import {
 async function main() {
   const REQUIRED_ARGS = ["GIT_SHA", "GCP_DOCKER_ARTIFACT_REPO"];
   const OPTIONAL_ARGS = ["WAIT_FOR_IMAGE_SECONDS"];
-  const BOOLEAN_ARGS = ["RELEASE_DEFAULT_ONLY"];
+  const BOOLEAN_ARGS = ["RELEASE_DEFAULT", "PERF", "FAILPOINTS"];
 
   const parsedArgs = parseArgsFromFlagOrEnv(REQUIRED_ARGS, OPTIONAL_ARGS, BOOLEAN_ARGS);
+
+  // if none are set, check all images
+  if (!parsedArgs.RELEASE_DEFAULT && !parsedArgs.PERF && !parsedArgs.FAILPOINTS) {
+    parsedArgs.RELEASE_DEFAULT = parsedArgs.PERF = parsedArgs.FAILPOINTS = true;
+  }
 
   await assertExecutingInRepoRoot();
   await installCrane();
 
-  const imagesToWaitFor = getImagesToWaitFor(parsedArgs.RELEASE_DEFAULT_ONLY);
+  const imagesToWaitFor = getImagesToWaitFor(parsedArgs);
   
   // default 10 seconds
   parsedArgs.WAIT_FOR_IMAGE_SECONDS = parseInt(parsedArgs.WAIT_FOR_IMAGE_SECONDS ?? 10, 10);


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

### Problem: 

Ticket involved: https://app.clickup.com/t/868d02t85

replay-verify-on-archive workflow fails if an image tag passed in does not exist. 

### Solution: 
Fix issue on replay-verify-on-archive running without proper image being built. This PR fixes that by building the image if it's does not already exist and no other job is currently building them. 

It checks first if the image is built: 
- If its already built, it skips the building process and goes straight into the test
- If its not built, it checks if there is another workflow building the images via existence of a lock file in a gcs bucket
    - If the lock file exists, the workflow is intended to exit with a message specifying where the image is already being built/ workflow is being run
    - if the lock file doesn't exist, the docker image build process will be triggered

Additional changes: 
- add dryrun for replay-verify-testnet|mainnet for developers to be able to test workflow changes without building & pushing the image and actually running the replay-verify process

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

workflow-run-replay-verify-on-archive.yaml: 
prereq: Enable docker build run on replay-verify-testnet dryruns
1. Run replay-verify-testnet where the image is not yet built and no one has built/is building yet: https://github.com/aptos-labs/aptos-core/actions/runs/16810558263 [run through image build]
2. Run second workflow while the first is running: https://github.com/aptos-labs/aptos-core/actions/runs/16810699132 [fail workflow w/ link to workflow that's currently building the image]
3. Run workflow when first is finished running: https://github.com/aptos-labs/aptos-core/actions/runs/16811392529 [skip build step]
(revert prereq)

For CLI changes to wait images: 
Run with multiple flags (no flags, release_default, perf, failpoints, release_default & perf) and checked output matches image checked.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify) - CI build

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
