### PR TITLE
[Keyless] Clean up pepper service client example.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2783,9 +2783,12 @@ dependencies = [
  "ark-bls12-381",
  "ark-serialize",
  "bcs 0.1.4",
+ "clap 4.5.21",
  "firestore",
  "hex",
+ "rand 0.7.3",
  "reqwest 0.11.23",
+ "serde",
  "serde_json",
  "tokio",
 ]

--- a/keyless/pepper/README.md
+++ b/keyless/pepper/README.md
@@ -45,13 +45,13 @@ Next, you can start the Pepper Service by running the `start-pepper-service.sh` 
 
 ```bash
 cd keyless/pepper/scripts
-./start-pepper-service.sh <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <PROJECT_ID>
+./start-pepper-service.sh <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <GOOGLE_PROJECT_ID>
 ```
 
 The script arguments are:
-- `<FIRESTORE_EMULATOR_HOST>`: The host and port of the Firestore emulator, e.g., `localhost:8081`.
+- `<FIRESTORE_EMULATOR_HOST>`: The host and port of the Firestore emulator, e.g., `http://localhost:8081`.
 - `<GOOGLE_APPLICATION_CREDENTIALS>`: The path to your service account credential file (in JSON format).
-- `<PROJECT_ID>`: The ID of your GCP project.
+- `<GOOGLE_PROJECT_ID>`: The ID of your GCP project.
 
 Note that the Pepper Service will run in the foreground, so you will need to keep this terminal
 window open while you interact with the Pepper Service.
@@ -66,10 +66,15 @@ To run the example client, execute the `start-pepper-client.sh` script in this r
 
 ```bash
 cd keyless/pepper/scripts
-./start-pepper-client.sh <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <PROJECT_ID>
+./start-pepper-client.sh <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <PEPPER_SERVICE_URL> <GOOGLE_PROJECT_ID> <FIRESTORE_DATABASE_ID>"
 ```
 
-The script arguments are the same as those used for starting the Pepper Service (above).
+The script arguments are:
+- `<FIRESTORE_EMULATOR_HOST>`: The host and port of the Firestore emulator, e.g., `http://localhost:8081`.
+- `<GOOGLE_APPLICATION_CREDENTIALS>`: The path to your service account credential file (in JSON format).
+- `<PEPPER_SERVICE_URL>`: The host and port of the Pepper Service, e.g., `http://localhost:8000`.
+- `<GOOGLE_PROJECT_ID>`: The ID of your GCP project.
+- `<FIRESTORE_DATABASE_ID>`: The ID of your Firestore database.
 
 Note: the client is an interactive console program, so you will need to follow the instructions
 to manually complete a session with the Pepper Service.

--- a/keyless/pepper/example-client-rust/Cargo.toml
+++ b/keyless/pepper/example-client-rust/Cargo.toml
@@ -20,8 +20,11 @@ aptos-types = { workspace = true }
 ark-bls12-381 = { workspace = true }
 ark-serialize = { workspace = true }
 bcs = { workspace = true }
+clap = { workspace = true }
 firestore = { workspace = true }
 hex = { workspace = true }
+rand = { workspace = true }
 reqwest = { workspace = true }
+serde = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }

