### PR TITLE
[gha] add retry to get-latest-docker-image-tag

### DIFF
--- a/.github/actions/get-latest-docker-image-tag/action.yml
+++ b/.github/actions/get-latest-docker-image-tag/action.yml
@@ -23,18 +23,23 @@ runs:
         ref: ${{ inputs.branch }}
         path: checkout_branch
         fetch-depth: 0
+
     - uses: ./checkout_branch/.github/actions/python-setup # use python-setup from that branch
       with:
         pyproject_directory: checkout_branch/testsuite
+
     - name: Determine image tag
       id: determine-test-image-tag
-      # Forge relies on the default and failpoints variants
-      run: |
-        variants=(${{ inputs.variants }}) # split the variants string into an array
-        variants_args=()
-        for variant in "${variants[@]}"; do
-          variants_args+=("--variant" "$variant")
-        done
-        ./testrun find_latest_image.py "${variants_args[@]}"
-      shell: bash
       working-directory: checkout_branch/testsuite # the checkout_branch is a subdirectory
+      uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3.0.2
+      with:
+        max_attempts: 5
+        timeout_minutes: 20
+        command: |
+          cd checkout_branch/testsuite
+          variants=(${{ inputs.variants }}) # split the variants string into an array
+          variants_args=()
+          for variant in "${variants[@]}"; do
+            variants_args+=("--variant" "$variant")
+          done
+          ./testrun find_latest_image.py "${variants_args[@]}"

--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -52,7 +52,7 @@ jobs:
           poetry_version: 2.1.2
 
       # Run CLI tests against local testnet built from devnet branch.
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3.0.2
         if: ${{ !inputs.SKIP_JOB }}
         name: devnet-tests
         with:
@@ -61,7 +61,7 @@ jobs:
           command: cd ./crates/aptos/e2e && poetry run python main.py -d --base-network devnet --image-repo-with-project ${{ vars.GCP_DOCKER_ARTIFACT_REPO }} --test-cli-tag ${{ inputs.GIT_SHA }} --working-directory ${{ runner.temp }}/aptos-e2e-tests-devnet
 
       # Run CLI tests against local testnet built from testnet branch.
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3.0.2
         if: ${{ !inputs.SKIP_JOB }}
         name: testnet-tests
         with:
@@ -70,7 +70,7 @@ jobs:
           command: cd ./crates/aptos/e2e && poetry run python main.py -d --base-network testnet --image-repo-with-project ${{ vars.GCP_DOCKER_ARTIFACT_REPO }} --test-cli-tag ${{ inputs.GIT_SHA }} --working-directory ${{ runner.temp }}/aptos-e2e-tests-testnet
 
       # Run CLI tests against local testnet built from mainnet branch.
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3.0.2
         if: ${{ !inputs.SKIP_JOB }}
         name: mainnet-tests
         with:

--- a/.github/workflows/forge-stable.yaml
+++ b/.github/workflows/forge-stable.yaml
@@ -3,6 +3,7 @@ name: Continuous Forge Tests - Stable
 
 # We have various Forge Stable tests here, that test out different situations and workloads.
 #
+#
 # Dashboard showing historical results: https://grafana.aptoslabs.com/d/bdnt45ggsg000f/forge-stable-performance?orgId=1
 
 # Tests are named based on how they are set up, some of the common flavors are:
@@ -121,7 +122,7 @@ on:
       - "testsuite/find_latest_image.py"
 
 concurrency:
-  group: forge-stable-${{ format('{0}-{1}-{2}-{3}', github.ref_name, inputs.GIT_SHA, inputs.IMAGE_TAG, inputs.TEST_NAME) }}
+  group: forge-stable-${{ format('{0}-{1}-{2}-{3}', github.ref_name, inputs.GIT_SHA || github.sha || github.head_ref || github.ref, inputs.IMAGE_TAG, inputs.TEST_NAME) }}
   cancel-in-progress: true
 
 env:

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -83,7 +83,7 @@ jobs:
         if: ${{ !inputs.SKIP_JOB }}
 
       # Build the API specs.
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3.0.2
         if: ${{ !inputs.SKIP_JOB }}
         name: generate-yaml-spec
         with:
@@ -91,7 +91,7 @@ jobs:
           timeout_minutes: 20
           command: docker run --rm --mount=type=bind,source=${{ runner.temp }}/specs,target=/specs ${{ vars.GCP_DOCKER_ARTIFACT_REPO }}/tools:${IMAGE_TAG} aptos-openapi-spec-generator -f yaml -o /specs/spec.yaml
 
-      - uses: nick-fields/retry@7f8f3d9f0f62fe5925341be21c2e8314fd4f7c7c # pin@v2
+      - uses: nick-fields/retry@ce71cc2ab81d554ebbe88c79ab5975992d79ba08 # pin@v3.0.2
         if: ${{ !inputs.SKIP_JOB }}
         name: generate-json-spec
         with:


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

`get-latest-docker-image-tag` sometimes times out. Add a simple retry

Example failure:
https://github.com/aptos-labs/aptos-core/actions/runs/17309005899/attempts/1

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Workflows run on PR that use that composite action

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
