### PR TITLE
[Hot State] Add hot state to speculative state workflow test

### DIFF
--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -19,6 +19,7 @@ use aptos_storage_interface::{
 use aptos_types::{
     proof::SparseMerkleProofExt,
     state_store::{
+        hot_state::LRUEntry,
         state_key::StateKey,
         state_slot::StateSlot,
         state_storage_usage::StateStorageUsage,
@@ -29,11 +30,13 @@ use aptos_types::{
     write_set::{BaseStateOp, HotStateOp, WriteOp},
 };
 use itertools::Itertools;
+use lru::LruCache;
 use proptest::{collection::vec, prelude::*, sample::Index};
 use rayon::prelude::*;
 use std::{
     collections::{HashMap, HashSet},
     fmt::{Debug, Formatter},
+    num::NonZeroUsize,
     ops::Deref,
     sync::{
         mpsc::{channel, Receiver, Sender},
@@ -46,6 +49,8 @@ const NUM_KEYS: usize = 10;
 const HOT_STATE_MAX_ITEMS: usize = NUM_KEYS / 2;
 const HOT_STATE_MAX_BYTES: usize = NUM_KEYS / 2 * ARB_STATE_VALUE_MAX_SIZE / 3;
 const HOT_STATE_MAX_SINGLE_VALUE_BYTES: usize = ARB_STATE_VALUE_MAX_SIZE / 2;
+const MAX_PROMOTIONS_PER_BLOCK: usize = 10;
+const REFRESH_INTERVAL_VERSIONS: usize = 50;
 
 #[derive(Debug)]
 struct UserTxn {
@@ -148,6 +153,7 @@ prop_compose! {
 #[derive(Clone)]
 struct VersionState {
     usage: StateStorageUsage,
+    hot_state: LruCache<StateKey, StateSlot>,
     state: HashMap<StateKey, (Version, StateValue)>,
     summary: NaiveSmt,
     next_version: Version,
@@ -157,6 +163,7 @@ impl VersionState {
     fn new_empty() -> Self {
         Self {
             usage: StateStorageUsage::zero(),
+            hot_state: LruCache::new(NonZeroUsize::new(HOT_STATE_MAX_ITEMS).unwrap()),
             state: HashMap::new(),
             summary: NaiveSmt::default(),
             next_version: 0,
@@ -166,23 +173,47 @@ impl VersionState {
     fn update<'a>(
         &self,
         version: Version,
-        kvs: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
+        writes: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
+        promotions: impl IntoIterator<Item = (&'a StateKey, &'a StateSlot)>,
     ) -> Self {
         assert_eq!(version, self.next_version);
 
+        let mut hot_state = self.hot_state.clone();
         let mut state = self.state.clone();
         let mut smt_updates = vec![];
 
-        for (k, v_opt) in kvs.into_iter() {
+        for (k, v_opt) in writes {
             match v_opt {
                 None => {
+                    let slot = StateSlot::HotVacant {
+                        hot_since_version: version,
+                        lru_info: LRUEntry::uninitialized(),
+                    };
+                    hot_state.put(k.clone(), slot);
                     state.remove(k);
                     smt_updates.push((k.hash(), None));
                 },
                 Some(v) => {
+                    let slot = StateSlot::HotOccupied {
+                        value_version: version,
+                        value: v.clone(),
+                        hot_since_version: version,
+                        lru_info: LRUEntry::uninitialized(),
+                    };
+                    hot_state.put(k.clone(), slot);
                     state.insert(k.clone(), (version, v.clone()));
                     smt_updates.push((k.hash(), Some(v.hash())));
                 },
+            }
+        }
+
+        for (k, prev_slot) in promotions {
+            if prev_slot.is_cold() {
+                hot_state.put(k.clone(), prev_slot.clone().to_hot(version));
+            } else {
+                let mut slot = prev_slot.clone();
+                slot.refresh(version);
+                hot_state.put(k.clone(), slot);
             }
         }
 
@@ -193,9 +224,10 @@ impl VersionState {
         let usage = StateStorageUsage::new(items, bytes);
 
         Self {
+            usage,
+            hot_state,
             state,
             summary,
-            usage,
             next_version: version + 1,
         }
     }
@@ -205,7 +237,15 @@ impl TStateView for VersionState {
     type Key = StateKey;
 
     fn get_state_slot(&self, key: &Self::Key) -> StateViewResult<StateSlot> {
-        Ok(StateSlot::from_db_get(self.state.get(key).cloned()))
+        let from_cold = StateSlot::from_db_get(self.state.get(key).cloned());
+        let slot = match self.hot_state.peek(key) {
+            Some(slot) => {
+                assert_eq!(slot.as_state_value_opt(), from_cold.as_state_value_opt());
+                slot.clone()
+            },
+            None => from_cold,
+        };
+        Ok(slot)
     }
 
     fn get_usage(&self) -> StateViewResult<StateStorageUsage> {
@@ -235,14 +275,15 @@ impl StateByVersion {
 
     fn append_version<'a>(
         &mut self,
-        kvs: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
+        writes: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
+        promotions: impl IntoIterator<Item = (&'a StateKey, &'a StateSlot)>,
     ) {
-        let kvs = kvs.into_iter().collect_vec();
         self.state_by_next_version.push(Arc::new(
-            self.state_by_next_version
-                .last()
-                .unwrap()
-                .update(self.next_version(), kvs.clone()),
+            self.state_by_next_version.last().unwrap().update(
+                self.next_version(),
+                writes,
+                promotions,
+            ),
         ));
     }
 
@@ -508,10 +549,15 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
         let base_view = state_by_version
             .get_state(next_version.checked_sub(1))
             .clone();
-        let mut op_accu =
-            BlockHotStateOpAccumulator::<StateKey, _>::new_with_config(&base_view, 10, 50);
+        let mut op_accu = BlockHotStateOpAccumulator::<StateKey, _>::new_with_config(
+            &base_view,
+            MAX_PROMOTIONS_PER_BLOCK,
+            REFRESH_INTERVAL_VERSIONS,
+        );
         for txn in block_txns {
-            state_by_version.append_version(txn.writes.iter().map(|(k, v)| (k, v.as_ref())));
+            // No promotions except for block epilogue.
+            state_by_version
+                .append_version(txn.writes.iter().map(|(k, v)| (k, v.as_ref())), vec![]);
             op_accu.add_transaction(txn.writes.iter().map(|(k, _v)| k), txn.reads.iter());
             all_txns.push(Txn {
                 reads: txn.reads,
@@ -528,12 +574,10 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
             next_version += 1;
         }
         if append_epilogue {
-            // TODO(HotState): revisit
-            // all ops are hotness only, no effect on the global state
-            state_by_version.append_version(vec![]);
+            let to_make_hot = op_accu.get_slots_to_make_hot();
+            state_by_version.append_version(vec![], to_make_hot.iter());
 
-            let write_set = op_accu
-                .get_slots_to_make_hot()
+            let write_set = to_make_hot
                 .into_iter()
                 .map(|(k, slot)| (k, HotStateOp::make_hot(slot).into_base_op()))
                 .collect_vec();

--- a/types/src/state_store/state_slot.rs
+++ b/types/src/state_store/state_slot.rs
@@ -158,12 +158,43 @@ impl StateSlot {
         self.hot_since_version_opt().expect("expecting hot")
     }
 
+    pub fn refresh(&mut self, version: Version) {
+        match self {
+            HotOccupied {
+                hot_since_version, ..
+            }
+            | HotVacant {
+                hot_since_version, ..
+            } => *hot_since_version = version,
+            _ => panic!("Should not be called on cold slots."),
+        }
+    }
+
     pub fn expect_value_version(&self) -> Version {
         match self {
             ColdVacant | HotVacant { .. } => unreachable!("expecting occupied"),
             ColdOccupied { value_version, .. } | HotOccupied { value_version, .. } => {
                 *value_version
             },
+        }
+    }
+
+    pub fn to_hot(self, hot_since_version: Version) -> Self {
+        match self {
+            ColdOccupied {
+                value_version,
+                value,
+            } => HotOccupied {
+                value_version,
+                value,
+                hot_since_version,
+                lru_info: LRUEntry::uninitialized(),
+            },
+            ColdVacant => HotVacant {
+                hot_since_version,
+                lru_info: LRUEntry::uninitialized(),
+            },
+            _ => panic!("Should not be called on hot slots."),
         }
     }
 


### PR DESCRIPTION

Basically, this test runs state update using both the real implementation and a
naive implementation, then compares the results.

This commit adds hot state modification to the naive implementation, so once we
complete the real hot state implementation, we can quickly use this test to
verify.