--- a/keyless/pepper/example-client-rust/src/lib.rs
+++ b/keyless/pepper/example-client-rust/src/lib.rs
@@ -1,0 +1,473 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_crypto::{ed25519::Ed25519PrivateKey, PrivateKey, Uniform};
+use aptos_infallible::duration_since_epoch;
+use aptos_keyless_pepper_common::{
+    account_recovery_db::AccountRecoveryDbEntry,
+    jwt,
+    vuf::{self, VUF},
+    PepperInput, PepperRequest, PepperResponse, PepperV0VufPubKey, SignatureResponse,
+};
+use aptos_types::{keyless::OpenIdSig, transaction::authenticator::EphemeralPublicKey};
+use ark_bls12_381::G2Projective;
+use ark_serialize::CanonicalDeserialize;
+use firestore::{path, paths, FirestoreDb, FirestoreDbOptions};
+use rand::RngCore;
+use reqwest::{Client, StatusCode};
+
+mod utils;
+
+// Default values
+const DEFAULT_CLIENT_TIMEOUT_SECS: u64 = 10;
+const DEFAULT_FIRESTORE_COLLECTION: &str = "accounts";
+const DEFAULT_JWT: &str =
+    "eyJhbGciOiJSUzI1NiIsImtpZCI6ImUxYjkzYzY0MDE0NGI4NGJkMDViZjI5NmQ2NzI2MmI2\
+     YmM2MWE0ODciLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZ\
+     S5jb20iLCJhenAiOiI0MDc0MDg3MTgxOTIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iL\
+     CJhdWQiOiI0MDc0MDg3MTgxOTIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiO\
+     iIxMTE2Mjc3NzI0NjA3NTIzNDIzMTIiLCJhdF9oYXNoIjoiaG5OWHFJVTZ3dWFPYlVqR05lR\
+     VhGQSIsIm5vbmNlIjoiNzQyMDQxODMxNDYwMDk1MDM0MTU3NzQ0MzEzMzY0MTU4OTk0NzYwN\
+     TExMjc1MDEwNDIyNjY5MDY3NTc3OTY3NTIyNDAwNjA0OTI0NCIsIm5hbWUiOiJPbGl2ZXIgS\
+     GUiLCJnaXZlbl9uYW1lIjoiT2xpdmVyIiwiZmFtaWx5X25hbWUiOiJIZSIsImlhdCI6MTcxN\
+     DQ0MTc4MywiZXhwIjoxNzE0NDQ1MzgzfQ.iNeVzp4BTQj2I_WH6UaUOfUBV4Q_wUriV7jWkh\
+     1fUqTPSs30jMMSjEDZml8lQ_NUIpivnGvfEHt_rF9rlrsuRur9pTVKRRKhJUNf5avrAujvLz\
+     rz-bwdgKXtTY_nmYisNNNQwmFIVP004ICois4DHD7EmO8PI88CzSzdDbl9qAIoxOP3JRKRwU\
+     05wK5qkGz6FpYzTYiG50lQCybSzzUN5Lws49ANCAOZiROG5lmszOW41mAbFSd6MUX469uvyM\
+     A2ZZ5av9ArKricHJPutGtLoOSWpzKQ_mlCzofVs5tHoMhGgcOFKuhnEVdY4J7TdcV6pZv9Ih\
+     5F8MX3-Wz9Iz9O4w";
+const DEFAULT_UID_KEY: &str = "sub";
+
+// The Google Playground URL for generating JWTs
+const GOOGLE_PLAYGROUND_URL: &str =
+    "https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?\
+      redirect_uri=https%3A%2F%2Fdevelopers.google.com%2Foauthplayground\
+      &prompt=consent\
+      &response_type=code\
+      &client_id=407408718192.apps.googleusercontent.com\
+      &scope=profile\
+      &access_type=offline\
+      &service=lso\
+      &o2v=2\
+      &theme=glif\
+      &flowName=GeneralOAuthFlow\
+      &nonce=";
+
+// Endpoints for the pepper service
+const PEPPER_SERVICE_FETCH_URL: &str = "/v0/fetch";
+const PEPPER_SERVICE_SIG_URL: &str = "/v0/signature";
+const PEPPER_SERVICE_VUF_PUB_KEY_URL: &str = "/v0/vuf-pub-key";
+
+// Useful type annotations
+type Blinder = [u8; 31];
+
+/// Runs the example client that interacts with the pepper service
+pub async fn run_client_example(
+    pepper_service_url: String,
+    firestore_google_project_id: String,
+    firestore_database_id: String,
+) {
+    utils::print(
+        "Starting the example client that interacts with the Aptos OIDB Pepper Service.",
+        true,
+    );
+
+    // Step 1: Fetch the verification key from the pepper service
+    let mut request_client = utils::create_request_client();
+    let verification_public_key =
+        fetch_verification_public_key(&mut request_client, &pepper_service_url).await;
+
+    // Step 2: Create the blinder, ephemeral key and ephemeral key expiry time
+    let (blinder, ephemeral_public_key, ephemeral_key_expiry_secs) =
+        generate_blinder_and_ephemeral_key();
+
+    // Step 3: Generate an OAuth nonce using the blinder, ephemeral public key and expiry time
+    let nonce_str = generate_oauth_nonce(blinder, ephemeral_key_expiry_secs, &ephemeral_public_key);
+
+    // Step 4: Fetch a JWT with the given nonce
+    let jwt = fetch_jwt_with_nonce(nonce_str);
+
+    // Step 5: Request a pepper from the pepper service
+    let pepper_request = request_pepper_from_service(
+        &mut request_client,
+        &pepper_service_url,
+        blinder,
+        ephemeral_public_key,
+        ephemeral_key_expiry_secs,
+        &jwt,
+    )
+    .await;
+
+    // Step 6: Request a signature from the pepper service for the pepper request
+    let signature =
+        request_signature_from_service(&mut request_client, &pepper_service_url, &pepper_request)
+            .await;
+
+    // (Optional) Step 7: Verify the pepper signature using the verification key, JWT and signature
+    let pepper_input = verify_pepper_signature(&verification_public_key, jwt, &signature);
+
+    // (Optional) Step 8: Verify the firestore entry for the pepper input
+    verify_firestore_pepper_entry(
+        pepper_input,
+        firestore_google_project_id,
+        firestore_database_id,
+    )
+    .await;
+}
+
+/// Step 1: Fetch the verification key from the pepper service
+async fn fetch_verification_public_key(
+    request_client: &mut Client,
+    pepper_service_url: &str,
+) -> G2Projective {
+    let verification_key_url = format!("{}{}", pepper_service_url, PEPPER_SERVICE_VUF_PUB_KEY_URL);
+    utils::print(
+        &format!("Step 1: Fetching the verification key from the pepper service ({}) with a GET request to {}.", pepper_service_url, verification_key_url),
+        true,
+    );
+
+    // Send the GET request
+    let response = request_client
+        .get(verification_key_url)
+        .send()
+        .await
+        .unwrap();
+
+    // Parse the verification key from the response
+    let verification_key = response.json::<PepperV0VufPubKey>().await.unwrap();
+    utils::print(
+        &format!(
+            "Received the verification key: {}",
+            utils::to_string_pretty(&verification_key)
+        ),
+        false,
+    );
+
+    // Deserialize the verification key
+    ark_bls12_381::G2Affine::deserialize_compressed(verification_key.public_key.as_slice())
+        .unwrap()
+        .into()
+}
+
+/// Step 2: Generate a blinder, an ephemeral key pair, and an expiry time for the ephemeral key
+fn generate_blinder_and_ephemeral_key() -> (Blinder, EphemeralPublicKey, u64) {
+    utils::print(
+        "Step 2: Generating a blinder, ephemeral keypair and keypair expiration time.",
+        true,
+    );
+
+    // Generate a random blinder
+    let mut blinder = Blinder::default();
+    rand::thread_rng().fill_bytes(&mut blinder);
+    utils::print(
+        &format!("Generated blinder (hex): {}", hex::encode(blinder)),
+        false,
+    );
+
+    // Generate a new ephemeral key pair
+    let private_key = Ed25519PrivateKey::generate(&mut rand::thread_rng());
+    let ephemeral_public_key = EphemeralPublicKey::ed25519(private_key.public_key());
+    utils::print(
+        &format!(
+            "Generated ephemeral public key (hex): {} and private key (hex): {}",
+            hex::encode(ephemeral_public_key.to_bytes()),
+            hex::encode(private_key.to_bytes())
+        ),
+        false,
+    );
+
+    // Generate a UNIX expiry time for the keypair (e.g., 1 hour from now)
+    let expiry_time_secs = duration_since_epoch().as_secs() + 3600;
+    utils::print(
+        &format!(
+            "Generated UNIX expiry time (1 hour from now): {}",
+            expiry_time_secs
+        ),
+        false,
+    );
+
+    (blinder, ephemeral_public_key, expiry_time_secs)
+}
+
+/// Step 3: Generate the OAuth nonce using the given blinder, expiry time, and ephemeral public key
+fn generate_oauth_nonce(
+    blinder: Blinder,
+    epk_expiry_time_secs: u64,
+    ephemeral_public_key: &EphemeralPublicKey,
+) -> String {
+    utils::print(
+        "Step 3: Generating the OAuth nonce using the blinder, expiry time, and ephemeral public key.",
+        true,
+    );
+
+    // Generate the nonce
+    let oauth_nonce = OpenIdSig::reconstruct_oauth_nonce(
+        blinder.as_slice(),
+        epk_expiry_time_secs,
+        ephemeral_public_key,
+        &utils::get_keyless_configuration(),
+    )
+    .unwrap();
+    utils::print(&format!("Generated OAuth nonce: {}", oauth_nonce), false);
+
+    oauth_nonce
+}
+
+/// Step 4: Fetch a JWT with the given nonce
+fn fetch_jwt_with_nonce(nonce_str: String) -> String {
+    utils::print(
+        &format!("Step 4: Fetch a JWT with the given nonce: {}", nonce_str),
+        true,
+    );
+
+    // Print instructions for the user to follow
+    utils::print("To fetch a JWT with the nonce, we will use an example from the Google OAuth 2.0 Playground.", false);
+    utils::print("First, open the following URL in your web browser:", false);
+    utils::print(&format!("{}{}", GOOGLE_PLAYGROUND_URL, nonce_str), false);
+    utils::print("Then, sign in as requested by the web UI.", false);
+    utils::print(
+        "Once you are signed in to 'OAuth 2.0 Playground' click the blue button called \
+                 'Exchange authorization code for tokens'.",
+        false,
+    );
+    utils::print(
+        "You should see a response. In the response, take the value of the field 'id_token' \
+                    (exclude the double-quotes) and save it to a file. This is your JWT.",
+        false,
+    );
+
+    // Get the JWT from the user
+    utils::get_jwt()
+}
+
+/// Step 5: Request a pepper from the pepper service for the given parameters
+async fn request_pepper_from_service(
+    request_client: &mut Client,
+    pepper_service_url: &str,
+    blinder: Blinder,
+    ephemeral_public_key: EphemeralPublicKey,
+    ephemeral_key_expiry_secs: u64,
+    jwt: &str,
+) -> PepperRequest {
+    let pepper_fetch_url = format!("{}{}", pepper_service_url, PEPPER_SERVICE_FETCH_URL);
+    utils::print(
+        &format!(
+            "Step 5: Requesting a pepper from the pepper service with a POST request to {}.",
+            pepper_fetch_url
+        ),
+        true,
+    );
+
+    // Create the pepper request
+    let pepper_request = PepperRequest {
+        jwt: jwt.into(),
+        epk: ephemeral_public_key,
+        exp_date_secs: ephemeral_key_expiry_secs,
+        uid_key: None,
+        epk_blinder: blinder.to_vec(),
+        derivation_path: None,
+    };
+
+    // Send the request to fetch the pepper
+    utils::print(
+        &format!(
+            "Sending the request to fetch the pepper. Request body: {}",
+            utils::to_string_pretty(&pepper_request)
+        ),
+        false,
+    );
+    let response = request_client
+        .post(pepper_fetch_url)
+        .json(&pepper_request)
+        .send()
+        .await
+        .unwrap();
+
+    // Parse the response
+    let pepper_response = match response.status() {
+        StatusCode::OK => response.json::<PepperResponse>().await.unwrap(),
+        status => {
+            panic!(
+                "Failed to fetch the pepper from the service. Response status: {}",
+                status
+            );
+        },
+    };
+    utils::print(
+        &format!(
+            "Received the pepper response from the service: {}",
+            utils::to_string_pretty(&pepper_response)
+        ),
+        false,
+    );
+
+    pepper_request
+}
+
+/// Step 6: Request a signature from the pepper service for the given pepper request
+async fn request_signature_from_service(
+    request_client: &mut Client,
+    pepper_service_url: &str,
+    pepper_request: &PepperRequest,
+) -> Vec<u8> {
+    let pepper_sig_url = format!("{}{}", pepper_service_url, PEPPER_SERVICE_SIG_URL);
+    utils::print(
+        &format!(
+            "Step 6: Requesting a signature from the pepper service with a POST request to {}.",
+            pepper_sig_url
+        ),
+        true,
+    );
+
+    // Send the request to fetch the signature
+    utils::print(
+        &format!(
+            "Sending the request to fetch the signature. Request body: {}",
+            utils::to_string_pretty(&pepper_request)
+        ),
+        false,
+    );
+    let response = request_client
+        .post(pepper_sig_url)
+        .json(&pepper_request)
+        .send()
+        .await
+        .unwrap();
+
+    // Parse the response
+    let signature_response = match response.status() {
+        StatusCode::OK => response.json::<SignatureResponse>().await.unwrap(),
+        status => {
+            panic!(
+                "Failed to fetch the signature from the service. Response status: {}",
+                status
+            );
+        },
+    };
+    utils::print(
+        &format!(
+            "Received the signature response from the service: {}",
+            utils::to_string_pretty(&signature_response)
+        ),
+        false,
+    );
+
+    // Return the signature
+    let SignatureResponse { signature } = signature_response;
+    signature
+}
+
+/// (Optional) Step 7: Verify the pepper signature using the verification public key, JWT and signature
+fn verify_pepper_signature(
+    verification_public_key: &G2Projective,
+    jwt: String,
+    signature: &[u8],
+) -> PepperInput {
+    utils::print(
+        "(Optional) Step 7: Verifying the pepper signature using the verification public key, JWT and signature.",
+        true,
+    );
+
+    // Parse the claims from the JWT
+    let claims = jwt::parse(&jwt).unwrap();
+    let iss = claims.claims.iss.clone();
+    let uid_key = DEFAULT_UID_KEY.to_string();
+    let uid_val = claims.claims.sub.clone();
+    let aud = claims.claims.aud.clone();
+
+    // Construct the pepper input and serialize it
+    let pepper_input = PepperInput {
+        iss,
+        uid_key,
+        uid_val,
+        aud,
+    };
+    utils::print(
+        &format!(
+            "Constructed the pepper input to verify the signature: {}",
+            utils::to_string_pretty(&pepper_input)
+        ),
+        false,
+    );
+    let pepper_input_bytes = bcs::to_bytes(&pepper_input).unwrap();
+
+    // Verify the pepper service signature over the pepper input
+    vuf::bls12381_g1_bls::Bls12381G1Bls::verify(
+        verification_public_key,
+        &pepper_input_bytes,
+        signature,
+        &[],
+    )
+    .unwrap();
+    utils::print(
+        "The signature over the pepper input was verified successfully!",
+        false,
+    );
+
+    pepper_input
+}
+
+/// (Optional) Step 8: Verify that a firestore entry exists for the given pepper input
+async fn verify_firestore_pepper_entry(
+    pepper_input: PepperInput,
+    google_project_id: String,
+    database_id: String,
+) {
+    utils::print(
+        &format!("(Optional) Step 8: Verifying that a firestore entry exists for the given pepper input. Project ID: {}, Database: {}", google_project_id, database_id),
+        true,
+    );
+
+    // Create the firestore DB client
+    let firestore_db_options = FirestoreDbOptions {
+        google_project_id,
+        database_id,
+        max_retries: 1,
+        firebase_api_url: None,
+    };
+    let firestore_db = FirestoreDb::with_options(firestore_db_options)
+        .await
+        .unwrap();
+
+    // Query the firestore DB for the pepper input entry
+    let docs: Vec<AccountRecoveryDbEntry> = firestore_db
+        .fluent()
+        .select()
+        .fields(paths!(AccountRecoveryDbEntry::{iss, aud, uid_key, uid_val, last_request_unix_ms, first_request_unix_ms_minus_1q, num_requests}))
+        .from(DEFAULT_FIRESTORE_COLLECTION)
+        .filter(|q| {
+            q.for_all([
+                q.field(path!(AccountRecoveryDbEntry::iss))
+                    .eq(pepper_input.iss.clone()),
+                q.field(path!(AccountRecoveryDbEntry::aud))
+                    .eq(pepper_input.aud.clone()),
+                q.field(path!(AccountRecoveryDbEntry::uid_key))
+                    .eq(pepper_input.uid_key.clone()),
+                q.field(path!(AccountRecoveryDbEntry::uid_val))
+                    .eq(pepper_input.uid_val.clone()),
+            ])
+        })
+        .obj()
+        .query()
+        .await
+        .unwrap();
+
+    // Verify that exactly one entry was found
+    match docs.len() {
+        0 => panic!(
+            "No firestore entry found for the given pepper input: {}",
+            utils::to_string_pretty(&pepper_input)
+        ),
+        1 => utils::print(
+            &format!(
+                "Successfully found exactly one firestore entry for the given pepper input: {:?}",
+                docs
+            ),
+            false,
+        ),
+        n => panic!(
+            "Multiple ({}) firestore entries found for the given pepper input!",
+            n
+        ),
+    }
+}

