### PR TITLE
[hot state] Compute promotions only at the end of each block

### DIFF
--- a/aptos-move/block-executor/src/hot_state_op_accumulator.rs
+++ b/aptos-move/block-executor/src/hot_state_op_accumulator.rs
@@ -8,15 +8,18 @@ use aptos_types::{
     state_store::{state_slot::StateSlot, TStateView},
     transaction::Version,
 };
-use std::{collections::BTreeMap, fmt::Debug, hash::Hash};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+    hash::Hash,
+};
 
 pub struct BlockHotStateOpAccumulator<'base_view, Key, BaseView> {
     first_version: Version,
     base_view: &'base_view BaseView,
-    /// Keys read but never written to across the entire block are to be made hot (or refreshed
-    /// `hot_since_version` one is already hot but last refresh is far in the history) as the side
-    /// effect of the block epilogue (subject to per block limit)
-    to_make_hot: BTreeMap<Key, StateSlot>,
+    /// Keep track of all the keys that are read across the whole block. These keys are candidates
+    /// for hot state promotion (subject to rules such as per block limit).
+    reads: hashbrown::HashSet<Key>,
     /// Keep track of all the keys that are written to across the whole block, these keys are made
     /// hot (or have a refreshed `hot_since_version`) immediately at the version they got changed,
     /// so no need to issue separate HotStateOps to promote them to the hot state.
@@ -54,82 +57,71 @@ where
         Self {
             first_version: base_view.next_version(),
             base_view,
-            to_make_hot: BTreeMap::new(),
+            reads: hashbrown::HashSet::new(),
             writes: hashbrown::HashSet::new(),
             max_promotions_per_block,
             _refresh_interval_versions: refresh_interval_versions,
         }
     }
 
