### PR TITLE
[compiler-v2] Errors and warnings for inline functions

### DIFF
--- a/aptos-move/framework/aptos-experimental/doc/large_packages.md
+++ b/aptos-move/framework/aptos-experimental/doc/large_packages.md
@@ -319,7 +319,7 @@ Object reference should be provided when upgrading object code.
     metadata_chunk: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;,
     code_indices: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u16&gt;,
     code_chunks: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;&gt;
-): &<b>mut</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> <b>acquires</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
+): &<b>mut</b> <a href="large_packages.md#0x7_large_packages_StagingArea">StagingArea</a> {
     <b>assert</b>!(
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&code_indices) == <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_length">vector::length</a>(&code_chunks),
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="large_packages.md#0x7_large_packages_ECODE_MISMATCH">ECODE_MISMATCH</a>)

--- a/aptos-move/framework/aptos-experimental/doc/market_types.md
+++ b/aptos-move/framework/aptos-experimental/doc/market_types.md
@@ -500,9 +500,9 @@
     place_maker_order_f: |<b>address</b>, OrderIdType, bool, u64, u64, M| <b>has</b> drop + <b>copy</b>,
     // cleanup_order_f arguments: <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>, order_id, is_bid, remaining_size
     cleanup_order_f: |<b>address</b>, OrderIdType, bool, u64| <b>has</b> drop + <b>copy</b>,
-    /// decrease_order_size_f arguments: <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>, order_id, is_bid, price, size
+    // decrease_order_size_f arguments: <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>, order_id, is_bid, price, size
     decrease_order_size_f: |<b>address</b>, OrderIdType, bool, u64, u64| <b>has</b> drop + <b>copy</b>,
