### PR TITLE
chore(ci): upgrade checkout to v5

### DIFF
--- a/.github/actions/determine-or-use-target-branch-and-get-last-released-image/action.yaml
+++ b/.github/actions/determine-or-use-target-branch-and-get-last-released-image/action.yaml
@@ -32,7 +32,7 @@ runs:
   steps:
     # Checkout repository based on base branch or target branch
     - name: Checkout branch
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ inputs.base-branch || inputs.branch }}
         path: checkout_branch
@@ -61,7 +61,7 @@ runs:
     # Checkout the determined or target branch
     - name: Checkout target branch
       if: ${{ steps.set-target-branch.outputs.TARGET_BRANCH != inputs.branch }}
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
       with:
         ref: ${{ steps.set-target-branch.outputs.TARGET_BRANCH }}
         path: checkout_branch

--- a/.github/actions/get-latest-docker-image-tag/action.yml
+++ b/.github/actions/get-latest-docker-image-tag/action.yml
@@ -18,7 +18,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: ${{ inputs.branch }}
         path: checkout_branch

--- a/.github/actions/test-target-determinator/action.yaml
+++ b/.github/actions/test-target-determinator/action.yaml
@@ -16,7 +16,7 @@ runs:
   using: composite
   steps:
     # Checkout the repository and setup the rust toolchain
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v5
       with:
         ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 0 # Fetch all git history for accurate target determination

--- a/.github/workflows/aptos-node-release.yaml
+++ b/.github/workflows/aptos-node-release.yaml
@@ -19,7 +19,7 @@ jobs:
   release-aptos-node:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.branch }}
 

--- a/.github/workflows/bump-release-version.yaml
+++ b/.github/workflows/bump-release-version.yaml
@@ -21,7 +21,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.branch }}
 

--- a/.github/workflows/cargo-metadata-upload.yaml
+++ b/.github/workflows/cargo-metadata-upload.yaml
@@ -13,7 +13,7 @@ jobs:
   cargo-metadata:
     runs-on: runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: dsherret/rust-toolchain-file@v1
       - id: auth
         uses: "google-github-actions/auth@v2"

--- a/.github/workflows/check-minimum-revision.yaml
+++ b/.github/workflows/check-minimum-revision.yaml
@@ -20,7 +20,7 @@ jobs:
   check-minimum-revision:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
           fetch-depth: 1000

--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -30,7 +30,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/cli-external-deps.yaml
+++ b/.github/workflows/cli-external-deps.yaml
@@ -11,7 +11,7 @@ jobs:
   check-dynamic-deps:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/cli-release.yaml
+++ b/.github/workflows/cli-release.yaml
@@ -32,7 +32,7 @@ jobs:
     name: "Build Ubuntu 22.04 binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -49,7 +49,7 @@ jobs:
     name: "Build Ubuntu 24.04 binary"
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -68,7 +68,7 @@ jobs:
     name: "Build Linux binary"
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -85,7 +85,7 @@ jobs:
     name: "Build Linux ARM binary"
     runs-on: ubuntu-22.04-arm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -101,7 +101,7 @@ jobs:
     name: "Build MacOS x86_64 binary"
     runs-on: macos-13
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -117,7 +117,7 @@ jobs:
     name: "Build MacOS ARM binary"
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       - uses: aptos-labs/aptos-core/.github/actions/cli-rust-setup@main
@@ -133,7 +133,7 @@ jobs:
     name: "Build Windows binary"
     runs-on: windows-2025
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.inputs.source_git_ref_override }}
       # Ensure that long paths work

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/copy-images-to-dockerhub-nightly.yaml
+++ b/.github/workflows/copy-images-to-dockerhub-nightly.yaml
@@ -13,7 +13,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -41,7 +41,7 @@ jobs:
     # Run on a machine with more local storage for large docker images
     runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:

--- a/.github/workflows/coverage-move-only.yaml
+++ b/.github/workflows/coverage-move-only.yaml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 60
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - name: prepare move lang prover tooling.
         shell: bash

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -29,7 +29,7 @@ jobs:
     timeout-minutes: 720
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -59,7 +59,7 @@ jobs:
     timeout-minutes: 720 # incremented from 240 due to execution time limit hit in cron
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
@@ -93,7 +93,7 @@ jobs:
     env:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/download-artifact@v4
         with:
           name: lcov_unit

--- a/.github/workflows/cut-release-branch.yaml
+++ b/.github/workflows/cut-release-branch.yaml
@@ -31,7 +31,7 @@ jobs:
   cut-release-branch:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           token: ${{ secrets.CUT_RELEASE_BRANCH_CREDENTIALS }}
           fetch-depth: 0

