### PR TITLE
Set jemalloc dependencies in workspace

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -642,6 +642,12 @@ inferno = "0.11.14"
 internment = { version = "0.5.0", features = ["arc"] }
 ipnet = "2.5.0"
 itertools = "0.13"
+jemallocator = { version = "0.5.4", features = [
+    "profiling",
+    "unprefixed_malloc_on_supported_platforms",
+] }
+jemalloc-ctl = "0.5.4"
+jemalloc-sys = "0.5.4"
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
 jwt = "0.16.0"

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -82,10 +82,7 @@ ureq = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 rstack-self = { workspace = true }

--- a/crates/aptos-admin-service/Cargo.toml
+++ b/crates/aptos-admin-service/Cargo.toml
@@ -33,5 +33,5 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemalloc-ctl = "0.5.4"
-jemalloc-sys = "0.5.4"
+jemalloc-ctl = { workspace = true }
+jemalloc-sys = { workspace = true }

--- a/crates/aptos-debugger/Cargo.toml
+++ b/crates/aptos-debugger/Cargo.toml
@@ -23,7 +23,4 @@ clap = { workspace = true }
 tokio = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/crates/aptos-profiler/Cargo.toml
+++ b/crates/aptos-profiler/Cargo.toml
@@ -18,9 +18,6 @@ regex = { workspace = true }
 [target.'cfg(unix)'.dependencies]
 pprof = { workspace = true }
 backtrace = { workspace = true }
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
-jemalloc-sys = "0.5.4"
+jemallocator = { workspace = true }
+jemalloc-sys = { workspace = true }
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -111,10 +111,7 @@ tracing-subscriber = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [features]
 default = []

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/Cargo.toml
@@ -33,10 +33,7 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [dev-dependencies]
 aptos-config = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/Cargo.toml
@@ -38,7 +38,4 @@ uuid = { workspace = true }
 warp = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/Cargo.toml
@@ -37,7 +37,4 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-file-checker/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-checker/Cargo.toml
@@ -27,7 +27,4 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store-backfiller/Cargo.toml
@@ -28,7 +28,4 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-file-store/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-file-store/Cargo.toml
@@ -28,7 +28,4 @@ tokio = { workspace = true }
 tracing = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-in-memory-cache-benchmark/Cargo.toml
@@ -23,7 +23,4 @@ redis-test = { workspace = true }
 tokio = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-manager/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-manager/Cargo.toml
@@ -39,7 +39,4 @@ aptos-config = { workspace = true }
 serde_json = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-v2-file-store-backfiller/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-v2-file-store-backfiller/Cargo.toml
@@ -29,7 +29,4 @@ tracing = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }

--- a/execution/block-partitioner/Cargo.toml
+++ b/execution/block-partitioner/Cargo.toml
@@ -32,10 +32,7 @@ serde = { workspace = true }
 criterion = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [features]
 default = []

--- a/execution/executor-benchmark/Cargo.toml
+++ b/execution/executor-benchmark/Cargo.toml
@@ -64,10 +64,7 @@ toml = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
 aptos-profiler = { workspace = true }
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [dev-dependencies]
 aptos-temppath = { workspace = true }

--- a/experimental/storage/hexy/Cargo.toml
+++ b/experimental/storage/hexy/Cargo.toml
@@ -28,10 +28,7 @@ proptest = { workspace = true }
 rand = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [[bench]]
 name = "sort_dedup"

--- a/experimental/storage/layered-map/Cargo.toml
+++ b/experimental/storage/layered-map/Cargo.toml
@@ -33,10 +33,7 @@ rand = { workspace = true }
 rocksdb = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [lib]
 bench = false

--- a/storage/scratchpad/Cargo.toml
+++ b/storage/scratchpad/Cargo.toml
@@ -36,10 +36,7 @@ proptest = { workspace = true }
 rand = { workspace = true }
 
 [target.'cfg(unix)'.dev-dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [features]
 fuzzing = ["aptos-types/fuzzing", "proptest"]

--- a/testsuite/forge-cli/Cargo.toml
+++ b/testsuite/forge-cli/Cargo.toml
@@ -38,10 +38,7 @@ tokio = { workspace = true }
 url = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-jemallocator = { version = "0.5.0", features = [
-    "profiling",
-    "unprefixed_malloc_on_supported_platforms",
-] }
+jemallocator = { workspace = true }
 
 [[bin]]
 name = "forge"


### PR DESCRIPTION

It seems like we can set it in workspace just like other dependencies.

No changes to `Cargo.lock`.
