### PR TITLE
[transaction simulation session] initial implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.7.0"
+version = "7.8.0"
 dependencies = [
  "anyhow",
  "aptos-api-types",
@@ -336,6 +336,8 @@ dependencies = [
  "aptos-storage-interface",
  "aptos-telemetry",
  "aptos-temppath",
+ "aptos-transaction-simulation",
+ "aptos-transaction-simulation-session",
  "aptos-types",
  "aptos-vm",
  "aptos-vm-environment",
@@ -4574,6 +4576,31 @@ dependencies = [
  "parking_lot 0.12.1",
  "proptest",
  "serde",
+]
+
+[[package]]
+name = "aptos-transaction-simulation-session"
+version = "0.0.1"
+dependencies = [
+ "anyhow",
+ "aptos-api-types",
+ "aptos-resource-viewer",
+ "aptos-rest-client",
+ "aptos-transaction-simulation",
+ "aptos-types",
+ "aptos-validator-interface",
+ "aptos-vm",
+ "aptos-vm-environment",
+ "aptos-vm-logging",
+ "aptos-vm-types",
+ "bcs 0.1.4",
+ "hex",
+ "move-core-types",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "aptos-move/aptos-sdk-builder",
     "aptos-move/aptos-transaction-benchmarks",
     "aptos-move/aptos-transaction-simulation",
+    "aptos-move/aptos-transaction-simulation-session",
     "aptos-move/aptos-transactional-test-harness",
     "aptos-move/aptos-validator-interface",
     "aptos-move/aptos-vm",
@@ -463,6 +464,7 @@ aptos-transaction-emitter-lib = { path = "crates/transaction-emitter-lib" }
 aptos-transaction-generator-lib = { path = "crates/transaction-generator-lib" }
 aptos-transaction-workloads-lib = { path = "crates/transaction-workloads-lib" }
 aptos-transaction-simulation = { path = "aptos-move/aptos-transaction-simulation" }
+aptos-transaction-simulation-session = { path = "aptos-move/aptos-transaction-simulation-session" }
 aptos-transactional-test-harness = { path = "aptos-move/aptos-transactional-test-harness" }
 aptos-types = { path = "types" }
 aptos-validator-interface = { path = "aptos-move/aptos-validator-interface" }

--- a/aptos-move/aptos-resource-viewer/src/lib.rs
+++ b/aptos-move/aptos-resource-viewer/src/lib.rs
@@ -83,6 +83,17 @@ impl<'a, S: StateView> AptosValueAnnotator<'a, S> {
             .view_function_arguments(module, function, ty_args, args)
     }
 
+    pub fn view_function_returns(
+        &self,
+        module: &ModuleId,
+        function: &IdentStr,
+        ty_args: &[TypeTag],
+        returns: &[Vec<u8>],
+    ) -> anyhow::Result<Vec<AnnotatedMoveValue>> {
+        self.0
+            .view_function_returns(module, function, ty_args, returns)
+    }
+
     pub fn view_script_arguments(
         &self,
         script_bytes: &[u8],

--- a/aptos-move/aptos-transaction-simulation-session/Cargo.toml
+++ b/aptos-move/aptos-transaction-simulation-session/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "aptos-transaction-simulation-session"
+description = "Aptos Transaction Simulation Session"
+version = "0.0.1"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+anyhow = { workspace = true }
+bcs = { workspace = true }
+hex = { workspace = true }
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+url = { workspace = true }
+
+move-core-types = { workspace = true }
+
+aptos-api-types = { workspace = true }
+aptos-resource-viewer = { workspace = true }
+aptos-rest-client = { workspace = true }
+aptos-transaction-simulation = { workspace = true }
+aptos-types = { workspace = true }
+aptos-validator-interface = { workspace = true }
+aptos-vm = { workspace = true }
+aptos-vm-environment = { workspace = true }
+aptos-vm-logging = { workspace = true }
+aptos-vm-types = { workspace = true }
+
+[dev-dependencies]
+tempfile = { workspace = true }

--- a/aptos-move/aptos-transaction-simulation-session/examples/local.sh
+++ b/aptos-move/aptos-transaction-simulation-session/examples/local.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+set -e
+
+rm -rf sess
+
+# initialize session
+cargo run -p aptos -- move sim init --path sess
+
+# fund account with 1 APT
+cargo run -p aptos -- move sim fund --session sess --account default --amount 100000000
+
+# transfer 100 Octa to self
+cargo run -p aptos -- move run --session sess --function-id 0x1::aptos_account::transfer --args address:default u64:100
+
+# view account sequence number
+cargo run -p aptos -- move view --session sess --function-id 0x1::account::get_sequence_number --args address:default

--- a/aptos-move/aptos-transaction-simulation-session/examples/remote.sh
+++ b/aptos-move/aptos-transaction-simulation-session/examples/remote.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+API_KEY = ""
+
+set -e
+
+rm -rf sess
+
+# initialize session
+cargo run -p aptos -- move sim init --path sess --network devnet --api-key $API_KEY
+
+# fund account with 1 APT
+cargo run -p aptos -- move sim fund --session sess --account default --amount 100000000
+
+# transfer 100 Octa to self
+cargo run -p aptos -- move run --session sess --function-id 0x1::aptos_account::transfer --args address:default u64:100
+
+# view account sequence number
+cargo run -p aptos -- move view --session sess --function-id 0x1::account::get_sequence_number --args address:default

--- a/aptos-move/aptos-transaction-simulation-session/src/config.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/config.rs
@@ -1,0 +1,104 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+use url::Url;
+
+// TODO: Config versioning?
+
+/// Represents the (optional) base state of a session.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub enum BaseState {
+    /// No base state; the session is entirely local (e.g., for integration tests or synthetic simulations).
+    Empty,
+    /// The session starts from a remote network state (a "forked state").
+    Remote {
+        node_url: Url,
+        network_version: u64,
+        api_key: Option<String>,
+    },
+}
+
+/// The configuration for a session, stored to a file in the session directory
+/// to allow the session to be restored.
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
+pub struct Config {
+    /// The base state of the session.
+    pub base: BaseState,
+
+    /// The number of operations the session has performed.
+    pub ops: u64,
+}
+
+impl Config {
+    /// Creates a new empty configuration.
+    pub fn new() -> Self {
+        Self {
+            base: BaseState::Empty,
+            ops: 0,
+        }
+    }
+
+    /// Creates a configuration with remote base state.
+    pub fn with_remote(node_url: Url, network_version: u64, api_key: Option<String>) -> Self {
+        Self {
+            base: BaseState::Remote {
+                node_url,
+                network_version,
+                api_key,
+            },
+            ops: 0,
+        }
+    }
+
+    /// Saves the configuration to a file.
+    pub fn save_to_file(&self, path: &std::path::Path) -> Result<()> {
+        let json = serde_json::to_string_pretty(self)?;
+        std::fs::write(path, json)?;
+        Ok(())
+    }
+
+    /// Loads the configuration from a file.
+    pub fn load_from_file(path: &std::path::Path) -> Result<Self> {
+        let json = std::fs::read_to_string(path)?;
+        let config = serde_json::from_str(&json)?;
+        Ok(config)
+    }
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[test]
+fn test_config_roundtrip_empty_base() -> Result<()> {
+    let config = Config::new();
+    let temp_file = tempfile::NamedTempFile::new()?;
+
+    config.save_to_file(temp_file.path())?;
+    let config_loaded = Config::load_from_file(temp_file.path())?;
+
+    assert_eq!(config, config_loaded);
+
+    Ok(())
+}
+
+#[test]
+fn test_config_roundtrip_remote_base() -> Result<()> {
+    let config = Config::with_remote(
+        Url::parse("https://fullnode.testnet.aptoslabs.com")?,
+        1,
+        Some("some_api_key".to_string()),
+    );
+    let temp_file = tempfile::NamedTempFile::new()?;
+
+    config.save_to_file(temp_file.path())?;
+    let config_loaded = Config::load_from_file(temp_file.path())?;
+
+    assert_eq!(config, config_loaded);
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/src/delta.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/delta.rs
@@ -1,0 +1,74 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::state_store::HumanReadable;
+use anyhow::Result;
+use aptos_types::state_store::{state_key::StateKey, state_value::StateValue};
+use std::{
+    collections::{BTreeMap, HashMap},
+    path::Path,
+};
+
+// TODO: Store state values in human readable format
+
+/// Saves the state delta to a file.
+pub fn save_delta(delta_path: &Path, delta: &HashMap<StateKey, Option<StateValue>>) -> Result<()> {
+    // Use BTreeMap to ensure deterministic ordering
+    let mut delta_str = BTreeMap::new();
+
+    for (k, v) in delta {
+        let key_str = HumanReadable(k).to_string();
+        let val_str_opt = match v {
+            Some(v) => Some(hex::encode(&bcs::to_bytes(&v)?)),
+            None => None,
+        };
+        delta_str.insert(key_str, val_str_opt);
+    }
+
+    let json = serde_json::to_string_pretty(&delta_str)?;
+    std::fs::write(delta_path, json)?;
+
+    Ok(())
+}
+
+/// Loads the state delta from a file.
+pub fn load_delta(delta_path: &Path) -> Result<HashMap<StateKey, Option<StateValue>>> {
+    let json = std::fs::read_to_string(delta_path)?;
+    let delta_str: HashMap<HumanReadable<StateKey>, Option<String>> = serde_json::from_str(&json)?;
+
+    let mut delta = HashMap::new();
+
+    for (k, v) in delta_str {
+        let key = k.into_inner();
+        let val = match v {
+            Some(v) => Some(bcs::from_bytes(&hex::decode(v)?)?),
+            None => None,
+        };
+        delta.insert(key, val);
+    }
+
+    Ok(delta)
+}
+
+#[test]
+fn test_delta_roundtrip() -> Result<()> {
+    use aptos_transaction_simulation::{
+        DeltaStateStore, EmptyStateView, SimulationStateStore, GENESIS_CHANGE_SET_HEAD,
+    };
+    use tempfile::NamedTempFile;
+
+    let state_store = DeltaStateStore::new_with_base(EmptyStateView);
+    state_store.apply_write_set(GENESIS_CHANGE_SET_HEAD.write_set())?;
+
+    let delta = state_store.delta();
+
+    // Use a temporary file for the delta
+    let temp_file = NamedTempFile::new()?;
+    let delta_path = temp_file.path();
+
+    save_delta(delta_path, &delta)?;
+    let delta_loaded = load_delta(delta_path)?;
+    assert_eq!(delta, delta_loaded);
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/src/lib.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/lib.rs
@@ -1,0 +1,10 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod config;
+mod delta;
+mod session;
+mod state_store;
+mod txn_output;
+
+pub use session::Session;

--- a/aptos-move/aptos-transaction-simulation-session/src/session.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/session.rs
@@ -1,0 +1,457 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    config::{BaseState, Config},
+    delta::{load_delta, save_delta},
+    txn_output::{save_events, save_write_set},
+};
+use anyhow::Result;
+use aptos_resource_viewer::AptosValueAnnotator;
+use aptos_rest_client::{AptosBaseUrl, Client};
+use aptos_transaction_simulation::{
+    DeltaStateStore, EitherStateView, EmptyStateView, SimulationStateStore, GENESIS_CHANGE_SET_HEAD,
+};
+use aptos_types::{
+    account_address::AccountAddress,
+    fee_statement::FeeStatement,
+    transaction::{
+        AuxiliaryInfo, PersistedAuxiliaryInfo, SignedTransaction, TransactionExecutable,
+        TransactionOutput, TransactionPayload, TransactionPayloadInner, TransactionStatus,
+    },
+    vm_status::VMStatus,
+};
+use aptos_validator_interface::{DebuggerStateView, RestDebuggerInterface};
+use aptos_vm::{data_cache::AsMoveResolver, AptosVM};
+use aptos_vm_environment::environment::AptosEnvironment;
+use aptos_vm_logging::log_schema::AdapterLogSchema;
+use aptos_vm_types::{module_and_script_storage::AsAptosCodeStorage, resolver::StateStorageView};
+use move_core_types::{
+    identifier::Identifier,
+    language_storage::{ModuleId, TypeTag},
+};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::HashMap,
+    path::{Path, PathBuf},
+    sync::Arc,
+};
+use url::Url;
+
+type SessionStateStore = DeltaStateStore<EitherStateView<EmptyStateView, DebuggerStateView>>;
+
+/// Formats a module ID for display by adjusting the address for better readability.
+fn format_module_id(module_id: &ModuleId) -> String {
+    let address = module_id.address();
+    let name = module_id.name();
+
+    // Format address: add 0x prefix, trim leading zeros, limit to 4 digits
+    let address_str = format!("{:x}", address);
+    let trimmed = address_str.trim_start_matches('0');
+    let display_address = if trimmed.is_empty() {
+        "0".to_string()
+    } else if trimmed.len() > 4 {
+        format!("{}...", &trimmed[..4])
+    } else {
+        trimmed.to_string()
+    };
+
+    format!("0x{}::{}", display_address, name)
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ViewResult {
+    Success(Vec<serde_json::Value>),
+    Error(String),
+}
+
+/// A summary of a completed session operation.
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum Summary {
+    FundFungible {
+        account: AccountAddress,
+        amount: u64,
+        before: u64,
+        after: u64,
+    },
+    ExecuteTransaction {
+        status: TransactionStatus,
+        gas_used: u64,
+        fee_statement: Option<FeeStatement>,
+    },
+    View {
+        result: ViewResult,
+        gas_used: u64,
+    },
+}
+
+/// A session for simulating transactions, with data being persisted to a directory, allowing the session
+/// to be restored or continued in the future.
+///
+/// For each session operation, additional info gets saved to allow for easy inspection.
+pub struct Session {
+    config: Config,
+    path: PathBuf,
+    state_store: SessionStateStore,
+}
+
+impl Session {
+    /// Returns a reference to the underlying state store.
+    pub fn state_store(&self) -> &impl SimulationStateStore {
+        &self.state_store
+    }
+
+    /// Creates a new session using an empty base state, then applies the Aptos genesis
+    /// change set on top of it.
+    ///
+    /// Useful for local simulations and integration tests where a clean genesis state is required.
+    pub fn init(session_path: impl AsRef<Path>) -> Result<Self> {
+        let session_path = session_path.as_ref().to_path_buf();
+
+        std::fs::create_dir_all(&session_path)?;
+
+        if session_path.read_dir()?.next().is_some() {
+            anyhow::bail!(
+                "Cannot initialize new session at {} -- directory is not empty.",
+                session_path.display()
+            );
+        }
+
+        // Write config with empty base state
+        let config = Config::new();
+        let config_path = session_path.join("config.json");
+        config.save_to_file(&config_path)?;
+
+        // Initialize state store -- need to populate with head genesis
+        // TODO: allow caller to specify genesis
+        let state_store = DeltaStateStore::new_with_base(EitherStateView::Left(EmptyStateView));
+        state_store.apply_write_set(GENESIS_CHANGE_SET_HEAD.write_set())?;
+
+        // Save delta to file
+        let delta_path = session_path.join("delta.json");
+        save_delta(&delta_path, &state_store.delta())?;
+
+        Ok(Self {
+            config,
+            path: session_path,
+            state_store,
+        })
+    }
+
+    /// Initializes a new session by forking from a remote network state. Data will be fetched
+    /// from the remote network on-demand.
+    ///
+    /// It is strongly recommended that the caller provides an API key to avoid rate limiting.
+    pub fn init_with_remote_state(
+        session_path: impl AsRef<Path>,
+        node_url: Url,
+        network_version: u64,
+        api_key: Option<String>,
+    ) -> Result<Self> {
+        let session_path = session_path.as_ref().to_path_buf();
+
+        std::fs::create_dir_all(&session_path)?;
+
+        if session_path.read_dir()?.next().is_some() {
+            anyhow::bail!(
+                "Cannot initialize new session at {} -- directory is not empty.",
+                session_path.display()
+            );
+        }
+
+        let config = Config::with_remote(node_url.clone(), network_version, api_key.clone());
+        let config_path = session_path.join("config.json");
+        config.save_to_file(&config_path)?;
+
+        let delta_path = session_path.join("delta.json");
+        save_delta(&delta_path, &HashMap::new())?;
+
+        let mut builder = Client::builder(AptosBaseUrl::Custom(node_url));
+        if let Some(api_key) = api_key {
+            builder = builder.api_key(&api_key)?;
+        }
+        let client = builder.build();
+
+        let state_store =
+            DeltaStateStore::new_with_base(EitherStateView::Right(DebuggerStateView::new(
+                Arc::new(RestDebuggerInterface::new(client)),
+                network_version,
+            )));
+
+        Ok(Self {
+            config,
+            path: session_path,
+            state_store,
+        })
+    }
+
+    /// Loads a previously stored session from disk.
+    pub fn load(session_path: impl AsRef<Path>) -> Result<Self> {
+        let session_path = session_path.as_ref().to_path_buf();
+        let config = Config::load_from_file(&session_path.join("config.json"))?;
+
+        let base = match &config.base {
+            BaseState::Empty => EitherStateView::Left(EmptyStateView),
+            BaseState::Remote {
+                node_url,
+                network_version,
+                api_key,
+            } => {
+                let mut builder = Client::builder(AptosBaseUrl::Custom(node_url.clone()));
+                if let Some(api_key) = api_key {
+                    builder = builder.api_key(api_key)?;
+                }
+                let client = builder.build();
+
+                let debugger = DebuggerStateView::new(
+                    Arc::new(RestDebuggerInterface::new(client)),
+                    *network_version,
+                );
+                EitherStateView::Right(debugger)
+            },
+        };
+
+        let delta = load_delta(&session_path.join("delta.json"))?;
+        let state_store = DeltaStateStore::new_with_base_and_delta(base, delta);
+
+        Ok(Self {
+            config,
+            path: session_path,
+            state_store,
+        })
+    }
+
+    /// Funds an account with APT.
+    ///
+    /// This counts as a session operation but is not a real transaction, as it modifies the
+    /// storage state directly.
+    ///
+    /// This can be useful for testing -- for example, to fund an account before using it to
+    /// send its first transaction.
+    pub fn fund_account(&mut self, account: AccountAddress, amount: u64) -> Result<()> {
+        let (before, after) = self.state_store.fund_apt_fungible_store(account, amount)?;
+
+        let summary = Summary::FundFungible {
+            account,
+            amount,
+            before,
+            after,
+        };
+        let summary_path = self
+            .path
+            .join(format!("[{}] fund (fungible)", self.config.ops))
+            .join("summary.json");
+        std::fs::create_dir_all(summary_path.parent().unwrap())?;
+        std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
+
+        self.config.ops += 1;
+
+        self.config.save_to_file(&self.path.join("config.json"))?;
+        save_delta(&self.path.join("delta.json"), &self.state_store.delta())?;
+
+        Ok(())
+    }
+
+    /// Executes a transaction and updates the session state.
+    ///
+    /// After execution, selected parts of the transaction output get saved to a dedicated directory for inspection:
+    /// - Write set changes
+    /// - Emitted events
+    pub fn execute_transaction(
+        &mut self,
+        txn: SignedTransaction,
+    ) -> Result<(VMStatus, TransactionOutput)> {
+        let env = AptosEnvironment::new(&self.state_store);
+        let vm = AptosVM::new(&env, &self.state_store);
+        let log_context = AdapterLogSchema::new(self.state_store.id(), 0);
+
+        let resolver = self.state_store.as_move_resolver();
+        let code_storage = self.state_store.as_aptos_code_storage(&env);
+
+        let (vm_status, vm_output) = vm.execute_user_transaction(
+            &resolver,
+            &code_storage,
+            &txn,
+            &log_context,
+            &AuxiliaryInfo::new(
+                PersistedAuxiliaryInfo::V1 {
+                    transaction_index: 0,
+                },
+                None,
+            ),
+        );
+        let txn_output = vm_output.try_materialize_into_transaction_output(&resolver)?;
+
+        self.state_store.apply_write_set(txn_output.write_set())?;
+
+        fn name_from_executable(executable: &TransactionExecutable) -> String {
+            match executable {
+                TransactionExecutable::Script(_script) => "script".to_string(),
+                TransactionExecutable::EntryFunction(entry_function) => {
+                    format!(
+                        "{}::{}",
+                        format_module_id(entry_function.module()),
+                        entry_function.function()
+                    )
+                },
+                TransactionExecutable::Empty => {
+                    unimplemented!("empty executable -- unclear how this should be handled")
+                },
+            }
+        }
+        let name = match &txn.payload() {
+            TransactionPayload::EntryFunction(entry_function) => {
+                format!(
+                    "{}::{}",
+                    format_module_id(entry_function.module()),
+                    entry_function.function()
+                )
+            },
+            TransactionPayload::Script(_script) => "script".to_string(),
+            TransactionPayload::Multisig(multi_sig) => {
+                name_from_executable(&multi_sig.as_transaction_executable())
+            },
+            TransactionPayload::Payload(TransactionPayloadInner::V1 { executable, .. }) => {
+                name_from_executable(executable)
+            },
+            TransactionPayload::ModuleBundle(_) => unreachable!(),
+        };
+
+        let output_path = self
+            .path
+            .join(format!("[{}] execute {}", self.config.ops, name));
+        std::fs::create_dir_all(&output_path)?;
+
+        let summary = Summary::ExecuteTransaction {
+            status: txn_output.status().clone(),
+            gas_used: txn_output.gas_used(),
+            fee_statement: txn_output.try_extract_fee_statement()?,
+        };
+        let summary_path = output_path.join("summary.json");
+        std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
+
+        // Dump events to file
+        let events_path = output_path.join("events.json");
+        save_events(&events_path, &self.state_store, txn_output.events())?;
+
+        let write_set_path = output_path.join("write_set.json");
+        save_write_set(&self.state_store, &write_set_path, txn_output.write_set())?;
+
+        self.config.ops += 1;
+        self.config.save_to_file(&self.path.join("config.json"))?;
+        save_delta(&self.path.join("delta.json"), &self.state_store.delta())?;
+
+        Ok((vm_status, txn_output))
+    }
+
+    /// Executes a view function and returns the output values.
+    pub fn execute_view_function(
+        &mut self,
+        module_id: ModuleId,
+        function_name: Identifier,
+        ty_args: Vec<TypeTag>,
+        args: Vec<Vec<u8>>,
+    ) -> Result<Vec<serde_json::Value>> {
+        let output = AptosVM::execute_view_function(
+            &self.state_store,
+            module_id.clone(),
+            function_name.clone(),
+            ty_args.clone(),
+            args,
+            u64::MAX,
+        );
+
+        let (summary, res) = match output.values {
+            Ok(values) => {
+                let annotator = AptosValueAnnotator::new(&self.state_store);
+
+                let returns = annotator.view_function_returns(
+                    &module_id,
+                    &function_name,
+                    &ty_args,
+                    &values,
+                )?;
+
+                let mut vals = Vec::new();
+                for ret_val in returns {
+                    vals.push(aptos_api_types::MoveValue::try_from(ret_val)?.json()?);
+                }
+
+                let summary = Summary::View {
+                    result: ViewResult::Success(vals.clone()),
+                    gas_used: output.gas_used,
+                };
+
+                (summary, Ok(vals))
+            },
+            Err(e) => {
+                let summary = Summary::View {
+                    result: ViewResult::Error(e.to_string()),
+                    gas_used: output.gas_used,
+                };
+
+                (summary, Err(anyhow::anyhow!(e)))
+            },
+        };
+
+        let summary_path = self
+            .path
+            .join(format!(
+                "[{}] view {}::{}",
+                self.config.ops,
+                format_module_id(&module_id),
+                function_name
+            ))
+            .join("summary.json");
+        std::fs::create_dir_all(summary_path.parent().unwrap())?;
+        std::fs::write(summary_path, serde_json::to_string_pretty(&summary)?)?;
+
+        self.config.ops += 1;
+        self.config.save_to_file(&self.path.join("config.json"))?;
+
+        res
+    }
+
+    // TODO: view resource
+}
+
+#[test]
+fn test_init_then_load_session_local() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let session_path = temp_dir.path();
+
+    let session = Session::init(session_path)?;
+    let session_loaded = Session::load(session_path)?;
+
+    assert_eq!(session.config, session_loaded.config);
+    assert_eq!(
+        session.state_store.delta(),
+        session_loaded.state_store.delta()
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_init_then_load_session_remote() -> Result<()> {
+    let temp_dir = tempfile::tempdir()?;
+    let session_path = temp_dir.path();
+
+    let session = Session::init_with_remote_state(
+        session_path,
+        Url::parse("https://mainnet.aptoslabs.com")?,
+        12345,
+        Some("my_api_key_12345".to_string()),
+    )?;
+    let session_loaded = Session::load(session_path)?;
+
+    assert_eq!(session.config, session_loaded.config);
+    assert_eq!(
+        session.state_store.delta(),
+        session_loaded.state_store.delta()
+    );
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/state_store.rs
@@ -1,0 +1,180 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use anyhow::{bail, Result};
+use aptos_types::{
+    access_path::Path,
+    state_store::{
+        state_key::{inner::StateKeyInner, StateKey},
+        table::TableHandle,
+    },
+};
+use move_core_types::{
+    account_address::AccountAddress, identifier::IdentStr, language_storage::StructTag,
+};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
+use std::str::FromStr;
+
+/// Wrapper around a value to provide human readable serialization/deserialization.
+///
+/// Currently only used for `StateKey`s, but could be extended to other types.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct HumanReadable<T>(pub T);
+
+impl<'a> Serialize for HumanReadable<&'a StateKey> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl Serialize for HumanReadable<StateKey> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for HumanReadable<StateKey> {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::from_str(&String::deserialize(deserializer)?).map_err(serde::de::Error::custom)
+    }
+}
+
+impl<T> HumanReadable<T> {
+    pub fn into_inner(self) -> T {
+        self.0
+    }
+}
+
+impl<'a> std::fmt::Display for HumanReadable<&'a StateKey> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.0.inner() {
+            StateKeyInner::AccessPath(access_path) => {
+                let mut s = String::new();
+
+                let header;
+
+                s.push_str(&format!("{}::", access_path.address));
+                match access_path.get_path() {
+                    Path::Code(module_id) => {
+                        header = "code";
+                        s.push_str(&format!("{}", module_id.name));
+                    },
+                    Path::Resource(struct_tag) => {
+                        header = "resource";
+                        s.push_str(&struct_tag.to_canonical_string());
+                    },
+                    Path::ResourceGroup(struct_tag) => {
+                        header = "resource_group";
+                        s.push_str(&struct_tag.to_canonical_string());
+                    },
+                }
+
+                write!(f, "{}::{}", header, s)
+            },
+            StateKeyInner::TableItem { handle, key } => {
+                write!(f, "table_item::{}::{}", handle.0, hex::encode(key))
+            },
+            StateKeyInner::Raw(bytes) => write!(f, "raw::{}", hex::encode(bytes)),
+        }
+    }
+}
+
+impl std::fmt::Display for HumanReadable<StateKey> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", &HumanReadable(&self.0))
+    }
+}
+
+impl FromStr for HumanReadable<StateKey> {
+    type Err = anyhow::Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let parts: Vec<&str> = s.split("::").collect();
+
+        // TODO: Consider using a real parser here.
+
+        match parts.as_slice() {
+            ["code", address, name] => {
+                let address = AccountAddress::from_str(address)?;
+                Ok(HumanReadable(StateKey::module(
+                    &address,
+                    IdentStr::new(name)?,
+                )))
+            },
+            ["resource", address, module_address, module_name, rest @ ..] => {
+                let address = AccountAddress::from_str(address)?;
+
+                let struct_tag = StructTag::from_str(&format!(
+                    "{}::{}::{}",
+                    module_address,
+                    module_name,
+                    rest.join("::")
+                ))?;
+
+                Ok(HumanReadable(StateKey::resource(&address, &struct_tag)?))
+            },
+            ["resource_group", address, module_address, module_name, rest @ ..] => {
+                let address = AccountAddress::from_str(address)?;
+
+                let struct_tag = StructTag::from_str(&format!(
+                    "{}::{}::{}",
+                    module_address,
+                    module_name,
+                    rest.join("::")
+                ))?;
+
+                Ok(HumanReadable(StateKey::resource_group(
+                    &address,
+                    &struct_tag,
+                )))
+            },
+            ["table_item", handle, key] => {
+                let handle = TableHandle(AccountAddress::from_str(handle)?);
+                let key = hex::decode(key)?;
+                Ok(HumanReadable(StateKey::table_item(&handle, &key)))
+            },
+            ["raw", bytes] => {
+                let bytes = hex::decode(bytes)?;
+                Ok(HumanReadable(StateKey::raw(&bytes)))
+            },
+            _ => bail!("Unknown StateKey format: {}", s),
+        }
+    }
+}
+
+#[test]
+fn test_state_key_roundtrip() -> Result<()> {
+    let keys = [
+        "code::0x1::my_module",
+        "resource::0x1::0x2::my_module::my_type",
+        "resource::0x1::0x2::my_module::my_type<>",
+        "resource::0x1::0x2::my_module::my_type<u64>",
+        "resource::0x1::0x2::my_module::my_type<0x1::my_module::bar<bool, u64>, u8>",
+        "resource_group::0x1::0x2::my_module::my_type",
+        "resource_group::0x1::0x2::my_module::my_type<>",
+        "resource_group::0x1::0x2::my_module::my_type<u64>",
+        "resource_group::0x1::0x2::my_module::my_type<0x1::my_module::bar<bool, u64>, u8>",
+        "table_item::0x1::aabbccdd",
+        "table_item::0x1::",
+        "raw::aabbccdd",
+        "raw::",
+    ];
+
+    for key in keys {
+        let key = HumanReadable::<StateKey>::from_str(key)?;
+        let json = serde_json::to_string(&key)?;
+        let decoded: HumanReadable<StateKey> = serde_json::from_str(&json)?;
+        assert_eq!(key, decoded);
+    }
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation-session/src/txn_output.rs
+++ b/aptos-move/aptos-transaction-simulation-session/src/txn_output.rs
@@ -1,0 +1,161 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::state_store::HumanReadable;
+use anyhow::{bail, Result};
+use aptos_resource_viewer::AptosValueAnnotator;
+use aptos_types::{
+    access_path::Path as AccessPath,
+    contract_event::ContractEvent,
+    state_store::{state_key::inner::StateKeyInner, StateView},
+    write_set::{PersistedWriteOp, WriteSet},
+};
+use move_core_types::language_storage::{StructTag, TypeTag};
+use serde_json::json;
+use std::{collections::BTreeMap, path::Path};
+
+/// Writes a write set to a file in a human-readable format.
+///
+/// Specifically, state values are decoded and annotated with field names and structure
+/// for easier inspection.
+///
+/// This format is intended for debugging and inspection only, and is not meant to be
+/// reversible.
+pub fn save_write_set(
+    state_view: &impl StateView,
+    write_set_path: &Path,
+    write_set: &WriteSet,
+) -> Result<()> {
+    let mut entries = BTreeMap::new();
+
+    let annotator = AptosValueAnnotator::new(state_view);
+
+    for (k, v) in write_set.write_op_iter() {
+        let key = HumanReadable(k).to_string();
+
+        let encode_data = |data: &[u8]| -> Result<serde_json::Value> {
+            let val = match k.inner() {
+                StateKeyInner::AccessPath(access_path) => match access_path.get_path() {
+                    AccessPath::Resource(struct_tag) => {
+                        json!(annotator.view_resource(&struct_tag, data)?)
+                    },
+                    AccessPath::ResourceGroup(_struct_tag) => {
+                        let group: BTreeMap<StructTag, Vec<u8>> = bcs::from_bytes(data)?;
+
+                        let mut group_pretty = BTreeMap::new();
+
+                        for (k, v) in group {
+                            group_pretty
+                                .insert(k.to_canonical_string(), annotator.view_resource(&k, &v)?);
+                        }
+
+                        json!(group_pretty)
+                    },
+                    _ => json!(hex::encode(&data)),
+                },
+                _ => json!(hex::encode(&data)),
+            };
+            Ok(val)
+        };
+
+        let val = match v.to_persistable() {
+            PersistedWriteOp::Creation(data) => {
+                json!({
+                    "create": {
+                        "data": encode_data(&data)?,
+                    }
+                })
+            },
+            PersistedWriteOp::Modification(data) => {
+                json!({
+                    "modify": {
+                        "data": encode_data(&data)?,
+                    }
+                })
+            },
+            PersistedWriteOp::Deletion => {
+                json!({
+                    "delete": {}
+                })
+            },
+            PersistedWriteOp::CreationWithMetadata { data, metadata } => {
+                json!({
+                    "create": {
+                        "data": encode_data(&data)?,
+                        "metadata": metadata,
+                    }
+                })
+            },
+            PersistedWriteOp::ModificationWithMetadata { data, metadata } => {
+                json!({
+                    "modify": {
+                        "data": encode_data(&data)?,
+                        "metadata": metadata,
+                    }
+                })
+            },
+            PersistedWriteOp::DeletionWithMetadata { metadata } => {
+                json!({
+                    "delete": {
+                        "metadata": metadata,
+                    }
+                })
+            },
+        };
+
+        entries.insert(key, val);
+    }
+
+    std::fs::write(write_set_path, serde_json::to_string_pretty(&entries)?)?;
+
+    Ok(())
+}
+
+/// Saves events to a file, in a human readable format.
+///
+/// Specifically, event data is decoded and annotated with field names and structure
+/// for easier inspection.
+///
+/// This format is intended for debugging and inspection only, and is not meant to be
+/// reversible.
+pub fn save_events(
+    events_path: &Path,
+    state_view: &impl StateView,
+    events: &[ContractEvent],
+) -> Result<()> {
+    let mut entries = vec![];
+
+    let annotator = AptosValueAnnotator::new(state_view);
+
+    fn struct_tag_from_type_tag(type_tag: &TypeTag) -> Result<&StructTag> {
+        match type_tag {
+            TypeTag::Struct(struct_tag) => Ok(struct_tag),
+            _ => bail!("Expected struct type tag, got: {:?}", type_tag),
+        }
+    }
+
+    for event in events {
+        let val = match event {
+            ContractEvent::V1(event) => json!({
+                "V1": {
+                    "key": event.key().clone(),
+                    "sequence_number": event.sequence_number(),
+                    "type_tag": event.type_tag().to_canonical_string(),
+                    "event_data": annotator.view_resource(struct_tag_from_type_tag(event.type_tag())?, event.event_data())?
+                }
+            }),
+            ContractEvent::V2(event) => json!({
+                "V2": {
+                    "type_tag": event.type_tag().to_canonical_string(),
+                    "event_data": annotator.view_resource(struct_tag_from_type_tag(event.type_tag())?, event.event_data())?
+                }
+            }),
+        };
+
+        entries.push(val);
+    }
+
+    std::fs::write(events_path, serde_json::to_string_pretty(&entries)?)?;
+
+    Ok(())
+}

--- a/aptos-move/aptos-transaction-simulation/Cargo.toml
+++ b/aptos-move/aptos-transaction-simulation/Cargo.toml
@@ -14,7 +14,7 @@ rust-version = { workspace = true }
 
 [dependencies]
 anyhow = { workspace = true }
-aptos-crypto = { workspace = true }
+aptos-crypto = { workspace = true, features = ["cloneable-private-keys"] }
 aptos-keygen = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm-genesis = { workspace = true }
@@ -26,6 +26,3 @@ once_cell = { workspace = true }
 parking_lot = { workspace = true }
 proptest = { workspace = true }
 serde = { workspace = true }
-
-[dev-dependencies]
-aptos-crypto = { workspace = true, features = ["cloneable-private-keys"] }

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -4,6 +4,9 @@
 use crate::{genesis::GENESIS_CHANGE_SET_HEAD, Account, AccountData};
 use anyhow::{anyhow, bail, Result};
 use aptos_types::{
+    account_config::{
+        primary_apt_store, CoinStoreResource, FungibleStoreResource, ObjectGroupResource,
+    },
     chain_id::ChainId,
     on_chain_config::{FeatureFlag, Features, OnChainConfig},
     state_store::{
@@ -12,11 +15,14 @@ use aptos_types::{
     },
     transaction::Version,
     write_set::{TransactionWrite, WriteSet},
+    AptosCoinType,
 };
 use bytes::Bytes;
 use move_binary_format::{deserializer::DeserializerConfig, CompiledModule};
 use move_core_types::{
-    account_address::AccountAddress, language_storage::ModuleId, move_resource::MoveResource,
+    account_address::AccountAddress,
+    language_storage::{ModuleId, StructTag},
+    move_resource::{MoveResource, MoveStructType},
 };
 use parking_lot::RwLock;
 use serde::Serialize;
@@ -79,6 +85,29 @@ pub trait SimulationStateStore: TStateView<Key = StateKey> {
         };
         modify(&mut resource)?;
         self.set_resource(addr, &resource)
+    }
+
+    fn get_resource_group<G: MoveResource>(
+        &self,
+        addr: AccountAddress,
+    ) -> Result<Option<BTreeMap<StructTag, Vec<u8>>>> {
+        let state_key = StateKey::resource_group(&addr, &G::struct_tag());
+
+        match self.get_state_value_bytes(&state_key)? {
+            Some(blob) => Ok(Some(bcs::from_bytes(&blob)?)),
+            None => Ok(None),
+        }
+    }
+
+    fn set_resource_group<G: MoveResource>(
+        &self,
+        addr: AccountAddress,
+        resource_group: &BTreeMap<StructTag, Vec<u8>>,
+    ) -> Result<()> {
+        self.set_state_value(
+            StateKey::resource_group(&addr, &G::struct_tag()),
+            StateValue::new_legacy(bcs::to_bytes(resource_group)?.into()),
+        )
     }
 
     /// Sets an on-chain config.
@@ -223,6 +252,69 @@ pub trait SimulationStateStore: TStateView<Key = StateKey> {
         self.add_account_data(&data)?;
         Ok(data)
     }
+
+    /// Fetches the APT balance of an account from the legacy coin store.
+    fn get_apt_balance_legacy(&self, address: AccountAddress) -> Result<u64> {
+        let coin_store = match self.get_resource::<CoinStoreResource<AptosCoinType>>(address)? {
+            Some(coin_store) => coin_store,
+            None => return Ok(0),
+        };
+
+        Ok(coin_store.coin())
+    }
+
+    /// Fetches the APT balance of an account from the fungible store.
+    fn get_apt_balance_fungible_store(&self, address: AccountAddress) -> Result<u64> {
+        let primary_store_object_address = primary_apt_store(address);
+        let resource_group =
+            match self.get_resource_group::<ObjectGroupResource>(primary_store_object_address)? {
+                Some(resource_group) => resource_group,
+                None => return Ok(0),
+            };
+        let fungible_store: FungibleStoreResource =
+            match resource_group.get(&FungibleStoreResource::struct_tag()) {
+                Some(blob) => bcs::from_bytes(blob)?,
+                None => return Ok(0),
+            };
+
+        Ok(fungible_store.balance)
+    }
+
+    /// Fetches the APT balance of an account.
+    /// This includes both legacy and fungible store balances.
+    fn get_apt_balance(&self, address: AccountAddress) -> Result<u64> {
+        Ok(self.get_apt_balance_legacy(address)? + self.get_apt_balance_fungible_store(address)?)
+    }
+
+    /// Adds APT to an account's fungible store.
+    fn fund_apt_fungible_store(&self, address: AccountAddress, amount: u64) -> Result<(u64, u64)> {
+        let primary_store_object_address = primary_apt_store(address);
+
+        let mut resource_group = self
+            .get_resource_group::<ObjectGroupResource>(primary_store_object_address)?
+            .unwrap_or_else(BTreeMap::new);
+
+        let mut fungible_store = match resource_group.get(&FungibleStoreResource::struct_tag()) {
+            Some(blob) => bcs::from_bytes(blob)?,
+            None => FungibleStoreResource::new(AccountAddress::TEN, 0, false),
+        };
+
+        let before = fungible_store.balance;
+        fungible_store.balance += amount;
+        let after = fungible_store.balance;
+
+        resource_group.insert(
+            FungibleStoreResource::struct_tag(),
+            bcs::to_bytes(&fungible_store)?,
+        );
+
+        self.set_resource_group::<ObjectGroupResource>(
+            primary_store_object_address,
+            &resource_group,
+        )?;
+
+        Ok((before, after))
+    }
 }
 
 /***************************************************************************************************
@@ -327,6 +419,7 @@ where
  * Delta State Store
  *
  **************************************************************************************************/
+
 /// A state storage that allows changes to be stacked on top of a base state view.
 ///
 /// This is useful for staging reversible state changes or performing simulations on top of
@@ -436,6 +529,17 @@ impl<V> DeltaStateStore<V> {
             base,
             states: RwLock::new(state_vals.into_iter().map(|(k, v)| (k, Some(v))).collect()),
         }
+    }
+
+    pub fn new_with_base_and_delta(base: V, delta: HashMap<StateKey, Option<StateValue>>) -> Self {
+        Self {
+            base,
+            states: RwLock::new(delta),
+        }
+    }
+
+    pub fn delta(&self) -> HashMap<StateKey, Option<StateValue>> {
+        self.states.read().clone()
     }
 }
 

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+##[7.8.0]
+- New beta feature: Transaction Simulation Session
+
 ## [7.7.0]
 - Turn off sharding in the local testnet
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.7.0"
+version = "7.8.0"
 
 # Workspace inherited keys
 authors = { workspace = true }
