### PR TITLE
[compiler-v2] Adding unit test for peephole optimizer

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/optimizers.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/peephole_optimizer/optimizers.rs
@@ -7,6 +7,7 @@ use move_binary_format::file_format::{Bytecode, CodeOffset};
 
 /// A contiguous chunk of bytecode that may have been transformed from some
 /// other "original" contiguous chunk of bytecode.
+#[derive(PartialEq, Eq)]
 pub struct TransformedCodeChunk {
     /// The transformed bytecode.
     pub code: Vec<Bytecode>,


### PR DESCRIPTION
## Description

In this PR, we add a unit test for peephole optimization (for both the code transformation and offset remapping calculation used for source locations).

While the peephole optimization itself is reasonably well tested with compiler end-to-end tests and transactional tests, the location transformation was not explicitly tested, which this PR addresses.

The added unit test triggers multiple peephole optimizations in multiple passes and multiple basic block merges. It fails before the bug fix in #17403, but passes now.

## How Has This Been Tested?

Adds a new test.

## Type of Change
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
