### PR TITLE
Orderless TransactionFactory improvements and integration with executor benchmark

### DIFF
--- a/api/src/tests/account_abstraction_test.rs
+++ b/api/src/tests/account_abstraction_test.rs
@@ -84,7 +84,7 @@ async fn test_account_abstraction_single_signer(
         factory
             .account_transfer(other.address(), 1)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -115,7 +115,7 @@ async fn test_account_abstraction_single_signer(
         factory
             .account_transfer(other.address(), 4)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -212,7 +212,7 @@ async fn test_account_abstraction_multi_agent_with_abstracted_sender(
                 vec![bcs::to_bytes(&d.address()).unwrap()],
             ))
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,

--- a/api/src/tests/accounts_test.rs
+++ b/api/src/tests/accounts_test.rs
@@ -319,7 +319,7 @@ async fn test_get_account_balance(
                 AptosCoinType::type_tag(),
             ))
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -358,7 +358,7 @@ async fn test_get_account_balance(
                 vec![bcs::to_bytes(&primary_apt_store(root_account.address())).unwrap()],
             )))
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -387,7 +387,7 @@ async fn test_get_account_modules_by_ledger_version_with_context(mut context: Te
             .transaction_factory()
             .payload(payload)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,

--- a/api/src/tests/simulation_test.rs
+++ b/api/src/tests/simulation_test.rs
@@ -306,7 +306,7 @@ async fn test_simulate_txn_with_aggregator(
             .transaction_factory()
             .payload(payload)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,

--- a/api/src/tests/state_test.rs
+++ b/api/src/tests/state_test.rs
@@ -160,7 +160,7 @@ async fn test_merkle_leaves_with_nft_transfer(
             vec![false, false, false],
         ))
         .expiration_timestamp_secs(ctx.get_expiration_time())
-        .upgrade_payload(
+        .upgrade_payload_with_rng(
             &mut ctx.rng,
             use_txn_payload_v2_format,
             use_orderless_transactions,
@@ -185,7 +185,7 @@ async fn test_merkle_leaves_with_nft_transfer(
             vec!["int".as_bytes().to_vec()],
         ))
         .expiration_timestamp_secs(ctx.get_expiration_time())
-        .upgrade_payload(
+        .upgrade_payload_with_rng(
             &mut ctx.rng,
             use_txn_payload_v2_format,
             use_orderless_transactions,
@@ -212,7 +212,7 @@ async fn test_merkle_leaves_with_nft_transfer(
                 1,
             ))
             .expiration_timestamp_secs(ctx.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut ctx.rng,
                 use_txn_payload_v2_format,
                 use_orderless_transactions,
@@ -239,7 +239,7 @@ async fn test_merkle_leaves_with_nft_transfer(
                 1,
             ))
             .expiration_timestamp_secs(ctx.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut ctx.rng,
                 use_txn_payload_v2_format,
                 use_orderless_transactions,

--- a/api/src/tests/string_resource_test.rs
+++ b/api/src/tests/string_resource_test.rs
@@ -37,7 +37,7 @@ async fn test_renders_move_acsii_string_into_utf8_string(
             .transaction_factory()
             .payload(payload)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,

--- a/api/src/tests/transaction_vector_test.rs
+++ b/api/src/tests/transaction_vector_test.rs
@@ -283,7 +283,7 @@ async fn entry_function_payload(context: &mut TestContext) -> Vec<serde_json::Va
             .max_gas_amount(gen_u64(&mut value_gen))
             .gas_unit_price(gen_u64(&mut value_gen))
             .chain_id(ChainId::new(gen_chain_id(&mut value_gen)))
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -354,7 +354,7 @@ async fn script_payload(context: &mut TestContext) -> Vec<serde_json::Value> {
             .max_gas_amount(gen_u64(&mut value_gen))
             .gas_unit_price(gen_u64(&mut value_gen))
             .chain_id(ChainId::new(gen_chain_id(&mut value_gen)))
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,

--- a/api/src/tests/transactions_test.rs
+++ b/api/src/tests/transactions_test.rs
@@ -329,7 +329,7 @@ async fn test_multi_agent_signed_transaction(
         factory
             .create_user_account(account.public_key())
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -418,7 +418,7 @@ async fn test_fee_payer_signed_transaction(
         factory
             .create_user_account(account.public_key())
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -488,7 +488,7 @@ async fn test_fee_payer_signed_transaction(
                 .max_gas_amount(200_000)
                 .gas_unit_price(1)
                 .expiration_timestamp_secs(context.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut context.rng,
                     context.use_txn_payload_v2_format,
                     context.use_orderless_transactions,
@@ -586,7 +586,7 @@ async fn test_multi_ed25519_signed_transaction() {
         factory
             .create_user_account(&Ed25519PrivateKey::generate_for_testing().public_key())
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -599,7 +599,7 @@ async fn test_multi_ed25519_signed_transaction() {
         .sender(auth_key.account_address())
         .sequence_number(0)
         .expiration_timestamp_secs(context.get_expiration_time())
-        .upgrade_payload(
+        .upgrade_payload_with_rng(
             &mut context.rng,
             context.use_txn_payload_v2_format,
             context.use_orderless_transactions,
@@ -1308,7 +1308,7 @@ async fn test_get_txn_execute_failed_by_invalid_script_payload_bytecode(
             .transaction_factory()
             .script(Script::new(invalid_bytecode, vec![], vec![]))
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -1662,7 +1662,7 @@ async fn test_get_txn_execute_failed_by_script_execution_failure() {
             .transaction_factory()
             .script(Script::new(script, vec![], vec![]))
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -1705,7 +1705,7 @@ async fn test_submit_entry_function_api_validation(
                 args,
             ))
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -1743,7 +1743,7 @@ async fn test_get_txn_execute_failed_by_invalid_entry_function(
                 args,
             ))
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -2327,7 +2327,7 @@ async fn test_simulation_failure_with_move_abort_error_rendering(
         .sender(account.address())
         .sequence_number(account.sequence_number())
         .expiration_timestamp_secs(context.get_expiration_time())
-        .upgrade_payload(
+        .upgrade_payload_with_rng(
             &mut context.rng,
             context.use_txn_payload_v2_format,
             context.use_orderless_transactions,
@@ -2384,7 +2384,7 @@ async fn test_simulation_failure_with_detail_error(
         .sender(account.address())
         .sequence_number(account.sequence_number())
         .expiration_timestamp_secs(context.get_expiration_time())
-        .upgrade_payload(
+        .upgrade_payload_with_rng(
             &mut context.rng,
             context.use_txn_payload_v2_format,
             context.use_orderless_transactions,
@@ -2431,7 +2431,7 @@ async fn test_runtime_error_message_in_interpreter(
             .transaction_factory()
             .payload(payload)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,

--- a/api/src/tests/view_function.rs
+++ b/api/src/tests/view_function.rs
@@ -409,7 +409,7 @@ async fn test_view_tuple(use_txn_payload_v2_format: bool, use_orderless_transact
             .transaction_factory()
             .payload(payload)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,
@@ -455,7 +455,7 @@ async fn test_view_aggregator(use_txn_payload_v2_format: bool, use_orderless_tra
             .transaction_factory()
             .payload(payload)
             .expiration_timestamp_secs(context.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut context.rng,
                 context.use_txn_payload_v2_format,
                 context.use_orderless_transactions,

--- a/api/test-context/src/test_context.rs
+++ b/api/test-context/src/test_context.rs
@@ -464,7 +464,7 @@ impl TestContext {
             factory
                 .account_transfer(account.address(), TRANSFER_AMOUNT)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -531,7 +531,7 @@ impl TestContext {
             factory
                 .account_transfer(account.address(), TRANSFER_AMOUNT)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -549,7 +549,7 @@ impl TestContext {
             factory
                 .add_dispatchable_authentication_function(func)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -618,7 +618,7 @@ impl TestContext {
             factory
                 .create_multisig_account(additional_owners, signatures_required)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -641,7 +641,7 @@ impl TestContext {
             factory
                 .create_multisig_account_with_existing_account(owners, signatures_required)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -663,7 +663,7 @@ impl TestContext {
             factory
                 .create_multisig_transaction(multisig_account, payload)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -683,7 +683,7 @@ impl TestContext {
             factory
                 .approve_multisig_transaction(multisig_account, transaction_id)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -703,7 +703,7 @@ impl TestContext {
             factory
                 .reject_multisig_transaction(multisig_account, transaction_id)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -723,7 +723,7 @@ impl TestContext {
             factory
                 .create_multisig_transaction_with_payload_hash(multisig_account, payload)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -753,7 +753,7 @@ impl TestContext {
                 .account_transfer(receiver, amount)
                 .expiration_timestamp_secs(self.get_expiration_time())
                 .sequence_number(sender.sequence_number())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -772,7 +772,7 @@ impl TestContext {
                 .create_user_account(account.public_key())
                 .expiration_timestamp_secs(self.get_expiration_time())
                 .sequence_number(creator.sequence_number())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,
@@ -788,7 +788,7 @@ impl TestContext {
             .sender(root_account.address())
             .sequence_number(root_account.sequence_number())
             .expiration_timestamp_secs(self.get_expiration_time())
-            .upgrade_payload(
+            .upgrade_payload_with_rng(
                 &mut self.rng,
                 self.use_txn_payload_v2_format,
                 self.use_orderless_transactions,
@@ -868,7 +868,7 @@ impl TestContext {
             self.transaction_factory()
                 .payload(payload)
                 .expiration_timestamp_secs(self.get_expiration_time())
-                .upgrade_payload(
+                .upgrade_payload_with_rng(
                     &mut self.rng,
                     self.use_txn_payload_v2_format,
                     self.use_orderless_transactions,

--- a/crates/aptos/src/common/transactions.rs
+++ b/crates/aptos/src/common/transactions.rs
@@ -204,7 +204,7 @@ impl TxnOptions {
             .sequence_number(sequence_number)
             .expiration_timestamp_secs(expiration_time_secs);
         if self.replay_protection_type == ReplayProtectionType::Nonce {
-            txn_builder = txn_builder.upgrade_payload(rng, true, true);
+            txn_builder = txn_builder.upgrade_payload_with_rng(rng, true, true);
         }
         let unsigned_transaction = txn_builder.build();
 

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1949,7 +1949,9 @@ impl TransactionOptions {
             let unsigned_transaction = if self.replay_protection_type == ReplayProtectionType::Nonce
             {
                 let mut rng = rand::thread_rng();
-                txn_builder.upgrade_payload(&mut rng, true, true).build()
+                txn_builder
+                    .upgrade_payload_with_rng(&mut rng, true, true)
+                    .build()
             } else {
                 txn_builder.build()
             };
@@ -2007,7 +2009,7 @@ impl TransactionOptions {
                 let mut txn_builder = transaction_factory.payload(payload);
                 if self.replay_protection_type == ReplayProtectionType::Nonce {
                     let mut rng = rand::thread_rng();
-                    txn_builder = txn_builder.upgrade_payload(&mut rng, true, true);
+                    txn_builder = txn_builder.upgrade_payload_with_rng(&mut rng, true, true);
                 };
                 sender_account.sign_with_transaction_builder(txn_builder)
             },
@@ -2025,7 +2027,7 @@ impl TransactionOptions {
                 let mut txn_builder = transaction_factory.payload(payload);
                 if self.replay_protection_type == ReplayProtectionType::Nonce {
                     let mut rng = rand::thread_rng();
-                    txn_builder = txn_builder.upgrade_payload(&mut rng, true, true);
+                    txn_builder = txn_builder.upgrade_payload_with_rng(&mut rng, true, true);
                 };
                 sender_account.sign_with_transaction_builder(txn_builder)?
             },

--- a/crates/transaction-workloads-lib/src/args.rs
+++ b/crates/transaction-workloads-lib/src/args.rs
@@ -26,6 +26,7 @@ pub enum TransactionTypeArg {
     RepublishAndCall,
     // Simple EntryPoints
     NoOp,
+    NoOpOrderless,
     NoOpFeePayer,
     NoOp2Signers,
     NoOp5Signers,
@@ -203,6 +204,7 @@ impl TransactionTypeArg {
                 use_account_pool: sender_use_account_pool,
             },
             TransactionTypeArg::NoOp => call_custom_module(EntryPoints::Nop),
+            TransactionTypeArg::NoOpOrderless => call_custom_module(EntryPoints::NopOrderless),
             TransactionTypeArg::NoOpFeePayer => call_custom_module(EntryPoints::NopFeePayer),
             TransactionTypeArg::NoOp2Signers => call_custom_module(EntryPoints::Nop),
             TransactionTypeArg::NoOp5Signers => call_custom_module(EntryPoints::Nop),

--- a/crates/transaction-workloads-lib/src/move_workloads.rs
+++ b/crates/transaction-workloads-lib/src/move_workloads.rs
@@ -80,6 +80,8 @@ pub enum EntryPoints {
     Republish,
     /// Empty (NoOp) function
     Nop,
+    /// Empty (NoOp) function, with replay protection nonce
+    NopOrderless,
     /// Empty (NoOp) function, signed by publisher as fee-payer
     NopFeePayer,
     /// Empty (NoOp) function, signed by 2 accounts
@@ -278,6 +280,7 @@ impl EntryPointTrait for EntryPoints {
         match self {
             EntryPoints::Republish
             | EntryPoints::Nop
+            | EntryPoints::NopOrderless
             | EntryPoints::NopFeePayer
             | EntryPoints::Nop2Signers
             | EntryPoints::Nop5Signers
@@ -343,6 +346,7 @@ impl EntryPointTrait for EntryPoints {
         match self {
             EntryPoints::Republish
             | EntryPoints::Nop
+            | EntryPoints::NopOrderless
             | EntryPoints::NopFeePayer
             | EntryPoints::Nop2Signers
             | EntryPoints::Nop5Signers
@@ -433,6 +437,8 @@ impl EntryPointTrait for EntryPoints {
             EntryPoints::Nop5Signers => {
                 get_payload_void(module_id, ident_str!("nop_5_signers").to_owned())
             },
+            EntryPoints::NopOrderless => get_payload_void(module_id, ident_str!("nop").to_owned())
+                .set_replay_protection_nonce(rng.expect("Must provide RNG").gen()),
             EntryPoints::Step => get_payload_void(module_id, ident_str!("step").to_owned()),
             EntryPoints::GetCounter => {
                 get_payload_void(module_id, ident_str!("get_counter").to_owned())
@@ -930,6 +936,7 @@ impl EntryPointTrait for EntryPoints {
         match self {
             EntryPoints::Republish => AutomaticArgs::Signer,
             EntryPoints::Nop
+            | EntryPoints::NopOrderless
             | EntryPoints::NopFeePayer
             | EntryPoints::Step
             | EntryPoints::GetCounter

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -983,6 +983,18 @@ mod tests {
     }
 
     #[test]
+    fn test_benchmark_orderless_transaction() {
+        AptosVM::set_num_shards_once(4);
+        AptosVM::set_concurrency_level_once(4);
+        AptosVM::set_processed_transactions_detailed_counters();
+        NativeConfig::set_concurrency_level_once(4);
+        test_generic_benchmark::<AptosVMBlockExecutor>(
+            Some(TransactionTypeArg::NoOpOrderless),
+            true,
+        );
+    }
+
+    #[test]
     fn test_native_vm_benchmark_transaction() {
         test_generic_benchmark::<NativeVMBlockExecutor>(
             Some(TransactionTypeArg::AptFaTransfer),

--- a/execution/executor-benchmark/src/transaction_generator.rs
+++ b/execution/executor-benchmark/src/transaction_generator.rs
@@ -221,7 +221,9 @@ impl TransactionGenerator {
 
     pub fn create_transaction_factory() -> TransactionFactory {
         TransactionFactory::new(ChainId::test())
-            .with_transaction_expiration_time(300)
+            // executor benchmark doesn't have BlockMetadata txns, time doesn't pass for it
+            // so we need to use absolute timestamp (so orderless txns are not rejected as too far in the future)
+            .with_absolute_transaction_expiration_timestamp(30)
             .with_gas_unit_price(100)
     }
 

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -16,7 +16,7 @@ use aptos_types::{
     function_info::FunctionInfo,
     transaction::{EntryFunction, Script},
 };
-use rand::{Rng, thread_rng};
+use rand::{thread_rng, Rng};
 
 pub struct TransactionBuilder {
     sender: Option<AccountAddress>,
@@ -360,7 +360,8 @@ impl TransactionFactory {
             payload: if self.use_txn_payload_v2_format || self.use_replay_protection_nonce {
                 payload.upgrade_payload_with_fn(
                     self.use_txn_payload_v2_format,
-                    self.use_replay_protection_nonce.then_some(|| thread_rng().gen()),
+                    self.use_replay_protection_nonce
+                        .then_some(|| thread_rng().gen()),
                 )
             } else {
                 payload

--- a/sdk/src/transaction_builder.rs
+++ b/sdk/src/transaction_builder.rs
@@ -16,7 +16,7 @@ use aptos_types::{
     function_info::FunctionInfo,
     transaction::{EntryFunction, Script},
 };
-use rand::Rng;
+use rand::{Rng, thread_rng};
 
 pub struct TransactionBuilder {
     sender: Option<AccountAddress>,
@@ -80,13 +80,13 @@ impl TransactionBuilder {
         self.payload.replay_protection_nonce().is_some()
     }
 
-    pub fn upgrade_payload(
+    pub fn upgrade_payload_with_rng(
         mut self,
         rng: &mut impl Rng,
         use_txn_payload_v2_format: bool,
         use_orderless_transactions: bool,
     ) -> Self {
-        self.payload = self.payload.upgrade_payload(
+        self.payload = self.payload.upgrade_payload_with_rng(
             rng,
             use_txn_payload_v2_format,
             use_orderless_transactions,
@@ -117,11 +117,20 @@ impl TransactionBuilder {
 }
 
 #[derive(Clone, Debug)]
+enum TransactionExpiration {
+    Relative { expiration_duration: u64 },
+    Absolute { expiration_timestamp: u64 },
+}
+
+#[derive(Clone, Debug)]
 pub struct TransactionFactory {
     max_gas_amount: u64,
     gas_unit_price: u64,
-    transaction_expiration_time: u64,
+    transaction_expiration: TransactionExpiration,
     chain_id: ChainId,
+
+    use_txn_payload_v2_format: bool,
+    use_replay_protection_nonce: bool,
 }
 
 impl TransactionFactory {
@@ -130,8 +139,12 @@ impl TransactionFactory {
             // TODO(Gas): double check if this right
             max_gas_amount: MAX_GAS_AMOUNT,
             gas_unit_price: GAS_UNIT_PRICE,
-            transaction_expiration_time: 30,
+            transaction_expiration: TransactionExpiration::Relative {
+                expiration_duration: 30,
+            },
             chain_id,
+            use_txn_payload_v2_format: false,
+            use_replay_protection_nonce: false,
         }
     }
 
@@ -146,7 +159,21 @@ impl TransactionFactory {
     }
 
     pub fn with_transaction_expiration_time(mut self, transaction_expiration_time: u64) -> Self {
-        self.transaction_expiration_time = transaction_expiration_time;
+        self.transaction_expiration = TransactionExpiration::Relative {
+            expiration_duration: transaction_expiration_time,
+        };
+        self
+    }
+
+    /// Sets the transaction expiration timestamp to an absolute value.
+    /// Generally only useful for testing.
+    pub fn with_absolute_transaction_expiration_timestamp(
+        mut self,
+        transaction_expiration_timestamp: u64,
+    ) -> Self {
+        self.transaction_expiration = TransactionExpiration::Absolute {
+            expiration_timestamp: transaction_expiration_timestamp,
+        };
         self
     }
 
@@ -163,8 +190,16 @@ impl TransactionFactory {
         self.gas_unit_price
     }
 
+    /// Returns relative duration of transaction expiration.
     pub fn get_transaction_expiration_time(&self) -> u64 {
-        self.transaction_expiration_time
+        match self.transaction_expiration {
+            TransactionExpiration::Relative {
+                expiration_duration,
+            } => expiration_duration,
+            TransactionExpiration::Absolute { .. } => {
+                unimplemented!()
+            },
+        }
     }
 
     pub fn get_chain_id(&self) -> ChainId {
@@ -322,7 +357,14 @@ impl TransactionFactory {
         TransactionBuilder {
             sender: None,
             sequence_number: None,
-            payload,
+            payload: if self.use_txn_payload_v2_format || self.use_replay_protection_nonce {
+                payload.upgrade_payload_with_fn(
+                    self.use_txn_payload_v2_format,
+                    self.use_replay_protection_nonce.then_some(|| thread_rng().gen()),
+                )
+            } else {
+                payload
+            },
             max_gas_amount: self.max_gas_amount,
             gas_unit_price: self.gas_unit_price,
             expiration_timestamp_secs: self.expiration_timestamp(),
@@ -331,10 +373,19 @@ impl TransactionFactory {
     }
 
     fn expiration_timestamp(&self) -> u64 {
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs()
-            + self.transaction_expiration_time
+        match self.transaction_expiration {
+            TransactionExpiration::Relative {
+                expiration_duration,
+            } => {
+                std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .unwrap()
+                    .as_secs()
+                    + expiration_duration
+            },
+            TransactionExpiration::Absolute {
+                expiration_timestamp,
+            } => expiration_timestamp,
+        }
     }
 }

--- a/testsuite/single_node_performance_values.tsv
+++ b/testsuite/single_node_performance_values.tsv
@@ -1,4 +1,5 @@
 no-op	1	VM	6	0.975	1.007	35206.7
+no-op-orderless	1	VM	1	0.7	1.3	35206.7
 no-op	1000	VM	6	0.982	1.022	32347.9
 apt-fa-transfer	1	VM	6	0.993	1.012	25008.6
 apt-fa-transfer	1	NativeVM	6	0.956	1.021	40094.5

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -900,12 +900,15 @@ impl TransactionPayload {
                 multisig_address,
                 replay_protection_nonce: old_replay_protection_nonce,
             } => {
-                assert!(old_replay_protection_nonce.is_none(), "trying to set replay protection nonce twice.");
+                assert!(
+                    old_replay_protection_nonce.is_none(),
+                    "trying to set replay protection nonce twice."
+                );
                 TransactionExtraConfig::V1 {
                     multisig_address,
                     replay_protection_nonce: Some(replay_protection_nonce),
                 }
-            }
+            },
         };
         TransactionPayload::Payload(TransactionPayloadInner::V1 {
             executable,


### PR DESCRIPTION
## Description
There are two ways folks will commonly use orderless:
* switch to always use orderless. For that it should be a flag in TransactionFactory, so it doesn't need to be done on per-txn level
* for a specific transaction, set nonce. upgrade_payload allows to set a random one, adding set_replay_protection_nonce when user wants to explicitly set it.

In executor benchmark, there is an issue that we don't create BlockMetadata, and so timestamp is always 0. because orderless txns can be only set with max 60s expiration, they all fail. Adding ability to set absolute expiration to transaction factory, and set it to 30 for executor benchmark.
Alternatively, we should allow BlockMetadata in benchmark, but I run into some issues implementing it (here is the change for that - https://github.com/aptos-labs/aptos-core/compare/main...igor/block_metadata_in_executor_benchmark), but also with generate-then-execute and other benchmark flags - setting time to current seems a bit problematic too. Maybe we should have BlockMetadata that increases time one 1us every block.
 



## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
