### PR TITLE
[Storage] Use thread local counters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3937,7 +3937,6 @@ dependencies = [
  "aptos-temppath",
  "byteorder",
  "dunce",
- "once_cell",
  "proptest",
  "rand 0.7.3",
  "rocksdb",

--- a/storage/aptosdb/src/metrics.rs
+++ b/storage/aptosdb/src/metrics.rs
@@ -3,9 +3,9 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{
-    exponential_buckets, register_histogram_vec, register_int_counter, register_int_counter_vec,
-    register_int_gauge, register_int_gauge_vec, HistogramVec, IntCounter, IntCounterVec, IntGauge,
-    IntGaugeVec,
+    exponential_buckets, make_thread_local_histogram_vec, make_thread_local_int_counter_vec,
+    register_histogram_vec, register_int_counter, register_int_gauge, register_int_gauge_vec,
+    HistogramVec, IntCounter, IntGauge, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
@@ -130,18 +130,17 @@ pub static OTHER_TIMERS_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static NODE_CACHE_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_storage_node_cache_seconds",
-        // metric description
-        "Latency of node cache.",
-        // metric labels (dimensions)
-        &["tag", "name"],
-        exponential_buckets(/*start=*/ 1e-9, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    NODE_CACHE_SECONDS,
+    // metric name
+    "aptos_storage_node_cache_seconds",
+    // metric description
+    "Latency of node cache.",
+    // metric labels (dimensions)
+    &["tag", "name"],
+    exponential_buckets(/*start=*/ 1e-9, /*factor=*/ 2.0, /*count=*/ 30).unwrap(),
+);
 
 /// Rocksdb metrics
 pub static ROCKSDB_PROPERTIES: Lazy<IntGaugeVec> = Lazy::new(|| {
@@ -243,14 +242,13 @@ pub static GAUGE: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!("aptos_storage_gauge", "Various gauges", &["name"]).unwrap()
 });
 
-pub static COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        // metric name
-        "aptos_storage_counter",
-        // metric description
-        "Various counters for Aptos DB / storage.",
-        // metric labels (dimensions)
-        &["name"],
-    )
-    .unwrap()
-});
+make_thread_local_int_counter_vec!(
+    pub,
+    COUNTER,
+    // metric name
+    "aptos_storage_counter",
+    // metric description
+    "Various counters for Aptos DB / storage.",
+    // metric labels (dimensions)
+    &["name"],
+);

--- a/storage/jellyfish-merkle/src/lib.rs
+++ b/storage/jellyfish-merkle/src/lib.rs
@@ -86,7 +86,7 @@ pub mod test_helper;
 use crate::metrics::{APTOS_JELLYFISH_LEAF_COUNT, APTOS_JELLYFISH_LEAF_DELETION_COUNT, COUNTER};
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
-use aptos_metrics_core::IntCounterVecHelper;
+use aptos_metrics_core::{IntCounterHelper, IntCounterVecHelper};
 use aptos_storage_interface::{db_ensure as ensure, db_other_bail, AptosDbError, Result};
 use aptos_types::{
     nibble::{nibble_path::NibblePath, Nibble, ROOT_NIBBLE_HEIGHT},

--- a/storage/jellyfish-merkle/src/metrics.rs
+++ b/storage/jellyfish-merkle/src/metrics.rs
@@ -3,8 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{
-    register_int_counter, register_int_counter_vec, register_int_gauge, IntCounter, IntCounterVec,
-    IntGauge,
+    make_thread_local_int_counter, make_thread_local_int_counter_vec, register_int_counter,
+    register_int_gauge, IntCounter, IntGauge,
 };
 use once_cell::sync::Lazy;
 
@@ -32,22 +32,20 @@ pub static APTOS_JELLYFISH_LEAF_COUNT: Lazy<IntGauge> = Lazy::new(|| {
     .unwrap()
 });
 
-pub static APTOS_JELLYFISH_LEAF_DELETION_COUNT: Lazy<IntCounter> = Lazy::new(|| {
-    register_int_counter!(
-        "aptos_jellyfish_leaf_deletion_count",
-        "The number of deletions happened in JMT."
-    )
-    .unwrap()
-});
+make_thread_local_int_counter!(
+    pub,
+    APTOS_JELLYFISH_LEAF_DELETION_COUNT,
+    "aptos_jellyfish_leaf_deletion_count",
+    "The number of deletions happened in JMT."
+);
 
-pub static COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        // metric name
-        "aptos_jellyfish_counter",
-        // metric description
-        "Various counters for the JellyfishMerkleTree",
-        // metric labels (dimensions)
-        &["name"],
-    )
-    .unwrap()
-});
+make_thread_local_int_counter_vec!(
+    pub,
+    COUNTER,
+    // metric name
+    "aptos_jellyfish_counter",
+    // metric description
+    "Various counters for the JellyfishMerkleTree",
+    // metric labels (dimensions)
+    &["name"],
+);

