### PR TITLE
[session][3/n] MoveVM to use data cache trait

### DIFF
--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -13,8 +13,12 @@ use move_core_types::{
 };
 use move_ir_compiler::Compiler;
 use move_vm_runtime::{
-    data_cache::TransactionDataCache, dispatch_loader, module_traversal::*, move_vm::MoveVM,
-    native_extensions::NativeContextExtensions, native_functions::NativeFunction,
+    data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
+    dispatch_loader,
+    module_traversal::*,
+    move_vm::MoveVM,
+    native_extensions::NativeContextExtensions,
+    native_functions::NativeFunction,
     AsUnsyncCodeStorage, InstantiatedFunctionLoader, LegacyLoaderConfig, RuntimeEnvironment,
     ScriptLoader,
 };
@@ -215,16 +219,16 @@ fn main() -> Result<()> {
             )?,
         };
 
+        let mut data_cache = TransactionDataCache::empty();
         MoveVM::execute_loaded_function(
             func,
             // No arguments.
             Vec::<Vec<u8>>::new(),
-            &mut TransactionDataCache::empty(),
+            &mut MoveVmDataCacheAdapter::new(&mut data_cache, &storage, &loader),
             &mut gas_meter,
             &mut traversal_context,
             &mut extensions,
             &loader,
-            &storage,
         )
     })?;
     println!("{:?}", return_values);

--- a/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/mod.rs
@@ -38,7 +38,7 @@ use move_core_types::{
 };
 use move_vm_runtime::{
     config::VMConfig,
-    data_cache::TransactionDataCache,
+    data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
     dispatch_loader,
     module_traversal::TraversalContext,
     move_vm::{MoveVM, SerializedReturnValues},
@@ -127,12 +127,11 @@ where
             MoveVM::execute_loaded_function(
                 func,
                 args,
-                &mut self.data_cache,
+                &mut MoveVmDataCacheAdapter::new(&mut self.data_cache, self.resolver, &loader),
                 gas_meter,
                 traversal_context,
                 &mut self.extensions,
                 &loader,
-                self.resolver,
             )
         })
     }
@@ -148,12 +147,11 @@ where
         MoveVM::execute_loaded_function(
             func,
             args,
-            &mut self.data_cache,
+            &mut MoveVmDataCacheAdapter::new(&mut self.data_cache, self.resolver, loader),
             gas_meter,
             traversal_context,
             &mut self.extensions,
             loader,
-            self.resolver,
         )
     }
 

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -539,7 +539,7 @@ fn native_contains_box(
     } else {
         None
     };
-    let exists = Value::bool(gv.exists()?);
+    let exists = Value::bool(gv.exists());
 
     drop(table_data);
 

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -537,7 +537,7 @@ fn native_contains_box(
         table.get_or_create_global_value(&function_value_extension, table_context, key_bytes)?;
     cost += common_gas_params.calculate_load_cost(loaded);
 
-    let exists = Value::bool(gv.exists()?);
+    let exists = Value::bool(gv.exists());
 
     Ok(NativeResult::ok(cost, smallvec![exists]))
 }

--- a/third_party/move/move-vm/integration-tests/src/tests/mod.rs
+++ b/third_party/move/move-vm/integration-tests/src/tests/mod.rs
@@ -10,7 +10,7 @@ use move_core_types::{
     language_storage::{ModuleId, TypeTag},
 };
 use move_vm_runtime::{
-    data_cache::TransactionDataCache,
+    data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
     dispatch_loader,
     module_traversal::{TraversalContext, TraversalStorage},
     move_vm::{MoveVM, SerializedReturnValues},
@@ -99,6 +99,8 @@ fn execute_function_for_test(
     ty_args: &[TypeTag],
     args: Vec<Vec<u8>>,
 ) -> VMResult<SerializedReturnValues> {
+    let mut data_cache = TransactionDataCache::empty();
+
     let mut gas_meter = UnmeteredGasMeter;
     let traversal_storage = TraversalStorage::new();
     let mut traversal_context = TraversalContext::new(&traversal_storage);
@@ -115,12 +117,11 @@ fn execute_function_for_test(
         MoveVM::execute_loaded_function(
             func,
             args,
-            &mut TransactionDataCache::empty(),
+            &mut MoveVmDataCacheAdapter::new(&mut data_cache, data_storage, &loader),
             &mut gas_meter,
             &mut traversal_context,
             &mut NativeContextExtensions::default(),
             &loader,
-            data_storage,
         )
     })
 }
