### PR TITLE
[Hot State] Do not include prev_slot in MakeHot op

### DIFF
--- a/aptos-move/block-executor/src/hot_state_op_accumulator.rs
+++ b/aptos-move/block-executor/src/hot_state_op_accumulator.rs
@@ -1,22 +1,17 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::counters::HOT_STATE_OP_ACCUMULATOR_COUNTER as COUNTER;
-use aptos_logger::error;
-use aptos_metrics_core::IntCounterVecHelper;
-use aptos_types::{
-    state_store::{state_slot::StateSlot, TStateView},
-    transaction::Version,
-};
-use std::{collections::BTreeMap, fmt::Debug, hash::Hash};
+#![allow(clippy::new_without_default)]
 
-pub struct BlockHotStateOpAccumulator<'base_view, Key, BaseView> {
-    first_version: Version,
-    base_view: &'base_view BaseView,
+use crate::counters::HOT_STATE_OP_ACCUMULATOR_COUNTER as COUNTER;
+use aptos_metrics_core::IntCounterVecHelper;
+use std::{collections::BTreeSet, fmt::Debug, hash::Hash};
+
+pub struct BlockHotStateOpAccumulator<Key> {
     /// Keys read but never written to across the entire block are to be made hot (or refreshed
     /// `hot_since_version` one is already hot but last refresh is far in the history) as the side
     /// effect of the block epilogue (subject to per block limit)
-    to_make_hot: BTreeMap<Key, StateSlot>,
+    to_make_hot: BTreeSet<Key>,
     /// Keep track of all the keys that are written to across the whole block, these keys are made
     /// hot (or have a refreshed `hot_since_version`) immediately at the version they got changed,
     /// so no need to issue separate HotStateOps to promote them to the hot state.
@@ -28,33 +23,28 @@ pub struct BlockHotStateOpAccumulator<'base_view, Key, BaseView> {
     _refresh_interval_versions: usize,
 }
 
-impl<'base_view, Key, BaseView> BlockHotStateOpAccumulator<'base_view, Key, BaseView>
+impl<Key> BlockHotStateOpAccumulator<Key>
 where
     Key: PartialOrd + Ord + Send + Sync + Clone + Hash + Eq + Debug,
