### PR TITLE
[api][trivial] fix identifier bug when converting RawMoveStruct into MoveStructValue

### DIFF
--- a/api/src/tests/function_value_test.rs
+++ b/api/src/tests/function_value_test.rs
@@ -137,3 +137,47 @@ async fn test_function_values_with_references(
         })
     );
 }
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[rstest(
+    use_txn_payload_v2_format,
+    use_orderless_transactions,
+    case(false, false),
+    case(true, false),
+    case(true, true)
+)]
+async fn test_function_values_with_captured_struct(
+    use_txn_payload_v2_format: bool,
+    use_orderless_transactions: bool,
+) {
+    let mut context = new_test_context_with_orderless_flags(
+        current_function_name!(),
+        use_txn_payload_v2_format,
+        use_orderless_transactions,
+    );
+    let mut account = context.create_account().await;
+    let addr = account.address();
+
+    let named_addresses = vec![("account".to_string(), addr)];
+    let txn = futures::executor::block_on(async move {
+        let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("src/tests/move/pack_function_values_with_struct");
+        TestContext::build_package_with_latest_language(path, named_addresses)
+    });
+    context.publish_package(&mut account, txn).await;
+
+    let resource = format!("{}::test::FunctionStore", addr);
+    let response = &context.gen_resource(&addr, &resource).await.unwrap();
+
+    let expected_name = format!("{}::test::id", addr);
+    assert_eq!(
+        response["data"],
+        json!({
+            "f": {
+                "__captured__": [ {"_0": "1"} ],
+                "__fun_name__": &expected_name,
+                "__mask__": "1",
+            }
+        })
+    );
+}

--- a/api/src/tests/move/pack_function_values_with_struct/Move.toml
+++ b/api/src/tests/move/pack_function_values_with_struct/Move.toml
@@ -1,0 +1,9 @@
+[package]
+name = "pack_function_values"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../aptos-move/framework/aptos-framework" }
+
+[addresses]
+account = "_"

--- a/api/src/tests/move/pack_function_values_with_struct/sources/test.move
+++ b/api/src/tests/move/pack_function_values_with_struct/sources/test.move
@@ -1,0 +1,18 @@
+module account::test {
+
+    struct FunctionStore has key {
+        f: ||R has copy+drop+store,
+    }
+
+    struct R(u64) has copy, drop, key, store;
+
+    public fun id(x: R): R {
+        x
+    }
+
+    fun init_module(account: &signer) {
+        let v = R(1);
+        let f: ||R has copy+drop+store = || id(v);
+        move_to(account, FunctionStore { f });
+    }
+}

--- a/api/types/src/move_types.rs
+++ b/api/types/src/move_types.rs
@@ -252,7 +252,7 @@ impl TryFrom<RawMoveStruct> for MoveStructValue {
         }
         for (pos, val) in s.field_values.into_iter().enumerate() {
             map.insert(
-                IdentifierWrapper::from_str(&pos.to_string())?,
+                IdentifierWrapper::from_str(format!("_{}", pos).as_str())?,
                 MoveValue::try_from(val)?.json()?,
             );
         }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

When converting from `RawMoveStruct` to `MoveStructValue`, positional field name cannot be directly used as the identifier. This PR adds `_` prefix to avoid the failure.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

A new test


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

Need to double check whether feature flag is needed.

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
