### PR TITLE
[compiler-v2] Compiler inlining optimization

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/inlining_optimization.rs
@@ -1,0 +1,695 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements the inlining optimization, whose aim is to reduce the number
+//! of function calls (which comes at the cost of increasing code size).
+//!
+//! See the documentation for the `optimize` function for more details on what inlining is.
+
+use crate::{
+    env_pipeline::rewrite_target::{RewriteState, RewriteTarget, RewriteTargets, RewritingScope},
+    file_format_generator::MAX_LOCAL_COUNT,
+};
+use codespan_reporting::diagnostic::Severity;
+use move_binary_format::file_format::Visibility;
+use move_model::{
+    ast::{Exp, ExpData, Operation, Pattern, TempIndex},
+    exp_rewriter::ExpRewriterFunctions,
+    metadata::LanguageVersion,
+    model::{
+        FunId, FunctionEnv, FunctionSize, GlobalEnv, Loc, ModuleEnv, ModuleId, NodeId, Parameter,
+        QualifiedId,
+    },
+    ty::Type,
+};
+use petgraph::{algo::kosaraju_scc, prelude::DiGraphMap};
+use std::collections::BTreeSet;
+
+/// [TODO]: tune the heuristic limits below
+/// A conservative heuristic limit posed by the inlining optimization on how
+/// large a caller function can grow to due to inlining.
+const MAX_CALLER_CODE_SIZE: usize = 1024;
+/// A conservative heuristic limit posed by the inlining optimization on how
+/// large a callee function can be for it to be considered for inlining.
+const MAX_CALLEE_CODE_SIZE: usize = 128;
+/// Number of times we want to apply "unrolling" of functions with inlining.
+const UNROLL_DEPTH: usize = 10;
+
+/// Optimize functions in target modules by applying inlining transformations.
+/// With inlining, a call site of the form:
+/// ```move
+/// foo(a, b, c, ...)
+/// ```
+/// with
+/// ```move
+/// fun foo(x, y, z, ...) { body }
+/// ```
+/// becomes:
+/// ```move
+/// let (x, y, z, ...) = (a, b, c, ...); body
+/// ```
+///
+/// The `across_package` value controls if inlining is performed across package boundaries.
+/// With across-package inlining, calls to functions in other packages may be inlined,
+/// which means that if the other package is upgraded, one would get the behavior
+/// at the inline-time rather than the latest upgrade.
+pub fn optimize(env: &mut GlobalEnv, across_package: bool) {
+    let mut targets = RewriteTargets::create(env, RewritingScope::CompilationTarget);
+    let skip_functions = find_cycles_in_call_graph(env, &targets);
+    targets.filter(|target, _| {
+        if let RewriteTarget::MoveFun(function_id) = target {
+            let function = env.get_function(*function_id);
+            // We will consider inlining the callees in a function only if it satisfies all of:
+            // - is not a part of a cycle in the call graph
+            // - is in a primary target module
+            // - is not in a script module
+            // - is not a test only function
+            // - is not a verify only function
+            // - is not a native function
+            // - is not an inline function
+            !skip_functions.contains(function_id)
+                && function.module_env.is_primary_target()
+                && !function.module_env.is_script_module()
+                && !function.is_test_only()
+                && !function.is_verify_only()
+                && !function.is_native()
+                && !function.is_inline()
+        } else {
+            // only move functions are considered for inlining optimization
+            false
+        }
+    });
+    let mut todo: Vec<_> = targets.keys().collect();
+    // Each time you unroll, a call site may be substituted with the original body of the callee.
+    for _ in 0..UNROLL_DEPTH {
+        if todo.is_empty() {
+            break;
+        }
+        todo = inline_call_sites(env, &mut targets, todo, across_package);
+    }
+    // Update the changed function definitions due to inlining.
+    targets.write_to_env(env);
+    // Inlining can cause direct calls to `package` functions that were previously
+    // indirect. Thus, it may require additional caller modules to become friends
+    // of the callee modules.
+    env.update_friend_decls_in_targets();
+}
+
+/// Inline call sites in the given `todo` list of functions.
+/// When inlining, the original definition of the callee is used, resulting in
+/// one-level of "unrolling".
+/// The function size estimates are also updated based on the inlining decisions.
+/// Return the list of functions that were changed due to inlining.
+fn inline_call_sites(
+    env: &GlobalEnv,
+    targets: &mut RewriteTargets,
+    todo: Vec<RewriteTarget>,
+    across_package: bool,
+) -> Vec<RewriteTarget> {
+    let mut changed_targets = Vec::new();
+    for target in todo {
+        let RewriteTarget::MoveFun(function_id) = target else {
+            continue;
+        };
+        let function_env = env.get_function(function_id);
+        if let Some(def) = get_latest_function_definition(targets, &target, &function_env) {
+            let caller_module = &function_env.module_env;
+            let current_caller_size = env
+                .function_size_estimate
+                .borrow()
+                .get(&function_id)
+                .copied();
+            let Some(caller_size) = current_caller_size else {
+                continue;
+            };
+            let (call_sites, new_size) = compute_call_sites_to_inline_and_new_function_size(
+                env,
+                caller_module,
+                def,
+                caller_size,
+                across_package,
+            );
+            let mut rewriter = CallerRewriter { env, call_sites };
+            // Rewrite the caller's body with inlined call sites.
+            let rewritten_def = rewriter.rewrite_exp(def.clone());
+            // If nothing has changed, no need to update.
+            if !ExpData::ptr_eq(&rewritten_def, def) {
+                *targets.state_mut(&target) = RewriteState::Def(rewritten_def);
+                env.function_size_estimate
+                    .borrow_mut()
+                    .insert(function_id, new_size);
+                changed_targets.push(target);
+            }
+        }
+    }
+    changed_targets
+}
+
+/// Get the "latest" definition of a `function`. If a function has some callsites
+/// already inlined (unrolled up to some depth), then that definition is used.
+fn get_latest_function_definition<'a>(
+    targets: &'a RewriteTargets,
+    target: &'a RewriteTarget,
+    function: &'a FunctionEnv,
+) -> Option<&'a Exp> {
+    if let RewriteState::Def(def) = targets.state(target) {
+        // If the code has changed due to inlining, use updated definition.
+        Some(def)
+    } else if let Some(def) = function.get_def() {
+        // If code is unchanged, use original definition.
+        Some(def)
+    } else {
+        None
+    }
+}
+
+/// Construct a call graph starting from the `targets`, and find all functions
+/// that are part of cycles (including self-recursion).
+fn find_cycles_in_call_graph(
+    env: &GlobalEnv,
+    targets: &RewriteTargets,
+) -> BTreeSet<QualifiedId<FunId>> {
+    let mut graph = DiGraphMap::<QualifiedId<FunId>, ()>::new();
+    let mut cycle_nodes = BTreeSet::new();
+    for target in targets.keys() {
+        if let RewriteTarget::MoveFun(function) = target {
+            graph.add_node(function);
+        }
+    }
+    for caller in graph.nodes().collect::<Vec<_>>() {
+        let caller_env = env.get_function(caller);
+        for callee in caller_env
+            .get_used_functions()
+            .expect("used functions must be computed")
+        {
+            if callee == &caller {
+                // self-recursion is added to the solution directly
+                cycle_nodes.insert(caller);
+            } else {
+                // non-self-recursion edges
+                graph.add_edge(caller, *callee, ());
+            }
+        }
+    }
+    for scc in kosaraju_scc(&graph) {
+        if scc.len() > 1 {
+            // cycle involving non-self-recursion
+            cycle_nodes.extend(scc.into_iter());
+        }
+    }
+    cycle_nodes
+}
+
+/// For a given caller function `def`, find all the call sites that are eligible for inlining,
+/// compute their costs, and pick as many as can fit within the heuristic limits.
+/// Return the set of call sites to inline, and the new estimated size of the caller function
+/// after inlining those call sites.
+fn compute_call_sites_to_inline_and_new_function_size(
+    env: &GlobalEnv,
+    caller_module: &ModuleEnv,
+    def: &Exp,
+    caller_function_size: FunctionSize,
+    across_package: bool,
+) -> (BTreeSet<NodeId>, FunctionSize) {
+    let caller_mid = caller_module.get_id();
+    let callees = def.called_funs_with_callsites_and_loop_depth();
+    // Find all the callees that are eligible for inlining.
+    let inline_eligible_functions = callees
+        .into_iter()
+        .filter_map(|(callee, sites_and_loop_depth)| {
+            let callee_env = env.get_function(callee);
+            let callee_size = get_function_size_estimate(env, &callee);
+            if callee_env.is_inline()
+                || callee_env.is_native()
+                || callee_size.code_size > MAX_CALLEE_CODE_SIZE
+                || has_explicit_return(&callee_env)
+                || has_privileged_operations(caller_mid, &callee_env)
+                || has_invisible_calls(caller_module, &callee_env, across_package)
+            {
+                // won't inline if:
+                // - callee is inline (should have been inlined already)
+                // - callee is native (no body to inline)
+                // - callee is too large (heuristic limit)
+                // - callee has an explicit return (cannot inline safely without additional
+                //   transformations)
+                // - callee has privileged operations on structs/enums that the caller cannot
+                //   perform directly
+                // - callee has calls to functions that are not visible from the caller module
+                None
+            } else {
+                let function_size = get_function_size_estimate(env, &callee);
+                let callee_frequency = sites_and_loop_depth.len();
+                assert!(callee_frequency > 0);
+                // Note that the number of locals introduced by inlining a callee can be amortized
+                // by the number of times the callee is called, because these variables have
+                // non-overlapping lifetimes and will likely be coalesced.
+                // We also currently either inline all the callsites of a callee or none (for simplicity).
+                let locals_per_site = function_size.num_locals;
+                let amortized_locals_per_site = locals_per_site.div_ceil(callee_frequency);
+                let max_loop_depth = sites_and_loop_depth
+                    .iter()
+                    .map(|(_, depth)| depth)
+                    .max()
+                    .copied()
+                    .unwrap_or_default();
+                let sites = sites_and_loop_depth
+                    .iter()
+                    .map(|(s, _)| s)
+                    .copied()
+                    .collect::<BTreeSet<_>>();
+                let code_size = callee_size.code_size;
+                Some((sites, CalleeInfo {
+                    max_loop_depth,
+                    amortized_locals_per_site,
+                    code_size,
+                    locals_per_site,
+                }))
+            }
+        })
+        .collect::<Vec<_>>();
+    pick_from_eligible_and_compute_cost(inline_eligible_functions, caller_function_size)
+}
+
+/// Various information about a callee function that is eligible for inlining.
+struct CalleeInfo {
+    /// Maximum loop depth of any of the call sites of this callee.
+    max_loop_depth: usize,
+    /// Amortized number of locals per call site after inlining.
+    amortized_locals_per_site: usize,
+    /// Estimated code size of the callee function.
+    code_size: usize,
+    /// Estimate number of locals in the callee function.
+    locals_per_site: usize,
+}
+
+/// Given a list of eligible callsites to inline, pick as many as possible within the
+/// heuristic limits, and compute the new estimated size of the caller function.
+/// Each element of `inline_eligible_callees` is a pair of:
+/// - set of call sites of a callee
+/// - information about the callee that can help in making inlining decisions
+fn pick_from_eligible_and_compute_cost(
+    mut inline_eligible_callees: Vec<(BTreeSet<NodeId>, CalleeInfo)>,
+    caller_function_size: FunctionSize,
+) -> (BTreeSet<NodeId>, FunctionSize) {
+    inline_eligible_callees.sort_by(|a, b| {
+        // Sort callees based on the following (tie-break leads to next criteria):
+        // 1. Highest loop depth of any of the call sites
+        // 2. Lower amortized locals per call site
+        // 3. Lower code size of callee
+        // 4. Lower frequency of callee
+        // 5. Lower locals per call site
+        b.1.max_loop_depth
+            .cmp(&a.1.max_loop_depth)
+            .then_with(|| {
+                a.1.amortized_locals_per_site
+                    .cmp(&b.1.amortized_locals_per_site)
+            })
+            .then_with(|| a.1.code_size.cmp(&b.1.code_size))
+            .then_with(|| a.0.len().cmp(&b.0.len()))
+            .then_with(|| a.1.locals_per_site.cmp(&b.1.locals_per_site))
+    });
+    let FunctionSize {
+        code_size,
+        num_locals,
+    } = caller_function_size;
+    let locals_budget = MAX_LOCAL_COUNT.saturating_sub(num_locals);
+    let code_size_budget = MAX_CALLER_CODE_SIZE.saturating_sub(code_size);
+    let mut locals_budget_remaining = locals_budget;
+    let mut code_size_budget_remaining = code_size_budget;
+    let mut call_sites_to_inline = BTreeSet::new();
+    // Go over the sorted callees and greedily pick as many as fit within the budget.
+    for (sites, callee_info) in inline_eligible_callees {
+        if locals_budget_remaining == 0 || code_size_budget_remaining == 0 {
+            // no more budget left
+            break;
+        }
+        if let (Some(locals_reduced), Some(code_size_reduced)) = (
+            locals_budget_remaining.checked_sub(callee_info.locals_per_site),
+            code_size_budget_remaining.checked_sub(callee_info.code_size * sites.len()),
+        ) {
+            call_sites_to_inline.extend(sites.into_iter());
+            // Note that we reduce the remaining budget for number of locals once for
+            // all the callsites of a callee, because we expect to coalesce the locals at
+            // different callsites.
+            // The remaining budget for code size is reduced for each callsite.
+            locals_budget_remaining = locals_reduced;
+            code_size_budget_remaining = code_size_reduced;
+        } else {
+            // cannot inline this callee due to budget limits
+            // maybe try the next candidate
+            continue;
+        }
+    }
+    (
+        call_sites_to_inline,
+        FunctionSize::new(
+            code_size + (code_size_budget - code_size_budget_remaining),
+            num_locals + (locals_budget - locals_budget_remaining),
+        ),
+    )
+}
+
+fn get_function_size_estimate(env: &GlobalEnv, function: &QualifiedId<FunId>) -> FunctionSize {
+    env.function_size_estimate
+        .borrow()
+        .get(function)
+        .copied()
+        .unwrap_or_default()
+}
+
+/// Does `callee` have any privileged operations on structs/enums that cannot be performed
+/// directly in a caller with module id `caller_mid`?
+fn has_privileged_operations(caller_mid: ModuleId, callee: &FunctionEnv) -> bool {
+    let env = callee.env();
+    // keep track if we have found any privileged operations
+    let mut found = false;
+    // used to track if we are within a spec block, privileged operations within
+    // spec blocks are allowed
+    let mut spec_blocks_seen = 0;
+    if let Some(body) = callee.get_def() {
+        body.visit_pre_post(&mut |post, exp: &ExpData| {
+            if !post {
+                if matches!(exp, ExpData::SpecBlock(..)) {
+                    spec_blocks_seen += 1;
+                }
+                if spec_blocks_seen > 0 {
+                    // within a spec block, we can have privileged operations
+                    return true;
+                }
+                // not inside a spec block, see if there are any privileged operations
+                match exp {
+                    ExpData::Call(id, op, _) => match op {
+                        Operation::Exists(_)
+                        | Operation::BorrowGlobal(_)
+                        | Operation::MoveFrom
+                        | Operation::MoveTo => {
+                            let inst = env.get_node_instantiation(*id);
+                            if let Some((struct_env, _)) = inst[0].get_struct(env) {
+                                let struct_mid = struct_env.module_env.get_id();
+                                if struct_mid != caller_mid {
+                                    found = true;
+                                }
+                            }
+                        },
+                        Operation::Select(mid, ..)
+                        | Operation::SelectVariants(mid, ..)
+                        | Operation::TestVariants(mid, ..)
+                        | Operation::Pack(mid, ..) => {
+                            if *mid != caller_mid {
+                                found = true;
+                            }
+                        },
+                        _ => {},
+                    },
+                    // various ways to unpack
+                    ExpData::Assign(_, pat, _)
+                    | ExpData::Block(_, pat, ..)
+                    | ExpData::Lambda(_, pat, ..) => pat.visit_pre_post(&mut |post, pat| {
+                        if !post {
+                            if let Pattern::Struct(_, sid, ..) = pat {
+                                let struct_mid = sid.module_id;
+                                if struct_mid != caller_mid {
+                                    found = true;
+                                }
+                            }
+                        }
+                    }),
+                    ExpData::Match(_, discriminator, _) => {
+                        let did = discriminator.node_id();
+                        if let Type::Struct(mid, ..) = env.get_node_type(did).drop_reference() {
+                            if mid != caller_mid {
+                                found = true;
+                            }
+                        }
+                    },
+                    _ => {},
+                }
+            } else {
+                // post visit
+                if matches!(exp, ExpData::SpecBlock(..)) {
+                    spec_blocks_seen -= 1;
+                }
+            }
+            // skip scanning for privileged operations if we already found one
+            !found
+        });
+    }
+    found
+}
+
+/// Does `callee` have any calls to functions that are not visible from `caller_module`?
+fn has_invisible_calls(
+    caller_module: &ModuleEnv,
+    callee: &FunctionEnv,
+    across_package: bool,
+) -> bool {
+    let env = callee.env();
+    let caller_mid = caller_module.get_id();
+    if let Some(body) = callee.get_def() {
+        for called_fun_id in body.used_funs() {
+            let called_function = env.get_function(called_fun_id);
+            let called_mid = called_function.module_env.get_id();
+            if called_mid == caller_mid {
+                // same module, so visible
+                continue;
+            }
+            // TODO(#13745): hack for checking if two modules are in the same package
+            let same_package = caller_module.self_address()
+                == called_function.module_env.self_address()
+                && caller_module.is_primary_target()
+                && called_function.module_env.is_primary_target();
+
+            match called_function.visibility() {
+                Visibility::Public => {
+                    if !same_package && !across_package {
+                        // public function in a different package cannot be inlined due to change
+                        // in semantics on package upgrade, but we allow it when across-package
+                        // inlining is enabled
+                        return true;
+                    }
+                },
+                Visibility::Private => {
+                    return true;
+                },
+                Visibility::Friend => {
+                    // Note: `is_friend` implies `same_package`
+                    let is_friend = called_function.module_env.has_friend(&caller_mid);
+                    if is_friend || (called_function.has_package_visibility() && same_package) {
+                        // 1. a call to a friend function whose module has the caller module as a friend
+                        //    is visible and belongs to the same package
+                        // 2. a call to a package function belonging to the same package is also visible
+                        continue;
+                    }
+                    return true;
+                },
+            }
+        }
+    }
+    false
+}
+
+/// Does `function` have an explicit return statement in its body?
+fn has_explicit_return(function: &FunctionEnv) -> bool {
+    let Some(exp) = function.get_def() else {
+        return false;
+    };
+    let mut found = false;
+    exp.visit_pre_order(&mut |e: &ExpData| {
+        if let ExpData::Return(..) = e {
+            found = true;
+        }
+        // Keep going if not yet found
+        !found
+    });
+    found
+}
+
+/// Rewriter for a caller function to inline the call sites in it.
+struct CallerRewriter<'env> {
+    env: &'env GlobalEnv,
+    // The call sites that have been picked to inline
+    call_sites: BTreeSet<NodeId>,
+}
+
+impl ExpRewriterFunctions for CallerRewriter<'_> {
+    fn rewrite_call(&mut self, call_id: NodeId, op: &Operation, args: &[Exp]) -> Option<Exp> {
+        if self.call_sites.contains(&call_id) {
+            if let Operation::MoveFunction(mid, fid) = op {
+                let callee = self.env.get_function(mid.qualified(*fid));
+                let type_args = self.env.get_node_instantiation(call_id);
+                let call_site_loc = self.env.get_node_loc(call_id);
+                let mut callee_rewriter = CalleeRewriter {
+                    function_env: &callee,
+                    type_args: &type_args,
+                    call_site_loc: &call_site_loc,
+                };
+                let body = callee.get_def()?;
+                // Rewrite the body of the callee to adjust node ids, types, and locations.
+                let rewritten_body = callee_rewriter.rewrite_exp(body.clone());
+                // Construct a pattern for the parameters of the callee to create a `let` binding.
+                let params_pattern = callee_rewriter.params_to_pattern(&callee);
+                // Perform inlining transformation at the call site.
+                Some(self.construct_inlined_call_expression(
+                    &call_site_loc,
+                    rewritten_body,
+                    params_pattern,
+                    args.to_vec(),
+                ))
+            } else {
+                unreachable!("callsites should be calls to MoveFunction")
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl CallerRewriter<'_> {
+    /// Given a transformed `body` of the callee, a tuple pattern `(x, y, ..)`
+    /// corresponding to the parameters of the callee, and the arguments
+    /// `a, b, ..` at the call site, construct the inlined expression:
+    /// ```move
+    /// let (x, y, ..) = (a, b, ..); body
+    /// ```
+    fn construct_inlined_call_expression(
+        &self,
+        call_site_loc: &Loc,
+        body: Exp,
+        params_pattern: Pattern,
+        args: Vec<Exp>,
+    ) -> Exp {
+        let body_node_id = body.as_ref().node_id();
+        let body_type = self.env.get_node_type(body_node_id);
+        let body_loc = self
+            .env
+            .get_node_loc(body_node_id)
+            .inlined_from(call_site_loc);
+
+        let new_block_id = self.env.new_node(body_loc, body_type);
+
+        let optional_binding_exp = if args.is_empty() {
+            None
+        } else {
+            let args_node_ids = args
+                .iter()
+                .map(|e| e.as_ref().node_id())
+                .collect::<Vec<_>>();
+            let args_types = args_node_ids
+                .iter()
+                .map(|id| self.env.get_node_type(*id))
+                .collect::<Vec<_>>();
+            let args_loc = Loc::enclosing(
+                args_node_ids
+                    .iter()
+                    .map(|id| self.env.get_node_loc(*id))
+                    .collect::<Vec<_>>()
+                    .as_slice(),
+            );
+            let new_binding_id = self.env.new_node(args_loc, Type::Tuple(args_types));
+            Some(ExpData::Call(new_binding_id, Operation::Tuple, args).into_exp())
+        };
+
+        ExpData::Block(new_block_id, params_pattern, optional_binding_exp, body).into_exp()
+    }
+}
+
+/// Rewriter for the callee function at a given call site.
+struct CalleeRewriter<'a> {
+    /// The function environment of the callee.
+    function_env: &'a FunctionEnv<'a>,
+    /// The type arguments at the call site.
+    type_args: &'a Vec<Type>,
+    /// The location of the call site.
+    call_site_loc: &'a Loc,
+}
+
+impl ExpRewriterFunctions for CalleeRewriter<'_> {
+    /// Update node ids to new ones, and update their locations to reflect inlining.
+    fn rewrite_node_id(&mut self, id: NodeId) -> Option<NodeId> {
+        let loc = self.function_env.env().get_node_loc(id);
+        let new_loc = loc.inlined_from(self.call_site_loc);
+        ExpData::instantiate_node_new_loc(self.function_env.env(), id, self.type_args, &new_loc)
+    }
+
+    /// Update patterns to use new node ids.
+    fn rewrite_pattern(&mut self, pat: &Pattern, _entering_scope: bool) -> Option<Pattern> {
+        let old_id = pat.node_id();
+        let new_id = ExpData::instantiate_node(self.function_env.env(), old_id, self.type_args)
+            .unwrap_or(old_id);
+        match pat {
+            Pattern::Struct(_, struct_id, variant, pattern_vec) => {
+                let new_struct_id = struct_id.clone().instantiate(self.type_args);
+                Some(Pattern::Struct(
+                    new_id,
+                    new_struct_id,
+                    *variant,
+                    pattern_vec.clone(),
+                ))
+            },
+            Pattern::Tuple(_, pattern_vec) => Some(Pattern::Tuple(new_id, pattern_vec.clone())),
+            Pattern::Var(_, symbol) => Some(Pattern::Var(new_id, *symbol)),
+            Pattern::Wildcard(_) => Some(Pattern::Wildcard(new_id)),
+            Pattern::Error(_) => None,
+        }
+    }
+
+    /// Replaces the temporary referring to the parameter with the corresponding symbol.
+    fn rewrite_temporary(&mut self, id: NodeId, idx: TempIndex) -> Option<Exp> {
+        if let Some(Parameter(sym, ty, loc)) = self.function_env.get_parameters_ref().get(idx) {
+            let inst_ty = ty.instantiate(self.type_args);
+            let new_node_id = self.function_env.env().new_node(loc.clone(), inst_ty);
+            Some(ExpData::LocalVar(new_node_id, *sym).into())
+        } else {
+            let loc = self.function_env.env().get_node_loc(id);
+            self.function_env.env().diag(
+                Severity::Bug,
+                &loc,
+                &format!(
+                    "temporary with invalid index `{}` when applying inlining optimization",
+                    idx
+                ),
+            );
+            None
+        }
+    }
+}
+
+impl CalleeRewriter<'_> {
+    /// Construct a tuple pattern for the parameters of the callee function.
+    /// E.g., for a function with parameters `x: T, y: bool`, this returns
+    /// the pattern `(x, y)`, with `x` and `y` instantiated with respective
+    /// types known at this call site.
+    fn params_to_pattern(&self, function: &FunctionEnv) -> Pattern {
+        let params = function.get_parameters();
+        let function_loc = function.get_id_loc();
+        let tuple_args = params
+            .iter()
+            .map(|Parameter(sym, ty, loc)| {
+                let id = self
+                    .function_env
+                    .env()
+                    .new_node(loc.clone(), ty.instantiate(self.type_args));
+                if self
+                    .function_env
+                    .env()
+                    .language_version()
+                    .is_at_least(LanguageVersion::V2_1)
+                    && self.function_env.symbol_pool().string(*sym).as_ref() == "_"
+                {
+                    Pattern::Wildcard(id)
+                } else {
+                    Pattern::Var(id, *sym)
+                }
+            })
+            .collect::<Vec<_>>();
+        let tuple_types = params
+            .iter()
+            .map(|p| p.1.instantiate(self.type_args))
+            .collect::<Vec<_>>();
+        let id = self.function_env.env().new_node(
+            function_loc.inlined_from(self.call_site_loc),
+            Type::Tuple(tuple_types),
+        );
+        Pattern::Tuple(id, tuple_args)
+    }
+}