-    BaseView: TStateView<Key = Key>,
 {
     /// TODO(HotState): make on-chain config
     const MAX_PROMOTIONS_PER_BLOCK: usize = 1024 * 10;
     /// TODO(HotState): make on-chain config
     const REFRESH_INTERVAL_VERSIONS: usize = 1_000_000;
 
-    pub fn new(base_view: &'base_view BaseView) -> Self {
+    pub fn new() -> Self {
         Self::new_with_config(
-            base_view,
             Self::MAX_PROMOTIONS_PER_BLOCK,
             Self::REFRESH_INTERVAL_VERSIONS,
         )
     }
 
     pub fn new_with_config(
-        base_view: &'base_view BaseView,
         max_promotions_per_block: usize,
         refresh_interval_versions: usize,
     ) -> Self {
         Self {
-            first_version: base_view.next_version(),
-            base_view,
-            to_make_hot: BTreeMap::new(),
+            to_make_hot: BTreeSet::new(),
             writes: hashbrown::HashSet::new(),
             max_promotions_per_block,
             _refresh_interval_versions: refresh_interval_versions,
@@ -69,7 +59,7 @@ where
         Key: 'a,
     {
         for key in writes {
-            if self.to_make_hot.remove(key).is_some() {
+            if self.to_make_hot.remove(key) {
                 COUNTER.inc_with(&["promotion_removed_by_write"]);
             }
             self.writes.get_or_insert_owned(key);
@@ -80,67 +70,14 @@ where
                 COUNTER.inc_with(&["max_promotions_per_block_hit"]);
                 continue;
             }
-            if self.to_make_hot.contains_key(key) {
-                continue;
-            }
             if self.writes.contains(key) {
                 continue;
             }
-            let slot = self
-                .base_view
-                .get_state_slot(key)
-                .expect("base_view.get_slot() failed.");
-            let make_hot = match slot {
-                StateSlot::ColdVacant => {
-                    COUNTER.inc_with(&["vacant_new"]);
-                    true
-                },
-                StateSlot::HotVacant {
-                    hot_since_version, ..
-                } => {
-                    if self.should_refresh(hot_since_version) {
-                        COUNTER.inc_with(&["vacant_refresh"]);
-                        true
-                    } else {
-                        COUNTER.inc_with(&["vacant_still_hot"]);
-                        false
-                    }
-                },
-                StateSlot::ColdOccupied { .. } => {
-                    COUNTER.inc_with(&["occupied_new"]);
-                    true
-                },
-                StateSlot::HotOccupied {
-                    hot_since_version, ..
-                } => {
-                    if self.should_refresh(hot_since_version) {
-                        COUNTER.inc_with(&["occupied_refresh"]);
-                        true
-                    } else {
-                        COUNTER.inc_with(&["occupied_still_hot"]);
-                        false
-                    }
-                },
-            };
-            if make_hot {
-                self.to_make_hot.insert(key.clone(), slot);
-            }
+            self.to_make_hot.insert(key.clone());
         }
     }
 
-    pub fn get_slots_to_make_hot(&self) -> BTreeMap<Key, StateSlot> {
+    pub fn get_keys_to_make_hot(&self) -> BTreeSet<Key> {
         self.to_make_hot.clone()
-    }
-
-    pub fn should_refresh(&self, hot_since_version: Version) -> bool {
-        if hot_since_version >= self.first_version {
-            error!(
-                "Unexpected: hot_since_version {} >= block first version {}",
-                hot_since_version, self.first_version
-            );
-        }
-        // TODO(HotState): understand perf impact. For now, we always refresh.
-        // hot_since_version + self.refresh_interval_versions as Version <= self.first_version
-        true
     }
 }

--- a/aptos-move/block-executor/src/txn_last_input_output.rs
+++ b/aptos-move/block-executor/src/txn_last_input_output.rs
@@ -15,7 +15,7 @@ use aptos_mvhashmap::{types::TxnIndex, MVHashMap};
 use aptos_types::{
     error::{code_invariant_error, PanicError, PanicOr},
     on_chain_config::BlockGasLimitType,
-    state_store::{state_value::StateValueMetadata, TStateView},
+    state_store::state_value::StateValueMetadata,
     transaction::BlockExecutableTransaction as Transaction,
     vm::modules::AptosModuleExtension,
     write_set::WriteOp,
@@ -154,14 +154,14 @@ impl<T: Transaction, O: TransactionOutput<Txn = T>, E: Debug + Send + Clone>
     // all be skipped), and
     // (2) the last txn did not emit a new epoch event.
     // To avoid unnecessarily inspecting events, we only check (2) if (1) is true.
-    pub(crate) fn commit<S: TStateView<Key = T::Key>>(
+    pub(crate) fn commit(
         &self,
         txn_idx: TxnIndex,
         num_txns: TxnIndex,
         num_workers: usize,
         user_txn_bytes_len: u64,
         block_gas_limit_type: &BlockGasLimitType,
-        block_limit_processor: &mut BlockGasLimitProcessor<T, S>,
+        block_limit_processor: &mut BlockGasLimitProcessor<T>,
         scheduler: &SchedulerWrapper,
     ) -> Result<bool, PanicOr<ParallelBlockExecutionError>> {
         let (mut skips_rest, mut must_create_epilogue_txn, maybe_fee_statement_and_output_size) =

--- a/aptos-move/e2e-move-tests/src/tests/storage_refund.rs
+++ b/aptos-move/e2e-move-tests/src/tests/storage_refund.rs
@@ -166,7 +166,7 @@ fn assert_result(
                 deletes += 1
             },
             BaseStateOp::Modification { .. } => (),
-            BaseStateOp::MakeHot { .. } | BaseStateOp::Eviction { .. } => unreachable!(),
+            BaseStateOp::MakeHot => unreachable!(),
         }
     }
     if expect_success {

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -24,7 +24,8 @@ use aptos_experimental_runtimes::thread_manager::THREAD_MANAGER;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::TimerHelper;
 use aptos_storage_interface::state_store::{
-    state::LedgerState, state_view::cached_state_view::CachedStateView,
+    state::LedgerState,
+    state_view::cached_state_view::{CachedStateView, PrimingPolicy},
 };
 #[cfg(feature = "consensus-only-perf-test")]
 use aptos_types::transaction::ExecutionStatus;
@@ -160,11 +161,11 @@ impl DoGetExecutionOutput {
                 assert!(output.status().is_kept(), "Block epilogue must be kept");
                 output.add_hotness(
                     payload
-                        .try_get_slots_to_make_hot()
+                        .try_get_keys_to_make_hot()
                         .cloned()
                         .unwrap_or_default()
                         .into_iter()
-                        .map(|(key, slot)| (key, HotStateOp::make_hot(slot)))
+                        .map(|key| (key, HotStateOp::make_hot()))
                         .collect(),
                 );
             }
@@ -400,9 +401,20 @@ impl Parser {
                 .transpose()?
         };
 
-        if prime_state_cache {
-            base_state_view.prime_cache(to_commit.state_update_refs())?;
-        }
+        base_state_view.prime_cache(
+            to_commit.state_update_refs(),
+            if prime_state_cache {
+                PrimingPolicy::All
+            } else {
+                // Most of the transaction reads should already be in the cache, but some module
+                // reads in the transactions might be done via the global module cache instead of
+                // cached state view, so they are not present in the cache.
+                // Therfore, we must prime the cache for the keys that we are going to promote into
+                // hot state, regardless of `prime_state_cache`, because the write sets have only
+                // the keys, not the values.
+                PrimingPolicy::MakeHotOnly
+            },
+        )?;
 
         let result_state = parent_state.update_with_memorized_reads(
             base_state_view.persisted_state(),

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -880,7 +880,12 @@ impl StateStore {
                 // TODO(aldenhu): cache changes here, should consume it.
                 let old_entry = cache
                     // TODO(HotState): Revisit: assuming every write op results in a hot slot
-                    .insert((*key).clone(), update_to_cold.to_result_slot())
+                    .insert(
+                        (*key).clone(),
+                        update_to_cold
+                            .to_result_slot()
+                            .expect("hot state ops should have been filtered out above"),
+                    )
                     .unwrap_or_else(|| {
                         // n.b. all updated state items must be read and recorded in the state cache,
                         // otherwise we can't calculate the correct usage. The is_untracked() hack

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -34,7 +34,7 @@ use lru::LruCache;
 use proptest::{collection::vec, prelude::*, sample::Index};
 use rayon::prelude::*;
 use std::{
-    collections::{HashMap, HashSet},
+    collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::{Debug, Formatter},
     num::NonZeroUsize,
     ops::Deref,
@@ -54,14 +54,14 @@ const REFRESH_INTERVAL_VERSIONS: usize = 50;
 
 #[derive(Debug)]
 struct UserTxn {
-    reads: Vec<StateKey>,
-    writes: Vec<(StateKey, Option<StateValue>)>,
+    reads: BTreeSet<StateKey>,
+    writes: BTreeMap<StateKey, Option<StateValue>>,
 }
 
 #[derive(Debug)]
 struct Txn {
-    reads: Vec<StateKey>,
-    write_set: Vec<(StateKey, BaseStateOp)>,
+    reads: BTreeSet<StateKey>,
+    write_set: BTreeMap<StateKey, BaseStateOp>,
     is_checkpoint: bool,
 }
 
@@ -80,9 +80,7 @@ impl Chunk {
             update_refs_builder: |txn_outs| {
                 StateUpdateRefs::index(
                     first_version,
-                    txn_outs
-                        .iter()
-                        .map(|t| t.write_set.iter().map(|(key, op)| (key, op))),
+                    txn_outs.iter().map(|t| t.write_set.iter()),
                     txn_outs.len(),
                     txn_outs.iter().rposition(|t| t.is_checkpoint),
                 )
@@ -130,20 +128,21 @@ prop_compose! {
         input
             .into_iter()
             .map(|(reads, writes)| {
-                let write_set: HashMap<_, _> = writes
+                let write_set: BTreeMap<_, _> = writes
                     .into_iter()
                     .map(|(idx, value)| (idx.get(&keys).clone(), value))
                     .collect();
 
                 // The read set is a super set of the write set.
-                let read_set: HashSet<_> = write_set
+                let read_set: BTreeSet<_> = write_set
                     .keys()
-                    .chain(reads.iter().map(|idx| idx.get(&keys)))
+                    .cloned()
+                    .chain(reads.iter().map(|idx| idx.get(&keys)).cloned())
                     .collect();
 
                 UserTxn {
-                    reads: read_set.into_iter().cloned().collect(),
-                    writes: write_set.into_iter().collect(),
+                    reads: read_set,
+                    writes: write_set,
                 }
             })
             .collect_vec()
@@ -174,7 +173,7 @@ impl VersionState {
         &self,
         version: Version,
         writes: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
-        promotions: impl IntoIterator<Item = (&'a StateKey, &'a StateSlot)>,
+        promotions: impl IntoIterator<Item = &'a StateKey>,
     ) -> Self {
         assert_eq!(version, self.next_version);
 
@@ -207,14 +206,24 @@ impl VersionState {
             }
         }
 
-        for (k, prev_slot) in promotions {
-            if prev_slot.is_cold() {
-                hot_state.put(k.clone(), prev_slot.clone().to_hot(version));
-            } else {
-                let mut slot = prev_slot.clone();
+        for k in promotions {
+            if let Some(slot) = hot_state.get_mut(k) {
                 slot.refresh(version);
-                hot_state.put(k.clone(), slot);
+                continue;
             }
+            let slot = match state.get(k) {
+                Some((value_version, value)) => StateSlot::HotOccupied {
+                    value_version: *value_version,
+                    value: value.clone(),
+                    hot_since_version: version,
+                    lru_info: LRUEntry::uninitialized(),
+                },
+                None => StateSlot::HotVacant {
+                    hot_since_version: version,
+                    lru_info: LRUEntry::uninitialized(),
+                },
+            };
+            hot_state.put(k.clone(), slot);
         }
 
         let summary = self.summary.clone().update(&smt_updates);
@@ -276,7 +285,7 @@ impl StateByVersion {
     fn append_version<'a>(
         &mut self,
         writes: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
-        promotions: impl IntoIterator<Item = (&'a StateKey, &'a StateSlot)>,
+        promotions: impl IntoIterator<Item = &'a StateKey>,
     ) {
         self.state_by_next_version.push(Arc::new(
             self.state_by_next_version.last().unwrap().update(
@@ -544,13 +553,8 @@ fn commit_state_buffer(
 fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVersion) {
     let mut all_txns = vec![];
     let mut state_by_version = StateByVersion::new_empty();
-    let mut next_version: Version = 0;
     for (block_txns, append_epilogue) in blocks {
-        let base_view = state_by_version
-            .get_state(next_version.checked_sub(1))
-            .clone();
-        let mut op_accu = BlockHotStateOpAccumulator::<StateKey, _>::new_with_config(
-            &base_view,
+        let mut op_accu = BlockHotStateOpAccumulator::<StateKey>::new_with_config(
             MAX_PROMOTIONS_PER_BLOCK,
             REFRESH_INTERVAL_VERSIONS,
         );
@@ -558,7 +562,7 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
             // No promotions except for block epilogue.
             state_by_version
                 .append_version(txn.writes.iter().map(|(k, v)| (k, v.as_ref())), vec![]);
-            op_accu.add_transaction(txn.writes.iter().map(|(k, _v)| k), txn.reads.iter());
+            op_accu.add_transaction(txn.writes.keys(), txn.reads.iter());
             all_txns.push(Txn {
                 reads: txn.reads,
                 write_set: txn
@@ -571,23 +575,21 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
                     .collect(),
                 is_checkpoint: false,
             });
-            next_version += 1;
         }
         if append_epilogue {
-            let to_make_hot = op_accu.get_slots_to_make_hot();
+            let to_make_hot = op_accu.get_keys_to_make_hot();
             state_by_version.append_version(vec![], to_make_hot.iter());
 
+            let reads = to_make_hot.clone();
             let write_set = to_make_hot
                 .into_iter()
-                .map(|(k, slot)| (k, HotStateOp::make_hot(slot).into_base_op()))
-                .collect_vec();
-            let reads = write_set.iter().map(|(k, _op)| k.clone()).collect_vec();
+                .map(|k| (k, HotStateOp::make_hot().into_base_op()))
+                .collect();
             all_txns.push(Txn {
                 reads,
                 write_set,
                 is_checkpoint: true,
             });
-            next_version += 1;
         }
     }
 

--- a/storage/storage-interface/src/state_store/state_summary.rs
+++ b/storage/storage-interface/src/state_store/state_summary.rs
@@ -10,7 +10,10 @@ use crate::{
     DbReader,
 };
 use anyhow::Result;
-use aptos_crypto::{hash::CORRUPTION_SENTINEL, HashValue};
+use aptos_crypto::{
+    hash::{CryptoHash, CORRUPTION_SENTINEL},
+    HashValue,
+};
 use aptos_metrics_core::TimerHelper;
 use aptos_scratchpad::{ProofRead, SparseMerkleTree};
 use aptos_types::{proof::SparseMerkleProofExt, transaction::Version};
@@ -87,7 +90,13 @@ impl StateSummary {
             .flat_map(|shard| {
                 shard
                     .iter()
-                    .map(|(k, u)| (*k, u.value_hash_opt()))
+                    .filter_map(|(k, u)| {
+                        // Filter out `MakeHot` ops.
+                        u.state_op
+                            .as_state_value_opt()
+                            .map(|value_opt| (k, value_opt))
+                    })
+                    .map(|(k, value_opt)| (*k, value_opt.map(|v| v.hash())))
                     // The keys in the shard are already unique, and shards are ordered by the
                     // first nibble of the key hash. `batch_update_sorted_uniq` can be
                     // called if within each shard items are sorted by key hash.

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -320,7 +320,7 @@ mod tests {
         let u = res.get(key).unwrap();
         assert_eq!(u.version, expected_version);
         assert_eq!(
-            u.state_op.as_state_value_opt().unwrap().bytes(),
+            u.state_op.as_state_value_opt().unwrap().unwrap().bytes(),
             expected_value
         );
     }

--- a/storage/storage-interface/src/state_store/versioned_state_value.rs
+++ b/storage/storage-interface/src/state_store/versioned_state_value.rs
@@ -1,7 +1,6 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_types::{
     state_store::{hot_state::LRUEntry, state_slot::StateSlot},
     transaction::Version,
@@ -17,62 +16,21 @@ pub struct StateUpdateRef<'kv> {
 
 impl StateUpdateRef<'_> {
     /// NOTE: the lru_info in the result is not initialized yet.
-    pub fn to_result_slot(&self) -> StateSlot {
+    pub fn to_result_slot(&self) -> Option<StateSlot> {
         match self.state_op.clone() {
             BaseStateOp::Creation(value) | BaseStateOp::Modification(value) => {
-                StateSlot::HotOccupied {
+                Some(StateSlot::HotOccupied {
                     value_version: self.version,
                     value,
                     hot_since_version: self.version,
                     lru_info: LRUEntry::uninitialized(),
-                }
+                })
             },
-            BaseStateOp::Deletion(_) => StateSlot::HotVacant {
+            BaseStateOp::Deletion(_) => Some(StateSlot::HotVacant {
                 hot_since_version: self.version,
                 lru_info: LRUEntry::uninitialized(),
-            },
-            BaseStateOp::MakeHot { prev_slot } => match prev_slot {
-                StateSlot::ColdVacant => StateSlot::HotVacant {
-                    hot_since_version: self.version,
-                    lru_info: LRUEntry::uninitialized(),
-                },
-                StateSlot::HotVacant { .. } => StateSlot::HotVacant {
-                    hot_since_version: self.version,
-                    lru_info: LRUEntry::uninitialized(),
-                },
-                StateSlot::ColdOccupied {
-                    value_version,
-                    value,
-                }
-                | StateSlot::HotOccupied {
-                    value_version,
-                    value,
-                    ..
-                } => StateSlot::HotOccupied {
-                    value_version,
-                    value,
-                    hot_since_version: self.version,
-                    lru_info: LRUEntry::uninitialized(),
-                },
-            },
-            BaseStateOp::Eviction { prev_slot } => match prev_slot {
-                StateSlot::HotVacant { .. } => StateSlot::ColdVacant,
-                StateSlot::HotOccupied {
-                    value_version,
-                    value,
-                    ..
-                } => StateSlot::ColdOccupied {
-                    value_version,
-                    value,
-                },
-                StateSlot::ColdVacant | StateSlot::ColdOccupied { .. } => {
-                    unreachable!("only hot slots can be evicted")
-                },
-            },
+            }),
+            BaseStateOp::MakeHot => None,
         }
-    }
-
-    pub fn value_hash_opt(&self) -> Option<HashValue> {
-        self.state_op.as_state_value_opt().map(|val| val.hash())
     }
 }

--- a/types/src/transaction/block_epilogue.rs
+++ b/types/src/transaction/block_epilogue.rs
@@ -1,14 +1,17 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::state_store::{state_key::StateKey, state_slot::StateSlot};
+use crate::state_store::state_key::StateKey;
 use aptos_crypto::HashValue;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest::prelude::*;
 #[cfg(any(test, feature = "fuzzing"))]
 use proptest_derive::Arbitrary;
 use serde::{Deserialize, Serialize};
-use std::{collections::BTreeMap, fmt::Debug};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::Debug,
+};
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
 #[cfg_attr(any(test, feature = "fuzzing"), derive(Arbitrary))]
@@ -32,7 +35,7 @@ impl BlockEpiloguePayload {
         }
     }
 
-    pub fn try_get_slots_to_make_hot(&self) -> Option<&BTreeMap<StateKey, StateSlot>> {
+    pub fn try_get_keys_to_make_hot(&self) -> Option<&BTreeSet<StateKey>> {
         match self {
             Self::V0 { .. } => None,
             Self::V1 { block_end_info, .. } => Some(&block_end_info.to_make_hot),
@@ -105,7 +108,7 @@ impl BlockEndInfo {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct TBlockEndInfoExt<Key: Debug + Ord> {
     inner: BlockEndInfo,
-    to_make_hot: BTreeMap<Key, StateSlot>,
+    to_make_hot: BTreeSet<Key>,
 }
 
 pub type BlockEndInfoExt = TBlockEndInfoExt<StateKey>;
@@ -114,11 +117,11 @@ impl<Key: Debug + Ord> TBlockEndInfoExt<Key> {
     pub fn new_empty() -> Self {
         Self {
             inner: BlockEndInfo::new_empty(),
-            to_make_hot: BTreeMap::new(),
+            to_make_hot: BTreeSet::new(),
         }
     }
 
-    pub fn new(inner: BlockEndInfo, to_make_hot: BTreeMap<Key, StateSlot>) -> Self {
+    pub fn new(inner: BlockEndInfo, to_make_hot: BTreeSet<Key>) -> Self {
         Self { inner, to_make_hot }
     }
 
@@ -148,7 +151,7 @@ where
         D: serde::Deserializer<'de>,
     {
         let inner = BlockEndInfo::deserialize(deserializer)?;
-        Ok(Self::new(inner, BTreeMap::new()))
+        Ok(Self::new(inner, BTreeSet::new()))
     }
 }
 
@@ -161,7 +164,7 @@ impl<Key: Debug + Ord> Arbitrary for TBlockEndInfoExt<Key> {
         // TODO(HotState): it's used in db tests (encode/decode), so we need to make sure that
         // serializing the data and then deserializing it reproduces the original value.
         any::<BlockEndInfo>()
-            .prop_map(|inner| Self::new(inner, BTreeMap::new()))
+            .prop_map(|inner| Self::new(inner, BTreeSet::new()))
             .boxed()
     }
 }


### PR DESCRIPTION

- Don't think this is strictly needed. Keep the data minimal and just say
  "these keys are read / need to be promoted" instead of attaching the value.
- If there's some inaccuracy in the read / write summary, the attached slot
  could be outdated, which makes it more likely to introduce bugs.
- `prime_cache` should be able to fetch these things a bit more efficiently than
  the current implementation in `BlockHotStateOpAccumulator` due to parallelism.

Removed eviction op as well, since it can be computed.
