### PR TITLE
[Hot State] Split per version updates into for_last_checkpoint and for_latest

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4140,6 +4140,7 @@ dependencies = [
  "aptos-types",
  "arr_macro",
  "bcs 0.1.4",
+ "bytes",
  "dashmap 7.0.0-rc2",
  "derive_more 0.99.17",
  "itertools 0.13.0",

--- a/storage/storage-interface/Cargo.toml
+++ b/storage/storage-interface/Cargo.toml
@@ -37,6 +37,7 @@ thiserror = { workspace = true }
 
 [dev-dependencies]
 aptos-types = { workspace = true, features = ["fuzzing"] }
+bytes = { workspace = true }
 lru = { workspace = true }
 
 [features]

--- a/storage/storage-interface/src/chunk_to_commit.rs
+++ b/storage/storage-interface/src/chunk_to_commit.rs
@@ -58,13 +58,11 @@ impl ChunkToCommit<'_> {
     pub fn estimated_total_state_updates(&self) -> usize {
         let for_last_checkpoint = self
             .state_update_refs
-            .for_last_checkpoint
-            .as_ref()
+            .for_last_checkpoint_batched()
             .map_or(0, |x| x.len());
         let for_latest = self
             .state_update_refs
-            .for_latest
-            .as_ref()
+            .for_latest_batched()
             .map_or(0, |x| x.len());
 
         for_latest + for_last_checkpoint

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -274,18 +274,18 @@ impl LedgerState {
     ) -> LedgerState {
         let _timer = TIMER.timer_with(&["ledger_state__update"]);
 
-        let last_checkpoint = if let Some(updates) = &updates.for_last_checkpoint {
+        let last_checkpoint = if let Some(updates) = updates.for_last_checkpoint_batched() {
             self.latest().update(persisted_snapshot, updates, reads)
         } else {
             self.last_checkpoint.clone()
         };
 
-        let base_of_latest = if updates.for_last_checkpoint.is_none() {
+        let base_of_latest = if updates.for_last_checkpoint_batched().is_none() {
             self.latest()
         } else {
             &last_checkpoint
         };
-        let latest = if let Some(updates) = &updates.for_latest {
+        let latest = if let Some(updates) = updates.for_latest_batched() {
             base_of_latest.update(persisted_snapshot, updates, reads)
         } else {
             base_of_latest.clone()

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -162,18 +162,18 @@ impl LedgerStateSummary {
     ) -> Result<Self> {
         let _timer = TIMER.timer_with(&["ledger_state_summary__update"]);
 
-        let last_checkpoint = if let Some(updates) = &updates.for_last_checkpoint {
+        let last_checkpoint = if let Some(updates) = updates.for_last_checkpoint_batched() {
             self.latest.update(persisted, updates)?
         } else {
             self.last_checkpoint.clone()
         };
 
-        let base_of_latest = if updates.for_last_checkpoint.is_none() {
+        let base_of_latest = if updates.for_last_checkpoint_batched().is_none() {
             self.latest()
         } else {
             &last_checkpoint
         };
-        let latest = if let Some(updates) = &updates.for_latest {
+        let latest = if let Some(updates) = updates.for_latest_batched() {
             base_of_latest.update(persisted, updates)?
         } else {
             base_of_latest.clone()

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -11,23 +11,30 @@ use aptos_types::{
 };
 use arr_macro::arr;
 use itertools::Itertools;
-use rayon::iter::{IndexedParallelIterator, IntoParallelRefMutIterator, ParallelIterator};
+use rayon::prelude::*;
 use std::{
     collections::{hash_map::Entry, HashMap},
     time::Duration,
 };
 
-#[derive(Debug)]
+#[derive(Clone, Debug)]
 pub struct PerVersionStateUpdateRefs<'kv> {
     pub first_version: Version,
     pub num_versions: usize,
-    /// Converting to Vec to Box<[]> to release over-allocated memory during construction
     /// TODO(HotState): let WriteOp always carry StateSlot, so we can use &'kv StateSlot here
-    pub shards: [Box<[(&'kv StateKey, StateUpdateRef<'kv>)]>; NUM_STATE_SHARDS],
+    pub shards: [Vec<(&'kv StateKey, StateUpdateRef<'kv>)>; NUM_STATE_SHARDS],
 }
 
 impl<'kv> PerVersionStateUpdateRefs<'kv> {
-    pub fn index<
+    fn new_empty(first_version: Version) -> Self {
+        Self {
+            first_version,
+            num_versions: 0,
+            shards: arr![Vec::new(); 16],
+        }
+    }
+
+    fn index<
         UpdateIter: IntoIterator<Item = (&'kv StateKey, &'kv BaseStateOp)>,
         VersionIter: IntoIterator<Item = UpdateIter>,
     >(
@@ -56,7 +63,11 @@ impl<'kv> PerVersionStateUpdateRefs<'kv> {
 
         Self {
             first_version,
-            shards: shards.map(|shard| shard.into_boxed_slice()),
+            shards: shards.map(|mut shard| {
+                // Release over-allocated memory during construction.
+                shard.shrink_to_fit();
+                shard
+            }),
             num_versions,
         }
     }
@@ -70,7 +81,7 @@ pub struct BatchedStateUpdateRefs<'kv> {
 }
 
 impl BatchedStateUpdateRefs<'_> {
-    pub fn new_empty(first_version: Version, num_versions: usize) -> Self {
+    fn new_empty(first_version: Version, num_versions: usize) -> Self {
         Self {
             first_version,
             num_versions,
@@ -97,20 +108,34 @@ impl BatchedStateUpdateRefs<'_> {
     pub fn is_empty(&self) -> bool {
         self.len() == 0
     }
+
+    #[cfg(test)]
+    fn get(&self, key: &str) -> Option<&StateUpdateRef> {
+        let state_key = StateKey::raw(key.as_bytes());
+        let shard_id = state_key.get_shard_id();
+        self.shards[shard_id].get(&state_key)
+    }
 }
 
 #[derive(Debug)]
 pub struct StateUpdateRefs<'kv> {
     pub per_version: PerVersionStateUpdateRefs<'kv>,
-    /// Batched updates (updates for the same keys are merged) from the
-    /// beginning of the block/chunk to the last checkpoint (if it exists).
-    pub for_last_checkpoint: Option<BatchedStateUpdateRefs<'kv>>,
-    /// Batched updates from the version after last check point to last version
-    /// (`None` if the last version is a checkpoint, e.g. in a regular block).
-    pub for_latest: Option<BatchedStateUpdateRefs<'kv>>,
+    /// Updates from the beginning of the block/chunk to the last checkpoint (if it exists).
+    for_last_checkpoint: Option<(PerVersionStateUpdateRefs<'kv>, BatchedStateUpdateRefs<'kv>)>,
+    /// Updates from the version after last checkpoint to last version (`None` if the last version
+    /// is a checkpoint, e.g. in a regular block).
+    for_latest: Option<(PerVersionStateUpdateRefs<'kv>, BatchedStateUpdateRefs<'kv>)>,
 }
 
 impl<'kv> StateUpdateRefs<'kv> {
+    pub(crate) fn for_last_checkpoint_batched(&self) -> Option<&BatchedStateUpdateRefs> {
+        self.for_last_checkpoint.as_ref().map(|x| &x.1)
+    }
+
+    pub(crate) fn for_latest_batched(&self) -> Option<&BatchedStateUpdateRefs> {
+        self.for_latest.as_ref().map(|x| &x.1)
+    }
+
     pub fn index_write_sets(
         first_version: Version,
         write_sets: impl IntoIterator<Item = &'kv WriteSet>,
@@ -136,83 +161,96 @@ impl<'kv> StateUpdateRefs<'kv> {
         num_versions: usize,
         last_checkpoint_index: Option<usize>,
     ) -> Self {
-        let per_version =
-            PerVersionStateUpdateRefs::index(first_version, updates_by_version, num_versions);
+        if num_versions == 0 {
+            return Self {
+                per_version: PerVersionStateUpdateRefs::new_empty(first_version),
+                for_last_checkpoint: None,
+                for_latest: None,
+            };
+        }
 
-        let (for_last_checkpoint, for_latest) =
-            Self::collect_updates(&per_version, last_checkpoint_index);
+        let mut updates_by_version = updates_by_version.into_iter();
+        let mut num_versions_for_last_checkpoint = 0;
+
+        let for_last_checkpoint = last_checkpoint_index.map(|index| {
+            num_versions_for_last_checkpoint = index + 1;
+            let per_version = PerVersionStateUpdateRefs::index(
+                first_version,
+                updates_by_version
+                    .by_ref()
+                    .take(num_versions_for_last_checkpoint),
+                num_versions_for_last_checkpoint,
+            );
+            let batched = Self::batch_updates(&per_version);
+            (per_version, batched)
+        });
+
+        let for_latest = match last_checkpoint_index {
+            Some(index) if index + 1 == num_versions => None,
+            _ => {
+                assert!(num_versions_for_last_checkpoint < num_versions);
+                let per_version = PerVersionStateUpdateRefs::index(
+                    first_version + num_versions_for_last_checkpoint as Version,
+                    updates_by_version,
+                    num_versions - num_versions_for_last_checkpoint,
+                );
+                let batched = Self::batch_updates(&per_version);
+                Some((per_version, batched))
+            },
+        };
+
         Self {
-            per_version,
+            per_version: Self::concat_per_version_updates(
+                for_last_checkpoint.as_ref().map(|x| &x.0),
+                for_latest.as_ref().map(|x| &x.0),
+            ),
             for_last_checkpoint,
             for_latest,
         }
     }
 
-    pub fn last_inner_checkpoint_index(&self) -> Option<usize> {
-        self.for_last_checkpoint
-            .as_ref()
-            .map(|updates| updates.num_versions - 1)
+    fn concat_per_version_updates(
+        for_last_checkpoint: Option<&PerVersionStateUpdateRefs<'kv>>,
+        for_latest: Option<&PerVersionStateUpdateRefs<'kv>>,
+    ) -> PerVersionStateUpdateRefs<'kv> {
+        match for_last_checkpoint {
+            Some(for_last_checkpoint) => {
+                let mut all = for_last_checkpoint.clone();
+                if let Some(for_latest) = for_latest {
+                    all.num_versions += for_latest.num_versions;
+                    for (dest, src) in all.shards.iter_mut().zip_eq(for_latest.shards.iter()) {
+                        dest.extend_from_slice(src);
+                    }
+                }
+                all
+            },
+            None => for_latest.cloned().expect("At least one should be Some."),
+        }
     }
 
-    fn collect_updates(
+    pub fn last_inner_checkpoint_index(&self) -> Option<usize> {
+        self.for_last_checkpoint.as_ref().map(|updates| {
+            assert_eq!(updates.0.num_versions, updates.1.num_versions);
+            updates.0.num_versions - 1
+        })
+    }
+
+    fn batch_updates(
         per_version_updates: &PerVersionStateUpdateRefs<'kv>,
-        last_checkpoint_index: Option<usize>,
-    ) -> (
-        Option<BatchedStateUpdateRefs<'kv>>,
-        Option<BatchedStateUpdateRefs<'kv>>,
-    ) {
+    ) -> BatchedStateUpdateRefs<'kv> {
         let _timer = TIMER.timer_with(&["index_state_updates__collect_batch"]);
 
-        let mut shard_iters = per_version_updates
+        let mut ret = BatchedStateUpdateRefs::new_empty(
+            per_version_updates.first_version,
+            per_version_updates.num_versions,
+        );
+        per_version_updates
             .shards
-            .iter()
+            .par_iter()
             .map(|shard| shard.iter().cloned())
-            .collect::<Vec<_>>();
-
-        let mut first_version_to_collect = per_version_updates.first_version;
-        let mut remaining_versions = per_version_updates.num_versions;
-        let updates_for_last_checkpoint = last_checkpoint_index.map(|idx| {
-            let num_versions = idx + 1;
-            let ret = Self::collect_some_updates(
-                first_version_to_collect,
-                num_versions,
-                &mut shard_iters,
-            );
-            first_version_to_collect += num_versions as Version;
-            remaining_versions -= num_versions;
-            ret
-        });
-        let updates_for_latest = if remaining_versions == 0 {
-            None
-        } else {
-            Some(Self::collect_some_updates(
-                first_version_to_collect,
-                remaining_versions,
-                &mut shard_iters,
-            ))
-        };
-
-        // Assert that all updates are consumed.
-        assert!(shard_iters.iter_mut().all(|iter| iter.next().is_none()));
-
-        (updates_for_last_checkpoint, updates_for_latest)
-    }
-
-    fn collect_some_updates(
-        first_version: Version,
-        num_versions: usize,
-        shard_iters: &mut [impl Iterator<Item = (&'kv StateKey, StateUpdateRef<'kv>)> + Clone + Send],
-    ) -> BatchedStateUpdateRefs<'kv> {
-        let mut ret = BatchedStateUpdateRefs::new_empty(first_version, num_versions);
-        // exclusive
-        let end_version = first_version + num_versions as Version;
-        shard_iters
-            .par_iter_mut()
             .zip_eq(ret.shards.par_iter_mut())
             .for_each(|(shard_iter, dedupped)| {
-                // n.b. take_while_ref so that in the next step we can process the rest of the
-                // entries from the iters.
-                for (k, u) in shard_iter.take_while_ref(|(_k, u)| u.version < end_version) {
+                for (k, u) in shard_iter {
                     // If it's a value write op (Creation/Modification/Deletion), just insert and
                     // overwrite the previous op.
                     if u.state_op.is_value_write_op() {
@@ -249,5 +287,110 @@ impl<'kv> StateUpdateRefs<'kv> {
                 }
             });
         ret
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BatchedStateUpdateRefs, StateUpdateRefs};
+    use aptos_types::{
+        state_store::{state_key::StateKey, state_value::StateValueMetadata},
+        transaction::Version,
+        write_set::{WriteOp, WriteSet, WriteSetMut},
+    };
+    use bytes::Bytes;
+
+    fn write_set(kvs: &[(&str, &str)]) -> WriteSet {
+        WriteSetMut::from_iter(kvs.iter().map(|(key, value)| {
+            let key = StateKey::raw(key.as_bytes());
+            let value = Bytes::copy_from_slice(value.as_bytes());
+            let op = WriteOp::modification(value, StateValueMetadata::none());
+            (key, op)
+        }))
+        .freeze()
+        .unwrap()
+    }
+
+    fn verify_batching(
+        res: &BatchedStateUpdateRefs,
+        key: &str,
+        expected_version: Version,
+        expected_value: &str,
+    ) {
+        let u = res.get(key).unwrap();
+        assert_eq!(u.version, expected_version);
+        assert_eq!(
+            u.state_op.as_state_value_opt().unwrap().bytes(),
+            expected_value
+        );
+    }
+
+    #[test]
+    fn test_regular_block() {
+        // A regular block, or a chunk that ends exactly at a block boundary.
+        let v0 = write_set(&[("A", "A0")]);
+        let v1 = write_set(&[("A", "A1"), ("B", "B1")]);
+        let v2 = write_set(&[("C", "C2")]);
+        let last_checkpoint_index = Some(2);
+        let ret =
+            StateUpdateRefs::index_write_sets(0, vec![&v0, &v1, &v2], 3, last_checkpoint_index);
+
+        let for_last_checkpoint = ret.for_last_checkpoint_batched().unwrap();
+        assert_eq!(for_last_checkpoint.first_version, 0);
+        assert_eq!(for_last_checkpoint.num_versions, 3);
+        verify_batching(for_last_checkpoint, "A", 1, "A1");
+        verify_batching(for_last_checkpoint, "B", 1, "B1");
+        verify_batching(for_last_checkpoint, "C", 2, "C2");
+
+        assert!(ret.for_latest_batched().is_none());
+    }
+
+    #[test]
+    fn test_chunk_with_checkpoint() {
+        // For example, the second half of a previous block and the first half of the current
+        // block.
+        let v0 = write_set(&[("A", "A0")]);
+        let v1 = write_set(&[("A", "A1"), ("B", "B1")]);
+        let v2 = write_set(&[("A", "A2"), ("B", "B2")]);
+        let v3 = write_set(&[("B", "B3"), ("C", "C3")]);
+        let last_checkpoint_index = Some(1);
+        let ret = StateUpdateRefs::index_write_sets(
+            0,
+            vec![&v0, &v1, &v2, &v3],
+            4,
+            last_checkpoint_index,
+        );
+
+        let for_last_checkpoint = ret.for_last_checkpoint_batched().unwrap();
+        assert_eq!(for_last_checkpoint.first_version, 0);
+        assert_eq!(for_last_checkpoint.num_versions, 2);
+        verify_batching(for_last_checkpoint, "A", 1, "A1");
+        verify_batching(for_last_checkpoint, "B", 1, "B1");
+
+        let for_latest = ret.for_latest_batched().unwrap();
+        assert_eq!(for_latest.first_version, 2);
+        assert_eq!(for_latest.num_versions, 2);
+        verify_batching(for_latest, "A", 2, "A2");
+        verify_batching(for_latest, "B", 3, "B3");
+        verify_batching(for_latest, "C", 3, "C3");
+    }
+
+    #[test]
+    fn test_chunk_with_no_checkpoint() {
+        // A chunk that is the middle of a large block.
+        let v0 = write_set(&[("A", "A0"), ("B", "B0")]);
+        let v1 = write_set(&[("A", "A1")]);
+        let v2 = write_set(&[("C", "C2")]);
+        let last_checkpoint = None;
+        let ret = StateUpdateRefs::index_write_sets(10, vec![&v0, &v1, &v2], 3, last_checkpoint);
+
+        assert!(ret.for_last_checkpoint_batched().is_none());
+
+        let for_latest = ret.for_latest_batched().unwrap();
+        assert_eq!(for_latest.first_version, 10);
+        assert_eq!(for_latest.num_versions, 3);
+        verify_batching(for_latest, "A", 11, "A1");
+        verify_batching(for_latest, "B", 10, "B0");
+        verify_batching(for_latest, "C", 12, "C2");
     }
 }

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -172,10 +172,10 @@ impl CachedStateView {
         let _timer = TIMER.timer_with(&["prime_state_cache"]);
 
         IO_POOL.install(|| {
-            if let Some(updates) = &updates.for_last_checkpoint {
+            if let Some(updates) = updates.for_last_checkpoint_batched() {
                 self.prime_cache_for_batched_updates(updates)?;
             }
-            if let Some(updates) = &updates.for_latest {
+            if let Some(updates) = updates.for_latest_batched() {
                 self.prime_cache_for_batched_updates(updates)?;
             }
             Ok(())


### PR DESCRIPTION

Right now in `StateUpdateRefs`, the batched updates are split into two
non-overlapping parts: the beginning to the last checkpoint and the rest.

This change splits the per version updates in the same way. They will later be
used when we compute the updates to the hot state.