@@ -150,12 +151,11 @@ fn execute_script_impl(
         MoveVM::execute_loaded_function(
             function,
             args,
-            &mut data_cache,
+            &mut MoveVmDataCacheAdapter::new(&mut data_cache, storage, &loader),
             &mut gas_meter,
             &mut traversal_context,
             &mut NativeContextExtensions::default(),
             &loader,
-            storage,
         )
     })?;
 

--- a/third_party/move/move-vm/runtime/src/data_cache.rs
+++ b/third_party/move/move-vm/runtime/src/data_cache.rs
@@ -4,12 +4,13 @@
 
 use crate::{
     module_traversal::TraversalContext,
+    native_functions::DependencyGasMeterWrapper,
     storage::{
         loader::traits::{ModuleMetadataLoader, StructDefinitionLoader},
         module_storage::FunctionValueExtensionAdapter,
         ty_layout_converter::LayoutConverter,
     },
-    ModuleStorage,
+    Loader, ModuleStorage,
 };
 use bytes::Bytes;
 use move_binary_format::errors::*;
@@ -31,20 +32,133 @@ use move_vm_types::{
 use std::collections::btree_map::{BTreeMap, Entry};
 use triomphe::Arc as TriompheArc;
 
+/// A hack to be able to use [MoveVmDataCache] in native context where there is no access to
+/// static gas meter.
+pub trait NativeContextMoveVmDataCache {
+    /// Used by native context only! Returns true if resource exists in global storage, and false
+    /// otherwise. Also, returns the number of bytes loaded (if any, otherwise [None]).
+    fn native_check_resource_exists(
+        &mut self,
+        gas_meter: &mut dyn DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(bool, Option<NumBytes>)>;
+}
+
+/// Provides access to global storage for Move VM.
+pub trait MoveVmDataCache: NativeContextMoveVmDataCache {
+    /// Loads resource from global storage. Returns the immutable reference to it, along with the
+    /// number of bytes loaded (if any, otherwise [None]).
+    ///
+    /// Note: default implementation loads the resource for mutation, casting the mutable reference
+    /// to immutable.
+    fn load_resource(
+        &mut self,
+        gas_meter: &mut impl DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(&GlobalValue, Option<NumBytes>)> {
+        let (gv, bytes_loaded) = self.load_resource_mut(gas_meter, traversal_context, addr, ty)?;
+        Ok((gv, bytes_loaded))
+    }
+
+    /// Loads resource from global storage. Returns the mutable reference to it, along with the
+    /// number of bytes loaded (if any, otherwise [None]).
+    fn load_resource_mut(
+        &mut self,
+        gas_meter: &mut impl DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)>;
+}
+
+/// Adapter for data cache that also stores references to code and data global storages. In case
+/// resource is not yet in data cache, global storage is used to add it there.
+pub struct MoveVmDataCacheAdapter<'a, LoaderImpl> {
+    data_cache: &'a mut TransactionDataCache,
+    resource_resolver: &'a dyn ResourceResolver,
+    loader: &'a LoaderImpl,
+}
+
+impl<'a, LoaderImpl> NativeContextMoveVmDataCache for MoveVmDataCacheAdapter<'a, LoaderImpl>
+where
+    LoaderImpl: Loader,
+{
+    fn native_check_resource_exists(
+        &mut self,
+        gas_meter: &mut dyn DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(bool, Option<NumBytes>)> {
+        let mut gas_meter = DependencyGasMeterWrapper::new(gas_meter);
+        let (gv, bytes_loaded) = self.load_resource(&mut gas_meter, traversal_context, addr, ty)?;
+        let exists = gv.exists();
+        Ok((exists, bytes_loaded))
+    }
+}
+
+impl<'a, LoaderImpl> MoveVmDataCacheAdapter<'a, LoaderImpl>
+where
+    LoaderImpl: Loader,
+{
+    pub fn new(
+        data_cache: &'a mut TransactionDataCache,
+        resource_resolver: &'a dyn ResourceResolver,
+        loader: &'a LoaderImpl,
+    ) -> Self {
+        Self {
+            data_cache,
+            resource_resolver,
+            loader,
+        }
+    }
+}
+
+impl<'a, LoaderImpl> MoveVmDataCache for MoveVmDataCacheAdapter<'a, LoaderImpl>
+where
+    LoaderImpl: Loader,
+{
+    fn load_resource_mut(
+        &mut self,
+        gas_meter: &mut impl DependencyGasMeter,
+        traversal_context: &mut TraversalContext,
+        addr: &AccountAddress,
+        ty: &Type,
+    ) -> PartialVMResult<(&mut GlobalValue, Option<NumBytes>)> {
+        let bytes_loaded = if !self.data_cache.contains_resource(addr, ty) {
+            let (entry, bytes_loaded) = TransactionDataCache::create_data_cache_entry(
+                self.loader,
+                &LayoutConverter::new(self.loader),
+                gas_meter,
+                traversal_context,
+                self.loader.unmetered_module_storage(),
+                self.resource_resolver,
+                addr,
+                ty,
+            )?;
+            self.data_cache.insert_resource(*addr, ty.clone(), entry)?;
+            Some(bytes_loaded)
+        } else {
+            None
+        };
+
+        let gv = self.data_cache.get_resource_mut(addr, ty)?;
+        Ok((gv, bytes_loaded))
+    }
+}
+
 /// An entry in the data cache, containing resource's [GlobalValue] as well as additional cached
 /// information such as tag, layout, and a flag whether there are any delayed fields inside the
 /// resource.
-pub(crate) struct DataCacheEntry {
+struct DataCacheEntry {
     struct_tag: StructTag,
     layout: TriompheArc<MoveTypeLayout>,
     contains_delayed_fields: bool,
     value: GlobalValue,
-}
-
-impl DataCacheEntry {
-    pub(crate) fn value(&self) -> &GlobalValue {
-        &self.value
-    }
 }
 
 /// Transaction data cache. Keep updates within a transaction so they can all be published at
@@ -138,7 +252,7 @@ impl TransactionDataCache {
     /// Retrieves data from the remote on-chain storage and converts it into a [DataCacheEntry].
     /// Also returns the size of the loaded resource in bytes. This method does not add the entry
     /// to the cache - it is the caller's responsibility to add it there.
-    pub(crate) fn create_data_cache_entry(
+    fn create_data_cache_entry(
         metadata_loader: &impl ModuleMetadataLoader,
         layout_converter: &LayoutConverter<impl StructDefinitionLoader>,
         gas_meter: &mut impl DependencyGasMeter,
@@ -214,7 +328,7 @@ impl TransactionDataCache {
 
     /// Returns true if resource has been inserted into the cache. Otherwise, returns false. The
     /// state of the cache does not chang when calling this function.
-    pub(crate) fn contains_resource(&self, addr: &AccountAddress, ty: &Type) -> bool {
+    fn contains_resource(&self, addr: &AccountAddress, ty: &Type) -> bool {
         self.account_map
             .get(addr)
             .is_some_and(|account_cache| account_cache.contains_key(ty))
@@ -222,7 +336,7 @@ impl TransactionDataCache {
 
     /// Stores a new entry for loaded resource into the data cache. Returns an error if there is an
     /// entry already for the specified address-type pair.
-    pub(crate) fn insert_resource(
+    fn insert_resource(
         &mut self,
         addr: AccountAddress,
         ty: Type,
@@ -242,7 +356,7 @@ impl TransactionDataCache {
 
     /// Returns the resource from the data cache. If resource has not been inserted (i.e., it does
     /// not exist in cache), an error is returned.
-    pub(crate) fn get_resource_mut(
+    fn get_resource_mut(
         &mut self,
         addr: &AccountAddress,
         ty: &Type,

--- a/third_party/move/move-vm/runtime/src/move_vm.rs
+++ b/third_party/move/move-vm/runtime/src/move_vm.rs
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    data_cache::TransactionDataCache,
+    data_cache::MoveVmDataCache,
     interpreter::Interpreter,
     interpreter_caches::InterpreterFunctionCaches,
     module_traversal::TraversalContext,
@@ -23,7 +23,6 @@ use move_vm_metrics::{Timer, VM_TIMER};
 use move_vm_types::{
     gas::GasMeter,
     loaded_data::runtime_types::Type,
-    resolver::ResourceResolver,
     value_serde::{FunctionValueExtension, ValueSerDeContext},
     values::{Locals, Reference, VMValueCast, Value},
 };
@@ -58,12 +57,11 @@ impl MoveVM {
     pub fn execute_loaded_function(
         function: LoadedFunction,
         serialized_args: Vec<impl Borrow<[u8]>>,
-        data_cache: &mut TransactionDataCache,
+        data_cache: &mut impl MoveVmDataCache,
         gas_meter: &mut impl GasMeter,
         traversal_context: &mut TraversalContext,
         extensions: &mut NativeContextExtensions,
         loader: &impl Loader,
-        resource_resolver: &impl ResourceResolver,
     ) -> VMResult<SerializedReturnValues> {
         let vm_config = loader.runtime_environment().vm_config();
 
@@ -105,7 +103,6 @@ impl MoveVM {
                 loader,
                 &ty_depth_checker,
                 &layout_converter,
-                resource_resolver,
                 gas_meter,
                 traversal_context,
                 extensions,

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -4,7 +4,7 @@
 
 use crate::{
     ambassador_impl_ModuleStorage, ambassador_impl_WithRuntimeEnvironment,
-    data_cache::{DataCacheEntry, TransactionDataCache},
+    data_cache::NativeContextMoveVmDataCache,
     dispatch_loader,
     interpreter::InterpreterDebugInterface,
     loader::{LazyLoadedFunction, LazyLoadedFunctionState},
@@ -38,7 +38,6 @@ use move_vm_types::{
     gas::{ambassador_impl_DependencyGasMeter, DependencyGasMeter, DependencyKind, NativeGasMeter},
     loaded_data::runtime_types::Type,
     natives::function::NativeResult,
-    resolver::ResourceResolver,
     values::{AbstractFunction, Value},
 };
 use std::{
@@ -116,8 +115,7 @@ impl NativeFunctions {
 
 pub struct NativeContext<'a, 'b, 'c> {
     interpreter: &'a dyn InterpreterDebugInterface,
-    data_store: &'a mut TransactionDataCache,
-    resource_resolver: &'a dyn ResourceResolver,
+    data_cache: &'a mut dyn NativeContextMoveVmDataCache,
     module_storage: &'a dyn ModuleStorage,
     extensions: &'a mut NativeContextExtensions<'b>,
     gas_meter: &'a mut dyn NativeGasMeter,
@@ -127,8 +125,7 @@ pub struct NativeContext<'a, 'b, 'c> {
 impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     pub(crate) fn new(
         interpreter: &'a dyn InterpreterDebugInterface,
-        data_store: &'a mut TransactionDataCache,
-        resource_resolver: &'a dyn ResourceResolver,
+        data_cache: &'a mut dyn NativeContextMoveVmDataCache,
         module_storage: &'a dyn ModuleStorage,
         extensions: &'a mut NativeContextExtensions<'b>,
         gas_meter: &'a mut dyn NativeGasMeter,
@@ -136,8 +133,7 @@ impl<'a, 'b, 'c> NativeContext<'a, 'b, 'c> {
     ) -> Self {
         Self {
             interpreter,
-            data_store,
-            resource_resolver,
+            data_cache,
             module_storage,
             extensions,
             gas_meter,
@@ -157,21 +153,12 @@ impl<'b, 'c> NativeContext<'_, 'b, 'c> {
         address: AccountAddress,
         ty: &Type,
     ) -> PartialVMResult<(bool, Option<NumBytes>)> {
-        // TODO(#16516):
-        //   Propagate exists call all the way to resolver, because we can implement the check more
-        //   efficiently, without the need to actually load bytes, deserialize the value and cache
-        //   it in the data cache.
-        Ok(if !self.data_store.contains_resource(&address, ty) {
-            let (entry, bytes_loaded) =
-                self.loader_context().create_data_cache_entry(address, ty)?;
-            let exists = entry.value().exists()?;
-            self.data_store
-                .insert_resource(address, ty.clone(), entry)?;
-            (exists, Some(bytes_loaded))
-        } else {
-            let exists = self.data_store.get_resource_mut(&address, ty)?.exists()?;
-            (exists, None)
-        })
+        self.data_cache.native_check_resource_exists(
+            self.gas_meter,
+            self.traversal_context,
+            &address,
+            ty,
+        )
     }
 
     pub fn type_to_type_tag(&self, ty: &Type) -> PartialVMResult<TypeTag> {
@@ -245,12 +232,7 @@ impl<'b, 'c> NativeContext<'_, 'b, 'c> {
     ) -> (&NativeContextExtensions<'b>, LoaderContext<'_, 'c>) {
         (
             self.extensions,
-            LoaderContext::new(
-                self.resource_resolver,
-                self.module_storage,
-                self.gas_meter,
-                self.traversal_context,
-            ),
+            LoaderContext::new(self.module_storage, self.gas_meter, self.traversal_context),
         )
     }
 
@@ -276,12 +258,7 @@ impl<'b, 'c> NativeContext<'_, 'b, 'c> {
 
     /// Returns the loader context used by the natives.
     pub fn loader_context(&mut self) -> LoaderContext<'_, 'c> {
-        LoaderContext::new(
-            self.resource_resolver,
-            self.module_storage,
-            self.gas_meter,
-            self.traversal_context,
-        )
+        LoaderContext::new(self.module_storage, self.gas_meter, self.traversal_context)
     }
 
     pub fn traversal_context(&self) -> &TraversalContext<'c> {
@@ -298,7 +275,6 @@ impl<'b, 'c> NativeContext<'_, 'b, 'c> {
 /// Helper struct that can be returned together with extensions so that layouts can be constructed
 /// while there is a live mutable reference to context extensions.
 pub struct LoaderContext<'a, 'b> {
-    resource_resolver: &'a dyn ResourceResolver,
     module_storage: ModuleStorageWrapper<'a>,
     gas_meter: DependencyGasMeterWrapper<'a>,
     traversal_context: &'a mut TraversalContext<'b>,
@@ -376,38 +352,15 @@ impl<'a, 'b> LoaderContext<'a, 'b> {
 impl<'a, 'b> LoaderContext<'a, 'b> {
     /// Creates a new loader context.
     fn new(
-        resource_resolver: &'a dyn ResourceResolver,
         module_storage: &'a dyn ModuleStorage,
         gas_meter: &'a mut dyn DependencyGasMeter,
         traversal_context: &'a mut TraversalContext<'b>,
     ) -> Self {
         Self {
-            resource_resolver,
             module_storage: ModuleStorageWrapper { module_storage },
             gas_meter: DependencyGasMeterWrapper { gas_meter },
             traversal_context,
         }
-    }
-
-    /// Creates a new [DataCacheEntry], loading its layout, deserializing it and recording its
-    /// size in bytes.
-    fn create_data_cache_entry(
-        &mut self,
-        address: AccountAddress,
-        ty: &Type,
-    ) -> PartialVMResult<(DataCacheEntry, NumBytes)> {
-        dispatch_loader!(&self.module_storage, loader, {
-            TransactionDataCache::create_data_cache_entry(
-                &loader,
-                &LayoutConverter::new(&loader),
-                &mut self.gas_meter,
-                self.traversal_context,
-                &self.module_storage,
-                self.resource_resolver,
-                &address,
-                ty,
-            )
-        })
     }
 
     /// Converts a runtime type into decorated layout for pretty-printing.
@@ -450,8 +403,14 @@ impl<'a> ModuleStorageWrapper<'a> {
     }
 }
 
-struct DependencyGasMeterWrapper<'a> {
+pub(crate) struct DependencyGasMeterWrapper<'a> {
     gas_meter: &'a mut dyn DependencyGasMeter,
+}
+
+impl<'a> DependencyGasMeterWrapper<'a> {
+    pub(crate) fn new(gas_meter: &'a mut dyn DependencyGasMeter) -> Self {
+        Self { gas_meter }
+    }
 }
 
 #[delegate_to_methods]

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -4100,10 +4100,10 @@ impl GlobalValueImpl {
         Ok(())
     }
 
-    fn exists(&self) -> PartialVMResult<bool> {
+    fn exists(&self) -> bool {
         match self {
-            Self::Fresh { .. } | Self::Cached { .. } => Ok(true),
-            Self::None | Self::Deleted => Ok(false),
+            Self::Fresh { .. } | Self::Cached { .. } => true,
+            Self::None | Self::Deleted => false,
         }
     }
 
@@ -4174,7 +4174,7 @@ impl GlobalValue {
         self.0.borrow_global()
     }
 
-    pub fn exists(&self) -> PartialVMResult<bool> {
+    pub fn exists(&self) -> bool {
         self.0.exists()
     }
 

--- a/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
+++ b/third_party/move/testing-infra/transactional-test-runner/src/vm_test_harness.rs
@@ -37,7 +37,7 @@ use move_stdlib::move_stdlib_named_addresses;
 use move_symbol_pool::Symbol;
 use move_vm_runtime::{
     config::VMConfig,
-    data_cache::TransactionDataCache,
+    data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
     dispatch_loader,
     module_traversal::*,
     move_vm::{MoveVM, SerializedReturnValues},
@@ -459,12 +459,11 @@ impl SimpleVMTestAdapter<'_> {
             MoveVM::execute_loaded_function(
                 function,
                 args,
-                &mut data_cache,
+                &mut MoveVmDataCacheAdapter::new(&mut data_cache, &self.storage, &loader),
                 &mut gas_meter,
                 &mut traversal_context,
                 &mut extensions,
                 &loader,
-                &self.storage,
             )?
         });
 

--- a/third_party/move/tools/move-unit-test/src/test_runner.rs
+++ b/third_party/move/tools/move-unit-test/src/test_runner.rs
@@ -28,7 +28,7 @@ use move_core_types::{
 };
 use move_resource_viewer::MoveValueAnnotator;
 use move_vm_runtime::{
-    data_cache::TransactionDataCache,
+    data_cache::{MoveVmDataCacheAdapter, TransactionDataCache},
     dispatch_loader,
     module_traversal::{TraversalContext, TraversalStorage},
     move_vm::MoveVM,
@@ -283,12 +283,15 @@ impl SharedTestingConfig {
                     MoveVM::execute_loaded_function(
                         function,
                         args,
-                        &mut data_cache,
+                        &mut MoveVmDataCacheAdapter::new(
+                            &mut data_cache,
+                            &self.starting_storage_state,
+                            &loader,
+                        ),
                         &mut gas_meter,
                         &mut traversal_context,
                         &mut extensions,
                         &loader,
-                        &self.starting_storage_state,
                     )
                 })
         });


### PR DESCRIPTION
## Description

This PR introduces a `MoveVmDataCache` trait with 2 APIs: `load_resource` and `load_resource_mut`. Both return number of bytes loaded so that gas can be charged, but first also returns `&GlobalValue` and second `&mut GlobalValue`. The idea is that implementation of this trait on Aptos VM side does pessimistic copy-on-write for `load_resource_mut` and no clones/copies for `load_resource`.

This trait is integrated in the current VM by passing `MoveVmDataCacheAdapter` - structure holding resource resolver, loader and old data cache implementation. The behaviour is unchanged.

To support native `exists_at`, factored out `NativeContextMoveVmDataCache` trait to allow `dyn` gas meter trait objects on that path. Ugly, but there is no way around until we make gas meter static in native context.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
