### PR TITLE
fix issue #17188

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/optimizers.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/optimizers.rs
@@ -32,6 +32,13 @@ impl TransformedCodeChunk {
         Self::new(vec![], vec![])
     }
 
+    /// Extract a contiguous sub-chunk from this chunk,
+    pub fn extract(&self, start: CodeOffset, end: CodeOffset) -> TransformedCodeChunk {
+        let new_code = self.code[start as usize..=end as usize].to_vec();
+        let new_offsets = self.original_offsets[start as usize..=end as usize].to_vec();
+        TransformedCodeChunk::new(new_code, new_offsets)
+    }
+
     /// Extend this chunk with another `other` chunk.
     /// The `original_offsets` for the `other` chunk are incremented by `adjust`.
     pub fn extend(&mut self, other: TransformedCodeChunk, adjust: CodeOffset) {

--- a/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.exp
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.exp
@@ -1,0 +1,109 @@
+Running Move unit tests
+[ FAIL    ] 0xc0ffee::m::bad_cast1
+[ FAIL    ] 0xc0ffee::m::bad_cast2
+[ FAIL    ] 0xc0ffee::m::empty_vec
+[ FAIL    ] 0xc0ffee::m::int_overflow1
+[ FAIL    ] 0xc0ffee::m::int_overflow2
+[ FAIL    ] 0xc0ffee::m::non_existent_native
+0xc0ffee::m::bad_cast1
+Output: Ok(Changes { accounts: {} })
+0xc0ffee::m::bad_cast2
+Output: Ok(Changes { accounts: {} })
+0xc0ffee::m::empty_vec
+Output: Ok(Changes { accounts: {} })
+0xc0ffee::m::int_overflow1
+Output: Ok(Changes { accounts: {} })
+0xc0ffee::m::int_overflow2
+Output: Ok(Changes { accounts: {} })
+0xc0ffee::m::non_existent_native
+Output: Ok(Changes { accounts: {} })
+
+Test failures:
+
+Failures in 0xc0ffee::m:
+
+┌── bad_cast1 ──────
+│ error[E11001]: test failure
+│   ┌─ issue_17188.move:9:32
+│   │
+│ 5 │     public fun bad_cast1() {
+│   │                --------- In this function in 0xc0ffee::m
+│   ·
+│ 9 │         let small_number: u8 = (big_number as u8);
+│   │                                ^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Cannot cast u64(1000) to u8". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│ 
+│ 
+└──────────────────
+
+
+┌── bad_cast2 ──────
+│ error[E11001]: test failure
+│    ┌─ issue_17188.move:21:28
+│    │
+│ 14 │     public fun bad_cast2() {
+│    │                --------- In this function in 0xc0ffee::m
+│    ·
+│ 21 │             small_number = (big_number as u8);
+│    │                            ^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Cannot cast u64(256) to u8". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│ 
+│ 
+└──────────────────
+
+
+┌── empty_vec ──────
+│ error[E11001]: test failure
+│    ┌─ issue_17188.move:63:9
+│    │
+│ 60 │     public fun empty_vec() {
+│    │                --------- In this function in 0xc0ffee::m
+│    ·
+│ 63 │         vector::borrow(&vector::empty<u64>(), 1);
+│    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Test was not expected to error, but it gave a vector operation error with sub-status 1 originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│ 
+│ 
+└──────────────────
+
+
+┌── int_overflow1 ──────
+│ error[E11001]: test failure
+│    ┌─ issue_17188.move:36:28
+│    │
+│ 29 │     public fun int_overflow1() {
+│    │                ------------- In this function in 0xc0ffee::m
+│    ·
+│ 36 │         let overflow: u8 = 1 + z;
+│    │                            ^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Addition overflow". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│ 
+│ 
+└──────────────────
+
+
+┌── int_overflow2 ──────
+│ error[E11001]: test failure
+│    ┌─ issue_17188.move:51:24
+│    │
+│ 41 │     public fun int_overflow2() {
+│    │                ------------- In this function in 0xc0ffee::m
+│    ·
+│ 51 │             overflow = overflow - 15;
+│    │                        ^^^^^^^^^^^^^ Test was not expected to error, but it gave an arithmetic error with error message: "Subtraction overflow". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│ 
+│ 
+└──────────────────
+
+
+┌── non_existent_native ──────
+│ error[E11001]: test failure
+│    ┌─ issue_17188.move:67:16
+│    │
+│ 67 │     native fun foo();
+│    │                ^^^
+│    │                │
+│    │                INTERNAL TEST ERROR: Unexpected Verification Error
+│ Test was not expected to error, but it gave a MISSING_DEPENDENCY (code 1021) error with error message: "Missing Native Function `foo`". Error originating in the module 0000000000000000000000000000000000000000000000000000000000c0ffee::m rooted here
+│    │                In this function in 0xc0ffee::m
+│ 
+│ 
+└──────────────────
+
+Test result: FAILED. Total tests: 6; passed: 0; failed: 6

--- a/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.move
+++ b/third_party/move/tools/move-unit-test/tests/test_sources/issue_17188.move
@@ -1,0 +1,75 @@
+module 0xc0ffee::m {
+    use std::vector;
+
+    #[test]
+    public fun bad_cast1() {
+        let x = 0;
+        assert!(x == 0, 700);
+        let big_number: u64 = 1000;
+        let small_number: u8 = (big_number as u8);
+        assert!(small_number == 255, 701);
+    }
+
+    #[test]
+    public fun bad_cast2() {
+        let x = 0;
+        assert!(x == 0, 700);
+        let big_number: u64 = 0;
+        assert!(x == 0, 701);
+        let small_number: u8 = (big_number as u8);
+        while (big_number < 1000) {
+            small_number = (big_number as u8);
+            big_number = big_number + 1;
+        };
+
+        assert!(small_number == 255, 702);
+    }
+
+    #[test]
+    public fun int_overflow1() {
+        let x: u8 = 0;
+        assert!(x == 0, 700);
+        let y: u16 = 255;
+        assert!(x == 0, 701);
+        let z: u8 = (y as u8);
+        assert!(x == 0, 702);
+        let overflow: u8 = 1 + z;
+        assert!(overflow <= 255, 703);
+    }
+
+    #[test]
+    public fun int_overflow2() {
+        let x: u8 = 0;
+        assert!(x == 0, 700);
+        let y: u16 = 255;
+        y = y - 100;
+        assert!(y <= 255, 701);
+        let z: u8 = (y as u8);
+        assert!(x == 0, 702);
+        let overflow: u8 = z;
+        while(overflow > 0) {
+            overflow = overflow - 15;
+            if (overflow > 15) {
+                overflow = overflow - 1;
+            };
+        };
+        assert!(overflow <= 255, 703);
+    }
+
+    #[test]
+    public fun empty_vec() {
+        let x: u8 = 0;
+        assert!(x == 0, 700);
+        vector::borrow(&vector::empty<u64>(), 1);
+        assert!(x == 0, 700);
+    }
+
+    native fun foo();
+    #[test]
+    public fun non_existent_native() {
+        let x: u8 = 0;
+        assert!(x == 0, 700);
+        foo();
+        assert!(x == 0, 700);
+    }
+}


### PR DESCRIPTION
## Description
The compiler's peephole optimizations on file-format bytecode has an issue on maintaining the code loc info. See #17188 for an example. 

Specifically, the optimizer ignored previously-maintained location mapping during recursive optimizations. This PR fixes the issue.

Close #17188 

## How Has This Been Tested?
- Existing `move-unit-test` with a new test case borrowed from #17188 

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)
