### PR TITLE
[Storage] Set cache_index_and_filter_blocks by default

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5931,20 +5931,18 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.69.4"
+version = "0.72.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+checksum = "4f72209734318d0b619a5e0f5129918b848c416e122a3c4ce054e03cb87b726f"
 dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
+ "itertools 0.13.0",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "shlex",
  "syn 2.0.87",
 ]
@@ -11202,12 +11200,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "lebe"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11347,14 +11339,13 @@ dependencies = [
 
 [[package]]
 name = "librocksdb-sys"
-version = "0.16.0+8.10.0"
+version = "0.17.3+10.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce3d60bc059831dc1c83903fb45c103f75db65c5a7bf22272764d9cc683e348c"
+checksum = "cef2a00ee60fe526157c9023edab23943fae1ce2ab6f4abb2a807c1746835de9"
 dependencies = [
  "bindgen",
  "bzip2-sys",
  "cc",
- "glob",
  "libc",
  "libz-sys",
  "lz4-sys",
@@ -15164,7 +15155,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.23.7",
  "thiserror",
  "tokio",
@@ -15180,7 +15171,7 @@ dependencies = [
  "bytes",
  "rand 0.8.5",
  "ring 0.17.7",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "rustls 0.23.7",
  "slab",
  "thiserror",
@@ -15802,9 +15793,9 @@ dependencies = [
 
 [[package]]
 name = "rocksdb"
-version = "0.22.0"
+version = "0.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd13e55d6d7b8cd0ea569161127567cd587676c99f4472f779a0279aa60a7a7"
+checksum = "ddb7af00d2b17dbd07d82c0063e25411959748ff03e8d4f96134c2ff41fce34f"
 dependencies = [
  "libc",
  "librocksdb-sys",
@@ -15925,6 +15916,12 @@ name = "rustc-hash"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
 
 [[package]]
 name = "rustc-hex"
@@ -17785,7 +17782,7 @@ dependencies = [
  "once_cell",
  "pbkdf2 0.4.0",
  "rand 0.7.3",
- "rustc-hash",
+ "rustc-hash 1.1.0",
  "sha2 0.9.9",
  "thiserror",
  "unicode-normalization",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -740,7 +740,7 @@ reqwest-retry = "0.2.1"
 ring = { version = "0.16.20", features = ["std"] }
 ripemd = "0.1.1"
 rlimit = "0.10.2"
-rocksdb = { version = "0.22.0", features = ["lz4"] }
+rocksdb = { version = "0.24.0", features = ["lz4"] }
 rsa = { version = "0.9.6" }
 rstack-self = { version = "0.3.0", features = ["dw"], default-features = false }
 rstest = "0.15.0"

--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -134,12 +134,12 @@ impl Default for RocksdbConfig {
             // This includes threads for flashing and compaction. Rocksdb will decide the # of
             // threads to use internally.
             max_background_jobs: 16,
-            // Default block cache size is 8MB,
-            block_cache_size: 8 * (1u64 << 20),
+            // Default block cache size is 1GB,
+            block_cache_size: 1 << 30,
             // Default block cache size is 4KB,
             block_size: 4 * (1u64 << 10),
             // Whether cache index and filter blocks into block cache.
-            cache_index_and_filter_blocks: false,
+            cache_index_and_filter_blocks: true,
         }
     }
 }
@@ -165,7 +165,10 @@ impl Default for RocksdbConfigs {
         Self {
             ledger_db_config: RocksdbConfig::default(),
             state_merkle_db_config: RocksdbConfig::default(),
-            state_kv_db_config: RocksdbConfig::default(),
+            state_kv_db_config: RocksdbConfig {
+                block_cache_size: 16 * (1 << 30),
+                ..Default::default()
+            },
             index_db_config: RocksdbConfig {
                 max_open_files: 1000,
                 ..Default::default()

--- a/storage/aptosdb/src/db_debugger/validation.rs
+++ b/storage/aptosdb/src/db_debugger/validation.rs
@@ -118,7 +118,7 @@ pub fn verify_state_kvs(
 ) -> Result<()> {
     println!("Validating db statekeys");
     let storage_dir = StorageDirPaths::from_path(db_root_path);
-    let state_kv_db = StateKvDb::open_sharded(&storage_dir, RocksdbConfig::default(), false)?;
+    let state_kv_db = StateKvDb::open_sharded(&storage_dir, RocksdbConfig::default(), None, false)?;
 
     //read all statekeys from internal db and store them in mem
     let mut all_internal_keys = HashSet::new();

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -24,7 +24,7 @@ use aptos_metrics_core::TimerHelper;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{
     batch::{SchemaBatch, WriteBatch},
-    ReadOptions, DB,
+    Cache, ReadOptions, DB,
 };
 use aptos_storage_interface::Result;
 use aptos_types::{
@@ -68,12 +68,22 @@ impl StateKvDb {
             });
         }
 
-        Self::open_sharded(db_paths, rocksdb_configs.state_kv_db_config, readonly)
+        let block_cache = Cache::new_hyper_clock_cache(
+            rocksdb_configs.state_kv_db_config.block_cache_size as usize,
+            0,
+        );
+        Self::open_sharded(
+            db_paths,
+            rocksdb_configs.state_kv_db_config,
+            Some(&block_cache),
+            readonly,
+        )
     }
 
     pub(crate) fn open_sharded(
         db_paths: &StorageDirPaths,
         state_kv_db_config: RocksdbConfig,
+        block_cache: Option<&Cache>,
         readonly: bool,
     ) -> Result<Self> {
         let state_kv_metadata_db_path =
@@ -83,6 +93,7 @@ impl StateKvDb {
             state_kv_metadata_db_path.clone(),
             STATE_KV_METADATA_DB_NAME,
             &state_kv_db_config,
+            block_cache,
             readonly,
             /* is_hot = */ false,
         )?);
@@ -100,6 +111,7 @@ impl StateKvDb {
                     shard_root_path,
                     shard_id,
                     &state_kv_db_config,
+                    block_cache,
                     readonly,
                     /* is_hot = */ false,
                 )
@@ -124,6 +136,7 @@ impl StateKvDb {
                             shard_root_path,
                             shard_id,
                             &state_kv_db_config,
+                            block_cache,
                             readonly,
                             /* is_hot = */ true,
                         )
@@ -217,6 +230,7 @@ impl StateKvDb {
         let state_kv_db = Self::open_sharded(
             &StorageDirPaths::from_path(db_root_path),
             RocksdbConfig::default(),
+            None,
             false,
         )?;
         let cp_state_kv_db_path = cp_root_path.as_ref().join(STATE_KV_DB_FOLDER_NAME);
@@ -293,6 +307,7 @@ impl StateKvDb {
         db_root_path: P,
         shard_id: usize,
         state_kv_db_config: &RocksdbConfig,
+        block_cache: Option<&Cache>,
         readonly: bool,
         is_hot: bool,
     ) -> Result<DB> {
@@ -305,6 +320,7 @@ impl StateKvDb {
             Self::db_shard_path(db_root_path, shard_id, is_hot),
             &db_name,
             state_kv_db_config,
+            block_cache,
             readonly,
             is_hot,
         )
@@ -314,6 +330,7 @@ impl StateKvDb {
         path: PathBuf,
         name: &str,
         state_kv_db_config: &RocksdbConfig,
+        block_cache: Option<&Cache>,
         readonly: bool,
         is_hot: bool,
     ) -> Result<DB> {
@@ -327,7 +344,7 @@ impl StateKvDb {
             gen_hot_state_kv_shard_cfds
         } else {
             gen_state_kv_shard_cfds
-        }(state_kv_db_config);
+        }(state_kv_db_config, block_cache);
 
         open_func(&rocksdb_opts, path, name, cfds)
     }

--- a/storage/aptosdb/src/state_merkle_db.rs
+++ b/storage/aptosdb/src/state_merkle_db.rs
@@ -25,7 +25,7 @@ use aptos_metrics_core::TimerHelper;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{
     batch::{IntoRawBatch, RawBatch, SchemaBatch, WriteBatch},
-    DB,
+    Cache, DB,
 };
 #[cfg(test)]
 use aptos_scratchpad::get_state_shard_id;
@@ -78,12 +78,16 @@ impl StateMerkleDb {
     ) -> Result<Self> {
         let sharding = rocksdb_configs.enable_storage_sharding;
         let state_merkle_db_config = rocksdb_configs.state_merkle_db_config;
+
         let mut version_caches = HashMap::with_capacity(NUM_STATE_SHARDS + 1);
         version_caches.insert(None, VersionedNodeCache::new());
         for i in 0..NUM_STATE_SHARDS {
             version_caches.insert(Some(i), VersionedNodeCache::new());
         }
         let lru_cache = NonZeroUsize::new(max_nodes_per_lru_cache_shard).map(LruNodeCache::new);
+        let block_cache =
+            Cache::new_hyper_clock_cache(state_merkle_db_config.block_cache_size as usize, 0);
+
         if !sharding {
             info!("Sharded state merkle DB is not enabled!");
             let state_merkle_db_path = db_paths.default_root_path().join(STATE_MERKLE_DB_NAME);
@@ -91,6 +95,7 @@ impl StateMerkleDb {
                 state_merkle_db_path,
                 STATE_MERKLE_DB_NAME,
                 &state_merkle_db_config,
+                &block_cache,
                 readonly,
             )?);
             return Ok(Self {
@@ -105,6 +110,7 @@ impl StateMerkleDb {
         Self::open(
             db_paths,
             state_merkle_db_config,
+            &block_cache,
             readonly,
             version_caches,
             lru_cache,
@@ -553,6 +559,7 @@ impl StateMerkleDb {
     fn open(
         db_paths: &StorageDirPaths,
         state_merkle_db_config: RocksdbConfig,
+        block_cache: &Cache,
         readonly: bool,
         version_caches: HashMap<Option<usize>, VersionedNodeCache>,
         lru_cache: Option<LruNodeCache>,
@@ -566,6 +573,7 @@ impl StateMerkleDb {
             state_merkle_metadata_db_path.clone(),
             STATE_MERKLE_METADATA_DB_NAME,
             &state_merkle_db_config,
+            block_cache,
             readonly,
         )?);
 
@@ -578,11 +586,16 @@ impl StateMerkleDb {
             .into_par_iter()
             .map(|shard_id| {
                 let shard_root_path = db_paths.state_merkle_db_shard_root_path(shard_id);
-                let db =
-                    Self::open_shard(shard_root_path, shard_id, &state_merkle_db_config, readonly)
-                        .unwrap_or_else(|e| {
-                            panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
-                        });
+                let db = Self::open_shard(
+                    shard_root_path,
+                    shard_id,
+                    &state_merkle_db_config,
+                    block_cache,
+                    readonly,
+                )
+                .unwrap_or_else(|e| {
+                    panic!("Failed to open state merkle db shard {shard_id}: {e:?}.")
+                });
                 Arc::new(db)
             })
             .collect::<Vec<_>>()
@@ -615,6 +628,7 @@ impl StateMerkleDb {
         db_root_path: P,
         shard_id: usize,
         state_merkle_db_config: &RocksdbConfig,
+        block_cache: &Cache,
         readonly: bool,
     ) -> Result<DB> {
         let db_name = format!("state_merkle_db_shard_{}", shard_id);
@@ -622,6 +636,7 @@ impl StateMerkleDb {
             Self::db_shard_path(db_root_path, shard_id),
             &db_name,
             state_merkle_db_config,
+            block_cache,
             readonly,
         )
     }
@@ -630,6 +645,7 @@ impl StateMerkleDb {
         path: PathBuf,
         name: &str,
         state_merkle_db_config: &RocksdbConfig,
+        block_cache: &Cache,
         readonly: bool,
     ) -> Result<DB> {
         Ok(if readonly {
@@ -637,14 +653,14 @@ impl StateMerkleDb {
                 &gen_rocksdb_options(state_merkle_db_config, true),
                 path,
                 name,
-                gen_state_merkle_cfds(state_merkle_db_config),
+                gen_state_merkle_cfds(state_merkle_db_config, Some(block_cache)),
             )?
         } else {
             DB::open_cf(
                 &gen_rocksdb_options(state_merkle_db_config, false),
                 path,
                 name,
-                gen_state_merkle_cfds(state_merkle_db_config),
+                gen_state_merkle_cfds(state_merkle_db_config, Some(block_cache)),
             )?
         })
     }


### PR DESCRIPTION

I'm not sure the current configuration makes a lot of sense in terms of memory
management.

`max_open_files = 5000` is quite high. Given that this limit is per database and
we have at least 40~50 of them (16 state kv shards, 16 state merkle shards,
etc), we probably rarely hit this limit. So the files remain open once they are
touched.

In addition, we have `cache_index_and_filter_blocks = false`.

The combination of these means that index/filter blocks also stay in memory
forever once they are loaded, even if they are just used once and never touched
again. Therefore, we can waste quite some memory on unused things. We can verify
this by looking at some full nodes that are running at 30~50GB RSS: the stats
show that `rocksdb.estimate-table-readers-mem` is a major contributor, often
more than 70%. See https://gist.github.com/wqfish/4b2b3bccba6466d31ab7732524967ed6
for an example.

This change puts index/filter blocks in the block cache, so the unused ones can
be evicted when the cache is full. I think for now the numbers are relatively
conservative, and we might able to reduce them further. Also we are using
separate caches for different things (bigger ones for each state kv shard and
smaller ones for everything else), but we can also consider experimenting with
using a single big cache for everything, so it's even easier to manage.