-    pub fn add_transaction<'a>(
+    pub fn add_transaction(
         &mut self,
-        writes: impl Iterator<Item = &'a Key>,
-        reads: impl Iterator<Item = &'a Key>,
-    ) where
-        Key: 'a,
-    {
-        for key in writes {
-            if self.to_make_hot.remove(key).is_some() {
-                COUNTER.inc_with(&["promotion_removed_by_write"]);
-            }
-            self.writes.get_or_insert_owned(key);
-        }
-
-        for key in reads {
-            if self.to_make_hot.len() >= self.max_promotions_per_block {
-                COUNTER.inc_with(&["max_promotions_per_block_hit"]);
-                continue;
-            }
-            if self.to_make_hot.contains_key(key) {
-                continue;
-            }
-            if self.writes.contains(key) {
-                continue;
-            }
-            let slot = self
-                .base_view
-                .get_state_slot(key)
-                .expect("base_view.get_slot() failed.");
-            let make_hot = match slot {
-                StateSlot::ColdVacant => {
-                    COUNTER.inc_with(&["vacant_new"]);
-                    true
-                },
-                StateSlot::HotVacant {
-                    hot_since_version, ..
-                } => {
-                    if self.should_refresh(hot_since_version) {
-                        COUNTER.inc_with(&["vacant_refresh"]);
-                        true
-                    } else {
-                        COUNTER.inc_with(&["vacant_still_hot"]);
-                        false
-                    }
-                },
-                StateSlot::ColdOccupied { .. } => {
-                    COUNTER.inc_with(&["occupied_new"]);
-                    true
-                },
-                StateSlot::HotOccupied {
-                    hot_since_version, ..
-                } => {
-                    if self.should_refresh(hot_since_version) {
-                        COUNTER.inc_with(&["occupied_refresh"]);
-                        true
-                    } else {
-                        COUNTER.inc_with(&["occupied_still_hot"]);
-                        false
-                    }
-                },
-            };
-            if make_hot {
-                self.to_make_hot.insert(key.clone(), slot);
-            }
-        }
+        writes: impl IntoIterator<Item = Key>,
+        reads: impl IntoIterator<Item = Key>,
+    ) {
+        self.writes.extend(writes);
+        self.reads.extend(reads);
     }
 
     pub fn get_slots_to_make_hot(&self) -> BTreeMap<Key, StateSlot> {
-        self.to_make_hot.clone()
+        let read_only: BTreeSet<_> = self.reads.difference(&self.writes).collect();
+        let to_make_hot: BTreeMap<_, _> = read_only
+            .into_iter()
+            .filter_map(|key| self.maybe_make_hot(key).map(|slot| (key.clone(), slot)))
+            .take(self.max_promotions_per_block)
+            .collect();
+        COUNTER.inc_with_by(&["total_make_hot"], to_make_hot.len() as u64);
+        to_make_hot
+    }
+
+    fn maybe_make_hot(&self, key: &Key) -> Option<StateSlot> {
+        let slot = self
+            .base_view
+            .get_state_slot(key)
+            .expect("base_view.get_slot() failed.");
+
+        match &slot {
+            StateSlot::ColdVacant => {
+                COUNTER.inc_with(&["vacant_new"]);
+                Some(slot)
+            },
+            StateSlot::HotVacant {
+                hot_since_version, ..
+            } => {
+                if self.should_refresh(*hot_since_version) {
+                    COUNTER.inc_with(&["vacant_refresh"]);
+                    Some(slot)
+                } else {
+                    COUNTER.inc_with(&["vacant_still_hot"]);
+                    None
+                }
+            },
+            StateSlot::ColdOccupied { .. } => {
+                COUNTER.inc_with(&["occupied_new"]);
+                Some(slot)
+            },
+            StateSlot::HotOccupied {
+                hot_since_version, ..
+            } => {
+                if self.should_refresh(*hot_since_version) {
+                    COUNTER.inc_with(&["occupied_refresh"]);
+                    Some(slot)
+                } else {
+                    COUNTER.inc_with(&["occupied_still_hot"]);
+                    None
+                }
+            },
+        }
     }
 
     pub fn should_refresh(&self, hot_since_version: Version) -> bool {

--- a/aptos-move/block-executor/src/limit_processor.rs
+++ b/aptos-move/block-executor/src/limit_processor.rs
@@ -89,7 +89,10 @@ impl<'s, T: Transaction, S: TStateView<Key = T::Key>> BlockGasLimitProcessor<'s,
                 txn_read_write_summary.collapse_resource_group_conflicts()
             };
             if let Some(x) = &mut self.hot_state_op_accumulator {
-                x.add_transaction(rw_summary.keys_written(), rw_summary.keys_read());
+                x.add_transaction(
+                    rw_summary.keys_written().cloned(),
+                    rw_summary.keys_read().cloned(),
+                );
             }
             self.txn_read_write_summaries.push(rw_summary);
             self.compute_conflict_multiplier(conflict_overlap_length as usize)

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -558,7 +558,10 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
             // No promotions except for block epilogue.
             state_by_version
                 .append_version(txn.writes.iter().map(|(k, v)| (k, v.as_ref())), vec![]);
-            op_accu.add_transaction(txn.writes.iter().map(|(k, _v)| k), txn.reads.iter());
+            op_accu.add_transaction(
+                txn.writes.iter().map(|(k, _v)| k).cloned(),
+                txn.reads.iter().cloned(),
+            );
             all_txns.push(Txn {
                 reads: txn.reads,
                 write_set: txn


### PR DESCRIPTION

Currently, the code takes each transaction's reads and writes, computes the
read-only keys to promote, then moves on to the next transaction.

There are a few problems:

- Let's say a transaction has read-only keys A and B. It could happen that A
  gets promoted, but B couldn't because it hits the per block limit. However,
  it's possible that a later transaction actually writes to A, so we could have
  promoted B.
- More importantly, the result may not be deterministic if the order we call
  `add_transaction` is not deterministic (which could happen in parallel
  execution).

Therefore, we simply record the reads and writes in `add_transaction` and only
compute the promotions at the end, once all transactions have been added.
Eviction will need to be computed this way as well.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/17356).
* #16963
* __->__ #17356