### PR TITLE
[Draft] Add Blockmetadata to executor benchmark

### DIFF
--- a/execution/executor-benchmark/src/block_preparation.rs
+++ b/execution/executor-benchmark/src/block_preparation.rs
@@ -12,10 +12,12 @@ use aptos_logger::info;
 use aptos_metrics_core::{IntCounterVecHelper, TimerHelper};
 use aptos_types::{
     block_executor::partitioner::{ExecutableBlock, ExecutableTransactions},
+    block_metadata::BlockMetadata,
     transaction::{signature_verified_transaction::SignatureVerifiedTransaction, Transaction},
 };
+use move_core_types::account_address::AccountAddress;
 use rayon::iter::{IndexedParallelIterator, IntoParallelIterator, ParallelIterator};
-use std::time::Instant;
+use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 /// Smallest number of transactions Rayon should put into a single worker task.
 /// Same as in consensus/src/execution_pipeline.rs
@@ -33,6 +35,10 @@ pub(crate) struct BlockPreparationStage {
     num_executor_shards: usize,
     /// When execution sharding is enabled, partitioner that splits block into shards
     maybe_partitioner: Option<Box<dyn BlockPartitioner>>,
+    /// Current epoch for BlockMetadata
+    epoch: u64,
+    /// Proposer address for BlockMetadata (using a default for benchmark)
+    proposer: AccountAddress,
 }
 
 impl BlockPreparationStage {
@@ -40,6 +46,8 @@ impl BlockPreparationStage {
         num_sig_verify_threads: usize,
         num_shards: usize,
         partitioner_config: &dyn PartitionerConfig,
+        epoch: Option<u64>,
+        proposer: Option<AccountAddress>,
     ) -> Self {
         let maybe_partitioner = if num_shards == 0 {
             None
@@ -58,18 +66,41 @@ impl BlockPreparationStage {
             num_blocks_processed: 0,
             maybe_partitioner,
             sig_verify_pool,
+            epoch: epoch.unwrap_or(0), // Default epoch 0
+            proposer: proposer.unwrap_or_else(|| crate::get_benchmark_proposer_address()), // Default proposer with initialized stake pool
         }
     }
 
     pub fn process(&mut self, txns: Vec<Transaction>) -> ExecuteBlockMessage {
         let current_block_start_time = Instant::now();
         info!(
-            "In iteration {}, received {:?} transactions.",
+            "In iteration {}, received {:?} transactions (+ BlockMetadata).",
             self.num_blocks_processed,
             txns.len()
         );
         let block_id = HashValue::random();
-        let sig_verified_txns: Vec<SignatureVerifiedTransaction> =
+
+        // Create BlockMetadata transaction for this block
+        let timestamp_usecs = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("Time went backwards")
+            .as_micros() as u64;
+
+        let block_metadata = BlockMetadata::new(
+            block_id,
+            self.epoch,
+            self.num_blocks_processed as u64, // Use block number as round
+            self.proposer,
+            vec![], // Empty previous_block_votes_bitvec for benchmark
+            vec![], // Empty failed_proposer_indices for benchmark
+            timestamp_usecs,
+        );
+
+        let block_metadata_txn = Transaction::BlockMetadata(block_metadata);
+        let block_metadata_sig_verified = SignatureVerifiedTransaction::from(block_metadata_txn);
+
+        // Process user transactions through signature verification
+        let user_sig_verified_txns: Vec<SignatureVerifiedTransaction> =
             self.sig_verify_pool.install(|| {
                 let _timer = TIMER.timer_with(&["sig_verify"]);
 
@@ -81,12 +112,17 @@ impl BlockPreparationStage {
                     .map(|t| t.into())
                     .collect::<Vec<_>>()
             });
+
+        // Combine BlockMetadata + user transactions (BlockMetadata first)
+        let mut all_sig_verified_txns = vec![block_metadata_sig_verified];
+        all_sig_verified_txns.extend(user_sig_verified_txns);
+
         let block: ExecutableBlock = match &self.maybe_partitioner {
-            None => (block_id, sig_verified_txns).into(),
+            None => (block_id, all_sig_verified_txns).into(),
             Some(partitioner) => {
-                NUM_TXNS.inc_with_by(&["partition"], sig_verified_txns.len() as u64);
+                NUM_TXNS.inc_with_by(&["partition"], all_sig_verified_txns.len() as u64);
                 let analyzed_transactions =
-                    sig_verified_txns.into_iter().map(|t| t.into()).collect();
+                    all_sig_verified_txns.into_iter().map(|t| t.into()).collect();
                 let timer = TIMER.timer_with(&["partition"]);
                 let partitioned_txns =
                     partitioner.partition(analyzed_transactions, self.num_executor_shards);

--- a/execution/executor-benchmark/src/native/native_transaction.rs
+++ b/execution/executor-benchmark/src/native/native_transaction.rs
@@ -42,8 +42,11 @@ impl NativeTransaction {
     pub fn parse(txn: &SignatureVerifiedTransaction) -> Self {
         match &txn.expect_valid() {
             aptos_types::transaction::Transaction::UserTransaction(user_txn) => {
-                match user_txn.payload() {
-                    aptos_types::transaction::TransactionPayload::EntryFunction(f) => {
+                // Use executable_ref() to handle both EntryFunction and Payload variants uniformly
+                match user_txn.payload().executable_ref() {
+                    Ok(aptos_types::transaction::TransactionExecutableRef::EntryFunction(f))
+                        if !user_txn.payload().is_multisig() =>
+                    {
                         match (
                             *f.module().address(),
                             f.module().name().as_str(),

--- a/execution/executor-benchmark/src/pipeline.rs
+++ b/execution/executor-benchmark/src/pipeline.rs
@@ -126,6 +126,8 @@ where
             // Assume the distributed executor and the distributed partitioner share the same worker set.
             config.num_executor_shards,
             &config.partitioner_config,
+            None, // Use default epoch (0)
+            None, // Use default proposer (AccountAddress::ZERO)
         );
 
         let mut exe = TransactionExecutor::new(executor_1, parent_block_id, ledger_update_sender);


### PR DESCRIPTION
## Description
This PR adds Blockmetadata transaction at the beginning of each block in the executor benchmark.
Earlier, due to lack of Blockmetadata transaction, the time in executor benchmark isn't updated making it hard to test Decibel orderbook transactions using monotonically increasing counter native function. This PR fixes it.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
