### PR TITLE
[Prover] Fixing boogie formatting command for fun values

### DIFF
--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -595,13 +595,12 @@ impl<'env> BoogieTranslator<'env> {
                 .map(|pos| format!("fun->p{}", pos))
                 .chain((0..params.len()).map(|pos| format!("p{}", pos)))
                 .join(", ");
-            emitln!(
-                self.writer,
-                "call {} := {}({});",
-                result_str,
-                fun_name,
-                args
-            );
+            let call_prefix = if result_str.is_empty() {
+                String::new()
+            } else {
+                format!("{result_str} := ")
+            };
+            emitln!(self.writer, "call {}{}({});", call_prefix, fun_name, args);
             self.writer.unindent();
             emitln!(self.writer, "} else ");
         }
@@ -2149,7 +2148,12 @@ impl FunctionTranslator<'_> {
                             )
                             .join(",");
                         let apply_fun = boogie_fun_apply_name(env, &fun_type);
-                        emitln!(writer, "call {} := {}({});", dest_str, apply_fun, args_str);
+                        let call_prefix = if dest_str.is_empty() {
+                            String::new()
+                        } else {
+                            format!("{dest_str} := ")
+                        };
+                        emitln!(writer, "call {}{}({});", call_prefix, apply_fun, args_str);
                     },
                     Pack(mid, sid, inst) => {
                         let inst = &self.inst_slice(inst);

--- a/third_party/move/move-prover/tests/sources/functional/closures/closure_empty_result.move
+++ b/third_party/move/move-prover/tests/sources/functional/closures/closure_empty_result.move
@@ -1,0 +1,11 @@
+module 0x42::test {
+    //This exercises the `invoke` arm of `translate_bytecode` with no return vars
+    public fun test_unit_closure(f: |u64| ()) {
+        f(0);
+    }
+
+    //This exercises the `translate_fun` function with no return vars
+    public fun wrapper() {
+        test_unit_closure(|_x| ())
+    }
+}


### PR DESCRIPTION
## Description
This fixes a boogie translation error when not storing results of function values. Without this fix, is possible to cause boogie compiler error from move code translation.

## How Has This Been Tested?
New tests added

## Key Areas to Review
There is one additional area that looks suspicious: the write statement on line 1969 of `bytecode_translate` (the `Function/Closure` arm of `translate_bytecode` function. This arm emits similar looking boogie code. I did not add a guard to check for empty `dest_str` here because I was unable to find a test case where `dest_str` is actually empty and so I am not sure it is even possible. Perhaps I should still add a check here just incase though?

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