--- a/storage/schemadb/Cargo.toml
+++ b/storage/schemadb/Cargo.toml
@@ -19,7 +19,6 @@ aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
 aptos-storage-interface = { workspace = true }
 dunce = { workspace = true }
-once_cell = { workspace = true }
 proptest = { workspace = true, optional = true }
 rand = { workspace = true }
 rocksdb = { workspace = true }

--- a/storage/schemadb/src/batch.rs
+++ b/storage/schemadb/src/batch.rs
@@ -174,7 +174,8 @@ impl WriteBatch for SchemaBatch {
 
 impl IntoRawBatch for SchemaBatch {
     fn into_raw_batch(self, db: &DB) -> DbResult<RawBatch> {
-        let _timer = TIMER.timer_with(&["schema_batch_to_raw_batch", &db.name]);
+        let labels = ["schema_batch_to_raw_batch", &db.name];
+        let _timer = TIMER.timer_with(&labels);
 
         let Self { rows, stats } = self;
 

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -265,7 +265,8 @@ impl DB {
     }
 
     fn write_schemas_inner(&self, batch: impl IntoRawBatch, option: &WriteOptions) -> DbResult<()> {
-        let _timer = APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS.timer_with(&[&self.name]);
+        let labels = [self.name.as_str()];
+        let _timer = APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS.timer_with(&labels);
 
         let raw_batch = batch.into_raw_batch(self)?;
 

--- a/storage/schemadb/src/metrics.rs
+++ b/storage/schemadb/src/metrics.rs
@@ -3,126 +3,114 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_metrics_core::{
-    exponential_buckets, register_histogram_vec, register_int_counter_vec, HistogramVec,
-    IntCounterVec,
+    exponential_buckets, make_thread_local_histogram_vec, make_thread_local_int_counter_vec,
 };
-use once_cell::sync::Lazy;
 
-pub static APTOS_SCHEMADB_SEEK_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_seek_latency_seconds",
-        // metric description
-        "Aptos schemadb seek latency in seconds",
-        // metric labels (dimensions)
-        &["cf_name", "tag"],
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_SEEK_LATENCY_SECONDS,
+    // metric name
+    "aptos_schemadb_seek_latency_seconds",
+    // metric description
+    "Aptos schemadb seek latency in seconds",
+    // metric labels (dimensions)
+    &["cf_name", "tag"],
+    exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
+);
 
-pub static APTOS_SCHEMADB_ITER_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_iter_latency_seconds",
-        // metric description
-        "Aptos schemadb iter latency in seconds",
-        // metric labels (dimensions)
-        &["cf_name"],
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_ITER_LATENCY_SECONDS,
+    // metric name
+    "aptos_schemadb_iter_latency_seconds",
+    // metric description
+    "Aptos schemadb iter latency in seconds",
+    // metric labels (dimensions)
+    &["cf_name"],
+    exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
+);
 
-pub static APTOS_SCHEMADB_ITER_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_iter_bytes",
-        // metric description
-        "Aptos schemadb iter size in bytes",
-        // metric labels (dimensions)
-        &["cf_name"]
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_ITER_BYTES,
+    // metric name
+    "aptos_schemadb_iter_bytes",
+    // metric description
+    "Aptos schemadb iter size in bytes",
+    // metric labels (dimensions)
+    &["cf_name"]
+);
 
-pub static APTOS_SCHEMADB_GET_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_get_latency_seconds",
-        // metric description
-        "Aptos schemadb get latency in seconds",
-        // metric labels (dimensions)
-        &["cf_name"],
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_GET_LATENCY_SECONDS,
+    // metric name
+    "aptos_schemadb_get_latency_seconds",
+    // metric description
+    "Aptos schemadb get latency in seconds",
+    // metric labels (dimensions)
+    &["cf_name"],
+    exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
+);
 