--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -19,7 +19,7 @@ jobs:
   build:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: aptos-labs/aptos-core/.github/actions/buildx-setup@main
 

--- a/.github/workflows/docker-build-test.yaml
+++ b/.github/workflows/docker-build-test.yaml
@@ -120,7 +120,7 @@ jobs:
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run the file change determinator
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
@@ -132,7 +132,7 @@ jobs:
     outputs:
       run_framework_upgrade_test: ${{ steps.determine_test_targets.outputs.run_framework_upgrade_test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run the test target determinator
         id: determine_test_targets
         uses: ./.github/actions/test-target-determinator
@@ -296,7 +296,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           ref: ${{ github.ref }}

--- a/.github/workflows/docker-indexer-grpc-test.yaml
+++ b/.github/workflows/docker-indexer-grpc-test.yaml
@@ -25,7 +25,7 @@ jobs:
       IMAGE_TAG: ${{ inputs.GIT_SHA || 'devnet' }} # hardcode to a known good build when not running on workflow_call
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.GIT_SHA || github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/docker-update-images.yaml
+++ b/.github/workflows/docker-update-images.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Login to Docker Hub
         uses: docker/login-action@v2

--- a/.github/workflows/faucet-tests-main.yaml
+++ b/.github/workflows/faucet-tests-main.yaml
@@ -51,7 +51,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ env.GIT_SHA }}

--- a/.github/workflows/faucet-tests-prod.yaml
+++ b/.github/workflows/faucet-tests-prod.yaml
@@ -39,7 +39,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -62,7 +62,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -6,6 +6,6 @@ jobs:
   find-packages-with-undeclared-feature-dependencies:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main
       - run: scripts/find-packages-with-undeclared-feature-dependencies.sh

--- a/.github/workflows/forge-continuous-land-blocking-test.yaml
+++ b/.github/workflows/forge-continuous-land-blocking-test.yaml
@@ -48,7 +48,7 @@ jobs:
     needs: [permission-check]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -104,7 +104,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 1
           ref: ${{ github.ref }}

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -203,7 +203,7 @@ jobs:
       BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
       BRANCH_HASH: ${{ steps.hash-branch.outputs.BRANCH_HASH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine branch based on cadence
         id: determine-test-branch

--- a/.github/workflows/forge-unstable.yaml
+++ b/.github/workflows/forge-unstable.yaml
@@ -47,7 +47,7 @@ jobs:
       BRANCH: ${{ steps.determine-test-branch.outputs.BRANCH }}
       BRANCH_HASH: ${{ steps.hash-branch.outputs.BRANCH_HASH }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Determine branch based on cadence
         id: determine-test-branch

--- a/.github/workflows/fullnode-execute-devnet-main.yaml
+++ b/.github/workflows/fullnode-execute-devnet-main.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-execute-devnet-stable.yaml
+++ b/.github/workflows/fullnode-execute-devnet-stable.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-fast-devnet-main.yaml
+++ b/.github/workflows/fullnode-fast-devnet-main.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-fast-devnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-devnet-stable.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-fast-mainnet-main.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-main.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-fast-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-mainnet-stable.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-fast-testnet-main.yaml
+++ b/.github/workflows/fullnode-fast-testnet-main.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-fast-testnet-stable.yaml
+++ b/.github/workflows/fullnode-fast-testnet-stable.yaml
@@ -17,7 +17,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-intelligent-devnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-devnet-main.yaml
@@ -18,7 +18,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-intelligent-mainnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-mainnet-main.yaml
@@ -18,7 +18,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-intelligent-mainnet-stable.yaml
+++ b/.github/workflows/fullnode-intelligent-mainnet-stable.yaml
@@ -18,7 +18,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fullnode-intelligent-testnet-main.yaml
+++ b/.github/workflows/fullnode-intelligent-testnet-main.yaml
@@ -18,7 +18,7 @@ jobs:
   check-repo:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/check-aptos-core@main
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/fuzzer-data-update.yml
+++ b/.github/workflows/fuzzer-data-update.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Rust
         uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/fuzzer-test.yaml
+++ b/.github/workflows/fuzzer-test.yaml
@@ -20,7 +20,7 @@ jobs:
           remove-dotnet: 'true'
           remove-android: 'true'
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install Dependencies
         shell: bash

--- a/.github/workflows/indexer-grpc-in-memory-cache-benchmark.yaml
+++ b/.github/workflows/indexer-grpc-in-memory-cache-benchmark.yaml
@@ -8,7 +8,7 @@ jobs:
   run-indexer-grpc-in-memory-cache-benchmark:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install grpcurl
         run: curl -sSL "https://github.com/fullstorydev/grpcurl/releases/download/v1.8.7/grpcurl_1.8.7_linux_x86_64.tar.gz" | sudo tar -xz -C /usr/local/bin
       - name: Rust setup

--- a/.github/workflows/indexer-processor-testing.yaml
+++ b/.github/workflows/indexer-processor-testing.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref }}
 

--- a/.github/workflows/indexer-protos-sdk-update.yaml
+++ b/.github/workflows/indexer-protos-sdk-update.yaml
@@ -11,7 +11,7 @@ jobs:
   check-protos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Install buf, which we use to generate code from the protos for Rust and TS.
       - name: Install buf
         uses: bufbuild/buf-setup-action@v1.24.0
@@ -61,7 +61,7 @@ jobs:
       )
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       # Install buf, which we use to generate code from the protos for Rust and TS.
       - name: Install buf

