### PR TITLE
[transactional-test] Fix features expected for transactional test runner

### DIFF
--- a/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
+++ b/third_party/move/testing-infra/transactional-test-runner/Cargo.toml
@@ -29,7 +29,7 @@ move-model = { workspace = true }
 move-resource-viewer = { workspace = true }
 move-stdlib = { path = "../../move-stdlib", features = ["testing"] }
 move-symbol-pool = { workspace = true }
-move-vm-runtime = { workspace = true, features = ["disable_verifier_cache"] }
+move-vm-runtime = { workspace = true, features = ["testing", "disable_verifier_cache"] }
 move-vm-test-utils = { workspace = true }
 move-vm-types = { workspace = true }
 once_cell = { workspace = true }


### PR DESCRIPTION
## Description

The interpreter attaches `exec_state` on error, only if `"testing"` or `"stacktrace"` features are enabled https://github.com/aptos-labs/aptos-core/blob/main/third_party/move/move-vm/runtime/src/interpreter.rs#L842).

Recently, `transactional-test-runner`'s dependency on `move-vm-runtime` was changed from `[features = "testing"]` to `features = ["disable_verifier_cache"]`. This caused transactional tests to no longer have `exec_state`s attached.

We fix it in this PR.

## How Has This Been Tested?

Existing tests.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Transactional tests
