### PR TITLE
[Fullnode Sync] Enable storage sharding on the fullnode sync tests.

### DIFF
--- a/.github/actions/fullnode-sync/fullnode_sync.py
+++ b/.github/actions/fullnode-sync/fullnode_sync.py
@@ -253,6 +253,9 @@ def setup_fullnode_config(bootstrapping_mode, continuous_syncing_mode, data_dir_
   # Avoid having to set ulimit configurations
   fullnode_config['storage'] = {"ensure_rlimit_nofile": 0}
 
+  # Enable storage sharding (AIP-97)
+  fullnode_config['storage']['rocksdb_configs'] = {"enable_storage_sharding": True}
+
   # Write the config file back to disk
   with open(FULLNODE_CONFIG_NAME, "w") as file:
     yaml.dump(fullnode_config, file)


### PR DESCRIPTION
## Description
This PR enables storage sharding on the fullnode sync Github actions (i.e., nightly tests). This is now required, and if it is not set, the fullnode panics. The tests are currently failing because of this.

## Testing Plan
Manual verification (e.g., see here: https://github.com/aptos-labs/aptos-core/actions/runs/17197860491)