-    /// get a <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">string</a> representation of order metadata <b>to</b> be used in events
+    // get a <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/string.md#0x1_string">string</a> representation of order metadata <b>to</b> be used in events
     get_order_metadata_bytes: |M| <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; <b>has</b> drop + <b>copy</b>
 ): <a href="market_types.md#0x7_market_types_MarketClearinghouseCallbacks">MarketClearinghouseCallbacks</a>&lt;M&gt; {
     MarketClearinghouseCallbacks::V1 {

--- a/aptos-move/framework/aptos-experimental/doc/price_time_index.md
+++ b/aptos-move/framework/aptos-experimental/doc/price_time_index.md
@@ -1,0 +1,851 @@
+
+<a id="0x7_price_time_index"></a>
+
+# Module `0x7::price_time_index`
+
+ActiveOrderBook: This is the main order book that keeps track of active orders and their states. The active order
+book is backed by a BigOrderedMap, which is a data structure that allows for efficient insertion, deletion, and matching of the order
+The orders are matched based on time-price priority.
+
+This is internal module, which cannot be used directly, use OrderBook instead.
+
+
+-  [Struct `PriceTime`](#0x7_price_time_index_PriceTime)
+-  [Struct `OrderData`](#0x7_price_time_index_OrderData)
+-  [Enum `PriceTimeIndex`](#0x7_price_time_index_PriceTimeIndex)
+-  [Constants](#@Constants_0)
+-  [Function `new_price_time_idx`](#0x7_price_time_index_new_price_time_idx)
+-  [Function `best_bid_price`](#0x7_price_time_index_best_bid_price)
+-  [Function `best_ask_price`](#0x7_price_time_index_best_ask_price)
+-  [Function `get_mid_price`](#0x7_price_time_index_get_mid_price)
+-  [Function `get_slippage_price`](#0x7_price_time_index_get_slippage_price)
+-  [Function `get_impact_bid_price`](#0x7_price_time_index_get_impact_bid_price)
+-  [Function `get_impact_ask_price`](#0x7_price_time_index_get_impact_ask_price)
+-  [Function `get_tie_breaker`](#0x7_price_time_index_get_tie_breaker)
+-  [Function `cancel_active_order`](#0x7_price_time_index_cancel_active_order)
+-  [Function `is_active_order`](#0x7_price_time_index_is_active_order)
+-  [Function `is_taker_order`](#0x7_price_time_index_is_taker_order)
+-  [Function `single_match_with_current_active_order`](#0x7_price_time_index_single_match_with_current_active_order)
+-  [Function `get_single_match_for_buy_order`](#0x7_price_time_index_get_single_match_for_buy_order)
+-  [Function `get_single_match_for_sell_order`](#0x7_price_time_index_get_single_match_for_sell_order)
+-  [Function `get_single_match_result`](#0x7_price_time_index_get_single_match_result)
+-  [Function `increase_order_size`](#0x7_price_time_index_increase_order_size)
+-  [Function `decrease_order_size`](#0x7_price_time_index_decrease_order_size)
+-  [Function `place_maker_order`](#0x7_price_time_index_place_maker_order)
+
+
+<pre><code><b>use</b> <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map">0x1::big_ordered_map</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="order_book_types.md#0x7_order_book_types">0x7::order_book_types</a>;
+<b>use</b> <a href="single_order_types.md#0x7_single_order_types">0x7::single_order_types</a>;
+</code></pre>
+
+
+
+<a id="0x7_price_time_index_PriceTime"></a>
+
+## Struct `PriceTime`
+
+
+
+<pre><code><b>struct</b> <a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>price: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>tie_breaker: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_price_time_index_OrderData"></a>
+
+## Struct `OrderData`
+
+
+
+<pre><code><b>struct</b> <a href="price_time_index.md#0x7_price_time_index_OrderData">OrderData</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>size: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_price_time_index_PriceTimeIndex"></a>
+
+## Enum `PriceTimeIndex`
+
+OrderBook tracking active (i.e. unconditional, immediately executable) limit orders.
+
+- invariant - all buys are smaller than sells, at all times.
+- tie_breaker in sells is U128_MAX-value, to make sure largest value in the book
+that is taken first, is the one inserted first, amongst those with same bid price.
+
+
+<pre><code>enum <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a> <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>buys: <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="price_time_index.md#0x7_price_time_index_PriceTime">price_time_index::PriceTime</a>, <a href="price_time_index.md#0x7_price_time_index_OrderData">price_time_index::OrderData</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>sells: <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="price_time_index.md#0x7_price_time_index_PriceTime">price_time_index::PriceTime</a>, <a href="price_time_index.md#0x7_price_time_index_OrderData">price_time_index::OrderData</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x7_price_time_index_EINTERNAL_INVARIANT_BROKEN"></a>
+
+There is a code bug that breaks internal invariant
+
+
+<pre><code><b>const</b> <a href="price_time_index.md#0x7_price_time_index_EINTERNAL_INVARIANT_BROKEN">EINTERNAL_INVARIANT_BROKEN</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x7_price_time_index_EINVALID_MAKER_ORDER"></a>
+
+
+
+<pre><code><b>const</b> <a href="price_time_index.md#0x7_price_time_index_EINVALID_MAKER_ORDER">EINVALID_MAKER_ORDER</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x7_price_time_index_U64_MAX"></a>
+
+========= Active OrderBook ===========
+
+
+<pre><code><b>const</b> <a href="price_time_index.md#0x7_price_time_index_U64_MAX">U64_MAX</a>: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a id="0x7_price_time_index_new_price_time_idx"></a>
+
+## Function `new_price_time_idx`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_new_price_time_idx">new_price_time_idx</a>(): <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_new_price_time_idx">new_price_time_idx</a>(): <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a> {
+    // potentially add max value <b>to</b> both sides (that will be skipped),
+    // so that max_key never changes, and doesn't create conflict.
+    PriceTimeIndex::V1 {
+        buys: new_default_big_ordered_map(),
+        sells: new_default_big_ordered_map()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_best_bid_price"></a>
+
+## Function `best_bid_price`
+
+Picks the best (i.e. highest) bid (i.e. buy) price from the active order book.
+aborts if there are no buys
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_best_bid_price">best_bid_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_best_bid_price">best_bid_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>): Option&lt;u64&gt; {
+    <b>if</b> (self.buys.is_empty()) {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    } <b>else</b> {
+        <b>let</b> (back_key, _back_value) = self.buys.borrow_back();
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(back_key.price)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_best_ask_price"></a>
+
+## Function `best_ask_price`
+
+Picks the best (i.e. lowest) ask (i.e. sell) price from the active order book.
+aborts if there are no sells
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_best_ask_price">best_ask_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_best_ask_price">best_ask_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>): Option&lt;u64&gt; {
+    <b>if</b> (self.sells.is_empty()) {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    } <b>else</b> {
+        <b>let</b> (front_key, _front_value) = self.sells.borrow_front();
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(front_key.price)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_mid_price"></a>
+
+## Function `get_mid_price`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_mid_price">get_mid_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_mid_price">get_mid_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>): Option&lt;u64&gt; {
+    <b>let</b> best_bid = self.<a href="price_time_index.md#0x7_price_time_index_best_bid_price">best_bid_price</a>();
+    <b>let</b> best_ask = self.<a href="price_time_index.md#0x7_price_time_index_best_ask_price">best_ask_price</a>();
+    <b>if</b> (best_bid.is_none() || best_ask.is_none()) {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>()
+    } <b>else</b> {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(
+            (best_bid.destroy_some() + best_ask.destroy_some()) / 2
+        )
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_slippage_price"></a>
+
+## Function `get_slippage_price`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_slippage_price">get_slippage_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, is_bid: bool, slippage_pct: u64): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_slippage_price">get_slippage_price</a>(
+    self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>, is_bid: bool, slippage_pct: u64
+): Option&lt;u64&gt; {
+    <b>let</b> mid_price = self.<a href="price_time_index.md#0x7_price_time_index_get_mid_price">get_mid_price</a>();
+    <b>if</b> (mid_price.is_none()) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>();
+    };
+    <b>let</b> mid_price = mid_price.destroy_some();
+    <b>let</b> slippage = mul_div(
+        mid_price, slippage_pct, get_slippage_pct_precision() * 100
+    );
+    <b>if</b> (is_bid) {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(mid_price + slippage)
+    } <b>else</b> {
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(mid_price - slippage)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_impact_bid_price"></a>
+
+## Function `get_impact_bid_price`
+
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_impact_bid_price">get_impact_bid_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, impact_size: u64): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_impact_bid_price">get_impact_bid_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>, impact_size: u64): Option&lt;u64&gt; {
+    <b>let</b> total_value = (0 <b>as</b> u128);
+    <b>let</b> total_size = 0;
+    <b>let</b> orders = &self.buys;
+    <b>if</b> (orders.is_empty()) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>();
+    };
+    <b>let</b> (front_key, front_value) = orders.borrow_back();
+    <b>while</b> (total_size &lt; impact_size) {
+        <b>let</b> matched_size =
+            <b>if</b> (total_size + front_value.size &gt; impact_size) {
+                impact_size - total_size
+            } <b>else</b> {
+                front_value.size
+            };
+        total_value +=(matched_size <b>as</b> u128) * (front_key.price <b>as</b> u128);
+        total_size += matched_size;
+        <b>let</b> next_key = orders.prev_key(&front_key);
+        <b>if</b> (next_key.is_none()) {
+            // TODO maybe we should <b>return</b> none <b>if</b> there is not enough depth?
+            <b>break</b>;
+        };
+        front_key = next_key.destroy_some();
+        front_value = orders.borrow(&front_key);
+    };
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>((total_value / (total_size <b>as</b> u128)) <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_impact_ask_price"></a>
+
+## Function `get_impact_ask_price`
+
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_impact_ask_price">get_impact_ask_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, impact_size: u64): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_impact_ask_price">get_impact_ask_price</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>, impact_size: u64): Option&lt;u64&gt; {
+    <b>let</b> total_value = 0 <b>as</b> u128;
+    <b>let</b> total_size = 0;
+    <b>let</b> orders = &self.sells;
+    <b>if</b> (orders.is_empty()) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>();
+    };
+    <b>let</b> (front_key, front_value) = orders.borrow_front();
+    <b>while</b> (total_size &lt; impact_size) {
+        <b>let</b> matched_size =
+            <b>if</b> (total_size + front_value.size &gt; impact_size) {
+                impact_size - total_size
+            } <b>else</b> {
+                front_value.size
+            };
+        total_value +=(matched_size <b>as</b> u128) * (front_key.price <b>as</b> u128);
+        total_size += matched_size;
+        <b>let</b> next_key = orders.next_key(&front_key);
+        <b>if</b> (next_key.is_none()) {
+            <b>break</b>;
+        };
+        front_key = next_key.destroy_some();
+        front_value = orders.borrow(&front_key);
+    };
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>((total_value / (total_size <b>as</b> u128)) <b>as</b> u64)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_tie_breaker"></a>
+
+## Function `get_tie_breaker`
+
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_tie_breaker">get_tie_breaker</a>(unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>, is_bid: bool): <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_tie_breaker">get_tie_breaker</a>(
+    unique_priority_idx: UniqueIdxType, is_bid: bool
+): UniqueIdxType {
+    <b>if</b> (is_bid) {
+        unique_priority_idx
+    } <b>else</b> {
+        unique_priority_idx.descending_idx()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_cancel_active_order"></a>
+
+## Function `cancel_active_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_cancel_active_order">cancel_active_order</a>(self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>, is_bid: bool): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_cancel_active_order">cancel_active_order</a>(
+    self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>,
+    price: u64,
+    unique_priority_idx: UniqueIdxType,
+    is_bid: bool
+): u64 {
+    <b>let</b> tie_breaker = <a href="price_time_index.md#0x7_price_time_index_get_tie_breaker">get_tie_breaker</a>(unique_priority_idx, is_bid);
+    <b>let</b> key = <a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a> { price, tie_breaker };
+    <b>let</b> value =
+        <b>if</b> (is_bid) {
+            self.buys.remove(&key)
+        } <b>else</b> {
+            self.sells.remove(&key)
+        };
+    value.size
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_is_active_order"></a>
+
+## Function `is_active_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_is_active_order">is_active_order</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>, is_bid: bool): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_is_active_order">is_active_order</a>(
+    self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>,
+    price: u64,
+    unique_priority_idx: UniqueIdxType,
+    is_bid: bool
+): bool {
+    <b>let</b> tie_breaker = <a href="price_time_index.md#0x7_price_time_index_get_tie_breaker">get_tie_breaker</a>(unique_priority_idx, is_bid);
+    <b>let</b> key = <a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a> { price: price, tie_breaker };
+    <b>if</b> (is_bid) {
+        self.buys.contains(&key)
+    } <b>else</b> {
+        self.sells.contains(&key)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_is_taker_order"></a>
+
+## Function `is_taker_order`
+
+Check if the order is a taker order - i.e. if it can be immediately matched with the order book fully or partially.
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_is_taker_order">is_taker_order</a>(self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, is_bid: bool): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_is_taker_order">is_taker_order</a>(
+    self: &<a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>, price: u64, is_bid: bool
+): bool {
+    <b>if</b> (is_bid) {
+        <b>let</b> best_ask_price = self.<a href="price_time_index.md#0x7_price_time_index_best_ask_price">best_ask_price</a>();
+        best_ask_price.is_some() && price &gt;= best_ask_price.destroy_some()
+    } <b>else</b> {
+        <b>let</b> best_bid_price = self.<a href="price_time_index.md#0x7_price_time_index_best_bid_price">best_bid_price</a>();
+        best_bid_price.is_some() && price &lt;= best_bid_price.destroy_some()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_single_match_with_current_active_order"></a>
+
+## Function `single_match_with_current_active_order`
+
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_single_match_with_current_active_order">single_match_with_current_active_order</a>(remaining_size: u64, cur_key: <a href="price_time_index.md#0x7_price_time_index_PriceTime">price_time_index::PriceTime</a>, cur_value: <a href="price_time_index.md#0x7_price_time_index_OrderData">price_time_index::OrderData</a>, orders: &<b>mut</b> <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="price_time_index.md#0x7_price_time_index_PriceTime">price_time_index::PriceTime</a>, <a href="price_time_index.md#0x7_price_time_index_OrderData">price_time_index::OrderData</a>&gt;): <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_single_match_with_current_active_order">single_match_with_current_active_order</a>(
+    remaining_size: u64,
+    cur_key: <a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a>,
+    cur_value: <a href="price_time_index.md#0x7_price_time_index_OrderData">OrderData</a>,
+    orders: &<b>mut</b> BigOrderedMap&lt;<a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a>, <a href="price_time_index.md#0x7_price_time_index_OrderData">OrderData</a>&gt;
+): ActiveMatchedOrder {
+    <b>let</b> is_cur_match_fully_consumed = cur_value.size &lt;= remaining_size;
+
+    <b>let</b> matched_size_for_this_order =
+        <b>if</b> (is_cur_match_fully_consumed) {
+            cur_value.size
+        } <b>else</b> {
+            remaining_size
+        };
+
+    <b>let</b> result =
+        new_active_matched_order(
+            cur_value.order_id,
+            matched_size_for_this_order, // Matched size on the maker order
+            cur_value.size - matched_size_for_this_order // Remaining size on the maker order
+        );
+
+    <b>if</b> (is_cur_match_fully_consumed) {
+        orders.remove(&cur_key);
+    } <b>else</b> {
+        orders.borrow_mut(&cur_key).size -= matched_size_for_this_order;
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_single_match_for_buy_order"></a>
+
+## Function `get_single_match_for_buy_order`
+
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_single_match_for_buy_order">get_single_match_for_buy_order</a>(self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, size: u64): <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_single_match_for_buy_order">get_single_match_for_buy_order</a>(
+    self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>, price: u64, size: u64
+): ActiveMatchedOrder {
+    <b>let</b> (smallest_key, smallest_value) = self.sells.borrow_front();
+    <b>assert</b>!(price &gt;= smallest_key.price, <a href="price_time_index.md#0x7_price_time_index_EINTERNAL_INVARIANT_BROKEN">EINTERNAL_INVARIANT_BROKEN</a>);
+    <a href="price_time_index.md#0x7_price_time_index_single_match_with_current_active_order">single_match_with_current_active_order</a>(
+        size,
+        smallest_key,
+        *smallest_value,
+        &<b>mut</b> self.sells
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_single_match_for_sell_order"></a>
+
+## Function `get_single_match_for_sell_order`
+
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_single_match_for_sell_order">get_single_match_for_sell_order</a>(self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, size: u64): <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_single_match_for_sell_order">get_single_match_for_sell_order</a>(
+    self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>, price: u64, size: u64
+): ActiveMatchedOrder {
+    <b>let</b> (largest_key, largest_value) = self.buys.borrow_back();
+    <b>assert</b>!(price &lt;= largest_key.price, <a href="price_time_index.md#0x7_price_time_index_EINTERNAL_INVARIANT_BROKEN">EINTERNAL_INVARIANT_BROKEN</a>);
+    <a href="price_time_index.md#0x7_price_time_index_single_match_with_current_active_order">single_match_with_current_active_order</a>(
+        size,
+        largest_key,
+        *largest_value,
+        &<b>mut</b> self.buys
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_get_single_match_result"></a>
+
+## Function `get_single_match_result`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_single_match_result">get_single_match_result</a>(self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, size: u64, is_bid: bool): <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_get_single_match_result">get_single_match_result</a>(
+    self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>,
+    price: u64,
+    size: u64,
+    is_bid: bool
+): ActiveMatchedOrder {
+    <b>if</b> (is_bid) {
+        self.<a href="price_time_index.md#0x7_price_time_index_get_single_match_for_buy_order">get_single_match_for_buy_order</a>(price, size)
+    } <b>else</b> {
+        self.<a href="price_time_index.md#0x7_price_time_index_get_single_match_for_sell_order">get_single_match_for_sell_order</a>(price, size)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_increase_order_size"></a>
+
+## Function `increase_order_size`
+
+Increase the size of the order in the orderbook without altering its position in the price-time priority.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_increase_order_size">increase_order_size</a>(self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>, size_delta: u64, is_bid: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_increase_order_size">increase_order_size</a>(
+    self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>,
+    price: u64,
+    unique_priority_idx: UniqueIdxType,
+    size_delta: u64,
+    is_bid: bool
+) {
+    <b>let</b> tie_breaker = <a href="price_time_index.md#0x7_price_time_index_get_tie_breaker">get_tie_breaker</a>(unique_priority_idx, is_bid);
+    <b>let</b> key = <a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a> { price, tie_breaker };
+    <b>if</b> (is_bid) {
+        self.buys.borrow_mut(&key).size += size_delta;
+    } <b>else</b> {
+        self.sells.borrow_mut(&key).size += size_delta;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_decrease_order_size"></a>
+
+## Function `decrease_order_size`
+
+Decrease the size of the order in the order book without altering its position in the price-time priority.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_decrease_order_size">decrease_order_size</a>(self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>, size_delta: u64, is_bid: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_decrease_order_size">decrease_order_size</a>(
+    self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>,
+    price: u64,
+    unique_priority_idx: UniqueIdxType,
+    size_delta: u64,
+    is_bid: bool
+) {
+    <b>let</b> tie_breaker = <a href="price_time_index.md#0x7_price_time_index_get_tie_breaker">get_tie_breaker</a>(unique_priority_idx, is_bid);
+    <b>let</b> key = <a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a> { price, tie_breaker };
+    <b>if</b> (is_bid) {
+        self.buys.borrow_mut(&key).size -= size_delta;
+    } <b>else</b> {
+        self.sells.borrow_mut(&key).size -= size_delta;
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_price_time_index_place_maker_order"></a>
+
+## Function `place_maker_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_place_maker_order">place_maker_order</a>(self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, price: u64, unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>, size: u64, is_bid: bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="price_time_index.md#0x7_price_time_index_place_maker_order">place_maker_order</a>(
+    self: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">PriceTimeIndex</a>,
+    order_id: OrderIdType,
+    price: u64,
+    unique_priority_idx: UniqueIdxType,
+    size: u64,
+    is_bid: bool
+) {
+    <b>let</b> tie_breaker = <a href="price_time_index.md#0x7_price_time_index_get_tie_breaker">get_tie_breaker</a>(unique_priority_idx, is_bid);
+    <b>let</b> key = <a href="price_time_index.md#0x7_price_time_index_PriceTime">PriceTime</a> { price, tie_breaker };
+    <b>let</b> value = <a href="price_time_index.md#0x7_price_time_index_OrderData">OrderData</a> { order_id, size };
+    // Assert that this is not a taker order
+    <b>assert</b>!(!self.<a href="price_time_index.md#0x7_price_time_index_is_taker_order">is_taker_order</a>(price, is_bid), <a href="price_time_index.md#0x7_price_time_index_EINVALID_MAKER_ORDER">EINVALID_MAKER_ORDER</a>);
+    <b>if</b> (is_bid) {
+        self.buys.add(key, value);
+    } <b>else</b> {
+        self.sells.add(key, value);
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-experimental/doc/single_order_book.md
+++ b/aptos-move/framework/aptos-experimental/doc/single_order_book.md
@@ -1,0 +1,1239 @@
+
+<a id="0x7_single_order_book"></a>
+
+# Module `0x7::single_order_book`
+
+This module provides a core order book functionality for a trading system. On a high level, it has three major
+components
+1. ActiveOrderBook: This is the main order book that keeps track of active orders and their states. The active order
+book is backed by a BigOrderedMap, which is a data structure that allows for efficient insertion, deletion, and matching of the order
+The orders are matched based on time-price priority.
+2. PendingOrderBookIndex: This keeps track of pending orders. The pending orders are those that are not active yet. Three
+types of pending orders are supported.
+- Price move up - Trigggered when the price moves above a certain price level
+- Price move down - Triggered when the price moves below a certain price level
+- Time based - Triggered when a certain time has passed
+3. Orders: This is a BigOrderMap of order id to order details.
+
+
+-  [Enum `OrderRequest`](#0x7_single_order_book_OrderRequest)
+-  [Enum `RetailOrderBook`](#0x7_single_order_book_RetailOrderBook)
+-  [Enum `OrderType`](#0x7_single_order_book_OrderType)
+-  [Struct `TestMetadata`](#0x7_single_order_book_TestMetadata)
+-  [Constants](#@Constants_0)
+-  [Function `new_order_request`](#0x7_single_order_book_new_order_request)
+-  [Function `new_single_order_book`](#0x7_single_order_book_new_single_order_book)
+-  [Function `new_price_time_index`](#0x7_single_order_book_new_price_time_index)
+-  [Function `cancel_order`](#0x7_single_order_book_cancel_order)
+-  [Function `try_cancel_order_with_client_order_id`](#0x7_single_order_book_try_cancel_order_with_client_order_id)
+-  [Function `client_order_id_exists`](#0x7_single_order_book_client_order_id_exists)
+-  [Function `place_maker_order`](#0x7_single_order_book_place_maker_order)
+-  [Function `reinsert_maker_order`](#0x7_single_order_book_reinsert_maker_order)
+-  [Function `modify_order`](#0x7_single_order_book_modify_order)
+-  [Function `modify_and_copy_order`](#0x7_single_order_book_modify_and_copy_order)
+-  [Function `modify_or_remove_order`](#0x7_single_order_book_modify_or_remove_order)
+-  [Function `place_pending_maker_order`](#0x7_single_order_book_place_pending_maker_order)
+-  [Function `get_single_match_for_taker`](#0x7_single_order_book_get_single_match_for_taker)
+-  [Function `decrease_order_size`](#0x7_single_order_book_decrease_order_size)
+-  [Function `get_order_id_by_client_id`](#0x7_single_order_book_get_order_id_by_client_id)
+-  [Function `get_order_metadata`](#0x7_single_order_book_get_order_metadata)
+-  [Function `set_order_metadata`](#0x7_single_order_book_set_order_metadata)
+-  [Function `is_active_order`](#0x7_single_order_book_is_active_order)
+-  [Function `get_order`](#0x7_single_order_book_get_order)
+-  [Function `get_remaining_size`](#0x7_single_order_book_get_remaining_size)
+-  [Function `take_ready_price_based_orders`](#0x7_single_order_book_take_ready_price_based_orders)
+-  [Function `take_ready_time_based_orders`](#0x7_single_order_book_take_ready_time_based_orders)
+
+
+<pre><code><b>use</b> <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map">0x1::big_ordered_map</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">0x1::vector</a>;
+<b>use</b> <a href="order_book_types.md#0x7_order_book_types">0x7::order_book_types</a>;
+<b>use</b> <a href="pending_order_book_index.md#0x7_pending_order_book_index">0x7::pending_order_book_index</a>;
+<b>use</b> <a href="price_time_index.md#0x7_price_time_index">0x7::price_time_index</a>;
+<b>use</b> <a href="single_order_types.md#0x7_single_order_types">0x7::single_order_types</a>;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_OrderRequest"></a>
+
+## Enum `OrderRequest`
+
+
+
+<pre><code>enum <a href="single_order_book.md#0x7_single_order_book_OrderRequest">OrderRequest</a>&lt;M: <b>copy</b>, drop, store&gt; <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code><a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>client_order_id: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>price: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>orig_size: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>remaining_size: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>is_bid: bool</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>trigger_condition: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="order_book_types.md#0x7_order_book_types_TriggerCondition">order_book_types::TriggerCondition</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>time_in_force: <a href="order_book_types.md#0x7_order_book_types_TimeInForce">order_book_types::TimeInForce</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>metadata: M</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="0x7_single_order_book_RetailOrderBook"></a>
+
+## Enum `RetailOrderBook`
+
+
+
+<pre><code>enum <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M: <b>copy</b>, drop, store&gt; <b>has</b> store
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>orders: <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>client_order_ids: <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="order_book_types.md#0x7_order_book_types_AccountClientOrderId">order_book_types::AccountClientOrderId</a>, <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>pending_orders: <a href="pending_order_book_index.md#0x7_pending_order_book_index_PendingOrderBookIndex">pending_order_book_index::PendingOrderBookIndex</a></code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="0x7_single_order_book_OrderType"></a>
+
+## Enum `OrderType`
+
+
+
+<pre><code>enum <a href="single_order_book.md#0x7_single_order_book_OrderType">OrderType</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>GoodTilCancelled</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+
+<details>
+<summary>PostOnly</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+
+<details>
+<summary>FillOrKill</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="0x7_single_order_book_TestMetadata"></a>
+
+## Struct `TestMetadata`
+
+
+
+<pre><code><b>struct</b> <a href="single_order_book.md#0x7_single_order_book_TestMetadata">TestMetadata</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>dummy_field: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x7_single_order_book_EORDER_ALREADY_EXISTS"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_EORDER_ALREADY_EXISTS">EORDER_ALREADY_EXISTS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_EINVALID_ADD_SIZE_TO_ORDER"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_EINVALID_ADD_SIZE_TO_ORDER">EINVALID_ADD_SIZE_TO_ORDER</a>: u64 = 6;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_EINVALID_INACTIVE_ORDER_STATE"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_EINVALID_INACTIVE_ORDER_STATE">EINVALID_INACTIVE_ORDER_STATE</a>: u64 = 5;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_EORDER_CREATOR_MISMATCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_EORDER_CREATOR_MISMATCH">EORDER_CREATOR_MISMATCH</a>: u64 = 9;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_EORDER_NOT_FOUND"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_EORDER_NOT_FOUND">EORDER_NOT_FOUND</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_EPOST_ONLY_FILLED"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_EPOST_ONLY_FILLED">EPOST_ONLY_FILLED</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_E_NOT_ACTIVE_ORDER"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_E_NOT_ACTIVE_ORDER">E_NOT_ACTIVE_ORDER</a>: u64 = 7;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_E_REINSERT_ORDER_MISMATCH"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>: u64 = 8;
+</code></pre>
+
+
+
+<a id="0x7_single_order_book_new_order_request"></a>
+
+## Function `new_order_request`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_new_order_request">new_order_request</a>&lt;M: <b>copy</b>, drop, store&gt;(<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <b>address</b>, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, client_order_id: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, price: u64, orig_size: u64, remaining_size: u64, is_bid: bool, trigger_condition: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="order_book_types.md#0x7_order_book_types_TriggerCondition">order_book_types::TriggerCondition</a>&gt;, time_in_force: <a href="order_book_types.md#0x7_order_book_types_TimeInForce">order_book_types::TimeInForce</a>, metadata: M): <a href="single_order_book.md#0x7_single_order_book_OrderRequest">single_order_book::OrderRequest</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_new_order_request">new_order_request</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <b>address</b>,
+    order_id: OrderIdType,
+    client_order_id: Option&lt;u64&gt;,
+    price: u64,
+    orig_size: u64,
+    remaining_size: u64,
+    is_bid: bool,
+    trigger_condition: Option&lt;TriggerCondition&gt;,
+    time_in_force: TimeInForce,
+    metadata: M
+): <a href="single_order_book.md#0x7_single_order_book_OrderRequest">OrderRequest</a>&lt;M&gt; {
+    OrderRequest::V1 {
+        <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+        order_id,
+        client_order_id,
+        price,
+        orig_size,
+        remaining_size,
+        is_bid,
+        trigger_condition,
+        time_in_force,
+        metadata
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_new_single_order_book"></a>
+
+## Function `new_single_order_book`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_new_single_order_book">new_single_order_book</a>&lt;M: <b>copy</b>, drop, store&gt;(): <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_new_single_order_book">new_single_order_book</a>&lt;M: store + <b>copy</b> + drop&gt;(): <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt; {
+    RetailOrderBook::V1 {
+        orders: new_default_big_ordered_map(),
+        client_order_ids: new_default_big_ordered_map(),
+        pending_orders: new_pending_order_book_index()
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_new_price_time_index"></a>
+
+## Function `new_price_time_index`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_new_price_time_index">new_price_time_index</a>(): <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_new_price_time_index">new_price_time_index</a>(): PriceTimeIndex {
+    new_price_time_idx()
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_cancel_order"></a>
+
+## Function `cancel_order`
+
+Cancels an order from the order book. If the order is active, it is removed from the active order book else
+it is removed from the pending order book.
+If order doesn't exist, it aborts with EORDER_NOT_FOUND.
+
+<code>order_creator</code> is passed to only verify order cancellation is authorized correctly
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_cancel_order">cancel_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, order_creator: <b>address</b>, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>): <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_cancel_order">cancel_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> PriceTimeIndex, order_creator: <b>address</b>, order_id: OrderIdType
+): Order&lt;M&gt; {
+    <b>assert</b>!(self.orders.contains(&order_id), <a href="single_order_book.md#0x7_single_order_book_EORDER_NOT_FOUND">EORDER_NOT_FOUND</a>);
+    <b>let</b> order_with_state = self.orders.remove(&order_id);
+    <b>let</b> (order, is_active) = order_with_state.destroy_order_from_state();
+    <b>assert</b>!(order_creator == order.get_account(), <a href="single_order_book.md#0x7_single_order_book_EORDER_CREATOR_MISMATCH">EORDER_CREATOR_MISMATCH</a>);
+    <b>if</b> (is_active) {
+        <b>let</b> unique_priority_idx = order.get_unique_priority_idx();
+        <b>let</b> (
+            <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+            _order_id,
+            client_order_id,
+            bid_price,
+            _orig_size,
+            _size,
+            is_bid,
+            _,
+            _,
+            _
+        ) = order.destroy_order();
+        price_time_idx.cancel_active_order(bid_price, unique_priority_idx, is_bid);
+        <b>if</b> (client_order_id.is_some()) {
+            self.client_order_ids.remove(
+                &new_account_client_order_id(<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>, client_order_id.destroy_some())
+            );
+        };
+    } <b>else</b> {
+        <b>let</b> unique_priority_idx = order.get_unique_priority_idx();
+        <b>let</b> (
+            _account,
+            _order_id,
+            client_order_id,
+            _bid_price,
+            _orig_size,
+            _size,
+            _is_bid,
+            trigger_condition,
+            _,
+            _
+        ) = order.destroy_order();
+        self.pending_orders.cancel_pending_order(
+            trigger_condition.destroy_some(), unique_priority_idx
+        );
+        <b>if</b> (client_order_id.is_some()) {
+            self.client_order_ids.remove(
+                &new_account_client_order_id(
+                    order.get_account(), client_order_id.destroy_some()
+                )
+            );
+        };
+    };
+    <b>return</b> order
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_try_cancel_order_with_client_order_id"></a>
+
+## Function `try_cancel_order_with_client_order_id`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_try_cancel_order_with_client_order_id">try_cancel_order_with_client_order_id</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, order_creator: <b>address</b>, client_order_id: u64): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_try_cancel_order_with_client_order_id">try_cancel_order_with_client_order_id</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> PriceTimeIndex, order_creator: <b>address</b>, client_order_id: u64
+): Option&lt;Order&lt;M&gt;&gt; {
+    <b>let</b> account_client_order_id =
+        new_account_client_order_id(order_creator, client_order_id);
+    <b>if</b> (!self.client_order_ids.contains(&account_client_order_id)) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>();
+    };
+    <b>let</b> order_id = self.client_order_ids.borrow(&account_client_order_id);
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(self.<a href="single_order_book.md#0x7_single_order_book_cancel_order">cancel_order</a>(price_time_idx, order_creator, *order_id))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_client_order_id_exists"></a>
+
+## Function `client_order_id_exists`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_client_order_id_exists">client_order_id_exists</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_creator: <b>address</b>, client_order_id: u64): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_client_order_id_exists">client_order_id_exists</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, order_creator: <b>address</b>, client_order_id: u64
+): bool {
+    <b>let</b> account_client_order_id =
+        new_account_client_order_id(order_creator, client_order_id);
+    self.client_order_ids.contains(&account_client_order_id)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_place_maker_order"></a>
+
+## Function `place_maker_order`
+
+Places a maker order to the order book. If the order is a pending order, it is added to the pending order book
+else it is added to the active order book. The API aborts if its not a maker order or if the order already exists
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_place_maker_order">place_maker_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, ascending_id_generator: &<b>mut</b> <a href="order_book_types.md#0x7_order_book_types_AscendingIdGenerator">order_book_types::AscendingIdGenerator</a>, order_req: <a href="single_order_book.md#0x7_single_order_book_OrderRequest">single_order_book::OrderRequest</a>&lt;M&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_place_maker_order">place_maker_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> PriceTimeIndex, ascending_id_generator: &<b>mut</b> AscendingIdGenerator, order_req: <a href="single_order_book.md#0x7_single_order_book_OrderRequest">OrderRequest</a>&lt;M&gt;
+) {
+    <b>if</b> (order_req.trigger_condition.is_some()) {
+        <b>return</b> self.<a href="single_order_book.md#0x7_single_order_book_place_pending_maker_order">place_pending_maker_order</a>(ascending_id_generator, order_req);
+    };
+
+    <b>let</b> ascending_idx =
+        new_unique_idx_type(ascending_id_generator.next_ascending_id());
+
+    <b>assert</b>!(
+        !self.orders.contains(&order_req.order_id),
+        <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="single_order_book.md#0x7_single_order_book_EORDER_ALREADY_EXISTS">EORDER_ALREADY_EXISTS</a>)
+    );
+
+    <b>let</b> order =
+        new_order(
+            order_req.order_id,
+            order_req.<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+            ascending_idx,
+            order_req.client_order_id,
+            order_req.price,
+            order_req.orig_size,
+            order_req.remaining_size,
+            order_req.is_bid,
+            order_req.trigger_condition,
+            order_req.time_in_force,
+            order_req.metadata
+        );
+    self.orders.add(order_req.order_id, new_order_with_state(order, <b>true</b>));
+    <b>if</b> (order_req.client_order_id.is_some()) {
+        self.client_order_ids.add(
+            new_account_client_order_id(
+                order_req.<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>, order_req.client_order_id.destroy_some()
+            ),
+            order_req.order_id
+        );
+    };
+    price_time_idx.<a href="single_order_book.md#0x7_single_order_book_place_maker_order">place_maker_order</a>(
+        order_req.order_id,
+        order_req.price,
+        ascending_idx,
+        order_req.remaining_size,
+        order_req.is_bid
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_reinsert_maker_order"></a>
+
+## Function `reinsert_maker_order`
+
+Reinserts a maker order to the order book. This is used when the order is removed from the order book
+but the clearinghouse fails to settle all or part of the order. If the order doesn't exist in the order book,
+it is added to the order book, if it exists, it's size is updated.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_reinsert_maker_order">reinsert_maker_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, ascending_id_generator: &<b>mut</b> <a href="order_book_types.md#0x7_order_book_types_AscendingIdGenerator">order_book_types::AscendingIdGenerator</a>, order_req: <a href="single_order_book.md#0x7_single_order_book_OrderRequest">single_order_book::OrderRequest</a>&lt;M&gt;, original_order: <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_reinsert_maker_order">reinsert_maker_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> PriceTimeIndex, ascending_id_generator: &<b>mut</b> AscendingIdGenerator, order_req: <a href="single_order_book.md#0x7_single_order_book_OrderRequest">OrderRequest</a>&lt;M&gt;, original_order: Order&lt;M&gt;
+) {
+    <b>assert</b>!(
+        &original_order.get_order_id() == &order_req.order_id,
+        <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>
+    );
+    <b>assert</b>!(
+        &original_order.get_account() == &order_req.<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+        <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>
+    );
+    <b>assert</b>!(
+        original_order.get_orig_size() == order_req.orig_size,
+        <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>
+    );
+    <b>assert</b>!(original_order.get_client_order_id() == order_req.client_order_id,
+        <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>);
+    // TODO check what should the rule be for remaining_size. check test_maker_order_reinsert_not_exists unit test.
+    // <b>assert</b>!(
+    //     original_order.<a href="single_order_book.md#0x7_single_order_book_get_remaining_size">get_remaining_size</a>() &gt;= order_req.remaining_size,
+    //     <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>
+    // );
+    <b>assert</b>!(original_order.get_price() == order_req.price, <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>);
+    <b>assert</b>!(original_order.is_bid() == order_req.is_bid, <a href="single_order_book.md#0x7_single_order_book_E_REINSERT_ORDER_MISMATCH">E_REINSERT_ORDER_MISMATCH</a>);
+
+    <b>assert</b>!(order_req.trigger_condition.is_none(), <a href="single_order_book.md#0x7_single_order_book_E_NOT_ACTIVE_ORDER">E_NOT_ACTIVE_ORDER</a>);
+    <b>if</b> (!self.orders.contains(&order_req.order_id)) {
+        <b>return</b> self.<a href="single_order_book.md#0x7_single_order_book_place_maker_order">place_maker_order</a>(price_time_idx, ascending_id_generator, order_req);
+    };
+
+    <a href="single_order_book.md#0x7_single_order_book_modify_order">modify_order</a>(&<b>mut</b> self.orders, &order_req.order_id, |order_with_state| {
+        order_with_state.increase_remaining_size(order_req.remaining_size);
+    });
+    price_time_idx.increase_order_size(
+        order_req.price,
+        original_order.get_unique_priority_idx(),
+        order_req.remaining_size,
+        order_req.is_bid
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_modify_order"></a>
+
+## Function `modify_order`
+
+
+
+<pre><code><b>fun</b> <a href="single_order_book.md#0x7_single_order_book_modify_order">modify_order</a>&lt;M: <b>copy</b>, drop, store&gt;(orders: &<b>mut</b> <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;&gt;, order_id: &<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, modify_fn: |&<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;|)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_modify_order">modify_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    orders: &<b>mut</b> BigOrderedMap&lt;OrderIdType, OrderWithState&lt;M&gt;&gt;, order_id: &OrderIdType, modify_fn: |&<b>mut</b>  OrderWithState&lt;M&gt;|
+) {
+    <b>let</b> order = *orders.borrow(order_id);
+    modify_fn(&<b>mut</b> order);
+    orders.upsert(*order_id, order);
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_modify_and_copy_order"></a>
+
+## Function `modify_and_copy_order`
+
+
+
+<pre><code><b>fun</b> <a href="single_order_book.md#0x7_single_order_book_modify_and_copy_order">modify_and_copy_order</a>&lt;M: <b>copy</b>, drop, store&gt;(orders: &<b>mut</b> <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;&gt;, order_id: &<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, modify_fn: |&<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;|): <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_modify_and_copy_order">modify_and_copy_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    orders: &<b>mut</b> BigOrderedMap&lt;OrderIdType, OrderWithState&lt;M&gt;&gt;, order_id: &OrderIdType, modify_fn: |&<b>mut</b>  OrderWithState&lt;M&gt;|
+): OrderWithState&lt;M&gt; {
+    <b>let</b> order = *orders.borrow(order_id);
+    modify_fn(&<b>mut</b> order);
+    orders.upsert(*order_id, order);
+    order
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_modify_or_remove_order"></a>
+
+## Function `modify_or_remove_order`
+
+
+
+<pre><code><b>fun</b> <a href="single_order_book.md#0x7_single_order_book_modify_or_remove_order">modify_or_remove_order</a>&lt;M: <b>copy</b>, drop, store&gt;(orders: &<b>mut</b> <a href="../../aptos-framework/doc/big_ordered_map.md#0x1_big_ordered_map_BigOrderedMap">big_ordered_map::BigOrderedMap</a>&lt;<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;&gt;, order_id: &<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, modify_fn: |&<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;|bool): <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_modify_or_remove_order">modify_or_remove_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    orders: &<b>mut</b> BigOrderedMap&lt;OrderIdType, OrderWithState&lt;M&gt;&gt;, order_id: &OrderIdType, modify_fn: |&<b>mut</b>  OrderWithState&lt;M&gt;| bool
+): OrderWithState&lt;M&gt; {
+    <b>let</b> order = orders.remove(order_id);
+    <b>let</b> keep = modify_fn(&<b>mut</b> order);
+    <b>if</b> (keep) {
+        orders.add(*order_id, order);
+    };
+    order
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_place_pending_maker_order"></a>
+
+## Function `place_pending_maker_order`
+
+
+
+<pre><code><b>fun</b> <a href="single_order_book.md#0x7_single_order_book_place_pending_maker_order">place_pending_maker_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, ascending_id_generator: &<b>mut</b> <a href="order_book_types.md#0x7_order_book_types_AscendingIdGenerator">order_book_types::AscendingIdGenerator</a>, order_req: <a href="single_order_book.md#0x7_single_order_book_OrderRequest">single_order_book::OrderRequest</a>&lt;M&gt;)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>fun</b> <a href="single_order_book.md#0x7_single_order_book_place_pending_maker_order">place_pending_maker_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, ascending_id_generator: &<b>mut</b> AscendingIdGenerator, order_req: <a href="single_order_book.md#0x7_single_order_book_OrderRequest">OrderRequest</a>&lt;M&gt;
+) {
+    <b>let</b> order_id = order_req.order_id;
+    <b>let</b> ascending_idx =
+        new_unique_idx_type(ascending_id_generator.next_ascending_id());
+    <b>let</b> order =
+        new_order(
+            order_id,
+            order_req.<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+            ascending_idx,
+            order_req.client_order_id,
+            order_req.price,
+            order_req.orig_size,
+            order_req.remaining_size,
+            order_req.is_bid,
+            order_req.trigger_condition,
+            order_req.time_in_force,
+            order_req.metadata
+        );
+
+    self.orders.add(order_id, new_order_with_state(order, <b>false</b>));
+
+    self.pending_orders.<a href="single_order_book.md#0x7_single_order_book_place_pending_maker_order">place_pending_maker_order</a>(
+        order_id,
+        order_req.trigger_condition.destroy_some(),
+        ascending_idx,
+    );
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_get_single_match_for_taker"></a>
+
+## Function `get_single_match_for_taker`
+
+Returns a single match for a taker order. It is responsibility of the caller to first call the <code>is_taker_order</code>
+API to ensure that the order is a taker order before calling this API, otherwise it will abort.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_single_match_for_taker">get_single_match_for_taker</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, price: u64, size: u64, is_bid: bool): <a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">single_order_types::SingleOrderMatch</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_single_match_for_taker">get_single_match_for_taker</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;,
+    price_time_idx: &<b>mut</b> PriceTimeIndex,
+    price: u64,
+    size: u64,
+    is_bid: bool
+): SingleOrderMatch&lt;M&gt; {
+    <b>let</b> result = price_time_idx.get_single_match_result(price, size, is_bid);
+    <b>let</b> (order_id, matched_size, remaining_size) =
+        result.destroy_active_matched_order();
+
+    <b>let</b> order_with_state = <a href="single_order_book.md#0x7_single_order_book_modify_or_remove_order">modify_or_remove_order</a>(&<b>mut</b> self.orders, &order_id, |order_with_state| {
+        order_with_state.set_remaining_size(remaining_size);
+        remaining_size &gt; 0
+    });
+
+    <b>let</b> (order, is_active) = order_with_state.destroy_order_from_state();
+    <b>if</b> (remaining_size == 0 && order.get_client_order_id().is_some()) {
+        self.client_order_ids.remove(
+            &new_account_client_order_id(
+                order.get_account(), order.get_client_order_id().destroy_some()
+            )
+        );
+    };
+    <b>assert</b>!(is_active, <a href="single_order_book.md#0x7_single_order_book_EINVALID_INACTIVE_ORDER_STATE">EINVALID_INACTIVE_ORDER_STATE</a>);
+    new_single_order_match(order, matched_size)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_decrease_order_size"></a>
+
+## Function `decrease_order_size`
+
+Decrease the size of the order by the given size delta. The API aborts if the order is not found in the order book or
+if the size delta is greater than or equal to the remaining size of the order. Please note that the API will abort and
+not cancel the order if the size delta is equal to the remaining size of the order, to avoid unintended
+cancellation of the order. Please use the <code>cancel_order</code> API to cancel the order.
+
+<code>order_creator</code> is passed to only verify order cancellation is authorized correctly
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_decrease_order_size">decrease_order_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, price_time_idx: &<b>mut</b> <a href="price_time_index.md#0x7_price_time_index_PriceTimeIndex">price_time_index::PriceTimeIndex</a>, order_creator: <b>address</b>, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, size_delta: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_decrease_order_size">decrease_order_size</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;,
+    price_time_idx: &<b>mut</b> PriceTimeIndex,
+    order_creator: <b>address</b>,
+    order_id: OrderIdType,
+    size_delta: u64
+) {
+    <b>assert</b>!(self.orders.contains(&order_id), <a href="single_order_book.md#0x7_single_order_book_EORDER_NOT_FOUND">EORDER_NOT_FOUND</a>);
+
+    <b>let</b> order_with_state = <a href="single_order_book.md#0x7_single_order_book_modify_and_copy_order">modify_and_copy_order</a>(&<b>mut</b> self.orders, &order_id, |order_with_state| {
+        <b>assert</b>!(
+            order_creator == order_with_state.get_order_from_state().get_account(),
+            <a href="single_order_book.md#0x7_single_order_book_EORDER_CREATOR_MISMATCH">EORDER_CREATOR_MISMATCH</a>
+        );
+        order_with_state.decrease_remaining_size(size_delta);
+
+        // TODO should we be asserting that remaining size is greater than 0?
+    });
+
+    <b>if</b> (order_with_state.<a href="single_order_book.md#0x7_single_order_book_is_active_order">is_active_order</a>()) {
+        <b>let</b> order = order_with_state.get_order_from_state();
+        price_time_idx
+            .<a href="single_order_book.md#0x7_single_order_book_decrease_order_size">decrease_order_size</a>(
+            order.get_price(),
+            order_with_state.get_unique_priority_idx_from_state(),
+            size_delta,
+            order.is_bid()
+        );
+    };
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_get_order_id_by_client_id"></a>
+
+## Function `get_order_id_by_client_id`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_order_id_by_client_id">get_order_id_by_client_id</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_creator: <b>address</b>, client_order_id: u64): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_order_id_by_client_id">get_order_id_by_client_id</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, order_creator: <b>address</b>, client_order_id: u64
+): Option&lt;OrderIdType&gt; {
+    <b>let</b> account_client_order_id =
+        new_account_client_order_id(order_creator, client_order_id);
+    <b>if</b> (!self.client_order_ids.contains(&account_client_order_id)) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>();
+    };
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(*self.client_order_ids.borrow(&account_client_order_id))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_get_order_metadata"></a>
+
+## Function `get_order_metadata`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_order_metadata">get_order_metadata</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_order_metadata">get_order_metadata</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, order_id: OrderIdType
+): Option&lt;M&gt; {
+    <b>if</b> (!self.orders.contains(&order_id)) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>();
+    };
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(self.orders.borrow(&order_id).get_metadata_from_state())
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_set_order_metadata"></a>
+
+## Function `set_order_metadata`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_set_order_metadata">set_order_metadata</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, metadata: M)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_set_order_metadata">set_order_metadata</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, order_id: OrderIdType, metadata: M
+) {
+    <b>assert</b>!(self.orders.contains(&order_id), <a href="single_order_book.md#0x7_single_order_book_EORDER_NOT_FOUND">EORDER_NOT_FOUND</a>);
+
+    <a href="single_order_book.md#0x7_single_order_book_modify_order">modify_order</a>(&<b>mut</b> self.orders, &order_id, |order_with_state| {
+        order_with_state.set_metadata_in_state(metadata);
+    });
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_is_active_order"></a>
+
+## Function `is_active_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_is_active_order">is_active_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_is_active_order">is_active_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, order_id: OrderIdType
+): bool {
+    <b>if</b> (!self.orders.contains(&order_id)) {
+        <b>return</b> <b>false</b>;
+    };
+    self.orders.borrow(&order_id).<a href="single_order_book.md#0x7_single_order_book_is_active_order">is_active_order</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_get_order"></a>
+
+## Function `get_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_order">get_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_order">get_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, order_id: OrderIdType
+): Option&lt;OrderWithState&lt;M&gt;&gt; {
+    <b>if</b> (!self.orders.contains(&order_id)) {
+        <b>return</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_none">option::none</a>();
+    };
+    <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_some">option::some</a>(*self.orders.borrow(&order_id))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_get_remaining_size"></a>
+
+## Function `get_remaining_size`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_remaining_size">get_remaining_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_get_remaining_size">get_remaining_size</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, order_id: OrderIdType
+): u64 {
+    <b>if</b> (!self.orders.contains(&order_id)) {
+        <b>return</b> 0;
+    };
+    self.orders.borrow(&order_id).get_remaining_size_from_state()
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_take_ready_price_based_orders"></a>
+
+## Function `take_ready_price_based_orders`
+
+Removes and returns the orders that are ready to be executed based on the current price.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_take_ready_price_based_orders">take_ready_price_based_orders</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, current_price: u64, order_limit: u64): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_take_ready_price_based_orders">take_ready_price_based_orders</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;, current_price: u64, order_limit: u64
+): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Order&lt;M&gt;&gt; {
+    <b>let</b> self_orders = &<b>mut</b> self.orders;
+    <b>let</b> order_ids = self.pending_orders.<a href="single_order_book.md#0x7_single_order_book_take_ready_price_based_orders">take_ready_price_based_orders</a>(current_price, order_limit);
+    <b>let</b> orders = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
+
+    order_ids.for_each(|order_id| {
+        <b>let</b> order_with_state = self_orders.remove(&order_id);
+        <b>let</b> (order, _) = order_with_state.destroy_order_from_state();
+        orders.push_back(order);
+    });
+    orders
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_book_take_ready_time_based_orders"></a>
+
+## Function `take_ready_time_based_orders`
+
+Removes and returns the orders that are ready to be executed based on the time condition.
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_take_ready_time_based_orders">take_ready_time_based_orders</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">single_order_book::RetailOrderBook</a>&lt;M&gt;, order_limit: u64): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_book.md#0x7_single_order_book_take_ready_time_based_orders">take_ready_time_based_orders</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_book.md#0x7_single_order_book_RetailOrderBook">RetailOrderBook</a>&lt;M&gt;,  order_limit: u64
+): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;Order&lt;M&gt;&gt; {
+    <b>let</b> self_orders = &<b>mut</b> self.orders;
+    <b>let</b> order_ids = self.pending_orders.take_time_time_based_orders(order_limit);
+    <b>let</b> orders = <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector_empty">vector::empty</a>();
+
+    order_ids.for_each(|order_id| {
+        <b>let</b> order_with_state = self_orders.remove(&order_id);
+        <b>let</b> (order, _) = order_with_state.destroy_order_from_state();
+        orders.push_back(order);
+    });
+    orders
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-experimental/doc/single_order_types.md
+++ b/aptos-move/framework/aptos-experimental/doc/single_order_types.md
@@ -1,0 +1,1192 @@
+
+<a id="0x7_single_order_types"></a>
+
+# Module `0x7::single_order_types`
+
+(work in progress)
+
+
+-  [Struct `ActiveMatchedOrder`](#0x7_single_order_types_ActiveMatchedOrder)
+-  [Enum `SingleOrderMatch`](#0x7_single_order_types_SingleOrderMatch)
+-  [Enum `Order`](#0x7_single_order_types_Order)
+-  [Enum `OrderWithState`](#0x7_single_order_types_OrderWithState)
+-  [Constants](#@Constants_0)
+-  [Function `get_slippage_pct_precision`](#0x7_single_order_types_get_slippage_pct_precision)
+-  [Function `new_active_matched_order`](#0x7_single_order_types_new_active_matched_order)
+-  [Function `destroy_active_matched_order`](#0x7_single_order_types_destroy_active_matched_order)
+-  [Function `new_order`](#0x7_single_order_types_new_order)
+-  [Function `new_single_order_match`](#0x7_single_order_types_new_single_order_match)
+-  [Function `get_active_matched_size`](#0x7_single_order_types_get_active_matched_size)
+-  [Function `get_matched_size`](#0x7_single_order_types_get_matched_size)
+-  [Function `new_order_with_state`](#0x7_single_order_types_new_order_with_state)
+-  [Function `get_order_from_state`](#0x7_single_order_types_get_order_from_state)
+-  [Function `get_metadata_from_state`](#0x7_single_order_types_get_metadata_from_state)
+-  [Function `set_metadata_in_state`](#0x7_single_order_types_set_metadata_in_state)
+-  [Function `get_order_id`](#0x7_single_order_types_get_order_id)
+-  [Function `get_account`](#0x7_single_order_types_get_account)
+-  [Function `get_unique_priority_idx`](#0x7_single_order_types_get_unique_priority_idx)
+-  [Function `get_metadata_from_order`](#0x7_single_order_types_get_metadata_from_order)
+-  [Function `get_time_in_force`](#0x7_single_order_types_get_time_in_force)
+-  [Function `get_trigger_condition_from_order`](#0x7_single_order_types_get_trigger_condition_from_order)
+-  [Function `increase_remaining_size`](#0x7_single_order_types_increase_remaining_size)
+-  [Function `decrease_remaining_size`](#0x7_single_order_types_decrease_remaining_size)
+-  [Function `set_remaining_size`](#0x7_single_order_types_set_remaining_size)
+-  [Function `get_remaining_size_from_state`](#0x7_single_order_types_get_remaining_size_from_state)
+-  [Function `get_unique_priority_idx_from_state`](#0x7_single_order_types_get_unique_priority_idx_from_state)
+-  [Function `get_remaining_size`](#0x7_single_order_types_get_remaining_size)
+-  [Function `get_orig_size`](#0x7_single_order_types_get_orig_size)
+-  [Function `get_client_order_id`](#0x7_single_order_types_get_client_order_id)
+-  [Function `destroy_order_from_state`](#0x7_single_order_types_destroy_order_from_state)
+-  [Function `destroy_active_match_order`](#0x7_single_order_types_destroy_active_match_order)
+-  [Function `destroy_order`](#0x7_single_order_types_destroy_order)
+-  [Function `destroy_single_order_match`](#0x7_single_order_types_destroy_single_order_match)
+-  [Function `is_active_order`](#0x7_single_order_types_is_active_order)
+-  [Function `get_price`](#0x7_single_order_types_get_price)
+-  [Function `is_bid`](#0x7_single_order_types_is_bid)
+
+
+<pre><code><b>use</b> <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option">0x1::option</a>;
+<b>use</b> <a href="order_book_types.md#0x7_order_book_types">0x7::order_book_types</a>;
+</code></pre>
+
+
+
+<a id="0x7_single_order_types_ActiveMatchedOrder"></a>
+
+## Struct `ActiveMatchedOrder`
+
+
+
+<pre><code><b>struct</b> <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">ActiveMatchedOrder</a> <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>matched_size: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>remaining_size: u64</code>
+</dt>
+<dd>
+ Remaining size of the maker order
+</dd>
+</dl>
+
+
+</details>
+
+<a id="0x7_single_order_types_SingleOrderMatch"></a>
+
+## Enum `SingleOrderMatch`
+
+
+
+<pre><code>enum <a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">SingleOrderMatch</a>&lt;M: <b>copy</b>, drop, store&gt; <b>has</b> <b>copy</b>, drop
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>order: <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>matched_size: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="0x7_single_order_types_Order"></a>
+
+## Enum `Order`
+
+
+
+<pre><code>enum <a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M: <b>copy</b>, drop, store&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code><a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <b>address</b></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>client_order_id: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>price: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>orig_size: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>remaining_size: u64</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>is_bid: bool</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>trigger_condition: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="order_book_types.md#0x7_order_book_types_TriggerCondition">order_book_types::TriggerCondition</a>&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>time_in_force: <a href="order_book_types.md#0x7_order_book_types_TimeInForce">order_book_types::TimeInForce</a></code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>metadata: M</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="0x7_single_order_types_OrderWithState"></a>
+
+## Enum `OrderWithState`
+
+
+
+<pre><code>enum <a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M: <b>copy</b>, drop, store&gt; <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Variants</summary>
+
+
+<details>
+<summary>V1</summary>
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>order: <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;</code>
+</dt>
+<dd>
+
+</dd>
+<dt>
+<code>is_active: bool</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+</details>
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x7_single_order_types_EINVALID_ORDER_SIZE_DECREASE"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_types.md#0x7_single_order_types_EINVALID_ORDER_SIZE_DECREASE">EINVALID_ORDER_SIZE_DECREASE</a>: u64 = 4;
+</code></pre>
+
+
+
+<a id="0x7_single_order_types_EINVALID_TRIGGER_CONDITION"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_types.md#0x7_single_order_types_EINVALID_TRIGGER_CONDITION">EINVALID_TRIGGER_CONDITION</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x7_single_order_types_EORDER_ALREADY_EXISTS"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_types.md#0x7_single_order_types_EORDER_ALREADY_EXISTS">EORDER_ALREADY_EXISTS</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x7_single_order_types_INVALID_MATCH_RESULT"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_types.md#0x7_single_order_types_INVALID_MATCH_RESULT">INVALID_MATCH_RESULT</a>: u64 = 3;
+</code></pre>
+
+
+
+<a id="0x7_single_order_types_SLIPPAGE_PCT_PRECISION"></a>
+
+
+
+<pre><code><b>const</b> <a href="single_order_types.md#0x7_single_order_types_SLIPPAGE_PCT_PRECISION">SLIPPAGE_PCT_PRECISION</a>: u64 = 100;
+</code></pre>
+
+
+
+<a id="0x7_single_order_types_get_slippage_pct_precision"></a>
+
+## Function `get_slippage_pct_precision`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_slippage_pct_precision">get_slippage_pct_precision</a>(): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_slippage_pct_precision">get_slippage_pct_precision</a>(): u64 {
+    <a href="single_order_types.md#0x7_single_order_types_SLIPPAGE_PCT_PRECISION">SLIPPAGE_PCT_PRECISION</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_new_active_matched_order"></a>
+
+## Function `new_active_matched_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_active_matched_order">new_active_matched_order</a>(order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, matched_size: u64, remaining_size: u64): <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_active_matched_order">new_active_matched_order</a>(
+    order_id: OrderIdType, matched_size: u64, remaining_size: u64
+): <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">ActiveMatchedOrder</a> {
+    <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">ActiveMatchedOrder</a> { order_id, matched_size, remaining_size }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_destroy_active_matched_order"></a>
+
+## Function `destroy_active_matched_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_active_matched_order">destroy_active_matched_order</a>(self: <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>): (<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_active_matched_order">destroy_active_matched_order</a>(
+    self: <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">ActiveMatchedOrder</a>
+): (OrderIdType, u64, u64) {
+    (self.order_id, self.matched_size, self.remaining_size)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_new_order"></a>
+
+## Function `new_order`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_order">new_order</a>&lt;M: <b>copy</b>, drop, store&gt;(order_id: <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <b>address</b>, unique_priority_idx: <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>, client_order_id: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, price: u64, orig_size: u64, size: u64, is_bid: bool, trigger_condition: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="order_book_types.md#0x7_order_book_types_TriggerCondition">order_book_types::TriggerCondition</a>&gt;, time_in_force: <a href="order_book_types.md#0x7_order_book_types_TimeInForce">order_book_types::TimeInForce</a>, metadata: M): <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_order">new_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    order_id: OrderIdType,
+    <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>: <b>address</b>,
+    unique_priority_idx: UniqueIdxType,
+    client_order_id: Option&lt;u64&gt;,
+    price: u64,
+    orig_size: u64,
+    size: u64,
+    is_bid: bool,
+    trigger_condition: Option&lt;TriggerCondition&gt;,
+    time_in_force: TimeInForce,
+    metadata: M
+): <a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt; {
+    Order::V1 {
+        order_id,
+        <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+        unique_priority_idx,
+        client_order_id,
+        price,
+        orig_size,
+        remaining_size: size,
+        is_bid,
+        trigger_condition,
+        time_in_force,
+        metadata
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_new_single_order_match"></a>
+
+## Function `new_single_order_match`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_single_order_match">new_single_order_match</a>&lt;M: <b>copy</b>, drop, store&gt;(order: <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;, matched_size: u64): <a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">single_order_types::SingleOrderMatch</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_single_order_match">new_single_order_match</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    order: <a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;, matched_size: u64
+): <a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">SingleOrderMatch</a>&lt;M&gt; {
+    SingleOrderMatch::V1 { order, matched_size }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_active_matched_size"></a>
+
+## Function `get_active_matched_size`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_active_matched_size">get_active_matched_size</a>(self: &<a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_active_matched_size">get_active_matched_size</a>(self: &<a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">ActiveMatchedOrder</a>): u64 {
+    self.matched_size
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_matched_size"></a>
+
+## Function `get_matched_size`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_matched_size">get_matched_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">single_order_types::SingleOrderMatch</a>&lt;M&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_matched_size">get_matched_size</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">SingleOrderMatch</a>&lt;M&gt;
+): u64 {
+    self.matched_size
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_new_order_with_state"></a>
+
+## Function `new_order_with_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_order_with_state">new_order_with_state</a>&lt;M: <b>copy</b>, drop, store&gt;(order: <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;, is_active: bool): <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_new_order_with_state">new_order_with_state</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    order: <a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;, is_active: bool
+): <a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt; {
+    OrderWithState::V1 { order, is_active }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_order_from_state"></a>
+
+## Function `get_order_from_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_order_from_state">get_order_from_state</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;): &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_order_from_state">get_order_from_state</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;
+): &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt; {
+    &self.order
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_metadata_from_state"></a>
+
+## Function `get_metadata_from_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_metadata_from_state">get_metadata_from_state</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;): M
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_metadata_from_state">get_metadata_from_state</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;
+): M {
+    self.order.metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_set_metadata_in_state"></a>
+
+## Function `set_metadata_in_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_set_metadata_in_state">set_metadata_in_state</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;, metadata: M)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_set_metadata_in_state">set_metadata_in_state</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;, metadata: M
+) {
+    self.order.metadata = metadata;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_order_id"></a>
+
+## Function `get_order_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_order_id">get_order_id</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_order_id">get_order_id</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): OrderIdType {
+    self.order_id
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_account"></a>
+
+## Function `get_account`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_account">get_account</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): <b>address</b>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_account">get_account</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): <b>address</b> {
+    self.<a href="../../aptos-framework/doc/account.md#0x1_account">account</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_unique_priority_idx"></a>
+
+## Function `get_unique_priority_idx`
+
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_unique_priority_idx">get_unique_priority_idx</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b>(<b>friend</b>) <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_unique_priority_idx">get_unique_priority_idx</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;
+): UniqueIdxType {
+    self.unique_priority_idx
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_metadata_from_order"></a>
+
+## Function `get_metadata_from_order`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_metadata_from_order">get_metadata_from_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): M
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_metadata_from_order">get_metadata_from_order</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): M {
+    self.metadata
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_time_in_force"></a>
+
+## Function `get_time_in_force`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_time_in_force">get_time_in_force</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): <a href="order_book_types.md#0x7_order_book_types_TimeInForce">order_book_types::TimeInForce</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_time_in_force">get_time_in_force</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;
+): TimeInForce {
+    self.time_in_force
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_trigger_condition_from_order"></a>
+
+## Function `get_trigger_condition_from_order`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_trigger_condition_from_order">get_trigger_condition_from_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="order_book_types.md#0x7_order_book_types_TriggerCondition">order_book_types::TriggerCondition</a>&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_trigger_condition_from_order">get_trigger_condition_from_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;
+): Option&lt;TriggerCondition&gt; {
+    self.trigger_condition
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_increase_remaining_size"></a>
+
+## Function `increase_remaining_size`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_increase_remaining_size">increase_remaining_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;, size: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_increase_remaining_size">increase_remaining_size</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;, size: u64
+) {
+    self.order.remaining_size += size;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_decrease_remaining_size"></a>
+
+## Function `decrease_remaining_size`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_decrease_remaining_size">decrease_remaining_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;, size: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_decrease_remaining_size">decrease_remaining_size</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;, size: u64
+) {
+    <b>assert</b>!(self.order.remaining_size &gt; size, <a href="single_order_types.md#0x7_single_order_types_EINVALID_ORDER_SIZE_DECREASE">EINVALID_ORDER_SIZE_DECREASE</a>);
+    self.order.remaining_size -= size;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_set_remaining_size"></a>
+
+## Function `set_remaining_size`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_set_remaining_size">set_remaining_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;, remaining_size: u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_set_remaining_size">set_remaining_size</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<b>mut</b> <a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;, remaining_size: u64
+) {
+    self.order.remaining_size = remaining_size;
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_remaining_size_from_state"></a>
+
+## Function `get_remaining_size_from_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_remaining_size_from_state">get_remaining_size_from_state</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_remaining_size_from_state">get_remaining_size_from_state</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;
+): u64 {
+    self.order.remaining_size
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_unique_priority_idx_from_state"></a>
+
+## Function `get_unique_priority_idx_from_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_unique_priority_idx_from_state">get_unique_priority_idx_from_state</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;): <a href="order_book_types.md#0x7_order_book_types_UniqueIdxType">order_book_types::UniqueIdxType</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_unique_priority_idx_from_state">get_unique_priority_idx_from_state</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;
+): UniqueIdxType {
+    self.order.unique_priority_idx
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_remaining_size"></a>
+
+## Function `get_remaining_size`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_remaining_size">get_remaining_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_remaining_size">get_remaining_size</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): u64 {
+    self.remaining_size
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_orig_size"></a>
+
+## Function `get_orig_size`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_orig_size">get_orig_size</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_orig_size">get_orig_size</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): u64 {
+    self.orig_size
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_client_order_id"></a>
+
+## Function `get_client_order_id`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_client_order_id">get_client_order_id</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_client_order_id">get_client_order_id</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): Option&lt;u64&gt; {
+    self.client_order_id
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_destroy_order_from_state"></a>
+
+## Function `destroy_order_from_state`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_order_from_state">destroy_order_from_state</a>&lt;M: <b>copy</b>, drop, store&gt;(self: <a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;): (<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;, bool)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_order_from_state">destroy_order_from_state</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: <a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;
+): (<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;, bool) {
+    (self.order, self.is_active)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_destroy_active_match_order"></a>
+
+## Function `destroy_active_match_order`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_active_match_order">destroy_active_match_order</a>(self: <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">single_order_types::ActiveMatchedOrder</a>): (<a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, u64, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_active_match_order">destroy_active_match_order</a>(self: <a href="single_order_types.md#0x7_single_order_types_ActiveMatchedOrder">ActiveMatchedOrder</a>): (OrderIdType, u64, u64) {
+    (self.order_id, self.matched_size, self.remaining_size)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_destroy_order"></a>
+
+## Function `destroy_order`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_order">destroy_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: <a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): (<b>address</b>, <a href="order_book_types.md#0x7_order_book_types_OrderIdType">order_book_types::OrderIdType</a>, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;u64&gt;, u64, u64, u64, bool, <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/option.md#0x1_option_Option">option::Option</a>&lt;<a href="order_book_types.md#0x7_order_book_types_TriggerCondition">order_book_types::TriggerCondition</a>&gt;, <a href="order_book_types.md#0x7_order_book_types_TimeInForce">order_book_types::TimeInForce</a>, M)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_order">destroy_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: <a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;
+): (
+    <b>address</b>, OrderIdType, Option&lt;u64&gt;, u64, u64, u64, bool, Option&lt;TriggerCondition&gt;, TimeInForce, M
+) {
+    <b>let</b> Order::V1 {
+        order_id,
+        <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+        client_order_id,
+        unique_priority_idx: _,
+        price,
+        orig_size,
+        remaining_size,
+        is_bid,
+        trigger_condition,
+        time_in_force,
+        metadata
+    } = self;
+    (
+        <a href="../../aptos-framework/doc/account.md#0x1_account">account</a>,
+        order_id,
+        client_order_id,
+        price,
+        orig_size,
+        remaining_size,
+        is_bid,
+        trigger_condition,
+        time_in_force,
+        metadata
+    )
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_destroy_single_order_match"></a>
+
+## Function `destroy_single_order_match`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_single_order_match">destroy_single_order_match</a>&lt;M: <b>copy</b>, drop, store&gt;(self: <a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">single_order_types::SingleOrderMatch</a>&lt;M&gt;): (<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_destroy_single_order_match">destroy_single_order_match</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: <a href="single_order_types.md#0x7_single_order_types_SingleOrderMatch">SingleOrderMatch</a>&lt;M&gt;
+): (<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;, u64) {
+    (self.order, self.matched_size)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_is_active_order"></a>
+
+## Function `is_active_order`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_is_active_order">is_active_order</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">single_order_types::OrderWithState</a>&lt;M&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_is_active_order">is_active_order</a>&lt;M: store + <b>copy</b> + drop&gt;(
+    self: &<a href="single_order_types.md#0x7_single_order_types_OrderWithState">OrderWithState</a>&lt;M&gt;
+): bool {
+    self.is_active
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_get_price"></a>
+
+## Function `get_price`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_price">get_price</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_get_price">get_price</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): u64 {
+    self.price
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x7_single_order_types_is_bid"></a>
+
+## Function `is_bid`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_is_bid">is_bid</a>&lt;M: <b>copy</b>, drop, store&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">single_order_types::Order</a>&lt;M&gt;): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="single_order_types.md#0x7_single_order_types_is_bid">is_bid</a>&lt;M: store + <b>copy</b> + drop&gt;(self: &<a href="single_order_types.md#0x7_single_order_types_Order">Order</a>&lt;M&gt;): bool {
+    self.is_bid
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/aptos-experimental/sources/large_packages.move
+++ b/aptos-move/framework/aptos-experimental/sources/large_packages.move
@@ -134,7 +134,7 @@ module aptos_experimental::large_packages {
         metadata_chunk: vector<u8>,
         code_indices: vector<u16>,
         code_chunks: vector<vector<u8>>
-    ): &mut StagingArea acquires StagingArea {
+    ): &mut StagingArea {
         assert!(
             vector::length(&code_indices) == vector::length(&code_chunks),
             error::invalid_argument(ECODE_MISMATCH)

--- a/aptos-move/framework/aptos-experimental/sources/trading/market/market_types.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/market/market_types.move
@@ -99,9 +99,9 @@ module aptos_experimental::market_types {
         place_maker_order_f: |address, OrderIdType, bool, u64, u64, M| has drop + copy,
         // cleanup_order_f arguments: account, order_id, is_bid, remaining_size
         cleanup_order_f: |address, OrderIdType, bool, u64| has drop + copy,
-        /// decrease_order_size_f arguments: account, order_id, is_bid, price, size
+        // decrease_order_size_f arguments: account, order_id, is_bid, price, size
         decrease_order_size_f: |address, OrderIdType, bool, u64, u64| has drop + copy,
-        /// get a string representation of order metadata to be used in events
+        // get a string representation of order metadata to be used in events
         get_order_metadata_bytes: |M| vector<u8> has drop + copy
     ): MarketClearinghouseCallbacks<M> {
         MarketClearinghouseCallbacks::V1 {

--- a/aptos-move/framework/aptos-framework/doc/account.md
+++ b/aptos-move/framework/aptos-framework/doc/account.md
@@ -1562,7 +1562,7 @@ When the feature flag is disabled:
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="account.md#0x1_account_ensure_resource_exists">ensure_resource_exists</a>(addr: <b>address</b>) <b>acquires</b> <a href="account.md#0x1_account_Account">Account</a>{
+<pre><code>inline <b>fun</b> <a href="account.md#0x1_account_ensure_resource_exists">ensure_resource_exists</a>(addr: <b>address</b>) {
     <b>if</b> (<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_default_account_resource_enabled">features::is_default_account_resource_enabled</a>()) {
         <a href="account.md#0x1_account_create_account_if_does_not_exist">create_account_if_does_not_exist</a>(addr);
     } <b>else</b> {

--- a/aptos-move/framework/aptos-framework/doc/coin.md
+++ b/aptos-move/framework/aptos-framework/doc/coin.md
@@ -2011,9 +2011,7 @@ Return the <code>BurnRef</code> with the hot potato receipt.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="coin.md#0x1_coin_borrow_paired_burn_ref">borrow_paired_burn_ref</a>&lt;CoinType&gt;(
-    _: &<a href="coin.md#0x1_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;
-): &BurnRef <b>acquires</b> <a href="coin.md#0x1_coin_CoinConversionMap">CoinConversionMap</a>, <a href="coin.md#0x1_coin_PairedFungibleAssetRefs">PairedFungibleAssetRefs</a> {
+<pre><code>inline <b>fun</b> <a href="coin.md#0x1_coin_borrow_paired_burn_ref">borrow_paired_burn_ref</a>&lt;CoinType&gt;(_: &<a href="coin.md#0x1_coin_BurnCapability">BurnCapability</a>&lt;CoinType&gt;): &BurnRef  {
     <b>let</b> metadata = <a href="coin.md#0x1_coin_assert_paired_metadata_exists">assert_paired_metadata_exists</a>&lt;CoinType&gt;();
     <b>let</b> metadata_addr = object_address(&metadata);
     <b>assert</b>!(<b>exists</b>&lt;<a href="coin.md#0x1_coin_PairedFungibleAssetRefs">PairedFungibleAssetRefs</a>&gt;(metadata_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_internal">error::internal</a>(<a href="coin.md#0x1_coin_EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND">EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND</a>));

--- a/aptos-move/framework/aptos-framework/doc/delegation_pool.md
+++ b/aptos-move/framework/aptos-framework/doc/delegation_pool.md
@@ -3935,9 +3935,7 @@ Update DelegatedVotes of a voter to up-to-date then return the total voting powe
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_borrow_mut_delegators_allowlist">borrow_mut_delegators_allowlist</a>(
-    pool_address: <b>address</b>
-): &<b>mut</b> SmartTable&lt;<b>address</b>, bool&gt; <b>acquires</b> <a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a> {
+<pre><code>inline <b>fun</b> <a href="delegation_pool.md#0x1_delegation_pool_borrow_mut_delegators_allowlist">borrow_mut_delegators_allowlist</a>(pool_address: <b>address</b>): &<b>mut</b> SmartTable&lt;<b>address</b>, bool&gt; {
     &<b>mut</b> <b>borrow_global_mut</b>&lt;<a href="delegation_pool.md#0x1_delegation_pool_DelegationPoolAllowlisting">DelegationPoolAllowlisting</a>&gt;(pool_address).allowlist
 }
 </code></pre>

--- a/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/dispatchable_fungible_asset.md
@@ -494,7 +494,7 @@ The semantics of supply will be governed by the function specified in DeriveSupp
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_borrow_transfer_ref">borrow_transfer_ref</a>&lt;T: key&gt;(metadata: Object&lt;T&gt;): &TransferRef <b>acquires</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_TransferRefStore">TransferRefStore</a> {
+<pre><code>inline <b>fun</b> <a href="dispatchable_fungible_asset.md#0x1_dispatchable_fungible_asset_borrow_transfer_ref">borrow_transfer_ref</a>&lt;T: key&gt;(metadata: Object&lt;T&gt;): &TransferRef {
     <b>let</b> metadata_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(
         &<a href="fungible_asset.md#0x1_fungible_asset_store_metadata">fungible_asset::store_metadata</a>(metadata)
     );

--- a/aptos-move/framework/aptos-framework/doc/fungible_asset.md
+++ b/aptos-move/framework/aptos-framework/doc/fungible_asset.md
@@ -3180,7 +3180,7 @@ Check the permission for withdraw operation.
     owner_address: <b>address</b>,
     store: Object&lt;T&gt;,
     abort_on_dispatch: bool,
-) <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_DispatchFunctionStore">DispatchFunctionStore</a> {
+) {
     <b>assert</b>!(<a href="object.md#0x1_object_owns">object::owns</a>(store, owner_address), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_permission_denied">error::permission_denied</a>(<a href="fungible_asset.md#0x1_fungible_asset_ENOT_STORE_OWNER">ENOT_STORE_OWNER</a>));
     <b>let</b> fa_store = <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>(&store);
     <b>assert</b>!(
@@ -3877,7 +3877,7 @@ Destroy an empty fungible asset.
 <pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_unchecked_deposit_with_no_events_inline">unchecked_deposit_with_no_events_inline</a>(
     store_addr: <b>address</b>,
     fa: <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a>
-): u64 <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_ConcurrentFungibleBalance">ConcurrentFungibleBalance</a> {
+): u64 {
     <b>let</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a> { metadata, amount } = fa;
     <b>assert</b>!(<b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_STORE_EXISTENCE">EFUNGIBLE_STORE_EXISTENCE</a>));
     <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr);
@@ -4007,7 +4007,7 @@ Extract <code>amount</code> of the fungible asset from <code>store</code> w/o em
 <pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_unchecked_withdraw_with_no_events">unchecked_withdraw_with_no_events</a>(
     store_addr: <b>address</b>,
     amount: u64,
-): <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a> <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>, <a href="fungible_asset.md#0x1_fungible_asset_ConcurrentFungibleBalance">ConcurrentFungibleBalance</a> {
+): <a href="fungible_asset.md#0x1_fungible_asset_FungibleAsset">FungibleAsset</a> {
     <b>assert</b>!(<b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_STORE_EXISTENCE">EFUNGIBLE_STORE_EXISTENCE</a>));
 
     <b>let</b> store = <b>borrow_global_mut</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr);
@@ -4142,9 +4142,7 @@ Decrease the supply of a fungible asset by burning.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_borrow_fungible_metadata">borrow_fungible_metadata</a>&lt;T: key&gt;(
-    metadata: &Object&lt;T&gt;
-): &<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
+<pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_borrow_fungible_metadata">borrow_fungible_metadata</a>&lt;T: key&gt;(metadata: &Object&lt;T&gt;): &<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
     <b>let</b> addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(metadata);
     <b>borrow_global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;(addr)
 }
@@ -4169,9 +4167,7 @@ Decrease the supply of a fungible asset by burning.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_borrow_fungible_metadata_mut">borrow_fungible_metadata_mut</a>&lt;T: key&gt;(
-    metadata: &Object&lt;T&gt;
-): &<b>mut</b> <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
+<pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_borrow_fungible_metadata_mut">borrow_fungible_metadata_mut</a>&lt;T: key&gt;(metadata: &Object&lt;T&gt;): &<b>mut</b> <a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a> {
     <b>let</b> addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(metadata);
     <b>borrow_global_mut</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_Metadata">Metadata</a>&gt;(addr)
 }
@@ -4196,7 +4192,7 @@ Decrease the supply of a fungible asset by burning.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>&lt;T: key&gt;(store: &Object&lt;T&gt;): &<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> <b>acquires</b> <a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
+<pre><code>inline <b>fun</b> <a href="fungible_asset.md#0x1_fungible_asset_borrow_store_resource">borrow_store_resource</a>&lt;T: key&gt;(store: &Object&lt;T&gt;): &<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a> {
     <b>let</b> store_addr = <a href="object.md#0x1_object_object_address">object::object_address</a>(store);
     <b>assert</b>!(<b>exists</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="fungible_asset.md#0x1_fungible_asset_EFUNGIBLE_STORE_EXISTENCE">EFUNGIBLE_STORE_EXISTENCE</a>));
     <b>borrow_global</b>&lt;<a href="fungible_asset.md#0x1_fungible_asset_FungibleStore">FungibleStore</a>&gt;(store_addr)

--- a/aptos-move/framework/aptos-framework/doc/multisig_account.md
+++ b/aptos-move/framework/aptos-framework/doc/multisig_account.md
@@ -3317,7 +3317,7 @@ This function is private so no other code can call this beside the VM itself as 
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_transaction_execution_cleanup_common">transaction_execution_cleanup_common</a>(executor: <b>address</b>, <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>): u64 <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_transaction_execution_cleanup_common">transaction_execution_cleanup_common</a>(executor: <b>address</b>, <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>): u64 {
     <b>let</b> sequence_number = <a href="multisig_account.md#0x1_multisig_account_last_resolved_sequence_number">last_resolved_sequence_number</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>) + 1;
     <b>let</b> implicit_approval = !<a href="multisig_account.md#0x1_multisig_account_has_voted_for_approval">has_voted_for_approval</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>, sequence_number, executor);
 
@@ -3569,7 +3569,7 @@ This function is private so no other code can call this beside the VM itself as 
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_assert_is_owner">assert_is_owner</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>) <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_assert_is_owner">assert_is_owner</a>(owner: &<a href="../../aptos-stdlib/../move-stdlib/doc/signer.md#0x1_signer">signer</a>, <a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>) {
     <b>let</b> multisig_account_resource = <b>borrow_global</b>&lt;<a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a>&gt;(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>);
     <a href="multisig_account.md#0x1_multisig_account_assert_is_owner_internal">assert_is_owner_internal</a>(owner, multisig_account_resource);
 }
@@ -3632,7 +3632,7 @@ This function is private so no other code can call this beside the VM itself as 
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_num_approvals_and_rejections">num_approvals_and_rejections</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64): (u64, u64) <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_num_approvals_and_rejections">num_approvals_and_rejections</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64): (u64, u64) {
     <b>let</b> multisig_account_resource = <b>borrow_global</b>&lt;<a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a>&gt;(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>);
     <b>let</b> transaction = <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(&multisig_account_resource.transactions, sequence_number);
     <a href="multisig_account.md#0x1_multisig_account_num_approvals_and_rejections_internal">num_approvals_and_rejections_internal</a>(&multisig_account_resource.owners, transaction)
@@ -3658,7 +3658,7 @@ This function is private so no other code can call this beside the VM itself as 
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_has_voted_for_approval">has_voted_for_approval</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64, owner: <b>address</b>): bool <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_has_voted_for_approval">has_voted_for_approval</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64, owner: <b>address</b>): bool {
     <b>let</b> (voted, vote) = <a href="multisig_account.md#0x1_multisig_account_vote">vote</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>, sequence_number, owner);
     voted && vote
 }
@@ -3683,7 +3683,7 @@ This function is private so no other code can call this beside the VM itself as 
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_has_voted_for_rejection">has_voted_for_rejection</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64, owner: <b>address</b>): bool <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_has_voted_for_rejection">has_voted_for_rejection</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64, owner: <b>address</b>): bool {
     <b>let</b> (voted, vote) = <a href="multisig_account.md#0x1_multisig_account_vote">vote</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>, sequence_number, owner);
     voted && !vote
 }
@@ -3732,7 +3732,7 @@ This function is private so no other code can call this beside the VM itself as 
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_assert_valid_sequence_number">assert_valid_sequence_number</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64) <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_assert_valid_sequence_number">assert_valid_sequence_number</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64) {
     <b>let</b> multisig_account_resource = <b>borrow_global</b>&lt;<a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a>&gt;(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>);
     <b>assert</b>!(
         sequence_number &gt; 0 && sequence_number &lt; multisig_account_resource.next_sequence_number,
@@ -3760,7 +3760,7 @@ This function is private so no other code can call this beside the VM itself as 
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_assert_transaction_exists">assert_transaction_exists</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64) <b>acquires</b> <a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a> {
+<pre><code>inline <b>fun</b> <a href="multisig_account.md#0x1_multisig_account_assert_transaction_exists">assert_transaction_exists</a>(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>: <b>address</b>, sequence_number: u64) {
     <b>let</b> multisig_account_resource = <b>borrow_global</b>&lt;<a href="multisig_account.md#0x1_multisig_account_MultisigAccount">MultisigAccount</a>&gt;(<a href="multisig_account.md#0x1_multisig_account">multisig_account</a>);
     <b>assert</b>!(
         <a href="../../aptos-stdlib/doc/table.md#0x1_table_contains">table::contains</a>(&multisig_account_resource.transactions, sequence_number),

--- a/aptos-move/framework/aptos-framework/doc/object.md
+++ b/aptos-move/framework/aptos-framework/doc/object.md
@@ -2061,7 +2061,7 @@ hierarchy.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="object.md#0x1_object_transfer_raw_inner">transfer_raw_inner</a>(<a href="object.md#0x1_object">object</a>: <b>address</b>, <b>to</b>: <b>address</b>) <b>acquires</b> <a href="object.md#0x1_object_ObjectCore">ObjectCore</a> {
+<pre><code>inline <b>fun</b> <a href="object.md#0x1_object_transfer_raw_inner">transfer_raw_inner</a>(<a href="object.md#0x1_object">object</a>: <b>address</b>, <b>to</b>: <b>address</b>) {
     <b>let</b> object_core = <b>borrow_global_mut</b>&lt;<a href="object.md#0x1_object_ObjectCore">ObjectCore</a>&gt;(<a href="object.md#0x1_object">object</a>);
     <b>if</b> (object_core.owner != <b>to</b>) {
         <b>if</b> (std::features::module_event_migration_enabled()) {

--- a/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
+++ b/aptos-move/framework/aptos-framework/doc/permissioned_signer.md
@@ -870,9 +870,7 @@ Destroys a storable permission handle. Clean up the permission stored in that ha
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_destroy_permissions_storage_address">destroy_permissions_storage_address</a>(
-    permissions_storage_addr: <b>address</b>
-) <b>acquires</b> <a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a> {
+<pre><code>inline <b>fun</b> <a href="permissioned_signer.md#0x1_permissioned_signer_destroy_permissions_storage_address">destroy_permissions_storage_address</a>(permissions_storage_addr: <b>address</b>) {
     <b>if</b> (<b>exists</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a>&gt;(permissions_storage_addr)) {
         <b>let</b> PermissionStorage::V1 { perms } =
             <b>move_from</b>&lt;<a href="permissioned_signer.md#0x1_permissioned_signer_PermissionStorage">PermissionStorage</a>&gt;(permissions_storage_addr);

--- a/aptos-move/framework/aptos-framework/doc/voting.md
+++ b/aptos-move/framework/aptos-framework/doc/voting.md
@@ -1937,7 +1937,7 @@ Return true if the voting period of the given proposal has already ended.
 <pre><code>inline <b>fun</b> <a href="voting.md#0x1_voting_get_proposal">get_proposal</a>&lt;ProposalType: store&gt;(
     voting_forum_address: <b>address</b>,
     proposal_id: u64,
-): &<a href="voting.md#0x1_voting_Proposal">Proposal</a>&lt;ProposalType&gt; <b>acquires</b> <a href="voting.md#0x1_voting_VotingForum">VotingForum</a> {
+): &<a href="voting.md#0x1_voting_Proposal">Proposal</a>&lt;ProposalType&gt; {
     <b>let</b> voting_forum = <b>borrow_global</b>&lt;<a href="voting.md#0x1_voting_VotingForum">VotingForum</a>&lt;ProposalType&gt;&gt;(voting_forum_address);
     <a href="../../aptos-stdlib/doc/table.md#0x1_table_borrow">table::borrow</a>(&voting_forum.proposals, proposal_id)
 }

--- a/aptos-move/framework/aptos-framework/sources/account/account.move
+++ b/aptos-move/framework/aptos-framework/sources/account/account.move
@@ -401,7 +401,7 @@ module aptos_framework::account {
         }
     }
 
-    inline fun ensure_resource_exists(addr: address) acquires Account{
+    inline fun ensure_resource_exists(addr: address) {
         if (features::is_default_account_resource_enabled()) {
             create_account_if_does_not_exist(addr);
         } else {

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -537,9 +537,7 @@ module aptos_framework::coin {
         option::fill(burn_ref_opt, burn_ref);
     }
 
-    inline fun borrow_paired_burn_ref<CoinType>(
-        _: &BurnCapability<CoinType>
-    ): &BurnRef acquires CoinConversionMap, PairedFungibleAssetRefs {
+    inline fun borrow_paired_burn_ref<CoinType>(_: &BurnCapability<CoinType>): &BurnRef  {
         let metadata = assert_paired_metadata_exists<CoinType>();
         let metadata_addr = object_address(&metadata);
         assert!(exists<PairedFungibleAssetRefs>(metadata_addr), error::internal(EPAIRED_FUNGIBLE_ASSET_REFS_NOT_FOUND));

--- a/aptos-move/framework/aptos-framework/sources/delegation_pool.move
+++ b/aptos-move/framework/aptos-framework/sources/delegation_pool.move
@@ -1311,9 +1311,7 @@ module aptos_framework::delegation_pool {
         calculate_total_voting_power(pool, delegated_votes)
     }
 
-    inline fun borrow_mut_delegators_allowlist(
-        pool_address: address
-    ): &mut SmartTable<address, bool> acquires DelegationPoolAllowlisting {
+    inline fun borrow_mut_delegators_allowlist(pool_address: address): &mut SmartTable<address, bool> {
         &mut borrow_global_mut<DelegationPoolAllowlisting>(pool_address).allowlist
     }
 

--- a/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/dispatchable_fungible_asset.move
@@ -208,7 +208,7 @@ module aptos_framework::dispatchable_fungible_asset {
         }
     }
 
-    inline fun borrow_transfer_ref<T: key>(metadata: Object<T>): &TransferRef acquires TransferRefStore {
+    inline fun borrow_transfer_ref<T: key>(metadata: Object<T>): &TransferRef {
         let metadata_addr = object::object_address(
             &fungible_asset::store_metadata(metadata)
         );

--- a/aptos-move/framework/aptos-framework/sources/fungible_asset.move
+++ b/aptos-move/framework/aptos-framework/sources/fungible_asset.move
@@ -926,7 +926,7 @@ module aptos_framework::fungible_asset {
         owner_address: address,
         store: Object<T>,
         abort_on_dispatch: bool,
-    ) acquires FungibleStore, DispatchFunctionStore {
+    ) {
         assert!(object::owns(store, owner_address), error::permission_denied(ENOT_STORE_OWNER));
         let fa_store = borrow_store_resource(&store);
         assert!(
@@ -1183,7 +1183,7 @@ module aptos_framework::fungible_asset {
     inline fun unchecked_deposit_with_no_events_inline(
         store_addr: address,
         fa: FungibleAsset
-    ): u64 acquires FungibleStore, ConcurrentFungibleBalance {
+    ): u64 {
         let FungibleAsset { metadata, amount } = fa;
         assert!(exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE));
         let store = borrow_global_mut<FungibleStore>(store_addr);
@@ -1233,7 +1233,7 @@ module aptos_framework::fungible_asset {
     inline fun unchecked_withdraw_with_no_events(
         store_addr: address,
         amount: u64,
-    ): FungibleAsset acquires FungibleStore, ConcurrentFungibleBalance {
+    ): FungibleAsset {
         assert!(exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE));
 
         let store = borrow_global_mut<FungibleStore>(store_addr);
@@ -1308,21 +1308,17 @@ module aptos_framework::fungible_asset {
         }
     }
 
-    inline fun borrow_fungible_metadata<T: key>(
-        metadata: &Object<T>
-    ): &Metadata acquires Metadata {
+    inline fun borrow_fungible_metadata<T: key>(metadata: &Object<T>): &Metadata {
         let addr = object::object_address(metadata);
         borrow_global<Metadata>(addr)
     }
 
-    inline fun borrow_fungible_metadata_mut<T: key>(
-        metadata: &Object<T>
-    ): &mut Metadata acquires Metadata {
+    inline fun borrow_fungible_metadata_mut<T: key>(metadata: &Object<T>): &mut Metadata {
         let addr = object::object_address(metadata);
         borrow_global_mut<Metadata>(addr)
     }
 
-    inline fun borrow_store_resource<T: key>(store: &Object<T>): &FungibleStore acquires FungibleStore {
+    inline fun borrow_store_resource<T: key>(store: &Object<T>): &FungibleStore {
         let store_addr = object::object_address(store);
         assert!(exists<FungibleStore>(store_addr), error::not_found(EFUNGIBLE_STORE_EXISTENCE));
         borrow_global<FungibleStore>(store_addr)

--- a/aptos-move/framework/aptos-framework/sources/multisig_account.move
+++ b/aptos-move/framework/aptos-framework/sources/multisig_account.move
@@ -1251,7 +1251,7 @@ module aptos_framework::multisig_account {
 
     ////////////////////////// Private functions ///////////////////////////////
 
-    inline fun transaction_execution_cleanup_common(executor: address, multisig_account: address): u64 acquires MultisigAccount {
+    inline fun transaction_execution_cleanup_common(executor: address, multisig_account: address): u64 {
         let sequence_number = last_resolved_sequence_number(multisig_account) + 1;
         let implicit_approval = !has_voted_for_approval(multisig_account, sequence_number, executor);
 
@@ -1364,7 +1364,7 @@ module aptos_framework::multisig_account {
         );
     }
 
-    inline fun assert_is_owner(owner: &signer, multisig_account: address) acquires MultisigAccount {
+    inline fun assert_is_owner(owner: &signer, multisig_account: address) {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         assert_is_owner_internal(owner, multisig_account_resource);
     }
@@ -1387,18 +1387,18 @@ module aptos_framework::multisig_account {
         (num_approvals, num_rejections)
     }
 
-    inline fun num_approvals_and_rejections(multisig_account: address, sequence_number: u64): (u64, u64) acquires MultisigAccount {
+    inline fun num_approvals_and_rejections(multisig_account: address, sequence_number: u64): (u64, u64) {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         let transaction = table::borrow(&multisig_account_resource.transactions, sequence_number);
         num_approvals_and_rejections_internal(&multisig_account_resource.owners, transaction)
     }
 
-    inline fun has_voted_for_approval(multisig_account: address, sequence_number: u64, owner: address): bool acquires MultisigAccount {
+    inline fun has_voted_for_approval(multisig_account: address, sequence_number: u64, owner: address): bool {
         let (voted, vote) = vote(multisig_account, sequence_number, owner);
         voted && vote
     }
 
-    inline fun has_voted_for_rejection(multisig_account: address, sequence_number: u64, owner: address): bool acquires MultisigAccount {
+    inline fun has_voted_for_rejection(multisig_account: address, sequence_number: u64, owner: address): bool {
         let (voted, vote) = vote(multisig_account, sequence_number, owner);
         voted && !vote
     }
@@ -1407,7 +1407,7 @@ module aptos_framework::multisig_account {
         assert!(exists<MultisigAccount>(multisig_account), error::invalid_state(EACCOUNT_NOT_MULTISIG));
     }
 
-    inline fun assert_valid_sequence_number(multisig_account: address, sequence_number: u64) acquires MultisigAccount {
+    inline fun assert_valid_sequence_number(multisig_account: address, sequence_number: u64) {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         assert!(
             sequence_number > 0 && sequence_number < multisig_account_resource.next_sequence_number,
@@ -1415,7 +1415,7 @@ module aptos_framework::multisig_account {
         );
     }
 
-    inline fun assert_transaction_exists(multisig_account: address, sequence_number: u64) acquires MultisigAccount {
+    inline fun assert_transaction_exists(multisig_account: address, sequence_number: u64) {
         let multisig_account_resource = borrow_global<MultisigAccount>(multisig_account);
         assert!(
             table::contains(&multisig_account_resource.transactions, sequence_number),

--- a/aptos-move/framework/aptos-framework/sources/object.move
+++ b/aptos-move/framework/aptos-framework/sources/object.move
@@ -554,7 +554,7 @@ module aptos_framework::object {
         transfer_raw_inner(object, to);
     }
 
-    inline fun transfer_raw_inner(object: address, to: address) acquires ObjectCore {
+    inline fun transfer_raw_inner(object: address, to: address) {
         let object_core = borrow_global_mut<ObjectCore>(object);
         if (object_core.owner != to) {
             if (std::features::module_event_migration_enabled()) {

--- a/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
+++ b/aptos-move/framework/aptos-framework/sources/permissioned_signer.move
@@ -311,9 +311,7 @@ module aptos_framework::permissioned_signer {
         destroy_permissions_storage_address(permissions_storage_addr);
     }
 
-    inline fun destroy_permissions_storage_address(
-        permissions_storage_addr: address
-    ) acquires PermissionStorage {
+    inline fun destroy_permissions_storage_address(permissions_storage_addr: address) {
         if (exists<PermissionStorage>(permissions_storage_addr)) {
             let PermissionStorage::V1 { perms } =
                 move_from<PermissionStorage>(permissions_storage_addr);

--- a/aptos-move/framework/aptos-framework/sources/voting.move
+++ b/aptos-move/framework/aptos-framework/sources/voting.move
@@ -774,7 +774,7 @@ module aptos_framework::voting {
     inline fun get_proposal<ProposalType: store>(
         voting_forum_address: address,
         proposal_id: u64,
-    ): &Proposal<ProposalType> acquires VotingForum {
+    ): &Proposal<ProposalType> {
         let voting_forum = borrow_global<VotingForum<ProposalType>>(voting_forum_address);
         table::borrow(&voting_forum.proposals, proposal_id)
     }

--- a/aptos-move/framework/aptos-token-objects/doc/property_map.md
+++ b/aptos-move/framework/aptos-token-objects/doc/property_map.md
@@ -788,7 +788,7 @@ Read a type and verify that the type is correct
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="property_map.md#0x4_property_map_read_typed">read_typed</a>&lt;T: key, V&gt;(<a href="../../aptos-framework/doc/object.md#0x1_object">object</a>: &Object&lt;T&gt;, key: &String): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; <b>acquires</b> <a href="property_map.md#0x4_property_map_PropertyMap">PropertyMap</a> {
+<pre><code>inline <b>fun</b> <a href="property_map.md#0x4_property_map_read_typed">read_typed</a>&lt;T: key, V&gt;(<a href="../../aptos-framework/doc/object.md#0x1_object">object</a>: &Object&lt;T&gt;, key: &String): <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt; {
     <b>let</b> (type, value) = <a href="property_map.md#0x4_property_map_read">read</a>(<a href="../../aptos-framework/doc/object.md#0x1_object">object</a>, key);
     <b>assert</b>!(
         type == <a href="../../aptos-framework/../aptos-stdlib/doc/type_info.md#0x1_type_info_type_name">type_info::type_name</a>&lt;V&gt;(),
@@ -1120,7 +1120,7 @@ Add a property that isn't already encoded as a <code><a href="../../aptos-framew
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="property_map.md#0x4_property_map_add_internal">add_internal</a>(ref: &<a href="property_map.md#0x4_property_map_MutatorRef">MutatorRef</a>, key: String, type: u8, value: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="property_map.md#0x4_property_map_PropertyMap">PropertyMap</a> {
+<pre><code>inline <b>fun</b> <a href="property_map.md#0x4_property_map_add_internal">add_internal</a>(ref: &<a href="property_map.md#0x4_property_map_MutatorRef">MutatorRef</a>, key: String, type: u8, value: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <a href="property_map.md#0x4_property_map_assert_exists">assert_exists</a>(ref.self);
     <b>let</b> <a href="property_map.md#0x4_property_map">property_map</a> = &<b>mut</b> <a href="property_map.md#0x4_property_map_PropertyMap">PropertyMap</a>[ref.self];
     <a href="property_map.md#0x4_property_map">property_map</a>.inner.<a href="property_map.md#0x4_property_map_add">add</a>(key, <a href="property_map.md#0x4_property_map_PropertyValue">PropertyValue</a> { type, value });
@@ -1199,7 +1199,7 @@ Updates a property in place that is not already bcs encoded
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="property_map.md#0x4_property_map_update_internal">update_internal</a>(ref: &<a href="property_map.md#0x4_property_map_MutatorRef">MutatorRef</a>, key: &String, type: u8, value: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) <b>acquires</b> <a href="property_map.md#0x4_property_map_PropertyMap">PropertyMap</a> {
+<pre><code>inline <b>fun</b> <a href="property_map.md#0x4_property_map_update_internal">update_internal</a>(ref: &<a href="property_map.md#0x4_property_map_MutatorRef">MutatorRef</a>, key: &String, type: u8, value: <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/vector.md#0x1_vector">vector</a>&lt;u8&gt;) {
     <a href="property_map.md#0x4_property_map_assert_exists">assert_exists</a>(ref.self);
     <b>let</b> <a href="property_map.md#0x4_property_map">property_map</a> = &<b>mut</b> <a href="property_map.md#0x4_property_map_PropertyMap">PropertyMap</a>[ref.self];
     <b>let</b> old_value = <a href="property_map.md#0x4_property_map">property_map</a>.inner.borrow_mut(key);

--- a/aptos-move/framework/aptos-token-objects/doc/token.md
+++ b/aptos-move/framework/aptos-token-objects/doc/token.md
@@ -1470,7 +1470,7 @@ Extracts the tokens address from a BurnRef.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="token.md#0x4_token_borrow">borrow</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: &Object&lt;T&gt;): &<a href="token.md#0x4_token_Token">Token</a> <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
+<pre><code>inline <b>fun</b> <a href="token.md#0x4_token_borrow">borrow</a>&lt;T: key&gt;(<a href="token.md#0x4_token">token</a>: &Object&lt;T&gt;): &<a href="token.md#0x4_token_Token">Token</a> {
     <b>let</b> token_address = <a href="../../aptos-framework/doc/object.md#0x1_object_object_address">object::object_address</a>(<a href="token.md#0x4_token">token</a>);
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="token.md#0x4_token_Token">Token</a>&gt;(token_address),
@@ -1723,7 +1723,7 @@ as that would prohibit transactions to be executed in parallel.
 <summary>Implementation</summary>
 
 
-<pre><code>inline <b>fun</b> <a href="token.md#0x4_token_borrow_mut">borrow_mut</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>): &<b>mut</b> <a href="token.md#0x4_token_Token">Token</a> <b>acquires</b> <a href="token.md#0x4_token_Token">Token</a> {
+<pre><code>inline <b>fun</b> <a href="token.md#0x4_token_borrow_mut">borrow_mut</a>(mutator_ref: &<a href="token.md#0x4_token_MutatorRef">MutatorRef</a>): &<b>mut</b> <a href="token.md#0x4_token_Token">Token</a> {
     <b>assert</b>!(
         <b>exists</b>&lt;<a href="token.md#0x4_token_Token">Token</a>&gt;(mutator_ref.self),
         <a href="../../aptos-framework/../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_not_found">error::not_found</a>(<a href="token.md#0x4_token_ETOKEN_DOES_NOT_EXIST">ETOKEN_DOES_NOT_EXIST</a>),

--- a/aptos-move/framework/aptos-token-objects/sources/property_map.move
+++ b/aptos-move/framework/aptos-token-objects/sources/property_map.move
@@ -235,7 +235,7 @@ module aptos_token_objects::property_map {
     }
 
     /// Read a type and verify that the type is correct
-    inline fun read_typed<T: key, V>(object: &Object<T>, key: &String): vector<u8> acquires PropertyMap {
+    inline fun read_typed<T: key, V>(object: &Object<T>, key: &String): vector<u8> {
         let (type, value) = read(object, key);
         assert!(
             type == type_info::type_name<V>(),
@@ -308,7 +308,7 @@ module aptos_token_objects::property_map {
         add_internal(ref, key, type, bcs::to_bytes(&value));
     }
 
-    inline fun add_internal(ref: &MutatorRef, key: String, type: u8, value: vector<u8>) acquires PropertyMap {
+    inline fun add_internal(ref: &MutatorRef, key: String, type: u8, value: vector<u8>) {
         assert_exists(ref.self);
         let property_map = &mut PropertyMap[ref.self];
         property_map.inner.add(key, PropertyValue { type, value });
@@ -327,7 +327,7 @@ module aptos_token_objects::property_map {
         update_internal(ref, key, type, bcs::to_bytes(&value));
     }
 
-    inline fun update_internal(ref: &MutatorRef, key: &String, type: u8, value: vector<u8>) acquires PropertyMap {
+    inline fun update_internal(ref: &MutatorRef, key: &String, type: u8, value: vector<u8>) {
         assert_exists(ref.self);
         let property_map = &mut PropertyMap[ref.self];
         let old_value = property_map.inner.borrow_mut(key);

--- a/aptos-move/framework/aptos-token-objects/sources/token.move
+++ b/aptos-move/framework/aptos-token-objects/sources/token.move
@@ -622,7 +622,7 @@ module aptos_token_objects::token {
 
     // Accessors
 
-    inline fun borrow<T: key>(token: &Object<T>): &Token acquires Token {
+    inline fun borrow<T: key>(token: &Object<T>): &Token {
         let token_address = object::object_address(token);
         assert!(
             exists<Token>(token_address),
@@ -723,7 +723,7 @@ module aptos_token_objects::token {
 
     // Mutators
 
-    inline fun borrow_mut(mutator_ref: &MutatorRef): &mut Token acquires Token {
+    inline fun borrow_mut(mutator_ref: &MutatorRef): &mut Token {
         assert!(
             exists<Token>(mutator_ref.self),
             error::not_found(ETOKEN_DOES_NOT_EXIST),

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg_inline.exp
@@ -14,7 +14,7 @@ error: missing acquires annotation for `Test`
 warning: storage operation on type `test::Test` can only be done within the defining module `0x42::test`, but `test::modify` could be called (and expanded) outside the module
    ┌─ tests/checking/inlining/acquires_error_msg_inline.move:10:23
    │
-10 │     public inline fun modify() acquires Test {
+10 │     public inline fun modify() {
    │                       ^^^^^^
 11 │         borrow_global_mut<Test>(@0xcafe).value = 2;
    │         -------------------------------- called here
@@ -22,7 +22,7 @@ warning: storage operation on type `test::Test` can only be done within the defi
 warning: access of the field `value` on type `test::Test` can only be done within the defining module `0x42::test`, but `test::modify` could be called (and expanded) outside the module
    ┌─ tests/checking/inlining/acquires_error_msg_inline.move:10:23
    │
-10 │     public inline fun modify() acquires Test {
+10 │     public inline fun modify() {
    │                       ^^^^^^
 11 │         borrow_global_mut<Test>(@0xcafe).value = 2;
    │         -------------------------------------- accessed here

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg_inline.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/acquires_error_msg_inline.move
@@ -7,7 +7,7 @@ module 0x42::test {
         modify(); // expect error message here
     }
 
-    public inline fun modify() acquires Test {
+    public inline fun modify() {
         borrow_global_mut<Test>(@0xcafe).value = 2;
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_acquires.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_acquires.exp
@@ -1,0 +1,45 @@
+
+Diagnostics:
+warning: acquires and access specifiers are not applicable to inline functions and should be removed
+  ┌─ tests/checking/inlining/inline_disallowed_acquires.move:6:16
+  │
+6 │     inline fun test() acquires R {}
+  │                ^^^^
+
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    struct R {
+        x: u64,
+    }
+    private inline fun test()
+        acquires R(*)
+     {
+        Tuple()
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    struct R has key {
+        x: u64,
+    }
+    inline fun test()
+        acquires R
+    {
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    struct R {
+        x: u64,
+    }
+    private inline fun test()
+        acquires R(*)
+     {
+        Tuple()
+    }
+} // end 0xc0ffee::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_acquires.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_acquires.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    struct R has key {
+        x: u64
+    }
+
+    inline fun test() acquires R {}
+}

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_attributes.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_attributes.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: inline functions cannot have the following attributes: `#[persistent]`, `#[module_lock]`
+  ┌─ tests/checking/inlining/inline_disallowed_attributes.move:3:16
+  │
+3 │     inline fun forty_two(): u64 {
+  │                ^^^^^^^^^
+
+error: inline functions cannot have the following attributes: `#[persistent]`, `#[module_lock]`
+  ┌─ tests/checking/inlining/inline_disallowed_attributes.move:8:16
+  │
+8 │     inline fun fifty_five(): u64 {
+  │                ^^^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_attributes.move
+++ b/third_party/move/move-compiler-v2/tests/checking/inlining/inline_disallowed_attributes.move
@@ -1,0 +1,11 @@
+module 0xc0ffee::m {
+    #[persistent]
+    inline fun forty_two(): u64 {
+        42
+    }
+
+    #[module_lock]
+    inline fun fifty_five(): u64 {
+        55
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/unused-assignment/bug-13880.move
+++ b/third_party/move/move-compiler-v2/tests/unused-assignment/bug-13880.move
@@ -73,7 +73,7 @@ module 0x42::object {
         inner: address,
     }
 
-    inline fun transfer_raw_inner(object: address, to: address, a1: bool) acquires ObjectCore {
+    inline fun transfer_raw_inner(object: address, to: address, a1: bool) {
         let object_core = borrow_global_mut<ObjectCore>(object);
         if (object_core.owner != to) {
             if (a1) {


### PR DESCRIPTION
## Description

In this PR:
- compiler will error on inline functions with attributes `#[persistent]` and `#[module_lock]`
- compiler will warn on inline functions with acquires (we may eventually make this an error)
- aptos framework code with above warnings (and some other warnings) are fixed

Closes #17189. Closes #17123.

## How Has This Been Tested?

Tests added for newly introduced functionality

## Type of Change
- [x] New feature
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Aptos Framework
- [x] Move Compiler
