### PR TITLE
[compiler-v2] Fix inlining when params are captured and shadowed in lambdas

### DIFF
--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_a.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_a.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-32:  publish [module 0xc0ffee::m {]
+task 1 lines 34-34:  run 0xc0ffee::m::test
+return values: 42

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_a.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_a.move
@@ -1,0 +1,34 @@
+//# publish
+module 0xc0ffee::m {
+    struct S has copy, drop {
+        x: u64
+    }
+
+    public fun test(): u64 {
+        let s = make();
+        s.foo()
+    }
+
+    fun foo(self: &mut S): u64 {
+        make().bar(|| {
+            // inline function captures param
+            mod(&mut self.x);
+        });
+        self.x
+    }
+
+    fun mod(x: &mut u64) {
+        *x = 42;
+    }
+
+    inline fun make(): S {
+        S { x: 0 }
+    }
+
+    inline fun bar(self: &mut S, f: ||) {
+        self.x = 12;
+        f()
+    }
+}
+
+//# run 0xc0ffee::m::test

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_b.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_b.exp
@@ -1,0 +1,4 @@
+processed 2 tasks
+task 0 lines 1-33:  publish [module 0xc0ffee::m {]
+task 1 lines 35-35:  run 0xc0ffee::m::test
+return values: 42

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_b.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_17283_b.move
@@ -1,0 +1,35 @@
+//# publish
+module 0xc0ffee::m {
+    struct S has copy, drop {
+        x: u64
+    }
+
+    public fun test(): u64 {
+        let s = make();
+        foo(&mut s)
+    }
+
+    fun foo(s: &mut S): u64 {
+        bar(make(), || {
+            // inline function captures param
+            s.x = 43;
+            mod(&mut s.x);
+        });
+        s.x
+    }
+
+    fun mod(x: &mut u64) {
+        *x = 42;
+    }
+
+    inline fun make(): S {
+        S { x: 0 }
+    }
+
+    inline fun bar(s: S, f: ||) {
+        s.x = 12;
+        f()
+    }
+}
+
+//# run 0xc0ffee::m::test

--- a/third_party/move/move-prover/tests/sources/functional/inline-lambda.exp
+++ b/third_party/move/move-prover/tests/sources/functional/inline-lambda.exp
@@ -67,7 +67,7 @@ error: unknown assertion failed
    =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/inline-lambda.move:77: call_inline_fail_1
-   =         y = <redacted>
+   =         y' = <redacted>
    =     at tests/sources/functional/inline-lambda.move:26: inline_1
    =     at tests/sources/functional/inline-lambda.move:77: call_inline_fail_1
    =         z = <redacted>
@@ -108,7 +108,7 @@ error: unknown assertion failed
    =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/inline-lambda.move:86: call_inline_fail_2
-   =         y = <redacted>
+   =         y' = <redacted>
    =     at tests/sources/functional/inline-lambda.move:26: inline_1
    =     at tests/sources/functional/inline-lambda.move:86: call_inline_fail_2
    =         z = <redacted>
@@ -171,7 +171,7 @@ error: precondition does not hold at this call
    =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/inline-lambda.move:86: call_inline_fail_2
-   =         y = <redacted>
+   =         y' = <redacted>
    =     at tests/sources/functional/inline-lambda.move:26: inline_1
    =     at tests/sources/functional/inline-lambda.move:86: call_inline_fail_2
    =         z = <redacted>
@@ -198,7 +198,7 @@ error: precondition does not hold at this call
    =         x = <redacted>
    =         result = <redacted>
    =     at tests/sources/functional/inline-lambda.move:86: call_inline_fail_2
-   =         y = <redacted>
+   =         y' = <redacted>
    =     at tests/sources/functional/inline-lambda.move:26: inline_1
    =     at tests/sources/functional/inline-lambda.move:86: call_inline_fail_2
    =         z = <redacted>


### PR DESCRIPTION
## Description

When inlining, if the free variables in the lambda expressions being inlined could get shadowed, then using name mangling, such shadowing is prevented.

But if lambda expressions captured function parameters of the inline function caller, then it would not be part of free variables (because it would show up as a used temporary). This caused incorrect shadowing, leading to compiler ICE, bytecode verification errors, etc.

This PR fixes the computation of free variables in the lambda expressions during inlining, and thus the above errors.

Close #17283.

## How Has This Been Tested?

Added new tests that failed with compiler ICE previously, that now perform computations as expected.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
