### PR TITLE
[Compiler v2] add compiler support for signed integers

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -55,6 +55,7 @@ mod remote_state;
 mod resource_groups;
 mod rotate_auth_key;
 mod scripts;
+mod signed_int;
 mod simple_defi;
 mod smart_data_structures;
 mod stake;

--- a/aptos-move/e2e-move-tests/src/tests/signed_int.data/pack/Move.toml
+++ b/aptos-move/e2e-move-tests/src/tests/signed_int.data/pack/Move.toml
@@ -1,0 +1,6 @@
+[package]
+name = "signed_int"
+version = "0.0.0"
+
+[dependencies]
+AptosFramework = { local = "../../../../../framework/aptos-framework" }

--- a/aptos-move/e2e-move-tests/src/tests/signed_int.data/pack/sources/test.move
+++ b/aptos-move/e2e-move-tests/src/tests/signed_int.data/pack/sources/test.move
@@ -1,0 +1,544 @@
+ /// Module for testing signed integers
+ module 0x99::signed_int {
+    use std::i64;
+    use std::i128;
+
+    // test `from`
+    // create an `i64/i128` from a positive `u64/u128`, and then check if the result equals to `i64/i128` created from literals
+    fun test_from() {
+        assert!(i64::from(0) == 0i64, 0);
+        assert!(i64::from(1) == 1, 0);
+        assert!(i64::from(0x7fffffffffffffff) == 0x7fffffffffffffff, 0);
+        assert!(i128::from(0) == 0, 0);
+        assert!(i128::from(1) == 1, 0);
+        assert!(i128::from(0x7fffffffffffffffffffffffffffffff) == 0x7fffffffffffffffffffffffffffffff, 0);
+    }
+
+    // test `from`:
+    // create an `i64/i128` from a "negative" `u64/u128`, and then check if the result equals to `i64/i128` created from literals
+    fun test_neg_from() {
+        assert!(i64::neg_from(0) == 0, 0);
+        assert!(i64::neg_from(1) == -1, 0);
+        assert!(i64::neg_from(0x8000000000000000) == -0x8000000000000000, 0);
+    }
+
+    // test `neg` with built-in `-` operator
+    fun test_neg(){
+        assert!(i64::from(0).neg() == 0, 0);
+        assert!(i64::from(3).neg() == -3, 0);
+        assert!(i64::neg_from(3).neg() == 3, 0);
+
+        assert!(i128::from(0).neg() == 0, 0);
+        assert!(i128::from(3).neg() == -3, 0);
+        assert!(i128::neg_from(3).neg() == 3, 0);
+
+        let a = -3i64;
+        assert!(-a == 3, 0);
+        assert!(--a == a, 0);
+
+        let a = -3i128;
+        assert!(-a == 3, 0);
+        assert!(--a == a, 0);
+
+        let a = 3i64;
+        assert!(-a == -3, 0);
+        assert!(--a == a, 0);
+
+        let a = 3i128;
+        assert!(-a == -3, 0);
+        assert!(--a == a, 0);
+    }
+
+    // test `add` with built-in `-` operator
+    fun test_add() {
+        assert!(i64::from(5).add(i64::neg_from(3)) == 2, 0);
+        assert!(i128::from(5).add(i128::neg_from(3)) == 2, 0);
+        assert!(i64::from(3).add(i64::neg_from(5)) == -2, 0);
+        assert!(i128::from(3).add(i128::neg_from(5)) == -2, 0);
+        assert!(i64::from(1).add(i64::neg_from(1)) == 0, 0);
+        assert!(i128::from(1).add(i128::neg_from(1)) == 0, 0);
+
+        assert!(5 + (-3) == i64::from(2), 0);
+        assert!(5 + (-3) == i128::from(2), 0);
+
+        assert!(-5 + 3 == i64::neg_from(2), 0);
+        assert!(-5 + 3 == i128::neg_from(2), 0);
+
+        assert!(-1 + 1 == i64::from(0), 0);
+        assert!(-1 + 1 == i128::from(0), 0);
+
+        assert!(5 + (-3) == 2i64, 0);
+        assert!(5 + (-3) == 2i128, 0);
+
+        assert!(-5 + 3 == -2i64, 0);
+        assert!(-5 + 3 == -2i128, 0);
+
+        assert!(-1 + 1 == 0i64, 0);
+        assert!(-1 + 1 == 0i128, 0);
+
+        let a = 1i64;
+        let b = 2i64;
+        b += a;
+        assert!(a + b == 4, 0);
+
+        let a = -1i64;
+        let b = -2i64;
+        b += a;
+        assert!(a + b == -4, 0);
+
+        let a = 1i128;
+        let b = 2i128;
+        b += a;
+        assert!(a + b == 4, 0);
+
+        let a = -1i128;
+        let b = -2i128;
+        b += a;
+        assert!(a + b == -4, 0);
+    }
+
+    // test `sub` with built-in `-` operator
+    fun test_sub() {
+        assert!(i64::from(5).sub(i64::neg_from(3)) == 8, 0);
+        assert!(i128::from(5).sub(i128::neg_from(3)) == 8, 0);
+        assert!(i64::from(3).sub(i64::neg_from(5)) == 8, 0);
+        assert!(i128::from(3).sub(i128::neg_from(5)) == 8, 0);
+        assert!(i64::neg_from(1).sub(i64::from(1)) == -2, 0);
+        assert!(i128::neg_from(1).sub(i128::from(1)) == -2, 0);
+
+        assert!(5 - (-3) == i64::from(8), 0);
+        assert!(5 - (-3) == i128::from(8), 0);
+
+        assert!(3 - (-5) == i64::from(8), 0);
+        assert!(3 - (-5) == i128::from(8), 0);
+
+        assert!(-1 - 1 == i64::neg_from(2), 0);
+        assert!(-1 - 1 == i128::neg_from(2), 0);
+
+        assert!(5 - (-3) == 8i64, 0);
+        assert!(5 - (-3) == 8i128, 0);
+
+        assert!(3 - (-5) == 8i64, 0);
+        assert!(3 - (-5) == 8i128, 0);
+
+        assert!(-1 - 1 == -2i64, 0);
+        assert!(-1 - 1 == -2i128, 0);
+
+        let a = 1i64;
+        let b = 2i64;
+        assert!(a - b == -1, 0);
+
+        let a = -1i64;
+        let b = -2i64;
+        assert!(a - b == 1, 0);
+
+        let a = 1i128;
+        let b = 2i128;
+        assert!(a - b == -1, 0);
+
+        let a = -1i128;
+        let b = -2i128;
+        assert!(a - b == 1, 0);
+    }
+
+    // test `mul` with built-in `*` operator
+    fun test_mul() {
+        assert!(i64::from(5).mul(i64::neg_from(3)) == -15i64, 0);
+        assert!(i128::from(5).mul(i128::neg_from(3)) == -15i128, 0);
+
+        assert!(i64::neg_from(5).mul(i64::neg_from(3)) == 15i64, 0);
+        assert!(i128::neg_from(5).mul(i128::neg_from(3)) == 15i128, 0);
+
+        assert!(i64::from(5).mul(i64::from(3)) == 15i64, 0);
+        assert!(i128::from(5).mul(i128::from(3)) == 15i128, 0);
+
+        assert!(i64::from(0).mul(i64::from(3)) == 0, 0);
+        assert!(i128::from(0).mul(i128::from(3)) == 0, 0);
+
+
+        assert!(5 * (-3) == i64::neg_from(15), 0);
+        assert!(5 * (-3) == i128::neg_from(15), 0);
+
+        assert!((-5) * (-3) == i64::from(15), 0);
+        assert!((-5) * (-3) == i128::from(15), 0);
+
+        assert!(5 * 3 == i64::from(15), 0);
+        assert!(5 * 3 == i128::from(15), 0);
+
+        assert!(0 * 3 == i64::from(0), 0);
+        assert!(0 * 3 == i128::from(0), 0);
+
+        assert!(5 * (-3) == -15i64, 0);
+        assert!(5 * (-3) == -15i128, 0);
+
+        assert!((-5) * (-3) == 15i64, 0);
+        assert!((-5) * (-3) == 15i128, 0);
+
+        assert!(5 * 3 == 15i64, 0);
+        assert!(5 * 3 == 15i128, 0);
+
+        assert!(0 * 3 == 0i64, 0);
+        assert!(0 * 3 == 0i128, 0);
+    }
+
+    // test `div` with built-in `/` operator
+    fun test_div() {
+        assert!(i64::from(3).div(i64::from(3)) == 1, 0);
+        assert!(i64::from(4).div(i64::from(3)) == 1, 0);
+        assert!(i64::from(5).div(i64::from(3)) == 1, 0);
+        assert!(i64::neg_from(3).div(i64::from(3)) == -1, 0);
+        assert!(i64::neg_from(4).div(i64::from(3)) == -1, 0);
+        assert!(i64::neg_from(5).div(i64::from(3)) == -1, 0);
+
+        assert!(i128::from(3).div(i128::from(3)) == 1, 0);
+        assert!(i128::from(4).div(i128::from(3)) == 1, 0);
+        assert!(i128::from(5).div(i128::from(3)) == 1, 0);
+        assert!(i128::neg_from(3).div(i128::from(3)) == -1, 0);
+        assert!(i128::neg_from(4).div(i128::from(3)) == -1, 0);
+        assert!(i128::neg_from(5).div(i128::from(3)) == -1, 0);
+
+        assert!(3 / 3 == 1i64, 0);
+        assert!(4 / 3 == 1i64, 0);
+        assert!(5 / 3 == 1i64, 0);
+        assert!((-3) / 3 == -1i64, 0);
+        assert!((-4) / 3 == -1i64, 0);
+        assert!((-5) / 3 == -1i64, 0);
+
+        assert!(3 / 3 == 1i128, 0);
+        assert!(4 / 3 == 1i128, 0);
+        assert!(5 / 3 == 1i128, 0);
+        assert!((-3) / 3 == -1i128, 0);
+        assert!((-4) / 3 == -1i128, 0);
+        assert!((-5) / 3 == -1i128, 0);
+
+    }
+
+    // test `mod` with built-in `%` operator
+    fun test_mod() {
+        assert!(i64::from(10).mod(i64::from(3)) == 1, 0);
+        assert!(i64::neg_from(10).mod(i64::from(3)) == -1, 0);
+        assert!(i64::from(10).mod(i64::neg_from(3)) == 1, 0);
+        assert!(i64::neg_from(10).mod(i64::neg_from(3)) == -1, 0);
+
+        assert!(i128::from(10).mod(i128::from(3)) == 1, 0);
+        assert!(i128::neg_from(10).mod(i128::from(3)) == -1, 0);
+        assert!(i128::from(10).mod(i128::neg_from(3)) == 1, 0);
+        assert!(i128::neg_from(10).mod(i128::neg_from(3)) == -1, 0);
+
+        assert!(10 % 3 == 1i64, 0);
+        assert!((-10) % 3 == -1i64, 0);
+        assert!(10 % (-3) == 1i64, 0);
+        assert!((-10) % (-3) == -1i64, 0);
+
+        assert!(10 % 3 == 1i128, 0);
+        assert!((-10) % 3 == -1i128, 0);
+        assert!(10 % (-3) == 1i128, 0);
+        assert!((-10) % (-3) == -1i128, 0);
+    }
+
+    // test `gt/gte` with built-in `> >=` operator
+    fun test_gt_gte() {
+        assert!(i64::from(5) > (i64::from(3)), 0);
+        assert!(!(i64::from(3) > i64::from(5)), 0);
+        assert!(!(i64::from(5) > i64::from(5)), 0);
+        assert!(i64::from(5) > (i64::neg_from(5)), 0);
+        assert!(i64::neg_from(2) > (i64::neg_from(3)), 0);
+
+        assert!(i64::from(5) >= (i64::from(3)), 0);
+        assert!(!(i64::from(3) >= i64::from(5)), 0);
+        assert!(i64::from(5) >= (i64::from(5)), 0);
+        assert!(i64::from(5) >= (i64::neg_from(5)), 0);
+        assert!(i64::neg_from(2) >= (i64::neg_from(3)), 0);
+
+        assert!(i128::from(5) > (i128::from(3)), 0);
+        assert!(!(i128::from(3) > i128::from(5)), 0);
+        assert!(!(i128::from(5) > i128::from(5)), 0);
+        assert!(i128::from(5) > (i128::neg_from(5)), 0);
+        assert!(i128::neg_from(2) > (i128::neg_from(3)), 0);
+
+        assert!(i128::from(5) >= (i128::from(3)), 0);
+        assert!(!(i128::from(3) >= i128::from(5)), 0);
+        assert!(i128::from(5) >= (i128::from(5)), 0);
+        assert!(i128::from(5) >= (i128::neg_from(5)), 0);
+        assert!(i128::neg_from(2) >= (i128::neg_from(3)), 0);
+
+
+        assert!(5 > 3i64, 0);
+        assert!(!(3 > 5i64), 0);
+        assert!(!(5 > 5i64), 0);
+        assert!(5 > -5i64, 0);
+        assert!(-2 > -3i64, 0);
+
+        assert!(5 >= 3i64, 0);
+        assert!(!(3 >= 5i64), 0);
+        assert!(5 >= 5i64, 0);
+        assert!(5 >= -5i64, 0);
+        assert!(-2 >= -3i64, 0);
+
+        assert!(5 > 3i128, 0);
+        assert!(!(3 > 5i128), 0);
+        assert!(!(5 > 5i128), 0);
+        assert!(5 > -5i128, 0);
+        assert!(-2 > -3i128, 0);
+
+        assert!(5 >= 3i128, 0);
+        assert!(!(3 >= 5i128), 0);
+        assert!(5 >= 5i128, 0);
+        assert!(5 >= -5i128, 0);
+        assert!(-2 >= -3i128, 0);
+    }
+
+    // test `lt/lte` with built-in `< <=` operator
+    fun test_lt_lte() {
+        assert!(!(i64::from(5) < i64::from(3)), 0);
+        assert!(i64::from(3) < i64::from(5), 0);
+        assert!(!(i64::from(5) < i64::from(5)), 0);
+        assert!(i64::from(5) > (i64::neg_from(5)), 0);
+        assert!(!(i64::neg_from(2) < i64::neg_from(3)), 0);
+
+        assert!(!(i64::from(5) <= i64::from(3)), 0);
+        assert!(i64::from(3) <= i64::from(5), 0);
+        assert!(i64::from(5) <= (i64::from(5)), 0);
+        assert!(!(i64::from(5) <= i64::neg_from(5)), 0);
+        assert!(!(i64::neg_from(2) <= i64::neg_from(3)), 0);
+
+        assert!(!(i128::from(5) < i128::from(3)), 0);
+        assert!(i128::from(3) < i128::from(5), 0);
+        assert!(!(i128::from(5) < i128::from(5)), 0);
+        assert!(i128::from(5) > (i128::neg_from(5)), 0);
+        assert!(!(i128::neg_from(2) < i128::neg_from(3)), 0);
+
+        assert!(!(i128::from(5) <= i128::from(3)), 0);
+        assert!(i128::from(3) <= i128::from(5), 0);
+        assert!(i128::from(5) <= (i128::from(5)), 0);
+        assert!(!(i128::from(5) <= i128::neg_from(5)), 0);
+        assert!(!(i128::neg_from(2) <= i128::neg_from(3)), 0);
+
+
+        assert!(!(5 < 3i64), 0);
+        assert!(3 < 5i64, 0);
+        assert!(!(5 < 5i64), 0);
+        assert!(!(5 < -5i64), 0);
+        assert!(!(-2 < -3i64), 0);
+
+        assert!(!(5 <= 3i64), 0);
+        assert!(3 <= 5i64, 0);
+        assert!(5 <= 5i64, 0);
+        assert!(!(5 <= -5i64), 0);
+        assert!(!(-2 <= -3i64), 0);
+
+        assert!(!(5 < 3i128), 0);
+        assert!(3 < 5i128, 0);
+        assert!(!(5 < 5i128), 0);
+        assert!(!(5 < -5i128), 0);
+        assert!(!(-2 < -3i128), 0);
+
+        assert!(!(5 <= 3i128), 0);
+        assert!(3 <= 5i128, 0);
+        assert!(5 <= 5i128, 0);
+        assert!(!(5 <= -5i128), 0);
+        assert!(!(-2 <= -3i128), 0);
+    }
+
+    // test `eq` with built-in `==` operator
+    fun test_eq() {
+        assert!(i64::from(5) == 5, 0);
+        assert!(-5 == i64::neg_from(5), 0);
+        assert!(5i64 == 5, 0);
+        assert!(-5i64 == -5, 0);
+
+        assert!(i128::from(5) == 5, 0);
+        assert!(-5 == i128::neg_from(5), 0);
+        assert!(5i128 == 5, 0);
+        assert!(-5i128 == -5, 0);
+    }
+
+    // test `neq` with built-in `!=` operator
+    fun test_neq() {
+        assert!(!(i64::from(5) != 5), 0);
+        assert!(5 != i64::neg_from(5), 0);
+        assert!(!(5i64 != 5), 0);
+        assert!(!(-5i64 != -5), 0);
+
+        assert!(!(i128::from(5) != 5), 0);
+        assert!(5 != i128::neg_from(5), 0);
+        assert!(!(5i128 != 5), 0);
+        assert!(!(-5i128 != -5), 0);
+    }
+
+    // test `cmp` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_cmp() {
+        assert!(i64::cmp(5, 3) == 2, 0);
+        assert!(i64::cmp(3, 5) == 0, 0);
+        assert!(i64::cmp(5, 5) == 1, 0);
+        assert!(i64::cmp(-5, 5) == 0, 0);
+        assert!(i64::cmp(5, -5) == 2, 0);
+        assert!(i64::cmp(-1, -2) == 2, 0);
+
+        assert!(i128::cmp(5, 3) == 2, 0);
+        assert!(i128::cmp(3, 5) == 0, 0);
+        assert!(i128::cmp(5, 5) == 1, 0);
+        assert!(i128::cmp(-5, 5) == 0, 0);
+        assert!(i128::cmp(5, -5) == 2, 0);
+        assert!(i128::cmp(-1, -2) == 2, 0);
+    }
+
+    // test `wrapping_add` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_wrapping_add() {
+        assert!(i64::wrapping_add(6, 3) == 9, 0);
+        assert!(i64::wrapping_add(0x7fffffffffffffff, 1) == -0x8000000000000000, 0);
+        assert!(i64::wrapping_add(-1, 1) == 0, 0);
+
+        assert!(i128::wrapping_add(6, 3) == 9, 0);
+        assert!(i128::wrapping_add(0x7fffffffffffffffffffffffffffffff, 1) == -0x80000000000000000000000000000000, 0);
+        assert!(i128::wrapping_add(-1, 1) == 0, 0);
+    }
+
+    // test `wrapping_sub` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_wrapping_sub() {
+        assert!(i64::wrapping_sub(6, 3) == 3, 0);
+        assert!(i64::wrapping_sub(-0x8000000000000000, 1) == 0x7fffffffffffffff, 0);
+        assert!(i64::wrapping_sub(1, 1) == 0, 0);
+
+        assert!(i128::wrapping_sub(6, 3) == 3, 0);
+        assert!(i128::wrapping_sub(-0x80000000000000000000000000000000, 1) == 0x7fffffffffffffffffffffffffffffff, 0);
+        assert!(i128::wrapping_sub(1, 1) == 0, 0);
+    }
+
+    // test `abs` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_abs() {
+        assert!(i64::abs(5) == 5, 0);
+        assert!(i64::abs(-5) == 5, 0);
+        assert!(i64::abs(-0) == 0, 0);
+
+        assert!(i128::abs(5) == 5, 0);
+        assert!(i128::abs(-5) == 5, 0);
+        assert!(i128::abs(-0) == 0, 0);
+    }
+
+     // test `abs_u64/abs_u128` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_abs_u64() {
+        assert!(i64::abs_u64(5) == 5, 0);
+        assert!(i64::abs_u64(-5) == 5, 0);
+        assert!(i64::abs_u64(-0) == 0, 0);
+
+        assert!(i128::abs_u128(5) == 5, 0);
+        assert!(i128::abs_u128(-5) == 5, 0);
+        assert!(i128::abs_u128(-0) == 0, 0);
+    }
+
+    // test `min/max` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_min_max() {
+        assert!(i64::min(3, 3) == 3, 0);
+        assert!(i64::min(3, 5) == 3, 0);
+        assert!(i64::min(3, -5) == -5, 0);
+
+        assert!(i64::max(3, 3) == 3, 0);
+        assert!(i64::max(3, 5) == 5, 0);
+        assert!(i64::max(3, -5) == 3, 0);
+
+        assert!(i128::min(3, 3) == 3, 0);
+        assert!(i128::min(3, 5) == 3, 0);
+        assert!(i128::min(3, -5) == -5, 0);
+
+        assert!(i128::max(3, 3) == 3, 0);
+        assert!(i128::max(3, 5) == 5, 0);
+        assert!(i128::max(3, -5) == 3, 0);
+    }
+
+    // test `pow` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_pow() {
+        assert!(i64::pow(2, 0) == 1, 0);
+        assert!(i64::pow(2, 3) == 8, 0);
+        assert!(i64::pow(-2, 3) == -8, 0);
+        assert!(i64::pow(-2, 4) == 16, 0);
+
+        assert!(i128::pow(2, 0) == 1, 0);
+        assert!(i128::pow(2, 3) == 8, 0);
+        assert!(i128::pow(-2, 3) == -8, 0);
+        assert!(i128::pow(-2, 4) == 16, 0);
+    }
+
+    // test `zero/is_zero` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_zero() {
+        assert!(i64::is_zero(0), 0);
+        assert!(i64::is_zero(i64::zero()), 0);
+        assert!(!i64::is_zero(1), 0);
+        assert!(!i64::is_zero(-1), 0);
+
+        assert!(i128::is_zero(0), 0);
+        assert!(i128::is_zero(i128::zero()), 0);
+        assert!(!i128::is_zero(1), 0);
+        assert!(!i128::is_zero(-1), 0);
+    }
+
+    // test `sign/is_neg` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_sign() {
+        assert!(i64::sign(5) == 0, 0);
+        assert!(i64::sign(-5) == 1, 0);
+        assert!(i64::sign(0) == 0, 0);
+
+        assert!(!i64::is_neg(5), 0);
+        assert!(i64::is_neg(-5), 0);
+        assert!(!i64::is_neg(0), 0);
+
+        assert!(i128::sign(5) == 0, 0);
+        assert!(i128::sign(-5) == 1, 0);
+        assert!(i128::sign(0) == 0, 0);
+
+        assert!(!i128::is_neg(5), 0);
+        assert!(i128::is_neg(-5), 0);
+        assert!(!i128::is_neg(0), 0);
+
+    }
+
+    // test `bits/pack/unpack` method from `std::i64/i128` together with `i64/i128` literals
+    fun test_bits_pack_unpack() {
+        assert!(i64::bits(&5) == 5, 0);
+        assert!(i64::bits(&(-5)) == 0xfffffffffffffffb, 0);
+
+        assert!(i64::pack(0) == 0, 0);
+        assert!(i64::pack(5) == 5, 0);
+        assert!(i64::pack(0xfffffffffffffffb) == -5, 0);
+
+        assert!(i64::unpack(0) == 0, 0);
+        assert!(i64::unpack(5) == 5, 0);
+        assert!(i64::unpack(-5) == 0xfffffffffffffffb, 0);
+
+        assert!(i128::bits(&5) == 5, 0);
+        assert!(i128::bits(&(-5)) == 0xfffffffffffffffffffffffffffffffb, 0);
+
+        assert!(i128::pack(0) == 0, 0);
+        assert!(i128::pack(5) == 5, 0);
+        assert!(i128::pack(0xfffffffffffffffffffffffffffffffb) == -5, 0);
+
+        assert!(i128::unpack(0) == 0, 0);
+        assert!(i128::unpack(5) == 5, 0);
+        assert!(i128::unpack(-5) == 0xfffffffffffffffffffffffffffffffb, 0);
+    }
+
+    entry fun test_entry() {
+        test_from();
+        test_neg_from();
+        test_neg();
+        test_add();
+        test_sub();
+        test_mul();
+        test_div();
+        test_mod();
+        test_gt_gte();
+        test_lt_lte();
+        test_eq();
+        test_neq();
+
+        test_cmp();
+        test_wrapping_add();
+        test_wrapping_sub();
+        test_abs();
+        test_min_max();
+        test_pow();
+        test_zero();
+        test_sign();
+        test_bits_pack_unpack();
+    }
+}

--- a/aptos-move/e2e-move-tests/src/tests/signed_int.rs
+++ b/aptos-move/e2e-move-tests/src/tests/signed_int.rs
@@ -1,0 +1,30 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Transactional tests for signed integers,
+//! introduced in Move language version 2.2.3 and onwards.
+
+use crate::{assert_success, tests::common, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_types::account_address::AccountAddress;
+
+#[test]
+fn function_signed_int() {
+    let mut h = MoveHarness::new();
+    // Load the code
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x99").unwrap());
+    assert_success!(h.publish_package_with_options(
+        &acc,
+        &common::test_dir_path("signed_int.data/pack"),
+        BuildOptions::move_2()
+            .set_latest_language()
+            .with_experiment("signed-int-rewrite")
+    ));
+
+    assert_success!(h.run_entry_function(
+        &acc,
+        str::parse("0x99::signed_int::test_entry").unwrap(),
+        vec![],
+        vec![],
+    ));
+}

--- a/aptos-move/framework/move-stdlib/doc/i128.md
+++ b/aptos-move/framework/move-stdlib/doc/i128.md
@@ -37,6 +37,7 @@ Implements the <code><a href="i128.md#0x1_i128">i128</a></code> type. The type n
 -  [Function `gte`](#0x1_i128_gte)
 -  [Function `lt`](#0x1_i128_lt)
 -  [Function `lte`](#0x1_i128_lte)
+-  [Function `into_inner`](#0x1_i128_into_inner)
 -  [Function `twos_complement`](#0x1_i128_twos_complement)
 -  [Function `sign_internal`](#0x1_i128_sign_internal)
 
@@ -942,6 +943,31 @@ Checks if the first I128 number is less than or equal to the second
 
 <pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_lte">lte</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
     self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) &lt;= <a href="i128.md#0x1_i128_EQ">EQ</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_into_inner"></a>
+
+## Function `into_inner`
+
+Get the sign and the absolute value of an I128 number
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_into_inner">into_inner</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): (bool, u128)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_into_inner">into_inner</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): (bool, u128) {
+    (self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>() == 0, self.<a href="i128.md#0x1_i128_abs_u128">abs_u128</a>())
 }
 </code></pre>
 

--- a/aptos-move/framework/move-stdlib/doc/i64.md
+++ b/aptos-move/framework/move-stdlib/doc/i64.md
@@ -37,6 +37,7 @@ Implements the <code><a href="i64.md#0x1_i64">i64</a></code> type. The type name
 -  [Function `gte`](#0x1_i64_gte)
 -  [Function `lt`](#0x1_i64_lt)
 -  [Function `lte`](#0x1_i64_lte)
+-  [Function `into_inner`](#0x1_i64_into_inner)
 -  [Function `twos_complement`](#0x1_i64_twos_complement)
 -  [Function `sign_internal`](#0x1_i64_sign_internal)
 
@@ -942,6 +943,31 @@ Checks if the first I64 number is less than or equal to the second
 
 <pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_lte">lte</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
     self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) &lt;= <a href="i64.md#0x1_i64_EQ">EQ</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_into_inner"></a>
+
+## Function `into_inner`
+
+Get the sign and the absolute value of an I64 number
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_into_inner">into_inner</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): (bool, u64)
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_into_inner">into_inner</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): (bool, u64) {
+    (self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() == 0, self.<a href="i64.md#0x1_i64_abs_u64">abs_u64</a>())
 }
 </code></pre>
 

--- a/third_party/move/move-binary-format/src/binary_views.rs
+++ b/third_party/move/move-binary-format/src/binary_views.rs
@@ -336,7 +336,7 @@ impl BinaryIndexedView<'_> {
         use SignatureToken::*;
 
         match ty {
-            Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => Ok(AbilitySet::PRIMITIVES),
+            Bool | U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Address => Ok(AbilitySet::PRIMITIVES),
 
             Reference(_) | MutableReference(_) => Ok(AbilitySet::REFERENCES),
             Signer => Ok(AbilitySet::SIGNER),

--- a/third_party/move/move-binary-format/src/builders.rs
+++ b/third_party/move/move-binary-format/src/builders.rs
@@ -226,6 +226,8 @@ impl CompiledScriptBuilder {
             U64 => U64,
             U128 => U128,
             U256 => U256,
+            I64 => I64,
+            I128 => I128,
             Bool => Bool,
             Address => Address,
             Signer => Signer,

--- a/third_party/move/move-binary-format/src/check_bounds.rs
+++ b/third_party/move/move-binary-format/src/check_bounds.rs
@@ -686,7 +686,7 @@ impl<'a> BoundsChecker<'a> {
 
         for ty in ty.preorder_traversal() {
             match ty {
-                Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address | Signer | TypeParameter(_)
+                Bool | U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Address | Signer | TypeParameter(_)
                 | Reference(_) | MutableReference(_) | Vector(_) | Function(..) => (),
                 Struct(idx) => {
                     check_bounds_impl(self.view.struct_handles(), *idx)?;

--- a/third_party/move/move-binary-format/src/check_complexity.rs
+++ b/third_party/move/move-binary-format/src/check_complexity.rs
@@ -67,7 +67,7 @@ impl BinaryComplexityMeter<'_> {
                     cost = cost.saturating_add(struct_name.len() as u64 * COST_PER_IDENT_BYTE);
                     cost = cost.saturating_add(moduel_name.len() as u64 * COST_PER_IDENT_BYTE);
                 },
-                U8 | U16 | U32 | U64 | U128 | U256 | Signer | Address | Bool | Vector(_)
+                U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Signer | Address | Bool | Vector(_)
                 | Function(..) | TypeParameter(_) | Reference(_) | MutableReference(_) => (),
             }
         }

--- a/third_party/move/move-binary-format/src/compatibility.rs
+++ b/third_party/move/move-binary-format/src/compatibility.rs
@@ -443,6 +443,8 @@ impl Compatibility {
             | (SignatureToken::U64, SignatureToken::U64)
             | (SignatureToken::U128, SignatureToken::U128)
             | (SignatureToken::U256, SignatureToken::U256)
+            | (SignatureToken::I64, SignatureToken::I64)
+            | (SignatureToken::I128, SignatureToken::I128)
             | (SignatureToken::Address, SignatureToken::Address)
             | (SignatureToken::Signer, SignatureToken::Signer) => true,
             (SignatureToken::TypeParameter(old_idx), SignatureToken::TypeParameter(new_idx)) => {
@@ -498,7 +500,9 @@ impl Compatibility {
             | (SignatureToken::TypeParameter(_), _)
             | (SignatureToken::U16, _)
             | (SignatureToken::U32, _)
-            | (SignatureToken::U256, _) => false,
+            | (SignatureToken::U256, _)
+            | (SignatureToken::I64, _)
+            | (SignatureToken::I128, _) => false,
         }
     }
 

--- a/third_party/move/move-binary-format/src/file_format.rs
+++ b/third_party/move/move-binary-format/src/file_format.rs
@@ -954,6 +954,10 @@ pub enum SignatureToken {
     U32,
     /// Unsigned integers, 256 bits length.
     U256,
+    /// Signed integers, 64 bits length.
+    I64,
+    /// Signed integers, 128 bits length.
+    I128,
 }
 
 /// An iterator to help traverse the `SignatureToken` in a non-recursive fashion to avoid
@@ -986,7 +990,7 @@ impl<'a> Iterator for SignatureTokenPreorderTraversalIter<'a> {
                         self.stack.extend(args.iter().rev());
                     },
 
-                    Signer | Bool | Address | U8 | U16 | U32 | U64 | U128 | U256 | Struct(_)
+                    Signer | Bool | Address | U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Struct(_)
                     | TypeParameter(_) => (),
                 }
                 Some(tok)
@@ -1026,7 +1030,7 @@ impl<'a> Iterator for SignatureTokenPreorderTraversalIterWithDepth<'a> {
                             .extend(args.iter().map(|tok| (tok, depth + 1)).rev());
                     },
 
-                    Signer | Bool | Address | U8 | U16 | U32 | U64 | U128 | U256 | Struct(_)
+                    Signer | Bool | Address | U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Struct(_)
                     | TypeParameter(_) => (),
                 }
                 Some((tok, depth))
@@ -1083,6 +1087,8 @@ impl std::fmt::Debug for SignatureToken {
             SignatureToken::U64 => write!(f, "U64"),
             SignatureToken::U128 => write!(f, "U128"),
             SignatureToken::U256 => write!(f, "U256"),
+            SignatureToken::I64 => write!(f, "I64"),
+            SignatureToken::I128 => write!(f, "I128"),
             SignatureToken::Address => write!(f, "Address"),
             SignatureToken::Signer => write!(f, "Signer"),
             SignatureToken::Vector(boxed) => write!(f, "Vector({:?})", boxed),
@@ -1105,7 +1111,7 @@ impl SignatureToken {
     pub fn is_integer(&self) -> bool {
         use SignatureToken::*;
         match self {
-            U8 | U16 | U32 | U64 | U128 | U256 => true,
+            U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 => true,
             Bool
             | Address
             | Signer
@@ -1146,7 +1152,7 @@ impl SignatureToken {
         use SignatureToken::*;
 
         match self {
-            Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => true,
+            Bool | U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Address => true,
             Vector(inner) => inner.is_valid_for_constant(),
             Signer
             | Function(..)
@@ -1221,6 +1227,8 @@ impl SignatureToken {
             U64 => U64,
             U128 => U128,
             U256 => U256,
+            I64 => I64,
+            I128 => I128,
             Address => Address,
             Signer => Signer,
             Vector(ty) => Vector(Box::new(ty.instantiate(subst_mapping))),

--- a/third_party/move/move-binary-format/src/proptest_types/functions.rs
+++ b/third_party/move/move-binary-format/src/proptest_types/functions.rs
@@ -1063,7 +1063,7 @@ impl BytecodeGen {
     fn check_signature_token(token: &SignatureToken) -> bool {
         use SignatureToken::*;
         match token {
-            U8 | U16 | U32 | U64 | U128 | U256 | Bool | Address | Signer | Struct(_)
+            U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Bool | Address | Signer | Struct(_)
             | TypeParameter(_) => true,
             Vector(element_token) => BytecodeGen::check_signature_token(element_token),
             StructInstantiation(_, type_arguments) => type_arguments

--- a/third_party/move/move-binary-format/src/proptest_types/types.rs
+++ b/third_party/move/move-binary-format/src/proptest_types/types.rs
@@ -63,7 +63,7 @@ impl StDefnMaterializeState {
         use SignatureToken::*;
 
         match ty {
-            Bool | U8 | U16 | U32 | U64 | U128 | U256 | Address => AbilitySet::PRIMITIVES,
+            Bool | U8 | U16 | U32 | U64 | U128 | U256 | I64 | I128 | Address => AbilitySet::PRIMITIVES,
 
             Reference(_) | MutableReference(_) => AbilitySet::REFERENCES,
             Signer => AbilitySet::SIGNER,

--- a/third_party/move/move-command-line-common/src/parser.rs
+++ b/third_party/move/move-command-line-common/src/parser.rs
@@ -345,10 +345,14 @@ pub enum NumberFormat {
 }
 
 // Determines the base of the number literal, depending on the prefix
-pub(crate) fn determine_num_text_and_base(s: &str) -> (&str, NumberFormat) {
-    match s.strip_prefix("0x") {
-        Some(s_hex) => (s_hex, NumberFormat::Hex),
-        None => (s, NumberFormat::Decimal),
+pub(crate) fn determine_num_text_and_base(s: &str) -> (String, NumberFormat) {
+    if let Some(s_hex) = s.strip_prefix("0x") {
+        (s_hex.to_string(), NumberFormat::Hex)
+    } else if let Some(s_hex) = s.strip_prefix("-0x") {
+        // if negative hex, need to add the '-' back
+        (format!("-{}", s_hex), NumberFormat::Hex)
+    } else {
+        (s.to_string(), NumberFormat::Decimal)
     }
 }
 
@@ -402,6 +406,24 @@ pub fn parse_u256(s: &str) -> Result<(U256, NumberFormat), U256FromStrError> {
     let (txt, base) = determine_num_text_and_base(s);
     Ok((
         U256::from_str_radix(&txt.replace('_', ""), base as u32)?,
+        base,
+    ))
+}
+
+/// Parse an i64 from a decimal or hex encoding and return its value in i64
+pub fn parse_i64(s: &str) -> Result<(i64, NumberFormat), ParseIntError> {
+    let (txt, base) = determine_num_text_and_base(s);
+    Ok((
+        i64::from_str_radix(&txt.replace('_', ""), base as u32)?,
+        base,
+    ))
+}
+
+/// Parse an i128 from a decimal or hex encoding and return its value in i128
+pub fn parse_i128(s: &str) -> Result<(i128, NumberFormat), ParseIntError> {
+    let (txt, base) = determine_num_text_and_base(s);
+    Ok((
+        i128::from_str_radix(&txt.replace('_', ""), base as u32)?,
         base,
     ))
 }

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/ast.rs
@@ -488,6 +488,10 @@ pub enum Value_ {
     U128(u128),
     // <num>u256
     U256(move_core_types::u256::U256),
+    // <num>i64
+    I64(i64),
+    // <num>i128
+    I128(i128),
     // true
     // false
     Bool(bool),
@@ -1596,6 +1600,8 @@ impl AstDebug for Value_ {
             V::U64(u) => w.write(&format!("{}u64", u)),
             V::U128(u) => w.write(&format!("{}u128", u)),
             V::U256(u) => w.write(&format!("{}u256", u)),
+            V::I64(i) => w.write(&format!("{}i64", i)),
+            V::I128(i) => w.write(&format!("{}i128", i)),
             V::Bool(b) => w.write(&format!("{}", b)),
             V::Bytearray(v) => w.write(&format!("{:?}", v)),
         }

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/ast.rs
@@ -571,6 +571,8 @@ pub type Value = Spanned<Value_>;
 pub enum UnaryOp_ {
     // !
     Not,
+    // -
+    Neg,
 }
 pub type UnaryOp = Spanned<UnaryOp_>;
 
@@ -924,12 +926,14 @@ impl Type_ {
 }
 
 impl UnaryOp_ {
+    pub const NEG: &'static str = "-";
     pub const NOT: &'static str = "!";
 
     pub fn symbol(&self) -> &'static str {
         use UnaryOp_ as U;
         match self {
             U::Not => U::NOT,
+            U::Neg => U::NEG,
         }
     }
 
@@ -937,6 +941,7 @@ impl UnaryOp_ {
         use UnaryOp_ as U;
         match self {
             U::Not => true,
+            U::Neg => false,
         }
     }
 }

--- a/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/lexer.rs
+++ b/third_party/move/move-compiler-v2/legacy-move-compiler/src/parser/lexer.rs
@@ -736,9 +736,13 @@ fn get_number_maybe_with_suffix(text: &str, num_text_len: usize) -> (Tok, usize)
     let rest = &text[num_text_len..];
     if rest.starts_with("u8") {
         (Tok::NumTypedValue, num_text_len + 2)
-    } else if rest.starts_with("u64") || rest.starts_with("u16") || rest.starts_with("u32") {
+    } else if rest.starts_with("u64")
+        || rest.starts_with("u16")
+        || rest.starts_with("u32")
+        || rest.starts_with("i64")
+    {
         (Tok::NumTypedValue, num_text_len + 3)
-    } else if rest.starts_with("u128") || rest.starts_with("u256") {
+    } else if rest.starts_with("u128") || rest.starts_with("u256") || rest.starts_with("i128") {
         (Tok::NumTypedValue, num_text_len + 4)
     } else {
         // No typed suffix

--- a/third_party/move/move-compiler-v2/src/bytecode_generator.rs
+++ b/third_party/move/move-compiler-v2/src/bytecode_generator.rs
@@ -909,6 +909,7 @@ impl Generator<'_> {
                 self.gen_test_variants(targets, id, mid.qualified(*sid), variants, args)
             },
             Operation::Cast => self.gen_cast_call(targets, id, args),
+            Operation::Neg => self.gen_op_call(targets, id, BytecodeOperation::Neg, args),
             Operation::Add => self.gen_op_call(targets, id, BytecodeOperation::Add, args),
             Operation::Sub => self.gen_op_call(targets, id, BytecodeOperation::Sub, args),
             Operation::Mul => self.gen_op_call(targets, id, BytecodeOperation::Mul, args),

--- a/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inliner.rs
@@ -467,6 +467,9 @@ impl<'env> Inliner<'env> {
                     *self.inline_targets.state_mut(&target) = Spec(new_spec)
                 }
             },
+            MoveStruct(_) => {
+                // Nothing to do for struct decls.
+            },
         }
     }
 

--- a/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
@@ -22,6 +22,7 @@ pub mod model_ast_lints;
 pub mod recursive_struct_checker;
 pub mod rewrite_target;
 pub mod seqs_in_binop_checker;
+pub mod signed_int_rewriter;
 pub mod spec_checker;
 pub mod spec_rewriter;
 pub mod unused_params_checker;

--- a/third_party/move/move-compiler-v2/src/env_pipeline/signed_int_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/signed_int_rewriter.rs
@@ -1,0 +1,1114 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+//!
+//! Signed integer rewriter
+//! - Since language version 2.3, primitive types for signed integers, `i64` and `i128`, are allowed with built-in operations `+ - (as both sub and neg) * / % < > <= >= == != as`. Yet, the types and operations remain syntactic sugar without MoveVM support.
+//! - This rewriter rewrites the AST to replace all uses of `i64` and `i128` with their struct-based counterparts `Struct I64` and `Struct I128` from `move-stdlib::i64` and `move-stdlib::i128`. Likewise, operations on `i64` and `i128` will be replaced with those on `Struct I64` and `Struct I128`.
+//! - For simplicity of presentation, code below will use `struct modules` to refer to `Struct I64` and `Struct I128`.
+//!
+//! Example:
+//!    fun example(a: i64, b: i64): i64 {
+//!        a + b
+//!    }
+//!    =======>
+//!    fun example(a: I64, b: I64): I64 {
+//!        std::i64::add(a, b)
+//!    }
+//!
+//! To ensure correctness of the rewriting, the following must be ensured:
+//! 1. All occurances of `i64` and `i128` must be replaced with `Struct I64` and `Struct I128`, which include
+//!   - field types in struct definition
+//!   - argument types and return type of both Move and spec function declaration
+//!   - node types of AST expressions (including those in spec blocks)
+//!   - node instantiation types of AST expressions
+//!   - Important: the type rewriting needs to be done recursively (e.g., `i64` and `i128` nested inside `vector` also need to be replaced)
+//! 2. All operations on `i64` and `i128` must be replaced with those on `Struct I64` and `Struct I128`, listed as below (semantics should refer to `move-stdlib`):
+//!   - Constant numbers --> `std::i64/i128::pack()` (e.g., `10i64` --> `std::i64::pack(10u64)`)
+//!   - `+` -> `std::i64/i128::add()`
+//!   - `-` (as sub) -> `std::i64/i128::sub()`
+//!   - `-` (as neg) -> `std::i64/i128::neg()`
+//!   - `*` -> `std::i64/i128::mul()`
+//!   - `/` -> `std::i64/i128::div()`
+//!   - `%` -> `std::i64/i128::mod()`
+//!   - `<` -> `std::i64/i128::lt()`
+//!   - `>` -> `std::i64/i128::gt()`
+//!   - `<=` -> `std::i64/i128::lte()`
+//!   - `>=` -> `std::i64/i128::gte()`
+//!   - `==` -> `std::i64/i128::eq()`
+//!   - `!=` -> `std::i64/i128::ne()`
+//!   - `i64/i128 as u64/u128` -> `std::i64/i128::unpack()`
+//!   - `u64/u128 as i64/i128` -> `std::i64/i128::pack()`
+//!
+//!
+//! Key impls:
+//! - `rewrite_struct_def` to rewrite field types in struct definition
+//! - `rewrite_func_decl` to rewrite argument and return types in declarations of both Move and spec functions
+//! - `rewrite_spec_blocks` to rewrite spec blocks attached to structs, Move and spec functions, and modules
+//! - `rewrite_func_def` to rewrite expressions in both Move and spec functions
+//! - How to get alerted if we miss anything: all propagation of `i64`/`i128` beyond the AST (to stackless bytecode, to boogie type, or type tags) will abort the compilation!
+//!
+//! Important notes about linking struct modules:
+//! - To ensure the `std::i64` and `std::i128` are preserved in GlobalEnv during compilation,
+//!   - code is added in `third_party/move/move-model/src/lib.rs` to keep `std::i64` and `std::i128` and its dependencies during the ast expansion phase
+//! - To ensure implicit dependencies introduced by comparison rewriting are maintained
+//!   - code is added in `third_party/move/move-compiler-v2/legacy-move-compiler/src/expansion/dependency_ordering.rs` to add dependency between every user module and `std::i64` and `std::i128`.
+//! - If the user does not include `std::i64` and `std::i128` for compilation,
+//!   - a compilation error "cannot find `std::i64` and `std::i128` module" will be raised.
+//!
+
+use crate::env_pipeline::rewrite_target::{
+    RewriteState, RewriteTarget, RewriteTargets, RewritingScope,
+};
+use move_core_types::{account_address::AccountAddress, identifier::Identifier};
+use move_model::{
+    ast::{Address, Exp, ExpData, ModuleName, Operation, QuantKind},
+    exp_rewriter::ExpRewriterFunctions,
+    model::{
+        FieldId, FunId, FunctionEnv, GlobalEnv, Loc, ModuleEnv, ModuleId, NodeId, Parameter,
+        QualifiedId, SpecFunId, StructId,
+    },
+    ty::*,
+    well_known,
+};
+use num::BigInt;
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    convert::TryFrom,
+    iter::Iterator,
+    vec,
+};
+
+const SIGNED_INT_PKG: &str = "std";
+const SIGNED_INT_LIB: &str = "move-stdlib";
+const MODULE_COVERAGE_MSG: &str = "library modules for primitive signed int types expected";
+const OP_NOT_SUPPORTED: &str = "operation not supported for signed integers";
+
+/// Macro to report errors if struct modules or needed apis are not found in `GlobalEnv`
+macro_rules! missing_module_error {
+    ($env:expr, $loc:expr, $ty:expr) => {
+        $env.error(
+            $loc,
+            &format!(
+                "cannot find {}::{} module. Include `{}` for compilation.",
+                SIGNED_INT_PKG,
+                SignedIntRewriter::primitive_type_to_module_name($ty).expect(MODULE_COVERAGE_MSG),
+                SIGNED_INT_LIB
+            ),
+        );
+    };
+}
+
+/// Main interface for the signed integer rewriter
+pub fn rewrite(env: &mut GlobalEnv) {
+    let mut rewriter = SignedIntRewriter::new(env);
+    let mut targets = RewriteTargets::create(env, RewritingScope::CompilationTarget);
+    // why clone `targets`: `rewrite_func_def` will overwrite the states set up by `rewrite_func_decl`
+    let mut fun_def_targets = targets.clone();
+    rewrite_struct_def(&mut rewriter, &mut targets);
+    rewrite_func_decl(&mut rewriter, &mut targets);
+    rewrite_spec_blocks(&mut rewriter, &mut targets);
+    rewrite_func_def(&mut rewriter, &mut fun_def_targets);
+
+    // Write the mutations back all together. This avoids mixed immutable and mutable references to `env`
+    targets.write_to_env(env);
+    fun_def_targets.write_to_env(env);
+}
+
+/// Rewrite struct defs
+fn rewrite_struct_def(rewriter: &mut SignedIntRewriter, targets: &mut RewriteTargets) {
+    let todo: BTreeSet<_> = targets.keys().collect();
+    for target in todo {
+        if let RewriteTarget::MoveStruct(struct_id) = target {
+            let new_def = rewriter.rewrite_struct_def(struct_id);
+            if let Some(field_map) = new_def {
+                *targets.state_mut(&target) = RewriteState::StructDef(field_map);
+            }
+        }
+    }
+}
+
+/// Rewrite Move and spec function declarations
+fn rewrite_func_decl(rewriter: &mut SignedIntRewriter, targets: &mut RewriteTargets) {
+    let todo: BTreeSet<_> = targets.keys().collect();
+    for target in todo {
+        match target {
+            RewriteTarget::MoveFun(func_id) => {
+                let new_decl = rewriter.rewrite_func_decl(func_id);
+                if let Some((params, ret_type)) = new_decl {
+                    *targets.state_mut(&target) = RewriteState::Decl(params, ret_type);
+                }
+            },
+
+            RewriteTarget::SpecFun(_spec_func_id) => {
+                let new_decl = rewriter.rewrite_specfunc_decl(_spec_func_id);
+                if let Some((params, ret_type)) = new_decl {
+                    *targets.state_mut(&target) = RewriteState::Decl(params, ret_type);
+                }
+            },
+            RewriteTarget::MoveStruct(_) | RewriteTarget::SpecBlock(_) => {},
+        }
+    }
+}
+
+/// Rewrite spec blocks attached to structs, Move functions, spec functions, and the module.
+fn rewrite_spec_blocks(rewriter: &mut SignedIntRewriter, targets: &mut RewriteTargets) {
+    let todo: BTreeSet<_> = targets.keys().collect();
+    for target in todo {
+        if let RewriteTarget::SpecBlock(ref spblock) = target {
+            let spec = rewriter.env.get_spec_block(spblock);
+            let (changed, new_spec) = rewriter.rewrite_spec_descent(spblock, &spec);
+            if changed {
+                *targets.state_mut(&target) = RewriteState::Spec(new_spec);
+            }
+        }
+    }
+}
+
+/// Rewrite Move and spec function defs
+fn rewrite_func_def(rewriter: &mut SignedIntRewriter, targets: &mut RewriteTargets) {
+    let todo: BTreeSet<_> = targets.keys().collect();
+    for target in todo {
+        match target {
+            RewriteTarget::MoveFun(func_id) => {
+                let func_env = rewriter.env.get_function(func_id);
+                if let Some(def_opt) = func_env.get_def() {
+                    let new_def = rewriter.rewrite_exp(def_opt.clone());
+                    if *def_opt != new_def {
+                        *targets.state_mut(&target) = RewriteState::Def(new_def);
+                    }
+                }
+            },
+            RewriteTarget::SpecFun(_spec_func_id) => {
+                let spec_fun = rewriter.env.get_spec_fun(_spec_func_id);
+                if let Some(def_opt) = spec_fun.body.clone() {
+                    let new_def = rewriter.rewrite_exp(def_opt.clone());
+                    if def_opt != new_def {
+                        *targets.state_mut(&target) = RewriteState::Def(new_def);
+                    }
+                }
+            },
+            RewriteTarget::MoveStruct(_) | RewriteTarget::SpecBlock(_) => {},
+        }
+    }
+}
+
+struct SignedIntRewriter<'env> {
+    env: &'env GlobalEnv,
+    // Mapping from struct modules to the list of APIs needed from each module
+    // key: module name in string
+    // value: (module_id, (function name in string, function_id))
+    signed_int_apis: Option<BTreeMap<&'static str, (ModuleId, BTreeMap<&'static str, FunId>)>>,
+    // Mapping from primitive signed int types to their corresponding struct type (e.g., i64 -> Struct std::i64::I64)
+    primitive_ty_to_struct: Option<BTreeMap<Type, Type>>,
+    // Mapping from struct types to their corresponding primitive signed int type (e.g., Struct std::i64::I64 -> i64)
+    struct_to_primitive_ty: Option<BTreeMap<Type, Type>>,
+}
+
+impl<'env> SignedIntRewriter<'env> {
+    fn new(env: &'env GlobalEnv) -> Self {
+        let mut module_map = BTreeMap::new();
+        // gather struct modules and the functions needed from them
+        for module_name in [well_known::I64_MODULE, well_known::I128_MODULE] {
+            if let Some(module) = Self::find_module(env, module_name) {
+                let mut api_map = BTreeMap::new();
+                for func_name in well_known::SIGNED_INT_FUNCTIONS {
+                    if let Some(func) = Self::find_function(&module, func_name) {
+                        api_map.insert(func_name, func.get_id());
+                    } else {
+                        // Abnormal and abort: module found but function not found
+                        panic!("expected signed int function {}", func_name);
+                    }
+                }
+                if !api_map.is_empty() {
+                    module_map.insert(module_name, (module.get_id(), api_map));
+                }
+            }
+        }
+
+        // Build bi-mapping between primitive types and struct types
+        let mut primitive_ty_to_struct = BTreeMap::new();
+        let mut struct_to_primitive_ty = BTreeMap::new();
+        for primitive_ty in [
+            Type::Primitive(PrimitiveType::I64),
+            Type::Primitive(PrimitiveType::I128),
+        ] {
+            let module_name =
+                Self::primitive_type_to_module_name(&primitive_ty).expect(MODULE_COVERAGE_MSG);
+            let struct_name =
+                Self::primitive_type_to_struct_name(&primitive_ty).expect(MODULE_COVERAGE_MSG);
+
+            if let Some(module_id) = Self::find_module_from_map(module_name, &module_map) {
+                let module = env.get_module(module_id);
+                let struct_identifier = Identifier::new_unchecked(struct_name);
+                if let Some(struct_id) = module.find_struct_by_identifier(struct_identifier) {
+                    primitive_ty_to_struct.insert(
+                        primitive_ty.clone(),
+                        Type::Struct(module_id, struct_id, vec![]),
+                    );
+                    struct_to_primitive_ty.insert(
+                        Type::Struct(module_id, struct_id, vec![]),
+                        primitive_ty.clone(),
+                    );
+                }
+            }
+        }
+
+        Self {
+            env,
+            signed_int_apis: (!module_map.is_empty()).then_some(module_map),
+            primitive_ty_to_struct: (!primitive_ty_to_struct.is_empty())
+                .then_some(primitive_ty_to_struct),
+            struct_to_primitive_ty: (!struct_to_primitive_ty.is_empty())
+                .then_some(struct_to_primitive_ty),
+        }
+    }
+
+    /// Function to iterate over struct fields and substitute their types from `i64`/`i128` to `Struct I64`/`Struct I128`
+    /// Return `None` is no substitution is made.
+    fn rewrite_struct_def(
+        &self,
+        struct_id: QualifiedId<StructId>,
+    ) -> Option<BTreeMap<FieldId, Type>> {
+        let struct_env = self.env.get_struct(struct_id);
+        let old_field_type: BTreeMap<_, _> = struct_env
+            .get_fields()
+            .map(|field| (field.get_id(), field.get_type()))
+            .collect();
+        let new_field_type: BTreeMap<_, _> = old_field_type
+            .iter()
+            .map(|(id, ty)| {
+                (
+                    *id,
+                    self.rewrite_type(ty, &struct_env.get_loc())
+                        .unwrap_or_else(|| ty.clone()),
+                )
+            })
+            .collect();
+
+        if old_field_type != new_field_type {
+            Some(new_field_type)
+        } else {
+            None
+        }
+    }
+
+    /// Function to check function arguments and return value and substitute their types from `i64`/`i128` to `Struct I64`/`Struct I128`
+    /// Return `None` is no substitution is made.
+    fn rewrite_func_decl(&self, func_id: QualifiedId<FunId>) -> Option<(Vec<Parameter>, Type)> {
+        let func_env = self.env.get_function(func_id);
+        let params = func_env.get_parameters();
+        let ret_type = func_env.get_result_type();
+
+        let new_params: Vec<_> = params
+            .iter()
+            .map(|param| {
+                let param_type = param.get_type();
+                let param_loc = param.get_loc();
+                self.rewrite_type(&param_type, &param_loc)
+                    .map(|new_param_type| Parameter(param.get_name(), new_param_type, param_loc))
+                    .unwrap_or_else(|| param.clone())
+            })
+            .collect();
+        let new_ret_type = self.rewrite_type(&ret_type, &func_env.get_loc());
+        if new_ret_type.is_some() || new_params != params {
+            Some((new_params, new_ret_type.unwrap_or_else(|| ret_type.clone())))
+        } else {
+            None
+        }
+    }
+
+    /// Function to check spec function arguments and return value and substitute their types from `i64`/`i128` to `Struct I64`/`Struct I128`
+    /// Return `None` is no substitution is made.
+    fn rewrite_specfunc_decl(
+        &self,
+        func_id: QualifiedId<SpecFunId>,
+    ) -> Option<(Vec<Parameter>, Type)> {
+        let spec_fun = self.env.get_spec_fun(func_id);
+        let params = spec_fun.params.clone();
+        let ret_type = spec_fun.result_type.clone();
+
+        let new_params: Vec<_> = params
+            .iter()
+            .map(|param| {
+                let param_type = param.get_type();
+                let param_loc = param.get_loc();
+                self.rewrite_type(&param_type, &param_loc)
+                    .map(|new_param_type| Parameter(param.get_name(), new_param_type, param_loc))
+                    .unwrap_or_else(|| param.clone())
+            })
+            .collect();
+
+        let new_ret_type = self.rewrite_type(&ret_type, &spec_fun.loc);
+
+        if new_ret_type.is_some() || new_params != params {
+            Some((new_params, new_ret_type.unwrap_or_else(|| ret_type.clone())))
+        } else {
+            None
+        }
+    }
+
+    /// Recursively rewrite `i64`/`i128` types to `Struct I64` and `Struct I128`
+    fn rewrite_type(&self, ty: &Type, loc: &Loc) -> Option<Type> {
+        match ty {
+            Type::Primitive(PrimitiveType::I64) | Type::Primitive(PrimitiveType::I128) => {
+                if let Some(primitive_ty_to_struct) = &self.primitive_ty_to_struct {
+                    primitive_ty_to_struct.get(ty).cloned()
+                } else {
+                    missing_module_error!(self.env, loc, ty);
+                    None
+                }
+            },
+            Type::Reference(ref_kind, ref_ty) => self
+                .rewrite_type(ref_ty, loc)
+                .map(|new_ty| Type::Reference(*ref_kind, Box::new(new_ty))),
+            Type::Tuple(elements) => {
+                let new_elements: Vec<_> = elements
+                    .iter()
+                    .map(|elem| self.rewrite_type(elem, loc).unwrap_or(elem.clone()))
+                    .collect();
+                if new_elements != *elements {
+                    Some(Type::Tuple(new_elements))
+                } else {
+                    None
+                }
+            },
+            Type::Vector(elem_ty) => {
+                let new_elem_ty = self.rewrite_type(elem_ty, loc)?;
+                Some(Type::Vector(Box::new(new_elem_ty)))
+            },
+            Type::Struct(mid, sid, type_args) => {
+                let new_type_args: Vec<_> = type_args
+                    .iter()
+                    .map(|arg| self.rewrite_type(arg, loc).unwrap_or(arg.clone()))
+                    .collect();
+
+                if new_type_args != *type_args {
+                    Some(Type::Struct(*mid, *sid, new_type_args))
+                } else {
+                    None
+                }
+            },
+            Type::Fun(param_type, ret_type, abi) => {
+                let new_param_ty = self
+                    .rewrite_type(param_type, loc)
+                    .unwrap_or(*param_type.clone());
+                let new_ret_ty = self
+                    .rewrite_type(ret_type, loc)
+                    .unwrap_or(*ret_type.clone());
+                if new_param_ty != **param_type || new_ret_ty != **ret_type {
+                    Some(Type::Fun(
+                        Box::new(new_param_ty),
+                        Box::new(new_ret_ty),
+                        *abi,
+                    ))
+                } else {
+                    None
+                }
+            },
+            Type::TypeDomain(ty) => {
+                let new_ty = self.rewrite_type(ty, loc).unwrap_or(*ty.clone());
+                if new_ty != **ty {
+                    Some(Type::TypeDomain(Box::new(new_ty)))
+                } else {
+                    None
+                }
+            },
+            Type::ResourceDomain(mid, sid, opt_tys) => opt_tys.as_ref().and_then(|tys| {
+                let new_opt_types: Vec<_> = tys
+                    .iter()
+                    .map(|ty| self.rewrite_type(ty, loc).unwrap_or_else(|| ty.clone()))
+                    .collect();
+                if new_opt_types != *tys {
+                    Some(Type::ResourceDomain(*mid, *sid, Some(new_opt_types)))
+                } else {
+                    None
+                }
+            }),
+            // These types cannot involve `i64` or `i128`
+            Type::Primitive(_) | Type::TypeParameter(_) | Type::Var(_) | Type::Error => None,
+        }
+    }
+
+    /// Recursively rewrite a vector of types
+    /// Any type that cannot be rewritten will be returned as it is
+    fn rewrite_type_vec(&self, tys: &Vec<Type>, loc: &Loc) -> Option<Vec<Type>> {
+        let new_tys: Vec<_> = tys
+            .iter()
+            .map(|t| self.rewrite_type(t, loc).unwrap_or(t.clone()))
+            .collect();
+        // if no arg is rewritten, return nothing
+        if &new_tys == tys {
+            None
+        } else {
+            Some(new_tys)
+        }
+    }
+
+    /******* A list of helper functions*******/
+    /// Locate a struct module by its name from the GlobalEnv
+    fn find_module(env: &'env GlobalEnv, name: &str) -> Option<ModuleEnv<'env>> {
+        let module_name = ModuleName::new(
+            Address::Numerical(AccountAddress::ONE),
+            env.symbol_pool().make(name),
+        );
+        env.find_module(&module_name)
+    }
+
+    /// Locate a function by its string identifier from the given ModuleEnv
+    fn find_function(module: &ModuleEnv<'env>, func_name: &str) -> Option<FunctionEnv<'env>> {
+        let func_sym = module.symbol_pool().make(func_name);
+        module.find_function(func_sym)
+    }
+
+    /// Find a struct module id by its string identifier, assuming we already have a map of the struct modules gathered from the GlobalEnv
+    /// `module_map` is guaranteed to use Address::ONE
+    fn find_module_from_map(
+        module_name: &'static str,
+        module_map: &BTreeMap<&'static str, (ModuleId, BTreeMap<&'static str, FunId>)>,
+    ) -> Option<ModuleId> {
+        module_map.get(module_name).map(|(module_id, _)| *module_id)
+    }
+
+    /// Mapping a primitive signed int type to its struct module name
+    fn primitive_type_to_module_name(ty: &Type) -> Option<&'static str> {
+        match ty {
+            Type::Primitive(PrimitiveType::I64) => Some(well_known::I64_MODULE),
+            Type::Primitive(PrimitiveType::I128) => Some(well_known::I128_MODULE),
+            _ => None,
+        }
+    }
+
+    /// Mapping a primitive signed int type to its counterpart struct name
+    fn primitive_type_to_struct_name(ty: &Type) -> Option<&'static str> {
+        match ty {
+            Type::Primitive(PrimitiveType::I64) => Some(well_known::I64_STRUCT),
+            Type::Primitive(PrimitiveType::I128) => Some(well_known::I128_STRUCT),
+            _ => None,
+        }
+    }
+
+    /// Mapping a primitive signed int type to its counterpart struct type
+    fn get_primitive_ty_from_struct(&self, ty: &Type) -> Option<Type> {
+        self.struct_to_primitive_ty
+            .as_ref()
+            .and_then(|map| map.get(ty))
+            .cloned()
+    }
+
+    /// Check if a type indicates the needs of rewriting
+    /// - Note: this function does not check nested types except for references!!!
+    fn need_rewrite(&self, ty: &Type) -> bool {
+        Self::is_signed_primitive_type(ty)
+            || self.is_signed_struct_type(ty)
+            || self.is_signed_ref_type(ty)
+    }
+
+    /// A variant of `need_rewrite` that does not check for references
+    fn need_rewrite_no_ref(&self, ty: &Type) -> bool {
+        Self::is_signed_primitive_type(ty) || self.is_signed_struct_type(ty)
+    }
+
+    fn is_signed_primitive_type(ty: &Type) -> bool {
+        matches!(
+            ty,
+            Type::Primitive(PrimitiveType::I64) | Type::Primitive(PrimitiveType::I128)
+        )
+    }
+
+    fn is_signed_struct_type(&self, ty: &Type) -> bool {
+        self.struct_to_primitive_ty
+            .as_ref()
+            .and_then(|map| map.get(ty))
+            .is_some()
+    }
+
+    fn is_signed_ref_type(&self, ty: &Type) -> bool {
+        matches!(ty, Type::Reference(_, ref_ty) if self.is_signed_struct_type(ref_ty) || Self::is_signed_primitive_type(ref_ty))
+    }
+
+    /// Rewrite an argument of an Operation. It requires that the given argument
+    /// - if a primitive signed integer, must have been rewritten to the struct type
+    /// - if a reference type, must refer to a signed integer struct type
+    fn rewrite_ref_allowed_arg(&mut self, arg: &Exp) -> Option<Exp> {
+        let res_ty = self.env.get_node_type(arg.node_id());
+        let loc = self.env.get_node_loc(arg.node_id());
+        match res_ty {
+            // If signed int primitive types, abort!
+            Type::Primitive(..) if Self::is_signed_primitive_type(&res_ty) => {
+                panic!("Primitive signed integers must have been rewritten")
+            },
+            // If signed struct types, return
+            Type::Struct(..) if self.is_signed_struct_type(&res_ty) => Some(arg.clone()),
+            // If reference types, strip the reference or dereference
+            Type::Reference(_, ref_ty) if self.is_signed_struct_type(&ref_ty) => {
+                // - if borrowed with one arg exp, return the arg exp as an optimization
+                if let ExpData::Call(_, Operation::Borrow(_), inner_args) = arg.as_ref() {
+                    if inner_args.len() == 1 {
+                        return Some(inner_args[0].clone());
+                    }
+                }
+                // - otherwise, dereference
+                let new_node_id = self.env.new_node(loc, (*ref_ty).clone());
+                Some(ExpData::Call(new_node_id, Operation::Deref, vec![arg.clone()]).into_exp())
+            },
+            _ => None,
+        }
+    }
+
+    /// Mapping an operation over signed int to a wrapper function from the struct module
+    fn get_operation_api(&self, res_ty: &Type, oper: &Operation) -> Option<(ModuleId, FunId)> {
+        // Get the struct module name based on the node type of the operation
+        let module_name = match res_ty {
+            Type::Primitive(PrimitiveType::I64) | Type::Primitive(PrimitiveType::I128) => {
+                Self::primitive_type_to_module_name(res_ty)
+            },
+            Type::Struct(_, _, _) => self
+                .struct_to_primitive_ty
+                .as_ref()
+                .and_then(|map| map.get(res_ty))
+                .and_then(Self::primitive_type_to_module_name),
+            _ => None,
+        }?;
+
+        let module_map = self.signed_int_apis.as_ref()?.get(module_name)?;
+        match oper {
+            Operation::Add => Some((module_map.0, *module_map.1.get("add")?)),
+            Operation::Sub => Some((module_map.0, *module_map.1.get("sub")?)),
+            Operation::Mul => Some((module_map.0, *module_map.1.get("mul")?)),
+            Operation::Div => Some((module_map.0, *module_map.1.get("div")?)),
+            Operation::Mod => Some((module_map.0, *module_map.1.get("mod")?)),
+            Operation::Eq => Some((module_map.0, *module_map.1.get("eq")?)),
+            Operation::Neq => Some((module_map.0, *module_map.1.get("neq")?)),
+            Operation::Gt => Some((module_map.0, *module_map.1.get("gt")?)),
+            Operation::Lt => Some((module_map.0, *module_map.1.get("lt")?)),
+            Operation::Ge => Some((module_map.0, *module_map.1.get("gte")?)),
+            Operation::Le => Some((module_map.0, *module_map.1.get("lte")?)),
+            Operation::Neg => Some((module_map.0, *module_map.1.get("neg")?)),
+            _ => None,
+        }
+    }
+
+    /// Mapping an node type and an api name to a function from the struct module
+    fn get_api_by_ty_and_name(&self, res_ty: &Type, name: &str) -> Option<(ModuleId, FunId)> {
+        // Get the struct module name based on the node type of the operation
+        let module_name = match res_ty {
+            Type::Primitive(PrimitiveType::I64) | Type::Primitive(PrimitiveType::I128) => {
+                Self::primitive_type_to_module_name(res_ty)
+            },
+            Type::Struct(_, _, _) => self
+                .struct_to_primitive_ty
+                .as_ref()
+                .and_then(|map| map.get(res_ty))
+                .and_then(Self::primitive_type_to_module_name),
+            _ => None,
+        }?;
+
+        let module_map = self.signed_int_apis.as_ref()?.get(module_name)?;
+        Some((module_map.0, *module_map.1.get(name)?))
+    }
+
+    /// Rewrite the node type and instantiation type as needed and return an updated node id
+    /// Either condition below indicates the need of a rewrite
+    /// - The the node type involves a signed int type
+    /// - The the node instantiation, if any (indicated by argument `inst`), involves a signed int type
+    fn update_node_type(&self, id: NodeId, inst: bool) -> Option<NodeId> {
+        let loc = self.env.get_node_loc(id);
+        let node_ty = self.env.get_node_type(id);
+        let node_inst_vec = self.env.get_node_instantiation(id);
+
+        let new_node_type = self.rewrite_type(&node_ty, &loc);
+        let new_inst_tys = if inst {
+            self.rewrite_type_vec(&node_inst_vec, &loc)
+        } else {
+            None
+        };
+
+        if new_node_type.is_some() || new_inst_tys.is_some() {
+            let new_node = self
+                .env
+                .new_node(loc.clone(), new_node_type.unwrap_or(node_ty));
+            if inst {
+                self.env
+                    .set_node_instantiation(new_node, new_inst_tys.unwrap_or(node_inst_vec));
+            }
+            Some(new_node)
+        } else {
+            None
+        }
+    }
+
+    /// Create a new node with potentially updated type and instantiation
+    fn update_node_op(&self, id: NodeId, inst: bool) -> NodeId {
+        self.update_node_type(id, inst).unwrap_or_else(|| {
+            self.env
+                .new_node(self.env.get_node_loc(id), self.env.get_node_type(id))
+        })
+    }
+}
+
+/// Rewrite different expressions by overriding the `rewrite_*` methods from the `ExpRewriterFunctions` trait
+/// - As descendant expressions are processed first, we can safely assume the arguments to an expression are already rewritten
+///
+/// To ensure handling of all signed int types, we must
+/// - rewrite all operations that need to be replaced with their corresponding functions from the struct modules
+/// - rewrite all node types that involve signed int
+/// - rewrite all type instantiations that involve signed int
+///
+impl ExpRewriterFunctions for SignedIntRewriter<'_> {
+    /// This function rewrite a constant `i64` or `i128`
+    /// - If the input node type has signed int type
+    ///   - It replaces the constant with a call to the corresponding `pack` function in the struct module to construct a struct value
+    ///   - No instantiation is needed for the new node, as `pack` takes none.
+    fn rewrite_value(&mut self, id: NodeId, value: &move_model::ast::Value) -> Option<Exp> {
+        // Not an integer
+        let move_model::ast::Value::Number(num) = value else {
+            return None;
+        };
+        let loc = self.env.get_node_loc(id);
+        let node_ty = self.env.get_node_type(id);
+        // Not a target of rewriting
+        if !self.need_rewrite_no_ref(&node_ty) {
+            return None;
+        }
+        // For ease of matching, get the primitive type if the node type is a struct type
+        // Why a value node can have a struct type: it can be unified with other signed int struct types used in user code
+        let node_ty = self
+            .get_primitive_ty_from_struct(&node_ty)
+            .unwrap_or(node_ty);
+        match node_ty {
+            // `i64` and `i128` constants have been properly stored into `num` with signedness handled by `translate_number`
+            // so we check if `num` falls into the correct signed int range
+            Type::Primitive(PrimitiveType::I64) if i64::try_from(num).is_ok() => {
+                // get the `pack` function from the struct module
+                let Some((mid, fid)) = self.get_api_by_ty_and_name(&node_ty, "pack") else {
+                    missing_module_error!(self.env, &loc, &node_ty);
+                    return None;
+                };
+                // prepare an `u64` argument for the `pack` function by copying the bits of the `i64` value, following the semantics of `pack`!
+                let arg = ExpData::Value(
+                    self.env.new_node(loc, Type::Primitive(PrimitiveType::U64)),
+                    move_model::ast::Value::Number(BigInt::from(
+                        i64::try_from(num).expect("value ensured to be `i64`") as u64,
+                    )),
+                )
+                .into_exp();
+                // assemble a call to `pack`
+                Some(
+                    ExpData::Call(
+                        self.update_node_op(id, false),
+                        Operation::MoveFunction(mid, fid),
+                        vec![arg],
+                    )
+                    .into_exp(),
+                )
+            },
+            Type::Primitive(PrimitiveType::I128) if i128::try_from(num).is_ok() => {
+                let Some((mid, fid)) = self.get_api_by_ty_and_name(&node_ty, "pack") else {
+                    missing_module_error!(self.env, &loc, &node_ty);
+                    return None;
+                };
+                // handled similarly to `i64`
+                let arg = ExpData::Value(
+                    self.env.new_node(loc, Type::Primitive(PrimitiveType::U128)),
+                    move_model::ast::Value::Number(BigInt::from(
+                        i128::try_from(num).expect("value ensured to be `i128`") as u128,
+                    )),
+                )
+                .into_exp();
+                Some(
+                    ExpData::Call(
+                        self.update_node_op(id, false),
+                        Operation::MoveFunction(mid, fid),
+                        vec![arg],
+                    )
+                    .into_exp(),
+                )
+            },
+            _ => panic!("expected signed int type and value"),
+        }
+    }
+
+    /// ExpData::Temporary
+    /// - Function parameters have been rewritten, so only need to rewrite the node type
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_temporary(&mut self, id: NodeId, idx: move_model::ast::TempIndex) -> Option<Exp> {
+        Some(ExpData::Temporary(self.update_node_type(id, true)?, idx).into_exp())
+    }
+
+    /// ExpData::LocalVar
+    /// - Node type: rewrite
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_local_var(&mut self, id: NodeId, sym: move_model::symbol::Symbol) -> Option<Exp> {
+        Some(ExpData::LocalVar(self.update_node_type(id, true)?, sym).into_exp())
+    }
+
+    /// ExpData::Invoke
+    /// - Node type: rewrite
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_invoke(&mut self, id: NodeId, target: &Exp, args: &[Exp]) -> Option<Exp> {
+        Some(
+            ExpData::Invoke(
+                self.update_node_type(id, true)?,
+                target.clone(),
+                args.to_vec(),
+            )
+            .into_exp(),
+        )
+    }
+
+    /// ExpData::Lambda
+    /// - Node type: rewrite
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_lambda(
+        &mut self,
+        id: NodeId,
+        pat: &move_model::ast::Pattern,
+        body: &Exp,
+        capture_kind: move_model::ast::LambdaCaptureKind,
+        spec_opt: &Option<Exp>,
+    ) -> Option<Exp> {
+        Some(
+            ExpData::Lambda(
+                self.update_node_type(id, true)?,
+                pat.clone(),
+                body.clone(),
+                capture_kind,
+                spec_opt.clone(),
+            )
+            .into_exp(),
+        )
+    }
+
+    /// ExpData::IfElse
+    /// - Node type: rewrite
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_if_else(&mut self, id: NodeId, cond: &Exp, then: &Exp, else_: &Exp) -> Option<Exp> {
+        Some(
+            ExpData::IfElse(
+                self.update_node_type(id, true)?,
+                cond.clone(),
+                then.clone(),
+                else_.clone(),
+            )
+            .into_exp(),
+        )
+    }
+
+    /// ExpData::Sequence
+    /// - Node type: rewrite
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_sequence(&mut self, id: NodeId, seq: &[Exp]) -> Option<Exp> {
+        Some(ExpData::Sequence(self.update_node_type(id, true)?, seq.to_vec()).into_exp())
+    }
+
+    /// ExpData::Block
+    /// - Node type: rewrite
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_block(
+        &mut self,
+        id: NodeId,
+        pat: &move_model::ast::Pattern,
+        binding: &Option<Exp>,
+        body: &Exp,
+    ) -> Option<Exp> {
+        Some(
+            ExpData::Block(
+                self.update_node_type(id, true)?,
+                pat.clone(),
+                binding.clone(),
+                body.clone(),
+            )
+            .into_exp(),
+        )
+    }
+
+    /// ExpData::Quant (spec only)
+    /// - Node type: rewrite
+    /// - Instantiation: following the original node; rewriting if needed
+    fn rewrite_quant(
+        &mut self,
+        id: NodeId,
+        kind: &QuantKind,
+        ranges: &[(move_model::ast::Pattern, Exp)],
+        triggers: &[Vec<Exp>],
+        cond: &Option<Exp>,
+        body: &Exp,
+    ) -> Option<Exp> {
+        Some(
+            ExpData::Quant(
+                self.update_node_type(id, true)?,
+                *kind,
+                ranges.to_vec(),
+                triggers.to_vec(),
+                cond.clone(),
+                body.clone(),
+            )
+            .into_exp(),
+        )
+    }
+
+    /// Pattern
+    /// `_creating_scope` or not does not matter here, since we only care about the `Var` type.
+    /// - For stand alone `Var`:
+    ///   - Node type: rewrite
+    ///   - Instantiation: following the original node; rewriting if needed
+    fn rewrite_pattern(
+        &mut self,
+        pat: &move_model::ast::Pattern,
+        _creating_scope: bool,
+    ) -> Option<move_model::ast::Pattern> {
+        match pat {
+            move_model::ast::Pattern::Var(id, sym) => Some(move_model::ast::Pattern::Var(
+                self.update_node_type(*id, true)?,
+                *sym,
+            )),
+            // Nested patterns are recursively handled by the rewriting framework, so safe to skip them
+            _ => None,
+        }
+    }
+
+    /// ExpData::Call
+    /// - Handled case by case
+    fn rewrite_call(&mut self, call_id: NodeId, oper: &Operation, args: &[Exp]) -> Option<Exp> {
+        let node_ty = self.env.get_node_type(call_id);
+        let node_loc = self.env.get_node_loc(call_id);
+        match oper {
+            // These operations will be replaced with their corresponding Move function calls
+            // - Arguments: should have all been rewritten
+            // - Node type: rewrite
+            // - Instantiation: not needed, following the definition of the Move functions
+            Operation::Add
+            | Operation::Sub
+            | Operation::Mul
+            | Operation::Div
+            | Operation::Mod
+            | Operation::Neg => {
+                if !self.need_rewrite_no_ref(&node_ty) {
+                    return None;
+                }
+                // Get the Move function for the operation
+                let Some((module_id, function_id)) = self.get_operation_api(&node_ty, oper) else {
+                    // Error if target module is missing
+                    missing_module_error!(self.env, &node_loc, &node_ty);
+                    return None;
+                };
+                let new_node_id = self.update_node_op(call_id, false);
+                Some(
+                    ExpData::Call(
+                        new_node_id,
+                        Operation::MoveFunction(module_id, function_id),
+                        args.to_vec(),
+                    )
+                    .into_exp(),
+                )
+            },
+            // Comparison operations will also be replaced with their corresponding Move function calls
+            // why handle them separately: they are allowed to take reference types by the built-in operators!
+            // - Arguments: should have all been rewritten
+            // - Node type: no rewrite needed, as they always return `bool`
+            // - Instantiation: not needed, following the definition of the Move functions
+            Operation::Eq
+            | Operation::Neq
+            | Operation::Lt
+            | Operation::Gt
+            | Operation::Ge
+            | Operation::Le => {
+                // incorrect arg number or type
+                if args.len() != 2
+                    || args
+                        .iter()
+                        .any(|arg| !self.need_rewrite(&self.env.get_node_type(arg.node_id())))
+                {
+                    return None;
+                }
+
+                // rewrite all the args
+                let new_args: Vec<_> = args
+                    .iter()
+                    .filter_map(|arg| self.rewrite_ref_allowed_arg(arg))
+                    .collect();
+
+                let Some((module_id, function_id)) =
+                    self.get_operation_api(&self.env.get_node_type(new_args[0].node_id()), oper)
+                else {
+                    let report_ty = self
+                        .struct_to_primitive_ty
+                        .as_ref()?
+                        .get(&self.env.get_node_type(new_args[0].node_id()))?;
+                    missing_module_error!(self.env, &node_loc, &report_ty);
+                    return None;
+                };
+                let new_node_id = self.env.new_node(node_loc.clone(), node_ty);
+                Some(
+                    ExpData::Call(
+                        new_node_id,
+                        Operation::MoveFunction(module_id, function_id),
+                        new_args,
+                    )
+                    .into_exp(),
+                )
+            },
+            // Cast needs special handling; Now we only allow two kinds of casting:
+            // - `i64/i128` -> `u64/u128` (via `std::i64/i128::unpack`)
+            // - `u64/u128` -> `i64/i128` (via `std::u64/u128::pack`)
+            // - both kinds follow the casting rule of Rust. They basically copy the bits without changing them.
+            Operation::Cast => {
+                // wrong arg number
+                if args.len() != 1 {
+                    return None;
+                }
+                let src_ty = self.env.get_node_type(args[0].node_id());
+                let dst_ty = node_ty.clone();
+                // no need to rewrite
+                if !self.need_rewrite_no_ref(&src_ty) && !self.need_rewrite_no_ref(&dst_ty) {
+                    return None;
+                }
+
+                // let's get the primitive types for easier check
+                let src_ty = self.get_primitive_ty_from_struct(&src_ty).unwrap_or(src_ty);
+                let dst_ty = self.get_primitive_ty_from_struct(&dst_ty).unwrap_or(dst_ty);
+
+                match (&src_ty, &dst_ty) {
+                    // src: i64/i128 -> dst: u64/u128
+                    (Type::Primitive(PrimitiveType::I64), Type::Primitive(PrimitiveType::U64))
+                    | (
+                        Type::Primitive(PrimitiveType::I128),
+                        Type::Primitive(PrimitiveType::U128),
+                    ) => {
+                        let Some((mid, fid)) = self.get_api_by_ty_and_name(&src_ty, "unpack")
+                        else {
+                            missing_module_error!(self.env, &node_loc, &src_ty);
+                            return None;
+                        };
+                        // arguments: have been rewritten
+                        // node type: no need to rewrite
+                        // instantiation: not needed as per `unpack`
+                        let new_node_id = self.env.new_node(node_loc.clone(), node_ty);
+                        Some(
+                            ExpData::Call(new_node_id, Operation::MoveFunction(mid, fid), vec![
+                                args[0].clone(),
+                            ])
+                            .into_exp(),
+                        )
+                    },
+                    // src: u64/u128 -> dst: i64/i128
+                    (Type::Primitive(PrimitiveType::U64), Type::Primitive(PrimitiveType::I64))
+                    | (
+                        Type::Primitive(PrimitiveType::U128),
+                        Type::Primitive(PrimitiveType::I128),
+                    ) => {
+                        let Some((mid, fid)) = self.get_api_by_ty_and_name(&dst_ty, "pack") else {
+                            missing_module_error!(self.env, &node_loc, &dst_ty);
+                            return None;
+                        };
+                        // arguments: no rewrite needed
+                        // node type: rewrite
+                        // instantiation: not needed as per `pack`
+                        Some(
+                            ExpData::Call(
+                                self.update_node_op(call_id, false),
+                                Operation::MoveFunction(mid, fid),
+                                vec![args[0].clone()],
+                            )
+                            .into_exp(),
+                        )
+                    },
+                    _ => {
+                        self.env.error(&node_loc, OP_NOT_SUPPORTED);
+                        None
+                    },
+                }
+            },
+
+            // The following operations may need to update their node types and instantiation types
+            Operation::MoveFunction(..)
+            | Operation::Pack(..)
+            | Operation::Closure(..)
+            | Operation::Tuple
+            | Operation::Select(..)
+            | Operation::SelectVariants(..)
+            | Operation::TestVariants(..)
+            | Operation::Copy
+            | Operation::Move
+            | Operation::Exists(..)
+            | Operation::BorrowGlobal(..)
+            | Operation::Borrow(..)
+            | Operation::Deref
+            | Operation::MoveTo
+            | Operation::MoveFrom
+            | Operation::Freeze(..)
+            | Operation::Vector => Some(
+                ExpData::Call(
+                    self.update_node_type(call_id, true)?,
+                    oper.clone(),
+                    args.to_vec(),
+                )
+                .into_exp(),
+            ),
+            // These operations are not supported for signed int types
+            Operation::BitAnd
+            | Operation::BitOr
+            | Operation::Shl
+            | Operation::Shr
+            | Operation::Xor
+            | Operation::And
+            | Operation::Or
+            | Operation::Not => {
+                if args.is_empty()
+                    || !self.need_rewrite_no_ref(&self.env.get_node_type(args[0].node_id()))
+                {
+                    return None;
+                }
+                self.env.error(&node_loc, OP_NOT_SUPPORTED);
+                None
+            },
+
+            // Nothing needs to be done
+            Operation::Abort
+            | Operation::NoOp
+            | Operation::SpecFunction(..)
+            | Operation::UpdateField(..)
+            | Operation::Result(_)
+            | Operation::Index
+            | Operation::Slice
+            | Operation::Range
+            | Operation::Implies
+            | Operation::Iff
+            | Operation::Identical
+            | Operation::Len
+            | Operation::TypeValue
+            | Operation::TypeDomain
+            | Operation::ResourceDomain
+            | Operation::Global(_)
+            | Operation::CanModify
+            | Operation::Old
+            | Operation::Trace(_)
+            | Operation::EmptyVec
+            | Operation::SingleVec
+            | Operation::UpdateVec
+            | Operation::ConcatVec
+            | Operation::IndexOfVec
+            | Operation::ContainsVec
+            | Operation::InRangeRange
+            | Operation::InRangeVec
+            | Operation::RangeVec
+            | Operation::MaxU8
+            | Operation::MaxU16
+            | Operation::MaxU32
+            | Operation::MaxU64
+            | Operation::MaxU128
+            | Operation::MaxU256
+            | Operation::Bv2Int
+            | Operation::Int2Bv
+            | Operation::AbortFlag
+            | Operation::AbortCode
+            | Operation::WellFormed
+            | Operation::BoxValue
+            | Operation::UnboxValue
+            | Operation::EmptyEventStore
+            | Operation::ExtendEventStore
+            | Operation::EventStoreIncludes
+            | Operation::EventStoreIncludedIn => None,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/spec_rewriter.rs
@@ -63,6 +63,7 @@ pub fn run_spec_rewriter(env: &mut GlobalEnv) {
             !fun.is_native
         },
         RewriteTarget::SpecBlock(_) => true,
+        RewriteTarget::MoveStruct(_) => false,
     });
 
     // Identify the Move functions transitively called by those targets. They need to be
@@ -85,6 +86,7 @@ pub fn run_spec_rewriter(env: &mut GlobalEnv) {
             RewriteTarget::SpecFun(_) | RewriteTarget::SpecBlock(_) => {
                 target.used_funs_with_uses(env).into_keys().collect()
             },
+            RewriteTarget::MoveStruct(_) => BTreeSet::new(),
         };
         for callee in callees {
             called_funs.insert(callee);

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -102,6 +102,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(true),
         },
         Experiment {
+            name: Experiment::SIGNED_INT_REWRITE.to_string(),
+            description: "Rewrite signed integer types and operations".to_string(),
+            default: Given(false),
+        },
+        Experiment {
             name: Experiment::INLINING.to_string(),
             description: "Turns on or off inlining".to_string(),
             default: Given(true),
@@ -326,6 +331,7 @@ impl Experiment {
     pub const REFERENCE_SAFETY: &'static str = "reference-safety";
     pub const REFERENCE_SAFETY_V3: &'static str = "reference-safety-v3";
     pub const SEQS_IN_BINOPS_CHECK: &'static str = "seqs-in-binops-check";
+    pub const SIGNED_INT_REWRITE: &'static str = "signed-int-rewrite";
     pub const SKIP_BAILOUT_ON_EXTENDED_CHECKS: &'static str = "skip-bailout-on-extended-checks";
     pub const SKIP_INLINING_INLINE_FUNS: &'static str = "skip-inlining-inline-funs";
     pub const SPEC_CHECK: &'static str = "spec-check";

--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -334,6 +334,8 @@ impl ModuleGenerator {
                 U64 => FF::SignatureToken::U64,
                 U128 => FF::SignatureToken::U128,
                 U256 => FF::SignatureToken::U256,
+                I64 => FF::SignatureToken::I64,
+                I128 => FF::SignatureToken::I128,
                 Address => FF::SignatureToken::Address,
                 Signer => FF::SignatureToken::Signer,
                 Num | Range | EventStore => {

--- a/third_party/move/move-compiler-v2/src/options.rs
+++ b/third_party/move/move-compiler-v2/src/options.rs
@@ -252,6 +252,17 @@ impl Options {
             ..self
         }
     }
+
+    pub fn add_dependency(self, values: Vec<String>) -> Self {
+        Self {
+            dependencies: {
+                let mut v = self.dependencies.clone();
+                v.extend(values);
+                v
+            },
+            ..self
+        }
+    }
 }
 
 /// Finds the experiment in the list of definitions. A definition

--- a/third_party/move/move-compiler-v2/tests/checking/control_flow/for_type_mismatch.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/control_flow/for_type_mismatch.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/control_flow/for_type_mismatch.move:5:9
   │
 5 │ ╭         for (i in true..false) {

--- a/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_const.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/bad_type_argument_arity_const.exp
@@ -20,7 +20,7 @@ error: Invalid type for constant
 6 │     const S1: S = S { f: 0 };
   │     --------------^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: expected 1 type argument but 0 were provided
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:7:15
@@ -42,7 +42,7 @@ error: Invalid type for constant
 7 │     const S2: S<> = S { f: 0 };
   │     ----------------^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: expected 1 type argument but 2 were provided
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:8:15
@@ -64,7 +64,7 @@ error: Invalid type for constant
 8 │     const S3: S<u64, bool> = S { f: 0 };
   │     -------------------------^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: expected 1 type argument but 2 were provided
   ┌─ tests/checking/typing/bad_type_argument_arity_const.move:9:17
@@ -87,4 +87,4 @@ error: Invalid type for constant
 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
   │     ----------------------------^^^^^^^^^^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_add_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_add_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_add_invalid.move:8:9
   │
 8 │         false + true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_add_invalid.move:9:13
   │
 9 │         1 + false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:10:9
    │
 10 │         false + 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:11:9
    │
 11 │         @0x0 + @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) + (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:13:9
    │
 13 │         r + r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:14:9
    │
 14 │         s + s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:15:13
    │
 15 │         1 + false + @0x0 + 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:15:21
    │
 15 │         1 + false + @0x0 + 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:16:9
    │
 16 │         () + ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:17:13
    │
 17 │         1 + ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:18:9
    │
 18 │         (0, 1) + (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_add_invalid.move:19:9
    │
 19 │         (1, 2) + (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_and_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_and_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_bit_and_invalid.move:8:9
   │
 8 │         false & true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_bit_and_invalid.move:9:13
   │
 9 │         1 & false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:10:9
    │
 10 │         false & 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:11:9
    │
 11 │         @0x0 & @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) & (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:13:9
    │
 13 │         r & r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:14:9
    │
 14 │         s & s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:15:13
    │
 15 │         1 & false & @0x0 & 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:15:21
    │
 15 │         1 & false & @0x0 & 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:16:9
    │
 16 │         () & ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:17:13
    │
 17 │         1 & ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:18:9
    │
 18 │         (0, 1) & (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_and_invalid.move:19:9
    │
 19 │         (1, 2) & (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_or_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_or_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_bit_or_invalid.move:8:9
   │
 8 │         false | true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_bit_or_invalid.move:9:13
   │
 9 │         1 | false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:10:9
    │
 10 │         false | 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:11:9
    │
 11 │         @0x0 | @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) | (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:13:9
    │
 13 │         r | r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:14:9
    │
 14 │         s | s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:15:13
    │
 15 │         1 | false | @0x0 | 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:15:21
    │
 15 │         1 | false | @0x0 | 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:16:9
    │
 16 │         () | ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:17:13
    │
 17 │         1 | ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:18:9
    │
 18 │         (0, 1) | (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_or_invalid.move:19:9
    │
 19 │         (1, 2) | (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_xor_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_bit_xor_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_bit_xor_invalid.move:8:9
   │
 8 │         false ^ true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_bit_xor_invalid.move:9:13
   │
 9 │         1 ^ false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:10:9
    │
 10 │         false ^ 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:11:9
    │
 11 │         @0x0 ^ @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) ^ (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:13:9
    │
 13 │         r ^ r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:14:9
    │
 14 │         s ^ s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:15:13
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:15:21
    │
 15 │         1 ^ false ^ @0x0 ^ 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:16:9
    │
 16 │         () ^ ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:17:13
    │
 17 │         1 ^ ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:18:9
    │
 18 │         (0, 1) ^ (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_bit_xor_invalid.move:19:9
    │
 19 │         (1, 2) ^ (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_div_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_div_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_div_invalid.move:8:9
   │
 8 │         false / true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_div_invalid.move:9:13
   │
 9 │         1 / false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:10:9
    │
 10 │         false / 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:11:9
    │
 11 │         @0x0 / @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) / (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:13:9
    │
 13 │         r / r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:14:9
    │
 14 │         s / s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:15:13
    │
 15 │         1 / false / @0x0 / 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:15:21
    │
 15 │         1 / false / @0x0 / 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:16:9
    │
 16 │         () / ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:17:13
    │
 17 │         1 / ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:18:9
    │
 18 │         (0, 1) / (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_div_invalid.move:19:9
    │
 19 │         (1, 2) / (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_geq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_geq_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_geq_invalid.move:8:9
   │
 8 │         false >= true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_geq_invalid.move:9:14
   │
 9 │         1 >= false;
   │              ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:10:9
    │
 10 │         false >= 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:11:9
    │
 11 │         @0x0 >= @0x1;
@@ -30,55 +30,55 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) >= (1: u128);
    │                     ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:13:9
    │
 13 │         r >= r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:14:9
    │
 14 │         s >= s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:15:9
    │
 15 │         0 >= 1 >= 2;
    │         ^^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:16:15
    │
 16 │         (1 >= false) && (@0x0 >= 0);
    │               ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:16:26
    │
 16 │         (1 >= false) && (@0x0 >= 0);
    │                          ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:17:9
    │
 17 │         () >= ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:18:14
    │
 18 │         1 >= ();
    │              ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:19:9
    │
 19 │         (0, 1) >= (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_geq_invalid.move:20:9
    │
 20 │         (1, 2) >= (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_gt_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_gt_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_gt_invalid.move:8:9
   │
 8 │         false > true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_gt_invalid.move:9:13
   │
 9 │         1 > false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:10:9
    │
 10 │         false > 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:11:9
    │
 11 │         @0x0 > @0x1;
@@ -30,55 +30,55 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) > (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:13:9
    │
 13 │         r > r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:14:9
    │
 14 │         s > s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:15:9
    │
 15 │         0 > 1 > 2;
    │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:16:14
    │
 16 │         (1 > false) && (@0x0 > 0);
    │              ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:16:25
    │
 16 │         (1 > false) && (@0x0 > 0);
    │                         ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:17:9
    │
 17 │         () > ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:18:13
    │
 18 │         1 > ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:19:9
    │
 19 │         (0, 1) > (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_gt_invalid.move:20:9
    │
 20 │         (1, 2) > (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_leq_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_leq_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_leq_invalid.move:8:9
   │
 8 │         false <= true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_leq_invalid.move:9:14
   │
 9 │         1 <= false;
   │              ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:10:9
    │
 10 │         false <= 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:11:9
    │
 11 │         @0x0 <= @0x1;
@@ -30,55 +30,55 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) <= (1: u128);
    │                     ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:13:9
    │
 13 │         r <= r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:14:9
    │
 14 │         s <= s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:15:9
    │
 15 │         0 <= 1 <= 2;
    │         ^^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:16:15
    │
 16 │         (1 <= false) && (@0x0 <= 0);
    │               ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:16:26
    │
 16 │         (1 <= false) && (@0x0 <= 0);
    │                          ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:17:9
    │
 17 │         () <= ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:18:14
    │
 18 │         1 <= ();
    │              ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:19:9
    │
 19 │         (0, 1) <= (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_leq_invalid.move:20:9
    │
 20 │         (1, 2) <= (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_lt_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_lt_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_lt_invalid.move:8:9
   │
 8 │         false < true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_lt_invalid.move:9:13
   │
 9 │         1 < false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:10:9
    │
 10 │         false < 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:11:9
    │
 11 │         @0x0 < @0x1;
@@ -30,55 +30,55 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) < (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:13:9
    │
 13 │         r < r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:14:9
    │
 14 │         s < s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:15:9
    │
 15 │         0 < 1 < 2;
    │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:16:14
    │
 16 │         (1 < false) && (@0x0 < 0);
    │              ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:16:25
    │
 16 │         (1 < false) && (@0x0 < 0);
    │                         ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:17:9
    │
 17 │         () < ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:18:13
    │
 18 │         1 < ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:19:9
    │
 19 │         (0, 1) < (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_lt_invalid.move:20:9
    │
 20 │         (1, 2) < (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_mod_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_mod_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_mod_invalid.move:8:9
   │
 8 │         false % true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_mod_invalid.move:9:13
   │
 9 │         1 % false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:10:9
    │
 10 │         false % 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:11:9
    │
 11 │         @0x0 % @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) % (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:13:9
    │
 13 │         r % r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:14:9
    │
 14 │         s % s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:15:13
    │
 15 │         1 % false % @0x0 % 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:15:21
    │
 15 │         1 % false % @0x0 % 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:16:9
    │
 16 │         () % ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:17:13
    │
 17 │         1 % ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:18:9
    │
 18 │         (0, 1) % (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mod_invalid.move:19:9
    │
 19 │         (1, 2) % (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_mul_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_mul_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_mul_invalid.move:8:9
   │
 8 │         false * true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_mul_invalid.move:9:13
   │
 9 │         1 * false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:10:9
    │
 10 │         false * 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:11:9
    │
 11 │         @0x0 * @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) * (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:13:9
    │
 13 │         r * r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:14:9
    │
 14 │         s * s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:15:13
    │
 15 │         1 * false * @0x0 * 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:15:21
    │
 15 │         1 * false * @0x0 * 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:16:9
    │
 16 │         () * ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:17:13
    │
 17 │         1 * ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:18:9
    │
 18 │         (0, 1) * (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_mul_invalid.move:19:9
    │
 19 │         (1, 2) * (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_shl_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_shl_invalid.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_shl_invalid.move:8:9
   │
 8 │         false << true;
@@ -12,13 +12,13 @@ error: cannot use `bool` with an operator which expects a value of type `u8`
 9 │         1 << false;
   │              ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shl_invalid.move:10:9
    │
 10 │         false << 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shl_invalid.move:11:9
    │
 11 │         @0x0 << @0x1;
@@ -30,13 +30,13 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) << (1: u128);
    │                     ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shl_invalid.move:13:9
    │
 13 │         r << r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shl_invalid.move:14:9
    │
 14 │         s << s;
@@ -54,7 +54,7 @@ error: cannot use `address` with an operator which expects a value of type `u8`
 15 │         1 << false << @0x0 << 0;
    │                       ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shl_invalid.move:16:9
    │
 16 │         () << ();
@@ -66,13 +66,13 @@ error: cannot use `()` with an operator which expects a value of type `u8`
 17 │         1 << ();
    │              ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shl_invalid.move:18:9
    │
 18 │         (0, 1) << (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shl_invalid.move:19:9
    │
 19 │         (1, 2) << (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_shr_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_shr_invalid.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_shr_invalid.move:8:9
   │
 8 │         false >> true;
@@ -12,13 +12,13 @@ error: cannot use `bool` with an operator which expects a value of type `u8`
 9 │         1 >> false;
   │              ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shr_invalid.move:10:9
    │
 10 │         false >> 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shr_invalid.move:11:9
    │
 11 │         @0x0 >> @0x1;
@@ -30,13 +30,13 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) >> (1: u128);
    │                     ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shr_invalid.move:13:9
    │
 13 │         r >> r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shr_invalid.move:14:9
    │
 14 │         s >> s;
@@ -54,7 +54,7 @@ error: cannot use `address` with an operator which expects a value of type `u8`
 15 │         1 >> false >> @0x0 >> 0;
    │                       ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shr_invalid.move:16:9
    │
 16 │         () >> ();
@@ -66,13 +66,13 @@ error: cannot use `()` with an operator which expects a value of type `u8`
 17 │         1 >> ();
    │              ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shr_invalid.move:18:9
    │
 18 │         (0, 1) >> (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_shr_invalid.move:19:9
    │
 19 │         (1, 2) >> (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub_invalid.exp
@@ -1,24 +1,24 @@
 
 Diagnostics:
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_sub_invalid.move:8:9
   │
 8 │         false - true;
   │         ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
   ┌─ tests/checking/typing/binary_sub_invalid.move:9:13
   │
 9 │         1 - false;
   │             ^^^^^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:10:9
    │
 10 │         false - 1;
    │         ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:11:9
    │
 11 │         @0x0 - @0x1;
@@ -30,49 +30,49 @@ error: cannot use `u128` with an operator which expects a value of type `u8`
 12 │         (0: u8) - (1: u128);
    │                    ^
 
-error: cannot use `R` with an operator which expects a value of type `integer`
+error: cannot use `R` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:13:9
    │
 13 │         r - r;
    │         ^
 
-error: cannot use `S` with an operator which expects a value of type `integer`
+error: cannot use `S` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:14:9
    │
 14 │         s - s;
    │         ^
 
-error: cannot use `bool` with an operator which expects a value of type `integer`
+error: cannot use `bool` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:15:13
    │
 15 │         1 - false - @0x0 - 0;
    │             ^^^^^
 
-error: cannot use `address` with an operator which expects a value of type `integer`
+error: cannot use `address` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:15:21
    │
 15 │         1 - false - @0x0 - 0;
    │                     ^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:16:9
    │
 16 │         () - ();
    │         ^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:17:13
    │
 17 │         1 - ();
    │             ^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:18:9
    │
 18 │         (0, 1) - (0, 1, 2);
    │         ^^^^^^
 
-error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/binary_sub_invalid.move:19:9
    │
 19 │         (1, 2) - (0, 1);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_invalid_base_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_invalid_base_type.exp
@@ -14,7 +14,7 @@ error: Invalid type for constant
 6 │     const C1: signer = abort 0;
   │     -------------------^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/constant_invalid_base_type.move:7:19
@@ -30,7 +30,7 @@ error: Invalid type for constant
 7 │     const C2: S = S{};
   │     --------------^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/constant_invalid_base_type.move:8:19
@@ -46,7 +46,7 @@ error: Invalid type for constant
 8 │     const C3: R = R{};
   │     --------------^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
   ┌─ tests/checking/typing/constant_invalid_base_type.move:9:27
@@ -62,7 +62,7 @@ error: Invalid type for constant
 9 │     const C4: vector<S> = abort 0;
   │     ----------------------^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
    ┌─ tests/checking/typing/constant_invalid_base_type.move:10:27
@@ -78,7 +78,7 @@ error: Invalid type for constant
 10 │     const C5: vector<R> = abort 0;
    │     ----------------------^^^^^^^-
    │     │
-   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
    ┌─ tests/checking/typing/constant_invalid_base_type.move:11:35
@@ -94,7 +94,7 @@ error: Invalid type for constant
 11 │     const C6: vector<vector<S>> = abort 0;
    │     ------------------------------^^^^^^^-
    │     │
-   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
    ┌─ tests/checking/typing/constant_invalid_base_type.move:12:35
@@ -110,4 +110,4 @@ error: Invalid type for constant
 12 │     const C7: vector<vector<R>> = abort 0;
    │     ------------------------------^^^^^^^-
    │     │
-   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+   │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.

--- a/third_party/move/move-compiler-v2/tests/checking/typing/constant_non_base_type.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/constant_non_base_type.exp
@@ -14,7 +14,7 @@ error: Invalid type for constant
 3 │     const C1: &u64 = &0;
   │     -----------------^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: expected `&mut u64` but found a value of type `&u64` (mutability mismatch)
   ┌─ tests/checking/typing/constant_non_base_type.move:4:26
@@ -36,7 +36,7 @@ error: Invalid type for constant
 4 │     const C2: &mut u64 = &0;
   │     ---------------------^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Invalid type for constant
   ┌─ tests/checking/typing/constant_non_base_type.move:5:20
@@ -44,7 +44,7 @@ error: Invalid type for constant
 5 │     const C3: () = ();
   │     ---------------^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Invalid type for constant
   ┌─ tests/checking/typing/constant_non_base_type.move:6:33
@@ -52,4 +52,4 @@ error: Invalid type for constant
 6 │     const C4: (address, bool) = (@0x0, false);
   │     ----------------------------^^^^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.

--- a/third_party/move/move-compiler-v2/tests/checking/typing/lambda_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/lambda_typed.exp
@@ -24,7 +24,7 @@ error: expected function of type `|integer|` but found `u64`
 61 │         x(1) // expected to be not a function
    │         ^^^^
 
-error: cannot use `&u64` with an operator which expects a value of type `integer`
+error: cannot use `&u64` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/checking/typing/lambda_typed.move:67:43
    │
 67 │         foreach(&v, |e: &u64| sum = sum + e) // expected to cannot infer type

--- a/third_party/move/move-compiler-v2/tests/folding/bad_type_argument_arity_const.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/bad_type_argument_arity_const.exp
@@ -20,7 +20,7 @@ error: Invalid type for constant
 6 │     const S1: S = S { f: 0 };
   │     --------------^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: expected 1 type argument but 0 were provided
   ┌─ tests/folding/bad_type_argument_arity_const.move:7:15
@@ -42,7 +42,7 @@ error: Invalid type for constant
 7 │     const S2: S<> = S { f: 0 };
   │     ----------------^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: expected 1 type argument but 2 were provided
   ┌─ tests/folding/bad_type_argument_arity_const.move:8:15
@@ -64,7 +64,7 @@ error: Invalid type for constant
 8 │     const S3: S<u64, bool> = S { f: 0 };
   │     -------------------------^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: expected 1 type argument but 2 were provided
   ┌─ tests/folding/bad_type_argument_arity_const.move:9:17
@@ -87,4 +87,4 @@ error: Invalid type for constant
 9 │     const S4: S<S<u64, bool>> = S { f: S { f: 0 } };
   │     ----------------------------^^^^^^^^^^^^^^^^^^^-
   │     │
-  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+  │     Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.

--- a/third_party/move/move-compiler-v2/tests/folding/constants_blocks.exp
+++ b/third_party/move/move-compiler-v2/tests/folding/constants_blocks.exp
@@ -60,7 +60,7 @@ error: Invalid type for constant
 14 │ │ │         x + y;
 15 │ │ │     };
    │ ╰─│─────^
-   │   ╰──────' Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+   │   ╰──────' Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
    ┌─ tests/folding/constants_blocks.move:16:25

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/constants_blocks.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/constants_blocks.exp
@@ -60,7 +60,7 @@ error: Invalid type for constant
 14 │ │ │         x + y;
 15 │ │ │     };
    │ ╰─│─────^
-   │   ╰──────' Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `bool`, `address`, or `vector<_>` with valid element type.
+   │   ╰──────' Expected one of `u8`, `u16, `u32`, `u64`, `u128`, `u256`, `i64`, `i128`, `bool`, `address`, or `vector<_>` with valid element type.
 
 error: Not a valid constant expression.
    ┌─ tests/more-v1/parser/constants_blocks.move:16:25

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/control_exp_associativity_typing_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/control_exp_associativity_typing_invalid.exp
@@ -6,7 +6,7 @@ error: expected expression with no value but found `u64`
 12 │         if (cond) bar() + 1;
    │         ^^^^^^^^^^^^^^^^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/more-v1/parser/control_exp_associativity_typing_invalid.move:15:9
    │
 15 │         if (cond) { foo() } + 1;
@@ -18,7 +18,7 @@ error: expected expression with no value but found `u64`
 19 │         while (cond) bar() + 2;
    │                      ^^^^^^^^^
 
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/more-v1/parser/control_exp_associativity_typing_invalid.move:22:9
    │
 22 │         while (cond) { foo() } + 2;

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/expr_unary_negation.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/expr_unary_negation.exp
@@ -1,10 +1,13 @@
 
 Diagnostics:
-error: unexpected token
-  ┌─ tests/more-v1/parser/expr_unary_negation.move:5:19
+error: constraint `u8|u16|u32|u64|u128|u256` incompatible with `i64|i128`
+  ┌─ tests/more-v1/parser/expr_unary_negation.move:5:20
   │
 5 │     assert!(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
-  │                   ^
-  │                   │
-  │                   Unexpected '-'
-  │                   Expected an expression term
+  │                    ^
+
+error: the function takes 2 arguments but 1 were provided
+  ┌─ tests/more-v1/parser/expr_unary_negation.move:5:33
+  │
+5 │     assert!(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
+  │                                 ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/spec_parsing_inside_fun.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/spec_parsing_inside_fun.exp
@@ -1,6 +1,6 @@
 
 Diagnostics:
-error: cannot use `()` with an operator which expects a value of type `integer`
+error: cannot use `()` with an operator which expects a value of type `u8|u16|u32|u64|u128|u256`
    ┌─ tests/more-v1/parser/spec_parsing_inside_fun.move:32:9
    │
 32 │         spec {} + 1;

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_arithmetic_logic.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_arithmetic_logic.exp
@@ -1,0 +1,73 @@
+
+Diagnostics:
+error: cannot use `&i64` with an operator which expects a value of type `integer`
+  ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:6:9
+  │
+6 │         &x + &x
+  │         ^^
+
+error: cannot use `&i128` with an operator which expects a value of type `integer`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:10:9
+   │
+10 │         &x + &x
+   │         ^^
+
+error: cannot use `i128` with an operator which expects a value of type `i64`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:14:13
+   │
+14 │         x + y
+   │             ^
+
+error: cannot use `i128` with an operator which expects a value of type `i64`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:18:13
+   │
+18 │         x + y
+   │             ^
+
+error: cannot pass `i128` to a function which expects argument of type `0x1::i64::I64`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:22:21
+   │
+22 │         i64::add(x, y)
+   │                     ^
+
+error: cannot pass `i64` to a function which expects argument of type `0x1::i128::I128`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:26:19
+   │
+26 │         i128::add(x, y)
+   │                   ^
+
+error: cannot use `i64` with an operator which expects a value of type `bool`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:30:9
+   │
+30 │         x && y
+   │         ^
+
+error: cannot use `i128` with an operator which expects a value of type `bool`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:34:9
+   │
+34 │         x && y
+   │         ^
+
+error: cannot use `i64` with an operator which expects a value of type `bool`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:38:9
+   │
+38 │         x || y
+   │         ^
+
+error: cannot use `i128` with an operator which expects a value of type `bool`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:42:9
+   │
+42 │         x || y
+   │         ^
+
+error: cannot use `i64` with an operator which expects a value of type `bool`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:46:10
+   │
+46 │         !x
+   │          ^
+
+error: cannot use `i128` with an operator which expects a value of type `bool`
+   ┌─ tests/signed-int/invalid/invalid_arithmetic_logic.move:50:10
+   │
+50 │         !x
+   │          ^

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_arithmetic_logic.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_arithmetic_logic.move
@@ -1,0 +1,52 @@
+module 0x42::invalid_arithmetic {
+    use std::i64;
+    use std::i128;
+
+    fun test_add_by_ref1(x: i64): i64 {
+        &x + &x
+    }
+
+    fun test_add_by_ref2(x: i128): i128 {
+        &x + &x
+    }
+
+    fun test_add_by_mix1(x: i64, y: i128): i64 {
+        x + y
+    }
+
+    fun test_add_by_mix2(x: i64, y: i128): i128 {
+        x + y
+    }
+
+    fun test_add_by_mix3(x: i64, y: i128): i64 {
+        i64::add(x, y)
+    }
+
+    fun test_add_by_mix4(x: i64, y: i128): i128 {
+        i128::add(x, y)
+    }
+
+    fun test_logic_and1(x: i64, y: i64): bool {
+        x && y
+    }
+
+    fun test_logic_and2(x: i128, y: i128): bool {
+        x && y
+    }
+
+    fun test_logic_or1(x: i64, y: i64): bool {
+        x || y
+    }
+
+    fun test_logic_or2(x: i128, y: i128): bool {
+        x || y
+    }
+
+    fun test_logic_not1(x: i64): bool {
+        !x
+    }
+
+    fun test_logic_not(x: i128): bool {
+        !x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_constants.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_constants.exp
@@ -1,0 +1,85 @@
+
+Diagnostics:
+error: invalid number literal
+  ┌─ tests/signed-int/invalid/invalid_constants.move:7:22
+  │
+7 │   const V3_64: i64 = 9223372036854775808i64; // out of upper bound: max value of i64 is 9223372036854775807
+  │                      ^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i64'
+
+error: invalid number literal
+  ┌─ tests/signed-int/invalid/invalid_constants.move:8:22
+  │
+8 │   const V4_64: i64 = -9223372036854775809; // out of lower bound: min value of i64 is -9223372036854775808
+  │                      ^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+  ┌─ tests/signed-int/invalid/invalid_constants.move:9:22
+  │
+9 │   const V5_64: i64 = -9223372036854775809i64; // out of lower bound: min value of i64 is -9223372036854775808
+  │                      ^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i64'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:14:24
+   │
+14 │   const V3_128: i128 = 170141183460469231731687303715884105728i128; // out of upper bound: max value of i128 is 170141183460469231731687303715884105727
+   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i128'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:15:24
+   │
+15 │   const V4_128: i128 = -170141183460469231731687303715884105729; // out of lower bound: min value of i64 is -170141183460469231731687303715884105728
+   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:16:24
+   │
+16 │   const V5_128: i128 = -170141183460469231731687303715884105729i128; // out of lower bound: min value of i64 is -170141183460469231731687303715884105728
+   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i128'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:19:32
+   │
+19 │   const V_STRUCT64: i64::I64 = -1;
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:20:35
+   │
+20 │   const V_STRUCT128: i128::I128 = -1;
+   │                                   ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:25:13
+   │
+25 │     let c = 9223372036854775808i64; // constant does not fit into i64 && type mismatch in `res7 + c`, expected u64|u128|u256|i128, actual i64
+   │             ^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i64'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:26:13
+   │
+26 │     let d = -9223372036854775809; // interpreted as an i128
+   │             ^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:27:13
+   │
+27 │     let e = -9223372036854775809i64; // constant does not fit into i64 && type mismatch in `res9 + e`, expected i128, actual i64
+   │             ^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i64'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:45:13
+   │
+45 │     let c = 170141183460469231731687303715884105728i128; // type mismatch in `res7 + c`, expected u128|u256, actual i128
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i128'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:46:13
+   │
+46 │     let d = -170141183460469231731687303715884105729; // no type can be inffered
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/invalid/invalid_constants.move:47:13
+   │
+47 │     let e = -170141183460469231731687303715884105729i128; // constant does not fit into i128
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i128'

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_constants.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_constants.move
@@ -1,0 +1,61 @@
+module 0x42::invalid_constants {
+  use std::i64;
+  use std::i128;
+
+  const V1_64: i64 = 1u64; // type mismatch: expected i64, actual u64
+  const V2_64: i64 = 9223372036854775808; // out of upper bound: max value of i64 is 9223372036854775807
+  const V3_64: i64 = 9223372036854775808i64; // out of upper bound: max value of i64 is 9223372036854775807
+  const V4_64: i64 = -9223372036854775809; // out of lower bound: min value of i64 is -9223372036854775808
+  const V5_64: i64 = -9223372036854775809i64; // out of lower bound: min value of i64 is -9223372036854775808
+  const V6_64: i64 = -1i128; // type mismatch: expected i64, actual i128
+
+  const V1_128: i128 = 1u128; // type mismatch: expected i128, actual u128
+  const V2_128: i128 = 170141183460469231731687303715884105728; // out of upper bound: max value of i128 is 170141183460469231731687303715884105727
+  const V3_128: i128 = 170141183460469231731687303715884105728i128; // out of upper bound: max value of i128 is 170141183460469231731687303715884105727
+  const V4_128: i128 = -170141183460469231731687303715884105729; // out of lower bound: min value of i64 is -170141183460469231731687303715884105728
+  const V5_128: i128 = -170141183460469231731687303715884105729i128; // out of lower bound: min value of i64 is -170141183460469231731687303715884105728
+  const V6_128: i128 = -1i64; // type mismatch: expected i128, actual i64
+
+  const V_STRUCT64: i64::I64 = -1;
+  const V_STRUCT128: i128::I128 = -1;
+
+  public fun  test_i64() : i64 {
+    let a = 1u64; // type mismatch in `res5 + a`: expected i64, actual u64
+    let b = 9223372036854775808; // interpreted as a possible u64|u128|u256|i128
+    let c = 9223372036854775808i64; // constant does not fit into i64 && type mismatch in `res7 + c`, expected u64|u128|u256|i128, actual i64
+    let d = -9223372036854775809; // interpreted as an i128
+    let e = -9223372036854775809i64; // constant does not fit into i64 && type mismatch in `res9 + e`, expected i128, actual i64
+
+    let res1 = V1_64 + V2_64;
+    let res2 = res1 + V3_64;
+    let res3 = res2 + V4_64;
+    let res4 = res3 + V5_64;
+    let res5 = res4 + V6_64;
+    let res6 = res5 + a;
+    let res7 = res6 + b;
+    let res8 = res7 + c;
+    let res9 = res8 + d;
+    let res10 = res9 + e;
+    res10
+  }
+
+  public fun  test_i128() : i128 {
+    let a = 1u128; // type mismatch in `res5 + a`: expected i128, actual u128
+    let b = 170141183460469231731687303715884105728; // interpreted as a possible u128|u256
+    let c = 170141183460469231731687303715884105728i128; // type mismatch in `res7 + c`, expected u128|u256, actual i128
+    let d = -170141183460469231731687303715884105729; // no type can be inffered
+    let e = -170141183460469231731687303715884105729i128; // constant does not fit into i128
+
+    let res1 = V1_128 + V2_128;
+    let res2 = res1 + V3_128;
+    let res3 = res2 + V4_128;
+    let res4 = res3 + V5_128;
+    let res5 = res4 + V6_128;
+    let res6 = res5 + a;
+    let res7 = res6 + b;
+    let res8 = res7 + c;
+    let res9 = res8 + d;
+    let res10 = res9 + e;
+    res10
+  }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_resource.exp
@@ -1,0 +1,129 @@
+
+Diagnostics:
+error: type `0x1::i64::I64` is missing required ability `key`
+  ┌─ tests/signed-int/invalid/invalid_resource.move:6:20
+  │
+6 │         if (exists<i64::I64>(addr)) {
+  │                    ^^^^^^^^
+  │
+  = required by instantiating type parameter `T:key` of function `exists`
+
+error: type `i64` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:14:20
+   │
+14 │         if (exists<i64>(addr)) {
+   │                    ^^^
+   │
+   = required by instantiating type parameter `T:key` of function `exists`
+
+error: type `0x1::i128::I128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:22:20
+   │
+22 │         if (exists<i128::I128>(addr)) {
+   │                    ^^^^^^^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `exists`
+
+error: type `i128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:30:20
+   │
+30 │         if (exists<i128>(addr)) {
+   │                    ^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `exists`
+
+error: type `0x1::i64::I64` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:38:31
+   │
+38 │         let s = borrow_global<i64::I64>(addr);
+   │                               ^^^^^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `borrow_global`
+
+error: type `i64` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:43:31
+   │
+43 │         let s = borrow_global<i64>(addr);
+   │                               ^^^
+   │
+   = required by instantiating type parameter `T:key` of function `borrow_global`
+
+error: type `0x1::i128::I128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:48:31
+   │
+48 │         let s = borrow_global<i128::I128>(addr);
+   │                               ^^^^^^^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `borrow_global`
+
+error: type `i128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:53:31
+   │
+53 │         let s = borrow_global<i128>(addr);
+   │                               ^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `borrow_global`
+
+error: type `0x1::i64::I64` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:58:16
+   │
+58 │        move_to<i64::I64>(account, x)
+   │                ^^^^^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_to`
+
+error: type `i64` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:62:16
+   │
+62 │        move_to<i64>(account, x)
+   │                ^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_to`
+
+error: type `0x1::i128::I128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:66:16
+   │
+66 │        move_to<i128::I128>(account, x)
+   │                ^^^^^^^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_to`
+
+error: type `i128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:70:16
+   │
+70 │        move_to<i128>(account, x)
+   │                ^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_to`
+
+error: type `0x1::i64::I64` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:74:19
+   │
+74 │         move_from<i64::I64>(signer::address_of(account))
+   │                   ^^^^^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_from`
+
+error: type `i64` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:78:19
+   │
+78 │         move_from<i64>(signer::address_of(account))
+   │                   ^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_from`
+
+error: type `0x1::i128::I128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:82:19
+   │
+82 │         move_from<i128::I128>(signer::address_of(account))
+   │                   ^^^^^^^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_from`
+
+error: type `i128` is missing required ability `key`
+   ┌─ tests/signed-int/invalid/invalid_resource.move:86:19
+   │
+86 │         move_from<i128>(signer::address_of(account))
+   │                   ^^^^
+   │
+   = required by instantiating type parameter `T:key` of function `move_from`

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_resource.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/invalid_resource.move
@@ -1,0 +1,88 @@
+module 0x42::invalid_resource {
+    use std::signer;
+    use std::i64;
+    use std::i128;
+    fun test_exist1(addr: address): i64 {
+        if (exists<i64::I64>(addr)) {
+            1
+        } else {
+            2
+        }
+     }
+
+     fun test_exist2(addr: address): i64 {
+        if (exists<i64>(addr)) {
+            1
+        } else {
+            2
+        }
+     }
+
+     fun test_exist3(addr: address): i128 {
+        if (exists<i128::I128>(addr)) {
+            1
+        } else {
+            2
+        }
+     }
+
+     fun test_exist4(addr: address): i128 {
+        if (exists<i128>(addr)) {
+            1
+        } else {
+            2
+        }
+     }
+
+     fun test_borrow1(addr: address): i64 {
+        let s = borrow_global<i64::I64>(addr);
+        *s
+     }
+
+     fun test_borrow2(addr: address): i64 {
+        let s = borrow_global<i64>(addr);
+        *s
+     }
+
+     fun test_borrow3(addr: address): i128 {
+        let s = borrow_global<i128::I128>(addr);
+        *s
+     }
+
+     fun test_borrow4(addr: address): i128 {
+        let s = borrow_global<i128>(addr);
+        *s
+     }
+
+     fun test_move_to1(account: &signer, x: i64::I64) {
+       move_to<i64::I64>(account, x)
+     }
+
+     fun test_move_to2(account: &signer, x: i64) {
+       move_to<i64>(account, x)
+     }
+
+     fun test_move_to3(account: &signer, x: i128::I128) {
+       move_to<i128::I128>(account, x)
+     }
+
+     fun test_move_to4(account: &signer, x: i128) {
+       move_to<i128>(account, x)
+     }
+
+     fun test_move_from1(account: &signer): i64 {
+        move_from<i64::I64>(signer::address_of(account))
+     }
+
+     fun test_move_from2(account: &signer): i64 {
+        move_from<i64>(signer::address_of(account))
+     }
+
+     fun test_move_from3(account: &signer): i128 {
+        move_from<i128::I128>(signer::address_of(account))
+     }
+
+     fun test_move_from4(account: &signer): i128 {
+        move_from<i128>(signer::address_of(account))
+     }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/non_supported_ops.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/non_supported_ops.exp
@@ -1,0 +1,145 @@
+
+Diagnostics:
+error: operation not supported for signed integers
+  ┌─ tests/signed-int/invalid/non_supported_ops.move:3:9
+  │
+3 │         x | y
+  │         ^^^^^
+
+error: operation not supported for signed integers
+  ┌─ tests/signed-int/invalid/non_supported_ops.move:7:9
+  │
+7 │         x | y
+  │         ^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:11:9
+   │
+11 │         x & y
+   │         ^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:15:9
+   │
+15 │         x & y
+   │         ^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:19:9
+   │
+19 │         x ^ y
+   │         ^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:23:9
+   │
+23 │         x ^ y
+   │         ^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:27:9
+   │
+27 │         x << y
+   │         ^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:31:9
+   │
+31 │         x >> y
+   │         ^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:35:9
+   │
+35 │         x << y
+   │         ^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:39:9
+   │
+39 │         x >> y
+   │         ^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:51:9
+   │
+51 │         x as i128
+   │         ^^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:55:9
+   │
+55 │         x as u8
+   │         ^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:59:9
+   │
+59 │         x as u16
+   │         ^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:63:9
+   │
+63 │         x as u32
+   │         ^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:71:9
+   │
+71 │         x as u128
+   │         ^^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:75:9
+   │
+75 │         x as u256
+   │         ^^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:79:9
+   │
+79 │         x as i64
+   │         ^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:83:9
+   │
+83 │         x as u8
+   │         ^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:87:9
+   │
+87 │         x as u16
+   │         ^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:91:9
+   │
+91 │         x as u32
+   │         ^^^^^^^^
+
+error: operation not supported for signed integers
+   ┌─ tests/signed-int/invalid/non_supported_ops.move:95:9
+   │
+95 │         x as u64
+   │         ^^^^^^^^
+
+error: operation not supported for signed integers
+    ┌─ tests/signed-int/invalid/non_supported_ops.move:103:9
+    │
+103 │         x as u256
+    │         ^^^^^^^^^
+
+error: operation not supported for signed integers
+    ┌─ tests/signed-int/invalid/non_supported_ops.move:107:9
+    │
+107 │         x as i128
+    │         ^^^^^^^^^
+
+error: operation not supported for signed integers
+    ┌─ tests/signed-int/invalid/non_supported_ops.move:111:9
+    │
+111 │         x as i64
+    │         ^^^^^^^^

--- a/third_party/move/move-compiler-v2/tests/signed-int/invalid/non_supported_ops.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/invalid/non_supported_ops.move
@@ -1,0 +1,113 @@
+module 0x42::not_supported_ops {
+    fun test_or1(x: i64, y: i64): i64 {
+        x | y
+    }
+
+    fun test_or2(x: i128, y: i128): i128 {
+        x | y
+    }
+
+    fun test_and1(x: i64, y: i64): i64 {
+        x & y
+    }
+
+    fun test_and2(x: i128, y: i128): i128 {
+        x & y
+    }
+
+    fun test_xor1(x: i64, y: i64): i64 {
+        x ^ y
+    }
+
+    fun test_xor2(x: i128, y: i128): i128 {
+        x ^ y
+    }
+
+    fun test_lsf1(x: i64, y: u8): i64 {
+        x << y
+    }
+
+    fun test_lsf2(x: i128, y: u8): i128 {
+        x >> y
+    }
+
+    fun test_rsf1(x: i64, y: u8): i64 {
+        x << y
+    }
+
+    fun test_rsf2(x: i128, y: u8): i128 {
+        x >> y
+    }
+
+    fun test_neq1(x: i64, y: i64): bool {
+        x != y
+    }
+
+    fun test_neq2(x: i128, y: i128): bool {
+        x != y
+    }
+
+    fun cast1(x: i64): i128 {
+        x as i128
+    }
+
+    fun cast2(x: i64): u8 {
+        x as u8
+    }
+
+    fun cast3(x: i64): u16 {
+        x as u16
+    }
+
+    fun cast4(x: i64): u32 {
+        x as u32
+    }
+
+    fun cast5(x: i64): u64 {
+        x as u64
+    }
+
+    fun cast6(x: i64): u128 {
+        x as u128
+    }
+
+    fun cast7(x: i64): u256 {
+        x as u256
+    }
+
+    fun cast8(x: i128): i64 {
+        x as i64
+    }
+
+    fun cast9(x: i128): u8 {
+        x as u8
+    }
+
+    fun cast10(x: i128): u16 {
+        x as u16
+    }
+
+    fun cast11(x: i128): u32 {
+        x as u32
+    }
+
+    fun cast12(x: i128): u64 {
+        x as u64
+    }
+
+    fun cast13(x: i128): u128 {
+        x as u128
+    }
+
+    fun cast14(x: i128): u256 {
+        x as u256
+    }
+
+    fun cast15(x: u64): i128 {
+        x as i128
+    }
+
+    fun cast16(x: u128): i64 {
+        x as i64
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/signed_int_dep/i128.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/signed_int_dep/i128.move
@@ -1,0 +1,249 @@
+/// Implements the `i128` type. The type name `i128` is a shortcut for the `struct I128` defined in this module. One can use `+`, `-`, `==`, etc. with `i128`, which are mapped to Move functions in this module.
+module std::i128 {
+    /// Arithmetic operation resulted in overflow (value outside the range [-2^127, 2^127 - 1])
+    const EOVERFLOW: u64 = 1;
+    /// Division by Zero is not allowed
+    const EDIVISION_BY_ZERO: u64 = 2;
+
+    /// min number that a I128 could represent = (1 followed by 127 0s) = 1 << 127
+    const BITS_MIN_I128: u128 = 0x80000000000000000000000000000000;
+
+    /// max number that a I128 could represent = (0 followed by 127 1s) = (1 << 127) - 1
+    const BITS_MAX_I128: u128 = 0x7fffffffffffffffffffffffffffffff;
+
+    /// (1 << 128) - 1
+    const MAX_U128: u128 = 0xffffffffffffffffffffffffffffffff;
+
+    /// 1 << 128
+    const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
+
+    const LT: u8 = 0;
+    const EQ: u8 = 1;
+    const GT: u8 = 2;
+
+    /// Implementation of the `i128` primitive type. Do not use this type directly, instead use `i128`.
+    struct I128 has copy, drop, store {
+        bits: u128
+    }
+
+    /// Creates an I128 from a u128, asserting that it's not greater than the maximum positive value
+    public fun from(v: u128): I128 {
+        assert!(v <= BITS_MAX_I128, EOVERFLOW);
+        I128 { bits: v }
+    }
+
+    /// Creates a negative I128 from a u128, asserting that it's not greater than the minimum negative value
+    public fun neg_from(v: u128): I128 {
+        assert!(v <= BITS_MIN_I128, EOVERFLOW);
+        I128 { bits: twos_complement(v) }
+    }
+
+    public fun neg(self: I128): I128 {
+        if (self.is_neg()) { self.abs() }
+        else {
+            neg_from(self.bits)
+        }
+    }
+
+    /// Performs wrapping addition on two I128 numbers
+    public fun wrapping_add(self: I128, num2: I128): I128 {
+        I128 { bits: (((self.bits as u256) + (num2.bits as u256)) % TWO_POW_128 as u128) }
+    }
+
+    /// Performs checked addition on two I128 numbers, abort on overflow
+    public fun add(self: I128, num2: I128): I128 {
+        let sum = self.wrapping_add(num2);
+        // overflow only if: (1) postive + postive = negative, OR (2) negative + negative = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign == num2.sign() && self_sign != sum.sign();
+        assert!(!overflow, EOVERFLOW);
+        sum
+    }
+
+    /// Performs wrapping subtraction on two I128 numbers
+    public fun wrapping_sub(self: I128, num2: I128): I128 {
+        self.wrapping_add(I128 { bits: twos_complement(num2.bits) })
+    }
+
+    /// Performs checked subtraction on two I128 numbers, asserting on overflow
+    public fun sub(self: I128, num2: I128): I128 {
+        let difference = self.wrapping_sub(num2);
+        // overflow only if: (1) positive - negative = negative, OR (2) negative - positive = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign != num2.sign_internal() && self_sign != difference.sign_internal();
+        assert!(!overflow, EOVERFLOW);
+        difference
+    }
+
+    /// Performs multiplication on two I128 numbers
+    public fun mul(self: I128, num2: I128): I128 {
+        let product = (self.abs_u128() as u256) * (num2.abs_u128() as u256);
+        if (self.sign_internal() != num2.sign_internal()) {
+            assert!(product <= (BITS_MIN_I128 as u256), EOVERFLOW);
+            neg_from((product as u128))
+        } else {
+            assert!(product <= (BITS_MAX_I128 as u256), EOVERFLOW);
+            from((product as u128))
+        }
+    }
+
+    /// Performs division on two I128 numbers
+    /// Note that we mimic the behavior of solidity int division that it rounds towards 0 rather than rounds down
+    /// - rounds towards 0: (-4) / 3 = -(4 / 3) = -1 (remainder = -1)
+    /// - rounds down: (-4) / 3 = -2 (remainder = 2)
+    public fun div(self: I128, num2: I128): I128 {
+        assert!(!num2.is_zero(), EDIVISION_BY_ZERO);
+        let result = self.abs_u128() / num2.abs_u128();
+        if (self.sign_internal() != num2.sign_internal()) neg_from(result)
+        else from(result)
+    }
+
+    /// Performs modulo on two I128 numbers
+    /// a mod b = a - b * (a / b)
+    public fun mod(self: I128, num2: I128): I128 {
+        let quotient = self.div(num2);
+        self.sub(num2.mul(quotient))
+    }
+
+    /// Returns the absolute value of an I128 number
+    public fun abs(self: I128): I128 {
+        let bits = if (self.sign_internal() == 0) { self.bits }
+        else {
+            assert!(self.bits > BITS_MIN_I128, EOVERFLOW);
+            twos_complement(self.bits)
+        };
+        I128 { bits }
+    }
+
+    /// Returns the absolute value of an I128 number as a u128
+    public fun abs_u128(self: I128): u128 {
+        if (self.sign_internal() == 0) self.bits
+        else twos_complement(self.bits)
+    }
+
+    /// Returns the minimum of two I128 numbers
+    public fun min(self: I128, b: I128): I128 {
+        if (self.lt(b)) self else b
+    }
+
+    /// Returns the maximum of two I128 numbers
+    public fun max(self: I128, b: I128): I128 {
+        if (self.gt(b)) self else b
+    }
+
+    /// Raises an I128 number to a u64 power
+    public fun pow(self: I128, exponent: u64): I128 {
+        if (exponent == 0) {
+            return from(1)
+        };
+        let result = from(1);
+        while (exponent > 0) {
+            if (exponent % 2 == 1) {
+                result = result.mul(self);
+            };
+            self = self.mul(self);
+            exponent /= 2;
+        };
+        result
+    }
+
+    /// Creates an I128 from a u128 without any checks
+    public fun pack(v: u128): I128 {
+        I128 { bits: v }
+    }
+
+    /// Destroys an I128 and returns its internal bits
+    public fun unpack(self: I128): u128 {
+        self.bits
+    }
+
+    /// Get internal bits of I128
+    public fun bits(self: &I128): u128 {
+        self.bits
+    }
+
+    /// Returns the sign of an I128 number (0 for positive, 1 for negative)
+    public fun sign(self: I128): u8 {
+        self.sign_internal()
+    }
+
+    /// Creates and returns an I128 representing zero
+    public fun zero(): I128 {
+        I128 { bits: 0 }
+    }
+
+    /// Checks if an I128 number is zero
+    public fun is_zero(self: I128): bool {
+        self.bits == 0
+    }
+
+    /// Checks if an I128 number is negative
+    public fun is_neg(self: I128): bool {
+        self.sign_internal() == 1
+    }
+
+    /// Compares two I128 numbers, returning LT, EQ, or GT
+    public fun cmp(self: I128, num2: I128): u8 {
+        let sign1 = self.sign_internal();
+        let sign2 = num2.sign_internal();
+
+        if (sign1 > sign2) {
+            LT
+        } else if (sign1 < sign2) {
+            GT
+        } else if (self.bits > num2.bits) {
+            GT
+        } else if (self.bits < num2.bits) {
+            LT
+        } else {
+            EQ
+        }
+    }
+
+    /// Checks if two I128 numbers are equal
+    public fun eq(self: I128, num2: I128): bool {
+        self.bits == num2.bits
+    }
+
+    /// Checks if two I128 numbers are not equal
+    public fun neq(self: I128, num2: I128): bool {
+        self.bits != num2.bits
+    }
+
+    /// Checks if the first I128 number is greater than the second
+    public fun gt(self: I128, num2: I128): bool {
+        self.cmp(num2) == GT
+    }
+
+    /// Checks if the first I128 number is greater than or equal to the second
+    public fun gte(self: I128, num2: I128): bool {
+        self.cmp(num2) >= EQ
+    }
+
+    /// Checks if the first I128 number is less than the second
+    public fun lt(self: I128, num2: I128): bool {
+        self.cmp(num2) == LT
+    }
+
+    /// Checks if the first I128 number is less than or equal to the second
+    public fun lte(self: I128, num2: I128): bool {
+        self.cmp(num2) <= EQ
+    }
+
+    /// Get the sign and the absolute value of an I128 number
+    public fun into_inner(self: I128): (bool, u128) {
+        (self.sign_internal() == 0, self.abs_u128())
+    }
+
+    /// Two's complement in order to dervie negative representation of bits
+    /// It is overflow-proof because we hardcode 2's complement of 0 to be 0
+    /// Which is fine for our specific use case
+    inline fun twos_complement(v: u128): u128 {
+        if (v == 0) 0 else MAX_U128 - v + 1
+    }
+
+    /// Returns the sign of an I128 number (0 for positive, 1 for negative)
+    inline fun sign_internal(self: I128): u8 {
+        ((self.bits / BITS_MIN_I128) as u8)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/signed_int_dep/i64.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/signed_int_dep/i64.move
@@ -1,0 +1,249 @@
+/// Implements the `i64` type. The type name `i64` is a shortcut for the `struct I64` defined in this module. One can use `+`, `-`, `==`, etc. with `i64`, which are mapped to Move functions in this module.
+module std::i64 {
+    /// Arithmetic operation resulted in overflow (value outside the range [-2^63, 2^63 - 1])
+    const EOVERFLOW: u64 = 1;
+    /// Division by Zero is not allowed
+    const EDIVISION_BY_ZERO: u64 = 2;
+
+    /// min number that a I64 could represent = (1 followed by 63 0s) = 1 << 63
+    const BITS_MIN_I64: u64 = 0x8000000000000000;
+
+    /// max number that a I64 could represent = (0 followed by 63 1s) = (1 << 63) - 1
+    const BITS_MAX_I64: u64 = 0x7fffffffffffffff;
+
+    /// (1 << 64) - 1
+    const MAX_U64: u64 = 0xffffffffffffffff;
+
+    /// 1 << 64
+    const TWO_POW_64: u128 = 0x10000000000000000;
+
+    const LT: u8 = 0;
+    const EQ: u8 = 1;
+    const GT: u8 = 2;
+
+    /// Implementation of the `i64` primitive type. Do not use this type directly, instead use `i64`.
+    struct I64 has copy, drop, store {
+        bits: u64
+    }
+
+    /// Creates an I64 from a u64, asserting that it's not greater than the maximum positive value
+    public fun from(v: u64): I64 {
+        assert!(v <= BITS_MAX_I64, EOVERFLOW);
+        I64 { bits: v }
+    }
+
+    /// Creates a negative I64 from a u64, asserting that it's not greater than the minimum negative value
+    public fun neg_from(v: u64): I64 {
+        assert!(v <= BITS_MIN_I64, EOVERFLOW);
+        I64 { bits: twos_complement(v) }
+    }
+
+    public fun neg(self: I64): I64 {
+        if (self.is_neg()) { self.abs() }
+        else {
+            neg_from(self.bits)
+        }
+    }
+
+    /// Performs wrapping addition on two I64 numbers
+    public fun wrapping_add(self: I64, num2: I64): I64 {
+        I64 { bits: (((self.bits as u128) + (num2.bits as u128)) % TWO_POW_64 as u64) }
+    }
+
+    /// Performs checked addition on two I64 numbers, abort on overflow
+    public fun add(self: I64, num2: I64): I64 {
+        let sum = self.wrapping_add(num2);
+        // overflow only if: (1) postive + postive = negative, OR (2) negative + negative = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign == num2.sign_internal() && self_sign != sum.sign_internal();
+        assert!(!overflow, EOVERFLOW);
+        sum
+    }
+
+    /// Performs wrapping subtraction on two I64 numbers
+    public fun wrapping_sub(self: I64, num2: I64): I64 {
+        self.wrapping_add(I64 { bits: twos_complement(num2.bits) })
+    }
+
+    /// Performs checked subtraction on two I64 numbers, asserting on overflow
+    public fun sub(self: I64, num2: I64): I64 {
+        let difference = self.wrapping_sub(num2);
+        // overflow only if: (1) positive - negative = negative, OR (2) negative - positive = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign != num2.sign_internal() && self_sign != difference.sign_internal();
+        assert!(!overflow, EOVERFLOW);
+        difference
+    }
+
+    /// Performs multiplication on two I64 numbers
+    public fun mul(self: I64, num2: I64): I64 {
+        let product = (self.abs_u64() as u128) * (num2.abs_u64() as u128);
+        if (self.sign_internal() != num2.sign_internal()) {
+            assert!(product <= (BITS_MIN_I64 as u128), EOVERFLOW);
+            neg_from((product as u64))
+        } else {
+            assert!(product <= (BITS_MAX_I64 as u128), EOVERFLOW);
+            from((product as u64))
+        }
+    }
+
+    /// Performs division on two I64 numbers
+    /// Note that we mimic the behavior of solidity int division that it rounds towards 0 rather than rounds down
+    /// - rounds towards 0: (-4) / 3 = -(4 / 3) = -1 (remainder = -1)
+    /// - rounds down: (-4) / 3 = -2 (remainder = 2)
+    public fun div(self: I64, num2: I64): I64 {
+        assert!(!num2.is_zero(), EDIVISION_BY_ZERO);
+        let result = self.abs_u64() / num2.abs_u64();
+        if (self.sign_internal() != num2.sign_internal()) neg_from(result)
+        else from(result)
+    }
+
+    /// Performs modulo on two I64 numbers
+    /// a mod b = a - b * (a / b)
+    public fun mod(self: I64, num2: I64): I64 {
+        let quotient = self.div(num2);
+        self.sub(num2.mul(quotient))
+    }
+
+    /// Returns the absolute value of an I64 number
+    public fun abs(self: I64): I64 {
+        let bits = if (self.sign_internal() == 0) { self.bits }
+        else {
+            assert!(self.bits > BITS_MIN_I64, EOVERFLOW);
+            twos_complement(self.bits)
+        };
+        I64 { bits }
+    }
+
+    /// Returns the absolute value of an I64 number as a u64
+    public fun abs_u64(self: I64): u64 {
+        if (self.sign_internal() == 0) self.bits
+        else twos_complement(self.bits)
+    }
+
+    /// Returns the minimum of two I64 numbers
+    public fun min(self: I64, b: I64): I64 {
+        if (self.lt(b)) self else b
+    }
+
+    /// Returns the maximum of two I64 numbers
+    public fun max(self: I64, b: I64): I64 {
+        if (self.gt(b)) self else b
+    }
+
+    /// Raises an I64 number to a u64 power
+    public fun pow(self: I64, exponent: u64): I64 {
+        if (exponent == 0) {
+            return from(1)
+        };
+        let result = from(1);
+        while (exponent > 0)  {
+            if (exponent % 2 == 1) {
+                result = result.mul(self);
+            };
+            self = self.mul(self);
+            exponent /= 2;
+        };
+        result
+    }
+
+    /// Creates an I64 from a u64 without any checks
+    public fun pack(v: u64): I64 {
+        I64 { bits: v }
+    }
+
+    /// Destroys an I64 and returns its internal bits
+    public fun unpack(self: I64): u64 {
+        self.bits
+    }
+
+    /// Get internal bits of I64
+    public fun bits(self: &I64): u64 {
+        self.bits
+    }
+
+    /// Returns the sign of an I64 number (0 for positive, 1 for negative)
+    public fun sign(self: I64): u8 {
+        self.sign_internal()
+    }
+
+    /// Creates and returns an I64 representing zero
+    public fun zero(): I64 {
+        I64 { bits: 0 }
+    }
+
+    /// Checks if an I64 number is zero
+    public fun is_zero(self: I64): bool {
+        self.bits == 0
+    }
+
+    /// Checks if an I64 number is negative
+    public fun is_neg(self: I64): bool {
+        self.sign_internal() == 1
+    }
+
+    /// Compares two I64 numbers, returning LT, EQ, or GT
+    public fun cmp(self: I64, num2: I64): u8 {
+        let sign1 = self.sign_internal();
+        let sign2 = num2.sign_internal();
+
+        if (sign1 > sign2) {
+            LT
+        } else if (sign1 < sign2) {
+            GT
+        } else if (self.bits > num2.bits) {
+            GT
+        } else if (self.bits < num2.bits)  {
+            LT
+        } else {
+            EQ
+        }
+    }
+
+    /// Checks if two I64 numbers are equal
+    public fun eq(self: I64, num2: I64): bool {
+        self.bits == num2.bits
+    }
+
+    /// Checks if two I64 numbers are not equal
+    public fun neq(self: I64, num2: I64): bool {
+        self.bits != num2.bits
+    }
+
+    /// Checks if the first I64 number is greater than the second
+    public fun gt(self: I64, num2: I64): bool {
+        self.cmp(num2) == GT
+    }
+
+    /// Checks if the first I64 number is greater than or equal to the second
+    public fun gte(self: I64, num2: I64): bool {
+        self.cmp(num2) >= EQ
+    }
+
+    /// Checks if the first I64 number is less than the second
+    public fun lt(self: I64, num2: I64): bool {
+        self.cmp(num2) == LT
+    }
+
+    /// Checks if the first I64 number is less than or equal to the second
+    public fun lte(self: I64, num2: I64): bool {
+        self.cmp(num2) <= EQ
+    }
+
+    /// Get the sign and the absolute value of an I64 number
+    public fun into_inner(self: I64): (bool, u64) {
+        (self.sign_internal() == 0, self.abs_u64())
+    }
+
+    /// Two's complement in order to dervie negative representation of bits
+    /// It is overflow-proof because we hardcode 2's complement of 0 to be 0
+    /// Which is fine for our specific use case
+    inline fun twos_complement(v: u64): u64 {
+        if (v == 0) 0 else MAX_U64 - v + 1
+    }
+
+    /// Returns the sign of an I64 number (0 for positive, 1 for negative)
+    inline fun sign_internal(self: I64): u8 {
+        ((self.bits / BITS_MIN_I64) as u8)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_arithmetic.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_arithmetic.exp
@@ -1,0 +1,4591 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::valid_arithmetic {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test_add1(x: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::add(x, x)
+    }
+    private fun test_add2(x: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::add(x, x)
+    }
+    private fun test_add3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::add(i64::add(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_add4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::add(i128::add(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_div1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::div(x, y)
+    }
+    private fun test_div2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::div(x, y)
+    }
+    private fun test_div3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::div(i64::div(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_div4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::div(i128::div(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_mix1(x: 0x1::i64::I64,y: 0x1::i64::I64,z: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::mod(i64::div(i64::mul(i64::sub(i64::add(x, y), z), x), y), z)
+    }
+    private fun test_mix2(x: 0x1::i128::I128,y: 0x1::i128::I128,z: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::mod(i128::div(i128::mul(i128::sub(i128::add(x, y), z), x), y), z)
+    }
+    private fun test_mix3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::mod(i64::div(i64::mul(i64::sub(i64::add(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3)), select valid_arithmetic::S1.y<S1>(s1)), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_mix4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::mod(i128::div(i128::mul(i128::sub(i128::add(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3)), select valid_arithmetic::S1.z<S1>(s1)), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_mod1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::mod(x, y)
+    }
+    private fun test_mod2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::mod(x, y)
+    }
+    private fun test_mod3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::mod(i64::mod(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_mod4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::mod(i128::mod(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_mul1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::mul(x, y)
+    }
+    private fun test_mul2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::mul(x, y)
+    }
+    private fun test_mul3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::mul(i64::mul(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_mul4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::mul(i128::mul(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_neg1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::sub(i64::add(i64::neg(x), y), i64::mod(i64::div(i64::mul(i64::neg(x), i64::neg(y)), i64::neg(x)), i64::neg(y)))
+    }
+    private fun test_neg2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::sub(i128::add(i128::neg(x), y), i128::mod(i128::div(i128::mul(i128::neg(x), i128::neg(y)), i128::neg(x)), i128::neg(y)))
+    }
+    private fun test_sub1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::sub(x, y)
+    }
+    private fun test_sub2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::sub(x, y)
+    }
+    private fun test_sub3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::sub(i64::sub(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_sub4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::sub(i128::sub(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+} // end 0x42::valid_arithmetic
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::valid_arithmetic {
+    enum E1 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 has copy, drop {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 has copy, drop {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> has copy, drop {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    fun test_add1(x: 0x1::i64::I64): 0x1::i64::I64 {
+        0x1::i64::add(x, x)
+    }
+    fun test_add2(x: 0x1::i128::I128): 0x1::i128::I128 {
+        0x1::i128::add(x, x)
+    }
+    fun test_add3(s1: S1, s2: S2, s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        0x1::i64::add(0x1::i64::add(s1.y, s2.y), s3.x)
+    }
+    fun test_add4(s1: S1, s2: S2, s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        0x1::i128::add(0x1::i128::add(s1.z, s2.z), s3.x)
+    }
+    fun test_div1(x: 0x1::i64::I64, y: 0x1::i64::I64): 0x1::i64::I64 {
+        0x1::i64::div(x, y)
+    }
+    fun test_div2(x: 0x1::i128::I128, y: 0x1::i128::I128): 0x1::i128::I128 {
+        0x1::i128::div(x, y)
+    }
+    fun test_div3(s1: S1, s2: S2, s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        0x1::i64::div(0x1::i64::div(s1.y, s2.y), s3.x)
+    }
+    fun test_div4(s1: S1, s2: S2, s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        0x1::i128::div(0x1::i128::div(s1.z, s2.z), s3.x)
+    }
+    fun test_mix1(x: 0x1::i64::I64, y: 0x1::i64::I64, z: 0x1::i64::I64): 0x1::i64::I64 {
+        0x1::i64::mod(0x1::i64::div(0x1::i64::mul(0x1::i64::sub(0x1::i64::add(x, y), z), x), y), z)
+    }
+    fun test_mix2(x: 0x1::i128::I128, y: 0x1::i128::I128, z: 0x1::i128::I128): 0x1::i128::I128 {
+        0x1::i128::mod(0x1::i128::div(0x1::i128::mul(0x1::i128::sub(0x1::i128::add(x, y), z), x), y), z)
+    }
+    fun test_mix3(s1: S1, s2: S2, s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        0x1::i64::mod(0x1::i64::div(0x1::i64::mul(0x1::i64::sub(0x1::i64::add(s1.y, s2.y), s3.x), s1.y), s2.y), s3.x)
+    }
+    fun test_mix4(s1: S1, s2: S2, s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        0x1::i128::mod(0x1::i128::div(0x1::i128::mul(0x1::i128::sub(0x1::i128::add(s1.z, s2.z), s3.x), s1.z), s2.z), s3.x)
+    }
+    fun test_mod1(x: 0x1::i64::I64, y: 0x1::i64::I64): 0x1::i64::I64 {
+        0x1::i64::mod(x, y)
+    }
+    fun test_mod2(x: 0x1::i128::I128, y: 0x1::i128::I128): 0x1::i128::I128 {
+        0x1::i128::mod(x, y)
+    }
+    fun test_mod3(s1: S1, s2: S2, s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        0x1::i64::mod(0x1::i64::mod(s1.y, s2.y), s3.x)
+    }
+    fun test_mod4(s1: S1, s2: S2, s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        0x1::i128::mod(0x1::i128::mod(s1.z, s2.z), s3.x)
+    }
+    fun test_mul1(x: 0x1::i64::I64, y: 0x1::i64::I64): 0x1::i64::I64 {
+        0x1::i64::mul(x, y)
+    }
+    fun test_mul2(x: 0x1::i128::I128, y: 0x1::i128::I128): 0x1::i128::I128 {
+        0x1::i128::mul(x, y)
+    }
+    fun test_mul3(s1: S1, s2: S2, s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        0x1::i64::mul(0x1::i64::mul(s1.y, s2.y), s3.x)
+    }
+    fun test_mul4(s1: S1, s2: S2, s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        0x1::i128::mul(0x1::i128::mul(s1.z, s2.z), s3.x)
+    }
+    fun test_neg1(x: 0x1::i64::I64, y: 0x1::i64::I64): 0x1::i64::I64 {
+        0x1::i64::sub(0x1::i64::add(0x1::i64::neg(x), y), 0x1::i64::mod(0x1::i64::div(0x1::i64::mul(0x1::i64::neg(x), 0x1::i64::neg(y)), 0x1::i64::neg(x)), 0x1::i64::neg(y)))
+    }
+    fun test_neg2(x: 0x1::i128::I128, y: 0x1::i128::I128): 0x1::i128::I128 {
+        0x1::i128::sub(0x1::i128::add(0x1::i128::neg(x), y), 0x1::i128::mod(0x1::i128::div(0x1::i128::mul(0x1::i128::neg(x), 0x1::i128::neg(y)), 0x1::i128::neg(x)), 0x1::i128::neg(y)))
+    }
+    fun test_sub1(x: 0x1::i64::I64, y: 0x1::i64::I64): 0x1::i64::I64 {
+        0x1::i64::sub(x, y)
+    }
+    fun test_sub2(x: 0x1::i128::I128, y: 0x1::i128::I128): 0x1::i128::I128 {
+        0x1::i128::sub(x, y)
+    }
+    fun test_sub3(s1: S1, s2: S2, s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        0x1::i64::sub(0x1::i64::sub(s1.y, s2.y), s3.x)
+    }
+    fun test_sub4(s1: S1, s2: S2, s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        0x1::i128::sub(0x1::i128::sub(s1.z, s2.z), s3.x)
+    }
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_arithmetic::test_add1($t0: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64
+     var $t2: 0x1::i64::I64
+  0: $t2 := infer($t0)
+  1: $t1 := i64::add($t2, $t0)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add2($t0: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128
+     var $t2: 0x1::i128::I128
+  0: $t2 := infer($t0)
+  1: $t1 := i128::add($t2, $t0)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::add($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::add($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::add($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::add($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::div($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::div($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::div($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::div($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::div($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::div($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64, $t2: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+  0: $t8 := infer($t0)
+  1: $t7 := i64::add($t8, $t1)
+  2: $t6 := i64::sub($t7, $t2)
+  3: $t5 := i64::mul($t6, $t0)
+  4: $t4 := i64::div($t5, $t1)
+  5: $t3 := i64::mod($t4, $t2)
+  6: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128, $t2: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+  0: $t8 := infer($t0)
+  1: $t7 := i128::add($t8, $t1)
+  2: $t6 := i128::sub($t7, $t2)
+  3: $t5 := i128::mul($t6, $t0)
+  4: $t4 := i128::div($t5, $t1)
+  5: $t3 := i128::mod($t4, $t2)
+  6: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i64::I64
+     var $t14: 0x1::i64::I64
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t16: &0x1::i64::I64
+     var $t17: 0x1::i64::I64
+     var $t18: &0x42::valid_arithmetic::S1
+     var $t19: &0x1::i64::I64
+     var $t20: 0x1::i64::I64
+     var $t21: &0x42::valid_arithmetic::S2
+     var $t22: &0x1::i64::I64
+     var $t23: 0x1::i64::I64
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t25: &0x1::i64::I64
+  0: $t9 := borrow_local($t0)
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.y($t9)
+  2: $t8 := read_ref($t10)
+  3: $t12 := borrow_local($t1)
+  4: $t13 := borrow_field<0x42::valid_arithmetic::S2>.y($t12)
+  5: $t11 := read_ref($t13)
+  6: $t7 := i64::add($t8, $t11)
+  7: $t15 := borrow_local($t2)
+  8: $t16 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t15)
+  9: $t14 := read_ref($t16)
+ 10: $t6 := i64::sub($t7, $t14)
+ 11: $t18 := borrow_local($t0)
+ 12: $t19 := borrow_field<0x42::valid_arithmetic::S1>.y($t18)
+ 13: $t17 := read_ref($t19)
+ 14: $t5 := i64::mul($t6, $t17)
+ 15: $t21 := borrow_local($t1)
+ 16: $t22 := borrow_field<0x42::valid_arithmetic::S2>.y($t21)
+ 17: $t20 := read_ref($t22)
+ 18: $t4 := i64::div($t5, $t20)
+ 19: $t24 := borrow_local($t2)
+ 20: $t25 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t24)
+ 21: $t23 := read_ref($t25)
+ 22: $t3 := i64::mod($t4, $t23)
+ 23: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i128::I128
+     var $t14: 0x1::i128::I128
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t16: &0x1::i128::I128
+     var $t17: 0x1::i128::I128
+     var $t18: &0x42::valid_arithmetic::S1
+     var $t19: &0x1::i128::I128
+     var $t20: 0x1::i128::I128
+     var $t21: &0x42::valid_arithmetic::S2
+     var $t22: &0x1::i128::I128
+     var $t23: 0x1::i128::I128
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t25: &0x1::i128::I128
+  0: $t9 := borrow_local($t0)
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.z($t9)
+  2: $t8 := read_ref($t10)
+  3: $t12 := borrow_local($t1)
+  4: $t13 := borrow_field<0x42::valid_arithmetic::S2>.z($t12)
+  5: $t11 := read_ref($t13)
+  6: $t7 := i128::add($t8, $t11)
+  7: $t15 := borrow_local($t2)
+  8: $t16 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t15)
+  9: $t14 := read_ref($t16)
+ 10: $t6 := i128::sub($t7, $t14)
+ 11: $t18 := borrow_local($t0)
+ 12: $t19 := borrow_field<0x42::valid_arithmetic::S1>.z($t18)
+ 13: $t17 := read_ref($t19)
+ 14: $t5 := i128::mul($t6, $t17)
+ 15: $t21 := borrow_local($t1)
+ 16: $t22 := borrow_field<0x42::valid_arithmetic::S2>.z($t21)
+ 17: $t20 := read_ref($t22)
+ 18: $t4 := i128::div($t5, $t20)
+ 19: $t24 := borrow_local($t2)
+ 20: $t25 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t24)
+ 21: $t23 := read_ref($t25)
+ 22: $t3 := i128::mod($t4, $t23)
+ 23: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::mod($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::mod($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::mod($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::mod($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::mod($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::mod($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::mul($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::mul($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::mul($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::mul($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::mul($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::mul($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: 0x1::i64::I64
+  0: $t4 := i64::neg($t0)
+  1: $t3 := i64::add($t4, $t1)
+  2: $t8 := i64::neg($t0)
+  3: $t9 := i64::neg($t1)
+  4: $t7 := i64::mul($t8, $t9)
+  5: $t10 := i64::neg($t0)
+  6: $t6 := i64::div($t7, $t10)
+  7: $t11 := i64::neg($t1)
+  8: $t5 := i64::mod($t6, $t11)
+  9: $t2 := i64::sub($t3, $t5)
+ 10: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+  0: $t4 := i128::neg($t0)
+  1: $t3 := i128::add($t4, $t1)
+  2: $t8 := i128::neg($t0)
+  3: $t9 := i128::neg($t1)
+  4: $t7 := i128::mul($t8, $t9)
+  5: $t10 := i128::neg($t0)
+  6: $t6 := i128::div($t7, $t10)
+  7: $t11 := i128::neg($t1)
+  8: $t5 := i128::mod($t6, $t11)
+  9: $t2 := i128::sub($t3, $t5)
+ 10: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::sub($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::sub($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::sub($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::sub($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::sub($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::sub($t4, $t11)
+ 11: return $t3
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_arithmetic::test_add1($t0: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64
+     var $t2: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  1: $t1 := i64::add($t2, $t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add2($t0: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128
+     var $t2: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  1: $t1 := i128::add($t2, $t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 35
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `y`] at line 35
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 35
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `y`] at line 35
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i64::add($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 35
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 35
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i64::add($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 39
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `z`] at line 39
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 39
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `z`] at line 39
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i128::add($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 39
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 39
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i128::add($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i64::div($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i128::div($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 83
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `y`] at line 83
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 83
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `y`] at line 83
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i64::div($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 83
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 83
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i64::div($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 87
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `z`] at line 87
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 87
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `z`] at line 87
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i128::div($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 87
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 87
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i128::div($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64, $t2: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t8 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+  1: $t7 := i64::add($t8, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+  2: $t6 := i64::sub($t7, $t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+  3: $t5 := i64::mul($t6, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  4: $t4 := i64::div($t5, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  5: $t3 := i64::mod($t4, $t2)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+  6: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128, $t2: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t8 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+  1: $t7 := i128::add($t8, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+  2: $t6 := i128::sub($t7, $t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+  3: $t5 := i128::mul($t6, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  4: $t4 := i128::div($t5, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  5: $t3 := i128::mod($t4, $t2)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+  6: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i64::I64
+     var $t14: 0x1::i64::I64
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t16: &0x1::i64::I64
+     var $t17: 0x1::i64::I64
+     var $t18: &0x42::valid_arithmetic::S1
+     var $t19: &0x1::i64::I64
+     var $t20: 0x1::i64::I64
+     var $t21: &0x42::valid_arithmetic::S2
+     var $t22: &0x1::i64::I64
+     var $t23: 0x1::i64::I64
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t25: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t9 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s1`] at line 115
+     #
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.y($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s1`, field `y`] at line 115
+     #
+  2: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+  3: $t12 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s2`] at line 115
+     #
+  4: $t13 := borrow_field<0x42::valid_arithmetic::S2>.y($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s2`, field `y`] at line 115
+     #
+  5: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8, $t11
+     # refs: []
+     #
+  6: $t7 := i64::add($t8, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+  7: $t15 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7, $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => #15 via [local `s3`] at line 115
+     #
+  8: $t16 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `s3`, field `x`] at line 115
+     #
+  9: $t14 := read_ref($t16)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7, $t14
+     # refs: []
+     #
+ 10: $t6 := i64::sub($t7, $t14)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 11: $t18 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `s1`] at line 115
+     #
+ 12: $t19 := borrow_field<0x42::valid_arithmetic::S1>.y($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `s1`, field `y`] at line 115
+     #
+ 13: $t17 := read_ref($t19)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6, $t17
+     # refs: []
+     #
+ 14: $t5 := i64::mul($t6, $t17)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+ 15: $t21 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t21
+     # refs: [$t21 => #21]
+     # #21
+     #   <no edges>
+     # #root
+     #   => #21 via [local `s2`] at line 115
+     #
+ 16: $t22 := borrow_field<0x42::valid_arithmetic::S2>.y($t21)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t22
+     # refs: [$t22 => #22]
+     # #22
+     #   <no edges>
+     # #root
+     #   => #22 via [local `s2`, field `y`] at line 115
+     #
+ 17: $t20 := read_ref($t22)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t20
+     # refs: []
+     #
+ 18: $t4 := i64::div($t5, $t20)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+ 19: $t24 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t24
+     # refs: [$t24 => #24]
+     # #24
+     #   <no edges>
+     # #root
+     #   => #24 via [local `s3`] at line 115
+     #
+ 20: $t25 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t25
+     # refs: [$t25 => #25]
+     # #25
+     #   <no edges>
+     # #root
+     #   => #25 via [local `s3`, field `x`] at line 115
+     #
+ 21: $t23 := read_ref($t25)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t23
+     # refs: []
+     #
+ 22: $t3 := i64::mod($t4, $t23)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 23: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i128::I128
+     var $t14: 0x1::i128::I128
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t16: &0x1::i128::I128
+     var $t17: 0x1::i128::I128
+     var $t18: &0x42::valid_arithmetic::S1
+     var $t19: &0x1::i128::I128
+     var $t20: 0x1::i128::I128
+     var $t21: &0x42::valid_arithmetic::S2
+     var $t22: &0x1::i128::I128
+     var $t23: 0x1::i128::I128
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t25: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t9 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s1`] at line 119
+     #
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.z($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s1`, field `z`] at line 119
+     #
+  2: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+  3: $t12 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s2`] at line 119
+     #
+  4: $t13 := borrow_field<0x42::valid_arithmetic::S2>.z($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s2`, field `z`] at line 119
+     #
+  5: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8, $t11
+     # refs: []
+     #
+  6: $t7 := i128::add($t8, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+  7: $t15 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7, $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => #15 via [local `s3`] at line 119
+     #
+  8: $t16 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `s3`, field `x`] at line 119
+     #
+  9: $t14 := read_ref($t16)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7, $t14
+     # refs: []
+     #
+ 10: $t6 := i128::sub($t7, $t14)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 11: $t18 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `s1`] at line 119
+     #
+ 12: $t19 := borrow_field<0x42::valid_arithmetic::S1>.z($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `s1`, field `z`] at line 119
+     #
+ 13: $t17 := read_ref($t19)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6, $t17
+     # refs: []
+     #
+ 14: $t5 := i128::mul($t6, $t17)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+ 15: $t21 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t21
+     # refs: [$t21 => #21]
+     # #21
+     #   <no edges>
+     # #root
+     #   => #21 via [local `s2`] at line 119
+     #
+ 16: $t22 := borrow_field<0x42::valid_arithmetic::S2>.z($t21)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t22
+     # refs: [$t22 => #22]
+     # #22
+     #   <no edges>
+     # #root
+     #   => #22 via [local `s2`, field `z`] at line 119
+     #
+ 17: $t20 := read_ref($t22)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t20
+     # refs: []
+     #
+ 18: $t4 := i128::div($t5, $t20)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+ 19: $t24 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t24
+     # refs: [$t24 => #24]
+     # #24
+     #   <no edges>
+     # #root
+     #   => #24 via [local `s3`] at line 119
+     #
+ 20: $t25 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t25
+     # refs: [$t25 => #25]
+     # #25
+     #   <no edges>
+     # #root
+     #   => #25 via [local `s3`, field `x`] at line 119
+     #
+ 21: $t23 := read_ref($t25)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t23
+     # refs: []
+     #
+ 22: $t3 := i128::mod($t4, $t23)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 23: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i64::mod($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i128::mod($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 99
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `y`] at line 99
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 99
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `y`] at line 99
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i64::mod($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 99
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 99
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i64::mod($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 103
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `z`] at line 103
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 103
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `z`] at line 103
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i128::mod($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 103
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 103
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i128::mod($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i64::mul($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i128::mul($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 67
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `y`] at line 67
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 67
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `y`] at line 67
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i64::mul($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 67
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 67
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i64::mul($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 71
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `z`] at line 71
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 71
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `z`] at line 71
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i128::mul($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 71
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 71
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i128::mul($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := i64::neg($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t3 := i64::add($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  2: $t8 := i64::neg($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: []
+     #
+  3: $t9 := i64::neg($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8, $t9
+     # refs: []
+     #
+  4: $t7 := i64::mul($t8, $t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: []
+     #
+  5: $t10 := i64::neg($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t7, $t10
+     # refs: []
+     #
+  6: $t6 := i64::div($t7, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t6
+     # refs: []
+     #
+  7: $t11 := i64::neg($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t11
+     # refs: []
+     #
+  8: $t5 := i64::mod($t6, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  9: $t2 := i64::sub($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 10: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := i128::neg($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t3 := i128::add($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  2: $t8 := i128::neg($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: []
+     #
+  3: $t9 := i128::neg($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8, $t9
+     # refs: []
+     #
+  4: $t7 := i128::mul($t8, $t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: []
+     #
+  5: $t10 := i128::neg($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t7, $t10
+     # refs: []
+     #
+  6: $t6 := i128::div($t7, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t6
+     # refs: []
+     #
+  7: $t11 := i128::neg($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t11
+     # refs: []
+     #
+  8: $t5 := i128::mod($t6, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  9: $t2 := i128::sub($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 10: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i64::sub($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  1: $t2 := i128::sub($t3, $t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 51
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `y`] at line 51
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 51
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `y`] at line 51
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i64::sub($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 51
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 51
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i64::sub($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t6 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s1`] at line 55
+     #
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s1`, field `z`] at line 55
+     #
+  2: $t5 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2, $t5
+     # refs: []
+     #
+  3: $t9 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s2`] at line 55
+     #
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s2`, field `z`] at line 55
+     #
+  5: $t8 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t8
+     # refs: []
+     #
+  6: $t4 := i128::sub($t5, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  7: $t12 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s3`] at line 55
+     #
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t13
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s3`, field `x`] at line 55
+     #
+  9: $t11 := read_ref($t13)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t11
+     # refs: []
+     #
+ 10: $t3 := i128::sub($t4, $t11)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 11: return $t3
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::valid_arithmetic {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test_add1(x: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::add(x, x)
+    }
+    private fun test_add2(x: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::add(x, x)
+    }
+    private fun test_add3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::add(i64::add(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_add4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::add(i128::add(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_div1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::div(x, y)
+    }
+    private fun test_div2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::div(x, y)
+    }
+    private fun test_div3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::div(i64::div(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_div4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::div(i128::div(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_mix1(x: 0x1::i64::I64,y: 0x1::i64::I64,z: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::mod(i64::div(i64::mul(i64::sub(i64::add(x, y), z), x), y), z)
+    }
+    private fun test_mix2(x: 0x1::i128::I128,y: 0x1::i128::I128,z: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::mod(i128::div(i128::mul(i128::sub(i128::add(x, y), z), x), y), z)
+    }
+    private fun test_mix3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::mod(i64::div(i64::mul(i64::sub(i64::add(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3)), select valid_arithmetic::S1.y<S1>(s1)), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_mix4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::mod(i128::div(i128::mul(i128::sub(i128::add(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3)), select valid_arithmetic::S1.z<S1>(s1)), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_mod1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::mod(x, y)
+    }
+    private fun test_mod2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::mod(x, y)
+    }
+    private fun test_mod3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::mod(i64::mod(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_mod4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::mod(i128::mod(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_mul1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::mul(x, y)
+    }
+    private fun test_mul2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::mul(x, y)
+    }
+    private fun test_mul3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::mul(i64::mul(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_mul4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::mul(i128::mul(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+    private fun test_neg1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::sub(i64::add(i64::neg(x), y), i64::mod(i64::div(i64::mul(i64::neg(x), i64::neg(y)), i64::neg(x)), i64::neg(y)))
+    }
+    private fun test_neg2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::sub(i128::add(i128::neg(x), y), i128::mod(i128::div(i128::mul(i128::neg(x), i128::neg(y)), i128::neg(x)), i128::neg(y)))
+    }
+    private fun test_sub1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        i64::sub(x, y)
+    }
+    private fun test_sub2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        i128::sub(x, y)
+    }
+    private fun test_sub3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): 0x1::i64::I64 {
+        i64::sub(i64::sub(select valid_arithmetic::S1.y<S1>(s1), select valid_arithmetic::S2.y<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i64::I64>>(s3))
+    }
+    private fun test_sub4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): 0x1::i128::I128 {
+        i128::sub(i128::sub(select valid_arithmetic::S1.z<S1>(s1), select valid_arithmetic::S2.z<S2>(s2)), select valid_arithmetic::S3.x<S3<0x1::i128::I128>>(s3))
+    }
+} // end 0x42::valid_arithmetic
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_arithmetic::test_add1($t0: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64
+     var $t2: 0x1::i64::I64
+  0: $t2 := infer($t0)
+  1: $t1 := i64::add($t2, $t0)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add2($t0: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128
+     var $t2: 0x1::i128::I128
+  0: $t2 := infer($t0)
+  1: $t1 := i128::add($t2, $t0)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::add($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::add($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::add($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::add($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::div($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::div($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::div($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::div($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::div($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::div($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64, $t2: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+  0: $t8 := infer($t0)
+  1: $t7 := i64::add($t8, $t1)
+  2: $t6 := i64::sub($t7, $t2)
+  3: $t5 := i64::mul($t6, $t0)
+  4: $t4 := i64::div($t5, $t1)
+  5: $t3 := i64::mod($t4, $t2)
+  6: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128, $t2: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+  0: $t8 := infer($t0)
+  1: $t7 := i128::add($t8, $t1)
+  2: $t6 := i128::sub($t7, $t2)
+  3: $t5 := i128::mul($t6, $t0)
+  4: $t4 := i128::div($t5, $t1)
+  5: $t3 := i128::mod($t4, $t2)
+  6: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i64::I64
+     var $t14: 0x1::i64::I64
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t16: &0x1::i64::I64
+     var $t17: 0x1::i64::I64
+     var $t18: &0x42::valid_arithmetic::S1
+     var $t19: &0x1::i64::I64
+     var $t20: 0x1::i64::I64
+     var $t21: &0x42::valid_arithmetic::S2
+     var $t22: &0x1::i64::I64
+     var $t23: 0x1::i64::I64
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t25: &0x1::i64::I64
+  0: $t9 := borrow_local($t0)
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.y($t9)
+  2: $t8 := read_ref($t10)
+  3: $t12 := borrow_local($t1)
+  4: $t13 := borrow_field<0x42::valid_arithmetic::S2>.y($t12)
+  5: $t11 := read_ref($t13)
+  6: $t7 := i64::add($t8, $t11)
+  7: $t15 := borrow_local($t2)
+  8: $t16 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t15)
+  9: $t14 := read_ref($t16)
+ 10: $t6 := i64::sub($t7, $t14)
+ 11: $t18 := borrow_local($t0)
+ 12: $t19 := borrow_field<0x42::valid_arithmetic::S1>.y($t18)
+ 13: $t17 := read_ref($t19)
+ 14: $t5 := i64::mul($t6, $t17)
+ 15: $t21 := borrow_local($t1)
+ 16: $t22 := borrow_field<0x42::valid_arithmetic::S2>.y($t21)
+ 17: $t20 := read_ref($t22)
+ 18: $t4 := i64::div($t5, $t20)
+ 19: $t24 := borrow_local($t2)
+ 20: $t25 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t24)
+ 21: $t23 := read_ref($t25)
+ 22: $t3 := i64::mod($t4, $t23)
+ 23: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i128::I128
+     var $t14: 0x1::i128::I128
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t16: &0x1::i128::I128
+     var $t17: 0x1::i128::I128
+     var $t18: &0x42::valid_arithmetic::S1
+     var $t19: &0x1::i128::I128
+     var $t20: 0x1::i128::I128
+     var $t21: &0x42::valid_arithmetic::S2
+     var $t22: &0x1::i128::I128
+     var $t23: 0x1::i128::I128
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t25: &0x1::i128::I128
+  0: $t9 := borrow_local($t0)
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.z($t9)
+  2: $t8 := read_ref($t10)
+  3: $t12 := borrow_local($t1)
+  4: $t13 := borrow_field<0x42::valid_arithmetic::S2>.z($t12)
+  5: $t11 := read_ref($t13)
+  6: $t7 := i128::add($t8, $t11)
+  7: $t15 := borrow_local($t2)
+  8: $t16 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t15)
+  9: $t14 := read_ref($t16)
+ 10: $t6 := i128::sub($t7, $t14)
+ 11: $t18 := borrow_local($t0)
+ 12: $t19 := borrow_field<0x42::valid_arithmetic::S1>.z($t18)
+ 13: $t17 := read_ref($t19)
+ 14: $t5 := i128::mul($t6, $t17)
+ 15: $t21 := borrow_local($t1)
+ 16: $t22 := borrow_field<0x42::valid_arithmetic::S2>.z($t21)
+ 17: $t20 := read_ref($t22)
+ 18: $t4 := i128::div($t5, $t20)
+ 19: $t24 := borrow_local($t2)
+ 20: $t25 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t24)
+ 21: $t23 := read_ref($t25)
+ 22: $t3 := i128::mod($t4, $t23)
+ 23: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::mod($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::mod($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::mod($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::mod($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::mod($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::mod($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::mul($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::mul($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::mul($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::mul($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::mul($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::mul($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: 0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: 0x1::i64::I64
+  0: $t4 := i64::neg($t0)
+  1: $t3 := i64::add($t4, $t1)
+  2: $t8 := i64::neg($t0)
+  3: $t9 := i64::neg($t1)
+  4: $t7 := i64::mul($t8, $t9)
+  5: $t10 := i64::neg($t0)
+  6: $t6 := i64::div($t7, $t10)
+  7: $t11 := i64::neg($t1)
+  8: $t5 := i64::mod($t6, $t11)
+  9: $t2 := i64::sub($t3, $t5)
+ 10: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: 0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+  0: $t4 := i128::neg($t0)
+  1: $t3 := i128::add($t4, $t1)
+  2: $t8 := i128::neg($t0)
+  3: $t9 := i128::neg($t1)
+  4: $t7 := i128::mul($t8, $t9)
+  5: $t10 := i128::neg($t0)
+  6: $t6 := i128::div($t7, $t10)
+  7: $t11 := i128::neg($t1)
+  8: $t5 := i128::mod($t6, $t11)
+  9: $t2 := i128::sub($t3, $t5)
+ 10: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: 0x1::i64::I64
+  0: $t3 := infer($t0)
+  1: $t2 := i64::sub($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: 0x1::i128::I128
+  0: $t3 := infer($t0)
+  1: $t2 := i128::sub($t3, $t1)
+  2: return $t2
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i64::sub($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i64::sub($t4, $t11)
+ 11: return $t3
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128
+  0: $t6 := borrow_local($t0)
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+  2: $t5 := read_ref($t7)
+  3: $t9 := borrow_local($t1)
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+  5: $t8 := read_ref($t10)
+  6: $t4 := i128::sub($t5, $t8)
+  7: $t12 := borrow_local($t2)
+  8: $t13 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+  9: $t11 := read_ref($t13)
+ 10: $t3 := i128::sub($t4, $t11)
+ 11: return $t3
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_arithmetic::test_add1($t0: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64 [unused]
+     var $t2: 0x1::i64::I64
+     # live vars: $t0
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  1: $t0 := i64::add($t2, $t0)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add2($t0: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128 [unused]
+     var $t2: 0x1::i128::I128
+     # live vars: $t0
+  0: $t2 := copy($t0)
+     # live vars: $t0, $t2
+  1: $t0 := i128::add($t2, $t0)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64 [unused]
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64 [unused]
+     var $t11: 0x1::i64::I64 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i64::add($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i64::add($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_add4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i128::add($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i128::add($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64 [unused]
+     var $t3: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i64::div($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128 [unused]
+     var $t3: 0x1::i128::I128 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i128::div($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64 [unused]
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64 [unused]
+     var $t11: 0x1::i64::I64 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i64::div($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i64::div($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_div4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i128::div($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i128::div($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64, $t2: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64 [unused]
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     var $t7: 0x1::i64::I64 [unused]
+     var $t8: 0x1::i64::I64
+     # live vars: $t0, $t1, $t2
+  0: $t8 := copy($t0)
+     # live vars: $t0, $t1, $t2, $t8
+  1: $t8 := i64::add($t8, $t1)
+     # live vars: $t0, $t1, $t2, $t8
+  2: $t8 := i64::sub($t8, $t2)
+     # live vars: $t0, $t1, $t2, $t8
+  3: $t0 := i64::mul($t8, $t0)
+     # live vars: $t0, $t1, $t2
+  4: $t0 := i64::div($t0, $t1)
+     # live vars: $t0, $t2
+  5: $t0 := i64::mod($t0, $t2)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128, $t2: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128 [unused]
+     var $t6: 0x1::i128::I128 [unused]
+     var $t7: 0x1::i128::I128 [unused]
+     var $t8: 0x1::i128::I128
+     # live vars: $t0, $t1, $t2
+  0: $t8 := copy($t0)
+     # live vars: $t0, $t1, $t2, $t8
+  1: $t8 := i128::add($t8, $t1)
+     # live vars: $t0, $t1, $t2, $t8
+  2: $t8 := i128::sub($t8, $t2)
+     # live vars: $t0, $t1, $t2, $t8
+  3: $t0 := i128::mul($t8, $t0)
+     # live vars: $t0, $t1, $t2
+  4: $t0 := i128::div($t0, $t1)
+     # live vars: $t0, $t2
+  5: $t0 := i128::mod($t0, $t2)
+     # live vars: $t0
+  6: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64 [unused]
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     var $t7: 0x1::i64::I64 [unused]
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i64::I64 [unused]
+     var $t14: 0x1::i64::I64 [unused]
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t16: &0x1::i64::I64 [unused]
+     var $t17: 0x1::i64::I64 [unused]
+     var $t18: &0x42::valid_arithmetic::S1 [unused]
+     var $t19: &0x1::i64::I64 [unused]
+     var $t20: 0x1::i64::I64 [unused]
+     var $t21: &0x42::valid_arithmetic::S2 [unused]
+     var $t22: &0x1::i64::I64 [unused]
+     var $t23: 0x1::i64::I64 [unused]
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i64::I64> [unused]
+     var $t25: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t9
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.y($t9)
+     # live vars: $t0, $t1, $t2, $t10
+  2: $t8 := read_ref($t10)
+     # live vars: $t0, $t1, $t2, $t8
+  3: $t12 := borrow_local($t1)
+     # live vars: $t0, $t1, $t2, $t8, $t12
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t12)
+     # live vars: $t0, $t1, $t2, $t8, $t10
+  5: $t11 := read_ref($t10)
+     # live vars: $t0, $t1, $t2, $t8, $t11
+  6: $t8 := i64::add($t8, $t11)
+     # live vars: $t0, $t1, $t2, $t8
+  7: $t15 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t8, $t15
+  8: $t10 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t15)
+     # live vars: $t0, $t1, $t2, $t8, $t10
+  9: $t11 := read_ref($t10)
+     # live vars: $t0, $t1, $t2, $t8, $t11
+ 10: $t8 := i64::sub($t8, $t11)
+     # live vars: $t0, $t1, $t2, $t8
+ 11: $t9 := borrow_local($t0)
+     # live vars: $t1, $t2, $t8, $t9
+ 12: $t10 := borrow_field<0x42::valid_arithmetic::S1>.y($t9)
+     # live vars: $t1, $t2, $t8, $t10
+ 13: $t11 := read_ref($t10)
+     # live vars: $t1, $t2, $t8, $t11
+ 14: $t8 := i64::mul($t8, $t11)
+     # live vars: $t1, $t2, $t8
+ 15: $t12 := borrow_local($t1)
+     # live vars: $t2, $t8, $t12
+ 16: $t10 := borrow_field<0x42::valid_arithmetic::S2>.y($t12)
+     # live vars: $t2, $t8, $t10
+ 17: $t11 := read_ref($t10)
+     # live vars: $t2, $t8, $t11
+ 18: $t8 := i64::div($t8, $t11)
+     # live vars: $t2, $t8
+ 19: $t15 := borrow_local($t2)
+     # live vars: $t8, $t15
+ 20: $t10 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t15)
+     # live vars: $t8, $t10
+ 21: $t11 := read_ref($t10)
+     # live vars: $t8, $t11
+ 22: $t8 := i64::mod($t8, $t11)
+     # live vars: $t8
+ 23: return $t8
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mix4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128 [unused]
+     var $t6: 0x1::i128::I128 [unused]
+     var $t7: 0x1::i128::I128 [unused]
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S1
+     var $t10: &0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: &0x42::valid_arithmetic::S2
+     var $t13: &0x1::i128::I128 [unused]
+     var $t14: 0x1::i128::I128 [unused]
+     var $t15: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t16: &0x1::i128::I128 [unused]
+     var $t17: 0x1::i128::I128 [unused]
+     var $t18: &0x42::valid_arithmetic::S1 [unused]
+     var $t19: &0x1::i128::I128 [unused]
+     var $t20: 0x1::i128::I128 [unused]
+     var $t21: &0x42::valid_arithmetic::S2 [unused]
+     var $t22: &0x1::i128::I128 [unused]
+     var $t23: 0x1::i128::I128 [unused]
+     var $t24: &0x42::valid_arithmetic::S3<0x1::i128::I128> [unused]
+     var $t25: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t9
+  1: $t10 := borrow_field<0x42::valid_arithmetic::S1>.z($t9)
+     # live vars: $t0, $t1, $t2, $t10
+  2: $t8 := read_ref($t10)
+     # live vars: $t0, $t1, $t2, $t8
+  3: $t12 := borrow_local($t1)
+     # live vars: $t0, $t1, $t2, $t8, $t12
+  4: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t12)
+     # live vars: $t0, $t1, $t2, $t8, $t10
+  5: $t11 := read_ref($t10)
+     # live vars: $t0, $t1, $t2, $t8, $t11
+  6: $t8 := i128::add($t8, $t11)
+     # live vars: $t0, $t1, $t2, $t8
+  7: $t15 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t8, $t15
+  8: $t10 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t15)
+     # live vars: $t0, $t1, $t2, $t8, $t10
+  9: $t11 := read_ref($t10)
+     # live vars: $t0, $t1, $t2, $t8, $t11
+ 10: $t8 := i128::sub($t8, $t11)
+     # live vars: $t0, $t1, $t2, $t8
+ 11: $t9 := borrow_local($t0)
+     # live vars: $t1, $t2, $t8, $t9
+ 12: $t10 := borrow_field<0x42::valid_arithmetic::S1>.z($t9)
+     # live vars: $t1, $t2, $t8, $t10
+ 13: $t11 := read_ref($t10)
+     # live vars: $t1, $t2, $t8, $t11
+ 14: $t8 := i128::mul($t8, $t11)
+     # live vars: $t1, $t2, $t8
+ 15: $t12 := borrow_local($t1)
+     # live vars: $t2, $t8, $t12
+ 16: $t10 := borrow_field<0x42::valid_arithmetic::S2>.z($t12)
+     # live vars: $t2, $t8, $t10
+ 17: $t11 := read_ref($t10)
+     # live vars: $t2, $t8, $t11
+ 18: $t8 := i128::div($t8, $t11)
+     # live vars: $t2, $t8
+ 19: $t15 := borrow_local($t2)
+     # live vars: $t8, $t15
+ 20: $t10 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t15)
+     # live vars: $t8, $t10
+ 21: $t11 := read_ref($t10)
+     # live vars: $t8, $t11
+ 22: $t8 := i128::mod($t8, $t11)
+     # live vars: $t8
+ 23: return $t8
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64 [unused]
+     var $t3: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i64::mod($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128 [unused]
+     var $t3: 0x1::i128::I128 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i128::mod($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64 [unused]
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64 [unused]
+     var $t11: 0x1::i64::I64 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i64::mod($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i64::mod($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mod4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i128::mod($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i128::mod($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64 [unused]
+     var $t3: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i64::mul($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128 [unused]
+     var $t3: 0x1::i128::I128 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i128::mul($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64 [unused]
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64 [unused]
+     var $t11: 0x1::i64::I64 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i64::mul($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i64::mul($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_mul4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i128::mul($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i128::mul($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64 [unused]
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     var $t7: 0x1::i64::I64 [unused]
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64 [unused]
+     var $t11: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := i64::neg($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t4 := i64::add($t4, $t1)
+     # live vars: $t0, $t1, $t4
+  2: $t8 := i64::neg($t0)
+     # live vars: $t0, $t1, $t4, $t8
+  3: $t9 := i64::neg($t1)
+     # live vars: $t0, $t1, $t4, $t8, $t9
+  4: $t8 := i64::mul($t8, $t9)
+     # live vars: $t0, $t1, $t4, $t8
+  5: $t0 := i64::neg($t0)
+     # live vars: $t0, $t1, $t4, $t8
+  6: $t0 := i64::div($t8, $t0)
+     # live vars: $t0, $t1, $t4
+  7: $t1 := i64::neg($t1)
+     # live vars: $t0, $t1, $t4
+  8: $t0 := i64::mod($t0, $t1)
+     # live vars: $t0, $t4
+  9: $t0 := i64::sub($t4, $t0)
+     # live vars: $t0
+ 10: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_neg2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128 [unused]
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128 [unused]
+     var $t6: 0x1::i128::I128 [unused]
+     var $t7: 0x1::i128::I128 [unused]
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := i128::neg($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t4 := i128::add($t4, $t1)
+     # live vars: $t0, $t1, $t4
+  2: $t8 := i128::neg($t0)
+     # live vars: $t0, $t1, $t4, $t8
+  3: $t9 := i128::neg($t1)
+     # live vars: $t0, $t1, $t4, $t8, $t9
+  4: $t8 := i128::mul($t8, $t9)
+     # live vars: $t0, $t1, $t4, $t8
+  5: $t0 := i128::neg($t0)
+     # live vars: $t0, $t1, $t4, $t8
+  6: $t0 := i128::div($t8, $t0)
+     # live vars: $t0, $t1, $t4
+  7: $t1 := i128::neg($t1)
+     # live vars: $t0, $t1, $t4
+  8: $t0 := i128::mod($t0, $t1)
+     # live vars: $t0, $t4
+  9: $t0 := i128::sub($t4, $t0)
+     # live vars: $t0
+ 10: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64 [unused]
+     var $t3: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i64::sub($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128 [unused]
+     var $t3: 0x1::i128::I128 [unused]
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t0 := i128::sub($t0, $t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub3($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i64::I64>): 0x1::i64::I64 {
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64 [unused]
+     var $t5: 0x1::i64::I64
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i64::I64
+     var $t8: 0x1::i64::I64
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i64::I64 [unused]
+     var $t11: 0x1::i64::I64 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i64::I64>
+     var $t13: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.y($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.y($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i64::sub($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i64::I64>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i64::sub($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+[variant baseline]
+fun valid_arithmetic::test_sub4($t0: 0x42::valid_arithmetic::S1, $t1: 0x42::valid_arithmetic::S2, $t2: 0x42::valid_arithmetic::S3<0x1::i128::I128>): 0x1::i128::I128 {
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: &0x42::valid_arithmetic::S1
+     var $t7: &0x1::i128::I128
+     var $t8: 0x1::i128::I128
+     var $t9: &0x42::valid_arithmetic::S2
+     var $t10: &0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: &0x42::valid_arithmetic::S3<0x1::i128::I128>
+     var $t13: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t6 := borrow_local($t0)
+     # live vars: $t1, $t2, $t6
+  1: $t7 := borrow_field<0x42::valid_arithmetic::S1>.z($t6)
+     # live vars: $t1, $t2, $t7
+  2: $t5 := read_ref($t7)
+     # live vars: $t1, $t2, $t5
+  3: $t9 := borrow_local($t1)
+     # live vars: $t2, $t5, $t9
+  4: $t7 := borrow_field<0x42::valid_arithmetic::S2>.z($t9)
+     # live vars: $t2, $t5, $t7
+  5: $t8 := read_ref($t7)
+     # live vars: $t2, $t5, $t8
+  6: $t5 := i128::sub($t5, $t8)
+     # live vars: $t2, $t5
+  7: $t12 := borrow_local($t2)
+     # live vars: $t5, $t12
+  8: $t7 := borrow_field<0x42::valid_arithmetic::S3<0x1::i128::I128>>.x($t12)
+     # live vars: $t5, $t7
+  9: $t8 := read_ref($t7)
+     # live vars: $t5, $t8
+ 10: $t5 := i128::sub($t5, $t8)
+     # live vars: $t5
+ 11: return $t5
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module 42.valid_arithmetic {
+use 0000000000000000000000000000000000000000000000000000000000000001::i64;
+use 0000000000000000000000000000000000000000000000000000000000000001::i128;
+
+
+enum E1 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I64>
+ }
+}
+enum E2 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I128>
+ }
+}
+enum E3<T> has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<T>
+ }
+}
+struct S1 has copy, drop {
+	x: u64,
+	y: I64,
+	z: I128
+}
+struct S2 has copy, drop {
+	x: S1,
+	y: I64,
+	z: I128
+}
+struct S3<T> has copy, drop {
+	x: T,
+	y: S1,
+	z: S2
+}
+
+test_add1(x: I64): I64 /* def_idx: 0 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: MoveLoc[0](x: I64)
+	2: Call i64::add(I64, I64): I64
+	3: Ret
+}
+test_add2(x: I128): I128 /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: MoveLoc[0](x: I128)
+	2: Call i128::add(I128, I128): I128
+	3: Ret
+}
+test_add3(s1: S1, s2: S2, s3: S3<I64>): I64 /* def_idx: 2 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[0](S1.y: I64)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[1](S2.y: I64)
+	5: ReadRef
+	6: Call i64::add(I64, I64): I64
+	7: ImmBorrowLoc[2](s3: S3<I64>)
+	8: ImmBorrowFieldGeneric[0](S3.x: T)
+	9: ReadRef
+	10: Call i64::add(I64, I64): I64
+	11: Ret
+}
+test_add4(s1: S1, s2: S2, s3: S3<I128>): I128 /* def_idx: 3 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[3](S1.z: I128)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[4](S2.z: I128)
+	5: ReadRef
+	6: Call i128::add(I128, I128): I128
+	7: ImmBorrowLoc[2](s3: S3<I128>)
+	8: ImmBorrowFieldGeneric[1](S3.x: T)
+	9: ReadRef
+	10: Call i128::add(I128, I128): I128
+	11: Ret
+}
+test_div1(x: I64, y: I64): I64 /* def_idx: 4 */ {
+B0:
+	0: MoveLoc[0](x: I64)
+	1: MoveLoc[1](y: I64)
+	2: Call i64::div(I64, I64): I64
+	3: Ret
+}
+test_div2(x: I128, y: I128): I128 /* def_idx: 5 */ {
+B0:
+	0: MoveLoc[0](x: I128)
+	1: MoveLoc[1](y: I128)
+	2: Call i128::div(I128, I128): I128
+	3: Ret
+}
+test_div3(s1: S1, s2: S2, s3: S3<I64>): I64 /* def_idx: 6 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[0](S1.y: I64)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[1](S2.y: I64)
+	5: ReadRef
+	6: Call i64::div(I64, I64): I64
+	7: ImmBorrowLoc[2](s3: S3<I64>)
+	8: ImmBorrowFieldGeneric[0](S3.x: T)
+	9: ReadRef
+	10: Call i64::div(I64, I64): I64
+	11: Ret
+}
+test_div4(s1: S1, s2: S2, s3: S3<I128>): I128 /* def_idx: 7 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[3](S1.z: I128)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[4](S2.z: I128)
+	5: ReadRef
+	6: Call i128::div(I128, I128): I128
+	7: ImmBorrowLoc[2](s3: S3<I128>)
+	8: ImmBorrowFieldGeneric[1](S3.x: T)
+	9: ReadRef
+	10: Call i128::div(I128, I128): I128
+	11: Ret
+}
+test_mix1(x: I64, y: I64, z: I64): I64 /* def_idx: 8 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[1](y: I64)
+	2: Call i64::add(I64, I64): I64
+	3: CopyLoc[2](z: I64)
+	4: Call i64::sub(I64, I64): I64
+	5: MoveLoc[0](x: I64)
+	6: Call i64::mul(I64, I64): I64
+	7: MoveLoc[1](y: I64)
+	8: Call i64::div(I64, I64): I64
+	9: MoveLoc[2](z: I64)
+	10: Call i64::mod(I64, I64): I64
+	11: Ret
+}
+test_mix2(x: I128, y: I128, z: I128): I128 /* def_idx: 9 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: CopyLoc[1](y: I128)
+	2: Call i128::add(I128, I128): I128
+	3: CopyLoc[2](z: I128)
+	4: Call i128::sub(I128, I128): I128
+	5: MoveLoc[0](x: I128)
+	6: Call i128::mul(I128, I128): I128
+	7: MoveLoc[1](y: I128)
+	8: Call i128::div(I128, I128): I128
+	9: MoveLoc[2](z: I128)
+	10: Call i128::mod(I128, I128): I128
+	11: Ret
+}
+test_mix3(s1: S1, s2: S2, s3: S3<I64>): I64 /* def_idx: 10 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[0](S1.y: I64)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[1](S2.y: I64)
+	5: ReadRef
+	6: Call i64::add(I64, I64): I64
+	7: ImmBorrowLoc[2](s3: S3<I64>)
+	8: ImmBorrowFieldGeneric[0](S3.x: T)
+	9: ReadRef
+	10: Call i64::sub(I64, I64): I64
+	11: ImmBorrowLoc[0](s1: S1)
+	12: ImmBorrowField[0](S1.y: I64)
+	13: ReadRef
+	14: Call i64::mul(I64, I64): I64
+	15: ImmBorrowLoc[1](s2: S2)
+	16: ImmBorrowField[1](S2.y: I64)
+	17: ReadRef
+	18: Call i64::div(I64, I64): I64
+	19: ImmBorrowLoc[2](s3: S3<I64>)
+	20: ImmBorrowFieldGeneric[0](S3.x: T)
+	21: ReadRef
+	22: Call i64::mod(I64, I64): I64
+	23: Ret
+}
+test_mix4(s1: S1, s2: S2, s3: S3<I128>): I128 /* def_idx: 11 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[3](S1.z: I128)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[4](S2.z: I128)
+	5: ReadRef
+	6: Call i128::add(I128, I128): I128
+	7: ImmBorrowLoc[2](s3: S3<I128>)
+	8: ImmBorrowFieldGeneric[1](S3.x: T)
+	9: ReadRef
+	10: Call i128::sub(I128, I128): I128
+	11: ImmBorrowLoc[0](s1: S1)
+	12: ImmBorrowField[3](S1.z: I128)
+	13: ReadRef
+	14: Call i128::mul(I128, I128): I128
+	15: ImmBorrowLoc[1](s2: S2)
+	16: ImmBorrowField[4](S2.z: I128)
+	17: ReadRef
+	18: Call i128::div(I128, I128): I128
+	19: ImmBorrowLoc[2](s3: S3<I128>)
+	20: ImmBorrowFieldGeneric[1](S3.x: T)
+	21: ReadRef
+	22: Call i128::mod(I128, I128): I128
+	23: Ret
+}
+test_mod1(x: I64, y: I64): I64 /* def_idx: 12 */ {
+B0:
+	0: MoveLoc[0](x: I64)
+	1: MoveLoc[1](y: I64)
+	2: Call i64::mod(I64, I64): I64
+	3: Ret
+}
+test_mod2(x: I128, y: I128): I128 /* def_idx: 13 */ {
+B0:
+	0: MoveLoc[0](x: I128)
+	1: MoveLoc[1](y: I128)
+	2: Call i128::mod(I128, I128): I128
+	3: Ret
+}
+test_mod3(s1: S1, s2: S2, s3: S3<I64>): I64 /* def_idx: 14 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[0](S1.y: I64)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[1](S2.y: I64)
+	5: ReadRef
+	6: Call i64::mod(I64, I64): I64
+	7: ImmBorrowLoc[2](s3: S3<I64>)
+	8: ImmBorrowFieldGeneric[0](S3.x: T)
+	9: ReadRef
+	10: Call i64::mod(I64, I64): I64
+	11: Ret
+}
+test_mod4(s1: S1, s2: S2, s3: S3<I128>): I128 /* def_idx: 15 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[3](S1.z: I128)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[4](S2.z: I128)
+	5: ReadRef
+	6: Call i128::mod(I128, I128): I128
+	7: ImmBorrowLoc[2](s3: S3<I128>)
+	8: ImmBorrowFieldGeneric[1](S3.x: T)
+	9: ReadRef
+	10: Call i128::mod(I128, I128): I128
+	11: Ret
+}
+test_mul1(x: I64, y: I64): I64 /* def_idx: 16 */ {
+B0:
+	0: MoveLoc[0](x: I64)
+	1: MoveLoc[1](y: I64)
+	2: Call i64::mul(I64, I64): I64
+	3: Ret
+}
+test_mul2(x: I128, y: I128): I128 /* def_idx: 17 */ {
+B0:
+	0: MoveLoc[0](x: I128)
+	1: MoveLoc[1](y: I128)
+	2: Call i128::mul(I128, I128): I128
+	3: Ret
+}
+test_mul3(s1: S1, s2: S2, s3: S3<I64>): I64 /* def_idx: 18 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[0](S1.y: I64)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[1](S2.y: I64)
+	5: ReadRef
+	6: Call i64::mul(I64, I64): I64
+	7: ImmBorrowLoc[2](s3: S3<I64>)
+	8: ImmBorrowFieldGeneric[0](S3.x: T)
+	9: ReadRef
+	10: Call i64::mul(I64, I64): I64
+	11: Ret
+}
+test_mul4(s1: S1, s2: S2, s3: S3<I128>): I128 /* def_idx: 19 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[3](S1.z: I128)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[4](S2.z: I128)
+	5: ReadRef
+	6: Call i128::mul(I128, I128): I128
+	7: ImmBorrowLoc[2](s3: S3<I128>)
+	8: ImmBorrowFieldGeneric[1](S3.x: T)
+	9: ReadRef
+	10: Call i128::mul(I128, I128): I128
+	11: Ret
+}
+test_neg1(x: I64, y: I64): I64 /* def_idx: 20 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: Call i64::neg(I64): I64
+	2: CopyLoc[1](y: I64)
+	3: Call i64::add(I64, I64): I64
+	4: CopyLoc[0](x: I64)
+	5: Call i64::neg(I64): I64
+	6: CopyLoc[1](y: I64)
+	7: Call i64::neg(I64): I64
+	8: Call i64::mul(I64, I64): I64
+	9: MoveLoc[0](x: I64)
+	10: Call i64::neg(I64): I64
+	11: Call i64::div(I64, I64): I64
+	12: MoveLoc[1](y: I64)
+	13: Call i64::neg(I64): I64
+	14: Call i64::mod(I64, I64): I64
+	15: Call i64::sub(I64, I64): I64
+	16: Ret
+}
+test_neg2(x: I128, y: I128): I128 /* def_idx: 21 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: Call i128::neg(I128): I128
+	2: CopyLoc[1](y: I128)
+	3: Call i128::add(I128, I128): I128
+	4: CopyLoc[0](x: I128)
+	5: Call i128::neg(I128): I128
+	6: CopyLoc[1](y: I128)
+	7: Call i128::neg(I128): I128
+	8: Call i128::mul(I128, I128): I128
+	9: MoveLoc[0](x: I128)
+	10: Call i128::neg(I128): I128
+	11: Call i128::div(I128, I128): I128
+	12: MoveLoc[1](y: I128)
+	13: Call i128::neg(I128): I128
+	14: Call i128::mod(I128, I128): I128
+	15: Call i128::sub(I128, I128): I128
+	16: Ret
+}
+test_sub1(x: I64, y: I64): I64 /* def_idx: 22 */ {
+B0:
+	0: MoveLoc[0](x: I64)
+	1: MoveLoc[1](y: I64)
+	2: Call i64::sub(I64, I64): I64
+	3: Ret
+}
+test_sub2(x: I128, y: I128): I128 /* def_idx: 23 */ {
+B0:
+	0: MoveLoc[0](x: I128)
+	1: MoveLoc[1](y: I128)
+	2: Call i128::sub(I128, I128): I128
+	3: Ret
+}
+test_sub3(s1: S1, s2: S2, s3: S3<I64>): I64 /* def_idx: 24 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[0](S1.y: I64)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[1](S2.y: I64)
+	5: ReadRef
+	6: Call i64::sub(I64, I64): I64
+	7: ImmBorrowLoc[2](s3: S3<I64>)
+	8: ImmBorrowFieldGeneric[0](S3.x: T)
+	9: ReadRef
+	10: Call i64::sub(I64, I64): I64
+	11: Ret
+}
+test_sub4(s1: S1, s2: S2, s3: S3<I128>): I128 /* def_idx: 25 */ {
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[3](S1.z: I128)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[4](S2.z: I128)
+	5: ReadRef
+	6: Call i128::sub(I128, I128): I128
+	7: ImmBorrowLoc[2](s3: S3<I128>)
+	8: ImmBorrowFieldGeneric[1](S3.x: T)
+	9: ReadRef
+	10: Call i128::sub(I128, I128): I128
+	11: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_arithmetic.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_arithmetic.move
@@ -1,0 +1,129 @@
+module 0x42::valid_arithmetic {
+    struct S1  has copy, drop { x: u64, y: i64, z: i128 }
+
+    struct S2 has copy, drop { x: S1, y: i64, z: i128  }
+
+    struct S3<T>  has copy, drop { x: T, y: S1, z: S2 }
+
+    enum E1 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i64>},
+    }
+
+    enum E2 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i128>},
+    }
+
+    enum E3<T> has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<T>},
+    }
+
+    fun test_add1(x: i64): i64 {
+        x + x
+    }
+
+    fun test_add2(x: i128): i128 {
+        x + x
+    }
+
+    fun test_add3(s1: S1, s2: S2, s3: S3<i64>): i64 {
+        s1.y + s2.y + s3.x
+    }
+
+    fun test_add4(s1: S1, s2: S2, s3: S3<i128>): i128 {
+        s1.z + s2.z + s3.x
+    }
+
+    fun test_sub1(x: i64, y: i64): i64 {
+        x - y
+    }
+
+    fun test_sub2(x: i128, y: i128): i128 {
+        x - y
+    }
+
+    fun test_sub3(s1: S1, s2: S2, s3: S3<i64>): i64 {
+        s1.y - s2.y - s3.x
+    }
+
+    fun test_sub4(s1: S1, s2: S2, s3: S3<i128>): i128 {
+        s1.z - s2.z - s3.x
+    }
+
+    fun test_mul1(x: i64, y: i64): i64 {
+        x * y
+    }
+
+    fun test_mul2(x: i128, y: i128): i128 {
+        x * y
+    }
+
+    fun test_mul3(s1: S1, s2: S2, s3: S3<i64>): i64 {
+        s1.y * s2.y * s3.x
+    }
+
+    fun test_mul4(s1: S1, s2: S2, s3: S3<i128>): i128 {
+        s1.z * s2.z * s3.x
+    }
+
+    fun test_div1(x: i64, y: i64): i64 {
+        x / y
+    }
+
+    fun test_div2(x: i128, y: i128): i128 {
+        x / y
+    }
+
+    fun test_div3(s1: S1, s2: S2, s3: S3<i64>): i64 {
+        s1.y / s2.y / s3.x
+    }
+
+    fun test_div4(s1: S1, s2: S2, s3: S3<i128>): i128 {
+        s1.z / s2.z / s3.x
+    }
+
+    fun test_mod1(x: i64, y: i64): i64 {
+        x % y
+    }
+
+    fun test_mod2(x: i128, y: i128): i128 {
+        x % y
+    }
+
+    fun test_mod3(s1: S1, s2: S2, s3: S3<i64>): i64 {
+        s1.y % s2.y % s3.x
+    }
+
+    fun test_mod4(s1: S1, s2: S2, s3: S3<i128>): i128 {
+        s1.z % s2.z % s3.x
+    }
+
+    fun test_mix1(x: i64, y: i64, z: i64): i64 {
+        ((x + y) - z) * x / y % z
+    }
+
+    fun test_mix2(x: i128, y: i128, z: i128): i128 {
+        ((x + y) - z) * x / y % z
+    }
+
+    fun test_mix3(s1: S1, s2: S2, s3: S3<i64>): i64 {
+        ((s1.y + s2.y) - s3.x) * s1.y / s2.y % s3.x
+    }
+
+    fun test_mix4(s1: S1, s2: S2, s3: S3<i128>): i128 {
+        ((s1.z + s2.z) - s3.x) * s1.z / s2.z % s3.x
+    }
+
+    fun test_neg1(x: i64, y: i64): i64 {
+        -x + y - -x * -y / -x % -y
+    }
+
+    fun test_neg2(x: i128, y: i128): i128 {
+        -x + y - -x * -y / -x % -y
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_cast.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_cast.exp
@@ -1,0 +1,1283 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::valid_cast {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test_cast1(x: u64): 0x1::i64::I64 {
+        i64::pack(x)
+    }
+    private fun test_cast2(x: 0x1::i64::I64): u64 {
+        i64::unpack(x)
+    }
+    private fun test_cast3(x: u128): 0x1::i128::I128 {
+        i128::pack(x)
+    }
+    private fun test_cast4(x: 0x1::i128::I128): u128 {
+        i128::unpack(x)
+    }
+    private fun test_cast5(a: 0x1::i64::I64,b: 0x1::i128::I128): u64 {
+        {
+          let s1: S1 = pack valid_cast::S1(1, a, b);
+          {
+            let s2: S2 = pack valid_cast::S2(s1, a, b);
+            {
+              let s3: S3<0x1::i64::I64> = pack valid_cast::S3<0x1::i64::I64>(a, s1, s2);
+              Add<u64>(Add<u64>(i64::unpack(select valid_cast::S1.y<S1>(s1)), i64::unpack(select valid_cast::S2.y<S2>(s2))), i64::unpack(select valid_cast::S3.x<S3<0x1::i64::I64>>(s3)))
+            }
+          }
+        }
+    }
+    private fun test_cast6(a: 0x1::i64::I64,b: 0x1::i128::I128): u128 {
+        {
+          let s1: S1 = pack valid_cast::S1(1, a, b);
+          {
+            let s2: S2 = pack valid_cast::S2(s1, a, b);
+            {
+              let s3: S3<0x1::i128::I128> = pack valid_cast::S3<0x1::i128::I128>(b, s1, s2);
+              Add<u128>(Add<u128>(i128::unpack(select valid_cast::S1.z<S1>(s1)), i128::unpack(select valid_cast::S2.z<S2>(s2))), i128::unpack(select valid_cast::S3.x<S3<0x1::i128::I128>>(s3)))
+            }
+          }
+        }
+    }
+} // end 0x42::valid_cast
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::valid_cast {
+    enum E1 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 has copy, drop {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 has copy, drop {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> has copy, drop {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    fun test_cast1(x: u64): 0x1::i64::I64 {
+        0x1::i64::pack(x)
+    }
+    fun test_cast2(x: 0x1::i64::I64): u64 {
+        0x1::i64::unpack(x)
+    }
+    fun test_cast3(x: u128): 0x1::i128::I128 {
+        0x1::i128::pack(x)
+    }
+    fun test_cast4(x: 0x1::i128::I128): u128 {
+        0x1::i128::unpack(x)
+    }
+    fun test_cast5(a: 0x1::i64::I64, b: 0x1::i128::I128): u64 {
+        let s1 = S1{x: 1, y: a, z: b};
+        let s2 = S2{x: s1, y: a, z: b};
+        let s3 = S3<0x1::i64::I64>{x: a, y: s1, z: s2};
+        0x1::i64::unpack(s1.y) + 0x1::i64::unpack(s2.y) + 0x1::i64::unpack(s3.x)
+    }
+    fun test_cast6(a: 0x1::i64::I64, b: 0x1::i128::I128): u128 {
+        let s1 = S1{x: 1, y: a, z: b};
+        let s2 = S2{x: s1, y: a, z: b};
+        let s3 = S3<0x1::i128::I128>{x: b, y: s1, z: s2};
+        0x1::i128::unpack(s1.z) + 0x1::i128::unpack(s2.z) + 0x1::i128::unpack(s3.x)
+    }
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_cast::test_cast1($t0: u64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64
+  0: $t1 := i64::pack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast2($t0: 0x1::i64::I64): u64 {
+     var $t1: u64
+  0: $t1 := i64::unpack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast3($t0: u128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128
+  0: $t1 := i128::pack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast4($t0: 0x1::i128::I128): u128 {
+     var $t1: u128
+  0: $t1 := i128::unpack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast5($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u64 {
+     var $t2: u64
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64
+     var $t9: 0x42::valid_cast::S3<0x1::i64::I64>
+     var $t10: 0x1::i64::I64
+     var $t11: 0x42::valid_cast::S1
+     var $t12: u64
+     var $t13: u64
+     var $t14: 0x1::i64::I64
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i64::I64
+     var $t17: u64
+     var $t18: 0x1::i64::I64
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i64::I64
+     var $t21: u64
+     var $t22: 0x1::i64::I64
+     var $t23: &0x42::valid_cast::S3<0x1::i64::I64>
+     var $t24: &0x1::i64::I64
+  0: $t4 := 1
+  1: $t5 := infer($t0)
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+  3: $t7 := infer($t3)
+  4: $t8 := infer($t0)
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t8, $t1)
+  6: $t10 := infer($t0)
+  7: $t11 := infer($t3)
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i64::I64>($t10, $t11, $t6)
+  9: $t15 := borrow_local($t3)
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.y($t15)
+ 11: $t14 := read_ref($t16)
+ 12: $t13 := i64::unpack($t14)
+ 13: $t19 := borrow_local($t6)
+ 14: $t20 := borrow_field<0x42::valid_cast::S2>.y($t19)
+ 15: $t18 := read_ref($t20)
+ 16: $t17 := i64::unpack($t18)
+ 17: $t12 := +($t13, $t17)
+ 18: $t23 := borrow_local($t9)
+ 19: $t24 := borrow_field<0x42::valid_cast::S3<0x1::i64::I64>>.x($t23)
+ 20: $t22 := read_ref($t24)
+ 21: $t21 := i64::unpack($t22)
+ 22: $t2 := +($t12, $t21)
+ 23: return $t2
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast6($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u128 {
+     var $t2: u128
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64
+     var $t9: 0x42::valid_cast::S3<0x1::i128::I128>
+     var $t10: 0x1::i128::I128
+     var $t11: 0x42::valid_cast::S1
+     var $t12: u128
+     var $t13: u128
+     var $t14: 0x1::i128::I128
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i128::I128
+     var $t17: u128
+     var $t18: 0x1::i128::I128
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i128::I128
+     var $t21: u128
+     var $t22: 0x1::i128::I128
+     var $t23: &0x42::valid_cast::S3<0x1::i128::I128>
+     var $t24: &0x1::i128::I128
+  0: $t4 := 1
+  1: $t5 := infer($t0)
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+  3: $t7 := infer($t3)
+  4: $t8 := infer($t0)
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t8, $t1)
+  6: $t10 := infer($t1)
+  7: $t11 := infer($t3)
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i128::I128>($t10, $t11, $t6)
+  9: $t15 := borrow_local($t3)
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.z($t15)
+ 11: $t14 := read_ref($t16)
+ 12: $t13 := i128::unpack($t14)
+ 13: $t19 := borrow_local($t6)
+ 14: $t20 := borrow_field<0x42::valid_cast::S2>.z($t19)
+ 15: $t18 := read_ref($t20)
+ 16: $t17 := i128::unpack($t18)
+ 17: $t12 := +($t13, $t17)
+ 18: $t23 := borrow_local($t9)
+ 19: $t24 := borrow_field<0x42::valid_cast::S3<0x1::i128::I128>>.x($t23)
+ 20: $t22 := read_ref($t24)
+ 21: $t21 := i128::unpack($t22)
+ 22: $t2 := +($t12, $t21)
+ 23: return $t2
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_cast::test_cast1($t0: u64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t1 := i64::pack($t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast2($t0: 0x1::i64::I64): u64 {
+     var $t1: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t1 := i64::unpack($t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast3($t0: u128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t1 := i128::pack($t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast4($t0: 0x1::i128::I128): u128 {
+     var $t1: u128
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t1 := i128::unpack($t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast5($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u64 {
+     var $t2: u64
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64
+     var $t9: 0x42::valid_cast::S3<0x1::i64::I64>
+     var $t10: 0x1::i64::I64
+     var $t11: 0x42::valid_cast::S1
+     var $t12: u64
+     var $t13: u64
+     var $t14: 0x1::i64::I64
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i64::I64
+     var $t17: u64
+     var $t18: 0x1::i64::I64
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i64::I64
+     var $t21: u64
+     var $t22: 0x1::i64::I64
+     var $t23: &0x42::valid_cast::S3<0x1::i64::I64>
+     var $t24: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t5
+     # refs: []
+     #
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  3: $t7 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: []
+     #
+  4: $t8 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t8
+     # refs: []
+     #
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t8, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t6
+     # refs: []
+     #
+  6: $t10 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t10
+     # refs: []
+     #
+  7: $t11 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t10, $t11
+     # refs: []
+     #
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i64::I64>($t10, $t11, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t9
+     # refs: []
+     #
+  9: $t15 := borrow_local($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => #15 via [local `s1`] at line 46
+     #
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.y($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `s1`, field `y`] at line 46
+     #
+ 11: $t14 := read_ref($t16)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t14
+     # refs: []
+     #
+ 12: $t13 := i64::unpack($t14)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t13
+     # refs: []
+     #
+ 13: $t19 := borrow_local($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `s2`] at line 46
+     #
+ 14: $t20 := borrow_field<0x42::valid_cast::S2>.y($t19)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t20
+     # refs: [$t20 => #20]
+     # #20
+     #   <no edges>
+     # #root
+     #   => #20 via [local `s2`, field `y`] at line 46
+     #
+ 15: $t18 := read_ref($t20)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t18
+     # refs: []
+     #
+ 16: $t17 := i64::unpack($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t17
+     # refs: []
+     #
+ 17: $t12 := +($t13, $t17)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t12
+     # refs: []
+     #
+ 18: $t23 := borrow_local($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t23
+     # refs: [$t23 => #23]
+     # #23
+     #   <no edges>
+     # #root
+     #   => #23 via [local `s3`] at line 46
+     #
+ 19: $t24 := borrow_field<0x42::valid_cast::S3<0x1::i64::I64>>.x($t23)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t24
+     # refs: [$t24 => #24]
+     # #24
+     #   <no edges>
+     # #root
+     #   => #24 via [local `s3`, field `x`] at line 46
+     #
+ 20: $t22 := read_ref($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t22
+     # refs: []
+     #
+ 21: $t21 := i64::unpack($t22)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t21
+     # refs: []
+     #
+ 22: $t2 := +($t12, $t21)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 23: return $t2
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast6($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u128 {
+     var $t2: u128
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64
+     var $t9: 0x42::valid_cast::S3<0x1::i128::I128>
+     var $t10: 0x1::i128::I128
+     var $t11: 0x42::valid_cast::S1
+     var $t12: u128
+     var $t13: u128
+     var $t14: 0x1::i128::I128
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i128::I128
+     var $t17: u128
+     var $t18: 0x1::i128::I128
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i128::I128
+     var $t21: u128
+     var $t22: 0x1::i128::I128
+     var $t23: &0x42::valid_cast::S3<0x1::i128::I128>
+     var $t24: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t5
+     # refs: []
+     #
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  3: $t7 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: []
+     #
+  4: $t8 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t7, $t8
+     # refs: []
+     #
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t8, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t6
+     # refs: []
+     #
+  6: $t10 := infer($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t10
+     # refs: []
+     #
+  7: $t11 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t10, $t11
+     # refs: []
+     #
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i128::I128>($t10, $t11, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t6, $t9
+     # refs: []
+     #
+  9: $t15 := borrow_local($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => #15 via [local `s1`] at line 53
+     #
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.z($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `s1`, field `z`] at line 53
+     #
+ 11: $t14 := read_ref($t16)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t14
+     # refs: []
+     #
+ 12: $t13 := i128::unpack($t14)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9, $t13
+     # refs: []
+     #
+ 13: $t19 := borrow_local($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `s2`] at line 53
+     #
+ 14: $t20 := borrow_field<0x42::valid_cast::S2>.z($t19)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t20
+     # refs: [$t20 => #20]
+     # #20
+     #   <no edges>
+     # #root
+     #   => #20 via [local `s2`, field `z`] at line 53
+     #
+ 15: $t18 := read_ref($t20)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t18
+     # refs: []
+     #
+ 16: $t17 := i128::unpack($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13, $t17
+     # refs: []
+     #
+ 17: $t12 := +($t13, $t17)
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t12
+     # refs: []
+     #
+ 18: $t23 := borrow_local($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t23
+     # refs: [$t23 => #23]
+     # #23
+     #   <no edges>
+     # #root
+     #   => #23 via [local `s3`] at line 53
+     #
+ 19: $t24 := borrow_field<0x42::valid_cast::S3<0x1::i128::I128>>.x($t23)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t24
+     # refs: [$t24 => #24]
+     # #24
+     #   <no edges>
+     # #root
+     #   => #24 via [local `s3`, field `x`] at line 53
+     #
+ 20: $t22 := read_ref($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t22
+     # refs: []
+     #
+ 21: $t21 := i128::unpack($t22)
+     # abort state: {returns,aborts}
+     # live vars: $t12, $t21
+     # refs: []
+     #
+ 22: $t2 := +($t12, $t21)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 23: return $t2
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::valid_cast {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test_cast1(x: u64): 0x1::i64::I64 {
+        i64::pack(x)
+    }
+    private fun test_cast2(x: 0x1::i64::I64): u64 {
+        i64::unpack(x)
+    }
+    private fun test_cast3(x: u128): 0x1::i128::I128 {
+        i128::pack(x)
+    }
+    private fun test_cast4(x: 0x1::i128::I128): u128 {
+        i128::unpack(x)
+    }
+    private fun test_cast5(a: 0x1::i64::I64,b: 0x1::i128::I128): u64 {
+        {
+          let s1: S1 = pack valid_cast::S1(1, a, b);
+          {
+            let s2: S2 = pack valid_cast::S2(s1, a, b);
+            {
+              let s3: S3<0x1::i64::I64> = pack valid_cast::S3<0x1::i64::I64>(a, s1, s2);
+              Add<u64>(Add<u64>(i64::unpack(select valid_cast::S1.y<S1>(s1)), i64::unpack(select valid_cast::S2.y<S2>(s2))), i64::unpack(select valid_cast::S3.x<S3<0x1::i64::I64>>(s3)))
+            }
+          }
+        }
+    }
+    private fun test_cast6(a: 0x1::i64::I64,b: 0x1::i128::I128): u128 {
+        {
+          let s1: S1 = pack valid_cast::S1(1, a, b);
+          {
+            let s2: S2 = pack valid_cast::S2(s1, a, b);
+            {
+              let s3: S3<0x1::i128::I128> = pack valid_cast::S3<0x1::i128::I128>(b, s1, s2);
+              Add<u128>(Add<u128>(i128::unpack(select valid_cast::S1.z<S1>(s1)), i128::unpack(select valid_cast::S2.z<S2>(s2))), i128::unpack(select valid_cast::S3.x<S3<0x1::i128::I128>>(s3)))
+            }
+          }
+        }
+    }
+} // end 0x42::valid_cast
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_cast::test_cast1($t0: u64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64
+  0: $t1 := i64::pack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast2($t0: 0x1::i64::I64): u64 {
+     var $t1: u64
+  0: $t1 := i64::unpack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast3($t0: u128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128
+  0: $t1 := i128::pack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast4($t0: 0x1::i128::I128): u128 {
+     var $t1: u128
+  0: $t1 := i128::unpack($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast5($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u64 {
+     var $t2: u64
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64
+     var $t9: 0x42::valid_cast::S3<0x1::i64::I64>
+     var $t10: 0x1::i64::I64
+     var $t11: 0x42::valid_cast::S1
+     var $t12: u64
+     var $t13: u64
+     var $t14: 0x1::i64::I64
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i64::I64
+     var $t17: u64
+     var $t18: 0x1::i64::I64
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i64::I64
+     var $t21: u64
+     var $t22: 0x1::i64::I64
+     var $t23: &0x42::valid_cast::S3<0x1::i64::I64>
+     var $t24: &0x1::i64::I64
+  0: $t4 := 1
+  1: $t5 := infer($t0)
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+  3: $t7 := infer($t3)
+  4: $t8 := infer($t0)
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t8, $t1)
+  6: $t10 := infer($t0)
+  7: $t11 := infer($t3)
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i64::I64>($t10, $t11, $t6)
+  9: $t15 := borrow_local($t3)
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.y($t15)
+ 11: $t14 := read_ref($t16)
+ 12: $t13 := i64::unpack($t14)
+ 13: $t19 := borrow_local($t6)
+ 14: $t20 := borrow_field<0x42::valid_cast::S2>.y($t19)
+ 15: $t18 := read_ref($t20)
+ 16: $t17 := i64::unpack($t18)
+ 17: $t12 := +($t13, $t17)
+ 18: $t23 := borrow_local($t9)
+ 19: $t24 := borrow_field<0x42::valid_cast::S3<0x1::i64::I64>>.x($t23)
+ 20: $t22 := read_ref($t24)
+ 21: $t21 := i64::unpack($t22)
+ 22: $t2 := +($t12, $t21)
+ 23: return $t2
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast6($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u128 {
+     var $t2: u128
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64
+     var $t9: 0x42::valid_cast::S3<0x1::i128::I128>
+     var $t10: 0x1::i128::I128
+     var $t11: 0x42::valid_cast::S1
+     var $t12: u128
+     var $t13: u128
+     var $t14: 0x1::i128::I128
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i128::I128
+     var $t17: u128
+     var $t18: 0x1::i128::I128
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i128::I128
+     var $t21: u128
+     var $t22: 0x1::i128::I128
+     var $t23: &0x42::valid_cast::S3<0x1::i128::I128>
+     var $t24: &0x1::i128::I128
+  0: $t4 := 1
+  1: $t5 := infer($t0)
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+  3: $t7 := infer($t3)
+  4: $t8 := infer($t0)
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t8, $t1)
+  6: $t10 := infer($t1)
+  7: $t11 := infer($t3)
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i128::I128>($t10, $t11, $t6)
+  9: $t15 := borrow_local($t3)
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.z($t15)
+ 11: $t14 := read_ref($t16)
+ 12: $t13 := i128::unpack($t14)
+ 13: $t19 := borrow_local($t6)
+ 14: $t20 := borrow_field<0x42::valid_cast::S2>.z($t19)
+ 15: $t18 := read_ref($t20)
+ 16: $t17 := i128::unpack($t18)
+ 17: $t12 := +($t13, $t17)
+ 18: $t23 := borrow_local($t9)
+ 19: $t24 := borrow_field<0x42::valid_cast::S3<0x1::i128::I128>>.x($t23)
+ 20: $t22 := read_ref($t24)
+ 21: $t21 := i128::unpack($t22)
+ 22: $t2 := +($t12, $t21)
+ 23: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_cast::test_cast1($t0: u64): 0x1::i64::I64 {
+     var $t1: 0x1::i64::I64
+     # live vars: $t0
+  0: $t1 := i64::pack($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast2($t0: 0x1::i64::I64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := i64::unpack($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast3($t0: u128): 0x1::i128::I128 {
+     var $t1: 0x1::i128::I128
+     # live vars: $t0
+  0: $t1 := i128::pack($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast4($t0: 0x1::i128::I128): u128 {
+     var $t1: u128
+     # live vars: $t0
+  0: $t1 := i128::unpack($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast5($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u64 {
+     var $t2: u64 [unused]
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64 [unused]
+     var $t9: 0x42::valid_cast::S3<0x1::i64::I64>
+     var $t10: 0x1::i64::I64 [unused]
+     var $t11: 0x42::valid_cast::S1 [unused]
+     var $t12: u64 [unused]
+     var $t13: u64 [unused]
+     var $t14: 0x1::i64::I64 [unused]
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i64::I64
+     var $t17: u64
+     var $t18: 0x1::i64::I64 [unused]
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i64::I64 [unused]
+     var $t21: u64 [unused]
+     var $t22: 0x1::i64::I64 [unused]
+     var $t23: &0x42::valid_cast::S3<0x1::i64::I64>
+     var $t24: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t4, $t5
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+     # live vars: $t0, $t1, $t3
+  3: $t7 := copy($t3)
+     # live vars: $t0, $t1, $t3, $t7
+  4: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t3, $t5, $t7
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t5, $t1)
+     # live vars: $t0, $t3, $t6
+  6: $t0 := move($t0)
+     # live vars: $t0, $t3, $t6
+  7: $t7 := copy($t3)
+     # live vars: $t0, $t3, $t6, $t7
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i64::I64>($t0, $t7, $t6)
+     # live vars: $t3, $t6, $t9
+  9: $t15 := borrow_local($t3)
+     # live vars: $t6, $t9, $t15
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.y($t15)
+     # live vars: $t6, $t9, $t16
+ 11: $t0 := read_ref($t16)
+     # live vars: $t0, $t6, $t9
+ 12: $t4 := i64::unpack($t0)
+     # live vars: $t4, $t6, $t9
+ 13: $t19 := borrow_local($t6)
+     # live vars: $t4, $t9, $t19
+ 14: $t16 := borrow_field<0x42::valid_cast::S2>.y($t19)
+     # live vars: $t4, $t9, $t16
+ 15: $t0 := read_ref($t16)
+     # live vars: $t0, $t4, $t9
+ 16: $t17 := i64::unpack($t0)
+     # live vars: $t4, $t9, $t17
+ 17: $t4 := +($t4, $t17)
+     # live vars: $t4, $t9
+ 18: $t23 := borrow_local($t9)
+     # live vars: $t4, $t23
+ 19: $t16 := borrow_field<0x42::valid_cast::S3<0x1::i64::I64>>.x($t23)
+     # live vars: $t4, $t16
+ 20: $t0 := read_ref($t16)
+     # live vars: $t0, $t4
+ 21: $t17 := i64::unpack($t0)
+     # live vars: $t4, $t17
+ 22: $t4 := +($t4, $t17)
+     # live vars: $t4
+ 23: return $t4
+}
+
+
+[variant baseline]
+fun valid_cast::test_cast6($t0: 0x1::i64::I64, $t1: 0x1::i128::I128): u128 {
+     var $t2: u128 [unused]
+     var $t3: 0x42::valid_cast::S1
+     var $t4: u64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x42::valid_cast::S2
+     var $t7: 0x42::valid_cast::S1
+     var $t8: 0x1::i64::I64 [unused]
+     var $t9: 0x42::valid_cast::S3<0x1::i128::I128>
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x42::valid_cast::S1 [unused]
+     var $t12: u128 [unused]
+     var $t13: u128
+     var $t14: 0x1::i128::I128 [unused]
+     var $t15: &0x42::valid_cast::S1
+     var $t16: &0x1::i128::I128
+     var $t17: u128
+     var $t18: 0x1::i128::I128 [unused]
+     var $t19: &0x42::valid_cast::S2
+     var $t20: &0x1::i128::I128 [unused]
+     var $t21: u128 [unused]
+     var $t22: 0x1::i128::I128 [unused]
+     var $t23: &0x42::valid_cast::S3<0x1::i128::I128>
+     var $t24: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := 1
+     # live vars: $t0, $t1, $t4
+  1: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t4, $t5
+  2: $t3 := pack 0x42::valid_cast::S1($t4, $t5, $t1)
+     # live vars: $t0, $t1, $t3
+  3: $t7 := copy($t3)
+     # live vars: $t0, $t1, $t3, $t7
+  4: $t0 := move($t0)
+     # live vars: $t0, $t1, $t3, $t7
+  5: $t6 := pack 0x42::valid_cast::S2($t7, $t0, $t1)
+     # live vars: $t1, $t3, $t6
+  6: $t1 := move($t1)
+     # live vars: $t1, $t3, $t6
+  7: $t7 := copy($t3)
+     # live vars: $t1, $t3, $t6, $t7
+  8: $t9 := pack 0x42::valid_cast::S3<0x1::i128::I128>($t1, $t7, $t6)
+     # live vars: $t3, $t6, $t9
+  9: $t15 := borrow_local($t3)
+     # live vars: $t6, $t9, $t15
+ 10: $t16 := borrow_field<0x42::valid_cast::S1>.z($t15)
+     # live vars: $t6, $t9, $t16
+ 11: $t1 := read_ref($t16)
+     # live vars: $t1, $t6, $t9
+ 12: $t13 := i128::unpack($t1)
+     # live vars: $t6, $t9, $t13
+ 13: $t19 := borrow_local($t6)
+     # live vars: $t9, $t13, $t19
+ 14: $t16 := borrow_field<0x42::valid_cast::S2>.z($t19)
+     # live vars: $t9, $t13, $t16
+ 15: $t1 := read_ref($t16)
+     # live vars: $t1, $t9, $t13
+ 16: $t17 := i128::unpack($t1)
+     # live vars: $t9, $t13, $t17
+ 17: $t13 := +($t13, $t17)
+     # live vars: $t9, $t13
+ 18: $t23 := borrow_local($t9)
+     # live vars: $t13, $t23
+ 19: $t16 := borrow_field<0x42::valid_cast::S3<0x1::i128::I128>>.x($t23)
+     # live vars: $t13, $t16
+ 20: $t1 := read_ref($t16)
+     # live vars: $t1, $t13
+ 21: $t17 := i128::unpack($t1)
+     # live vars: $t13, $t17
+ 22: $t13 := +($t13, $t17)
+     # live vars: $t13
+ 23: return $t13
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module 42.valid_cast {
+use 0000000000000000000000000000000000000000000000000000000000000001::i64;
+use 0000000000000000000000000000000000000000000000000000000000000001::i128;
+
+
+enum E1 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I64>
+ }
+}
+enum E2 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I128>
+ }
+}
+enum E3<T> has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<T>
+ }
+}
+struct S1 has copy, drop {
+	x: u64,
+	y: I64,
+	z: I128
+}
+struct S2 has copy, drop {
+	x: S1,
+	y: I64,
+	z: I128
+}
+struct S3<T> has copy, drop {
+	x: T,
+	y: S1,
+	z: S2
+}
+
+test_cast1(x: u64): I64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](x: u64)
+	1: Call i64::pack(u64): I64
+	2: Ret
+}
+test_cast2(x: I64): u64 /* def_idx: 1 */ {
+B0:
+	0: MoveLoc[0](x: I64)
+	1: Call i64::unpack(I64): u64
+	2: Ret
+}
+test_cast3(x: u128): I128 /* def_idx: 2 */ {
+B0:
+	0: MoveLoc[0](x: u128)
+	1: Call i128::pack(u128): I128
+	2: Ret
+}
+test_cast4(x: I128): u128 /* def_idx: 3 */ {
+B0:
+	0: MoveLoc[0](x: I128)
+	1: Call i128::unpack(I128): u128
+	2: Ret
+}
+test_cast5(a: I64, b: I128): u64 /* def_idx: 4 */ {
+L2:	s1: S1
+L3:	s2: S2
+L4:	s3: S3<I64>
+B0:
+	0: LdU64(1)
+	1: CopyLoc[0](a: I64)
+	2: CopyLoc[1](b: I128)
+	3: Pack[3](S1)
+	4: StLoc[2](s1: S1)
+	5: CopyLoc[2](s1: S1)
+	6: CopyLoc[0](a: I64)
+	7: MoveLoc[1](b: I128)
+	8: Pack[4](S2)
+	9: StLoc[3](s2: S2)
+	10: MoveLoc[0](a: I64)
+	11: CopyLoc[2](s1: S1)
+	12: CopyLoc[3](s2: S2)
+	13: PackGeneric[0](S3<I64>)
+	14: StLoc[4](s3: S3<I64>)
+	15: ImmBorrowLoc[2](s1: S1)
+	16: ImmBorrowField[0](S1.y: I64)
+	17: ReadRef
+	18: Call i64::unpack(I64): u64
+	19: ImmBorrowLoc[3](s2: S2)
+	20: ImmBorrowField[1](S2.y: I64)
+	21: ReadRef
+	22: Call i64::unpack(I64): u64
+	23: Add
+	24: ImmBorrowLoc[4](s3: S3<I64>)
+	25: ImmBorrowFieldGeneric[0](S3.x: T)
+	26: ReadRef
+	27: Call i64::unpack(I64): u64
+	28: Add
+	29: Ret
+}
+test_cast6(a: I64, b: I128): u128 /* def_idx: 5 */ {
+L2:	s1: S1
+L3:	s2: S2
+L4:	s3: S3<I128>
+B0:
+	0: LdU64(1)
+	1: CopyLoc[0](a: I64)
+	2: CopyLoc[1](b: I128)
+	3: Pack[3](S1)
+	4: StLoc[2](s1: S1)
+	5: CopyLoc[2](s1: S1)
+	6: MoveLoc[0](a: I64)
+	7: CopyLoc[1](b: I128)
+	8: Pack[4](S2)
+	9: StLoc[3](s2: S2)
+	10: MoveLoc[1](b: I128)
+	11: CopyLoc[2](s1: S1)
+	12: CopyLoc[3](s2: S2)
+	13: PackGeneric[1](S3<I128>)
+	14: StLoc[4](s3: S3<I128>)
+	15: ImmBorrowLoc[2](s1: S1)
+	16: ImmBorrowField[3](S1.z: I128)
+	17: ReadRef
+	18: Call i128::unpack(I128): u128
+	19: ImmBorrowLoc[3](s2: S2)
+	20: ImmBorrowField[4](S2.z: I128)
+	21: ReadRef
+	22: Call i128::unpack(I128): u128
+	23: Add
+	24: ImmBorrowLoc[4](s3: S3<I128>)
+	25: ImmBorrowFieldGeneric[1](S3.x: T)
+	26: ReadRef
+	27: Call i128::unpack(I128): u128
+	28: Add
+	29: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_cast.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_cast.move
@@ -1,0 +1,55 @@
+module 0x42::valid_cast {
+    struct S1  has copy, drop { x: u64, y: i64, z: i128 }
+
+    struct S2 has copy, drop { x: S1, y: i64, z: i128  }
+
+    struct S3<T>  has copy, drop { x: T, y: S1, z: S2 }
+
+    enum E1 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i64>},
+    }
+
+    enum E2 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i128>},
+    }
+
+    enum E3<T> has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<T>},
+    }
+
+    fun test_cast1(x: u64): i64 {
+        x as i64
+    }
+
+    fun test_cast2(x: i64): u64 {
+        x as u64
+    }
+
+    fun test_cast3(x: u128): i128 {
+        x as i128
+    }
+
+    fun test_cast4(x: i128): u128 {
+        x as u128
+    }
+
+    fun test_cast5(a: i64, b: i128): u64 {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i64> {x: a, y: s1, z: s2};
+        (s1.y as u64) + (s2.y as u64) + (s3.x as u64)
+    }
+
+    fun test_cast6(a: i64, b: i128): u128 {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i128> {x: b, y: s1, z: s2};
+        (s1.z as u128) + (s2.z as u128) + (s3.x as u128)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constant_new.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constant_new.exp
@@ -1,0 +1,13 @@
+
+Diagnostics:
+error: invalid number literal
+  ┌─ tests/signed-int/valid/valid_constant_new.move:7:23
+  │
+7 │   const V10_64: i64 = 9223372036854775808i64;
+  │                       ^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i64'
+
+error: invalid number literal
+  ┌─ tests/signed-int/valid/valid_constant_new.move:8:23
+  │
+8 │   const V11_64: i64 = -   9223372036854775809i64;
+  │                       ^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into 'i64'

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constant_new.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constant_new.move
@@ -1,0 +1,14 @@
+module 0x42::constants {
+  const V3_64: i64 = 1i64; // constant with annotated type and annotated value
+  const V5_64: i64 = -1i64; // constant with annotated type and annotated negative value
+  const V7_64: i64 = 9223372036854775807i64; // constant with annotated type and annotated, max value
+  const V9_64: i64 = -9223372036854775808i64; // constant with annotated type and annotated, min value
+
+  const V10_64: i64 = 9223372036854775808i64;
+  const V11_64: i64 = -9223372036854775809i64;
+
+
+  public fun  test_i64(): i64{
+    V3_64 + V5_64 + V7_64 + V9_64
+  }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constants.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constants.exp
@@ -1,0 +1,85 @@
+
+Diagnostics:
+error: invalid number literal
+  ┌─ tests/signed-int/valid/valid_constants.move:5:22
+  │
+5 │   const V4_64: i64 = -1; // constant with annotated type but non-annotated negative value
+  │                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+  ┌─ tests/signed-int/valid/valid_constants.move:9:22
+  │
+9 │   const V8_64: i64 = -9223372036854775808; // constant with annotated type but non-annotated, min value
+  │                      ^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:15:24
+   │
+15 │   const V4_128: i128 = -1; // constant with annotated type but non-annotated negative value
+   │                        ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:19:24
+   │
+19 │   const V8_128: i128 = -170141183460469231731687303715884105728; // constant with annotated type but non-annotated, min value
+   │                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:31:13
+   │
+31 │     let c = -1; // constant with non-annotated type and non-annotated, negative value
+   │             ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:33:13
+   │
+33 │     let e = -9223372036854775808; // constant with non-annotated type and non-annotated, min value
+   │             ^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:35:22
+   │
+35 │     let (x, y, z) = (-1, -2, -3); // constants in tuple
+   │                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:35:26
+   │
+35 │     let (x, y, z) = (-1, -2, -3); // constants in tuple
+   │                          ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:35:30
+   │
+35 │     let (x, y, z) = (-1, -2, -3); // constants in tuple
+   │                              ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:49:13
+   │
+49 │     let c = -1; // constant with non-annotated type and non-annotated, negative value
+   │             ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:51:13
+   │
+51 │     let e = -170141183460469231731687303715884105728; // constant with non-annotated type and non-annotated, min value
+   │             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:53:22
+   │
+53 │     let (x, y, z) = (-1, -2, -3); // constants in tuple
+   │                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:53:26
+   │
+53 │     let (x, y, z) = (-1, -2, -3); // constants in tuple
+   │                          ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_constants.move:53:30
+   │
+53 │     let (x, y, z) = (-1, -2, -3); // constants in tuple
+   │                              ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constants.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_constants.move
@@ -1,0 +1,57 @@
+module 0x42::constants {
+  const V1_64: i64 = 0; // constant with annotated type but non-annotated value
+  const V2_64: i64 = 1; // constant with annotated type but non-annotated value
+  const V3_64: i64 = 1i64; // constant with annotated type and annotated value
+  const V4_64: i64 = -1; // constant with annotated type but non-annotated negative value
+  const V5_64: i64 = -1i64; // constant with annotated type and annotated negative value
+  const V6_64: i64 = 9223372036854775807; // constant with annotated type but non-annotated, max value
+  const V7_64: i64 = 9223372036854775807i64; // constant with annotated type and annotated, max value
+  const V8_64: i64 = -9223372036854775808; // constant with annotated type but non-annotated, min value
+  const V9_64: i64 = -9223372036854775808i64; // constant with annotated type and annotated, min value
+
+  const V1_128: i128 = 0; // constant with annotated type but non-annotated value
+  const V2_128: i128 = 1; // constant with annotated type but non-annotated value
+  const V3_128: i128 = 1i128; // constant with annotated type and annotated value
+  const V4_128: i128 = -1; // constant with annotated type but non-annotated negative value
+  const V5_128: i128 = -1i128; // constant with annotated type and annotated negative value
+  const V6_128: i128 = 170141183460469231731687303715884105727; // constant with annotated type but non-annotated, max value
+  const V7_128: i128 = 170141183460469231731687303715884105727i128; // constant with annotated type and annotated, max value
+  const V8_128: i128 = -170141183460469231731687303715884105728; // constant with annotated type but non-annotated, min value
+  const V9_128: i128 = -170141183460469231731687303715884105728i128; // constant with annotated type and annotated, min value
+
+  public fun  test_i64() : i64 {
+    let a_ann = 0i64; // constant with non-annotated type but annotated value
+    let b_ann = 1i64; // constant with non-annotated type but annotated value
+    let c_ann = -1i64; // constant with non-annotated type but annotated, negative value
+    let d_ann = 9223372036854775807i64; // constant with non-annotated type but annotated, max value
+    let e_ann = -9223372036854775808i64; // constant with non-annotated type but annotated, min value
+
+    let a = 0; // constant with non-annotated type and non-annotated value
+    let b = 1; // constant with non-annotated type and non-annotated value
+    let c = -1; // constant with non-annotated type and non-annotated, negative value
+    let d = 9223372036854775807; // constant with non-annotated type and non-annotated, max value
+    let e = -9223372036854775808; // constant with non-annotated type and non-annotated, min value
+
+    let (x, y, z) = (-1, -2, -3); // constants in tuple
+
+    V1_64 + V2_64 + V3_64 + V4_64 + V5_64 + V6_64 + V7_64 + V8_64 + V9_64 + a_ann + b_ann + c_ann + d_ann + e_ann + a + b + c + d + e + x + y + z
+  }
+
+  public fun  test_i128() : i128 {
+    let a_ann = 0i128; // constant with non-annotated type but annotated value
+    let b_ann = 1i128; // constant with non-annotated type but annotated value
+    let c_ann = -1i128; // constant with non-annotated type but annotated, negative value
+    let d_ann = 170141183460469231731687303715884105727i128; // constant with non-annotated type but annotated, max value
+    let e_ann = -170141183460469231731687303715884105728i128; // constant with non-annotated type but annotated, min value
+
+    let a = 0; // constant with non-annotated type and non-annotated value
+    let b = 1; // constant with non-annotated type and non-annotated value
+    let c = -1; // constant with non-annotated type and non-annotated, negative value
+    let d = 170141183460469231731687303715884105727; // constant with non-annotated type and non-annotated, max value
+    let e = -170141183460469231731687303715884105728; // constant with non-annotated type and non-annotated, min value
+
+    let (x, y, z) = (-1, -2, -3); // constants in tuple
+
+    V1_128 + V2_128 + V3_128 + V4_128 + V5_128 + V6_128 + V7_128 + V8_128 + V9_128 + a_ann + b_ann + c_ann + d_ann + e_ann + a + b + c + d + e + x + y + z
+  }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_control_flow.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_control_flow.exp
@@ -1,0 +1,2001 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::valid_control_flow {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        if Or(i64::gt(x, y), i64::eq(x, y)) {
+          x
+        } else {
+          y
+        }
+    }
+    private fun test2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        if Or(i128::gt(x, y), i128::eq(x, y)) {
+          x
+        } else {
+          y
+        }
+    }
+    private fun test3(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        loop {
+          if Not(i64::eq(x, i64::pack(0))) {
+            {
+              let y: 0x1::i64::I64 = i64::add(x, i64::pack(1));
+              {
+                let z: 0x1::i64::I64 = i64::sub(x, i64::pack(1));
+                {
+                  let res: 0x1::i64::I64 = if i64::lt(y, z) {
+                    y
+                  } else {
+                    if i64::lt(z, y) {
+                      z
+                    } else {
+                      break
+                    }
+                  };
+                  x: 0x1::i64::I64 = i64::mul(x, i64::pack(2));
+                  Tuple()
+                }
+              }
+            }
+          } else {
+            break
+          }
+        };
+        x
+    }
+    private fun test4(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        loop {
+          if Not(i128::eq(x, i128::pack(0))) {
+            {
+              let y: 0x1::i128::I128 = i128::add(x, i128::pack(1));
+              {
+                let z: 0x1::i128::I128 = i128::sub(x, i128::pack(1));
+                {
+                  let res: 0x1::i128::I128 = if i128::lt(y, z) {
+                    y
+                  } else {
+                    if i128::lt(z, y) {
+                      z
+                    } else {
+                      break
+                    }
+                  };
+                  x: 0x1::i128::I128 = i128::mul(x, i128::pack(2));
+                  Tuple()
+                }
+              }
+            }
+          } else {
+            break
+          }
+        };
+        x
+    }
+} // end 0x42::valid_control_flow
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::valid_control_flow {
+    enum E1 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 has copy, drop {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 has copy, drop {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> has copy, drop {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    fun test1(x: 0x1::i64::I64, y: 0x1::i64::I64): 0x1::i64::I64 {
+        if (0x1::i64::gt(x, y) || 0x1::i64::eq(x, y)) x else y
+    }
+    fun test2(x: 0x1::i128::I128, y: 0x1::i128::I128): 0x1::i128::I128 {
+        if (0x1::i128::gt(x, y) || 0x1::i128::eq(x, y)) x else y
+    }
+    fun test3(x: 0x1::i64::I64, y: 0x1::i64::I64): 0x1::i64::I64 {
+        while (!0x1::i64::eq(x, 0x1::i64::pack(0))) {
+            let y = 0x1::i64::add(x, 0x1::i64::pack(1));
+            let z = 0x1::i64::sub(x, 0x1::i64::pack(1));
+            let res = if (0x1::i64::lt(y, z)) y else if (0x1::i64::lt(z, y)) z else break;
+            x = 0x1::i64::mul(x, 0x1::i64::pack(2));
+        };
+        x
+    }
+    fun test4(x: 0x1::i128::I128, y: 0x1::i128::I128): 0x1::i128::I128 {
+        while (!0x1::i128::eq(x, 0x1::i128::pack(0u128))) {
+            let y = 0x1::i128::add(x, 0x1::i128::pack(1u128));
+            let z = 0x1::i128::sub(x, 0x1::i128::pack(1u128));
+            let res = if (0x1::i128::lt(y, z)) y else if (0x1::i128::lt(z, y)) z else break;
+            x = 0x1::i128::mul(x, 0x1::i128::pack(2u128));
+        };
+        x
+    }
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_control_flow::test1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t5 := infer($t0)
+  1: $t4 := i64::gt($t5, $t1)
+  2: if ($t4) goto 3 else goto 6
+  3: label L0
+  4: $t3 := true
+  5: goto 9
+  6: label L1
+  7: $t6 := infer($t0)
+  8: $t3 := i64::eq($t6, $t1)
+  9: label L2
+ 10: if ($t3) goto 11 else goto 14
+ 11: label L3
+ 12: $t2 := infer($t0)
+ 13: goto 16
+ 14: label L4
+ 15: $t2 := infer($t1)
+ 16: label L5
+ 17: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+  0: $t5 := infer($t0)
+  1: $t4 := i128::gt($t5, $t1)
+  2: if ($t4) goto 3 else goto 6
+  3: label L0
+  4: $t3 := true
+  5: goto 9
+  6: label L1
+  7: $t6 := infer($t0)
+  8: $t3 := i128::eq($t6, $t1)
+  9: label L2
+ 10: if ($t3) goto 11 else goto 14
+ 11: label L3
+ 12: $t2 := infer($t0)
+ 13: goto 16
+ 14: label L4
+ 15: $t2 := infer($t1)
+ 16: label L5
+ 17: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: u64
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: u64
+     var $t12: 0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: 0x1::i64::I64
+     var $t15: u64
+     var $t16: 0x1::i64::I64
+     var $t17: bool
+     var $t18: 0x1::i64::I64
+     var $t19: bool
+     var $t20: 0x1::i64::I64
+     var $t21: 0x1::i64::I64
+     var $t22: 0x1::i64::I64
+     var $t23: 0x1::i64::I64
+     var $t24: u64
+  0: label L0
+  1: $t5 := infer($t0)
+  2: $t7 := 0
+  3: $t6 := i64::pack($t7)
+  4: $t4 := i64::eq($t5, $t6)
+  5: $t3 := !($t4)
+  6: if ($t3) goto 7 else goto 39
+  7: label L2
+  8: $t9 := infer($t0)
+  9: $t11 := 1
+ 10: $t10 := i64::pack($t11)
+ 11: $t8 := i64::add($t9, $t10)
+ 12: $t13 := infer($t0)
+ 13: $t15 := 1
+ 14: $t14 := i64::pack($t15)
+ 15: $t12 := i64::sub($t13, $t14)
+ 16: $t18 := infer($t8)
+ 17: $t17 := i64::lt($t18, $t12)
+ 18: if ($t17) goto 19 else goto 22
+ 19: label L5
+ 20: $t16 := infer($t8)
+ 21: goto 32
+ 22: label L6
+ 23: $t20 := infer($t12)
+ 24: $t19 := i64::lt($t20, $t8)
+ 25: if ($t19) goto 26 else goto 29
+ 26: label L8
+ 27: $t16 := infer($t12)
+ 28: goto 31
+ 29: label L9
+ 30: goto 43
+ 31: label L10
+ 32: label L7
+ 33: $t22 := infer($t0)
+ 34: $t24 := 2
+ 35: $t23 := i64::pack($t24)
+ 36: $t21 := i64::mul($t22, $t23)
+ 37: $t0 := infer($t21)
+ 38: goto 41
+ 39: label L3
+ 40: goto 43
+ 41: label L4
+ 42: goto 0
+ 43: label L1
+ 44: $t2 := infer($t0)
+ 45: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: u128
+     var $t12: 0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: 0x1::i128::I128
+     var $t15: u128
+     var $t16: 0x1::i128::I128
+     var $t17: bool
+     var $t18: 0x1::i128::I128
+     var $t19: bool
+     var $t20: 0x1::i128::I128
+     var $t21: 0x1::i128::I128
+     var $t22: 0x1::i128::I128
+     var $t23: 0x1::i128::I128
+     var $t24: u128
+  0: label L0
+  1: $t5 := infer($t0)
+  2: $t7 := 0
+  3: $t6 := i128::pack($t7)
+  4: $t4 := i128::eq($t5, $t6)
+  5: $t3 := !($t4)
+  6: if ($t3) goto 7 else goto 39
+  7: label L2
+  8: $t9 := infer($t0)
+  9: $t11 := 1
+ 10: $t10 := i128::pack($t11)
+ 11: $t8 := i128::add($t9, $t10)
+ 12: $t13 := infer($t0)
+ 13: $t15 := 1
+ 14: $t14 := i128::pack($t15)
+ 15: $t12 := i128::sub($t13, $t14)
+ 16: $t18 := infer($t8)
+ 17: $t17 := i128::lt($t18, $t12)
+ 18: if ($t17) goto 19 else goto 22
+ 19: label L5
+ 20: $t16 := infer($t8)
+ 21: goto 32
+ 22: label L6
+ 23: $t20 := infer($t12)
+ 24: $t19 := i128::lt($t20, $t8)
+ 25: if ($t19) goto 26 else goto 29
+ 26: label L8
+ 27: $t16 := infer($t12)
+ 28: goto 31
+ 29: label L9
+ 30: goto 43
+ 31: label L10
+ 32: label L7
+ 33: $t22 := infer($t0)
+ 34: $t24 := 2
+ 35: $t23 := i128::pack($t24)
+ 36: $t21 := i128::mul($t22, $t23)
+ 37: $t0 := infer($t21)
+ 38: goto 41
+ 39: label L3
+ 40: goto 43
+ 41: label L4
+ 42: goto 0
+ 43: label L1
+ 44: $t2 := infer($t0)
+ 45: return $t2
+}
+
+
+Diagnostics:
+warning: Unused value of parameter `y`. Consider removing the parameter, or prefixing with an underscore (e.g., `_y`), or binding to `_`
+   ┌─ tests/signed-int/valid/valid_control_flow.move:42:23
+   │
+42 │     fun test3(x: i64, y: i64) : i64 {
+   │                       ^
+
+warning: This assignment/binding to the left-hand-side variable `res` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_res`), or renaming to `_`
+   ┌─ tests/signed-int/valid/valid_control_flow.move:47:26
+   │
+47 │             if (y < z) { y }
+   │                          ^
+
+warning: This assignment/binding to the left-hand-side variable `res` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_res`), or renaming to `_`
+   ┌─ tests/signed-int/valid/valid_control_flow.move:48:31
+   │
+48 │             else if (z < y) { z }
+   │                               ^
+
+warning: Unused value of parameter `y`. Consider removing the parameter, or prefixing with an underscore (e.g., `_y`), or binding to `_`
+   ┌─ tests/signed-int/valid/valid_control_flow.move:55:24
+   │
+55 │     fun test4(x: i128, y: i128) : i128 {
+   │                        ^
+
+warning: This assignment/binding to the left-hand-side variable `res` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_res`), or renaming to `_`
+   ┌─ tests/signed-int/valid/valid_control_flow.move:60:26
+   │
+60 │             if (y < z) { y }
+   │                          ^
+
+warning: This assignment/binding to the left-hand-side variable `res` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_res`), or renaming to `_`
+   ┌─ tests/signed-int/valid/valid_control_flow.move:61:31
+   │
+61 │             else if (z < y) { z }
+   │                               ^
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_control_flow::test1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+  1: $t4 := i64::gt($t5, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  2: if ($t4) goto 3 else goto 6
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  3: label L0
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  4: $t3 := true
+     # abort state: {returns}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  5: goto 9
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  6: label L1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  7: $t6 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t6
+     # refs: []
+     #
+  8: $t3 := i64::eq($t6, $t1)
+     # abort state: {returns}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  9: label L2
+     # abort state: {returns}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 10: if ($t3) goto 11 else goto 14
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 11: label L3
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 12: $t2 := infer($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 13: goto 16
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 14: label L4
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 15: $t2 := infer($t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 16: label L5
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 17: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+  1: $t4 := i128::gt($t5, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  2: if ($t4) goto 3 else goto 6
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  3: label L0
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  4: $t3 := true
+     # abort state: {returns}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  5: goto 9
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  6: label L1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  7: $t6 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t6
+     # refs: []
+     #
+  8: $t3 := i128::eq($t6, $t1)
+     # abort state: {returns}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  9: label L2
+     # abort state: {returns}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 10: if ($t3) goto 11 else goto 14
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 11: label L3
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 12: $t2 := infer($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 13: goto 16
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 14: label L4
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 15: $t2 := infer($t1)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 16: label L5
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 17: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: u64
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: u64
+     var $t12: 0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: 0x1::i64::I64
+     var $t15: u64
+     var $t16: 0x1::i64::I64
+     var $t17: bool
+     var $t18: 0x1::i64::I64
+     var $t19: bool
+     var $t20: 0x1::i64::I64
+     var $t21: 0x1::i64::I64
+     var $t22: 0x1::i64::I64
+     var $t23: 0x1::i64::I64
+     var $t24: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  1: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  2: $t7 := 0
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5, $t7
+     # refs: []
+     #
+  3: $t6 := i64::pack($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5, $t6
+     # refs: []
+     #
+  4: $t4 := i64::eq($t5, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+  5: $t3 := !($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+  6: if ($t3) goto 7 else goto 39
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  8: $t9 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9
+     # refs: []
+     #
+  9: $t11 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9, $t11
+     # refs: []
+     #
+ 10: $t10 := i64::pack($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9, $t10
+     # refs: []
+     #
+ 11: $t8 := i64::add($t9, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8
+     # refs: []
+     #
+ 12: $t13 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t13
+     # refs: []
+     #
+ 13: $t15 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t13, $t15
+     # refs: []
+     #
+ 14: $t14 := i64::pack($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t13, $t14
+     # refs: []
+     #
+ 15: $t12 := i64::sub($t13, $t14)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 16: $t18 := infer($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12, $t18
+     # refs: []
+     #
+ 17: $t17 := i64::lt($t18, $t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12, $t17
+     # refs: []
+     #
+ 18: if ($t17) goto 19 else goto 22
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 19: label L5
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8
+     # refs: []
+     #
+ 20: $t16 := infer($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 21: goto 32
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 22: label L6
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 23: $t20 := infer($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12, $t20
+     # refs: []
+     #
+ 24: $t19 := i64::lt($t20, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12, $t19
+     # refs: []
+     #
+ 25: if ($t19) goto 26 else goto 29
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 26: label L8
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 27: $t16 := infer($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 28: goto 31
+     # abort state: {returns}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 29: label L9
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 30: goto 43
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 31: label L10
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 32: label L7
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 33: $t22 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t22
+     # refs: []
+     #
+ 34: $t24 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t22, $t24
+     # refs: []
+     #
+ 35: $t23 := i64::pack($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t22, $t23
+     # refs: []
+     #
+ 36: $t21 := i64::mul($t22, $t23)
+     # abort state: {returns,aborts}
+     # live vars: $t21
+     # refs: []
+     #
+ 37: $t0 := infer($t21)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 38: goto 41
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 39: label L3
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 40: goto 43
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 41: label L4
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 42: goto 0
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 43: label L1
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 44: $t2 := infer($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 45: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: u128
+     var $t12: 0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: 0x1::i128::I128
+     var $t15: u128
+     var $t16: 0x1::i128::I128
+     var $t17: bool
+     var $t18: 0x1::i128::I128
+     var $t19: bool
+     var $t20: 0x1::i128::I128
+     var $t21: 0x1::i128::I128
+     var $t22: 0x1::i128::I128
+     var $t23: 0x1::i128::I128
+     var $t24: u128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  1: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  2: $t7 := 0
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5, $t7
+     # refs: []
+     #
+  3: $t6 := i128::pack($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5, $t6
+     # refs: []
+     #
+  4: $t4 := i128::eq($t5, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+  5: $t3 := !($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+  6: if ($t3) goto 7 else goto 39
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  8: $t9 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9
+     # refs: []
+     #
+  9: $t11 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9, $t11
+     # refs: []
+     #
+ 10: $t10 := i128::pack($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9, $t10
+     # refs: []
+     #
+ 11: $t8 := i128::add($t9, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8
+     # refs: []
+     #
+ 12: $t13 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t13
+     # refs: []
+     #
+ 13: $t15 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t13, $t15
+     # refs: []
+     #
+ 14: $t14 := i128::pack($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t13, $t14
+     # refs: []
+     #
+ 15: $t12 := i128::sub($t13, $t14)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 16: $t18 := infer($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12, $t18
+     # refs: []
+     #
+ 17: $t17 := i128::lt($t18, $t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12, $t17
+     # refs: []
+     #
+ 18: if ($t17) goto 19 else goto 22
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 19: label L5
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8
+     # refs: []
+     #
+ 20: $t16 := infer($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 21: goto 32
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 22: label L6
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12
+     # refs: []
+     #
+ 23: $t20 := infer($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8, $t12, $t20
+     # refs: []
+     #
+ 24: $t19 := i128::lt($t20, $t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12, $t19
+     # refs: []
+     #
+ 25: if ($t19) goto 26 else goto 29
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 26: label L8
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 27: $t16 := infer($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 28: goto 31
+     # abort state: {returns}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 29: label L9
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 30: goto 43
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 31: label L10
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 32: label L7
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 33: $t22 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t22
+     # refs: []
+     #
+ 34: $t24 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t22, $t24
+     # refs: []
+     #
+ 35: $t23 := i128::pack($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t22, $t23
+     # refs: []
+     #
+ 36: $t21 := i128::mul($t22, $t23)
+     # abort state: {returns,aborts}
+     # live vars: $t21
+     # refs: []
+     #
+ 37: $t0 := infer($t21)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 38: goto 41
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 39: label L3
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 40: goto 43
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 41: label L4
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 42: goto 0
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 43: label L1
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 44: $t2 := infer($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 45: return $t2
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::valid_control_flow {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test1(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        if Or(i64::gt(x, y), i64::eq(x, y)) {
+          x
+        } else {
+          y
+        }
+    }
+    private fun test2(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        if Or(i128::gt(x, y), i128::eq(x, y)) {
+          x
+        } else {
+          y
+        }
+    }
+    private fun test3(x: 0x1::i64::I64,y: 0x1::i64::I64): 0x1::i64::I64 {
+        loop {
+          if Not(i64::eq(x, i64::pack(0))) {
+            {
+              let y: 0x1::i64::I64 = i64::add(x, i64::pack(1));
+              {
+                let z: 0x1::i64::I64 = i64::sub(x, i64::pack(1));
+                {
+                  let res: 0x1::i64::I64 = if i64::lt(y, z) {
+                    y
+                  } else {
+                    if i64::lt(z, y) {
+                      z
+                    } else {
+                      break
+                    }
+                  };
+                  x: 0x1::i64::I64 = i64::mul(x, i64::pack(2));
+                  Tuple()
+                }
+              }
+            }
+          } else {
+            break
+          }
+        };
+        x
+    }
+    private fun test4(x: 0x1::i128::I128,y: 0x1::i128::I128): 0x1::i128::I128 {
+        loop {
+          if Not(i128::eq(x, i128::pack(0))) {
+            {
+              let y: 0x1::i128::I128 = i128::add(x, i128::pack(1));
+              {
+                let z: 0x1::i128::I128 = i128::sub(x, i128::pack(1));
+                {
+                  let res: 0x1::i128::I128 = if i128::lt(y, z) {
+                    y
+                  } else {
+                    if i128::lt(z, y) {
+                      z
+                    } else {
+                      break
+                    }
+                  };
+                  x: 0x1::i128::I128 = i128::mul(x, i128::pack(2));
+                  Tuple()
+                }
+              }
+            }
+          } else {
+            break
+          }
+        };
+        x
+    }
+} // end 0x42::valid_control_flow
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_control_flow::test1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t5 := infer($t0)
+  1: $t4 := i64::gt($t5, $t1)
+  2: if ($t4) goto 3 else goto 6
+  3: label L0
+  4: $t3 := true
+  5: goto 9
+  6: label L1
+  7: $t6 := infer($t0)
+  8: $t3 := i64::eq($t6, $t1)
+  9: label L2
+ 10: if ($t3) goto 11 else goto 14
+ 11: label L3
+ 12: $t2 := infer($t0)
+ 13: goto 16
+ 14: label L4
+ 15: $t2 := infer($t1)
+ 16: label L5
+ 17: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+  0: $t5 := infer($t0)
+  1: $t4 := i128::gt($t5, $t1)
+  2: if ($t4) goto 3 else goto 6
+  3: label L0
+  4: $t3 := true
+  5: goto 9
+  6: label L1
+  7: $t6 := infer($t0)
+  8: $t3 := i128::eq($t6, $t1)
+  9: label L2
+ 10: if ($t3) goto 11 else goto 14
+ 11: label L3
+ 12: $t2 := infer($t0)
+ 13: goto 16
+ 14: label L4
+ 15: $t2 := infer($t1)
+ 16: label L5
+ 17: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     var $t7: u64
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: u64
+     var $t12: 0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: 0x1::i64::I64
+     var $t15: u64
+     var $t16: 0x1::i64::I64
+     var $t17: bool
+     var $t18: 0x1::i64::I64
+     var $t19: bool
+     var $t20: 0x1::i64::I64
+     var $t21: 0x1::i64::I64
+     var $t22: 0x1::i64::I64
+     var $t23: 0x1::i64::I64
+     var $t24: u64
+  0: label L0
+  1: $t5 := infer($t0)
+  2: $t7 := 0
+  3: $t6 := i64::pack($t7)
+  4: $t4 := i64::eq($t5, $t6)
+  5: $t3 := !($t4)
+  6: if ($t3) goto 7 else goto 39
+  7: label L2
+  8: $t9 := infer($t0)
+  9: $t11 := 1
+ 10: $t10 := i64::pack($t11)
+ 11: $t8 := i64::add($t9, $t10)
+ 12: $t13 := infer($t0)
+ 13: $t15 := 1
+ 14: $t14 := i64::pack($t15)
+ 15: $t12 := i64::sub($t13, $t14)
+ 16: $t18 := infer($t8)
+ 17: $t17 := i64::lt($t18, $t12)
+ 18: if ($t17) goto 19 else goto 22
+ 19: label L5
+ 20: $t16 := infer($t8)
+ 21: goto 32
+ 22: label L6
+ 23: $t20 := infer($t12)
+ 24: $t19 := i64::lt($t20, $t8)
+ 25: if ($t19) goto 26 else goto 29
+ 26: label L8
+ 27: $t16 := infer($t12)
+ 28: goto 31
+ 29: label L9
+ 30: goto 43
+ 31: label L10
+ 32: label L7
+ 33: $t22 := infer($t0)
+ 34: $t24 := 2
+ 35: $t23 := i64::pack($t24)
+ 36: $t21 := i64::mul($t22, $t23)
+ 37: $t0 := infer($t21)
+ 38: goto 41
+ 39: label L3
+ 40: goto 43
+ 41: label L4
+ 42: goto 0
+ 43: label L1
+ 44: $t2 := infer($t0)
+ 45: return $t2
+}
+
+
+[variant baseline]
+fun valid_control_flow::test4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128
+     var $t3: bool
+     var $t4: bool
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: u128
+     var $t12: 0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: 0x1::i128::I128
+     var $t15: u128
+     var $t16: 0x1::i128::I128
+     var $t17: bool
+     var $t18: 0x1::i128::I128
+     var $t19: bool
+     var $t20: 0x1::i128::I128
+     var $t21: 0x1::i128::I128
+     var $t22: 0x1::i128::I128
+     var $t23: 0x1::i128::I128
+     var $t24: u128
+  0: label L0
+  1: $t5 := infer($t0)
+  2: $t7 := 0
+  3: $t6 := i128::pack($t7)
+  4: $t4 := i128::eq($t5, $t6)
+  5: $t3 := !($t4)
+  6: if ($t3) goto 7 else goto 39
+  7: label L2
+  8: $t9 := infer($t0)
+  9: $t11 := 1
+ 10: $t10 := i128::pack($t11)
+ 11: $t8 := i128::add($t9, $t10)
+ 12: $t13 := infer($t0)
+ 13: $t15 := 1
+ 14: $t14 := i128::pack($t15)
+ 15: $t12 := i128::sub($t13, $t14)
+ 16: $t18 := infer($t8)
+ 17: $t17 := i128::lt($t18, $t12)
+ 18: if ($t17) goto 19 else goto 22
+ 19: label L5
+ 20: $t16 := infer($t8)
+ 21: goto 32
+ 22: label L6
+ 23: $t20 := infer($t12)
+ 24: $t19 := i128::lt($t20, $t8)
+ 25: if ($t19) goto 26 else goto 29
+ 26: label L8
+ 27: $t16 := infer($t12)
+ 28: goto 31
+ 29: label L9
+ 30: goto 43
+ 31: label L10
+ 32: label L7
+ 33: $t22 := infer($t0)
+ 34: $t24 := 2
+ 35: $t23 := i128::pack($t24)
+ 36: $t21 := i128::mul($t22, $t23)
+ 37: $t0 := infer($t21)
+ 38: goto 41
+ 39: label L3
+ 40: goto 43
+ 41: label L4
+ 42: goto 0
+ 43: label L1
+ 44: $t2 := infer($t0)
+ 45: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_control_flow::test1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64 [unused]
+     var $t3: bool [unused]
+     var $t4: bool
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := i64::gt($t5, $t1)
+     # live vars: $t0, $t1, $t4
+  2: if ($t4) goto 3 else goto 14
+     # live vars: $t0, $t1
+  3: label L0
+     # live vars: $t0, $t1
+  4: $t4 := true
+     # live vars: $t0, $t1, $t4
+  5: label L2
+     # live vars: $t0, $t1, $t4
+  6: if ($t4) goto 7 else goto 11
+     # live vars: $t0, $t1
+  7: label L3
+     # live vars: $t0
+  8: $t5 := move($t0)
+     # live vars: $t5
+  9: label L5
+     # live vars: $t5
+ 10: return $t5
+     # live vars: $t0, $t1
+ 11: label L4
+     # live vars: $t1
+ 12: $t5 := move($t1)
+     # live vars: $t5
+ 13: goto 9
+     # live vars: $t0, $t1
+ 14: label L1
+     # live vars: $t0, $t1
+ 15: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t5
+ 16: $t4 := i64::eq($t5, $t1)
+     # live vars: $t0, $t1, $t4
+ 17: goto 5
+}
+
+
+[variant baseline]
+fun valid_control_flow::test2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128 [unused]
+     var $t3: bool [unused]
+     var $t4: bool
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := i128::gt($t5, $t1)
+     # live vars: $t0, $t1, $t4
+  2: if ($t4) goto 3 else goto 14
+     # live vars: $t0, $t1
+  3: label L0
+     # live vars: $t0, $t1
+  4: $t4 := true
+     # live vars: $t0, $t1, $t4
+  5: label L2
+     # live vars: $t0, $t1, $t4
+  6: if ($t4) goto 7 else goto 11
+     # live vars: $t0, $t1
+  7: label L3
+     # live vars: $t0
+  8: $t5 := move($t0)
+     # live vars: $t5
+  9: label L5
+     # live vars: $t5
+ 10: return $t5
+     # live vars: $t0, $t1
+ 11: label L4
+     # live vars: $t1
+ 12: $t5 := move($t1)
+     # live vars: $t5
+ 13: goto 9
+     # live vars: $t0, $t1
+ 14: label L1
+     # live vars: $t0, $t1
+ 15: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t5
+ 16: $t4 := i128::eq($t5, $t1)
+     # live vars: $t0, $t1, $t4
+ 17: goto 5
+}
+
+
+[variant baseline]
+fun valid_control_flow::test3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): 0x1::i64::I64 {
+     var $t2: 0x1::i64::I64 [unused]
+     var $t3: bool [unused]
+     var $t4: bool
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64
+     var $t7: u64
+     var $t8: 0x1::i64::I64 [unused]
+     var $t9: 0x1::i64::I64 [unused]
+     var $t10: 0x1::i64::I64 [unused]
+     var $t11: u64 [unused]
+     var $t12: 0x1::i64::I64 [unused]
+     var $t13: 0x1::i64::I64 [unused]
+     var $t14: 0x1::i64::I64
+     var $t15: u64 [unused]
+     var $t16: 0x1::i64::I64 [unused]
+     var $t17: bool [unused]
+     var $t18: 0x1::i64::I64 [unused]
+     var $t19: bool [unused]
+     var $t20: 0x1::i64::I64 [unused]
+     var $t21: 0x1::i64::I64 [unused]
+     var $t22: 0x1::i64::I64 [unused]
+     var $t23: 0x1::i64::I64
+     var $t24: u64 [unused]
+     # live vars: $t0, $t1
+  0: label L0
+     # live vars: $t0
+  1: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  2: $t7 := 0
+     # live vars: $t0, $t1, $t7
+  3: $t6 := i64::pack($t7)
+     # live vars: $t0, $t1, $t6
+  4: $t4 := i64::eq($t1, $t6)
+     # live vars: $t0, $t4
+  5: $t4 := !($t4)
+     # live vars: $t0, $t4
+  6: if ($t4) goto 9 else goto 7
+     # live vars: $t0
+  7: label L9
+     # live vars: $t0
+  8: goto 37
+     # live vars: $t0
+  9: label L2
+     # live vars: $t0
+ 10: $t1 := copy($t0)
+     # live vars: $t0, $t1
+ 11: $t7 := 1
+     # live vars: $t0, $t1, $t7
+ 12: $t6 := i64::pack($t7)
+     # live vars: $t0, $t1, $t6
+ 13: $t1 := i64::add($t1, $t6)
+     # live vars: $t0, $t1
+ 14: $t6 := copy($t0)
+     # live vars: $t0, $t1, $t6
+ 15: $t7 := 1
+     # live vars: $t0, $t1, $t6, $t7
+ 16: $t14 := i64::pack($t7)
+     # live vars: $t0, $t1, $t6, $t14
+ 17: $t6 := i64::sub($t6, $t14)
+     # live vars: $t0, $t1, $t6
+ 18: $t14 := copy($t1)
+     # live vars: $t0, $t1, $t6, $t14
+ 19: $t4 := i64::lt($t14, $t6)
+     # live vars: $t0, $t1, $t4, $t6
+ 20: if ($t4) goto 21 else goto 29
+     # live vars: $t0, $t1, $t6
+ 21: label L5
+     # live vars: $t0
+ 22: label L7
+     # live vars: $t0
+ 23: $t14 := move($t0)
+     # live vars: $t14
+ 24: $t7 := 2
+     # live vars: $t7, $t14
+ 25: $t23 := i64::pack($t7)
+     # live vars: $t14, $t23
+ 26: $t14 := i64::mul($t14, $t23)
+     # live vars: $t14
+ 27: $t0 := move($t14)
+     # live vars: $t0
+ 28: goto 0
+     # live vars: $t0, $t1, $t6
+ 29: label L6
+     # live vars: $t0, $t1, $t6
+ 30: $t6 := copy($t6)
+     # live vars: $t0, $t1, $t6
+ 31: $t4 := i64::lt($t6, $t1)
+     # live vars: $t0, $t4
+ 32: if ($t4) goto 35 else goto 33
+     # live vars: $t0
+ 33: label L10
+     # live vars: $t0
+ 34: goto 37
+     # live vars: $t0
+ 35: label L8
+     # live vars: $t0
+ 36: goto 22
+     # live vars: $t0
+ 37: label L1
+     # live vars: $t0
+ 38: return $t0
+}
+
+
+[variant baseline]
+fun valid_control_flow::test4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): 0x1::i128::I128 {
+     var $t2: 0x1::i128::I128 [unused]
+     var $t3: bool [unused]
+     var $t4: bool
+     var $t5: 0x1::i128::I128 [unused]
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128 [unused]
+     var $t9: 0x1::i128::I128 [unused]
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: u128 [unused]
+     var $t12: 0x1::i128::I128 [unused]
+     var $t13: 0x1::i128::I128 [unused]
+     var $t14: 0x1::i128::I128
+     var $t15: u128 [unused]
+     var $t16: 0x1::i128::I128 [unused]
+     var $t17: bool [unused]
+     var $t18: 0x1::i128::I128 [unused]
+     var $t19: bool [unused]
+     var $t20: 0x1::i128::I128 [unused]
+     var $t21: 0x1::i128::I128 [unused]
+     var $t22: 0x1::i128::I128 [unused]
+     var $t23: 0x1::i128::I128
+     var $t24: u128 [unused]
+     # live vars: $t0, $t1
+  0: label L0
+     # live vars: $t0
+  1: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  2: $t7 := 0
+     # live vars: $t0, $t1, $t7
+  3: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t6
+  4: $t4 := i128::eq($t1, $t6)
+     # live vars: $t0, $t4
+  5: $t4 := !($t4)
+     # live vars: $t0, $t4
+  6: if ($t4) goto 9 else goto 7
+     # live vars: $t0
+  7: label L9
+     # live vars: $t0
+  8: goto 37
+     # live vars: $t0
+  9: label L2
+     # live vars: $t0
+ 10: $t1 := copy($t0)
+     # live vars: $t0, $t1
+ 11: $t7 := 1
+     # live vars: $t0, $t1, $t7
+ 12: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t6
+ 13: $t1 := i128::add($t1, $t6)
+     # live vars: $t0, $t1
+ 14: $t6 := copy($t0)
+     # live vars: $t0, $t1, $t6
+ 15: $t7 := 1
+     # live vars: $t0, $t1, $t6, $t7
+ 16: $t14 := i128::pack($t7)
+     # live vars: $t0, $t1, $t6, $t14
+ 17: $t6 := i128::sub($t6, $t14)
+     # live vars: $t0, $t1, $t6
+ 18: $t14 := copy($t1)
+     # live vars: $t0, $t1, $t6, $t14
+ 19: $t4 := i128::lt($t14, $t6)
+     # live vars: $t0, $t1, $t4, $t6
+ 20: if ($t4) goto 21 else goto 29
+     # live vars: $t0, $t1, $t6
+ 21: label L5
+     # live vars: $t0
+ 22: label L7
+     # live vars: $t0
+ 23: $t14 := move($t0)
+     # live vars: $t14
+ 24: $t7 := 2
+     # live vars: $t7, $t14
+ 25: $t23 := i128::pack($t7)
+     # live vars: $t14, $t23
+ 26: $t14 := i128::mul($t14, $t23)
+     # live vars: $t14
+ 27: $t0 := move($t14)
+     # live vars: $t0
+ 28: goto 0
+     # live vars: $t0, $t1, $t6
+ 29: label L6
+     # live vars: $t0, $t1, $t6
+ 30: $t6 := copy($t6)
+     # live vars: $t0, $t1, $t6
+ 31: $t4 := i128::lt($t6, $t1)
+     # live vars: $t0, $t4
+ 32: if ($t4) goto 35 else goto 33
+     # live vars: $t0
+ 33: label L10
+     # live vars: $t0
+ 34: goto 37
+     # live vars: $t0
+ 35: label L8
+     # live vars: $t0
+ 36: goto 22
+     # live vars: $t0
+ 37: label L1
+     # live vars: $t0
+ 38: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module 42.valid_control_flow {
+use 0000000000000000000000000000000000000000000000000000000000000001::i64;
+use 0000000000000000000000000000000000000000000000000000000000000001::i128;
+
+
+enum E1 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I64>
+ }
+}
+enum E2 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I128>
+ }
+}
+enum E3<T> has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<T>
+ }
+}
+struct S1 has copy, drop {
+	x: u64,
+	y: I64,
+	z: I128
+}
+struct S2 has copy, drop {
+	x: S1,
+	y: I64,
+	z: I128
+}
+struct S3<T> has copy, drop {
+	x: T,
+	y: S1,
+	z: S2
+}
+
+test1(x: I64, y: I64): I64 /* def_idx: 0 */ {
+L2:	$t4: bool
+L3:	$t5: I64
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[1](y: I64)
+	2: Call i64::gt(I64, I64): bool
+	3: BrFalse(15)
+B1:
+	4: LdTrue
+	5: StLoc[2]($t4: bool)
+B2:
+	6: MoveLoc[2]($t4: bool)
+	7: BrFalse(12)
+B3:
+	8: MoveLoc[0](x: I64)
+	9: StLoc[3]($t5: I64)
+B4:
+	10: MoveLoc[3]($t5: I64)
+	11: Ret
+B5:
+	12: MoveLoc[1](y: I64)
+	13: StLoc[3]($t5: I64)
+	14: Branch(10)
+B6:
+	15: CopyLoc[0](x: I64)
+	16: CopyLoc[1](y: I64)
+	17: Call i64::eq(I64, I64): bool
+	18: StLoc[2]($t4: bool)
+	19: Branch(6)
+}
+test2(x: I128, y: I128): I128 /* def_idx: 1 */ {
+L2:	$t4: bool
+L3:	$t5: I128
+B0:
+	0: CopyLoc[0](x: I128)
+	1: CopyLoc[1](y: I128)
+	2: Call i128::gt(I128, I128): bool
+	3: BrFalse(15)
+B1:
+	4: LdTrue
+	5: StLoc[2]($t4: bool)
+B2:
+	6: MoveLoc[2]($t4: bool)
+	7: BrFalse(12)
+B3:
+	8: MoveLoc[0](x: I128)
+	9: StLoc[3]($t5: I128)
+B4:
+	10: MoveLoc[3]($t5: I128)
+	11: Ret
+B5:
+	12: MoveLoc[1](y: I128)
+	13: StLoc[3]($t5: I128)
+	14: Branch(10)
+B6:
+	15: CopyLoc[0](x: I128)
+	16: CopyLoc[1](y: I128)
+	17: Call i128::eq(I128, I128): bool
+	18: StLoc[2]($t4: bool)
+	19: Branch(6)
+}
+test3(x: I64, y: I64): I64 /* def_idx: 2 */ {
+L2:	$t6: I64
+B0:
+	0: CopyLoc[0](x: I64)
+	1: LdU64(0)
+	2: Call i64::pack(u64): I64
+	3: Call i64::eq(I64, I64): bool
+	4: BrFalse(6)
+B1:
+	5: Branch(32)
+B2:
+	6: CopyLoc[0](x: I64)
+	7: LdU64(1)
+	8: Call i64::pack(u64): I64
+	9: Call i64::add(I64, I64): I64
+	10: StLoc[1](y: I64)
+	11: CopyLoc[0](x: I64)
+	12: LdU64(1)
+	13: Call i64::pack(u64): I64
+	14: Call i64::sub(I64, I64): I64
+	15: StLoc[2]($t6: I64)
+	16: CopyLoc[1](y: I64)
+	17: CopyLoc[2]($t6: I64)
+	18: Call i64::lt(I64, I64): bool
+	19: BrFalse(26)
+B3:
+	20: MoveLoc[0](x: I64)
+	21: LdU64(2)
+	22: Call i64::pack(u64): I64
+	23: Call i64::mul(I64, I64): I64
+	24: StLoc[0](x: I64)
+	25: Branch(0)
+B4:
+	26: CopyLoc[2]($t6: I64)
+	27: MoveLoc[1](y: I64)
+	28: Call i64::lt(I64, I64): bool
+	29: BrTrue(31)
+B5:
+	30: Branch(32)
+B6:
+	31: Branch(20)
+B7:
+	32: MoveLoc[0](x: I64)
+	33: Ret
+}
+test4(x: I128, y: I128): I128 /* def_idx: 3 */ {
+L2:	$t6: I128
+B0:
+	0: CopyLoc[0](x: I128)
+	1: LdU128(0)
+	2: Call i128::pack(u128): I128
+	3: Call i128::eq(I128, I128): bool
+	4: BrFalse(6)
+B1:
+	5: Branch(32)
+B2:
+	6: CopyLoc[0](x: I128)
+	7: LdU128(1)
+	8: Call i128::pack(u128): I128
+	9: Call i128::add(I128, I128): I128
+	10: StLoc[1](y: I128)
+	11: CopyLoc[0](x: I128)
+	12: LdU128(1)
+	13: Call i128::pack(u128): I128
+	14: Call i128::sub(I128, I128): I128
+	15: StLoc[2]($t6: I128)
+	16: CopyLoc[1](y: I128)
+	17: CopyLoc[2]($t6: I128)
+	18: Call i128::lt(I128, I128): bool
+	19: BrFalse(26)
+B3:
+	20: MoveLoc[0](x: I128)
+	21: LdU128(2)
+	22: Call i128::pack(u128): I128
+	23: Call i128::mul(I128, I128): I128
+	24: StLoc[0](x: I128)
+	25: Branch(0)
+B4:
+	26: CopyLoc[2]($t6: I128)
+	27: MoveLoc[1](y: I128)
+	28: Call i128::lt(I128, I128): bool
+	29: BrTrue(31)
+B5:
+	30: Branch(32)
+B6:
+	31: Branch(20)
+B7:
+	32: MoveLoc[0](x: I128)
+	33: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_control_flow.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_control_flow.move
@@ -1,0 +1,67 @@
+module 0x42::valid_control_flow {
+    struct S1  has copy, drop { x: u64, y: i64, z: i128 }
+
+    struct S2 has copy, drop { x: S1, y: i64, z: i128  }
+
+    struct S3<T>  has copy, drop { x: T, y: S1, z: S2 }
+
+    enum E1 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i64>},
+    }
+
+    enum E2 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i128>},
+    }
+
+    enum E3<T> has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<T>},
+    }
+
+    fun test1(x: i64, y: i64) : i64 {
+        if (x > y || x == y) {
+            x
+        } else {
+            y
+        }
+    }
+
+    fun test2(x: i128, y: i128) : i128 {
+        if (x > y || x == y) {
+            x
+        } else {
+            y
+        }
+    }
+
+    fun test3(x: i64, y: i64) : i64 {
+        while (! (x == 0)) {
+            let y = x + 1;
+            let z = x - 1;
+            let res =
+            if (y < z) { y }
+            else if (z < y) { z }
+            else break;
+            x = x * 2;
+        };
+        x
+    }
+
+    fun test4(x: i128, y: i128) : i128 {
+        while (! (x == 0)) {
+            let y = x + 1;
+            let z = x - 1;
+            let res =
+            if (y < z) { y }
+            else if (z < y) { z }
+            else break;
+            x = x * 2;
+        };
+        x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_fun_val.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_fun_val.exp
@@ -1,0 +1,97 @@
+
+Diagnostics:
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:78:31
+   │
+78 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:78:38
+   │
+78 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:84:31
+   │
+84 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:84:38
+   │
+84 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:85:32
+   │
+85 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:85:39
+   │
+85 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:91:31
+   │
+91 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:91:38
+   │
+91 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:92:32
+   │
+92 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:92:39
+   │
+92 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:93:30
+   │
+93 │         let s3 = S3<i64> {x: -1, y: s1, z: s2};
+   │                              ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:99:31
+   │
+99 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_fun_val.move:99:38
+   │
+99 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_fun_val.move:100:32
+    │
+100 │         let s2 = S2 {x: s1, y: -1, z: -2};
+    │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_fun_val.move:100:39
+    │
+100 │         let s2 = S2 {x: s1, y: -1, z: -2};
+    │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_fun_val.move:101:31
+    │
+101 │         let s3 = S3<i128> {x: -1, y: s1, z: s2};
+    │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_fun_val.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_fun_val.move
@@ -1,0 +1,105 @@
+module 0x42::valid_fv {
+    struct S1  has copy, drop { x: u64, y: i64, z: i128 }
+
+    struct S2 has copy, drop { x: S1, y: i64, z: i128  }
+
+    struct S3<T>  has copy, drop { x: T, y: S1, z: S2 }
+
+    enum E1 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i64>},
+    }
+
+    enum E2 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i128>},
+    }
+
+    enum E3<T> has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<T>},
+    }
+
+    fun test_64(x: i64): i64 {
+        x + x
+    }
+
+    fun test_128(x: i128): i128 {
+        x + x
+    }
+
+    fun test1(fv1: |i64| i64 has copy+drop, x: i64) : i64 {
+        let fv2: |i64| i64 has copy+drop = |x| x * x; // function value involving i64
+        fv1(x)
+    }
+
+    fun test2(fv1: |i128| i128 has copy+drop, x: i128) : i128 { // function value involving i128
+        let fv2: |i128| i128 has copy+drop = |x| x * x;
+        fv1(x)
+    }
+
+    fun test3(fv1: |(|i64|i64)| i64 has copy+drop, x: i64) : i64 { // function value involving nested function value with i64
+        fv1(test_64)
+    }
+
+    fun test4(fv1: |(|i128|i128)| i128 has copy+drop, x: i128) : i128 { // function value involving nested function value with i128
+        fv1(test_128)
+    }
+
+    fun test5(fv: |S1| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: a, z: b};
+        fv(s1)
+    }
+
+    fun test6(fv: |S2| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s2 = S2 {x: s1, y: a, z: b};
+        fv(s2)
+    }
+
+    fun test7(fv: |S3<i64>| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i64> {x: a, y: s1, z: s2};
+        fv(s3)
+    }
+
+    fun test8(fv: |S3<i128>| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i128> {x: b, y: s1, z: s2};
+        fv(s3)
+    }
+
+    fun test9(fv: |E1| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let e = E1::V1{s: s1};
+        fv(e)
+    }
+
+    fun test10(fv: |E2| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let e = E2::V2{s: s2};
+        fv(e)
+    }
+
+    fun test11(fv: |E3<i64>| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let s3 = S3<i64> {x: -1, y: s1, z: s2};
+        let e = E3::V3{s: s3};
+        fv(e)
+    }
+
+    fun test12(fv: |E3<i128>| i64 has copy+drop, a: i64, b: i128) : i64 {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let s3 = S3<i128> {x: -1, y: s1, z: s2};
+        let e = E3::V3{s: s3};
+        fv(e)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_logic.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_logic.exp
@@ -1,0 +1,5485 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::valid_logic {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test_cmp1(x: 0x1::i64::I64): bool {
+        And(And(And(And(And(And(i64::eq(x, x), i64::gte(x, x)), i64::lte(x, x)), i64::gt(x, x)), i64::lt(x, x)), i64::eq(x, x)), i64::gte(x, x))
+    }
+    private fun test_cmp2(x: 0x1::i128::I128): bool {
+        And(And(And(And(And(And(i128::eq(x, x), i128::gte(x, x)), i128::lte(x, x)), i128::gt(x, x)), i128::lt(x, x)), i128::eq(x, x)), i128::gte(x, x))
+    }
+    private fun test_cmp3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): bool {
+        And(And(And(And(And(And(i64::eq(select valid_logic::S1.y<S1>(s1), select valid_logic::S2.y<S2>(s2)), i64::lte(select valid_logic::S1.y<S1>(s1), select valid_logic::S3.x<S3<0x1::i64::I64>>(s3))), i64::gte(select valid_logic::S2.y<S2>(s2), select valid_logic::S3.x<S3<0x1::i64::I64>>(s3))), i64::gt(select valid_logic::S3.x<S3<0x1::i64::I64>>(s3), select valid_logic::S1.y<S1>(s1))), i64::lt(select valid_logic::S3.x<S3<0x1::i64::I64>>(s3), select valid_logic::S2.y<S2>(s2))), i64::eq(select valid_logic::S1.y<S1>(s1), select valid_logic::S2.y<S2>(s2))), i64::eq(select valid_logic::S1.y<S1>(s1), select valid_logic::S2.y<S2>(s2)))
+    }
+    private fun test_cmp4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): bool {
+        And(And(And(And(And(And(i128::eq(select valid_logic::S1.z<S1>(s1), select valid_logic::S2.z<S2>(s2)), i128::lte(select valid_logic::S1.z<S1>(s1), select valid_logic::S3.x<S3<0x1::i128::I128>>(s3))), i128::gte(select valid_logic::S2.z<S2>(s2), select valid_logic::S3.x<S3<0x1::i128::I128>>(s3))), i128::gt(select valid_logic::S3.x<S3<0x1::i128::I128>>(s3), select valid_logic::S1.z<S1>(s1))), i128::lt(select valid_logic::S3.x<S3<0x1::i128::I128>>(s3), select valid_logic::S2.z<S2>(s2))), i128::eq(select valid_logic::S1.z<S1>(s1), select valid_logic::S2.z<S2>(s2))), i128::eq(select valid_logic::S1.z<S1>(s1), select valid_logic::S2.z<S2>(s2)))
+    }
+    private fun test_mix1(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::add(x, y), i64::add(y, x))
+    }
+    private fun test_mix10(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::mul(i128::mod(x, i128::pack(2)), y), i128::mul(i128::mod(x, i128::pack(3)), y))
+    }
+    private fun test_mix2(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::lte(i128::add(x, i128::mul(i128::pack(2), y)), i128::add(x, i128::mul(i128::pack(3), y)))
+    }
+    private fun test_mix3(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::sub(x, y), i64::sub(y, x))
+    }
+    private fun test_mix4(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::sub(x, i128::mul(i128::pack(2), y)), i128::sub(x, i128::mul(i128::pack(3), y)))
+    }
+    private fun test_mix5(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::mul(x, y), i64::mul(y, x))
+    }
+    private fun test_mix6(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::mul(i128::mul(x, i128::pack(2)), y), i128::mul(i128::mul(x, i128::pack(3)), y))
+    }
+    private fun test_mix7(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::div(x, y), i64::div(y, x))
+    }
+    private fun test_mix8(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::mul(i128::div(x, i128::pack(2)), y), i128::mul(i128::div(x, i128::pack(3)), y))
+    }
+    private fun test_mix9(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::mod(x, y), i64::mod(y, x))
+    }
+} // end 0x42::valid_logic
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::valid_logic {
+    enum E1 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> has copy, drop {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 has copy, drop {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 has copy, drop {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> has copy, drop {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    fun test_cmp1(x: 0x1::i64::I64): bool {
+        0x1::i64::eq(x, x) && 0x1::i64::gte(x, x) && 0x1::i64::lte(x, x) && 0x1::i64::gt(x, x) && 0x1::i64::lt(x, x) && 0x1::i64::eq(x, x) && 0x1::i64::gte(x, x)
+    }
+    fun test_cmp2(x: 0x1::i128::I128): bool {
+        0x1::i128::eq(x, x) && 0x1::i128::gte(x, x) && 0x1::i128::lte(x, x) && 0x1::i128::gt(x, x) && 0x1::i128::lt(x, x) && 0x1::i128::eq(x, x) && 0x1::i128::gte(x, x)
+    }
+    fun test_cmp3(s1: S1, s2: S2, s3: S3<0x1::i64::I64>): bool {
+        0x1::i64::eq(s1.y, s2.y) && 0x1::i64::lte(s1.y, s3.x) && 0x1::i64::gte(s2.y, s3.x) && 0x1::i64::gt(s3.x, s1.y) && 0x1::i64::lt(s3.x, s2.y) && 0x1::i64::eq(s1.y, s2.y) && 0x1::i64::eq(s1.y, s2.y)
+    }
+    fun test_cmp4(s1: S1, s2: S2, s3: S3<0x1::i128::I128>): bool {
+        0x1::i128::eq(s1.z, s2.z) && 0x1::i128::lte(s1.z, s3.x) && 0x1::i128::gte(s2.z, s3.x) && 0x1::i128::gt(s3.x, s1.z) && 0x1::i128::lt(s3.x, s2.z) && 0x1::i128::eq(s1.z, s2.z) && 0x1::i128::eq(s1.z, s2.z)
+    }
+    fun test_mix1(x: 0x1::i64::I64, y: 0x1::i64::I64): bool {
+        0x1::i64::eq(0x1::i64::add(x, y), 0x1::i64::add(y, x))
+    }
+    fun test_mix10(x: 0x1::i128::I128, y: 0x1::i128::I128): bool {
+        0x1::i128::gt(0x1::i128::mul(0x1::i128::mod(x, 0x1::i128::pack(2u128)), y), 0x1::i128::mul(0x1::i128::mod(x, 0x1::i128::pack(3u128)), y))
+    }
+    fun test_mix2(x: 0x1::i128::I128, y: 0x1::i128::I128): bool {
+        0x1::i128::lte(0x1::i128::add(x, 0x1::i128::mul(0x1::i128::pack(2u128), y)), 0x1::i128::add(x, 0x1::i128::mul(0x1::i128::pack(3u128), y)))
+    }
+    fun test_mix3(x: 0x1::i64::I64, y: 0x1::i64::I64): bool {
+        0x1::i64::eq(0x1::i64::sub(x, y), 0x1::i64::sub(y, x))
+    }
+    fun test_mix4(x: 0x1::i128::I128, y: 0x1::i128::I128): bool {
+        0x1::i128::gt(0x1::i128::sub(x, 0x1::i128::mul(0x1::i128::pack(2u128), y)), 0x1::i128::sub(x, 0x1::i128::mul(0x1::i128::pack(3u128), y)))
+    }
+    fun test_mix5(x: 0x1::i64::I64, y: 0x1::i64::I64): bool {
+        0x1::i64::eq(0x1::i64::mul(x, y), 0x1::i64::mul(y, x))
+    }
+    fun test_mix6(x: 0x1::i128::I128, y: 0x1::i128::I128): bool {
+        0x1::i128::gt(0x1::i128::mul(0x1::i128::mul(x, 0x1::i128::pack(2u128)), y), 0x1::i128::mul(0x1::i128::mul(x, 0x1::i128::pack(3u128)), y))
+    }
+    fun test_mix7(x: 0x1::i64::I64, y: 0x1::i64::I64): bool {
+        0x1::i64::eq(0x1::i64::div(x, y), 0x1::i64::div(y, x))
+    }
+    fun test_mix8(x: 0x1::i128::I128, y: 0x1::i128::I128): bool {
+        0x1::i128::gt(0x1::i128::mul(0x1::i128::div(x, 0x1::i128::pack(2u128)), y), 0x1::i128::mul(0x1::i128::div(x, 0x1::i128::pack(3u128)), y))
+    }
+    fun test_mix9(x: 0x1::i64::I64, y: 0x1::i64::I64): bool {
+        0x1::i64::eq(0x1::i64::mod(x, y), 0x1::i64::mod(y, x))
+    }
+}
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_logic::test_cmp1($t0: 0x1::i64::I64): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: 0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: 0x1::i64::I64
+  0: $t8 := infer($t0)
+  1: $t7 := i64::eq($t8, $t0)
+  2: if ($t7) goto 3 else goto 7
+  3: label L0
+  4: $t9 := infer($t0)
+  5: $t6 := i64::gte($t9, $t0)
+  6: goto 9
+  7: label L1
+  8: $t6 := false
+  9: label L2
+ 10: if ($t6) goto 11 else goto 15
+ 11: label L3
+ 12: $t10 := infer($t0)
+ 13: $t5 := i64::lte($t10, $t0)
+ 14: goto 17
+ 15: label L4
+ 16: $t5 := false
+ 17: label L5
+ 18: if ($t5) goto 19 else goto 23
+ 19: label L6
+ 20: $t11 := infer($t0)
+ 21: $t4 := i64::gt($t11, $t0)
+ 22: goto 25
+ 23: label L7
+ 24: $t4 := false
+ 25: label L8
+ 26: if ($t4) goto 27 else goto 31
+ 27: label L9
+ 28: $t12 := infer($t0)
+ 29: $t3 := i64::lt($t12, $t0)
+ 30: goto 33
+ 31: label L10
+ 32: $t3 := false
+ 33: label L11
+ 34: if ($t3) goto 35 else goto 39
+ 35: label L12
+ 36: $t13 := infer($t0)
+ 37: $t2 := i64::eq($t13, $t0)
+ 38: goto 41
+ 39: label L13
+ 40: $t2 := false
+ 41: label L14
+ 42: if ($t2) goto 43 else goto 47
+ 43: label L15
+ 44: $t14 := infer($t0)
+ 45: $t1 := i64::gte($t14, $t0)
+ 46: goto 49
+ 47: label L16
+ 48: $t1 := false
+ 49: label L17
+ 50: return $t1
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp2($t0: 0x1::i128::I128): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: 0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: 0x1::i128::I128
+  0: $t8 := infer($t0)
+  1: $t7 := i128::eq($t8, $t0)
+  2: if ($t7) goto 3 else goto 7
+  3: label L0
+  4: $t9 := infer($t0)
+  5: $t6 := i128::gte($t9, $t0)
+  6: goto 9
+  7: label L1
+  8: $t6 := false
+  9: label L2
+ 10: if ($t6) goto 11 else goto 15
+ 11: label L3
+ 12: $t10 := infer($t0)
+ 13: $t5 := i128::lte($t10, $t0)
+ 14: goto 17
+ 15: label L4
+ 16: $t5 := false
+ 17: label L5
+ 18: if ($t5) goto 19 else goto 23
+ 19: label L6
+ 20: $t11 := infer($t0)
+ 21: $t4 := i128::gt($t11, $t0)
+ 22: goto 25
+ 23: label L7
+ 24: $t4 := false
+ 25: label L8
+ 26: if ($t4) goto 27 else goto 31
+ 27: label L9
+ 28: $t12 := infer($t0)
+ 29: $t3 := i128::lt($t12, $t0)
+ 30: goto 33
+ 31: label L10
+ 32: $t3 := false
+ 33: label L11
+ 34: if ($t3) goto 35 else goto 39
+ 35: label L12
+ 36: $t13 := infer($t0)
+ 37: $t2 := i128::eq($t13, $t0)
+ 38: goto 41
+ 39: label L13
+ 40: $t2 := false
+ 41: label L14
+ 42: if ($t2) goto 43 else goto 47
+ 43: label L15
+ 44: $t14 := infer($t0)
+ 45: $t1 := i128::gte($t14, $t0)
+ 46: goto 49
+ 47: label L16
+ 48: $t1 := false
+ 49: label L17
+ 50: return $t1
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp3($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i64::I64>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: 0x1::i64::I64
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i64::I64
+     var $t16: 0x1::i64::I64
+     var $t17: &0x42::valid_logic::S1
+     var $t18: &0x1::i64::I64
+     var $t19: 0x1::i64::I64
+     var $t20: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t21: &0x1::i64::I64
+     var $t22: 0x1::i64::I64
+     var $t23: &0x42::valid_logic::S2
+     var $t24: &0x1::i64::I64
+     var $t25: 0x1::i64::I64
+     var $t26: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t27: &0x1::i64::I64
+     var $t28: 0x1::i64::I64
+     var $t29: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t30: &0x1::i64::I64
+     var $t31: 0x1::i64::I64
+     var $t32: &0x42::valid_logic::S1
+     var $t33: &0x1::i64::I64
+     var $t34: 0x1::i64::I64
+     var $t35: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t36: &0x1::i64::I64
+     var $t37: 0x1::i64::I64
+     var $t38: &0x42::valid_logic::S2
+     var $t39: &0x1::i64::I64
+     var $t40: 0x1::i64::I64
+     var $t41: &0x42::valid_logic::S1
+     var $t42: &0x1::i64::I64
+     var $t43: 0x1::i64::I64
+     var $t44: &0x42::valid_logic::S2
+     var $t45: &0x1::i64::I64
+     var $t46: 0x1::i64::I64
+     var $t47: &0x42::valid_logic::S1
+     var $t48: &0x1::i64::I64
+     var $t49: 0x1::i64::I64
+     var $t50: &0x42::valid_logic::S2
+     var $t51: &0x1::i64::I64
+  0: $t11 := borrow_local($t0)
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+  2: $t10 := read_ref($t12)
+  3: $t14 := borrow_local($t1)
+  4: $t15 := borrow_field<0x42::valid_logic::S2>.y($t14)
+  5: $t13 := read_ref($t15)
+  6: $t9 := i64::eq($t10, $t13)
+  7: if ($t9) goto 8 else goto 17
+  8: label L0
+  9: $t17 := borrow_local($t0)
+ 10: $t18 := borrow_field<0x42::valid_logic::S1>.y($t17)
+ 11: $t16 := read_ref($t18)
+ 12: $t20 := borrow_local($t2)
+ 13: $t21 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t20)
+ 14: $t19 := read_ref($t21)
+ 15: $t8 := i64::lte($t16, $t19)
+ 16: goto 19
+ 17: label L1
+ 18: $t8 := false
+ 19: label L2
+ 20: if ($t8) goto 21 else goto 30
+ 21: label L3
+ 22: $t23 := borrow_local($t1)
+ 23: $t24 := borrow_field<0x42::valid_logic::S2>.y($t23)
+ 24: $t22 := read_ref($t24)
+ 25: $t26 := borrow_local($t2)
+ 26: $t27 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t26)
+ 27: $t25 := read_ref($t27)
+ 28: $t7 := i64::gte($t22, $t25)
+ 29: goto 32
+ 30: label L4
+ 31: $t7 := false
+ 32: label L5
+ 33: if ($t7) goto 34 else goto 43
+ 34: label L6
+ 35: $t29 := borrow_local($t2)
+ 36: $t30 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t29)
+ 37: $t28 := read_ref($t30)
+ 38: $t32 := borrow_local($t0)
+ 39: $t33 := borrow_field<0x42::valid_logic::S1>.y($t32)
+ 40: $t31 := read_ref($t33)
+ 41: $t6 := i64::gt($t28, $t31)
+ 42: goto 45
+ 43: label L7
+ 44: $t6 := false
+ 45: label L8
+ 46: if ($t6) goto 47 else goto 56
+ 47: label L9
+ 48: $t35 := borrow_local($t2)
+ 49: $t36 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t35)
+ 50: $t34 := read_ref($t36)
+ 51: $t38 := borrow_local($t1)
+ 52: $t39 := borrow_field<0x42::valid_logic::S2>.y($t38)
+ 53: $t37 := read_ref($t39)
+ 54: $t5 := i64::lt($t34, $t37)
+ 55: goto 58
+ 56: label L10
+ 57: $t5 := false
+ 58: label L11
+ 59: if ($t5) goto 60 else goto 69
+ 60: label L12
+ 61: $t41 := borrow_local($t0)
+ 62: $t42 := borrow_field<0x42::valid_logic::S1>.y($t41)
+ 63: $t40 := read_ref($t42)
+ 64: $t44 := borrow_local($t1)
+ 65: $t45 := borrow_field<0x42::valid_logic::S2>.y($t44)
+ 66: $t43 := read_ref($t45)
+ 67: $t4 := i64::eq($t40, $t43)
+ 68: goto 71
+ 69: label L13
+ 70: $t4 := false
+ 71: label L14
+ 72: if ($t4) goto 73 else goto 82
+ 73: label L15
+ 74: $t47 := borrow_local($t0)
+ 75: $t48 := borrow_field<0x42::valid_logic::S1>.y($t47)
+ 76: $t46 := read_ref($t48)
+ 77: $t50 := borrow_local($t1)
+ 78: $t51 := borrow_field<0x42::valid_logic::S2>.y($t50)
+ 79: $t49 := read_ref($t51)
+ 80: $t3 := i64::eq($t46, $t49)
+ 81: goto 84
+ 82: label L16
+ 83: $t3 := false
+ 84: label L17
+ 85: return $t3
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp4($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i128::I128>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: 0x1::i128::I128
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i128::I128
+     var $t16: 0x1::i128::I128
+     var $t17: &0x42::valid_logic::S1
+     var $t18: &0x1::i128::I128
+     var $t19: 0x1::i128::I128
+     var $t20: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t21: &0x1::i128::I128
+     var $t22: 0x1::i128::I128
+     var $t23: &0x42::valid_logic::S2
+     var $t24: &0x1::i128::I128
+     var $t25: 0x1::i128::I128
+     var $t26: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t27: &0x1::i128::I128
+     var $t28: 0x1::i128::I128
+     var $t29: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t30: &0x1::i128::I128
+     var $t31: 0x1::i128::I128
+     var $t32: &0x42::valid_logic::S1
+     var $t33: &0x1::i128::I128
+     var $t34: 0x1::i128::I128
+     var $t35: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t36: &0x1::i128::I128
+     var $t37: 0x1::i128::I128
+     var $t38: &0x42::valid_logic::S2
+     var $t39: &0x1::i128::I128
+     var $t40: 0x1::i128::I128
+     var $t41: &0x42::valid_logic::S1
+     var $t42: &0x1::i128::I128
+     var $t43: 0x1::i128::I128
+     var $t44: &0x42::valid_logic::S2
+     var $t45: &0x1::i128::I128
+     var $t46: 0x1::i128::I128
+     var $t47: &0x42::valid_logic::S1
+     var $t48: &0x1::i128::I128
+     var $t49: 0x1::i128::I128
+     var $t50: &0x42::valid_logic::S2
+     var $t51: &0x1::i128::I128
+  0: $t11 := borrow_local($t0)
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+  2: $t10 := read_ref($t12)
+  3: $t14 := borrow_local($t1)
+  4: $t15 := borrow_field<0x42::valid_logic::S2>.z($t14)
+  5: $t13 := read_ref($t15)
+  6: $t9 := i128::eq($t10, $t13)
+  7: if ($t9) goto 8 else goto 17
+  8: label L0
+  9: $t17 := borrow_local($t0)
+ 10: $t18 := borrow_field<0x42::valid_logic::S1>.z($t17)
+ 11: $t16 := read_ref($t18)
+ 12: $t20 := borrow_local($t2)
+ 13: $t21 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t20)
+ 14: $t19 := read_ref($t21)
+ 15: $t8 := i128::lte($t16, $t19)
+ 16: goto 19
+ 17: label L1
+ 18: $t8 := false
+ 19: label L2
+ 20: if ($t8) goto 21 else goto 30
+ 21: label L3
+ 22: $t23 := borrow_local($t1)
+ 23: $t24 := borrow_field<0x42::valid_logic::S2>.z($t23)
+ 24: $t22 := read_ref($t24)
+ 25: $t26 := borrow_local($t2)
+ 26: $t27 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t26)
+ 27: $t25 := read_ref($t27)
+ 28: $t7 := i128::gte($t22, $t25)
+ 29: goto 32
+ 30: label L4
+ 31: $t7 := false
+ 32: label L5
+ 33: if ($t7) goto 34 else goto 43
+ 34: label L6
+ 35: $t29 := borrow_local($t2)
+ 36: $t30 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t29)
+ 37: $t28 := read_ref($t30)
+ 38: $t32 := borrow_local($t0)
+ 39: $t33 := borrow_field<0x42::valid_logic::S1>.z($t32)
+ 40: $t31 := read_ref($t33)
+ 41: $t6 := i128::gt($t28, $t31)
+ 42: goto 45
+ 43: label L7
+ 44: $t6 := false
+ 45: label L8
+ 46: if ($t6) goto 47 else goto 56
+ 47: label L9
+ 48: $t35 := borrow_local($t2)
+ 49: $t36 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t35)
+ 50: $t34 := read_ref($t36)
+ 51: $t38 := borrow_local($t1)
+ 52: $t39 := borrow_field<0x42::valid_logic::S2>.z($t38)
+ 53: $t37 := read_ref($t39)
+ 54: $t5 := i128::lt($t34, $t37)
+ 55: goto 58
+ 56: label L10
+ 57: $t5 := false
+ 58: label L11
+ 59: if ($t5) goto 60 else goto 69
+ 60: label L12
+ 61: $t41 := borrow_local($t0)
+ 62: $t42 := borrow_field<0x42::valid_logic::S1>.z($t41)
+ 63: $t40 := read_ref($t42)
+ 64: $t44 := borrow_local($t1)
+ 65: $t45 := borrow_field<0x42::valid_logic::S2>.z($t44)
+ 66: $t43 := read_ref($t45)
+ 67: $t4 := i128::eq($t40, $t43)
+ 68: goto 71
+ 69: label L13
+ 70: $t4 := false
+ 71: label L14
+ 72: if ($t4) goto 73 else goto 82
+ 73: label L15
+ 74: $t47 := borrow_local($t0)
+ 75: $t48 := borrow_field<0x42::valid_logic::S1>.z($t47)
+ 76: $t46 := read_ref($t48)
+ 77: $t50 := borrow_local($t1)
+ 78: $t51 := borrow_field<0x42::valid_logic::S2>.z($t50)
+ 79: $t49 := read_ref($t51)
+ 80: $t3 := i128::eq($t46, $t49)
+ 81: goto 84
+ 82: label L16
+ 83: $t3 := false
+ 84: label L17
+ 85: return $t3
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::add($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::add($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix10($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t5 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t4 := i128::mod($t5, $t6)
+  4: $t3 := i128::mul($t4, $t1)
+  5: $t10 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t9 := i128::mod($t10, $t11)
+  9: $t8 := i128::mul($t9, $t1)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t4 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t5 := i128::mul($t6, $t1)
+  4: $t3 := i128::add($t4, $t5)
+  5: $t9 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t10 := i128::mul($t11, $t1)
+  9: $t8 := i128::add($t9, $t10)
+ 10: $t2 := i128::lte($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::sub($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::sub($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t4 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t5 := i128::mul($t6, $t1)
+  4: $t3 := i128::sub($t4, $t5)
+  5: $t9 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t10 := i128::mul($t11, $t1)
+  9: $t8 := i128::sub($t9, $t10)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix5($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::mul($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::mul($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix6($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t5 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t4 := i128::mul($t5, $t6)
+  4: $t3 := i128::mul($t4, $t1)
+  5: $t10 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t9 := i128::mul($t10, $t11)
+  9: $t8 := i128::mul($t9, $t1)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix7($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::div($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::div($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix8($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t5 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t4 := i128::div($t5, $t6)
+  4: $t3 := i128::mul($t4, $t1)
+  5: $t10 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t9 := i128::div($t10, $t11)
+  9: $t8 := i128::mul($t9, $t1)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix9($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::mod($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::mod($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_logic::test_cmp1($t0: 0x1::i64::I64): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: 0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t8 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8
+     # refs: []
+     #
+  1: $t7 := i64::eq($t8, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t7
+     # refs: []
+     #
+  2: if ($t7) goto 3 else goto 7
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  3: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t9 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9
+     # refs: []
+     #
+  5: $t6 := i64::gte($t9, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t6
+     # refs: []
+     #
+  6: goto 9
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L1
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  8: $t6 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t6
+     # refs: []
+     #
+  9: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t6
+     # refs: []
+     #
+ 10: if ($t6) goto 11 else goto 15
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 11: label L3
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 12: $t10 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t10
+     # refs: []
+     #
+ 13: $t5 := i64::lte($t10, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+ 14: goto 17
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 15: label L4
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 16: $t5 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+ 17: label L5
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+ 18: if ($t5) goto 19 else goto 23
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 19: label L6
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 20: $t11 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t11
+     # refs: []
+     #
+ 21: $t4 := i64::gt($t11, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+ 22: goto 25
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 23: label L7
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 24: $t4 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+ 25: label L8
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+ 26: if ($t4) goto 27 else goto 31
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 27: label L9
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 28: $t12 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 29: $t3 := i64::lt($t12, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+ 30: goto 33
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 31: label L10
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 32: $t3 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+ 33: label L11
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+ 34: if ($t3) goto 35 else goto 39
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 35: label L12
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 36: $t13 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t13
+     # refs: []
+     #
+ 37: $t2 := i64::eq($t13, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+ 38: goto 41
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 39: label L13
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 40: $t2 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+ 41: label L14
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+ 42: if ($t2) goto 43 else goto 47
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 43: label L15
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 44: $t14 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t14
+     # refs: []
+     #
+ 45: $t1 := i64::gte($t14, $t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 46: goto 49
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 47: label L16
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 48: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 49: label L17
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 50: return $t1
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp2($t0: 0x1::i128::I128): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: 0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: 0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t8 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8
+     # refs: []
+     #
+  1: $t7 := i128::eq($t8, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t7
+     # refs: []
+     #
+  2: if ($t7) goto 3 else goto 7
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  3: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t9 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t9
+     # refs: []
+     #
+  5: $t6 := i128::gte($t9, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t6
+     # refs: []
+     #
+  6: goto 9
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L1
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  8: $t6 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t6
+     # refs: []
+     #
+  9: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t6
+     # refs: []
+     #
+ 10: if ($t6) goto 11 else goto 15
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 11: label L3
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 12: $t10 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t10
+     # refs: []
+     #
+ 13: $t5 := i128::lte($t10, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+ 14: goto 17
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 15: label L4
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 16: $t5 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+ 17: label L5
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+ 18: if ($t5) goto 19 else goto 23
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 19: label L6
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 20: $t11 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t11
+     # refs: []
+     #
+ 21: $t4 := i128::gt($t11, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+ 22: goto 25
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 23: label L7
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 24: $t4 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+ 25: label L8
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: []
+     #
+ 26: if ($t4) goto 27 else goto 31
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 27: label L9
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 28: $t12 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t12
+     # refs: []
+     #
+ 29: $t3 := i128::lt($t12, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+ 30: goto 33
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 31: label L10
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 32: $t3 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+ 33: label L11
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+ 34: if ($t3) goto 35 else goto 39
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 35: label L12
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 36: $t13 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t13
+     # refs: []
+     #
+ 37: $t2 := i128::eq($t13, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+ 38: goto 41
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 39: label L13
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 40: $t2 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+ 41: label L14
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+ 42: if ($t2) goto 43 else goto 47
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 43: label L15
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 44: $t14 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t14
+     # refs: []
+     #
+ 45: $t1 := i128::gte($t14, $t0)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 46: goto 49
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+ 47: label L16
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 48: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 49: label L17
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 50: return $t1
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp3($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i64::I64>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: 0x1::i64::I64
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i64::I64
+     var $t16: 0x1::i64::I64
+     var $t17: &0x42::valid_logic::S1
+     var $t18: &0x1::i64::I64
+     var $t19: 0x1::i64::I64
+     var $t20: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t21: &0x1::i64::I64
+     var $t22: 0x1::i64::I64
+     var $t23: &0x42::valid_logic::S2
+     var $t24: &0x1::i64::I64
+     var $t25: 0x1::i64::I64
+     var $t26: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t27: &0x1::i64::I64
+     var $t28: 0x1::i64::I64
+     var $t29: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t30: &0x1::i64::I64
+     var $t31: 0x1::i64::I64
+     var $t32: &0x42::valid_logic::S1
+     var $t33: &0x1::i64::I64
+     var $t34: 0x1::i64::I64
+     var $t35: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t36: &0x1::i64::I64
+     var $t37: 0x1::i64::I64
+     var $t38: &0x42::valid_logic::S2
+     var $t39: &0x1::i64::I64
+     var $t40: 0x1::i64::I64
+     var $t41: &0x42::valid_logic::S1
+     var $t42: &0x1::i64::I64
+     var $t43: 0x1::i64::I64
+     var $t44: &0x42::valid_logic::S2
+     var $t45: &0x1::i64::I64
+     var $t46: 0x1::i64::I64
+     var $t47: &0x42::valid_logic::S1
+     var $t48: &0x1::i64::I64
+     var $t49: 0x1::i64::I64
+     var $t50: &0x42::valid_logic::S2
+     var $t51: &0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t11 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => #11 via [local `s1`] at line 35
+     #
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s1`, field `y`] at line 35
+     #
+  2: $t10 := read_ref($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10
+     # refs: []
+     #
+  3: $t14 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10, $t14
+     # refs: [$t14 => #14]
+     # #14
+     #   <no edges>
+     # #root
+     #   => #14 via [local `s2`] at line 35
+     #
+  4: $t15 := borrow_field<0x42::valid_logic::S2>.y($t14)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10, $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => #15 via [local `s2`, field `y`] at line 35
+     #
+  5: $t13 := read_ref($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10, $t13
+     # refs: []
+     #
+  6: $t9 := i64::eq($t10, $t13)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t9
+     # refs: []
+     #
+  7: if ($t9) goto 8 else goto 17
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  8: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  9: $t17 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `s1`] at line 35
+     #
+ 10: $t18 := borrow_field<0x42::valid_logic::S1>.y($t17)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `s1`, field `y`] at line 35
+     #
+ 11: $t16 := read_ref($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16
+     # refs: []
+     #
+ 12: $t20 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16, $t20
+     # refs: [$t20 => #20]
+     # #20
+     #   <no edges>
+     # #root
+     #   => #20 via [local `s3`] at line 35
+     #
+ 13: $t21 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t20)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16, $t21
+     # refs: [$t21 => #21]
+     # #21
+     #   <no edges>
+     # #root
+     #   => #21 via [local `s3`, field `x`] at line 35
+     #
+ 14: $t19 := read_ref($t21)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16, $t19
+     # refs: []
+     #
+ 15: $t8 := i64::lte($t16, $t19)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+ 16: goto 19
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 17: label L1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 18: $t8 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+ 19: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+ 20: if ($t8) goto 21 else goto 30
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 21: label L3
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 22: $t23 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t23
+     # refs: [$t23 => #23]
+     # #23
+     #   <no edges>
+     # #root
+     #   => #23 via [local `s2`] at line 35
+     #
+ 23: $t24 := borrow_field<0x42::valid_logic::S2>.y($t23)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t24
+     # refs: [$t24 => #24]
+     # #24
+     #   <no edges>
+     # #root
+     #   => #24 via [local `s2`, field `y`] at line 35
+     #
+ 24: $t22 := read_ref($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22
+     # refs: []
+     #
+ 25: $t26 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22, $t26
+     # refs: [$t26 => #26]
+     # #26
+     #   <no edges>
+     # #root
+     #   => #26 via [local `s3`] at line 35
+     #
+ 26: $t27 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t26)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22, $t27
+     # refs: [$t27 => #27]
+     # #27
+     #   <no edges>
+     # #root
+     #   => #27 via [local `s3`, field `x`] at line 35
+     #
+ 27: $t25 := read_ref($t27)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22, $t25
+     # refs: []
+     #
+ 28: $t7 := i64::gte($t22, $t25)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+ 29: goto 32
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 30: label L4
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 31: $t7 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+ 32: label L5
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+ 33: if ($t7) goto 34 else goto 43
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 34: label L6
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 35: $t29 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t29
+     # refs: [$t29 => #29]
+     # #29
+     #   <no edges>
+     # #root
+     #   => #29 via [local `s3`] at line 35
+     #
+ 36: $t30 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t29)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t30
+     # refs: [$t30 => #30]
+     # #30
+     #   <no edges>
+     # #root
+     #   => #30 via [local `s3`, field `x`] at line 35
+     #
+ 37: $t28 := read_ref($t30)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28
+     # refs: []
+     #
+ 38: $t32 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28, $t32
+     # refs: [$t32 => #32]
+     # #32
+     #   <no edges>
+     # #root
+     #   => #32 via [local `s1`] at line 35
+     #
+ 39: $t33 := borrow_field<0x42::valid_logic::S1>.y($t32)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28, $t33
+     # refs: [$t33 => #33]
+     # #33
+     #   <no edges>
+     # #root
+     #   => #33 via [local `s1`, field `y`] at line 35
+     #
+ 40: $t31 := read_ref($t33)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28, $t31
+     # refs: []
+     #
+ 41: $t6 := i64::gt($t28, $t31)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 42: goto 45
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 43: label L7
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 44: $t6 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 45: label L8
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 46: if ($t6) goto 47 else goto 56
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 47: label L9
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 48: $t35 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t35
+     # refs: [$t35 => #35]
+     # #35
+     #   <no edges>
+     # #root
+     #   => #35 via [local `s3`] at line 35
+     #
+ 49: $t36 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t35)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t36
+     # refs: [$t36 => #36]
+     # #36
+     #   <no edges>
+     # #root
+     #   => #36 via [local `s3`, field `x`] at line 35
+     #
+ 50: $t34 := read_ref($t36)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34
+     # refs: []
+     #
+ 51: $t38 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34, $t38
+     # refs: [$t38 => #38]
+     # #38
+     #   <no edges>
+     # #root
+     #   => #38 via [local `s2`] at line 35
+     #
+ 52: $t39 := borrow_field<0x42::valid_logic::S2>.y($t38)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34, $t39
+     # refs: [$t39 => #39]
+     # #39
+     #   <no edges>
+     # #root
+     #   => #39 via [local `s2`, field `y`] at line 35
+     #
+ 53: $t37 := read_ref($t39)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34, $t37
+     # refs: []
+     #
+ 54: $t5 := i64::lt($t34, $t37)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+ 55: goto 58
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 56: label L10
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 57: $t5 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+ 58: label L11
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+ 59: if ($t5) goto 60 else goto 69
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 60: label L12
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 61: $t41 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t41
+     # refs: [$t41 => #41]
+     # #41
+     #   <no edges>
+     # #root
+     #   => #41 via [local `s1`] at line 35
+     #
+ 62: $t42 := borrow_field<0x42::valid_logic::S1>.y($t41)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t42
+     # refs: [$t42 => #42]
+     # #42
+     #   <no edges>
+     # #root
+     #   => #42 via [local `s1`, field `y`] at line 35
+     #
+ 63: $t40 := read_ref($t42)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40
+     # refs: []
+     #
+ 64: $t44 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40, $t44
+     # refs: [$t44 => #44]
+     # #44
+     #   <no edges>
+     # #root
+     #   => #44 via [local `s2`] at line 35
+     #
+ 65: $t45 := borrow_field<0x42::valid_logic::S2>.y($t44)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40, $t45
+     # refs: [$t45 => #45]
+     # #45
+     #   <no edges>
+     # #root
+     #   => #45 via [local `s2`, field `y`] at line 35
+     #
+ 66: $t43 := read_ref($t45)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40, $t43
+     # refs: []
+     #
+ 67: $t4 := i64::eq($t40, $t43)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+ 68: goto 71
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 69: label L13
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 70: $t4 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+ 71: label L14
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+ 72: if ($t4) goto 73 else goto 82
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 73: label L15
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 74: $t47 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t47
+     # refs: [$t47 => #47]
+     # #47
+     #   <no edges>
+     # #root
+     #   => #47 via [local `s1`] at line 35
+     #
+ 75: $t48 := borrow_field<0x42::valid_logic::S1>.y($t47)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t48
+     # refs: [$t48 => #48]
+     # #48
+     #   <no edges>
+     # #root
+     #   => #48 via [local `s1`, field `y`] at line 35
+     #
+ 76: $t46 := read_ref($t48)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t46
+     # refs: []
+     #
+ 77: $t50 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t46, $t50
+     # refs: [$t50 => #50]
+     # #50
+     #   <no edges>
+     # #root
+     #   => #50 via [local `s2`] at line 35
+     #
+ 78: $t51 := borrow_field<0x42::valid_logic::S2>.y($t50)
+     # abort state: {returns,aborts}
+     # live vars: $t46, $t51
+     # refs: [$t51 => #51]
+     # #51
+     #   <no edges>
+     # #root
+     #   => #51 via [local `s2`, field `y`] at line 35
+     #
+ 79: $t49 := read_ref($t51)
+     # abort state: {returns,aborts}
+     # live vars: $t46, $t49
+     # refs: []
+     #
+ 80: $t3 := i64::eq($t46, $t49)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 81: goto 84
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 82: label L16
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 83: $t3 := false
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 84: label L17
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 85: return $t3
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp4($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i128::I128>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: 0x1::i128::I128
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i128::I128
+     var $t16: 0x1::i128::I128
+     var $t17: &0x42::valid_logic::S1
+     var $t18: &0x1::i128::I128
+     var $t19: 0x1::i128::I128
+     var $t20: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t21: &0x1::i128::I128
+     var $t22: 0x1::i128::I128
+     var $t23: &0x42::valid_logic::S2
+     var $t24: &0x1::i128::I128
+     var $t25: 0x1::i128::I128
+     var $t26: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t27: &0x1::i128::I128
+     var $t28: 0x1::i128::I128
+     var $t29: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t30: &0x1::i128::I128
+     var $t31: 0x1::i128::I128
+     var $t32: &0x42::valid_logic::S1
+     var $t33: &0x1::i128::I128
+     var $t34: 0x1::i128::I128
+     var $t35: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t36: &0x1::i128::I128
+     var $t37: 0x1::i128::I128
+     var $t38: &0x42::valid_logic::S2
+     var $t39: &0x1::i128::I128
+     var $t40: 0x1::i128::I128
+     var $t41: &0x42::valid_logic::S1
+     var $t42: &0x1::i128::I128
+     var $t43: 0x1::i128::I128
+     var $t44: &0x42::valid_logic::S2
+     var $t45: &0x1::i128::I128
+     var $t46: 0x1::i128::I128
+     var $t47: &0x42::valid_logic::S1
+     var $t48: &0x1::i128::I128
+     var $t49: 0x1::i128::I128
+     var $t50: &0x42::valid_logic::S2
+     var $t51: &0x1::i128::I128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  0: $t11 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => #11 via [local `s1`] at line 39
+     #
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s1`, field `z`] at line 39
+     #
+  2: $t10 := read_ref($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10
+     # refs: []
+     #
+  3: $t14 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10, $t14
+     # refs: [$t14 => #14]
+     # #14
+     #   <no edges>
+     # #root
+     #   => #14 via [local `s2`] at line 39
+     #
+  4: $t15 := borrow_field<0x42::valid_logic::S2>.z($t14)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10, $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => #15 via [local `s2`, field `z`] at line 39
+     #
+  5: $t13 := read_ref($t15)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t10, $t13
+     # refs: []
+     #
+  6: $t9 := i128::eq($t10, $t13)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t9
+     # refs: []
+     #
+  7: if ($t9) goto 8 else goto 17
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  8: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  9: $t17 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `s1`] at line 39
+     #
+ 10: $t18 := borrow_field<0x42::valid_logic::S1>.z($t17)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `s1`, field `z`] at line 39
+     #
+ 11: $t16 := read_ref($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16
+     # refs: []
+     #
+ 12: $t20 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16, $t20
+     # refs: [$t20 => #20]
+     # #20
+     #   <no edges>
+     # #root
+     #   => #20 via [local `s3`] at line 39
+     #
+ 13: $t21 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t20)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16, $t21
+     # refs: [$t21 => #21]
+     # #21
+     #   <no edges>
+     # #root
+     #   => #21 via [local `s3`, field `x`] at line 39
+     #
+ 14: $t19 := read_ref($t21)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t16, $t19
+     # refs: []
+     #
+ 15: $t8 := i128::lte($t16, $t19)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+ 16: goto 19
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 17: label L1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 18: $t8 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+ 19: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t8
+     # refs: []
+     #
+ 20: if ($t8) goto 21 else goto 30
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 21: label L3
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 22: $t23 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t23
+     # refs: [$t23 => #23]
+     # #23
+     #   <no edges>
+     # #root
+     #   => #23 via [local `s2`] at line 39
+     #
+ 23: $t24 := borrow_field<0x42::valid_logic::S2>.z($t23)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t24
+     # refs: [$t24 => #24]
+     # #24
+     #   <no edges>
+     # #root
+     #   => #24 via [local `s2`, field `z`] at line 39
+     #
+ 24: $t22 := read_ref($t24)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22
+     # refs: []
+     #
+ 25: $t26 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22, $t26
+     # refs: [$t26 => #26]
+     # #26
+     #   <no edges>
+     # #root
+     #   => #26 via [local `s3`] at line 39
+     #
+ 26: $t27 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t26)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22, $t27
+     # refs: [$t27 => #27]
+     # #27
+     #   <no edges>
+     # #root
+     #   => #27 via [local `s3`, field `x`] at line 39
+     #
+ 27: $t25 := read_ref($t27)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t22, $t25
+     # refs: []
+     #
+ 28: $t7 := i128::gte($t22, $t25)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+ 29: goto 32
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 30: label L4
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 31: $t7 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+ 32: label L5
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t7
+     # refs: []
+     #
+ 33: if ($t7) goto 34 else goto 43
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 34: label L6
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 35: $t29 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t29
+     # refs: [$t29 => #29]
+     # #29
+     #   <no edges>
+     # #root
+     #   => #29 via [local `s3`] at line 39
+     #
+ 36: $t30 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t29)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t30
+     # refs: [$t30 => #30]
+     # #30
+     #   <no edges>
+     # #root
+     #   => #30 via [local `s3`, field `x`] at line 39
+     #
+ 37: $t28 := read_ref($t30)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28
+     # refs: []
+     #
+ 38: $t32 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28, $t32
+     # refs: [$t32 => #32]
+     # #32
+     #   <no edges>
+     # #root
+     #   => #32 via [local `s1`] at line 39
+     #
+ 39: $t33 := borrow_field<0x42::valid_logic::S1>.z($t32)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28, $t33
+     # refs: [$t33 => #33]
+     # #33
+     #   <no edges>
+     # #root
+     #   => #33 via [local `s1`, field `z`] at line 39
+     #
+ 40: $t31 := read_ref($t33)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t28, $t31
+     # refs: []
+     #
+ 41: $t6 := i128::gt($t28, $t31)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 42: goto 45
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 43: label L7
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 44: $t6 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 45: label L8
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t6
+     # refs: []
+     #
+ 46: if ($t6) goto 47 else goto 56
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 47: label L9
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 48: $t35 := borrow_local($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t35
+     # refs: [$t35 => #35]
+     # #35
+     #   <no edges>
+     # #root
+     #   => #35 via [local `s3`] at line 39
+     #
+ 49: $t36 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t35)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t36
+     # refs: [$t36 => #36]
+     # #36
+     #   <no edges>
+     # #root
+     #   => #36 via [local `s3`, field `x`] at line 39
+     #
+ 50: $t34 := read_ref($t36)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34
+     # refs: []
+     #
+ 51: $t38 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34, $t38
+     # refs: [$t38 => #38]
+     # #38
+     #   <no edges>
+     # #root
+     #   => #38 via [local `s2`] at line 39
+     #
+ 52: $t39 := borrow_field<0x42::valid_logic::S2>.z($t38)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34, $t39
+     # refs: [$t39 => #39]
+     # #39
+     #   <no edges>
+     # #root
+     #   => #39 via [local `s2`, field `z`] at line 39
+     #
+ 53: $t37 := read_ref($t39)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t34, $t37
+     # refs: []
+     #
+ 54: $t5 := i128::lt($t34, $t37)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+ 55: goto 58
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+ 56: label L10
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 57: $t5 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+ 58: label L11
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+ 59: if ($t5) goto 60 else goto 69
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 60: label L12
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 61: $t41 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t41
+     # refs: [$t41 => #41]
+     # #41
+     #   <no edges>
+     # #root
+     #   => #41 via [local `s1`] at line 39
+     #
+ 62: $t42 := borrow_field<0x42::valid_logic::S1>.z($t41)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t42
+     # refs: [$t42 => #42]
+     # #42
+     #   <no edges>
+     # #root
+     #   => #42 via [local `s1`, field `z`] at line 39
+     #
+ 63: $t40 := read_ref($t42)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40
+     # refs: []
+     #
+ 64: $t44 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40, $t44
+     # refs: [$t44 => #44]
+     # #44
+     #   <no edges>
+     # #root
+     #   => #44 via [local `s2`] at line 39
+     #
+ 65: $t45 := borrow_field<0x42::valid_logic::S2>.z($t44)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40, $t45
+     # refs: [$t45 => #45]
+     # #45
+     #   <no edges>
+     # #root
+     #   => #45 via [local `s2`, field `z`] at line 39
+     #
+ 66: $t43 := read_ref($t45)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t40, $t43
+     # refs: []
+     #
+ 67: $t4 := i128::eq($t40, $t43)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+ 68: goto 71
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 69: label L13
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 70: $t4 := false
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+ 71: label L14
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+ 72: if ($t4) goto 73 else goto 82
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 73: label L15
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 74: $t47 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t47
+     # refs: [$t47 => #47]
+     # #47
+     #   <no edges>
+     # #root
+     #   => #47 via [local `s1`] at line 39
+     #
+ 75: $t48 := borrow_field<0x42::valid_logic::S1>.z($t47)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t48
+     # refs: [$t48 => #48]
+     # #48
+     #   <no edges>
+     # #root
+     #   => #48 via [local `s1`, field `z`] at line 39
+     #
+ 76: $t46 := read_ref($t48)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t46
+     # refs: []
+     #
+ 77: $t50 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t46, $t50
+     # refs: [$t50 => #50]
+     # #50
+     #   <no edges>
+     # #root
+     #   => #50 via [local `s2`] at line 39
+     #
+ 78: $t51 := borrow_field<0x42::valid_logic::S2>.z($t50)
+     # abort state: {returns,aborts}
+     # live vars: $t46, $t51
+     # refs: [$t51 => #51]
+     # #51
+     #   <no edges>
+     # #root
+     #   => #51 via [local `s2`, field `z`] at line 39
+     #
+ 79: $t49 := read_ref($t51)
+     # abort state: {returns,aborts}
+     # live vars: $t46, $t49
+     # refs: []
+     #
+ 80: $t3 := i128::eq($t46, $t49)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 81: goto 84
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+ 82: label L16
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 83: $t3 := false
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 84: label L17
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: []
+     #
+ 85: return $t3
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t3 := i64::add($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  2: $t6 := infer($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t6
+     # refs: []
+     #
+  3: $t5 := i64::add($t6, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  4: $t2 := i64::eq($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix10($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+  1: $t7 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5, $t7
+     # refs: []
+     #
+  2: $t6 := i128::pack($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5, $t6
+     # refs: []
+     #
+  3: $t4 := i128::mod($t5, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  4: $t3 := i128::mul($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  5: $t10 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10
+     # refs: []
+     #
+  6: $t12 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10, $t12
+     # refs: []
+     #
+  7: $t11 := i128::pack($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10, $t11
+     # refs: []
+     #
+  8: $t9 := i128::mod($t10, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9
+     # refs: []
+     #
+  9: $t8 := i128::mul($t9, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t8
+     # refs: []
+     #
+ 10: $t2 := i128::gt($t3, $t8)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t7 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t7
+     # refs: []
+     #
+  2: $t6 := i128::pack($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t6
+     # refs: []
+     #
+  3: $t5 := i128::mul($t6, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t5
+     # refs: []
+     #
+  4: $t3 := i128::add($t4, $t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  5: $t9 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9
+     # refs: []
+     #
+  6: $t12 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9, $t12
+     # refs: []
+     #
+  7: $t11 := i128::pack($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9, $t11
+     # refs: []
+     #
+  8: $t10 := i128::mul($t11, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t9, $t10
+     # refs: []
+     #
+  9: $t8 := i128::add($t9, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t8
+     # refs: []
+     #
+ 10: $t2 := i128::lte($t3, $t8)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t3 := i64::sub($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  2: $t6 := infer($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t6
+     # refs: []
+     #
+  3: $t5 := i64::sub($t6, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  4: $t2 := i64::eq($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t7 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t7
+     # refs: []
+     #
+  2: $t6 := i128::pack($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t6
+     # refs: []
+     #
+  3: $t5 := i128::mul($t6, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4, $t5
+     # refs: []
+     #
+  4: $t3 := i128::sub($t4, $t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  5: $t9 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9
+     # refs: []
+     #
+  6: $t12 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9, $t12
+     # refs: []
+     #
+  7: $t11 := i128::pack($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9, $t11
+     # refs: []
+     #
+  8: $t10 := i128::mul($t11, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t9, $t10
+     # refs: []
+     #
+  9: $t8 := i128::sub($t9, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t8
+     # refs: []
+     #
+ 10: $t2 := i128::gt($t3, $t8)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix5($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t3 := i64::mul($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  2: $t6 := infer($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t6
+     # refs: []
+     #
+  3: $t5 := i64::mul($t6, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  4: $t2 := i64::eq($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix6($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+  1: $t7 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5, $t7
+     # refs: []
+     #
+  2: $t6 := i128::pack($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5, $t6
+     # refs: []
+     #
+  3: $t4 := i128::mul($t5, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  4: $t3 := i128::mul($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  5: $t10 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10
+     # refs: []
+     #
+  6: $t12 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10, $t12
+     # refs: []
+     #
+  7: $t11 := i128::pack($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10, $t11
+     # refs: []
+     #
+  8: $t9 := i128::mul($t10, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9
+     # refs: []
+     #
+  9: $t8 := i128::mul($t9, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t8
+     # refs: []
+     #
+ 10: $t2 := i128::gt($t3, $t8)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix7($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t3 := i64::div($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  2: $t6 := infer($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t6
+     # refs: []
+     #
+  3: $t5 := i64::div($t6, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  4: $t2 := i64::eq($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix8($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: []
+     #
+  1: $t7 := 2
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5, $t7
+     # refs: []
+     #
+  2: $t6 := i128::pack($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5, $t6
+     # refs: []
+     #
+  3: $t4 := i128::div($t5, $t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  4: $t3 := i128::mul($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  5: $t10 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10
+     # refs: []
+     #
+  6: $t12 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10, $t12
+     # refs: []
+     #
+  7: $t11 := i128::pack($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t10, $t11
+     # refs: []
+     #
+  8: $t9 := i128::div($t10, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t9
+     # refs: []
+     #
+  9: $t8 := i128::mul($t9, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t8
+     # refs: []
+     #
+ 10: $t2 := i128::gt($t3, $t8)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix9($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: []
+     #
+  1: $t3 := i64::mod($t4, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  2: $t6 := infer($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t6
+     # refs: []
+     #
+  3: $t5 := i64::mod($t6, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  4: $t2 := i64::eq($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  5: return $t2
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::valid_logic {
+    enum E1 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i64::I64>,
+        }
+    }
+    enum E2 {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<0x1::i128::I128>,
+        }
+    }
+    enum E3<T> {
+        V1 {
+            s: S1,
+        }
+        V2 {
+            s: S2,
+        }
+        V3 {
+            s: S3<T>,
+        }
+    }
+    struct S1 {
+        x: u64,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S2 {
+        x: S1,
+        y: 0x1::i64::I64,
+        z: 0x1::i128::I128,
+    }
+    struct S3<T> {
+        x: T,
+        y: S1,
+        z: S2,
+    }
+    private fun test_cmp1(x: 0x1::i64::I64): bool {
+        And(And(And(And(And(And(i64::eq(x, x), i64::gte(x, x)), i64::lte(x, x)), i64::gt(x, x)), i64::lt(x, x)), i64::eq(x, x)), i64::gte(x, x))
+    }
+    private fun test_cmp2(x: 0x1::i128::I128): bool {
+        And(And(And(And(And(And(i128::eq(x, x), i128::gte(x, x)), i128::lte(x, x)), i128::gt(x, x)), i128::lt(x, x)), i128::eq(x, x)), i128::gte(x, x))
+    }
+    private fun test_cmp3(s1: S1,s2: S2,s3: S3<0x1::i64::I64>): bool {
+        And(And(And(And(And(And(i64::eq(select valid_logic::S1.y<S1>(s1), select valid_logic::S2.y<S2>(s2)), i64::lte(select valid_logic::S1.y<S1>(s1), select valid_logic::S3.x<S3<0x1::i64::I64>>(s3))), i64::gte(select valid_logic::S2.y<S2>(s2), select valid_logic::S3.x<S3<0x1::i64::I64>>(s3))), i64::gt(select valid_logic::S3.x<S3<0x1::i64::I64>>(s3), select valid_logic::S1.y<S1>(s1))), i64::lt(select valid_logic::S3.x<S3<0x1::i64::I64>>(s3), select valid_logic::S2.y<S2>(s2))), i64::eq(select valid_logic::S1.y<S1>(s1), select valid_logic::S2.y<S2>(s2))), i64::eq(select valid_logic::S1.y<S1>(s1), select valid_logic::S2.y<S2>(s2)))
+    }
+    private fun test_cmp4(s1: S1,s2: S2,s3: S3<0x1::i128::I128>): bool {
+        And(And(And(And(And(And(i128::eq(select valid_logic::S1.z<S1>(s1), select valid_logic::S2.z<S2>(s2)), i128::lte(select valid_logic::S1.z<S1>(s1), select valid_logic::S3.x<S3<0x1::i128::I128>>(s3))), i128::gte(select valid_logic::S2.z<S2>(s2), select valid_logic::S3.x<S3<0x1::i128::I128>>(s3))), i128::gt(select valid_logic::S3.x<S3<0x1::i128::I128>>(s3), select valid_logic::S1.z<S1>(s1))), i128::lt(select valid_logic::S3.x<S3<0x1::i128::I128>>(s3), select valid_logic::S2.z<S2>(s2))), i128::eq(select valid_logic::S1.z<S1>(s1), select valid_logic::S2.z<S2>(s2))), i128::eq(select valid_logic::S1.z<S1>(s1), select valid_logic::S2.z<S2>(s2)))
+    }
+    private fun test_mix1(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::add(x, y), i64::add(y, x))
+    }
+    private fun test_mix10(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::mul(i128::mod(x, i128::pack(2)), y), i128::mul(i128::mod(x, i128::pack(3)), y))
+    }
+    private fun test_mix2(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::lte(i128::add(x, i128::mul(i128::pack(2), y)), i128::add(x, i128::mul(i128::pack(3), y)))
+    }
+    private fun test_mix3(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::sub(x, y), i64::sub(y, x))
+    }
+    private fun test_mix4(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::sub(x, i128::mul(i128::pack(2), y)), i128::sub(x, i128::mul(i128::pack(3), y)))
+    }
+    private fun test_mix5(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::mul(x, y), i64::mul(y, x))
+    }
+    private fun test_mix6(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::mul(i128::mul(x, i128::pack(2)), y), i128::mul(i128::mul(x, i128::pack(3)), y))
+    }
+    private fun test_mix7(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::div(x, y), i64::div(y, x))
+    }
+    private fun test_mix8(x: 0x1::i128::I128,y: 0x1::i128::I128): bool {
+        i128::gt(i128::mul(i128::div(x, i128::pack(2)), y), i128::mul(i128::div(x, i128::pack(3)), y))
+    }
+    private fun test_mix9(x: 0x1::i64::I64,y: 0x1::i64::I64): bool {
+        i64::eq(i64::mod(x, y), i64::mod(y, x))
+    }
+} // end 0x42::valid_logic
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun valid_logic::test_cmp1($t0: 0x1::i64::I64): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64
+     var $t10: 0x1::i64::I64
+     var $t11: 0x1::i64::I64
+     var $t12: 0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: 0x1::i64::I64
+  0: $t8 := infer($t0)
+  1: $t7 := i64::eq($t8, $t0)
+  2: if ($t7) goto 3 else goto 7
+  3: label L0
+  4: $t9 := infer($t0)
+  5: $t6 := i64::gte($t9, $t0)
+  6: goto 9
+  7: label L1
+  8: $t6 := false
+  9: label L2
+ 10: if ($t6) goto 11 else goto 15
+ 11: label L3
+ 12: $t10 := infer($t0)
+ 13: $t5 := i64::lte($t10, $t0)
+ 14: goto 17
+ 15: label L4
+ 16: $t5 := false
+ 17: label L5
+ 18: if ($t5) goto 19 else goto 23
+ 19: label L6
+ 20: $t11 := infer($t0)
+ 21: $t4 := i64::gt($t11, $t0)
+ 22: goto 25
+ 23: label L7
+ 24: $t4 := false
+ 25: label L8
+ 26: if ($t4) goto 27 else goto 31
+ 27: label L9
+ 28: $t12 := infer($t0)
+ 29: $t3 := i64::lt($t12, $t0)
+ 30: goto 33
+ 31: label L10
+ 32: $t3 := false
+ 33: label L11
+ 34: if ($t3) goto 35 else goto 39
+ 35: label L12
+ 36: $t13 := infer($t0)
+ 37: $t2 := i64::eq($t13, $t0)
+ 38: goto 41
+ 39: label L13
+ 40: $t2 := false
+ 41: label L14
+ 42: if ($t2) goto 43 else goto 47
+ 43: label L15
+ 44: $t14 := infer($t0)
+ 45: $t1 := i64::gte($t14, $t0)
+ 46: goto 49
+ 47: label L16
+ 48: $t1 := false
+ 49: label L17
+ 50: return $t1
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp2($t0: 0x1::i128::I128): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: 0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: 0x1::i128::I128
+  0: $t8 := infer($t0)
+  1: $t7 := i128::eq($t8, $t0)
+  2: if ($t7) goto 3 else goto 7
+  3: label L0
+  4: $t9 := infer($t0)
+  5: $t6 := i128::gte($t9, $t0)
+  6: goto 9
+  7: label L1
+  8: $t6 := false
+  9: label L2
+ 10: if ($t6) goto 11 else goto 15
+ 11: label L3
+ 12: $t10 := infer($t0)
+ 13: $t5 := i128::lte($t10, $t0)
+ 14: goto 17
+ 15: label L4
+ 16: $t5 := false
+ 17: label L5
+ 18: if ($t5) goto 19 else goto 23
+ 19: label L6
+ 20: $t11 := infer($t0)
+ 21: $t4 := i128::gt($t11, $t0)
+ 22: goto 25
+ 23: label L7
+ 24: $t4 := false
+ 25: label L8
+ 26: if ($t4) goto 27 else goto 31
+ 27: label L9
+ 28: $t12 := infer($t0)
+ 29: $t3 := i128::lt($t12, $t0)
+ 30: goto 33
+ 31: label L10
+ 32: $t3 := false
+ 33: label L11
+ 34: if ($t3) goto 35 else goto 39
+ 35: label L12
+ 36: $t13 := infer($t0)
+ 37: $t2 := i128::eq($t13, $t0)
+ 38: goto 41
+ 39: label L13
+ 40: $t2 := false
+ 41: label L14
+ 42: if ($t2) goto 43 else goto 47
+ 43: label L15
+ 44: $t14 := infer($t0)
+ 45: $t1 := i128::gte($t14, $t0)
+ 46: goto 49
+ 47: label L16
+ 48: $t1 := false
+ 49: label L17
+ 50: return $t1
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp3($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i64::I64>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: 0x1::i64::I64
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i64::I64
+     var $t16: 0x1::i64::I64
+     var $t17: &0x42::valid_logic::S1
+     var $t18: &0x1::i64::I64
+     var $t19: 0x1::i64::I64
+     var $t20: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t21: &0x1::i64::I64
+     var $t22: 0x1::i64::I64
+     var $t23: &0x42::valid_logic::S2
+     var $t24: &0x1::i64::I64
+     var $t25: 0x1::i64::I64
+     var $t26: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t27: &0x1::i64::I64
+     var $t28: 0x1::i64::I64
+     var $t29: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t30: &0x1::i64::I64
+     var $t31: 0x1::i64::I64
+     var $t32: &0x42::valid_logic::S1
+     var $t33: &0x1::i64::I64
+     var $t34: 0x1::i64::I64
+     var $t35: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t36: &0x1::i64::I64
+     var $t37: 0x1::i64::I64
+     var $t38: &0x42::valid_logic::S2
+     var $t39: &0x1::i64::I64
+     var $t40: 0x1::i64::I64
+     var $t41: &0x42::valid_logic::S1
+     var $t42: &0x1::i64::I64
+     var $t43: 0x1::i64::I64
+     var $t44: &0x42::valid_logic::S2
+     var $t45: &0x1::i64::I64
+     var $t46: 0x1::i64::I64
+     var $t47: &0x42::valid_logic::S1
+     var $t48: &0x1::i64::I64
+     var $t49: 0x1::i64::I64
+     var $t50: &0x42::valid_logic::S2
+     var $t51: &0x1::i64::I64
+  0: $t11 := borrow_local($t0)
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+  2: $t10 := read_ref($t12)
+  3: $t14 := borrow_local($t1)
+  4: $t15 := borrow_field<0x42::valid_logic::S2>.y($t14)
+  5: $t13 := read_ref($t15)
+  6: $t9 := i64::eq($t10, $t13)
+  7: if ($t9) goto 8 else goto 17
+  8: label L0
+  9: $t17 := borrow_local($t0)
+ 10: $t18 := borrow_field<0x42::valid_logic::S1>.y($t17)
+ 11: $t16 := read_ref($t18)
+ 12: $t20 := borrow_local($t2)
+ 13: $t21 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t20)
+ 14: $t19 := read_ref($t21)
+ 15: $t8 := i64::lte($t16, $t19)
+ 16: goto 19
+ 17: label L1
+ 18: $t8 := false
+ 19: label L2
+ 20: if ($t8) goto 21 else goto 30
+ 21: label L3
+ 22: $t23 := borrow_local($t1)
+ 23: $t24 := borrow_field<0x42::valid_logic::S2>.y($t23)
+ 24: $t22 := read_ref($t24)
+ 25: $t26 := borrow_local($t2)
+ 26: $t27 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t26)
+ 27: $t25 := read_ref($t27)
+ 28: $t7 := i64::gte($t22, $t25)
+ 29: goto 32
+ 30: label L4
+ 31: $t7 := false
+ 32: label L5
+ 33: if ($t7) goto 34 else goto 43
+ 34: label L6
+ 35: $t29 := borrow_local($t2)
+ 36: $t30 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t29)
+ 37: $t28 := read_ref($t30)
+ 38: $t32 := borrow_local($t0)
+ 39: $t33 := borrow_field<0x42::valid_logic::S1>.y($t32)
+ 40: $t31 := read_ref($t33)
+ 41: $t6 := i64::gt($t28, $t31)
+ 42: goto 45
+ 43: label L7
+ 44: $t6 := false
+ 45: label L8
+ 46: if ($t6) goto 47 else goto 56
+ 47: label L9
+ 48: $t35 := borrow_local($t2)
+ 49: $t36 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t35)
+ 50: $t34 := read_ref($t36)
+ 51: $t38 := borrow_local($t1)
+ 52: $t39 := borrow_field<0x42::valid_logic::S2>.y($t38)
+ 53: $t37 := read_ref($t39)
+ 54: $t5 := i64::lt($t34, $t37)
+ 55: goto 58
+ 56: label L10
+ 57: $t5 := false
+ 58: label L11
+ 59: if ($t5) goto 60 else goto 69
+ 60: label L12
+ 61: $t41 := borrow_local($t0)
+ 62: $t42 := borrow_field<0x42::valid_logic::S1>.y($t41)
+ 63: $t40 := read_ref($t42)
+ 64: $t44 := borrow_local($t1)
+ 65: $t45 := borrow_field<0x42::valid_logic::S2>.y($t44)
+ 66: $t43 := read_ref($t45)
+ 67: $t4 := i64::eq($t40, $t43)
+ 68: goto 71
+ 69: label L13
+ 70: $t4 := false
+ 71: label L14
+ 72: if ($t4) goto 73 else goto 82
+ 73: label L15
+ 74: $t47 := borrow_local($t0)
+ 75: $t48 := borrow_field<0x42::valid_logic::S1>.y($t47)
+ 76: $t46 := read_ref($t48)
+ 77: $t50 := borrow_local($t1)
+ 78: $t51 := borrow_field<0x42::valid_logic::S2>.y($t50)
+ 79: $t49 := read_ref($t51)
+ 80: $t3 := i64::eq($t46, $t49)
+ 81: goto 84
+ 82: label L16
+ 83: $t3 := false
+ 84: label L17
+ 85: return $t3
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp4($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i128::I128>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool
+     var $t9: bool
+     var $t10: 0x1::i128::I128
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i128::I128
+     var $t16: 0x1::i128::I128
+     var $t17: &0x42::valid_logic::S1
+     var $t18: &0x1::i128::I128
+     var $t19: 0x1::i128::I128
+     var $t20: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t21: &0x1::i128::I128
+     var $t22: 0x1::i128::I128
+     var $t23: &0x42::valid_logic::S2
+     var $t24: &0x1::i128::I128
+     var $t25: 0x1::i128::I128
+     var $t26: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t27: &0x1::i128::I128
+     var $t28: 0x1::i128::I128
+     var $t29: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t30: &0x1::i128::I128
+     var $t31: 0x1::i128::I128
+     var $t32: &0x42::valid_logic::S1
+     var $t33: &0x1::i128::I128
+     var $t34: 0x1::i128::I128
+     var $t35: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t36: &0x1::i128::I128
+     var $t37: 0x1::i128::I128
+     var $t38: &0x42::valid_logic::S2
+     var $t39: &0x1::i128::I128
+     var $t40: 0x1::i128::I128
+     var $t41: &0x42::valid_logic::S1
+     var $t42: &0x1::i128::I128
+     var $t43: 0x1::i128::I128
+     var $t44: &0x42::valid_logic::S2
+     var $t45: &0x1::i128::I128
+     var $t46: 0x1::i128::I128
+     var $t47: &0x42::valid_logic::S1
+     var $t48: &0x1::i128::I128
+     var $t49: 0x1::i128::I128
+     var $t50: &0x42::valid_logic::S2
+     var $t51: &0x1::i128::I128
+  0: $t11 := borrow_local($t0)
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+  2: $t10 := read_ref($t12)
+  3: $t14 := borrow_local($t1)
+  4: $t15 := borrow_field<0x42::valid_logic::S2>.z($t14)
+  5: $t13 := read_ref($t15)
+  6: $t9 := i128::eq($t10, $t13)
+  7: if ($t9) goto 8 else goto 17
+  8: label L0
+  9: $t17 := borrow_local($t0)
+ 10: $t18 := borrow_field<0x42::valid_logic::S1>.z($t17)
+ 11: $t16 := read_ref($t18)
+ 12: $t20 := borrow_local($t2)
+ 13: $t21 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t20)
+ 14: $t19 := read_ref($t21)
+ 15: $t8 := i128::lte($t16, $t19)
+ 16: goto 19
+ 17: label L1
+ 18: $t8 := false
+ 19: label L2
+ 20: if ($t8) goto 21 else goto 30
+ 21: label L3
+ 22: $t23 := borrow_local($t1)
+ 23: $t24 := borrow_field<0x42::valid_logic::S2>.z($t23)
+ 24: $t22 := read_ref($t24)
+ 25: $t26 := borrow_local($t2)
+ 26: $t27 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t26)
+ 27: $t25 := read_ref($t27)
+ 28: $t7 := i128::gte($t22, $t25)
+ 29: goto 32
+ 30: label L4
+ 31: $t7 := false
+ 32: label L5
+ 33: if ($t7) goto 34 else goto 43
+ 34: label L6
+ 35: $t29 := borrow_local($t2)
+ 36: $t30 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t29)
+ 37: $t28 := read_ref($t30)
+ 38: $t32 := borrow_local($t0)
+ 39: $t33 := borrow_field<0x42::valid_logic::S1>.z($t32)
+ 40: $t31 := read_ref($t33)
+ 41: $t6 := i128::gt($t28, $t31)
+ 42: goto 45
+ 43: label L7
+ 44: $t6 := false
+ 45: label L8
+ 46: if ($t6) goto 47 else goto 56
+ 47: label L9
+ 48: $t35 := borrow_local($t2)
+ 49: $t36 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t35)
+ 50: $t34 := read_ref($t36)
+ 51: $t38 := borrow_local($t1)
+ 52: $t39 := borrow_field<0x42::valid_logic::S2>.z($t38)
+ 53: $t37 := read_ref($t39)
+ 54: $t5 := i128::lt($t34, $t37)
+ 55: goto 58
+ 56: label L10
+ 57: $t5 := false
+ 58: label L11
+ 59: if ($t5) goto 60 else goto 69
+ 60: label L12
+ 61: $t41 := borrow_local($t0)
+ 62: $t42 := borrow_field<0x42::valid_logic::S1>.z($t41)
+ 63: $t40 := read_ref($t42)
+ 64: $t44 := borrow_local($t1)
+ 65: $t45 := borrow_field<0x42::valid_logic::S2>.z($t44)
+ 66: $t43 := read_ref($t45)
+ 67: $t4 := i128::eq($t40, $t43)
+ 68: goto 71
+ 69: label L13
+ 70: $t4 := false
+ 71: label L14
+ 72: if ($t4) goto 73 else goto 82
+ 73: label L15
+ 74: $t47 := borrow_local($t0)
+ 75: $t48 := borrow_field<0x42::valid_logic::S1>.z($t47)
+ 76: $t46 := read_ref($t48)
+ 77: $t50 := borrow_local($t1)
+ 78: $t51 := borrow_field<0x42::valid_logic::S2>.z($t50)
+ 79: $t49 := read_ref($t51)
+ 80: $t3 := i128::eq($t46, $t49)
+ 81: goto 84
+ 82: label L16
+ 83: $t3 := false
+ 84: label L17
+ 85: return $t3
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::add($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::add($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix10($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t5 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t4 := i128::mod($t5, $t6)
+  4: $t3 := i128::mul($t4, $t1)
+  5: $t10 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t9 := i128::mod($t10, $t11)
+  9: $t8 := i128::mul($t9, $t1)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t4 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t5 := i128::mul($t6, $t1)
+  4: $t3 := i128::add($t4, $t5)
+  5: $t9 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t10 := i128::mul($t11, $t1)
+  9: $t8 := i128::add($t9, $t10)
+ 10: $t2 := i128::lte($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::sub($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::sub($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t4 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t5 := i128::mul($t6, $t1)
+  4: $t3 := i128::sub($t4, $t5)
+  5: $t9 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t10 := i128::mul($t11, $t1)
+  9: $t8 := i128::sub($t9, $t10)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix5($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::mul($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::mul($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix6($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t5 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t4 := i128::mul($t5, $t6)
+  4: $t3 := i128::mul($t4, $t1)
+  5: $t10 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t9 := i128::mul($t10, $t11)
+  9: $t8 := i128::mul($t9, $t1)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix7($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::div($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::div($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix8($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128
+     var $t10: 0x1::i128::I128
+     var $t11: 0x1::i128::I128
+     var $t12: u128
+  0: $t5 := infer($t0)
+  1: $t7 := 2
+  2: $t6 := i128::pack($t7)
+  3: $t4 := i128::div($t5, $t6)
+  4: $t3 := i128::mul($t4, $t1)
+  5: $t10 := infer($t0)
+  6: $t12 := 3
+  7: $t11 := i128::pack($t12)
+  8: $t9 := i128::div($t10, $t11)
+  9: $t8 := i128::mul($t9, $t1)
+ 10: $t2 := i128::gt($t3, $t8)
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix9($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64
+     var $t6: 0x1::i64::I64
+  0: $t4 := infer($t0)
+  1: $t3 := i64::mod($t4, $t1)
+  2: $t6 := infer($t1)
+  3: $t5 := i64::mod($t6, $t0)
+  4: $t2 := i64::eq($t3, $t5)
+  5: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun valid_logic::test_cmp1($t0: 0x1::i64::I64): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool [unused]
+     var $t7: bool
+     var $t8: 0x1::i64::I64
+     var $t9: 0x1::i64::I64 [unused]
+     var $t10: 0x1::i64::I64 [unused]
+     var $t11: 0x1::i64::I64 [unused]
+     var $t12: 0x1::i64::I64 [unused]
+     var $t13: 0x1::i64::I64 [unused]
+     var $t14: 0x1::i64::I64 [unused]
+     # live vars: $t0
+  0: $t8 := copy($t0)
+     # live vars: $t0, $t8
+  1: $t7 := i64::eq($t8, $t0)
+     # live vars: $t0, $t7
+  2: if ($t7) goto 3 else goto 48
+     # live vars: $t0
+  3: label L0
+     # live vars: $t0
+  4: $t8 := copy($t0)
+     # live vars: $t0, $t8
+  5: $t7 := i64::gte($t8, $t0)
+     # live vars: $t0, $t7
+  6: label L2
+     # live vars: $t0, $t7
+  7: if ($t7) goto 8 else goto 45
+     # live vars: $t0
+  8: label L3
+     # live vars: $t0
+  9: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 10: $t5 := i64::lte($t8, $t0)
+     # live vars: $t0, $t5
+ 11: label L5
+     # live vars: $t0, $t5
+ 12: if ($t5) goto 13 else goto 42
+     # live vars: $t0
+ 13: label L6
+     # live vars: $t0
+ 14: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 15: $t4 := i64::gt($t8, $t0)
+     # live vars: $t0, $t4
+ 16: label L8
+     # live vars: $t0, $t4
+ 17: if ($t4) goto 18 else goto 39
+     # live vars: $t0
+ 18: label L9
+     # live vars: $t0
+ 19: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 20: $t3 := i64::lt($t8, $t0)
+     # live vars: $t0, $t3
+ 21: label L11
+     # live vars: $t0, $t3
+ 22: if ($t3) goto 23 else goto 36
+     # live vars: $t0
+ 23: label L12
+     # live vars: $t0
+ 24: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 25: $t2 := i64::eq($t8, $t0)
+     # live vars: $t0, $t2
+ 26: label L14
+     # live vars: $t0, $t2
+ 27: if ($t2) goto 28 else goto 33
+     # live vars: $t0
+ 28: label L15
+     # live vars: $t0
+ 29: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 30: $t1 := i64::gte($t8, $t0)
+     # live vars: $t1
+ 31: label L17
+     # live vars: $t1
+ 32: return $t1
+     # live vars: $t0
+ 33: label L16
+     # live vars:
+ 34: $t1 := false
+     # live vars: $t1
+ 35: goto 31
+     # live vars: $t0
+ 36: label L13
+     # live vars: $t0
+ 37: $t2 := false
+     # live vars: $t0, $t2
+ 38: goto 26
+     # live vars: $t0
+ 39: label L10
+     # live vars: $t0
+ 40: $t3 := false
+     # live vars: $t0, $t3
+ 41: goto 21
+     # live vars: $t0
+ 42: label L7
+     # live vars: $t0
+ 43: $t4 := false
+     # live vars: $t0, $t4
+ 44: goto 16
+     # live vars: $t0
+ 45: label L4
+     # live vars: $t0
+ 46: $t5 := false
+     # live vars: $t0, $t5
+ 47: goto 11
+     # live vars: $t0
+ 48: label L1
+     # live vars: $t0
+ 49: $t7 := false
+     # live vars: $t0, $t7
+ 50: goto 6
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp2($t0: 0x1::i128::I128): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool [unused]
+     var $t7: bool
+     var $t8: 0x1::i128::I128
+     var $t9: 0x1::i128::I128 [unused]
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: 0x1::i128::I128 [unused]
+     var $t13: 0x1::i128::I128 [unused]
+     var $t14: 0x1::i128::I128 [unused]
+     # live vars: $t0
+  0: $t8 := copy($t0)
+     # live vars: $t0, $t8
+  1: $t7 := i128::eq($t8, $t0)
+     # live vars: $t0, $t7
+  2: if ($t7) goto 3 else goto 48
+     # live vars: $t0
+  3: label L0
+     # live vars: $t0
+  4: $t8 := copy($t0)
+     # live vars: $t0, $t8
+  5: $t7 := i128::gte($t8, $t0)
+     # live vars: $t0, $t7
+  6: label L2
+     # live vars: $t0, $t7
+  7: if ($t7) goto 8 else goto 45
+     # live vars: $t0
+  8: label L3
+     # live vars: $t0
+  9: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 10: $t5 := i128::lte($t8, $t0)
+     # live vars: $t0, $t5
+ 11: label L5
+     # live vars: $t0, $t5
+ 12: if ($t5) goto 13 else goto 42
+     # live vars: $t0
+ 13: label L6
+     # live vars: $t0
+ 14: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 15: $t4 := i128::gt($t8, $t0)
+     # live vars: $t0, $t4
+ 16: label L8
+     # live vars: $t0, $t4
+ 17: if ($t4) goto 18 else goto 39
+     # live vars: $t0
+ 18: label L9
+     # live vars: $t0
+ 19: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 20: $t3 := i128::lt($t8, $t0)
+     # live vars: $t0, $t3
+ 21: label L11
+     # live vars: $t0, $t3
+ 22: if ($t3) goto 23 else goto 36
+     # live vars: $t0
+ 23: label L12
+     # live vars: $t0
+ 24: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 25: $t2 := i128::eq($t8, $t0)
+     # live vars: $t0, $t2
+ 26: label L14
+     # live vars: $t0, $t2
+ 27: if ($t2) goto 28 else goto 33
+     # live vars: $t0
+ 28: label L15
+     # live vars: $t0
+ 29: $t8 := copy($t0)
+     # live vars: $t0, $t8
+ 30: $t1 := i128::gte($t8, $t0)
+     # live vars: $t1
+ 31: label L17
+     # live vars: $t1
+ 32: return $t1
+     # live vars: $t0
+ 33: label L16
+     # live vars:
+ 34: $t1 := false
+     # live vars: $t1
+ 35: goto 31
+     # live vars: $t0
+ 36: label L13
+     # live vars: $t0
+ 37: $t2 := false
+     # live vars: $t0, $t2
+ 38: goto 26
+     # live vars: $t0
+ 39: label L10
+     # live vars: $t0
+ 40: $t3 := false
+     # live vars: $t0, $t3
+ 41: goto 21
+     # live vars: $t0
+ 42: label L7
+     # live vars: $t0
+ 43: $t4 := false
+     # live vars: $t0, $t4
+ 44: goto 16
+     # live vars: $t0
+ 45: label L4
+     # live vars: $t0
+ 46: $t5 := false
+     # live vars: $t0, $t5
+ 47: goto 11
+     # live vars: $t0
+ 48: label L1
+     # live vars: $t0
+ 49: $t7 := false
+     # live vars: $t0, $t7
+ 50: goto 6
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp3($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i64::I64>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool [unused]
+     var $t9: bool
+     var $t10: 0x1::i64::I64
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i64::I64
+     var $t13: 0x1::i64::I64
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i64::I64 [unused]
+     var $t16: 0x1::i64::I64 [unused]
+     var $t17: &0x42::valid_logic::S1 [unused]
+     var $t18: &0x1::i64::I64 [unused]
+     var $t19: 0x1::i64::I64 [unused]
+     var $t20: &0x42::valid_logic::S3<0x1::i64::I64>
+     var $t21: &0x1::i64::I64 [unused]
+     var $t22: 0x1::i64::I64 [unused]
+     var $t23: &0x42::valid_logic::S2 [unused]
+     var $t24: &0x1::i64::I64 [unused]
+     var $t25: 0x1::i64::I64 [unused]
+     var $t26: &0x42::valid_logic::S3<0x1::i64::I64> [unused]
+     var $t27: &0x1::i64::I64 [unused]
+     var $t28: 0x1::i64::I64 [unused]
+     var $t29: &0x42::valid_logic::S3<0x1::i64::I64> [unused]
+     var $t30: &0x1::i64::I64 [unused]
+     var $t31: 0x1::i64::I64 [unused]
+     var $t32: &0x42::valid_logic::S1 [unused]
+     var $t33: &0x1::i64::I64 [unused]
+     var $t34: 0x1::i64::I64 [unused]
+     var $t35: &0x42::valid_logic::S3<0x1::i64::I64> [unused]
+     var $t36: &0x1::i64::I64 [unused]
+     var $t37: 0x1::i64::I64 [unused]
+     var $t38: &0x42::valid_logic::S2 [unused]
+     var $t39: &0x1::i64::I64 [unused]
+     var $t40: 0x1::i64::I64 [unused]
+     var $t41: &0x42::valid_logic::S1 [unused]
+     var $t42: &0x1::i64::I64 [unused]
+     var $t43: 0x1::i64::I64 [unused]
+     var $t44: &0x42::valid_logic::S2 [unused]
+     var $t45: &0x1::i64::I64 [unused]
+     var $t46: 0x1::i64::I64 [unused]
+     var $t47: &0x42::valid_logic::S1 [unused]
+     var $t48: &0x1::i64::I64 [unused]
+     var $t49: 0x1::i64::I64 [unused]
+     var $t50: &0x42::valid_logic::S2 [unused]
+     var $t51: &0x1::i64::I64 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t11
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+     # live vars: $t0, $t1, $t2, $t12
+  2: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+  3: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t2, $t10, $t14
+  4: $t12 := borrow_field<0x42::valid_logic::S2>.y($t14)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+  5: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+  6: $t9 := i64::eq($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t9
+  7: if ($t9) goto 8 else goto 83
+     # live vars: $t0, $t1, $t2
+  8: label L0
+     # live vars: $t0, $t1, $t2
+  9: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t11
+ 10: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+     # live vars: $t0, $t1, $t2, $t12
+ 11: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+ 12: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t10, $t20
+ 13: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t20)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+ 14: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+ 15: $t9 := i64::lte($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t9
+ 16: label L2
+     # live vars: $t0, $t1, $t2, $t9
+ 17: if ($t9) goto 18 else goto 80
+     # live vars: $t0, $t1, $t2
+ 18: label L3
+     # live vars: $t0, $t1, $t2
+ 19: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t2, $t14
+ 20: $t12 := borrow_field<0x42::valid_logic::S2>.y($t14)
+     # live vars: $t0, $t1, $t2, $t12
+ 21: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+ 22: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t10, $t20
+ 23: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t20)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+ 24: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+ 25: $t7 := i64::gte($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t7
+ 26: label L5
+     # live vars: $t0, $t1, $t2, $t7
+ 27: if ($t7) goto 28 else goto 77
+     # live vars: $t0, $t1, $t2
+ 28: label L6
+     # live vars: $t0, $t1, $t2
+ 29: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t20
+ 30: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t20)
+     # live vars: $t0, $t1, $t2, $t12
+ 31: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+ 32: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t10, $t11
+ 33: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+ 34: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+ 35: $t6 := i64::gt($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t6
+ 36: label L8
+     # live vars: $t0, $t1, $t2, $t6
+ 37: if ($t6) goto 38 else goto 74
+     # live vars: $t0, $t1, $t2
+ 38: label L9
+     # live vars: $t0, $t1, $t2
+ 39: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t20
+ 40: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i64::I64>>.x($t20)
+     # live vars: $t0, $t1, $t12
+ 41: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t10
+ 42: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t10, $t14
+ 43: $t12 := borrow_field<0x42::valid_logic::S2>.y($t14)
+     # live vars: $t0, $t1, $t10, $t12
+ 44: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t10, $t13
+ 45: $t5 := i64::lt($t10, $t13)
+     # live vars: $t0, $t1, $t5
+ 46: label L11
+     # live vars: $t0, $t1, $t5
+ 47: if ($t5) goto 48 else goto 71
+     # live vars: $t0, $t1
+ 48: label L12
+     # live vars: $t0, $t1
+ 49: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t11
+ 50: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+     # live vars: $t0, $t1, $t12
+ 51: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t10
+ 52: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t10, $t14
+ 53: $t12 := borrow_field<0x42::valid_logic::S2>.y($t14)
+     # live vars: $t0, $t1, $t10, $t12
+ 54: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t10, $t13
+ 55: $t4 := i64::eq($t10, $t13)
+     # live vars: $t0, $t1, $t4
+ 56: label L14
+     # live vars: $t0, $t1, $t4
+ 57: if ($t4) goto 58 else goto 68
+     # live vars: $t0, $t1
+ 58: label L15
+     # live vars: $t0, $t1
+ 59: $t11 := borrow_local($t0)
+     # live vars: $t1, $t11
+ 60: $t12 := borrow_field<0x42::valid_logic::S1>.y($t11)
+     # live vars: $t1, $t12
+ 61: $t10 := read_ref($t12)
+     # live vars: $t1, $t10
+ 62: $t14 := borrow_local($t1)
+     # live vars: $t10, $t14
+ 63: $t12 := borrow_field<0x42::valid_logic::S2>.y($t14)
+     # live vars: $t10, $t12
+ 64: $t13 := read_ref($t12)
+     # live vars: $t10, $t13
+ 65: $t3 := i64::eq($t10, $t13)
+     # live vars: $t3
+ 66: label L17
+     # live vars: $t3
+ 67: return $t3
+     # live vars: $t0, $t1
+ 68: label L16
+     # live vars:
+ 69: $t3 := false
+     # live vars: $t3
+ 70: goto 66
+     # live vars: $t0, $t1
+ 71: label L13
+     # live vars: $t0, $t1
+ 72: $t4 := false
+     # live vars: $t0, $t1, $t4
+ 73: goto 56
+     # live vars: $t0, $t1, $t2
+ 74: label L10
+     # live vars: $t0, $t1
+ 75: $t5 := false
+     # live vars: $t0, $t1, $t5
+ 76: goto 46
+     # live vars: $t0, $t1, $t2
+ 77: label L7
+     # live vars: $t0, $t1, $t2
+ 78: $t6 := false
+     # live vars: $t0, $t1, $t2, $t6
+ 79: goto 36
+     # live vars: $t0, $t1, $t2
+ 80: label L4
+     # live vars: $t0, $t1, $t2
+ 81: $t7 := false
+     # live vars: $t0, $t1, $t2, $t7
+ 82: goto 26
+     # live vars: $t0, $t1, $t2
+ 83: label L1
+     # live vars: $t0, $t1, $t2
+ 84: $t9 := false
+     # live vars: $t0, $t1, $t2, $t9
+ 85: goto 16
+}
+
+
+[variant baseline]
+fun valid_logic::test_cmp4($t0: 0x42::valid_logic::S1, $t1: 0x42::valid_logic::S2, $t2: 0x42::valid_logic::S3<0x1::i128::I128>): bool {
+     var $t3: bool
+     var $t4: bool
+     var $t5: bool
+     var $t6: bool
+     var $t7: bool
+     var $t8: bool [unused]
+     var $t9: bool
+     var $t10: 0x1::i128::I128
+     var $t11: &0x42::valid_logic::S1
+     var $t12: &0x1::i128::I128
+     var $t13: 0x1::i128::I128
+     var $t14: &0x42::valid_logic::S2
+     var $t15: &0x1::i128::I128 [unused]
+     var $t16: 0x1::i128::I128 [unused]
+     var $t17: &0x42::valid_logic::S1 [unused]
+     var $t18: &0x1::i128::I128 [unused]
+     var $t19: 0x1::i128::I128 [unused]
+     var $t20: &0x42::valid_logic::S3<0x1::i128::I128>
+     var $t21: &0x1::i128::I128 [unused]
+     var $t22: 0x1::i128::I128 [unused]
+     var $t23: &0x42::valid_logic::S2 [unused]
+     var $t24: &0x1::i128::I128 [unused]
+     var $t25: 0x1::i128::I128 [unused]
+     var $t26: &0x42::valid_logic::S3<0x1::i128::I128> [unused]
+     var $t27: &0x1::i128::I128 [unused]
+     var $t28: 0x1::i128::I128 [unused]
+     var $t29: &0x42::valid_logic::S3<0x1::i128::I128> [unused]
+     var $t30: &0x1::i128::I128 [unused]
+     var $t31: 0x1::i128::I128 [unused]
+     var $t32: &0x42::valid_logic::S1 [unused]
+     var $t33: &0x1::i128::I128 [unused]
+     var $t34: 0x1::i128::I128 [unused]
+     var $t35: &0x42::valid_logic::S3<0x1::i128::I128> [unused]
+     var $t36: &0x1::i128::I128 [unused]
+     var $t37: 0x1::i128::I128 [unused]
+     var $t38: &0x42::valid_logic::S2 [unused]
+     var $t39: &0x1::i128::I128 [unused]
+     var $t40: 0x1::i128::I128 [unused]
+     var $t41: &0x42::valid_logic::S1 [unused]
+     var $t42: &0x1::i128::I128 [unused]
+     var $t43: 0x1::i128::I128 [unused]
+     var $t44: &0x42::valid_logic::S2 [unused]
+     var $t45: &0x1::i128::I128 [unused]
+     var $t46: 0x1::i128::I128 [unused]
+     var $t47: &0x42::valid_logic::S1 [unused]
+     var $t48: &0x1::i128::I128 [unused]
+     var $t49: 0x1::i128::I128 [unused]
+     var $t50: &0x42::valid_logic::S2 [unused]
+     var $t51: &0x1::i128::I128 [unused]
+     # live vars: $t0, $t1, $t2
+  0: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t11
+  1: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+     # live vars: $t0, $t1, $t2, $t12
+  2: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+  3: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t2, $t10, $t14
+  4: $t12 := borrow_field<0x42::valid_logic::S2>.z($t14)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+  5: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+  6: $t9 := i128::eq($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t9
+  7: if ($t9) goto 8 else goto 83
+     # live vars: $t0, $t1, $t2
+  8: label L0
+     # live vars: $t0, $t1, $t2
+  9: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t11
+ 10: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+     # live vars: $t0, $t1, $t2, $t12
+ 11: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+ 12: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t10, $t20
+ 13: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t20)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+ 14: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+ 15: $t9 := i128::lte($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t9
+ 16: label L2
+     # live vars: $t0, $t1, $t2, $t9
+ 17: if ($t9) goto 18 else goto 80
+     # live vars: $t0, $t1, $t2
+ 18: label L3
+     # live vars: $t0, $t1, $t2
+ 19: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t2, $t14
+ 20: $t12 := borrow_field<0x42::valid_logic::S2>.z($t14)
+     # live vars: $t0, $t1, $t2, $t12
+ 21: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+ 22: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t10, $t20
+ 23: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t20)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+ 24: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+ 25: $t7 := i128::gte($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t7
+ 26: label L5
+     # live vars: $t0, $t1, $t2, $t7
+ 27: if ($t7) goto 28 else goto 77
+     # live vars: $t0, $t1, $t2
+ 28: label L6
+     # live vars: $t0, $t1, $t2
+ 29: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t2, $t20
+ 30: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t20)
+     # live vars: $t0, $t1, $t2, $t12
+ 31: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10
+ 32: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t10, $t11
+ 33: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+     # live vars: $t0, $t1, $t2, $t10, $t12
+ 34: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t2, $t10, $t13
+ 35: $t6 := i128::gt($t10, $t13)
+     # live vars: $t0, $t1, $t2, $t6
+ 36: label L8
+     # live vars: $t0, $t1, $t2, $t6
+ 37: if ($t6) goto 38 else goto 74
+     # live vars: $t0, $t1, $t2
+ 38: label L9
+     # live vars: $t0, $t1, $t2
+ 39: $t20 := borrow_local($t2)
+     # live vars: $t0, $t1, $t20
+ 40: $t12 := borrow_field<0x42::valid_logic::S3<0x1::i128::I128>>.x($t20)
+     # live vars: $t0, $t1, $t12
+ 41: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t10
+ 42: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t10, $t14
+ 43: $t12 := borrow_field<0x42::valid_logic::S2>.z($t14)
+     # live vars: $t0, $t1, $t10, $t12
+ 44: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t10, $t13
+ 45: $t5 := i128::lt($t10, $t13)
+     # live vars: $t0, $t1, $t5
+ 46: label L11
+     # live vars: $t0, $t1, $t5
+ 47: if ($t5) goto 48 else goto 71
+     # live vars: $t0, $t1
+ 48: label L12
+     # live vars: $t0, $t1
+ 49: $t11 := borrow_local($t0)
+     # live vars: $t0, $t1, $t11
+ 50: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+     # live vars: $t0, $t1, $t12
+ 51: $t10 := read_ref($t12)
+     # live vars: $t0, $t1, $t10
+ 52: $t14 := borrow_local($t1)
+     # live vars: $t0, $t1, $t10, $t14
+ 53: $t12 := borrow_field<0x42::valid_logic::S2>.z($t14)
+     # live vars: $t0, $t1, $t10, $t12
+ 54: $t13 := read_ref($t12)
+     # live vars: $t0, $t1, $t10, $t13
+ 55: $t4 := i128::eq($t10, $t13)
+     # live vars: $t0, $t1, $t4
+ 56: label L14
+     # live vars: $t0, $t1, $t4
+ 57: if ($t4) goto 58 else goto 68
+     # live vars: $t0, $t1
+ 58: label L15
+     # live vars: $t0, $t1
+ 59: $t11 := borrow_local($t0)
+     # live vars: $t1, $t11
+ 60: $t12 := borrow_field<0x42::valid_logic::S1>.z($t11)
+     # live vars: $t1, $t12
+ 61: $t10 := read_ref($t12)
+     # live vars: $t1, $t10
+ 62: $t14 := borrow_local($t1)
+     # live vars: $t10, $t14
+ 63: $t12 := borrow_field<0x42::valid_logic::S2>.z($t14)
+     # live vars: $t10, $t12
+ 64: $t13 := read_ref($t12)
+     # live vars: $t10, $t13
+ 65: $t3 := i128::eq($t10, $t13)
+     # live vars: $t3
+ 66: label L17
+     # live vars: $t3
+ 67: return $t3
+     # live vars: $t0, $t1
+ 68: label L16
+     # live vars:
+ 69: $t3 := false
+     # live vars: $t3
+ 70: goto 66
+     # live vars: $t0, $t1
+ 71: label L13
+     # live vars: $t0, $t1
+ 72: $t4 := false
+     # live vars: $t0, $t1, $t4
+ 73: goto 56
+     # live vars: $t0, $t1, $t2
+ 74: label L10
+     # live vars: $t0, $t1
+ 75: $t5 := false
+     # live vars: $t0, $t1, $t5
+ 76: goto 46
+     # live vars: $t0, $t1, $t2
+ 77: label L7
+     # live vars: $t0, $t1, $t2
+ 78: $t6 := false
+     # live vars: $t0, $t1, $t2, $t6
+ 79: goto 36
+     # live vars: $t0, $t1, $t2
+ 80: label L4
+     # live vars: $t0, $t1, $t2
+ 81: $t7 := false
+     # live vars: $t0, $t1, $t2, $t7
+ 82: goto 26
+     # live vars: $t0, $t1, $t2
+ 83: label L1
+     # live vars: $t0, $t1, $t2
+ 84: $t9 := false
+     # live vars: $t0, $t1, $t2, $t9
+ 85: goto 16
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix1($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t4 := i64::add($t4, $t1)
+     # live vars: $t0, $t1, $t4
+  2: $t1 := move($t1)
+     # live vars: $t0, $t1, $t4
+  3: $t0 := i64::add($t1, $t0)
+     # live vars: $t0, $t4
+  4: $t2 := i64::eq($t4, $t0)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix10($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128 [unused]
+     var $t9: 0x1::i128::I128 [unused]
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: u128 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t7 := 2
+     # live vars: $t0, $t1, $t5, $t7
+  2: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t5, $t6
+  3: $t5 := i128::mod($t5, $t6)
+     # live vars: $t0, $t1, $t5
+  4: $t5 := i128::mul($t5, $t1)
+     # live vars: $t0, $t1, $t5
+  5: $t0 := move($t0)
+     # live vars: $t0, $t1, $t5
+  6: $t7 := 3
+     # live vars: $t0, $t1, $t5, $t7
+  7: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t5, $t6
+  8: $t0 := i128::mod($t0, $t6)
+     # live vars: $t0, $t1, $t5
+  9: $t0 := i128::mul($t0, $t1)
+     # live vars: $t0, $t5
+ 10: $t2 := i128::gt($t5, $t0)
+     # live vars: $t2
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix2($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128 [unused]
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128 [unused]
+     var $t9: 0x1::i128::I128 [unused]
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: u128 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t7 := 2
+     # live vars: $t0, $t1, $t4, $t7
+  2: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t4, $t6
+  3: $t6 := i128::mul($t6, $t1)
+     # live vars: $t0, $t1, $t4, $t6
+  4: $t4 := i128::add($t4, $t6)
+     # live vars: $t0, $t1, $t4
+  5: $t0 := move($t0)
+     # live vars: $t0, $t1, $t4
+  6: $t7 := 3
+     # live vars: $t0, $t1, $t4, $t7
+  7: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t4, $t6
+  8: $t1 := i128::mul($t6, $t1)
+     # live vars: $t0, $t1, $t4
+  9: $t0 := i128::add($t0, $t1)
+     # live vars: $t0, $t4
+ 10: $t2 := i128::lte($t4, $t0)
+     # live vars: $t2
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix3($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t4 := i64::sub($t4, $t1)
+     # live vars: $t0, $t1, $t4
+  2: $t1 := move($t1)
+     # live vars: $t0, $t1, $t4
+  3: $t0 := i64::sub($t1, $t0)
+     # live vars: $t0, $t4
+  4: $t2 := i64::eq($t4, $t0)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix4($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128
+     var $t5: 0x1::i128::I128 [unused]
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128 [unused]
+     var $t9: 0x1::i128::I128 [unused]
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: u128 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t7 := 2
+     # live vars: $t0, $t1, $t4, $t7
+  2: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t4, $t6
+  3: $t6 := i128::mul($t6, $t1)
+     # live vars: $t0, $t1, $t4, $t6
+  4: $t4 := i128::sub($t4, $t6)
+     # live vars: $t0, $t1, $t4
+  5: $t0 := move($t0)
+     # live vars: $t0, $t1, $t4
+  6: $t7 := 3
+     # live vars: $t0, $t1, $t4, $t7
+  7: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t4, $t6
+  8: $t1 := i128::mul($t6, $t1)
+     # live vars: $t0, $t1, $t4
+  9: $t0 := i128::sub($t0, $t1)
+     # live vars: $t0, $t4
+ 10: $t2 := i128::gt($t4, $t0)
+     # live vars: $t2
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix5($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t4 := i64::mul($t4, $t1)
+     # live vars: $t0, $t1, $t4
+  2: $t1 := move($t1)
+     # live vars: $t0, $t1, $t4
+  3: $t0 := i64::mul($t1, $t0)
+     # live vars: $t0, $t4
+  4: $t2 := i64::eq($t4, $t0)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix6($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128 [unused]
+     var $t9: 0x1::i128::I128 [unused]
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: u128 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t7 := 2
+     # live vars: $t0, $t1, $t5, $t7
+  2: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t5, $t6
+  3: $t5 := i128::mul($t5, $t6)
+     # live vars: $t0, $t1, $t5
+  4: $t5 := i128::mul($t5, $t1)
+     # live vars: $t0, $t1, $t5
+  5: $t0 := move($t0)
+     # live vars: $t0, $t1, $t5
+  6: $t7 := 3
+     # live vars: $t0, $t1, $t5, $t7
+  7: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t5, $t6
+  8: $t0 := i128::mul($t0, $t6)
+     # live vars: $t0, $t1, $t5
+  9: $t0 := i128::mul($t0, $t1)
+     # live vars: $t0, $t5
+ 10: $t2 := i128::gt($t5, $t0)
+     # live vars: $t2
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix7($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t4 := i64::div($t4, $t1)
+     # live vars: $t0, $t1, $t4
+  2: $t1 := move($t1)
+     # live vars: $t0, $t1, $t4
+  3: $t0 := i64::div($t1, $t0)
+     # live vars: $t0, $t4
+  4: $t2 := i64::eq($t4, $t0)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix8($t0: 0x1::i128::I128, $t1: 0x1::i128::I128): bool {
+     var $t2: bool
+     var $t3: 0x1::i128::I128 [unused]
+     var $t4: 0x1::i128::I128 [unused]
+     var $t5: 0x1::i128::I128
+     var $t6: 0x1::i128::I128
+     var $t7: u128
+     var $t8: 0x1::i128::I128 [unused]
+     var $t9: 0x1::i128::I128 [unused]
+     var $t10: 0x1::i128::I128 [unused]
+     var $t11: 0x1::i128::I128 [unused]
+     var $t12: u128 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t7 := 2
+     # live vars: $t0, $t1, $t5, $t7
+  2: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t5, $t6
+  3: $t5 := i128::div($t5, $t6)
+     # live vars: $t0, $t1, $t5
+  4: $t5 := i128::mul($t5, $t1)
+     # live vars: $t0, $t1, $t5
+  5: $t0 := move($t0)
+     # live vars: $t0, $t1, $t5
+  6: $t7 := 3
+     # live vars: $t0, $t1, $t5, $t7
+  7: $t6 := i128::pack($t7)
+     # live vars: $t0, $t1, $t5, $t6
+  8: $t0 := i128::div($t0, $t6)
+     # live vars: $t0, $t1, $t5
+  9: $t0 := i128::mul($t0, $t1)
+     # live vars: $t0, $t5
+ 10: $t2 := i128::gt($t5, $t0)
+     # live vars: $t2
+ 11: return $t2
+}
+
+
+[variant baseline]
+fun valid_logic::test_mix9($t0: 0x1::i64::I64, $t1: 0x1::i64::I64): bool {
+     var $t2: bool
+     var $t3: 0x1::i64::I64 [unused]
+     var $t4: 0x1::i64::I64
+     var $t5: 0x1::i64::I64 [unused]
+     var $t6: 0x1::i64::I64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t4
+  1: $t4 := i64::mod($t4, $t1)
+     # live vars: $t0, $t1, $t4
+  2: $t1 := move($t1)
+     # live vars: $t0, $t1, $t4
+  3: $t0 := i64::mod($t1, $t0)
+     # live vars: $t0, $t4
+  4: $t2 := i64::eq($t4, $t0)
+     # live vars: $t2
+  5: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module 42.valid_logic {
+use 0000000000000000000000000000000000000000000000000000000000000001::i64;
+use 0000000000000000000000000000000000000000000000000000000000000001::i128;
+
+
+enum E1 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I64>
+ }
+}
+enum E2 has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<I128>
+ }
+}
+enum E3<T> has copy, drop {
+ V1{
+	s: S1
+ },
+ V2{
+	s: S2
+ },
+ V3{
+	s: S3<T>
+ }
+}
+struct S1 has copy, drop {
+	x: u64,
+	y: I64,
+	z: I128
+}
+struct S2 has copy, drop {
+	x: S1,
+	y: I64,
+	z: I128
+}
+struct S3<T> has copy, drop {
+	x: T,
+	y: S1,
+	z: S2
+}
+
+test_cmp1(x: I64): bool /* def_idx: 0 */ {
+L1:	$t7: bool
+L2:	$t5: bool
+L3:	$t4: bool
+L4:	$t3: bool
+L5:	$t2: bool
+L6:	return: bool
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[0](x: I64)
+	2: Call i64::eq(I64, I64): bool
+	3: BrFalse(55)
+B1:
+	4: CopyLoc[0](x: I64)
+	5: CopyLoc[0](x: I64)
+	6: Call i64::gte(I64, I64): bool
+	7: StLoc[1]($t7: bool)
+B2:
+	8: MoveLoc[1]($t7: bool)
+	9: BrFalse(52)
+B3:
+	10: CopyLoc[0](x: I64)
+	11: CopyLoc[0](x: I64)
+	12: Call i64::lte(I64, I64): bool
+	13: StLoc[2]($t5: bool)
+B4:
+	14: MoveLoc[2]($t5: bool)
+	15: BrFalse(49)
+B5:
+	16: CopyLoc[0](x: I64)
+	17: CopyLoc[0](x: I64)
+	18: Call i64::gt(I64, I64): bool
+	19: StLoc[3]($t4: bool)
+B6:
+	20: MoveLoc[3]($t4: bool)
+	21: BrFalse(46)
+B7:
+	22: CopyLoc[0](x: I64)
+	23: CopyLoc[0](x: I64)
+	24: Call i64::lt(I64, I64): bool
+	25: StLoc[4]($t3: bool)
+B8:
+	26: MoveLoc[4]($t3: bool)
+	27: BrFalse(43)
+B9:
+	28: CopyLoc[0](x: I64)
+	29: CopyLoc[0](x: I64)
+	30: Call i64::eq(I64, I64): bool
+	31: StLoc[5]($t2: bool)
+B10:
+	32: MoveLoc[5]($t2: bool)
+	33: BrFalse(40)
+B11:
+	34: CopyLoc[0](x: I64)
+	35: MoveLoc[0](x: I64)
+	36: Call i64::gte(I64, I64): bool
+	37: StLoc[6](return: bool)
+B12:
+	38: MoveLoc[6](return: bool)
+	39: Ret
+B13:
+	40: LdFalse
+	41: StLoc[6](return: bool)
+	42: Branch(38)
+B14:
+	43: LdFalse
+	44: StLoc[5]($t2: bool)
+	45: Branch(32)
+B15:
+	46: LdFalse
+	47: StLoc[4]($t3: bool)
+	48: Branch(26)
+B16:
+	49: LdFalse
+	50: StLoc[3]($t4: bool)
+	51: Branch(20)
+B17:
+	52: LdFalse
+	53: StLoc[2]($t5: bool)
+	54: Branch(14)
+B18:
+	55: LdFalse
+	56: StLoc[1]($t7: bool)
+	57: Branch(8)
+}
+test_cmp2(x: I128): bool /* def_idx: 1 */ {
+L1:	$t7: bool
+L2:	$t5: bool
+L3:	$t4: bool
+L4:	$t3: bool
+L5:	$t2: bool
+L6:	return: bool
+B0:
+	0: CopyLoc[0](x: I128)
+	1: CopyLoc[0](x: I128)
+	2: Call i128::eq(I128, I128): bool
+	3: BrFalse(55)
+B1:
+	4: CopyLoc[0](x: I128)
+	5: CopyLoc[0](x: I128)
+	6: Call i128::gte(I128, I128): bool
+	7: StLoc[1]($t7: bool)
+B2:
+	8: MoveLoc[1]($t7: bool)
+	9: BrFalse(52)
+B3:
+	10: CopyLoc[0](x: I128)
+	11: CopyLoc[0](x: I128)
+	12: Call i128::lte(I128, I128): bool
+	13: StLoc[2]($t5: bool)
+B4:
+	14: MoveLoc[2]($t5: bool)
+	15: BrFalse(49)
+B5:
+	16: CopyLoc[0](x: I128)
+	17: CopyLoc[0](x: I128)
+	18: Call i128::gt(I128, I128): bool
+	19: StLoc[3]($t4: bool)
+B6:
+	20: MoveLoc[3]($t4: bool)
+	21: BrFalse(46)
+B7:
+	22: CopyLoc[0](x: I128)
+	23: CopyLoc[0](x: I128)
+	24: Call i128::lt(I128, I128): bool
+	25: StLoc[4]($t3: bool)
+B8:
+	26: MoveLoc[4]($t3: bool)
+	27: BrFalse(43)
+B9:
+	28: CopyLoc[0](x: I128)
+	29: CopyLoc[0](x: I128)
+	30: Call i128::eq(I128, I128): bool
+	31: StLoc[5]($t2: bool)
+B10:
+	32: MoveLoc[5]($t2: bool)
+	33: BrFalse(40)
+B11:
+	34: CopyLoc[0](x: I128)
+	35: MoveLoc[0](x: I128)
+	36: Call i128::gte(I128, I128): bool
+	37: StLoc[6](return: bool)
+B12:
+	38: MoveLoc[6](return: bool)
+	39: Ret
+B13:
+	40: LdFalse
+	41: StLoc[6](return: bool)
+	42: Branch(38)
+B14:
+	43: LdFalse
+	44: StLoc[5]($t2: bool)
+	45: Branch(32)
+B15:
+	46: LdFalse
+	47: StLoc[4]($t3: bool)
+	48: Branch(26)
+B16:
+	49: LdFalse
+	50: StLoc[3]($t4: bool)
+	51: Branch(20)
+B17:
+	52: LdFalse
+	53: StLoc[2]($t5: bool)
+	54: Branch(14)
+B18:
+	55: LdFalse
+	56: StLoc[1]($t7: bool)
+	57: Branch(8)
+}
+test_cmp3(s1: S1, s2: S2, s3: S3<I64>): bool /* def_idx: 2 */ {
+L3:	$t9: bool
+L4:	$t7: bool
+L5:	$t6: bool
+L6:	$t5: bool
+L7:	$t4: bool
+L8:	return: bool
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[0](S1.y: I64)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[1](S2.y: I64)
+	5: ReadRef
+	6: Call i64::eq(I64, I64): bool
+	7: BrFalse(83)
+B1:
+	8: ImmBorrowLoc[0](s1: S1)
+	9: ImmBorrowField[0](S1.y: I64)
+	10: ReadRef
+	11: ImmBorrowLoc[2](s3: S3<I64>)
+	12: ImmBorrowFieldGeneric[0](S3.x: T)
+	13: ReadRef
+	14: Call i64::lte(I64, I64): bool
+	15: StLoc[3]($t9: bool)
+B2:
+	16: MoveLoc[3]($t9: bool)
+	17: BrFalse(80)
+B3:
+	18: ImmBorrowLoc[1](s2: S2)
+	19: ImmBorrowField[1](S2.y: I64)
+	20: ReadRef
+	21: ImmBorrowLoc[2](s3: S3<I64>)
+	22: ImmBorrowFieldGeneric[0](S3.x: T)
+	23: ReadRef
+	24: Call i64::gte(I64, I64): bool
+	25: StLoc[4]($t7: bool)
+B4:
+	26: MoveLoc[4]($t7: bool)
+	27: BrFalse(77)
+B5:
+	28: ImmBorrowLoc[2](s3: S3<I64>)
+	29: ImmBorrowFieldGeneric[0](S3.x: T)
+	30: ReadRef
+	31: ImmBorrowLoc[0](s1: S1)
+	32: ImmBorrowField[0](S1.y: I64)
+	33: ReadRef
+	34: Call i64::gt(I64, I64): bool
+	35: StLoc[5]($t6: bool)
+B6:
+	36: MoveLoc[5]($t6: bool)
+	37: BrFalse(74)
+B7:
+	38: ImmBorrowLoc[2](s3: S3<I64>)
+	39: ImmBorrowFieldGeneric[0](S3.x: T)
+	40: ReadRef
+	41: ImmBorrowLoc[1](s2: S2)
+	42: ImmBorrowField[1](S2.y: I64)
+	43: ReadRef
+	44: Call i64::lt(I64, I64): bool
+	45: StLoc[6]($t5: bool)
+B8:
+	46: MoveLoc[6]($t5: bool)
+	47: BrFalse(71)
+B9:
+	48: ImmBorrowLoc[0](s1: S1)
+	49: ImmBorrowField[0](S1.y: I64)
+	50: ReadRef
+	51: ImmBorrowLoc[1](s2: S2)
+	52: ImmBorrowField[1](S2.y: I64)
+	53: ReadRef
+	54: Call i64::eq(I64, I64): bool
+	55: StLoc[7]($t4: bool)
+B10:
+	56: MoveLoc[7]($t4: bool)
+	57: BrFalse(68)
+B11:
+	58: ImmBorrowLoc[0](s1: S1)
+	59: ImmBorrowField[0](S1.y: I64)
+	60: ReadRef
+	61: ImmBorrowLoc[1](s2: S2)
+	62: ImmBorrowField[1](S2.y: I64)
+	63: ReadRef
+	64: Call i64::eq(I64, I64): bool
+	65: StLoc[8](return: bool)
+B12:
+	66: MoveLoc[8](return: bool)
+	67: Ret
+B13:
+	68: LdFalse
+	69: StLoc[8](return: bool)
+	70: Branch(66)
+B14:
+	71: LdFalse
+	72: StLoc[7]($t4: bool)
+	73: Branch(56)
+B15:
+	74: LdFalse
+	75: StLoc[6]($t5: bool)
+	76: Branch(46)
+B16:
+	77: LdFalse
+	78: StLoc[5]($t6: bool)
+	79: Branch(36)
+B17:
+	80: LdFalse
+	81: StLoc[4]($t7: bool)
+	82: Branch(26)
+B18:
+	83: LdFalse
+	84: StLoc[3]($t9: bool)
+	85: Branch(16)
+}
+test_cmp4(s1: S1, s2: S2, s3: S3<I128>): bool /* def_idx: 3 */ {
+L3:	$t9: bool
+L4:	$t7: bool
+L5:	$t6: bool
+L6:	$t5: bool
+L7:	$t4: bool
+L8:	return: bool
+B0:
+	0: ImmBorrowLoc[0](s1: S1)
+	1: ImmBorrowField[3](S1.z: I128)
+	2: ReadRef
+	3: ImmBorrowLoc[1](s2: S2)
+	4: ImmBorrowField[4](S2.z: I128)
+	5: ReadRef
+	6: Call i128::eq(I128, I128): bool
+	7: BrFalse(83)
+B1:
+	8: ImmBorrowLoc[0](s1: S1)
+	9: ImmBorrowField[3](S1.z: I128)
+	10: ReadRef
+	11: ImmBorrowLoc[2](s3: S3<I128>)
+	12: ImmBorrowFieldGeneric[1](S3.x: T)
+	13: ReadRef
+	14: Call i128::lte(I128, I128): bool
+	15: StLoc[3]($t9: bool)
+B2:
+	16: MoveLoc[3]($t9: bool)
+	17: BrFalse(80)
+B3:
+	18: ImmBorrowLoc[1](s2: S2)
+	19: ImmBorrowField[4](S2.z: I128)
+	20: ReadRef
+	21: ImmBorrowLoc[2](s3: S3<I128>)
+	22: ImmBorrowFieldGeneric[1](S3.x: T)
+	23: ReadRef
+	24: Call i128::gte(I128, I128): bool
+	25: StLoc[4]($t7: bool)
+B4:
+	26: MoveLoc[4]($t7: bool)
+	27: BrFalse(77)
+B5:
+	28: ImmBorrowLoc[2](s3: S3<I128>)
+	29: ImmBorrowFieldGeneric[1](S3.x: T)
+	30: ReadRef
+	31: ImmBorrowLoc[0](s1: S1)
+	32: ImmBorrowField[3](S1.z: I128)
+	33: ReadRef
+	34: Call i128::gt(I128, I128): bool
+	35: StLoc[5]($t6: bool)
+B6:
+	36: MoveLoc[5]($t6: bool)
+	37: BrFalse(74)
+B7:
+	38: ImmBorrowLoc[2](s3: S3<I128>)
+	39: ImmBorrowFieldGeneric[1](S3.x: T)
+	40: ReadRef
+	41: ImmBorrowLoc[1](s2: S2)
+	42: ImmBorrowField[4](S2.z: I128)
+	43: ReadRef
+	44: Call i128::lt(I128, I128): bool
+	45: StLoc[6]($t5: bool)
+B8:
+	46: MoveLoc[6]($t5: bool)
+	47: BrFalse(71)
+B9:
+	48: ImmBorrowLoc[0](s1: S1)
+	49: ImmBorrowField[3](S1.z: I128)
+	50: ReadRef
+	51: ImmBorrowLoc[1](s2: S2)
+	52: ImmBorrowField[4](S2.z: I128)
+	53: ReadRef
+	54: Call i128::eq(I128, I128): bool
+	55: StLoc[7]($t4: bool)
+B10:
+	56: MoveLoc[7]($t4: bool)
+	57: BrFalse(68)
+B11:
+	58: ImmBorrowLoc[0](s1: S1)
+	59: ImmBorrowField[3](S1.z: I128)
+	60: ReadRef
+	61: ImmBorrowLoc[1](s2: S2)
+	62: ImmBorrowField[4](S2.z: I128)
+	63: ReadRef
+	64: Call i128::eq(I128, I128): bool
+	65: StLoc[8](return: bool)
+B12:
+	66: MoveLoc[8](return: bool)
+	67: Ret
+B13:
+	68: LdFalse
+	69: StLoc[8](return: bool)
+	70: Branch(66)
+B14:
+	71: LdFalse
+	72: StLoc[7]($t4: bool)
+	73: Branch(56)
+B15:
+	74: LdFalse
+	75: StLoc[6]($t5: bool)
+	76: Branch(46)
+B16:
+	77: LdFalse
+	78: StLoc[5]($t6: bool)
+	79: Branch(36)
+B17:
+	80: LdFalse
+	81: StLoc[4]($t7: bool)
+	82: Branch(26)
+B18:
+	83: LdFalse
+	84: StLoc[3]($t9: bool)
+	85: Branch(16)
+}
+test_mix1(x: I64, y: I64): bool /* def_idx: 4 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[1](y: I64)
+	2: Call i64::add(I64, I64): I64
+	3: MoveLoc[1](y: I64)
+	4: MoveLoc[0](x: I64)
+	5: Call i64::add(I64, I64): I64
+	6: Call i64::eq(I64, I64): bool
+	7: Ret
+}
+test_mix10(x: I128, y: I128): bool /* def_idx: 5 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: LdU128(2)
+	2: Call i128::pack(u128): I128
+	3: Call i128::mod(I128, I128): I128
+	4: CopyLoc[1](y: I128)
+	5: Call i128::mul(I128, I128): I128
+	6: MoveLoc[0](x: I128)
+	7: LdU128(3)
+	8: Call i128::pack(u128): I128
+	9: Call i128::mod(I128, I128): I128
+	10: MoveLoc[1](y: I128)
+	11: Call i128::mul(I128, I128): I128
+	12: Call i128::gt(I128, I128): bool
+	13: Ret
+}
+test_mix2(x: I128, y: I128): bool /* def_idx: 6 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: LdU128(2)
+	2: Call i128::pack(u128): I128
+	3: CopyLoc[1](y: I128)
+	4: Call i128::mul(I128, I128): I128
+	5: Call i128::add(I128, I128): I128
+	6: MoveLoc[0](x: I128)
+	7: LdU128(3)
+	8: Call i128::pack(u128): I128
+	9: MoveLoc[1](y: I128)
+	10: Call i128::mul(I128, I128): I128
+	11: Call i128::add(I128, I128): I128
+	12: Call i128::lte(I128, I128): bool
+	13: Ret
+}
+test_mix3(x: I64, y: I64): bool /* def_idx: 7 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[1](y: I64)
+	2: Call i64::sub(I64, I64): I64
+	3: MoveLoc[1](y: I64)
+	4: MoveLoc[0](x: I64)
+	5: Call i64::sub(I64, I64): I64
+	6: Call i64::eq(I64, I64): bool
+	7: Ret
+}
+test_mix4(x: I128, y: I128): bool /* def_idx: 8 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: LdU128(2)
+	2: Call i128::pack(u128): I128
+	3: CopyLoc[1](y: I128)
+	4: Call i128::mul(I128, I128): I128
+	5: Call i128::sub(I128, I128): I128
+	6: MoveLoc[0](x: I128)
+	7: LdU128(3)
+	8: Call i128::pack(u128): I128
+	9: MoveLoc[1](y: I128)
+	10: Call i128::mul(I128, I128): I128
+	11: Call i128::sub(I128, I128): I128
+	12: Call i128::gt(I128, I128): bool
+	13: Ret
+}
+test_mix5(x: I64, y: I64): bool /* def_idx: 9 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[1](y: I64)
+	2: Call i64::mul(I64, I64): I64
+	3: MoveLoc[1](y: I64)
+	4: MoveLoc[0](x: I64)
+	5: Call i64::mul(I64, I64): I64
+	6: Call i64::eq(I64, I64): bool
+	7: Ret
+}
+test_mix6(x: I128, y: I128): bool /* def_idx: 10 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: LdU128(2)
+	2: Call i128::pack(u128): I128
+	3: Call i128::mul(I128, I128): I128
+	4: CopyLoc[1](y: I128)
+	5: Call i128::mul(I128, I128): I128
+	6: MoveLoc[0](x: I128)
+	7: LdU128(3)
+	8: Call i128::pack(u128): I128
+	9: Call i128::mul(I128, I128): I128
+	10: MoveLoc[1](y: I128)
+	11: Call i128::mul(I128, I128): I128
+	12: Call i128::gt(I128, I128): bool
+	13: Ret
+}
+test_mix7(x: I64, y: I64): bool /* def_idx: 11 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[1](y: I64)
+	2: Call i64::div(I64, I64): I64
+	3: MoveLoc[1](y: I64)
+	4: MoveLoc[0](x: I64)
+	5: Call i64::div(I64, I64): I64
+	6: Call i64::eq(I64, I64): bool
+	7: Ret
+}
+test_mix8(x: I128, y: I128): bool /* def_idx: 12 */ {
+B0:
+	0: CopyLoc[0](x: I128)
+	1: LdU128(2)
+	2: Call i128::pack(u128): I128
+	3: Call i128::div(I128, I128): I128
+	4: CopyLoc[1](y: I128)
+	5: Call i128::mul(I128, I128): I128
+	6: MoveLoc[0](x: I128)
+	7: LdU128(3)
+	8: Call i128::pack(u128): I128
+	9: Call i128::div(I128, I128): I128
+	10: MoveLoc[1](y: I128)
+	11: Call i128::mul(I128, I128): I128
+	12: Call i128::gt(I128, I128): bool
+	13: Ret
+}
+test_mix9(x: I64, y: I64): bool /* def_idx: 13 */ {
+B0:
+	0: CopyLoc[0](x: I64)
+	1: CopyLoc[1](y: I64)
+	2: Call i64::mod(I64, I64): I64
+	3: MoveLoc[1](y: I64)
+	4: MoveLoc[0](x: I64)
+	5: Call i64::mod(I64, I64): I64
+	6: Call i64::eq(I64, I64): bool
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_logic.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_logic.move
@@ -1,0 +1,81 @@
+module 0x42::valid_logic {
+    struct S1  has copy, drop { x: u64, y: i64, z: i128 }
+
+    struct S2 has copy, drop { x: S1, y: i64, z: i128  }
+
+    struct S3<T>  has copy, drop { x: T, y: S1, z: S2 }
+
+    enum E1 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i64>},
+    }
+
+    enum E2 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i128>},
+    }
+
+    enum E3<T> has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<T>},
+    }
+
+    fun test_cmp1(x: i64): bool {
+        x == x && x >= x && x<= x && x > x && x < x && &x == &x && &x >= &x
+    }
+
+    fun test_cmp2(x: i128): bool {
+        x == x && x >= x && x<= x && x > x && x < x && &x == &x && &x >= &x
+    }
+
+    fun test_cmp3(s1: S1, s2: S2, s3: S3<i64>): bool {
+        s1.y == s2.y && s1.y <= s3.x && s2.y >= s3.x && s3.x > s1.y && s3.x < s2.y && &s1.y == &s2.y && &s1.y == &s2.y
+    }
+
+    fun test_cmp4(s1: S1, s2: S2, s3: S3<i128>): bool {
+        s1.z == s2.z && s1.z <= s3.x && s2.z >= s3.x && s3.x > s1.z && s3.x < s2.z && &s1.z == &s2.z && &s1.z == &s2.z
+    }
+
+    fun test_mix1(x: i64, y: i64): bool {
+        x + y == y + x
+    }
+
+    fun test_mix2(x: i128, y: i128): bool {
+        x + 2*y <= x + 3*y
+    }
+
+    fun test_mix3(x: i64, y: i64): bool {
+        x - y == y - x
+    }
+
+    fun test_mix4(x: i128, y: i128): bool {
+        x - 2*y > x -3*y
+    }
+
+    fun test_mix5(x: i64, y: i64): bool {
+        x * y == y * x
+    }
+
+    fun test_mix6(x: i128, y: i128): bool {
+        x * 2*y > x * 3*y
+    }
+
+    fun test_mix7(x: i64, y: i64): bool {
+        x / y == y / x
+    }
+
+    fun test_mix8(x: i128, y: i128): bool {
+        x / 2*y > x / 3*y
+    }
+
+    fun test_mix9(x: i64, y: i64): bool {
+        x % y == y % x
+    }
+
+    fun test_mix10(x: i128, y: i128): bool {
+        x % 2*y > x % 3*y
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_mixed_type.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_mixed_type.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: invalid number literal
+  ┌─ tests/signed-int/valid/valid_mixed_type.move:9:26
+  │
+9 │         let d = i64::abs(-100);
+  │                          ^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_mixed_type.move:13:23
+   │
+13 │         let y : i64 = -10;
+   │                       ^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_mixed_type.move:21:27
+   │
+21 │         let d = i128::abs(-100);
+   │                           ^^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_mixed_type.move:25:24
+   │
+25 │         let y : i128 = -10;
+   │                        ^^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_mixed_type.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_mixed_type.move
@@ -1,0 +1,28 @@
+module 0x42::valid_mixed_type {
+    use std::i64;
+    use std::i128;
+
+    fun test_mix_i64_I64(x: i64): i64 {
+        let a = i64::add(x, x);
+        let b = i64::from(1u64);
+        let c = i64::neg_from(1u64);
+        let d = i64::abs(-100);
+        let e = i64::min(x, x);
+        let f = i64::max(x, x);
+        let g = i64::pow(x, 1);
+        let y : i64 = -10;
+        y + a + b + c + d + e + f + g
+    }
+
+    fun test_mix_i128_I128(x: i128): i128 {
+        let a = i128::add(x, x);
+        let b = i128::from(1u128);
+        let c = i128::neg_from(1u128);
+        let d = i128::abs(-100);
+        let e = i128::min(x, x);
+        let f = i128::max(x, x);
+        let g = i128::pow(x, 1);
+        let y : i128 = -10;
+        y + a + b + c + d + e + f + g
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_ref_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_ref_resource.exp
@@ -1,0 +1,25 @@
+
+Diagnostics:
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_ref_resource.move:41:31
+   │
+41 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_ref_resource.move:41:38
+   │
+41 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_ref_resource.move:48:31
+   │
+48 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_ref_resource.move:48:38
+   │
+48 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_ref_resource.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_ref_resource.move
@@ -1,0 +1,55 @@
+module 0x42::valid_ref_resource {
+    use std::signer;
+
+    struct S1  has copy, drop, key { x: u64, y: i64, z: i128 } // struct with i64 and i128 fields
+
+    fun test_borrow1(a: &i64): &i64 {
+        a
+    }
+
+    fun test_borrow2(a: &i128): &i128 {
+        a
+    }
+
+    fun test_deref1(a: &i64): i64 {
+        *a
+    }
+
+    fun test_deref2(a: &i128): i128 {
+        *a
+    }
+
+    fun test_exist1(addr: address): i64 {
+        if (exists<S1>(addr)) {
+            let s = borrow_global<S1>(addr);
+            s.y
+        } else {
+            1
+        }
+     }
+
+    fun test_exist2(addr: address): i128 {
+        if (exists<S1>(addr)) {
+            let s = borrow_global<S1>(addr);
+            s.z
+        } else {
+            1
+        }
+     }
+
+     fun test_move_to(account: &signer, addr: address) {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        if (!exists<S1>(addr)){
+            move_to<S1>(account, s1)
+        }
+     }
+
+     fun test_move_from(account: &signer, addr: address): i64 {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        if (exists<S1>(addr)){
+            move_from<S1>(signer::address_of(account)).y
+        } else {
+            s1.y
+        }
+     }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_struct.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_struct.exp
@@ -1,0 +1,157 @@
+
+Diagnostics:
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:35:31
+   │
+35 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:35:38
+   │
+35 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:36:32
+   │
+36 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:36:39
+   │
+36 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:37:30
+   │
+37 │         let s3 = S3<i64> {x: -1, y: s1, z: s2};
+   │                              ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:49:31
+   │
+49 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:49:38
+   │
+49 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:50:32
+   │
+50 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:50:39
+   │
+50 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:51:31
+   │
+51 │         let s3 = S3<i128> {x: -1, y: s1, z: s2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:56:31
+   │
+56 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:56:38
+   │
+56 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:62:31
+   │
+62 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:62:38
+   │
+62 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:63:32
+   │
+63 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:63:39
+   │
+63 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:69:31
+   │
+69 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:69:38
+   │
+69 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:70:32
+   │
+70 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:70:39
+   │
+70 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:71:30
+   │
+71 │         let s3 = S3<i64> {x: -1, y: s1, z: s2};
+   │                              ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:77:31
+   │
+77 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:77:38
+   │
+77 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:78:32
+   │
+78 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:78:39
+   │
+78 │         let s2 = S2 {x: s1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_struct.move:79:31
+   │
+79 │         let s3 = S3<i128> {x: -1, y: s1, z: s2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_struct.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_struct.move
@@ -1,0 +1,83 @@
+module 0x42::valid_struct {
+
+    struct S1  has copy, drop { x: u64, y: i64, z: i128 } // struct with i64 and i128 fields
+
+    struct S2 has copy, drop { x: S1, y: i64, z: i128  } // struct with i64 and i128 fields, as well as nested struct involving i64 and i128
+
+    struct S3<T>  has copy, drop { x: T, y: S1, z: S2 } // struct with two layers of nesting, and generic types
+
+    enum E1 has copy, drop { // enum with i64 and nested struct
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i64>},
+    }
+
+    enum E2 has copy, drop { // enum with i128 and nested struct
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i128>},
+    }
+
+    enum E3<T> has copy, drop { // enum with nested struct, and generic types
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<T>},
+    }
+
+    fun test1(a: i64, b: i128): S3<i64> {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i64> {x: a, y: s1, z: s2};
+        s3
+    }
+
+    fun test2(): S3<i64> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let s3 = S3<i64> {x: -1, y: s1, z: s2};
+        s3
+    }
+
+    fun test3(a: i64, b: i128): S3<i128> {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i128> {x: b, y: s1, z: s2};
+        s3
+    }
+
+    fun test4(): S3<i128> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let s3 = S3<i128> {x: -1, y: s1, z: s2};
+        s3
+    }
+
+    fun test5(): E1 {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let e = E1::V1{s: s1};
+        e
+    }
+
+    fun test6(): E2 {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let e = E2::V2{s: s2};
+        e
+    }
+
+    fun test7(): E3<i64> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let s3 = S3<i64> {x: -1, y: s1, z: s2};
+        let e = E3::V3{s: s3};
+        e
+    }
+
+    fun test8(): E3<i128> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: -1, z: -2};
+        let s3 = S3<i128> {x: -1, y: s1, z: s2};
+        let e = E3::V3{s: s3};
+        e
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_vector.exp
@@ -1,0 +1,145 @@
+
+Diagnostics:
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:33:35
+   │
+33 │         vector::push_back(&mut v, -1);
+   │                                   ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:42:35
+   │
+42 │         vector::push_back(&mut v, -1);
+   │                                   ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:48:32
+   │
+48 │         let s11 = S1 {x: 1, y: -1, z: -2};
+   │                                ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:48:39
+   │
+48 │         let s11 = S1 {x: 1, y: -1, z: -2};
+   │                                       ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:56:31
+   │
+56 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:56:38
+   │
+56 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:58:33
+   │
+58 │         let s21 = S2 {x: s1, y: -1, z: -2};
+   │                                 ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:58:40
+   │
+58 │         let s21 = S2 {x: s1, y: -1, z: -2};
+   │                                        ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:66:31
+   │
+66 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:66:38
+   │
+66 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:76:31
+   │
+76 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:76:38
+   │
+76 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:86:31
+   │
+86 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:86:38
+   │
+86 │         let s1 = S1 {x: 1, y: -1, z: -2};
+   │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+   ┌─ tests/signed-int/valid/valid_vector.move:88:30
+   │
+88 │         let s3 = S3<i64> {x: -1, y: s1, z: s2};
+   │                              ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:100:31
+    │
+100 │         let s1 = S1 {x: 1, y: -1, z: -2};
+    │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:100:38
+    │
+100 │         let s1 = S1 {x: 1, y: -1, z: -2};
+    │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:102:31
+    │
+102 │         let s3 = S3<i128> {x: -1, y: s1, z: s2};
+    │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:114:31
+    │
+114 │         let s1 = S1 {x: 1, y: -1, z: -2};
+    │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:114:38
+    │
+114 │         let s1 = S1 {x: 1, y: -1, z: -2};
+    │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:116:30
+    │
+116 │         let s3 = S3<i64> {x: -1, y: s1, z: s2};
+    │                              ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:128:31
+    │
+128 │         let s1 = S1 {x: 1, y: -1, z: -2};
+    │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:128:38
+    │
+128 │         let s1 = S1 {x: 1, y: -1, z: -2};
+    │                                      ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'
+
+error: invalid number literal
+    ┌─ tests/signed-int/valid/valid_vector.move:130:31
+    │
+130 │         let s3 = S3<i128> {x: -1, y: s1, z: s2};
+    │                               ^^ Invalid number literal. The given literal cannot fit into the largest possible integer type, 'u256'

--- a/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_vector.move
+++ b/third_party/move/move-compiler-v2/tests/signed-int/valid/valid_vector.move
@@ -1,0 +1,140 @@
+module 0x42::valid_vector {
+    use std::vector;
+
+    struct S1  has copy, drop { x: u64, y: i64, z: i128 }
+
+    struct S2 has copy, drop { x: S1, y: i64, z: i128  }
+
+    struct S3<T>  has copy, drop { x: T, y: S1, z: S2 }
+
+    enum E1 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i64>},
+    }
+
+    enum E2 has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<i128>},
+    }
+
+    enum E3<T> has copy, drop {
+        V1 {s: S1},
+        V2 {s: S2},
+        V3 {s: S3<T>},
+    }
+
+    fun test1(a: i64): vector<i64> {
+        let v = vector::empty<i64>(); // vector with i64
+        vector::push_back(&mut v, a);
+        vector::push_back(&mut v, a);
+        vector::push_back(&mut v, 1);
+        vector::push_back(&mut v, -1);
+        v
+    }
+
+    fun test2(a: i128): vector<i128> { // vector with i128
+        let v = vector::empty<i128>();
+        vector::push_back(&mut v, a);
+        vector::push_back(&mut v, a);
+        vector::push_back(&mut v, 1);
+        vector::push_back(&mut v, -1);
+        v
+    }
+
+    fun test3(a: i64, b: i128): vector<S1> {
+        let s1 = S1 {x: 1, y: a, z: b};
+        let s11 = S1 {x: 1, y: -1, z: -2};
+        let v = vector::empty<S1>(); // vector with struct involving i64 and i128
+        vector::push_back(&mut v, s1);
+        vector::push_back(&mut v, s11);
+        v
+    }
+
+    fun test4(a: i64, b: i128): vector<S2> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s21 = S2 {x: s1, y: -1, z: -2};
+        let v = vector::empty<S2>(); // vector with struct involving i64 and i128 and nested struct
+        vector::push_back(&mut v, s2);
+        vector::push_back(&mut v, s21);
+        v
+    }
+
+    fun test5(a: i64, b: i128): vector<S3<i64>> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i64> {x: a, y: s1, z: s2};
+        let v = vector::empty<S3<i64>>(); // vector with struct involving i64, i128, nested struct, and generic types
+        vector::push_back(&mut v, s3);
+        vector::push_back(&mut v, s3);
+        v
+    }
+
+    fun test6(a: i64, b: i128): vector<S3<i128>> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i128> {x: b, y: s1, z: s2};
+        let v = vector::empty<S3<i128>>(); // vector with struct involving i64, i128, nested struct, and generic types
+        vector::push_back(&mut v, s3);
+        vector::push_back(&mut v, s3);
+        v
+    }
+
+    fun test7(a: i64, b: i128): vector<E1> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i64> {x: -1, y: s1, z: s2};
+        let e1 = E1::V1{s: s1};
+        let e2 = E1::V2{s: s2};
+        let e3 = E1::V3{s: s3};
+        let v = vector::empty<E1>(); // vector with enums involving i64, i128, and nested struct,
+        vector::push_back(&mut v, e1);
+        vector::push_back(&mut v, e2);
+        vector::push_back(&mut v, e3);
+        v
+    }
+
+    fun test8(a: i64, b: i128): vector<E2> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i128> {x: -1, y: s1, z: s2};
+        let e1 = E2::V1{s: s1};
+        let e2 = E2::V2{s: s2};
+        let e3 = E2::V3{s: s3};
+        let v = vector::empty<E2>(); // vector with enums involving i64, i128, and nested struct,
+        vector::push_back(&mut v, e1);
+        vector::push_back(&mut v, e2);
+        vector::push_back(&mut v, e3);
+        v
+    }
+
+    fun test9(a: i64, b: i128): vector<E3<i64>> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i64> {x: -1, y: s1, z: s2};
+        let e1 = E3::V1{s: s1};
+        let e2 = E3::V2{s: s2};
+        let e3 = E3::V3{s: s3};
+        let v = vector::empty<E3<i64>>(); // vector with enums involving i64, i128, nested struct, and generic types
+        vector::push_back(&mut v, e1);
+        vector::push_back(&mut v, e2);
+        vector::push_back(&mut v, e3);
+        v
+    }
+
+    fun test10(a: i64, b: i128): vector<E3<i128>> {
+        let s1 = S1 {x: 1, y: -1, z: -2};
+        let s2 = S2 {x: s1, y: a, z: b};
+        let s3 = S3<i128> {x: -1, y: s1, z: s2};
+        let e1 = E3::V1{s: s1};
+        let e2 = E3::V2{s: s2};
+        let e3 = E3::V3{s: s3};
+        let v = vector::empty<E3<i128>>(); // vector with enums involving i64, i128, and nested struct, and generic types
+        vector::push_back(&mut v, e1);
+        vector::push_back(&mut v, e2);
+        vector::push_back(&mut v, e3);
+        v
+    }
+}

--- a/third_party/move/move-model/bytecode/src/astifier.rs
+++ b/third_party/move/move-model/bytecode/src/astifier.rs
@@ -2269,6 +2269,7 @@ impl AssignTransformer<'_> {
                 | Operation::Deref
                 | Operation::Not
                 | Operation::Cast
+                | Operation::Neg
                 | Operation::Select(_, _, _)
                 | Operation::SelectVariants(_, _, _)
                 | Operation::TestVariants(_, _, _) => args

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode.rs
@@ -232,6 +232,7 @@ pub enum Operation {
     CastU64,
     CastU128,
     Not,
+    Neg,
 
     // Binary
     Add,
@@ -340,6 +341,7 @@ impl Operation {
             Operation::CastU128 => true,
             Operation::CastU256 => true,
             Operation::Not => false,
+            Operation::Neg => true,
             Operation::Add => true,
             Operation::Sub => true,
             Operation::Mul => true,
@@ -1378,6 +1380,7 @@ impl fmt::Display for OperationDisplay<'_> {
             CastU64 => write!(f, "(u64)")?,
             CastU128 => write!(f, "(u128)")?,
             CastU256 => write!(f, "(u256)")?,
+            Neg => write!(f, "-")?,
             Not => write!(f, "!")?,
 
             // Binary

--- a/third_party/move/move-model/src/ast.rs
+++ b/third_party/move/move-model/src/ast.rs
@@ -1979,6 +1979,7 @@ pub enum Operation {
     // Unary operators
     Not,
     Cast,
+    Neg,
 
     // Builtin functions (impl and spec)
     Exists(Option<MemoryLabel>),
@@ -2721,7 +2722,18 @@ impl Operation {
         use Operation::*;
         matches!(
             self,
-            Tuple | Index | Slice | Range | Implies | Iff | Identical | Not | Cast | Len | Vector
+            Tuple
+                | Index
+                | Slice
+                | Range
+                | Implies
+                | Iff
+                | Identical
+                | Not
+                | Cast
+                | Neg
+                | Len
+                | Vector
         ) || self.is_binop()
     }
 
@@ -2800,6 +2812,7 @@ impl Operation {
             // Unary operators
             Not => true,
             Cast => false, // can overflow
+            Neg => false,  // can overflow
 
             // Builtin functions (impl and spec)
             Exists(..) => false, // Spec

--- a/third_party/move/move-model/src/exp_rewriter.rs
+++ b/third_party/move/move-model/src/exp_rewriter.rs
@@ -5,7 +5,7 @@
 use crate::{
     ast::{
         Condition, Exp, ExpData, LambdaCaptureKind, MatchArm, MemoryLabel, Operation, Pattern,
-        Spec, SpecBlockTarget, TempIndex, Value,
+        QuantKind, Spec, SpecBlockTarget, TempIndex, Value,
     },
     model::{GlobalEnv, Loc, ModuleId, NodeId, SpecVarId},
     symbol::Symbol,
@@ -259,6 +259,7 @@ pub trait ExpRewriterFunctions {
     fn rewrite_quant(
         &mut self,
         id: NodeId,
+        kind: &QuantKind,
         ranges: &[(Pattern, Exp)],
         triggers: &[Vec<Exp>],
         cond: &Option<Exp>,
@@ -443,9 +444,14 @@ pub trait ExpRewriterFunctions {
                 });
                 let (body_changed, new_body) = self.internal_rewrite_exp(body);
                 self.rewrite_exit_scope(new_id);
-                if let Some(new_exp) =
-                    self.rewrite_quant(new_id, &new_ranges, &new_triggers, &new_cond, &new_body)
-                {
+                if let Some(new_exp) = self.rewrite_quant(
+                    new_id,
+                    kind,
+                    &new_ranges,
+                    &new_triggers,
+                    &new_cond,
+                    &new_body,
+                ) {
                     new_exp
                 } else if id_changed
                     || ranges_changed

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -304,6 +304,10 @@ impl LanguageVersion {
             LanguageVersion::V2_3 => "2.3",
         }
     }
+
+    pub const fn signed_int_ver() -> Self {
+        LanguageVersion::V2_3
+    }
 }
 
 impl Display for LanguageVersion {

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -2051,6 +2051,43 @@ impl GlobalEnv {
             .map(|module| module.into_function(fun.id))
     }
 
+    pub fn set_struct_def(
+        &mut self,
+        struct_id: QualifiedId<StructId>,
+        fields: BTreeMap<FieldId, Type>,
+    ) {
+        let data = self
+            .module_data
+            .get_mut(struct_id.module_id.to_usize())
+            .unwrap()
+            .struct_data
+            .get_mut(&struct_id.id)
+            .unwrap();
+        fields.iter().for_each(|(id, ty)| {
+            if let Some(field) = data.field_data.get_mut(id) {
+                field.ty = ty.clone();
+            }
+        });
+    }
+
+    /// Sets the AST based declaration of the function.
+    pub fn set_function_decl(
+        &mut self,
+        fun: QualifiedId<FunId>,
+        params: Vec<Parameter>,
+        ret_type: Type,
+    ) {
+        let data = self
+            .module_data
+            .get_mut(fun.module_id.to_usize())
+            .unwrap()
+            .function_data
+            .get_mut(&fun.id)
+            .unwrap();
+        data.params = params;
+        data.result_type = ret_type;
+    }
+
     /// Sets the AST based definition of the function.
     pub fn set_function_def(&mut self, fun: QualifiedId<FunId>, def: Exp) {
         let data = self

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -1114,6 +1114,10 @@ impl<'a> ExpSourcifier<'a> {
                 let ty = self.env().get_node_type(id);
                 emit!(self.wr(), " as {}", self.ty(&ty))
             }),
+            Operation::Neg => self.parenthesize(context_prio, Prio::Prefix, || {
+                emit!(self.wr(), "-");
+                self.print_exp(Prio::Prefix, false, &args[0])
+            }),
             Operation::Exists(_) => self.parenthesize(context_prio, Prio::Postfix, || {
                 emit!(self.wr(), "exists");
                 self.print_node_inst(id);

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -43,6 +43,14 @@ pub const VECTOR_FUNCS_WITH_BYTECODE_INSTRS: &[&str] = &[
 ];
 
 pub const CMP_MODULE: &str = "cmp";
+pub const I64_MODULE: &str = "i64";
+pub const I128_MODULE: &str = "i128";
+pub const I64_STRUCT: &str = "I64";
+pub const I128_STRUCT: &str = "I128";
+pub const SIGNED_INT_FUNCTIONS: [&str; 15] = [
+    "add", "sub", "mul", "div", "mod", "eq", "neq", "gt", "lt", "gte", "lte", "from", "neg",
+    "pack", "unpack",
+];
 
 pub const TYPE_NAME_MOVE: &str = "type_info::type_name";
 pub const TYPE_NAME_SPEC: &str = "type_info::$type_name";

--- a/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/spec_translator.rs
@@ -27,6 +27,7 @@ use move_model::{
     },
     code_writer::CodeWriter,
     emit, emitln,
+    metadata::LanguageVersion,
     model::{
         FieldId, GlobalEnv, Loc, ModuleEnv, ModuleId, NodeId, Parameter, QualifiedInstId,
         SpecFunId, SpecVarId, StructId,
@@ -1036,6 +1037,7 @@ impl SpecTranslator<'_> {
             // Unary operators
             Operation::Not => self.translate_logical_unary_op("!", args),
             Operation::Cast => self.translate_cast(node_id, args),
+            Operation::Neg => unimplemented!("negation not supported"),
             Operation::Int2Bv => {
                 let exp_arith_flag = global_state.get_node_num_oper(args[0].node_id()) != Bitwise;
                 if exp_arith_flag {

--- a/third_party/move/move-prover/move-abigen/src/abigen.rs
+++ b/third_party/move/move-prover/move-abigen/src/abigen.rs
@@ -17,6 +17,7 @@ use move_core_types::{
 };
 use move_model::{
     ast::Address,
+    metadata::LanguageVersion,
     model::{FunctionEnv, GlobalEnv, ModuleEnv},
     ty,
     ty::ReferenceKind,
@@ -277,6 +278,7 @@ impl<'env> Abigen<'env> {
                     U256 => TypeTag::U256,
                     Address => TypeTag::Address,
                     Signer => TypeTag::Signer,
+                    I64 | I128 => unimplemented!("signed integers not supported"),
                     Num | Range | EventStore => {
                         bail!("Type {:?} is not allowed in scripts.", ty0)
                     },


### PR DESCRIPTION
## Description

This PR introduces compler syntactic sugar for signed integer types `i64` and `i128`. Important notes:
- New model AST types and operation

    - It introduces new model AST types `PrimitiveType::I64` and `PrimitiveType::I128`, and extends `translate_type` to regonize "`i64`" and "`i128`" as their type identifiers. 

    - It enables the built-in operators (`+, -, *, /, %, <, <=, >, >=, ==`) to accept `PrimitiveType::I64` and `PrimitiveType::I128`.

    - It extends the parser to recognize `-` as negation when used as a unary operator. It also introduces a new AST Operation `Neg` to represent it.

- New model AST rewriter:
    - It introduces a new AST rewriter `signed_int_rewriter` to replace all `PrimitiveType::I64` and `PrimitiveType::I128` with their struct-based counterparts `struct I64` and `struct I128` from  the `i64` and `i128` modules in `move-stdlib` (introduced [here](https://github.com/aptos-labs/aptos-core/pull/17569))

    - It also rewrites the built-in operators on those types with calls to corresponding functions from `move-stdlib` (e.g., `i64 + i64` -> `std::i64::add(struct I64, struct I64)`).

    - The rewriting considers all AST items where `PrimitiveType::I64` and `PrimitiveType::I128` can be used, including struct definitions (filed types), Move and spec function declarations (parameter types, return types), Move and spec function bodies as well as spec blocks (AST node types, instantiation types, patterns). 

     - To get alerted on any non-handled `PrimitiveType::I64` and `PrimitiveType::I128`, we explicitly abort the compiler whenever the two types propagate to a later compilation phase.

- Support `i64` and `i128` literals. 

    - It extends the parser to recognize literals like `123456i64` and `0xffffffi64` as valid `Num`, and translates them into newly introduced AST value types `Value_::I64` and `Value_::I128` during expansion phase.

    - It introduces compiler-time checks on the value range of the literals, taking their bit width and signedness into consideration.

    - Through the AST rewriter, each literal will be constructed into a `struct I64` or `struct I128`, using functions from `move-stdlib`. 

- Make calling other signed int functions from `move-stdlib::i64` and  `move-stdlib::i128` easy

    - `move-stdlib::i64` and  `move-stdlib::i128` offer many functions, like `abs`, to facilitate coding with signed integers. Yet, those functions only take their struct-based types, not recogonizing our newly suported `i64` and `i128`. In addition, we do not have built-in operators for those functions, meaning that we cannot do internal rewriting like handling `add`. 

    - To remove this barrier, this PR adapts the type unification of the compiler to recognize `PrimitiveType::I64` and `PrimitiveType::I128` as their counterparts `struct I64` and `struct I128`. Thus, following code becomes valid: `let a: i64 = -1; let b: i64 = std::i64::abs(a)`, although the signature of the function is `abs(struct I64): struct I64`.


- Others
    
    - `i64` and `i128` are only enabled in language version 2.3 or onward. Using a lower language version will lead to aborted compilation.
  
    -  the `signed_int_rewriter` rewriter is guarded by experimental flag `Experiment::SIGNED_INT_REWRITE`, which is disabled by default. 

With this PR landed and proper compilation configs, users can now use `i64`/`i128` just like `u64`/`u128`. An exemplary piece of code:

```Move

fun test(x: i64, y: i64): i64 { // a function taking `i64` args and return an `i64` value
    let a = -10; // creating an `i64` literal; type of `a` will be inferred later when it is used
    x = x + y * a; // arithmetic ops over `i64`

    if (x < 0) { // conditionals with `i64`
        x = i64::abs(x); // directly call functions from `move-stdlib::i64` with an `i64` arg
    }
    // ...
    x
}

```

Notable semantics of signed int operations, using `i64` as an example:

- Any `i64`, literal or variable, should be viewed as a `struct I64`.

- `+ - * / %`: 
    - Abort on overflow/underflow/division by zero 
    - Backed by `move-stdlib::i64::add()/sub()/mul()/div()/mod()`


- `> >= < <= ==`:
    -  Backed by `move-stdlib::i64::gt()/gte()/lt()/lte()/eq()`


## How Has This Been Tested?

- [New compiler unit tests](https://github.com/aptos-labs/aptos-core/tree/jun/compiler-signed-int/third_party/move/move-compiler-v2/tests/signed-int)
    - All affected syntax, grammar, types, and operations are covered, with both valid and invalid test cases
 
- [New e2e-move-tests](https://github.com/aptos-labs/aptos-core/blob/jun/compiler-signed-int/aptos-move/e2e-move-tests/src/tests/signed_int.data/pack/sources/test.move)
    - All test cases shipped with `move-stdlib/tests/i64_tests.move` and `move-stdlib/tests/i128_tests.move` are replicated and adapted for our compiler syntactic sugar and rewriting.


- Some existing compiler tests have changed results. Those are expected, as we extended the integer family to include both unsigned members and signed members.



## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)