-pub static APTOS_SCHEMADB_GET_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_get_bytes",
-        // metric description
-        "Aptos schemadb get call returned data size in bytes",
-        // metric labels (dimensions)
-        &["cf_name"]
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_GET_BYTES,
+    // metric name
+    "aptos_schemadb_get_bytes",
+    // metric description
+    "Aptos schemadb get call returned data size in bytes",
+    // metric labels (dimensions)
+    &["cf_name"]
+);
 
-pub static APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_batch_commit_latency_seconds",
-        // metric description
-        "Aptos schemadb schema batch commit latency in seconds",
-        // metric labels (dimensions)
-        &["db_name"],
-        exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 20).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_BATCH_COMMIT_LATENCY_SECONDS,
+    // metric name
+    "aptos_schemadb_batch_commit_latency_seconds",
+    // metric description
+    "Aptos schemadb schema batch commit latency in seconds",
+    // metric labels (dimensions)
+    &["db_name"],
+    exponential_buckets(/*start=*/ 1e-3, /*factor=*/ 2.0, /*count=*/ 20).unwrap(),
+);
 
-pub static APTOS_SCHEMADB_BATCH_COMMIT_BYTES: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_batch_commit_bytes",
-        // metric description
-        "Aptos schemadb schema batch commit size in bytes",
-        // metric labels (dimensions)
-        &["db_name"]
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_BATCH_COMMIT_BYTES,
+    // metric name
+    "aptos_schemadb_batch_commit_bytes",
+    // metric description
+    "Aptos schemadb schema batch commit size in bytes",
+    // metric labels (dimensions)
+    &["db_name"]
+);
 
-pub static APTOS_SCHEMADB_PUT_BYTES_SAMPLED: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        // metric name
-        "aptos_schemadb_put_bytes_sampled",
-        // metric description
-        "Aptos schemadb put call puts data size in bytes (sampled)",
-        // metric labels (dimensions)
-        &["cf_name"]
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    APTOS_SCHEMADB_PUT_BYTES_SAMPLED,
+    // metric name
+    "aptos_schemadb_put_bytes_sampled",
+    // metric description
+    "Aptos schemadb put call puts data size in bytes (sampled)",
+    // metric labels (dimensions)
+    &["cf_name"]
+);
 
-pub static APTOS_SCHEMADB_DELETES_SAMPLED: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        "aptos_storage_deletes_sampled",
-        "Aptos storage delete calls (sampled)",
-        &["cf_name"]
-    )
-    .unwrap()
-});
+make_thread_local_int_counter_vec!(
+    pub,
+    APTOS_SCHEMADB_DELETES_SAMPLED,
+    "aptos_storage_deletes_sampled",
+    "Aptos storage delete calls (sampled)",
+    &["cf_name"]
+);
 
-pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "aptos_schema_db_timer_seconds",
-        "Various timers for performance analysis.",
-        &["name", "sub_name"],
-        exponential_buckets(/*start=*/ 1e-9, /*factor=*/ 2.0, /*count=*/ 32).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    TIMER,
+    "aptos_schema_db_timer_seconds",
+    "Various timers for performance analysis.",
+    &["name", "sub_name"],
+    exponential_buckets(/*start=*/ 1e-9, /*factor=*/ 2.0, /*count=*/ 32).unwrap(),
+);

