### PR TITLE
[compiler-v2] Fix privileged access error when spec blocks are present

### DIFF
--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17477.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17477.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: Invalid operation: pack of `m::S` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/file-format-generator/bug_17477.move:10:16
+   │
+10 │     public fun test1() {
+   │                ^^^^^
+11 │         spec {};
+12 │         let _ = S { x: 42 };
+   │                 ----------- packed here

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17477.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17477.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    struct S has drop {
+        x: u64
+    }
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m::S;
+
+    public fun test1() {
+        spec {};
+        let _ = S { x: 42 };
+    }
+
+    public fun test2(s: S) {
+        spec { assert s.x > 0; };
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17477.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_17477.opt.exp
@@ -1,0 +1,10 @@
+
+Diagnostics:
+error: Invalid operation: pack of `m::S` can only be done within the defining module `0xc0ffee::m`
+   ┌─ tests/file-format-generator/bug_17477.move:10:16
+   │
+10 │     public fun test1() {
+   │                ^^^^^
+11 │         spec {};
+12 │         let _ = S { x: 42 };
+   │                 ----------- packed here


### PR DESCRIPTION
## Description

Closes #17477.

When a spec block is present, the checker for privileged access incorrectly did an early return, skipping checking other AST nodes coming after it. Instead, we now skip the check only for AST nodes that are descendants of a spec bloc.

## How Has This Been Tested?

Added a new test.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