@@ -43,6 +43,8 @@ aptos-sdk = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-telemetry = { workspace = true }
 aptos-temppath = { workspace = true }
+aptos-transaction-simulation = { workspace = true }
+aptos-transaction-simulation-session = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true, features = ["testing"] }
 aptos-vm-environment = { workspace = true }

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -43,7 +43,10 @@ use aptos_sdk::{
     transaction_builder::TransactionFactory,
     types::{HardwareWalletAccount, HardwareWalletType, LocalAccount, TransactionSigner},
 };
+use aptos_transaction_simulation::SimulationStateStore;
+use aptos_transaction_simulation_session::Session;
 use aptos_types::{
+    account_config::AccountResource,
     chain_id::ChainId,
     transaction::{
         authenticator::AuthenticationKey, EntryFunction, MultisigTransactionPayload,
@@ -74,7 +77,7 @@ use std::{
     convert::TryFrom,
     fmt::{Debug, Display, Formatter},
     fs::OpenOptions,
-    path::PathBuf,
+    path::{Path, PathBuf},
     str::FromStr,
     time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
@@ -1799,6 +1802,10 @@ pub struct TransactionOptions {
     #[clap(long)]
     pub(crate) profile_gas: bool,
 
+    /// If this option is set, simulate the transaction using a local session.
+    #[clap(long)]
+    pub(crate) session: Option<PathBuf>,
+
     /// Replay protection mechanism to use when generating the transaction.
     ///
     /// When "nonce" is chosen, the transaction will be an orderless transaction and contains a replay protection nonce.
@@ -1880,11 +1887,26 @@ impl TransactionOptions {
     }
 
     pub async fn view(&self, payload: ViewFunction) -> CliTypedResult<Vec<serde_json::Value>> {
-        let client = self.rest_client()?;
-        Ok(client
-            .view_bcs_with_json_response(&payload, None)
-            .await?
-            .into_inner())
+        match &self.session {
+            None => {
+                let client = self.rest_client()?;
+                Ok(client
+                    .view_bcs_with_json_response(&payload, None)
+                    .await?
+                    .into_inner())
+            },
+
+            Some(session_path) => {
+                let mut sess = Session::load(session_path)?;
+                let output = sess.execute_view_function(
+                    payload.module,
+                    payload.function,
+                    payload.ty_args,
+                    payload.args,
+                )?;
+                Ok(output)
+            },
+        }
     }
 
     /// Submit a transaction
@@ -2097,6 +2119,7 @@ impl TransactionOptions {
         const DEFAULT_MAX_GAS: u64 = 2_000_000;
 
         let (sender_key, sender_address) = self.get_key_and_address()?;
+        // TODO: Consider fetching the min gas unit price from the chain
         let gas_unit_price = self
             .gas_options
             .gas_unit_price
@@ -2148,6 +2171,76 @@ impl TransactionOptions {
             success,
             timestamp_us: None,
             version: Some(version), // The transaction is not comitted so there is no new version.
+            vm_status: Some(vm_status.to_string()),
+        };
+
+        Ok(summary)
+    }
+
+    pub async fn simulate_using_session(
+        &self,
+        session_path: &Path,
+        payload: TransactionPayload,
+    ) -> CliTypedResult<TransactionSummary> {
+        let mut sess = Session::load(session_path)?;
+
+        let state_store = sess.state_store();
+
+        // Fetch the chain states required for the simulation
+        const DEFAULT_GAS_UNIT_PRICE: u64 = 100;
+        const DEFAULT_MAX_GAS: u64 = 2_000_000;
+
+        let (sender_key, sender_address) = self.get_key_and_address()?;
+
+        // TODO: Support orderless transactions
+        let account = state_store.get_resource::<AccountResource>(sender_address)?;
+        let seq_num = match account {
+            Some(account) => account.sequence_number,
+            None => 0,
+        };
+
+        // TODO: Consider fetching the min gas unit price from the chain
+        let gas_unit_price = self
+            .gas_options
+            .gas_unit_price
+            .unwrap_or(DEFAULT_GAS_UNIT_PRICE);
+
+        let balance = state_store.get_apt_balance(sender_address)?;
+        let max_gas = self.gas_options.max_gas.unwrap_or_else(|| {
+            if gas_unit_price == 0 {
+                DEFAULT_MAX_GAS
+            } else {
+                std::cmp::min(balance / gas_unit_price, DEFAULT_MAX_GAS)
+            }
+        });
+
+        let transaction_factory = TransactionFactory::new(state_store.get_chain_id()?)
+            .with_gas_unit_price(gas_unit_price)
+            .with_max_gas_amount(max_gas)
+            .with_transaction_expiration_time(self.gas_options.expiration_secs);
+        let sender_account = &mut LocalAccount::new(sender_address, sender_key, seq_num);
+        let transaction =
+            sender_account.sign_with_transaction_builder(transaction_factory.payload(payload));
+        let hash = transaction.committed_hash();
+
+        let (vm_status, txn_output) = sess.execute_transaction(transaction)?;
+
+        let success = match txn_output.status() {
+            TransactionStatus::Keep(exec_status) => Some(exec_status.is_success()),
+            TransactionStatus::Discard(_) | TransactionStatus::Retry => None,
+        };
+
+        let summary = TransactionSummary {
+            transaction_hash: hash.into(),
+            gas_used: Some(txn_output.gas_used()),
+            gas_unit_price: Some(gas_unit_price),
+            pending: None,
+            sender: Some(sender_address),
+            sequence_number: Some(seq_num),
+            replay_protector: None,
+            success,
+            timestamp_us: None,
+            version: None,
             vm_status: Some(vm_status.to_string()),
         };
 

--- a/crates/aptos/src/move_tool/sim.rs
+++ b/crates/aptos/src/move_tool/sim.rs
@@ -1,0 +1,118 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{
+    common::types::{CliCommand, CliResult, CliTypedResult},
+    move_tool::ReplayNetworkSelection,
+};
+use aptos_rest_client::Client;
+use aptos_transaction_simulation_session::Session;
+use async_trait::async_trait;
+use clap::{Parser, Subcommand};
+use move_core_types::account_address::AccountAddress;
+use std::path::PathBuf;
+
+/// Initializes a new simulation session
+#[derive(Debug, Parser)]
+pub struct Init {
+    /// Path to the directory where the session data will be stored.
+    #[clap(long)]
+    path: PathBuf,
+
+    /// If specified, starts the simulation by forking from a remote network state.
+    #[clap(long)]
+    network: Option<ReplayNetworkSelection>,
+
+    /// The version of the network state to fork from.
+    ///
+    /// Only used if `--network` is specified.
+    ///
+    /// If not specified, the latest version of the network will be used.
+    #[clap(long)]
+    network_version: Option<u64>,
+
+    /// API key for connecting to the fullnode.
+    ///
+    /// It is strongly recommended to specify an API key to avoid rate limiting.
+    #[clap(long)]
+    api_key: Option<String>,
+}
+
+#[async_trait]
+impl CliCommand<()> for Init {
+    fn command_name(&self) -> &'static str {
+        "init"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        match self.network {
+            Some(network) => {
+                let network_version = match self.network_version {
+                    Some(txn_id) => txn_id,
+                    None => {
+                        let client = Client::builder(network.to_base_url()?).build();
+                        client.get_ledger_information().await?.inner().version
+                    },
+                };
+                let base_url = network.to_base_url()?;
+                let url = base_url.to_url();
+
+                Session::init_with_remote_state(&self.path, url, network_version, self.api_key)?;
+            },
+            None => {
+                Session::init(&self.path)?;
+            },
+        }
+
+        Ok(())
+    }
+}
+
+/// Funds an account with APT tokens
+#[derive(Debug, Parser)]
+pub struct Fund {
+    /// Path to a stored session
+    #[clap(long)]
+    session: PathBuf,
+
+    /// Account to fund, can be an address or a CLI profile name
+    #[clap(long, value_parser = crate::common::types::load_account_arg)]
+    account: AccountAddress,
+
+    /// Funding amount, in Octa (10^-8 APT)
+    #[clap(long)]
+    amount: u64,
+}
+
+#[async_trait]
+impl CliCommand<()> for Fund {
+    fn command_name(&self) -> &'static str {
+        "fund"
+    }
+
+    async fn execute(self) -> CliTypedResult<()> {
+        let mut session = Session::load(&self.session)?;
+
+        session.fund_account(self.account, self.amount)?;
+
+        Ok(())
+    }
+}
+
+/// BETA: Commands for interacting with a local simulation session
+///
+/// BETA: Subject to change
+#[derive(Subcommand)]
+pub enum Sim {
+    Init(Init),
+    Fund(Fund),
+}
+
+impl Sim {
+    pub async fn execute(self) -> CliResult {
+        match self {
+            Sim::Init(init) => init.execute_serialized_success().await,
+            Sim::Fund(fund) => fund.execute_serialized_success().await,
+        }
+    }
+}

--- a/types/src/write_set.rs
+++ b/types/src/write_set.rs
@@ -47,7 +47,7 @@ pub enum WriteOpKind {
 
 #[derive(Serialize, Deserialize)]
 #[serde(rename = "WriteOp")]
-enum PersistedWriteOp {
+pub enum PersistedWriteOp {
     Creation(Bytes),
     Modification(Bytes),
     Deletion,
@@ -134,7 +134,7 @@ impl BaseStateOp {
 pub struct WriteOp(BaseStateOp);
 
 impl WriteOp {
-    fn to_persistable(&self) -> PersistedWriteOp {
+    pub fn to_persistable(&self) -> PersistedWriteOp {
         use PersistedWriteOp::*;
 
         let metadata = self.metadata().clone().into_persistable();


### PR DESCRIPTION
## Overview
This implements a powerful new tool called **Transaction Simulation Session** that allows developers to create simulation environments either from a clean state (containing just the Aptos genesis) or by forking from a remote network state.

The session **persists all state to disk**, allowing developers to save, restore, and continue their simulation work. It supports essential operations like executing transactions, calling view functions, and other helpful testing utilities such as funding accounts. The outputs are saved to disk as well, for easy inspection and debugging.

## Use Cases
- **Integration Testing**
  - Can be used as an execution backend for integration testing frameworks, providing a controlled and repeatable environment for testing your contract.
- **Pre-deployment Simulation**
  - Test bug fixes, new versions, and data migrations against real network states before deploying.
- **Debugging Move contracts**
  - Debug with real states and easy state inspection through detailed human-readable transaction outputs.

## Using the Transaction Simulation Session
You can interact with the Transaction Simulation Session through Aptos CLI commands:
- New `aptos move sim` family of commands for session-specific operations
- `--session` option added to existing Move commands: `aptos move run`, `aptos move run-script`, `aptos move publish`, and `aptos move view`

Start a session:
```bash
# clean, local states
cargo run -p aptos -- move sim init --path sess

# forked state from remote network
cargo run -p aptos -- move sim init --path sess --network devnet --api-key "SOME_API_KEY"
```
```
{
  "Result": "Success"
}
```

Fund an account:
```bash
cargo run -p aptos -- move sim fund --session sess --account default --amount 100000000
```
```
{
  "Result": "Success"
}
```

Execute a transfer transaction
```bash
cargo run -p aptos -- move run --session sess --function-id 0x1::aptos_account::transfer --args address:default u64:100
```
```
{
  "Result": {
    "transaction_hash": "0xfb55a4c2909630a31bc9728e6f27b429f1ceef69491c9594caf2e633adbc7f39",
    "gas_used": 498,
    "gas_unit_price": 100,
    "sender": "dbcbe741d003a7369d87ec8717afb5df425977106497052f96f4e236372f7dd5",
    "success": true,
    "vm_status": "status EXECUTED of type Execution"
  }
}
```

Execute a view function
```bash
cargo run -p aptos -- move view --session sess --function-id 0x1::account::get_sequence_number --args address:default
```
```
{
  "Result": [
    "1"
  ]
}
```

## Session Data Layout
The Session stores all its data in a dedicated directory containing the session configuration, state delta, and detailed outputs for each operation:
```
sess
├── [0] fund (fungible)
│   └── summary.json
├── [1] execute 0x1::aptos_account::transfer
│   ├── events.json
│   ├── summary.json
│   └── write_set.json
├── [2] view 0x1::account::get_sequence_number
│   └── summary.json
├── config.json
└── delta.json
```

## Future Plan
- `aptos move sim view_resource` command
- Gas profiler integration
- Human-readable state delta (might be difficult)