--- a/keyless/pepper/example-client-rust/src/main.rs
+++ b/keyless/pepper/example-client-rust/src/main.rs
@@ -1,239 +1,35 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_crypto::ed25519::{Ed25519PrivateKey, Ed25519PublicKey};
-use aptos_infallible::duration_since_epoch;
-use aptos_keyless_pepper_common::{
-    account_recovery_db::AccountRecoveryDbEntry,
-    jwt,
-    vuf::{self, VUF},
-    PepperInput, PepperRequest, PepperResponse, PepperV0VufPubKey, SignatureResponse,
-};
-use aptos_types::{
-    keyless::{Configuration, OpenIdSig},
-    transaction::authenticator::EphemeralPublicKey,
-};
-use ark_serialize::CanonicalDeserialize;
-use firestore::{path, paths, FirestoreDb, FirestoreDbOptions};
-use reqwest::StatusCode;
-use std::{fs, io::stdin};
+use aptos_keyless_pepper_example_client_rust::run_client_example;
+use clap::Parser;
 
-const TEST_JWT: &str = "eyJhbGciOiJSUzI1NiIsImtpZCI6ImUxYjkzYzY0MDE0NGI4NGJkMDViZjI5NmQ2NzI2MmI2YmM2MWE0ODciLCJ0eXAiOiJKV1QifQ.eyJpc3MiOiJodHRwczovL2FjY291bnRzLmdvb2dsZS5jb20iLCJhenAiOiI0MDc0MDg3MTgxOTIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJhdWQiOiI0MDc0MDg3MTgxOTIuYXBwcy5nb29nbGV1c2VyY29udGVudC5jb20iLCJzdWIiOiIxMTE2Mjc3NzI0NjA3NTIzNDIzMTIiLCJhdF9oYXNoIjoiaG5OWHFJVTZ3dWFPYlVqR05lRVhGQSIsIm5vbmNlIjoiNzQyMDQxODMxNDYwMDk1MDM0MTU3NzQ0MzEzMzY0MTU4OTk0NzYwNTExMjc1MDEwNDIyNjY5MDY3NTc3OTY3NTIyNDAwNjA0OTI0NCIsIm5hbWUiOiJPbGl2ZXIgSGUiLCJnaXZlbl9uYW1lIjoiT2xpdmVyIiwiZmFtaWx5X25hbWUiOiJIZSIsImlhdCI6MTcxNDQ0MTc4MywiZXhwIjoxNzE0NDQ1MzgzfQ.iNeVzp4BTQj2I_WH6UaUOfUBV4Q_wUriV7jWkh1fUqTPSs30jMMSjEDZml8lQ_NUIpivnGvfEHt_rF9rlrsuRur9pTVKRRKhJUNf5avrAujvLzrz-bwdgKXtTY_nmYisNNNQwmFIVP004ICois4DHD7EmO8PI88CzSzdDbl9qAIoxOP3JRKRwU05wK5qkGz6FpYzTYiG50lQCybSzzUN5Lws49ANCAOZiROG5lmszOW41mAbFSd6MUX469uvyMA2ZZ5av9ArKricHJPutGtLoOSWpzKQ_mlCzofVs5tHoMhGgcOFKuhnEVdY4J7TdcV6pZv9Ih5F8MX3-Wz9Iz9O4w";
+#[derive(Parser, Debug)]
+#[command(author, version, about)]
+struct Args {
+    /// The URL of the Pepper Service
+    #[arg(long, default_value = "http://localhost:8000")]
+    pepper_service_url: String,
 
-fn read_line_from_stdin() -> String {
-    let mut line = String::new();
-    stdin().read_line(&mut line).unwrap();
-    line
-}
+    /// The Google project ID used by Firestore
+    #[arg(long)]
+    firestore_google_project_id: String,
 
-fn get_pepper_service_url() -> String {
-    match std::env::var("OIDB_PEPPER_TEST_CLIENT__SERVICE_URL") {
-        Ok(val) => {
-            println!();
-            println!(
-                "Pepper service url found from envvar OIDB_PEPPER_TEST_CLIENT__SERVICE_URL: {}",
-                val
-            );
-            val
-        },
-        Err(_) => {
-            println!();
-            println!("Pepper service url not found from envvar OIDB_PEPPER_SERVICE_URL.");
-            println!("Enter the URL of the targeted pepper service deployment (default: http://localhost:8000):");
-            let raw = read_line_from_stdin().trim().to_string();
-            if raw.is_empty() {
-                "http://localhost:8000".to_string()
-            } else {
-                raw
-            }
-        },
-    }
-}
-
-fn get_jwt_or_path() -> String {
-    println!();
-    println!(
-        "Enter the JWT token (defaults to test token), or a text file path that contains the JWT:"
-    );
-    let user_input = read_line_from_stdin().trim().to_string();
-    if !user_input.is_empty() {
-        user_input
-    } else {
-        println!("Using the test JWT token");
-        TEST_JWT.to_string()
-    }
+    /// The database ID used by Firestore
+    #[arg(long, default_value = "(default)")]
+    firestore_database_id: String,
 }
 
 #[tokio::main]
 async fn main() {
-    // if let Ok(x) = std::env::var("V0_VERIFY") {
-    //     test_v0_verify();
-    // }
-    println!();
-    println!("Starting an interaction with aptos-oidb-pepper-service.");
-    let url = get_pepper_service_url();
-    println!();
-    let vuf_pub_key_url = format!("{url}/v0/vuf-pub-key");
-    let fetch_url = format!("{url}/v0/fetch");
-    let sig_url = format!("{url}/v0/signature");
-    println!();
-    println!(
-        "Action 1: fetch its verification key with a GET request to {}",
-        vuf_pub_key_url
-    );
-    let client = reqwest::Client::new();
-    let response = client
-        .get(vuf_pub_key_url)
-        .send()
-        .await
-        .unwrap()
-        .json::<PepperV0VufPubKey>()
-        .await
-        .unwrap();
-    println!();
-    println!(
-        "response_json={}",
-        serde_json::to_string_pretty(&response).unwrap()
-    );
-    let PepperV0VufPubKey { public_key: vuf_pk } = response;
-    let vuf_pk: ark_bls12_381::G2Projective =
-        ark_bls12_381::G2Affine::deserialize_compressed(vuf_pk.as_slice())
-            .unwrap()
-            .into();
+    // Fetch the command line arguments
+    let args = Args::parse();
 
-    println!();
-    println!("Action 3: generate some random bytes as a blinder.");
-    let blinder: [u8; 31] = [0u8; 31];
-    println!("blinder_hexlified={}", hex::encode(blinder));
-
-    println!();
-    println!("Action 4: decide an expiry unix time.");
-    let epk_expiry_time_secs = duration_since_epoch().as_secs() + 3600;
-    println!("expiry_time_sec={}", epk_expiry_time_secs);
-
-    let esk_bytes =
-        hex::decode("1111111111111111111111111111111111111111111111111111111111111111").unwrap();
-    let serialized: &[u8] = esk_bytes.as_slice();
-    let esk = Ed25519PrivateKey::try_from(serialized).unwrap();
-    let epk = EphemeralPublicKey::ed25519(Ed25519PublicKey::from(&esk));
-    println!("esk_hexlified={}", hex::encode(esk.to_bytes()));
-    println!("epk_hexlified={}", hex::encode(epk.to_bytes()));
-
-    println!();
-    println!("Action 5: compute nonce.");
-    let nonce_str = OpenIdSig::reconstruct_oauth_nonce(
-        blinder.as_slice(),
-        epk_expiry_time_secs,
-        &epk,
-        &Configuration::new_for_devnet(),
+    // Run the client example
+    run_client_example(
+        args.pepper_service_url,
+        args.firestore_google_project_id,
+        args.firestore_database_id,
     )
-    .unwrap();
-    println!("nonce_string={}", nonce_str);
-    println!();
-    println!("Action 6: request a JWT with this nonce. Below are generated example that uses Google OAuth 2.0 Playground:");
-    println!("6.1: Go to https://accounts.google.com/o/oauth2/v2/auth/oauthchooseaccount?redirect_uri=https%3A%2F%2Fdevelopers.google.com%2Foauthplayground&prompt=consent&response_type=code&client_id=407408718192.apps.googleusercontent.com&scope=profile&access_type=offline&service=lso&o2v=2&theme=glif&flowName=GeneralOAuthFlow&nonce={nonce_str}");
-    println!("6.2: Sign in as requested by the web UI");
-    println!("6.3: Once you are signed in to 'OAuth 2.0 Playground' and see a blue button called 'Exchange authorization code for tokens', click it");
-    println!("6.4: You should see some response showing up. Take the value of the field 'id_token' (exclude the double-quotes) and save it to a file");
-    let jwt_or_path = get_jwt_or_path();
-    let jwt = match fs::read_to_string(jwt_or_path.clone()) {
-        Ok(raw_str) => raw_str.trim().to_string(),
-        Err(_) => jwt_or_path,
-    };
-
-    let pepper_request = PepperRequest {
-        jwt: jwt.clone(),
-        epk,
-        exp_date_secs: epk_expiry_time_secs,
-        uid_key: None,
-        epk_blinder: blinder.to_vec(),
-        derivation_path: None,
-    };
-    println!();
-    println!(
-        "Request pepper with a POST to {} and the body being {}",
-        fetch_url,
-        serde_json::to_string_pretty(&pepper_request).unwrap()
-    );
-    let pepper_raw_response = client
-        .post(fetch_url)
-        .json(&pepper_request)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(StatusCode::OK, pepper_raw_response.status());
-    let pepper_response = pepper_raw_response.json::<PepperResponse>().await.unwrap();
-    println!();
-    println!(
-        "pepper_service_response={}",
-        serde_json::to_string_pretty(&pepper_response).unwrap()
-    );
-    let PepperResponse { pepper, address } = pepper_response;
-
-    let signature_raw_response = client
-        .post(sig_url)
-        .json(&pepper_request)
-        .send()
-        .await
-        .unwrap();
-    assert_eq!(StatusCode::OK, signature_raw_response.status());
-    let signature_response = signature_raw_response
-        .json::<SignatureResponse>()
-        .await
-        .unwrap();
-    println!(
-        "signature_response={}",
-        serde_json::to_string_pretty(&signature_response).unwrap()
-    );
-    let SignatureResponse { signature } = signature_response;
-    println!("signature={:?}", hex::encode(signature.clone()));
-    println!("pepper={:?}", hex::encode(pepper.clone()));
-    println!("address={:?}", hex::encode(address.clone()));
-    let claims = jwt::parse(jwt.as_str()).unwrap();
-    println!();
-    println!("Verify the pepper against the server's verification key, part of the JWT, and the actual aud.");
-    let pepper_input = PepperInput {
-        iss: claims.claims.iss.clone(),
-        uid_key: "sub".to_string(),
-        uid_val: claims.claims.sub.clone(),
-        aud: claims.claims.aud.clone(),
-    };
-    let pepper_input_bytes = bcs::to_bytes(&pepper_input).unwrap();
-    vuf::bls12381_g1_bls::Bls12381G1Bls::verify(&vuf_pk, &pepper_input_bytes, &signature, &[])
-        .unwrap();
-    println!("Pepper verification succeeded!");
-
-    println!("Checking firestore records.");
-    let google_project_id = std::env::var("PROJECT_ID").unwrap();
-    let database_id = std::env::var("DATABASE_ID").unwrap();
-    let options = FirestoreDbOptions {
-        google_project_id,
-        database_id,
-        max_retries: 1,
-        firebase_api_url: None,
-    };
-    let db = FirestoreDb::with_options(options).await.unwrap();
-    let docs: Vec<AccountRecoveryDbEntry> = db
-        .fluent()
-        .select()
-        .fields(paths!(AccountRecoveryDbEntry::{iss, aud, uid_key, uid_val, last_request_unix_ms, first_request_unix_ms_minus_1q, num_requests}))
-        .from("accounts")
-        .filter(|q| {
-            q.for_all([
-                q.field(path!(AccountRecoveryDbEntry::iss))
-                    .eq(pepper_input.iss.clone()),
-                q.field(path!(AccountRecoveryDbEntry::aud))
-                    .eq(pepper_input.aud.clone()),
-                q.field(path!(AccountRecoveryDbEntry::uid_key))
-                    .eq(pepper_input.uid_key.clone()),
-                q.field(path!(AccountRecoveryDbEntry::uid_val))
-                    .eq(pepper_input.uid_val.clone()),
-            ])
-        })
-        .obj()
-        .query()
-        .await
-        .unwrap();
-    println!("docs={docs:?}");
-    assert_eq!(1, docs.len());
+    .await;
 }

--- a/keyless/pepper/example-client-rust/src/utils.rs
+++ b/keyless/pepper/example-client-rust/src/utils.rs
@@ -1,0 +1,69 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use crate::{DEFAULT_CLIENT_TIMEOUT_SECS, DEFAULT_JWT};
+use aptos_types::keyless::Configuration;
+use reqwest::Client;
+use serde::Serialize;
+use std::{fs, io::stdin, time::Duration};
+
+/// Creates and returns a new reqwest client
+pub fn create_request_client() -> Client {
+    Client::builder()
+        .timeout(Duration::from_secs(DEFAULT_CLIENT_TIMEOUT_SECS))
+        .build()
+        .unwrap()
+}
+
+/// Fetches the JWT from the user, or uses a test token if no input is provided
+pub fn get_jwt() -> String {
+    // Prompt the user for the token or file path
+    print(
+        "Enter the JWT, or a text file path that contains the JWT. If nothing is entered, \
+    a test token will be used.",
+        true,
+    );
+    let user_input = read_input_from_stdin().trim().to_string();
+
+    // Fetch the JWT or use the test token
+    if !user_input.is_empty() {
+        match fs::read_to_string(user_input.clone()) {
+            Ok(jwt) => {
+                print("Read the JWT from the file!", false);
+                jwt.trim().to_string()
+            },
+            Err(_) => {
+                print("Using the input as the JWT itself!", false);
+                user_input
+            },
+        }
+    } else {
+        print("Using the test JWT token!", false);
+        DEFAULT_JWT.to_string()
+    }
+}
+
+/// Returns a test keyless configuration
+pub fn get_keyless_configuration() -> Configuration {
+    Configuration::new_for_devnet()
+}
+
+/// Prints the given string. If `newline_header` is true, adds an empty line before the string.
+pub fn print(string: &str, newline_header: bool) {
+    if newline_header {
+        println!();
+    }
+    println!("{}", string);
+}
+
+/// Reads a line from stdin and returns it as string
+pub fn read_input_from_stdin() -> String {
+    let mut line = String::new();
+    stdin().read_line(&mut line).unwrap();
+    line.trim().to_string()
+}
+
+/// Serializes a value to a pretty JSON string
+pub fn to_string_pretty<T: ?Sized + Serialize>(value: &T) -> String {
+    serde_json::to_string_pretty(value).unwrap()
+}

--- a/keyless/pepper/scripts/start-pepper-client.sh
+++ b/keyless/pepper/scripts/start-pepper-client.sh
@@ -4,8 +4,8 @@
 set -e
 
 # Check if the required arguments are provided
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <PROJECT_ID>"
+if [ "$#" -ne 5 ]; then
+    echo "Usage: $0 <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <PEPPER_SERVICE_URL> <GOOGLE_PROJECT_ID> <FIRESTORE_DATABASE_ID>"
     exit 1
 fi
 
@@ -16,9 +16,10 @@ export FIRESTORE_EMULATOR_HOST=$1
 # Note: this should point to the service account credential JSON file.
 export GOOGLE_APPLICATION_CREDENTIALS=$2
 
-# Specify the account recovery DB location (passed as the third argument to the script).
-export PROJECT_ID=$3
-export DATABASE_ID='(default)' # the default name of a local firestore emulator
+# Fetch the Google Project ID, Firestore Database ID and Pepper Service URL from the script arguments
+PEPPER_SERVICE_URL=$3
+GOOGLE_PROJECT_ID=$4
+FIRESTORE_DATABASE_ID=$5
 
 # Start the pepper client example
-cargo run -p aptos-keyless-pepper-example-client-rust
+cargo run -p aptos-keyless-pepper-example-client-rust -- --pepper-service-url=${PEPPER_SERVICE_URL} --firestore-google-project-id=${GOOGLE_PROJECT_ID} --firestore-database-id=${FIRESTORE_DATABASE_ID}

--- a/keyless/pepper/scripts/start-pepper-service.sh
+++ b/keyless/pepper/scripts/start-pepper-service.sh
@@ -5,7 +5,7 @@ set -e
 
 # Check if the required arguments are provided
 if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <PROJECT_ID>"
+    echo "Usage: $0 <FIRESTORE_EMULATOR_HOST> <GOOGLE_APPLICATION_CREDENTIALS> <GOOGLE_PROJECT_ID>"
     exit 1
 fi
 


### PR DESCRIPTION
## Description
This PR cleans up the pepper service client example and attempts to make it a little more approachable from a developer perspective, e.g., make the required and optional steps clearer, refactor code into modular groups, standardize flows, use real random number generation, support command line inputs, etc. Outside of cosmetic changes, nothing else should really change.

## Testing Plan
Manual verification (i.e., I re-ran the client example against a local pepper service and verified that the flows worked correctly).