### PR TITLE
[State Sync] Add progress check to latency monitor.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -448,6 +448,8 @@ pub struct AptosDataClientConfig {
     pub max_transaction_output_chunk_size: u64,
     /// Timeout (in ms) when waiting for an optimistic fetch response
     pub optimistic_fetch_timeout_ms: u64,
+    /// The duration (in seconds) after which to panic if no progress has been made
+    pub progress_check_max_stall_time_secs: u64,
     /// First timeout (in ms) when waiting for a response
     pub response_timeout_ms: u64,
     /// Timeout (in ms) when waiting for a subscription response
@@ -474,8 +476,9 @@ impl Default for AptosDataClientConfig {
             max_subscription_lag_secs: 20, // 20 seconds
             max_transaction_chunk_size: MAX_TRANSACTION_CHUNK_SIZE,
             max_transaction_output_chunk_size: MAX_TRANSACTION_OUTPUT_CHUNK_SIZE,
-            optimistic_fetch_timeout_ms: 5000,        // 5 seconds
-            response_timeout_ms: 10_000,              // 10 seconds
+            optimistic_fetch_timeout_ms: 5000,         // 5 seconds
+            progress_check_max_stall_time_secs: 86400, // 24 hours (long enough to debug any issues at runtime)
+            response_timeout_ms: 10_000,               // 10 seconds
             subscription_response_timeout_ms: 15_000, // 15 seconds (longer than a regular timeout because of prefetching)
             use_compression: true,
         }


### PR DESCRIPTION
## Description
This PR adds a simple progress check to the latency monitor in state sync. The progress check ensures the node has made sufficient syncing progress in the last `X` period of time. If not, the node panics. This helps to automatically unblock stalled nodes (e.g., due to code bugs).

Note: the value for `X` is configurable, and the current default is 24 hours, so stalled nodes will panic after 24 hours of no syncing progress.

## Testing Plan
New and existing test infrastructure.
