### PR TITLE
move imports into the proper `test_only` / `verify_only` scopes for some files

### DIFF
--- a/aptos-move/framework/aptos-experimental/sources/trading/tests/market/pre_cancellation_tests.move
+++ b/aptos-move/framework/aptos-experimental/sources/trading/tests/market/pre_cancellation_tests.move
@@ -12,7 +12,7 @@ module aptos_experimental::pre_cancellation_tests {
         place_order_and_verify, verify_cancel_event,
     };
     use aptos_experimental::event_utils;
-    use aptos_experimental::market::{new_market, new_market_config, cancel_order_with_client_id};
+    use aptos_experimental::market::{new_market, new_market_config};
 
     const PRE_CANCEL_WINDOW_SECS: u64 = 1; // 1 second
 

--- a/aptos-move/framework/aptos-framework/sources/coin.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.move
@@ -8,7 +8,6 @@ module aptos_framework::coin {
     use aptos_std::table::{Self, Table};
 
     use aptos_framework::account;
-    use aptos_framework::aggregator_factory;
     use aptos_framework::aggregator::Aggregator;
     use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::guid;
@@ -21,6 +20,9 @@ module aptos_framework::coin {
     use aptos_framework::primary_fungible_store;
     use aptos_std::type_info::{Self, TypeInfo};
     use aptos_framework::create_signer;
+
+    #[test_only]
+    use aptos_framework::aggregator_factory;
 
     friend aptos_framework::aptos_coin;
     friend aptos_framework::genesis;

--- a/aptos-move/framework/aptos-framework/sources/coin.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/coin.spec.move
@@ -436,6 +436,7 @@ spec aptos_framework::coin {
     monitor_supply: bool,
     parallelizable: bool,
     ): (BurnCapability<CoinType>, FreezeCapability<CoinType>, MintCapability<CoinType>) {
+        use aptos_framework::aggregator_factory;
         include InitializeInternalSchema<CoinType> {
             name: name.bytes,
             symbol: symbol.bytes

--- a/aptos-move/framework/aptos-framework/sources/stake.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.move
@@ -34,7 +34,7 @@ module aptos_framework::stake {
     use aptos_framework::event::{Self, EventHandle};
     use aptos_framework::timestamp;
     use aptos_framework::system_addresses;
-    use aptos_framework::staking_config::{Self, StakingConfig, StakingRewardsConfig};
+    use aptos_framework::staking_config::{Self, StakingConfig};
     use aptos_framework::chain_status;
     use aptos_framework::permissioned_signer;
 

--- a/aptos-move/framework/aptos-framework/sources/stake.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/stake.spec.move
@@ -936,7 +936,7 @@ spec aptos_framework::stake {
         requires exists<ValidatorPerformance>(@aptos_framework);
         requires exists<ValidatorSet>(@aptos_framework);
         requires exists<StakingConfig>(@aptos_framework);
-        requires exists<StakingRewardsConfig>(@aptos_framework) || !features::spec_periodical_reward_rate_decrease_enabled();
+        requires exists<staking_config::StakingRewardsConfig>(@aptos_framework) || !features::spec_periodical_reward_rate_decrease_enabled();
         requires exists<timestamp::CurrentTimeMicroseconds>(@aptos_framework);
     }
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.move
@@ -7,7 +7,7 @@ module aptos_framework::transaction_fee {
     use aptos_framework::system_addresses;
     use std::error;
     use std::features;
-    use std::option::{Self, Option};
+    use std::option::Option;
     use std::signer;
     use aptos_framework::event;
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_fee.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_fee.spec.move
@@ -72,6 +72,7 @@ spec aptos_framework::transaction_fee {
 
     /// `AptosCoinCapabilities` should be exists.
     spec burn_fee(account: address, fee: u64) {
+        use std::option;
         use aptos_std::type_info;
         use aptos_framework::optional_aggregator;
         use aptos_framework::coin;

--- a/aptos-move/framework/move-stdlib/sources/configs/features.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.move
@@ -25,7 +25,6 @@
 module std::features {
     use std::error;
     use std::signer;
-    use std::vector;
 
     const EINVALID_FEATURE: u64 = 1;
     const EAPI_DISABLED: u64 = 2;

--- a/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
+++ b/aptos-move/framework/move-stdlib/sources/configs/features.spec.move
@@ -19,7 +19,7 @@ spec std::features {
     spec apply_diff(features: &mut vector<u8>, enable: vector<u64>, disable: vector<u64>) {
         aborts_if [abstract] false; // TODO(#12011)
         ensures [abstract] forall i in disable: !spec_contains(features, i);
-        ensures [abstract] forall i in enable: !vector::spec_contains(disable, i)
+        ensures [abstract] forall i in enable: !std::vector::spec_contains(disable, i)
             ==> spec_contains(features, i);
         pragma opaque;
     }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

I'm working on "unused import" diagnostic for the VSCode extension, and it seems that `aptos-cli` has some inconsistent behaviour regarding how it handles the imports in `#[test_only]`, `#[verify_only]` scopes. 

The behaviour is basically that this is invalid code:
```
module std::my_module {
    // use stmt has MAIN scope and for `aptos move compile` should fail with "unused import"
    use std::option;
}
spec std::my_module {
   spec fun main() {
       // this option:: is valid, as it uses import from the module itself
       option::call();
   }
}
```
Same thing with tests and `#[test_only]` import. 
There's one case where `MAIN` scoped import provides items for both `VERIFY` and `TEST` scopes, in `coin.move` with `aggregate_factory`. 

There's a number of occurrences throughout the code, all of which more or less trivial, and only change imports for tests / prover, and doesn't change any behaviour.  

The right person to review would be @gregnazario , as we've merged similar PRs in the part. Let me know if it's a valid PR, or whether I instead should incorporate those inconsistencies in my implementation. 

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
