### PR TITLE
[Keyless] Clean up JWK fetching logic, add tests, and a new endpoint.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,7 +2814,6 @@ dependencies = [
  "ark-groth16",
  "ark-serialize",
  "bcs 0.1.4",
- "dashmap 7.0.0-rc2",
  "firestore",
  "hex",
  "hyper 0.14.28",

--- a/keyless/pepper/service/Cargo.toml
+++ b/keyless/pepper/service/Cargo.toml
@@ -30,7 +30,6 @@ ark-ff = { workspace = true }
 ark-groth16 = { workspace = true }
 ark-serialize = { workspace = true }
 bcs = { workspace = true }
-dashmap = { workspace = true }
 firestore = { workspace = true }
 hex = { workspace = true }
 hyper = { workspace = true }

--- a/keyless/pepper/service/src/cached_resources.rs
+++ b/keyless/pepper/service/src/cached_resources.rs
@@ -6,7 +6,6 @@ use crate::{
 };
 use aptos_infallible::RwLock;
 use aptos_logger::{info, warn};
-use reqwest::Client;
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
 
@@ -14,7 +13,6 @@ use std::{sync::Arc, time::Duration};
 const ENV_ONCHAIN_KEYLESS_CONFIG_URL: &str = "ONCHAIN_KEYLESS_CONFIG_URL";
 const ENV_ONCHAIN_GROTH16_VK_URL: &str = "ONCHAIN_GROTH16_VK_URL";
 const RESOURCE_FETCH_INTERVAL_SECS: u64 = 10;
-const RESOURCE_FETCH_TIMEOUT_SECS: u64 = 10;
 
 /// A simple trait for resources that can be cached and refreshed
 pub trait CachedResource {
@@ -102,10 +100,7 @@ fn start_external_resource_refresh_loop<
     );
 
     // Create the request client
-    let client = Client::builder()
-        .timeout(Duration::from_secs(RESOURCE_FETCH_TIMEOUT_SECS))
-        .build()
-        .expect("Failed to build the HTTP client!");
+    let client = utils::create_request_client();
 
     // Start the resource fetcher loop
     tokio::spawn(async move {

--- a/keyless/pepper/service/src/jwk.rs
+++ b/keyless/pepper/service/src/jwk.rs
@@ -1,141 +1,232 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{metrics::JWK_FETCH_SECONDS, Issuer, KeyID};
+use crate::{metrics::JWK_FETCH_SECONDS, utils};
 use anyhow::{anyhow, Result};
+use aptos_infallible::Mutex;
 use aptos_keyless_pepper_common::jwt::parse;
-use aptos_logger::warn;
-use aptos_types::jwks::rsa::RSA_JWK;
-use dashmap::DashMap;
-use jsonwebtoken::DecodingKey;
+use aptos_logger::{info, warn};
+use aptos_types::{jwks::rsa::RSA_JWK, keyless::test_utils::get_sample_iss};
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde_json::Value;
-use std::{sync::Arc, time::Duration};
+use std::{collections::HashMap, sync::Arc, time::Duration};
 use tokio::time::Instant;
 
+// Issuer and JWK URL constants for Apple
+const ISSUER_APPLE: &str = "https://appleid.apple.com";
+const JWK_URL_APPLE: &str = "https://appleid.apple.com/auth/keys";
+
+// Issuer and JWK URL constants for Google
+const ISSUER_GOOGLE: &str = "https://accounts.google.com";
+const JWK_URL_GOOGLE: &str = "https://www.googleapis.com/oauth2/v3/certs";
+
+// The interval (in seconds) at which to refresh the JWKs
+const JWK_REFRESH_INTERVAL_SECS: u64 = 10;
+
+// Useful type declarations
+pub type Issuer = String;
+pub type KeyID = String;
+pub type JWKCache = Arc<Mutex<HashMap<Issuer, HashMap<KeyID, Arc<RSA_JWK>>>>>;
+
+/// A lazy static regex to match auth0 URLs
 static AUTH_0_REGEX: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^https://[a-zA-Z0-9-]+\.us\.auth0\.com/$").unwrap());
 
+/// A lazy static regex to match cognito URLs
 static COGNITO_REGEX: Lazy<Regex> = Lazy::new(|| {
     Regex::new(r"^https://cognito-idp\.[a-zA-Z0-9-_]+\.amazonaws\.com/[a-zA-Z0-9-_]+$").unwrap()
 });
 
-/// The JWK in-mem cache.
-pub static DECODING_KEY_CACHE: Lazy<DashMap<Issuer, DashMap<KeyID, Arc<RSA_JWK>>>> =
-    Lazy::new(DashMap::new);
+/// Fetches the JWKs from the given URL
+async fn fetch_jwks(jwk_url: &str) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
+    // Create the request client
+    let client = utils::create_request_client();
 
-pub async fn get_federated_jwk(jwt: &str) -> Result<Arc<RSA_JWK>> {
-    let payload = parse(jwt)?;
+    // Fetch the JWKs from the URL
+    let response = client
+        .get(jwk_url)
+        .send()
+        .await
+        .map_err(|error| anyhow!("Failed to fetch JWKs from {}! Error: {}", jwk_url, error))?;
 
-    let jwt_kid: String = match payload.header.kid {
-        Some(kid) => kid,
-        None => return Err(anyhow!("no kid found on jwt header")),
-    };
+    // Extract the response text
+    let response_text = response.text().await.map_err(|error| {
+        anyhow!(
+            "Failed to extract response text from {}! Error: {}",
+            jwk_url,
+            error
+        )
+    })?;
 
-    // Check if it is a test iss
-    let keys = if payload.claims.iss.eq("test.federated.oidc.provider") {
-        let test_jwk = include_str!("../../../../types/src/jwks/rsa/secure_test_jwk.json");
-        parse_jwks(test_jwk).expect("test jwk should parse")
-    } else if AUTH_0_REGEX.is_match(&payload.claims.iss) {
-        let jwk_url = format!("{}.well-known/jwks.json", &payload.claims.iss);
-        fetch_jwks(&jwk_url).await?
-    } else if COGNITO_REGEX.is_match(&payload.claims.iss) {
-        let jwk_url = format!("{}/.well-known/jwks.json", &payload.claims.iss);
-        fetch_jwks(&jwk_url).await?
-    } else {
-        return Err(anyhow!("not a federated iss"));
-    };
+    // Parse the JWKs from the response text
+    parse_jwks(&response_text)
+}
 
-    let key = keys
-        .get(&jwt_kid)
-        .ok_or_else(|| anyhow!("unknown kid: {}", jwt_kid))?;
+/// Returns a cached RSA JWK for the given issuer and key ID
+pub fn get_cached_jwk_as_rsa(
+    issuer: &String,
+    key_id: &String,
+    jwk_cache: JWKCache,
+) -> Result<Arc<RSA_JWK>> {
+    // Get the key set for the issuer
+    let jwk_cache = jwk_cache.lock();
+    let key_set = jwk_cache
+        .get(issuer)
+        .ok_or_else(|| anyhow!("Failed to get cached RSA JWK! Unknown issuer: {}", issuer))?;
+
+    // Get the key for the given key ID
+    let key = key_set
+        .get(key_id)
+        .ok_or_else(|| anyhow!("Failed to get cached RSA JWK! Unknown key ID: {}", key_id))?;
+
     Ok(key.clone())
 }
 
-/// Send a request to a JWK endpoint and return its JWK map.
-pub async fn fetch_jwks(jwk_url: &str) -> Result<DashMap<KeyID, Arc<RSA_JWK>>> {
-    let response = reqwest::get(jwk_url)
-        .await
-        .map_err(|e| anyhow!("jwk fetch error: {}", e))?;
-    let text = response
-        .text()
-        .await
-        .map_err(|e| anyhow!("error while getting response as text: {}", e))?;
-    parse_jwks(&text)
+/// Fetches the federated JWK for the given JWT
+pub async fn get_federated_jwk(jwt: &str) -> Result<Arc<RSA_JWK>> {
+    // Parse the JWT to extract the issuer and key ID
+    let payload = parse(jwt)?;
+    let jwt_issuer = payload.claims.iss;
+    let jwt_key_id: String = match payload.header.kid {
+        Some(kid) => kid,
+        None => return Err(anyhow!("No key ID (kid) found on JWT header!")),
+    };
+
+    // Fetch the keys for the issuer
+    let keys = if jwt_issuer.eq("test.federated.oidc.provider") {
+        let test_jwk = include_str!("../../../../types/src/jwks/rsa/secure_test_jwk.json");
+        parse_jwks(test_jwk).expect("The test JWK should parse successfully!")
+    } else if AUTH_0_REGEX.is_match(&jwt_issuer) {
+        let jwk_url = format!("{}.well-known/jwks.json", &jwt_issuer);
+        fetch_jwks(&jwk_url).await?
+    } else if COGNITO_REGEX.is_match(&jwt_issuer) {
+        let jwk_url = format!("{}/.well-known/jwks.json", &jwt_issuer);
+        fetch_jwks(&jwk_url).await?
+    } else {
+        return Err(anyhow!("Unsupported federated issuer: {}", jwt_issuer));
+    };
+
+    // Fetch the key for the given key ID
+    let key = keys
+        .get(&jwt_key_id)
+        .ok_or_else(|| anyhow!("unknown kid: {}", jwt_key_id))?;
+    Ok(key.clone())
 }
 
-pub fn parse_jwks(text: &str) -> Result<DashMap<KeyID, Arc<RSA_JWK>>> {
-    let endpoint_response_val = serde_json::from_str::<Value>(text)
-        .map_err(|e| anyhow!("error while parsing json: {}", e))?;
+/// Inserts the test JWK into the JWT cache
+fn insert_test_jwk(jwk_cache: JWKCache) {
+    let test_jwk = include_str!("../../../../types/src/jwks/rsa/secure_test_jwk.json");
+    let parsed_jwk = parse_jwks(test_jwk).expect("The test JWK should parse successfully!");
+    jwk_cache.lock().insert(get_sample_iss(), parsed_jwk);
+}
 
-    let keys: &Vec<Value> = endpoint_response_val
+/// Parses the JWKs from the given response text
+fn parse_jwks(response_text: &str) -> Result<HashMap<KeyID, Arc<RSA_JWK>>> {
+    // Parse the response text into a JSON value
+    let response_json_value = serde_json::from_str::<Value>(response_text)
+        .map_err(|error| anyhow!("Failed to parse response json! Error: {}", error))?;
+
+    // Extract the "keys" array from the JSON value
+    let keys: &Vec<Value> = response_json_value
         .get("keys")
-        .ok_or_else(|| anyhow!("Error while parsing jwk json: \"keys\" not found"))?
+        .ok_or_else(|| anyhow!("Failed to parse JWK json: \"keys\" entry not found!"))?
         .as_array()
-        .ok_or_else(|| anyhow!("Error while parsing jwk json: \"keys\" not array"))?;
-    let key_map: DashMap<KeyID, Arc<RSA_JWK>> = keys
+        .ok_or_else(|| anyhow!("Failed to parse JWK json: \"keys\" entry not an array!"))?;
+
+    // Parse each key, and filter out unsupported keys
+    let key_map: HashMap<KeyID, Arc<RSA_JWK>> = keys
         .iter()
         .filter_map(|jwk_val| match RSA_JWK::try_from(jwk_val) {
-            Ok(jwk) => {
-                if jwk.e == "AQAB" {
-                    Some((jwk.kid.clone(), Arc::new(jwk)))
+            Ok(rsa_jwk) => {
+                if rsa_jwk.e == "AQAB" {
+                    Some((rsa_jwk.kid.clone(), Arc::new(rsa_jwk)))
                 } else {
                     warn!("Unsupported RSA modulus for jwk: {}", jwk_val);
                     None
                 }
             },
-            Err(e) => {
-                warn!("error while parsing jwk {}: {e}", jwk_val);
+            Err(error) => {
+                warn!("Error while parsing JWK: {}! {}", jwk_val, error);
                 None
             },
         })
         .collect();
+
     Ok(key_map)
 }
 
-pub fn start_jwk_refresh_loop(issuer: &str, jwk_url: &str, refresh_interval: Duration) {
-    let issuer = issuer.to_string();
-    let jwk_url = jwk_url.to_string();
-    let _handle = tokio::spawn(async move {
+/// Starts the JWK refresh loops for known issuers. Note: we currently
+/// hardcode the known issuers here, instead of fetching them from on-chain
+/// configs. This is a security measure to ensure the pepper service only
+/// trusts a small set of known issuers, with deterministic and immutable
+/// JWK URLs. Otherwise, if these values were fetched from on-chain configs,
+/// an attacker who compromises governance could change these values to
+/// point to a malicious issuer (or JWK URL).
+pub fn start_jwk_fetchers() -> JWKCache {
+    // Create the JWK cache
+    let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
+
+    // Insert the test JWK. This is required for the automated end-to-end
+    // integration tests that run as a part of testing pipeline.
+    insert_test_jwk(jwk_cache.clone());
+
+    // Start the JWK refresh loops for known issuers
+    start_jwk_refresh_loop(
+        ISSUER_GOOGLE.into(),
+        JWK_URL_GOOGLE.into(),
+        jwk_cache.clone(),
+    );
+    start_jwk_refresh_loop(ISSUER_APPLE.into(), JWK_URL_APPLE.into(), jwk_cache.clone());
+
+    // Return the JWK cache
+    jwk_cache
+}
+
+/// Starts a background task that periodically fetches and caches the JWKs from the given URL
+fn start_jwk_refresh_loop(issuer: String, jwk_url: String, jwk_cache: JWKCache) {
+    tokio::spawn(async move {
         loop {
-            let timer = Instant::now();
-            let fetch_result = fetch_jwks(jwk_url.as_str()).await;
-            let fetch_time = timer.elapsed();
-            let succeeded = fetch_result.is_ok();
-            JWK_FETCH_SECONDS
-                .with_label_values(&[issuer.as_str(), succeeded.to_string().as_str()])
-                .observe(fetch_time.as_secs_f64());
-            match fetch_result {
+            // Fetch the JWKs from the URL
+            let time_now = Instant::now();
+            let fetch_result = fetch_jwks(&jwk_url).await;
+            let fetch_time = time_now.elapsed();
+
+            // Process the fetch result
+            match &fetch_result {
                 Ok(key_set) => {
-                    DECODING_KEY_CACHE.insert(issuer.clone(), key_set.clone());
+                    // Log the successful fetch
+                    info!(
+                        issuer = issuer,
+                        jwk_url = jwk_url,
+                        "Successfully fetched the JWK! Issuer: {}, Key set: {:?}",
+                        issuer,
+                        key_set
+                    );
+
+                    // Update the cache
+                    jwk_cache.lock().insert(issuer.clone(), key_set.clone());
                 },
-                Err(msg) => {
+                Err(error) => {
                     warn!(
                         issuer = issuer,
                         jwk_url = jwk_url,
-                        "error fetching JWK: {}",
-                        msg
+                        "Failed to fetch the JWK! Issuer: {}, Error: {}",
+                        issuer,
+                        error
                     );
                 },
             }
+
+            // Update the fetch metrics
+            let succeeded = fetch_result.is_ok();
+            JWK_FETCH_SECONDS
+                .with_label_values(&[&issuer, &succeeded.to_string()])
+                .observe(fetch_time.as_secs_f64());
+
+            // Sleep until the next refresh interval
+            let refresh_interval = Duration::from_secs(JWK_REFRESH_INTERVAL_SECS);
             tokio::time::sleep(refresh_interval).await;
         }
     });
-}
-
-pub fn cached_decoding_key_as_rsa(issuer: &String, kid: &String) -> Result<Arc<RSA_JWK>> {
-    let key_set = DECODING_KEY_CACHE
-        .get(issuer)
-        .ok_or_else(|| anyhow!("unknown issuer: {}", issuer))?;
-    let key = key_set
-        .get(kid)
-        .ok_or_else(|| anyhow!("unknown kid: {}", kid))?;
-    Ok(key.clone())
-}
-
-pub fn cached_decoding_key(issuer: &String, kid: &String) -> Result<DecodingKey> {
-    let key = cached_decoding_key_as_rsa(issuer, kid)?;
-    let decoding_key = DecodingKey::from_rsa_components(&key.n, &key.e)?;
-    Ok(decoding_key)
 }

--- a/keyless/pepper/service/src/metrics.rs
+++ b/keyless/pepper/service/src/metrics.rs
@@ -10,10 +10,11 @@ use std::convert::Infallible;
 // Default port for the metrics service
 pub const DEFAULT_METRICS_SERVER_PORT: u16 = 8080;
 
+// Histogram for tracking time taken to fetch JWKs by issuer and result
 pub static JWK_FETCH_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "keyless_pepper_service_jwk_fetch_seconds",
-        "Seconds taken to process pepper requests by scheme and result.",
+        "Time taken to fetch keyless pepper service jwks",
         &["issuer", "succeeded"],
         exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 24).unwrap()
     )

--- a/keyless/pepper/service/src/tests/process_common.rs
+++ b/keyless/pepper/service/src/tests/process_common.rs
@@ -3,6 +3,7 @@
 
 use crate::{error::PepperServiceError, process_common, tests::utils};
 use aptos_crypto::ed25519::Ed25519PublicKey;
+use aptos_infallible::Mutex;
 use aptos_types::{
     keyless::{
         circuit_testcases::{
@@ -13,9 +14,8 @@ use aptos_types::{
     },
     transaction::authenticator::EphemeralPublicKey,
 };
-use std::ops::Deref;
+use std::{collections::HashMap, ops::Deref, sync::Arc};
 use uuid::Uuid;
-
 // TODO: clean this up and add missing tests!
 
 #[tokio::test]
@@ -24,6 +24,7 @@ async fn process_common_should_fail_if_max_exp_data_secs_overflowed() {
     let sk = get_sample_esk();
     let pk = Ed25519PublicKey::from(&sk);
 
+    let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
     let jwt_payload = sample_jwt_payload_json_overrides(
         SAMPLE_TEST_ISS_VALUE,
         SAMPLE_UID_VAL,
@@ -39,6 +40,7 @@ async fn process_common_should_fail_if_max_exp_data_secs_overflowed() {
 
     let process_result = process_common(
         vuf_private_key,
+        jwk_cache,
         &session_id,
         jwt,
         EphemeralPublicKey::ed25519(pk),

--- a/keyless/pepper/service/src/utils.rs
+++ b/keyless/pepper/service/src/utils.rs
@@ -3,6 +3,19 @@
 
 use crate::error::PepperServiceError;
 use anyhow::{anyhow, ensure};
+use reqwest::Client;
+use std::time::Duration;
+
+// Timeout for client requests
+const CLIENT_REQUEST_TIMEOUT_SECS: u64 = 10;
+
+/// Creates and returns a reqwest HTTP client with a timeout
+pub fn create_request_client() -> Client {
+    Client::builder()
+        .timeout(Duration::from_secs(CLIENT_REQUEST_TIMEOUT_SECS))
+        .build()
+        .expect("Failed to build the request client!")
+}
 
 /// Attempts to read an environment variable and returns an error if it fails
 pub fn read_environment_variable(variable_name: &str) -> Result<String, PepperServiceError> {
@@ -14,13 +27,21 @@ pub fn read_environment_variable(variable_name: &str) -> Result<String, PepperSe
     })
 }
 
+/// Converts a hex-encoded string (with "0x" prefix) to a byte vector
 pub fn unhexlify_api_bytes(api_output: &str) -> anyhow::Result<Vec<u8>> {
+    // Verify the input format
     ensure!(api_output.len() >= 2);
     let lower = api_output.to_lowercase();
     ensure!(&lower[0..2] == "0x");
-    let bytes = hex::decode(&lower[2..])
-        .map_err(|e| anyhow!("unhexlify_api_bytes() failed at decoding: {e}"))?;
-    Ok(bytes)
+
+    // Decode the hex string
+    hex::decode(&lower[2..]).map_err(|error| {
+        anyhow!(
+            "unhexlify_api_bytes() failed to decode intput {}! Error: {}",
+            lower,
+            error
+        )
+    })
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Description
This PR makes several cleanups to the JWK fetching logic in the pepper service. For example, it:
- Removes the use of lazy/static variables (so that the code can be tested efficiently), and adds appropriate unit tests.
- Adds a new pepper service endpoint `/cached/jwk` which exposes the state of the JWK cache. This is useful for observability and debugging, e.g., at runtime we can see the supported JWK issuers and keys (see below).
- Refactors the code, improves runtime logging for JWK updates, etc.

The snippet below shows an example response when hitting the new endpoint:
```
{
...
  "https://accounts.google.com": {
    "2d7ed338c0f1457b214a274b5e0e667b44a42dde": {
      "kid": "2d7ed338c0f1457b214a274b5e0e667b44a42dde",
      "kty": "RSA",
      "alg": "RS256",
      "e": "AQAB",
      "n": "v85Io5Rp7vwbSlkuAowWVcfUxZdPckijmLAZ3WEl3nTUTkz9YfmKJUiqdZMRuJxL50F3TRBKDxvfFbWX602sPTShoK6H2pdbQNrKsGV_KIlLLsIkcVnG-KNuY-ZnkZ9ppCH9yqjGw08imHlLsIngSK8VF03nCwUiv_VtZ27FltUttRxkoZGxCYX0-MRicIXPNKILml-xmknGNLsDCvAYqhbg3tZRKi1dZuHLhCb_YTov5YhprvVzm5OagvrvZuia_qilk-ctgqRJRPFGrVm75gkV4WdwxQQukCPqf5UfIopdOAB4wBdovddX3jjpjphq8-gKMPO-t_6siCt1xETSOQ"
    },
    "9c6251587950844a656be3563d8c5bd6f894c407": {
      "kid": "9c6251587950844a656be3563d8c5bd6f894c407",
      "kty": "RSA",
      "alg": "RS256",
      "e": "AQAB",
      "n": "6GmQd18e3fKydx1Zg0mqWvk8qP1Zp5ahfvM5x1fD7-5NBz5J7NGy1mwvIzyEMukA9zrV5ib2F476_FsAD0LkdDPOuv3F8qU9y48J6JGEHZBxXm5Q-1FN4LABsU3hOtXgcrIHicrvGu40eippOCWinA5BIsCtobNsgl990yD96iyWJvAEVLrBM03l3eSWQbvo3YYgale5Bsy-_-BYQM-CfHoaxVpYUjXm8G9I0z3GBv5uytu6vUR9KSyOk07NTLcInzGV7Xpbv0WftvcqP4gG-h5bvg67mx2pBwSiJtQR5n0BTd4Gtx8R6EqAhX08oOdFDZSLQJ8jZqoG6psGtMfePw"
    }
  },
  "https://appleid.apple.com": {
    "UaIIFY2fW4": {
      "kid": "UaIIFY2fW4",
      "kty": "RSA",
      "alg": "RS256",
      "e": "AQAB",
      "n": "sxzLtSWjplO4nMymVwkknn6WrQvK4sz7F1rrIwOKPa3SpltaB719cfxFfoE4UqHfVxHXsoYew82ViYz5whp0CuqgWi2t4HYpSTCQdVCNIXpsMxA8QqTfIlc-EUFNuUMziY-hJXqi4i-woI0HiwPEkO-AhWy86L9-J_1I1yw22-BICacAU7J9UTBBwHu0wkRHiyPe4pHow1wa91v5OM09XHqjHpiFrJD7bOBl6Y3EuBXEWy3VEA-S2IchqVGmvNGNZo6J9WtSHEcL6ussFWPJoIo2GR4BrgHvZGUvhgbHrKjCPrIAhliH0er3pF5_0UTSqW0Xg_Q2iQpxo9TRn-kHpw"
    },
    "E6q83RB15n": {
      "kid": "E6q83RB15n",
      "kty": "RSA",
      "alg": "RS256",
      "e": "AQAB",
      "n": "qD2kjZNSBESRVJksHHnDpMPprhCymecPO8Ji6xlY_fGdUOioVf0nckGaiBwjPGo3xKadAGvbNJ1BjCZOmbLL7lQ5mT8fI6l5HaY8txcz3_PjOUHdiXBuThmQ2eEXtmOtRxi3LNnXaOCpl7QxHgyiPTVgJpJ18Teqz2ESVXg_Lpmw7ot3zBI0p9E56-HVZwxpwS8EoN53nx850fxAlpZj5d1szgV8YzhcRG-8FMOialu-me0OFZWghB-_jCMfdBhWHMWpGkfLPDA1o8eLkr0UByZwMHKCWA--JUvlKvSv3xavDD7ILj8t5PiItonVV9telbza-ToaOWMiG5gZ5QfWDQ"
    },
    "Sf2lFqwkpX": {
      "kid": "Sf2lFqwkpX",
      "kty": "RSA",
      "alg": "RS256",
      "e": "AQAB",
      "n": "oNe3ZKHU5-fnmbjhCamUpBSyLkR4jbQy-PCZU4cr7tyPcFokyZ1CjSGm44sw3EPONWO6bWgKZYBX2UPv7UM3GBIuB8qBkkN0_vu0Kdr8KUWJ-6m9fnKgceDil4K4TsSS8Owe9qnP9XjjmVRK7cCEjew4GYqQ7gRcHUjIQ-PrKkNBOOijxLlwckeQK2IN9WS_CBXVMleXLutfYAHpwr2KoAmt5BQvPFqBegozHaTc2UvarcUPKMrl-sjY_AXobH7NjqfbBLRJLzS2EzE4y865QiBpwwdhlK4ZQ3g1DCV57BDKvoBX0guCDNSFvoPuIjMmTxZEUbwrJ1CQ4Ib5j4VCkQ"
    },
    "bFwzleR8tf": {
      "kid": "bFwzleR8tf",
      "kty": "RSA",
      "alg": "RS256",
      "e": "AQAB",
      "n": "qM9ffgMqJdf3P8fRKYHNx31QtqumaA_puITT34Nlk3QVv7OOS2XM9a9Krt1sVs5N-SF1OoBWAy9D-zjyCymopYtRWMHdxEarZvAlWMpuT3jnHgotCOAcY9CZcXK5nz8eQrrqzaOlow-FHiUoGfDr-0y92NQhs8EYjf92fGIqQ5cQm5KHZAMUX1XtTpYVWQGVu56y5iUje3a78Pgu19n18MpGN52o4A3IM5ZSGlSV7372JwcBVzjmqukaY28Jmsjgh0mr4M5in7JANeUexKlREBVqPE3MlXnGkOdD7htMcMF1E31hBjIQBxVcE0J1hoyU7QybRsK5aroUYlpa0_FQCw"
    }
  }
}```

## Testing Plan
New and existing test infrastructure.