--- a/.github/workflows/links.yml
+++ b/.github/workflows/links.yml
@@ -17,7 +17,7 @@ jobs:
   linkChecker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Link Checker
         id: lychee

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       only_docs_changed: ${{ steps.determine_file_changes.outputs.only_docs_changed }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run the file change determinator
         id: determine_file_changes
         uses: ./.github/actions/file-change-determinator
@@ -41,7 +41,7 @@ jobs:
     needs: file_change_determinator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           fetch-depth: 0 # get all the history because python-lint-tests requires it.
@@ -59,7 +59,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: python3 scripts/check-cryptohasher-symbols.py
 
   # Run all rust lints. This is a PR required job.
@@ -67,7 +67,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
@@ -84,7 +84,7 @@ jobs:
     needs: file_change_determinator
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - uses: EmbarkStudios/cargo-deny-action@v2
         with:
@@ -103,7 +103,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run rust doc tests
         uses: ./.github/actions/rust-doc-tests
         with:
@@ -122,7 +122,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run rust smoke tests
         uses: ./.github/actions/rust-smoke-tests
@@ -141,7 +141,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
@@ -159,7 +159,7 @@ jobs:
     needs: file_change_determinator
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination
@@ -184,7 +184,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # Install Move Prover tools
       - name: Run dev_setup.sh
         run: |
@@ -207,7 +207,7 @@ jobs:
       )
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
       - name: Run aptos cached packages build test
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -220,7 +220,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: cargo nextest run --locked --workspace --exclude smoke-test --exclude aptos-testcases --exclude aptos-api --exclude aptos-executor-benchmark --exclude aptos-backup-cli --retries 3 --no-fail-fast -F consensus-only-perf-test
         env:
           RUST_MIN_STACK: 4297152
@@ -230,7 +230,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       # prebuild aptos-node binary, so that tests don't start before node is built.
       # also prebuild aptos-node binary as a separate step to avoid feature unification issues
       - run: cargo build --locked --package=aptos-node -F consensus-only-perf-test --release && LOCAL_SWARM_NODE_RELEASE=1 CONSENSUS_ONLY_PERF_TEST=1 cargo nextest run --release --package smoke-test -E "test(test_consensus_only_with_txn_emitter)" --run-ignored all

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -48,7 +48,7 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ env.GIT_SHA }}

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     timeout-minutes: ${{ github.event_name == 'pull_request' && 10 || 480}}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: ./.github/actions/move-prover-setup

--- a/.github/workflows/provision-replay-verify-archive-disks.yaml
+++ b/.github/workflows/provision-replay-verify-archive-disks.yaml
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/check-aptos-core
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/prune-old-workflow-runs.yaml
+++ b/.github/workflows/prune-old-workflow-runs.yaml
@@ -16,7 +16,7 @@ jobs:
     if: github.repository == 'aptos-labs/aptos-core'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: .node-version

--- a/.github/workflows/replay-verify-legacy.yaml
+++ b/.github/workflows/replay-verify-legacy.yaml
@@ -40,7 +40,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/check-aptos-core
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/replay-verify-mainnet.yaml
+++ b/.github/workflows/replay-verify-mainnet.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest-32-core # consider  moving this to a smaller machine since the compute runs on GKE
     steps:
       # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/check-aptos-core
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/replay-verify-testnet.yaml
+++ b/.github/workflows/replay-verify-testnet.yaml
@@ -44,7 +44,7 @@ jobs:
     runs-on: ubuntu-latest-32-core # consider  moving this to a smaller machine since the compute runs on GKE
     steps:
       # checkout the repo first, so check-aptos-core can use it and cancel the workflow if necessary
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/check-aptos-core
         with:
           cancel-workflow: ${{ github.event_name == 'schedule' }} # Cancel the workflow if it is scheduled on a fork

