### PR TITLE
Bump minimal Rust version to 1.85

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -27,6 +27,7 @@ xclippy = [
   "-Aclippy::sliced-string-as-bytes",
   "-Aclippy::obfuscated-if-else",
   "-Aclippy::unnecessary-map-or",
+  "-Aclippy::nonminimal-bool",
 ]
 x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -288,7 +288,7 @@ homepage = "https://aptoslabs.com"
 license = "Apache-2.0"
 publish = false
 repository = "https://github.com/aptos-labs/aptos-core"
-rust-version = "1.80.1"
+rust-version = "1.85"
 
 [workspace.dependencies]
 # Internal crate dependencies.


### PR DESCRIPTION

This allows us to start upgrading some crates to Rust 2024 Edition.

Our `rust-toolchain.toml` already points to 1.86.0.