--- a/storage/scratchpad/src/sparse_merkle/metrics.rs
+++ b/storage/scratchpad/src/sparse_merkle/metrics.rs
@@ -5,19 +5,18 @@
 #![forbid(unsafe_code)]
 
 use aptos_metrics_core::{
-    exponential_buckets, register_histogram_vec, register_int_gauge_vec, HistogramVec, IntGaugeVec,
+    exponential_buckets, make_thread_local_histogram_vec, register_int_gauge_vec, IntGaugeVec,
 };
 use once_cell::sync::Lazy;
 
-pub static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "aptos_scratchpad_smt_timer_seconds",
-        "Various timers for performance analysis.",
-        &["name"],
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub,
+    TIMER,
+    "aptos_scratchpad_smt_timer_seconds",
+    "Various timers for performance analysis.",
+    &["name"],
+    exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
+);
 
 pub static GENERATION: Lazy<IntGaugeVec> = Lazy::new(|| {
     register_int_gauge_vec!(

--- a/storage/storage-interface/src/metrics.rs
+++ b/storage/storage-interface/src/metrics.rs
@@ -4,29 +4,22 @@
 #![forbid(unsafe_code)]
 
 use aptos_metrics_core::{
-    exponential_buckets, register_histogram_vec, register_int_counter_vec, HistogramVec,
-    IntCounterVec,
+    exponential_buckets, make_thread_local_histogram_vec, make_thread_local_int_counter_vec,
 };
-use once_cell::sync::Lazy;
 
-pub(crate) static TIMER: Lazy<HistogramVec> = Lazy::new(|| {
-    register_histogram_vec!(
-        "aptos_storage_interface_timer_seconds",
-        "Various timers for performance analysis.",
-        &["name"],
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
-    )
-    .unwrap()
-});
+make_thread_local_histogram_vec!(
+    pub(crate),
+    TIMER,
+    "aptos_storage_interface_timer_seconds",
+    "Various timers for performance analysis.",
+    &["name"],
+    exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 22).unwrap(),
+);
 
-pub static COUNTER: Lazy<IntCounterVec> = Lazy::new(|| {
-    register_int_counter_vec!(
-        // metric name
-        "aptos_storage_interface_counter",
-        // metric description
-        "Various counters for storage-interface.",
-        // metric labels (dimensions)
-        &["name"],
-    )
-    .unwrap()
-});
+make_thread_local_int_counter_vec!(
+    pub(crate),
+    COUNTER,
+    "aptos_storage_interface_counter",
+    "Various counters for storage-interface.",
+    &["name"],
+);


### PR DESCRIPTION

This change switches majority of the storage counters to the thread local
version.

Not all of them are changed. For a few of them, some code is using the `get` API
or other things, which is a bit trickier for a thread local counter. So I'm not
touching these yet.

Tested by running

```
cargo run --release --package aptos-executor-benchmark \
  -- \
  --execution-threads 32 \
  --block-executor-type native-vm-with-block-stm \
  --transactions-per-sender 1 \
  --block-size 8086 \
  --enable-storage-sharding \
  run-executor \
  --enable-feature NEW_ACCOUNTS_DEFAULT_TO_FA_APT_STORE \
  --enable-feature OPERATIONS_DEFAULT_TO_FA_APT_STORE \
  --transaction-type apt-fa-transfer \
  --transaction-weights 1 \
  --module-working-set-size 1 \
  --main-signer-accounts 20000 \
  --additional-dst-pool-accounts 600000 \
  --data-dir ~/db_with_100M_account \
  --checkpoint-dir ~/checkpoint \
  --blocks 2000
```

before and after this change.

Overall I think we will get maybe a few percent throughput improvement, through
it depends on the number of threads used.