--- a/.github/workflows/run-fullnode-sync.yaml
+++ b/.github/workflows/run-fullnode-sync.yaml
@@ -60,7 +60,7 @@ jobs:
     runs-on: runs-on,family=c5ad.8xlarge,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=false
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES || 300 }} # the default run is 300 minutes (5 hours). Specified here because workflow_dispatch uses string rather than number
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - uses: ./.github/actions/fullnode-sync
         with:
@@ -105,6 +105,6 @@ jobs:
       # Because we have to checkout the actions and then check out a different
       # git ref, it's possible the actions directory will be modified. So, we
       # need to check it out again for the Post Run actions/checkout to succeed.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: actions

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -27,7 +27,7 @@ jobs:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0 # get all the history because cargo xtest --change-since origin/main requires it.
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -52,7 +52,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
@@ -71,7 +71,7 @@ jobs:
     needs: [permission-check]
     runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         with:
           GCP_WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}

--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -20,7 +20,7 @@ jobs:
     if: (github.actor != 'dependabot[bot]')
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - run: semgrep ci
         env:
            SEMGREP_RULES: >-

--- a/.github/workflows/test-copy-images-to-dockerhub.yaml
+++ b/.github/workflows/test-copy-images-to-dockerhub.yaml
@@ -18,7 +18,7 @@ jobs:
   test-copy-images:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: actions/setup-node@v4
         with:
           node-version-file: .node-version

--- a/.github/workflows/windows-build.yaml
+++ b/.github/workflows/windows-build.yaml
@@ -24,7 +24,7 @@ jobs:
       run:
         shell: pwsh
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0 # Fetch all git history for accurate target determination

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -75,7 +75,7 @@ jobs:
   rust-all:
     runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=large
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ env.GIT_SHA }}
 

--- a/.github/workflows/workflow-run-execution-performance.yaml
+++ b/.github/workflows/workflow-run-execution-performance.yaml
@@ -112,7 +112,7 @@ jobs:
     outputs:
       run_execution_performance_test: ${{ steps.determine_test_targets.outputs.run_execution_performance_test }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Run the test target determinator
         id: determine_test_targets
         uses: ./.github/actions/test-target-determinator
@@ -123,7 +123,7 @@ jobs:
     timeout-minutes: 120
     runs-on: ${{ inputs.RUNNER_NAME }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.GIT_SHA }}
         if: ${{ inputs.IGNORE_TARGET_DETERMINATION || needs.test-target-determinator.outputs.run_execution_performance_test == 'true' }}

--- a/.github/workflows/workflow-run-forge.yaml
+++ b/.github/workflows/workflow-run-forge.yaml
@@ -138,7 +138,7 @@ jobs:
     runs-on: runs-on,cpu=4,ram=16,family=m7a+m7i-flex,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         if: ${{ !inputs.SKIP_JOB }}
         with:
           ref: ${{ inputs.GIT_SHA }}

--- a/.github/workflows/workflow-run-module-verify.yaml
+++ b/.github/workflows/workflow-run-module-verify.yaml
@@ -38,7 +38,7 @@ jobs:
     timeout-minutes: ${{ inputs.TIMEOUT_MINUTES }}
     runs-on: ${{ inputs.RUNS_ON }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.GIT_SHA }}
 

--- a/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
+++ b/.github/workflows/workflow-run-replay-verify-archive-storage-provision.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
       

--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -45,7 +45,7 @@ jobs:
     timeout-minutes: 420 # 7 hours
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.ref || github.ref }}
           # get the last 10 commits to find images that have been built

--- a/.github/workflows/workflow-run-replay-verify.yaml
+++ b/.github/workflows/workflow-run-replay-verify.yaml
@@ -98,7 +98,7 @@ jobs:
       job_ids: ${{ steps.gen-jobs.outputs.job_ids }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           ref: ${{ inputs.GIT_SHA }}
 


### PR DESCRIPTION
GitHub-hosted runners now use Node 24, so actions/checkout@v5 is required. Minimum runner version v2.327.1. Workflows only updated—no functional changes.

See: https://github.com/actions/checkout/releases/tag/v5.0.0