### PR TITLE
[cli] Remove unused argument instruction_execution_bound

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -519,18 +519,6 @@ pub struct TestPackage {
     #[clap(flatten)]
     pub(crate) move_options: MovePackageOptions,
 
-    /// The maximum number of instructions that can be executed by a test
-    ///
-    /// If set, the number of instructions executed by one test will be bounded
-    // TODO: Remove short, it's against the style guidelines, and update the name here
-    #[clap(
-        name = "instructions",
-        default_value_t = 100000,
-        short = 'i',
-        long = "instructions"
-    )]
-    pub instruction_execution_bound: u64,
-
     /// Collect coverage information for later use with the various `aptos move coverage` subcommands
     #[clap(long = "coverage")]
     pub compute_coverage: bool,

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -852,7 +852,6 @@ impl CliTestFramework {
         filter: Option<&str>,
     ) -> CliTypedResult<&'static str> {
         TestPackage {
-            instruction_execution_bound: 100_000,
             move_options: self.move_options(account_strs),
             filter: filter.map(|str| str.to_string()),
             ignore_compile_warnings: false,


### PR DESCRIPTION
## Description
Unused argument 'instruction_execution_bound' can be removed.

## How Has This Been Tested?
If someone sets 'instruction_execution_bound' to zero by invoking:
`aptos move test --instructions 0`
```
➜  simple git:(main) ✗ aptos move test --instructions 0                                                                                                                                                                                                                                                                                                   git:(main|✚1…5
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING simple
Running Move unit tests
[ PASS    ] 0xcafe::Negation::neg_log_test
[ PASS    ] 0xcafe::Sum::sum_test
[ PASS    ] 0xcafe::BinaryReplacement::test_is_x_gt_zero
[ PASS    ] 0xcafe::BinaryReplacement::test_is_x_neq_to_zero
[ PASS    ] 0xcafe::StillSimple::sample1_valid_usage_test
[ PASS    ] 0xcafe::BinaryReplacement::test_is_zero
[ PASS    ] 0xcafe::BinaryReplacement::test_is_zero_lt_x
[ PASS    ] 0xcafe::StillSimple::sample2_valid_usage_test
```

Ran the tests, seems removing this argument has no effect on cargo tests.
The only difference with this change is that this argument is not shown in the help text of the `aptos move test` command.

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

