### PR TITLE
[Inspection Service] Add "identity_information" endpoint.

### DIFF
--- a/config/src/config/inspection_service_config.rs
+++ b/config/src/config/inspection_service_config.rs
@@ -18,6 +18,7 @@ pub struct InspectionServiceConfig {
     pub address: String,
     pub port: u16,
     pub expose_configuration: bool,
+    pub expose_identity_information: bool,
     pub expose_peer_information: bool,
     pub expose_system_information: bool,
 }
@@ -28,6 +29,7 @@ impl Default for InspectionServiceConfig {
             address: "0.0.0.0".to_string(),
             port: 9101,
             expose_configuration: false,
+            expose_identity_information: true,
             expose_peer_information: true,
             expose_system_information: true,
         }
@@ -85,6 +87,11 @@ impl ConfigOptimizer for InspectionServiceConfig {
                     modified_config = true;
                 }
 
+                if local_inspection_config_yaml["expose_identity_information"].is_null() {
+                    inspection_service_config.expose_identity_information = true;
+                    modified_config = true;
+                }
+
                 if local_inspection_config_yaml["expose_peer_information"].is_null() {
                     inspection_service_config.expose_peer_information = true;
                     modified_config = true;
@@ -111,6 +118,7 @@ mod tests {
         let mut node_config = NodeConfig {
             inspection_service: InspectionServiceConfig {
                 expose_configuration: false,
+                expose_identity_information: false,
                 expose_peer_information: false,
                 expose_system_information: false,
                 ..Default::default()
@@ -130,6 +138,7 @@ mod tests {
 
         // Verify all endpoints are still disabled
         assert!(!node_config.inspection_service.expose_configuration);
+        assert!(!node_config.inspection_service.expose_identity_information);
         assert!(!node_config.inspection_service.expose_peer_information);
         assert!(!node_config.inspection_service.expose_system_information);
     }
@@ -159,6 +168,7 @@ mod tests {
 
         // Verify all endpoints are now enabled
         assert!(node_config.inspection_service.expose_configuration);
+        assert!(node_config.inspection_service.expose_identity_information);
         assert!(node_config.inspection_service.expose_peer_information);
         assert!(node_config.inspection_service.expose_system_information);
     }
@@ -197,6 +207,7 @@ mod tests {
 
         // Verify only the system information endpoint is now enabled
         assert!(!node_config.inspection_service.expose_configuration);
+        assert!(node_config.inspection_service.expose_identity_information);
         assert!(node_config.inspection_service.expose_peer_information);
         assert!(node_config.inspection_service.expose_system_information);
     }

--- a/crates/aptos-inspection-service/src/server/identity_information.rs
+++ b/crates/aptos-inspection-service/src/server/identity_information.rs
@@ -1,0 +1,52 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::server::utils::CONTENT_TYPE_TEXT;
+use aptos_config::config::NodeConfig;
+use hyper::{Body, StatusCode};
+
+// The message to display when the identity information endpoint is disabled
+pub const IDENTITY_INFO_DISABLED_MESSAGE: &str =
+    "This endpoint is disabled! Enable it in the node config at inspection_service.expose_identity_information: true";
+
+/// Handles a new identity information request
+pub fn handle_identity_information_request(node_config: &NodeConfig) -> (StatusCode, Body, String) {
+    // Only return identity information if the endpoint is enabled
+    let (status_code, body) = if node_config.inspection_service.expose_identity_information {
+        let identity_information = get_identity_information(node_config);
+        (StatusCode::OK, Body::from(identity_information))
+    } else {
+        (
+            StatusCode::FORBIDDEN,
+            Body::from(IDENTITY_INFO_DISABLED_MESSAGE),
+        )
+    };
+
+    (status_code, body, CONTENT_TYPE_TEXT.into())
+}
+
+/// Returns a simple text formatted string with identity information
+fn get_identity_information(node_config: &NodeConfig) -> String {
+    let mut identity_information = Vec::<String>::new();
+    identity_information.push("Identity Information:".into());
+
+    // If the validator network is configured, fetch the identity information
+    if let Some(validator_network) = &node_config.validator_network {
+        identity_information.push(format!(
+            "\t- Validator network ({}), peer ID: {}",
+            validator_network.network_id,
+            validator_network.peer_id()
+        ));
+    }
+
+    // For each fullnode network, fetch the identity information
+    for fullnode_network in &node_config.full_node_networks {
+        identity_information.push(format!(
+            "\t- Fullnode network ({}), peer ID: {}",
+            fullnode_network.network_id,
+            fullnode_network.peer_id()
+        ));
+    }
+
+    identity_information.join("\n") // Separate each entry with a newline to construct the output
+}

--- a/crates/aptos-inspection-service/src/server/index.rs
+++ b/crates/aptos-inspection-service/src/server/index.rs
@@ -3,8 +3,8 @@
 
 use crate::{
     server::utils::CONTENT_TYPE_TEXT, CONFIGURATION_PATH, CONSENSUS_HEALTH_CHECK_PATH,
-    FORGE_METRICS_PATH, JSON_METRICS_PATH, METRICS_PATH, PEER_INFORMATION_PATH,
-    SYSTEM_INFORMATION_PATH,
+    FORGE_METRICS_PATH, IDENTITY_INFORMATION_PATH, JSON_METRICS_PATH, METRICS_PATH,
+    PEER_INFORMATION_PATH, SYSTEM_INFORMATION_PATH,
 };
 use hyper::{Body, StatusCode};
 
@@ -28,6 +28,7 @@ fn get_index_response() -> String {
     index_response.push(format!("\t- {}", CONFIGURATION_PATH));
     index_response.push(format!("\t- {}", CONSENSUS_HEALTH_CHECK_PATH));
     index_response.push(format!("\t- {}", FORGE_METRICS_PATH));
+    index_response.push(format!("\t- {}", IDENTITY_INFORMATION_PATH));
     index_response.push(format!("\t- {}", JSON_METRICS_PATH));
     index_response.push(format!("\t- {}", METRICS_PATH));
     index_response.push(format!("\t- {}", PEER_INFORMATION_PATH));

--- a/crates/aptos-inspection-service/src/server/mod.rs
+++ b/crates/aptos-inspection-service/src/server/mod.rs
@@ -18,6 +18,7 @@ use std::{
 };
 
 mod configuration;
+mod identity_information;
 mod index;
 mod json_encoder;
 mod metrics;
@@ -32,6 +33,7 @@ mod tests;
 pub const CONFIGURATION_PATH: &str = "/configuration";
 pub const CONSENSUS_HEALTH_CHECK_PATH: &str = "/consensus_health_check";
 pub const FORGE_METRICS_PATH: &str = "/forge_metrics";
+pub const IDENTITY_INFORMATION_PATH: &str = "/identity_information";
 pub const INDEX_PATH: &str = "/";
 pub const JSON_METRICS_PATH: &str = "/json_metrics";
 pub const METRICS_PATH: &str = "/metrics";
@@ -121,6 +123,11 @@ async fn serve_requests(
             // /forge_metrics
             // Exposes forge encoded metrics
             metrics::handle_forge_metrics()
+        },
+        IDENTITY_INFORMATION_PATH => {
+            // /identity_information
+            // Exposes the identity information of the node
+            identity_information::handle_identity_information_request(&node_config)
         },
         INDEX_PATH => {
             // /


### PR DESCRIPTION
## Description
This PR adds an `identity_information` endpoint to the node inspection service, allowing node operators to quickly fetch the peer IDs of each network in their nodes. 

For example, running a local PFN and accessing `localhost:9101/identity_information` will produce this output:
```
Identity Information:
	- Fullnode network (Public), peer ID: 0x595c2fc0fe636ebfeb89ea136c7494849cafe5d429f38200a0d5e197bdedde53
```

## Testing Plan
Existing test infrastructure and manual verification.
