### PR TITLE
Remove aptos-transaction-simulation dependency from executor-service

### DIFF
--- a/execution/executor-service/Cargo.toml
+++ b/execution/executor-service/Cargo.toml
@@ -24,7 +24,6 @@ aptos-node-resource-metrics = { workspace = true }
 aptos-push-metrics =  { workspace = true }
 aptos-secure-net = { workspace = true }
 aptos-storage-interface = { workspace = true }
-aptos-transaction-simulation = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
 bcs = { workspace = true }
@@ -41,4 +40,5 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 aptos-language-e2e-tests = { workspace = true }
+aptos-transaction-simulation = { workspace = true }
 aptos-vm = { workspace = true }


### PR DESCRIPTION

`cargo check -p aptos-consensus` now passes.