--- a/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/mod.rs
@@ -16,6 +16,7 @@ pub mod cyclic_instantiation_checker;
 pub mod flow_insensitive_checkers;
 pub mod function_checker;
 pub mod inliner;
+pub mod inlining_optimization;
 pub mod lambda_lifter;
 pub mod model_ast_lints;
 pub mod recursive_struct_checker;

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -107,6 +107,16 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(true),
         },
         Experiment {
+            name: Experiment::INLINING_OPTIMIZATION.to_string(),
+            description: "Turns on or off inlining optimizations".to_string(),
+            default: Given(false),
+        },
+        Experiment {
+            name: Experiment::ACROSS_PACKAGE_INLINING.to_string(),
+            description: "Turns on or off inlining across package boundaries".to_string(),
+            default: Given(false),
+        },
+        Experiment {
             name: Experiment::SPEC_CHECK.to_string(),
             description: "Turns on or off specification checks".to_string(),
             default: Inherited(Experiment::CHECKS.to_string()),
@@ -288,6 +298,7 @@ impl Experiment {
     pub const ABILITY_CHECK: &'static str = "ability-check";
     pub const ACCESS_CHECK: &'static str = "access-use-function-check";
     pub const ACQUIRES_CHECK: &'static str = "acquires-check";
+    pub const ACROSS_PACKAGE_INLINING: &'static str = "across-package-inlining";
     pub const AST_SIMPLIFY: &'static str = "ast-simplify";
     pub const AST_SIMPLIFY_FULL: &'static str = "ast-simplify-full";
     pub const ATTACH_COMPILED_MODULE: &'static str = "attach-compiled-module";
@@ -299,6 +310,7 @@ impl Experiment {
     pub const FAIL_ON_WARNING: &'static str = "fail-on-warning";
     pub const FLUSH_WRITES_OPTIMIZATION: &'static str = "flush-writes-optimization";
     pub const INLINING: &'static str = "inlining";
+    pub const INLINING_OPTIMIZATION: &'static str = "inlining-optimization";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
     pub const KEEP_UNINIT_ANNOTATIONS: &'static str = "keep-uninit-annotations";
     pub const LAMBDA_LIFTING_INLINE: &'static str = "lambda-lifting-inline";

--- a/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/mod.rs
@@ -138,4 +138,4 @@ const MAX_FIELD_INST_COUNT: usize = FF::TableIndex::MAX as usize;
 const MAX_FUNCTION_COUNT: usize = FF::TableIndex::MAX as usize;
 const MAX_FUNCTION_INST_COUNT: usize = FF::TableIndex::MAX as usize;
 const MAX_FUNCTION_DEF_COUNT: usize = FF::TableIndex::MAX as usize;
-const MAX_LOCAL_COUNT: usize = FF::LocalIndex::MAX as usize;
+pub const MAX_LOCAL_COUNT: usize = FF::LocalIndex::MAX as usize;

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -19,7 +19,7 @@ use crate::{
     env_pipeline::{
         acquires_checker, ast_simplifier, closure_checker, cmp_rewriter,
         cyclic_instantiation_checker, flow_insensitive_checkers, function_checker, inliner,
-        lambda_lifter, lambda_lifter::LambdaLiftingOptions, model_ast_lints,
+        inlining_optimization, lambda_lifter, lambda_lifter::LambdaLiftingOptions, model_ast_lints,
         recursive_struct_checker, rewrite_target::RewritingScope, seqs_in_binop_checker,
         spec_checker, spec_rewriter, unused_params_checker, EnvProcessorPipeline,
     },
@@ -311,6 +311,8 @@ pub fn run_stackless_bytecode_gen(env: &GlobalEnv) -> FunctionTargetsHolder {
             }
         }
     }
+    env.set_function_size_estimates(targets.compute_function_size_estimates());
+
     targets
 }
 
@@ -466,13 +468,26 @@ pub fn env_check_and_transform_pipeline<'a, 'b>(options: &'a Options) -> EnvProc
 pub fn env_optimization_pipeline<'a, 'b>(options: &'a Options) -> EnvProcessorPipeline<'b> {
     let mut env_pipeline = EnvProcessorPipeline::<'b>::default();
 
+    // Note: we should run inlining optimization before other AST simplifications, so that
+    // those simplifications can take advantage of the inlining.
+    let do_inlining_optimization = options.experiment_on(Experiment::INLINING_OPTIMIZATION);
+    if do_inlining_optimization {
+        let across_package = options.experiment_on(Experiment::ACROSS_PACKAGE_INLINING);
+        env_pipeline.add("inlining optimization", {
+            move |env: &mut GlobalEnv| inlining_optimization::optimize(env, across_package)
+        });
+    }
     if options.experiment_on(Experiment::AST_SIMPLIFY_FULL) {
         env_pipeline.add("simplifier with code elimination", {
-            |env: &mut GlobalEnv| ast_simplifier::run_simplifier(env, true)
+            move |env: &mut GlobalEnv| {
+                ast_simplifier::run_simplifier(env, true, do_inlining_optimization)
+            }
         });
     } else if options.experiment_on(Experiment::AST_SIMPLIFY) {
         env_pipeline.add("simplifier", {
-            |env: &mut GlobalEnv| ast_simplifier::run_simplifier(env, false)
+            move |env: &mut GlobalEnv| {
+                ast_simplifier::run_simplifier(env, false, do_inlining_optimization)
+            }
         });
     }
 

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/caller_callee_shadowing.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/caller_callee_shadowing.exp
@@ -1,0 +1,69 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    private fun callee(a: u64,_b: u64): u64 {
+        {
+          let x: u64 = 1;
+          {
+            let y: u64 = Add<u64>(a, x);
+            y
+          }
+        }
+    }
+    private fun caller(): u64 {
+        {
+          let x: u64 = 1;
+          {
+            let y: u64 = 1;
+            m::callee(x, y)
+          }
+        }
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    fun callee(a: u64, _b: u64): u64 {
+        let x = 1;
+        let y = a + x;
+        y
+    }
+    fun caller(): u64 {
+        let x = 1;
+        let y = 1;
+        callee(x, y)
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    private fun callee(a: u64,_b: u64): u64 {
+        {
+          let y: u64 = Add<u64>(a, 1);
+          y
+        }
+    }
+    private fun caller(): u64 {
+        2
+    }
+} // end 0xc0ffee::m
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+
+
+callee(a: u64, _b: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](a: u64)
+	1: LdU64(1)
+	2: Add
+	3: Ret
+}
+caller(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(2)
+	1: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/caller_callee_shadowing.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/caller_callee_shadowing.move
@@ -1,0 +1,13 @@
+module 0xc0ffee::m {
+    fun caller(): u64 {
+        let x = 1;
+        let y = 1;
+        callee(x, y)
+    }
+
+    fun callee(a: u64, _b: u64): u64 {
+        let x = 1;
+        let y = a + x;
+        y
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/fib.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/fib.exp
@@ -1,0 +1,63 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    private fun fib(n: u64): u64 {
+        if Lt<u64>(n, 2) {
+          n
+        } else {
+          Add<u64>(m::fib(Sub<u64>(n, 1)), m::fib(Sub<u64>(n, 2)))
+        }
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    fun fib(n: u64): u64 {
+        if (n < 2) n else fib(n - 1) + fib(n - 2)
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    private fun fib(n: u64): u64 {
+        if Lt<u64>(n, 2) {
+          n
+        } else {
+          Add<u64>(m::fib(Sub<u64>(n, 1)), m::fib(Sub<u64>(n, 2)))
+        }
+    }
+} // end 0xc0ffee::m
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+
+
+fib(n: u64): u64 /* def_idx: 0 */ {
+L1:	$t3: u64
+B0:
+	0: CopyLoc[0](n: u64)
+	1: LdU64(2)
+	2: Lt
+	3: BrFalse(8)
+B1:
+	4: MoveLoc[0](n: u64)
+	5: StLoc[1]($t3: u64)
+B2:
+	6: MoveLoc[1]($t3: u64)
+	7: Ret
+B3:
+	8: CopyLoc[0](n: u64)
+	9: LdU64(1)
+	10: Sub
+	11: Call fib(u64): u64
+	12: MoveLoc[0](n: u64)
+	13: LdU64(2)
+	14: Sub
+	15: Call fib(u64): u64
+	16: Add
+	17: StLoc[1]($t3: u64)
+	18: Branch(6)
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/fib.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/fib.move
@@ -1,0 +1,9 @@
+module 0xc0ffee::m {
+    fun fib(n: u64): u64 {
+        if (n < 2) {
+            n
+        } else {
+            fib(n - 1) + fib(n - 2)
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/if_else_const_bool_after_inlining.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/if_else_const_bool_after_inlining.exp
@@ -1,0 +1,95 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun code(is_sell: bool): u64 {
+        if is_sell {
+          m::one()
+        } else {
+          m::two()
+        }
+    }
+    private fun one(): u64 {
+        1
+    }
+    private fun sum_codes(): u64 {
+        Add<u64>(m::code(true), m::code(false))
+    }
+    private fun two(): u64 {
+        2
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun code(is_sell: bool): u64 {
+        if (is_sell) one() else two()
+    }
+    fun one(): u64 {
+        1
+    }
+    fun sum_codes(): u64 {
+        code(true) + code(false)
+    }
+    fun two(): u64 {
+        2
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    public fun code(is_sell: bool): u64 {
+        if is_sell {
+          1
+        } else {
+          2
+        }
+    }
+    private fun one(): u64 {
+        1
+    }
+    private fun sum_codes(): u64 {
+        3
+    }
+    private fun two(): u64 {
+        2
+    }
+} // end 0xc0ffee::m
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+
+
+public code(is_sell: bool): u64 /* def_idx: 0 */ {
+L1:	return: u64
+B0:
+	0: MoveLoc[0](is_sell: bool)
+	1: BrFalse(6)
+B1:
+	2: LdU64(1)
+	3: StLoc[1](return: u64)
+B2:
+	4: MoveLoc[1](return: u64)
+	5: Ret
+B3:
+	6: LdU64(2)
+	7: StLoc[1](return: u64)
+	8: Branch(4)
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+sum_codes(): u64 /* def_idx: 2 */ {
+B0:
+	0: LdU64(3)
+	1: Ret
+}
+two(): u64 /* def_idx: 3 */ {
+B0:
+	0: LdU64(2)
+	1: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/if_else_const_bool_after_inlining.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/if_else_const_bool_after_inlining.move
@@ -1,0 +1,21 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    fun two(): u64 {
+        2
+    }
+
+    fun sum_codes(): u64 {
+        code(true) + code(false)
+    }
+
+    public fun code(is_sell: bool): u64 {
+        if (is_sell) {
+            one()
+        } else {
+            two()
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/mut_refs_freeze.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/mut_refs_freeze.exp
@@ -1,0 +1,67 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    private fun read(r: &u64): u64 {
+        Deref(r)
+    }
+    private fun read_then_write(r: &mut u64) {
+        {
+          let v: u64 = m::read(Freeze(false)(r));
+          r = Add<u64>(v, 1);
+          Tuple()
+        }
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    fun read(r: &u64): u64 {
+        *r
+    }
+    fun read_then_write(r: &mut u64) {
+        let v = read(/*freeze*/r);
+        *r = v + 1;
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    private fun read(r: &u64): u64 {
+        Deref(r)
+    }
+    private fun read_then_write(r: &mut u64) {
+        {
+          let v: u64 = {
+            let (r: &u64): (&u64) = Tuple(Freeze(false)(r));
+            Deref(r)
+          };
+          r = Add<u64>(v, 1);
+          Tuple()
+        }
+    }
+} // end 0xc0ffee::m
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+
+
+read(r: &u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](r: &u64)
+	1: ReadRef
+	2: Ret
+}
+read_then_write(r: &mut u64) /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](r: &mut u64)
+	1: FreezeRef
+	2: ReadRef
+	3: LdU64(1)
+	4: Add
+	5: MoveLoc[0](r: &mut u64)
+	6: WriteRef
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/mut_refs_freeze.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/mut_refs_freeze.move
@@ -1,0 +1,10 @@
+module 0xc0ffee::m {
+    fun read(r: &u64): u64 {
+        *r
+    }
+
+    fun read_then_write(r: &mut u64) {
+        let v = read(r);
+        *r = v + 1;
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/unbounded_recursion.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/unbounded_recursion.exp
@@ -1,0 +1,40 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun infinite() {
+        m::infinite();
+        m::infinite();
+        Tuple()
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun infinite() {
+        infinite();
+        infinite();
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    public fun infinite() {
+        m::infinite();
+        m::infinite();
+        Tuple()
+    }
+} // end 0xc0ffee::m
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+
+
+public infinite() /* def_idx: 0 */ {
+B0:
+	0: Call infinite()
+	1: Call infinite()
+	2: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/unbounded_recursion.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/unbounded_recursion.move
@@ -1,0 +1,6 @@
+module 0xc0ffee::m {
+    public fun infinite() {
+        infinite();
+        infinite();
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/within_module_simple.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/within_module_simple.exp
@@ -1,0 +1,62 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun compute(): u64 {
+        Add<u64>(m::one(), m::two())
+    }
+    private fun one(): u64 {
+        1
+    }
+    public fun two(): u64 {
+        2
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    public fun compute(): u64 {
+        one() + two()
+    }
+    fun one(): u64 {
+        1
+    }
+    public fun two(): u64 {
+        2
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    public fun compute(): u64 {
+        3
+    }
+    private fun one(): u64 {
+        1
+    }
+    public fun two(): u64 {
+        2
+    }
+} // end 0xc0ffee::m
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+
+
+public compute(): u64 /* def_idx: 0 */ {
+B0:
+	0: LdU64(3)
+	1: Ret
+}
+one(): u64 /* def_idx: 1 */ {
+B0:
+	0: LdU64(1)
+	1: Ret
+}
+public two(): u64 /* def_idx: 2 */ {
+B0:
+	0: LdU64(2)
+	1: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/within_module_simple.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/within_module_simple.move
@@ -1,0 +1,13 @@
+module 0xc0ffee::m {
+    fun one(): u64 {
+        1
+    }
+
+    public fun two(): u64 {
+        2
+    }
+
+    public fun compute(): u64 {
+        one() + two()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -251,6 +251,18 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             dump_ast: DumpLevel::EndStage,
             ..config().exp(Experiment::AST_SIMPLIFY_FULL)
         },
+        // Tests for inlining optimization + full AST simplifier
+        TestConfig {
+            name: "inlining-optimization",
+            runner: |p| run_test(p, get_config_by_name("inlining-optimization")),
+            include: vec!["/inlining-optimization/"],
+            dump_ast: DumpLevel::EndStage,
+            dump_bytecode: DumpLevel::EndStage,
+            dump_bytecode_filter: Some(vec![FILE_FORMAT_STAGE]),
+            ..config()
+                .exp(Experiment::INLINING_OPTIMIZATION)
+                .exp(Experiment::AST_SIMPLIFY_FULL)
+        },
         // Tests for more-v1 tests
         TestConfig {
             name: "more-v1",

--- a/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
+++ b/third_party/move/move-model/bytecode/src/function_target_pipeline.rs
@@ -11,7 +11,7 @@ use crate::{
 use core::fmt;
 use itertools::{Either, Itertools};
 use log::debug;
-use move_model::model::{FunId, FunctionEnv, GlobalEnv, QualifiedId};
+use move_model::model::{FunId, FunctionEnv, FunctionSize, GlobalEnv, QualifiedId};
 use petgraph::graph::DiGraph;
 use std::{
     collections::{BTreeMap, BTreeSet},
@@ -294,6 +294,23 @@ impl FunctionTargetsHolder {
                 self.insert_target_data(&id, variant, processed_data);
             }
         }
+    }
+
+    /// Computes the estimated sizes of functions using their stackless bytecode.
+    pub fn compute_function_size_estimates(&self) -> BTreeMap<QualifiedId<FunId>, FunctionSize> {
+        self.targets
+            .iter()
+            .filter_map(|(fid, variants)| {
+                let baseline_function = variants.get(&FunctionVariant::Baseline)?;
+                Some((
+                    *fid,
+                    FunctionSize::new(
+                        baseline_function.code.len(),
+                        baseline_function.local_types.len(),
+                    ),
+                ))
+            })
+            .collect()
     }
 }
 

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -607,6 +607,8 @@ pub struct GlobalEnv {
     pub(crate) generated_by_v2: bool,
     /// A set of types that are instantiated in cmp module.
     pub cmp_types: RefCell<BTreeSet<Type>>,
+    /// An estimate of each target Move function's size.
+    pub function_size_estimate: RefCell<BTreeMap<QualifiedId<FunId>, FunctionSize>>,
 }
 
 /// A helper type for implementing fmt::Display depending on GlobalEnv
@@ -669,6 +671,7 @@ impl GlobalEnv {
             everything_is_target: Default::default(),
             generated_by_v2: false,
             cmp_types: RefCell::new(Default::default()),
+            function_size_estimate: RefCell::new(Default::default()),
         }
     }
 
@@ -2057,8 +2060,16 @@ impl GlobalEnv {
             .function_data
             .get_mut(&fun.id)
             .unwrap();
-        data.used_funs = Some(def.used_funs());
+        // Recompute called and used functions.
         data.called_funs = Some(def.called_funs());
+        data.used_funs = Some(def.used_funs());
+        // Reset various caches because the AST has changed.
+        *data.calling_funs.borrow_mut() = None;
+        *data.transitive_closure_of_called_funs.borrow_mut() = None;
+        *data.using_funs.borrow_mut() = None;
+        *data.transitive_closure_of_used_funs.borrow_mut() = None;
+        *data.used_functions_with_transitive_inline.borrow_mut() = None;
+        // Set the new function definition.
         data.def = Some(def);
     }
 
@@ -2660,6 +2671,42 @@ impl GlobalEnv {
             });
         }
     }
+
+    /// Update the friend declarations in all target modules, when the
+    /// callees could have changed due to AST-level optimizations.
+    pub fn update_friend_decls_in_targets(&mut self) {
+        let mut friend_decls_to_add = BTreeMap::new();
+        for module in self.get_target_modules() {
+            let module_name = module.get_name();
+            let needed = module.need_to_be_friended_by();
+            for need_to_be_friended_by in needed {
+                let need_to_be_friend_with = self.get_module(need_to_be_friended_by);
+                let already_friended = need_to_be_friend_with
+                    .get_friend_decls()
+                    .iter()
+                    .any(|friend_decl| &friend_decl.module_name == module_name);
+                if !already_friended {
+                    let loc = need_to_be_friend_with.get_loc();
+                    let friend_decl = FriendDecl {
+                        loc,
+                        module_name: module_name.clone(),
+                        module_id: Some(module.get_id()),
+                    };
+                    friend_decls_to_add
+                        .entry(need_to_be_friended_by)
+                        .or_insert_with(Vec::new)
+                        .push(friend_decl);
+                }
+            }
+        }
+        for (module_id, friend_decls) in friend_decls_to_add {
+            let module_data = self.get_module_data_mut(module_id);
+            module_data
+                .friend_modules
+                .extend(friend_decls.iter().flat_map(|d| d.module_id));
+            module_data.friend_decls.extend(friend_decls);
+        }
+    }
 }
 
 impl Default for GlobalEnv {
@@ -2933,6 +2980,10 @@ impl GlobalEnv {
             format!(": {}", result_type.display(tctx))
         };
         format!("{}({}){}", type_params_str, params_str, result_str)
+    }
+
+    pub fn set_function_size_estimates(&self, sizes: BTreeMap<QualifiedId<FunId>, FunctionSize>) {
+        *self.function_size_estimate.borrow_mut() = sizes;
     }
 }
 
@@ -5513,5 +5564,22 @@ impl fmt::Display for EnvDisplay<'_, Parameter> {
             p.get_name().display(self.env.symbol_pool()),
             p.get_type().display(&self.env.get_type_display_ctx())
         )
+    }
+}
+
+#[derive(Clone, Copy, Debug, Default)]
+pub struct FunctionSize {
+    /// Number of instructions in the function body
+    pub code_size: usize,
+    /// Number of local variables in the function
+    pub num_locals: usize,
+}
+
+impl FunctionSize {
+    pub fn new(code_size: usize, num_locals: usize) -> Self {
+        Self {
+            code_size,
+            num_locals,
+        }
     }
 }


### PR DESCRIPTION
## Description

In this PR, we implement the inlining compiler optimization:

With inlining, a call site of the form:
```move
foo(a, b, c, ...)
```
where, 
```move
fun foo(x, y, z, ...) { body }
```
becomes:
```move
let (x, y, z, ...) = (a, b, c, ...); body
```

The inlining is applicable only if it is safe to perform such inlinling (e.g., the inlined body should not have operations that cannot be performed by the caller directly, including having function calls that are not visible).

Various heuristics are used to decide whether or not inlining should be performed at a particular callsite: we expect these heuristics to evolve and be tuned. In this PR, we have some default heuristics.

Inlining also makes certain follow up optimizations like AST simplification and code elimination even more applicable. For example, consider the original code:
```move
module 0xc0ffee::m {
    fun one(): u64 {
        1
    }

    fun two(): u64 {
        2
    }

    fun sum_codes(): u64 {
        code(true) + code(false)
    }

    public fun code(is_sell: bool): u64 {
        if (is_sell) {
            one()
        } else {
            two()
        }
    }
}
```

With inlining and AST simplification + code elimination, the function `sum_codes` get optimized to just `3`.

Please note:
- inlining is not enabled by default: we would need additional testing and tuning of the heuristics to do this.
- we do not re-configure the inlining transformation of `inline` functions due to significant differences in that process vs. this optimization (such as not requiring lambda substitution, bottom up vs. layer by layer unrolling, etc).

## How Has This Been Tested?

Added some new tests to demonstrate the inlining in action.

## Key Areas to Review

The inlining optimization.

## Type of Change
- [x] New feature

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler
