### PR TITLE
Update jemalloc crates to tikv-jemalloc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -360,7 +360,6 @@ dependencies = [
  "hex",
  "indoc",
  "itertools 0.13.0",
- "jemallocator",
  "legacy-move-compiler",
  "maplit",
  "move-asm",
@@ -396,6 +395,7 @@ dependencies = [
  "shadow-rs",
  "tempfile",
  "thiserror",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.7.8",
  "tracing",
@@ -445,9 +445,9 @@ dependencies = [
  "futures-channel",
  "http 0.2.11",
  "hyper 0.14.28",
- "jemalloc-ctl",
- "jemalloc-sys",
  "sha256",
+ "tikv-jemalloc-ctl",
+ "tikv-jemalloc-sys",
  "tokio",
  "url",
 ]
@@ -764,12 +764,12 @@ dependencies = [
  "criterion",
  "dashmap 7.0.0-rc2",
  "itertools 0.13.0",
- "jemallocator",
  "move-core-types",
  "once_cell",
  "rand 0.7.3",
  "rayon",
  "serde",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1335,7 +1335,7 @@ dependencies = [
  "aptos-move-debugger",
  "aptos-push-metrics",
  "clap 4.5.21",
- "jemallocator",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -1559,7 +1559,6 @@ dependencies = [
  "derivative",
  "indicatif 0.15.0",
  "itertools 0.13.0",
- "jemallocator",
  "move-core-types",
  "move-vm-types",
  "num_cpus",
@@ -1568,6 +1567,7 @@ dependencies = [
  "rayon",
  "serde",
  "thread_local",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.7.8",
 ]
@@ -1682,10 +1682,10 @@ dependencies = [
  "aptos-metrics-core",
  "criterion",
  "itertools 0.13.0",
- "jemallocator",
  "once_cell",
  "proptest",
  "rand 0.7.3",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1703,11 +1703,11 @@ dependencies = [
  "bitvec 1.0.1",
  "criterion",
  "itertools 0.13.0",
- "jemallocator",
  "once_cell",
  "proptest",
  "rand 0.7.3",
  "rocksdb",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -1912,7 +1912,6 @@ dependencies = [
  "clap 4.5.21",
  "env_logger",
  "futures",
- "jemallocator",
  "once_cell",
  "rand 0.7.3",
  "random_word",
@@ -1920,6 +1919,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "sugars",
+ "tikv-jemallocator",
  "tokio",
  "url",
 ]
@@ -2179,13 +2179,13 @@ dependencies = [
  "clap 4.5.21",
  "futures",
  "futures-core",
- "jemallocator",
  "once_cell",
  "prost 0.13.4",
  "redis",
  "reqwest 0.11.23",
  "serde",
  "tempfile",
+ "tikv-jemallocator",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -2206,13 +2206,13 @@ dependencies = [
  "async-trait",
  "clap 4.5.21",
  "futures",
- "jemallocator",
  "once_cell",
  "prost 0.13.4",
  "redis",
  "rstest",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tonic 0.12.3",
@@ -2236,11 +2236,11 @@ dependencies = [
  "clap 4.5.21",
  "dashmap 7.0.0-rc2",
  "futures",
- "jemallocator",
  "once_cell",
  "prost 0.13.4",
  "rand 0.7.3",
  "serde",
+ "tikv-jemallocator",
  "tokio",
  "tokio-scoped",
  "tokio-stream",
@@ -2262,10 +2262,10 @@ dependencies = [
  "async-trait",
  "clap 4.5.21",
  "cloud-storage",
- "jemallocator",
  "once_cell",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -2282,10 +2282,10 @@ dependencies = [
  "async-trait",
  "clap 4.5.21",
  "futures",
- "jemallocator",
  "once_cell",
  "redis",
  "serde",
+ "tikv-jemallocator",
  "tokio",
  "tracing",
 ]
@@ -2301,9 +2301,9 @@ dependencies = [
  "async-trait",
  "clap 4.5.21",
  "futures",
- "jemallocator",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tonic 0.12.3",
  "tracing",
@@ -2371,11 +2371,11 @@ dependencies = [
  "aptos-indexer-grpc-utils",
  "aptos-protos 1.3.1",
  "futures",
- "jemallocator",
  "lazy_static",
  "once_cell",
  "redis",
  "redis-test",
+ "tikv-jemallocator",
  "tokio",
 ]
 
@@ -2394,12 +2394,12 @@ dependencies = [
  "clap 4.5.21",
  "dashmap 7.0.0-rc2",
  "futures",
- "jemallocator",
  "once_cell",
  "prost 0.13.4",
  "rand 0.7.3",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tokio-scoped",
  "tonic 0.12.3",
@@ -2507,9 +2507,9 @@ dependencies = [
  "async-trait",
  "clap 4.5.21",
  "futures",
- "jemallocator",
  "serde",
  "serde_json",
+ "tikv-jemallocator",
  "tokio",
  "tokio-scoped",
  "tonic 0.12.3",
@@ -3418,7 +3418,6 @@ dependencies = [
  "fail",
  "futures",
  "hex",
- "jemallocator",
  "num_cpus",
  "rand 0.7.3",
  "rayon",
@@ -3427,6 +3426,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml 0.8.26",
+ "tikv-jemallocator",
  "tokio",
  "ureq",
  "url",
@@ -3609,11 +3609,9 @@ name = "aptos-profiler"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "backtrace",
- "jemalloc-sys",
- "jemallocator",
  "pprof",
  "regex",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -3958,12 +3956,12 @@ dependencies = [
  "criterion",
  "dashmap 7.0.0-rc2",
  "itertools 0.13.0",
- "jemallocator",
  "once_cell",
  "proptest",
  "rand 0.7.3",
  "rayon",
  "thiserror",
+ "tikv-jemallocator",
 ]
 
 [[package]]
@@ -10839,24 +10837,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1a46d1a171d865aa5f83f92695765caa047a9b4cbae2cbf37dbd613a793fd4c"
 
 [[package]]
-name = "jemalloc-ctl"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cffc705424a344c054e135d12ee591402f4539245e8bbd64e6c9eaa9458b63c"
-dependencies = [
- "jemalloc-sys",
- "libc",
- "paste",
-]
-
-[[package]]
 name = "jemalloc-sys"
 version = "0.5.4+5.3.0-patched"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac6c1946e1cea1788cbfde01c993b52a10e2da07f4bac608228d1bed20bfebf2"
+source = "git+https://github.com/aptos-labs/jemalloc-sys-shim?rev=e0920246dd74303fab9a14b990768c6ac990a59b#e0920246dd74303fab9a14b990768c6ac990a59b"
 dependencies = [
- "cc",
- "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]
@@ -17761,6 +17746,37 @@ dependencies = [
  "flate2",
  "jpeg-decoder",
  "weezl",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -642,12 +642,12 @@ inferno = "0.11.14"
 internment = { version = "0.5.0", features = ["arc"] }
 ipnet = "2.5.0"
 itertools = "0.13"
-jemallocator = { version = "0.5.4", features = [
+jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "profiling",
     "unprefixed_malloc_on_supported_platforms",
 ] }
-jemalloc-ctl = "0.5.4"
-jemalloc-sys = "0.5.4"
+jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.0" }
+jemalloc-sys = { package = "tikv-jemalloc-sys", version = "0.6.0" }
 json-patch = "0.2.6"
 jsonwebtoken = "8.1"
 jwt = "0.16.0"
@@ -937,3 +937,8 @@ futures-sink = { git = "https://github.com/aptos-labs/futures-rs", branch = "bac
 futures-io = { git = "https://github.com/aptos-labs/futures-rs", branch = "backport" }
 futures-task = { git = "https://github.com/aptos-labs/futures-rs", branch = "backport" }
 futures-macro = { git = "https://github.com/aptos-labs/futures-rs", branch = "backport" }
+
+# There is a circular dependency between aptos-core, aptos-indexer-processor-sdk, and aptos-indexer-processors-v2,
+# so we cannot simply change the version and package for `jemalloc-sys` in one repo without running into conflicts.
+# We have to keep this shim until everything uses the same jemalloc dependency.
+jemalloc-sys = { git = "https://github.com/aptos-labs/jemalloc-sys-shim", rev = "e0920246dd74303fab9a14b990768c6ac990a59b" }

--- a/crates/aptos-profiler/Cargo.toml
+++ b/crates/aptos-profiler/Cargo.toml
@@ -16,8 +16,5 @@ anyhow = { workspace = true }
 regex = { workspace = true }
 
 [target.'cfg(unix)'.dependencies]
-pprof = { workspace = true }
-backtrace = { workspace = true }
-jemallocator = { workspace = true }
 jemalloc-sys = { workspace = true }
-
+pprof = { workspace = true }


### PR DESCRIPTION

I wanted to run a quick test with rocksdb's `jemalloc` feature, but realized
that `librocksdb-sys` has switched to `tikv-jemalloc-sys` a long time ago, which
conflicts with our `jemalloc-sys` dependency. It does seem like `tikv-jemalloc`
is a more "proper" version of `jemalloc`, so we can switch to that.

The upgrade turned out to be pretty tricky due to the circular dependencies, so
I had to create a shim crate and use that until all the repos have been changed.
