### PR TITLE
[transaction simulation infra] fix get_resource

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.8.0"
+version = "7.8.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/aptos-move/aptos-transaction-simulation/src/state_store.rs
+++ b/aptos-move/aptos-transaction-simulation/src/state_store.rs
@@ -67,7 +67,7 @@ pub trait SimulationStateStore: TStateView<Key = StateKey> {
         let state_key = StateKey::resource_typed::<R>(&addr)?;
 
         match self.get_state_value_bytes(&state_key)? {
-            Some(blob) => Ok(bcs::from_bytes(&blob)?),
+            Some(blob) => Ok(Some(bcs::from_bytes::<R>(&blob)?)),
             None => Ok(None),
         }
     }

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,7 +4,10 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
-##[7.8.0]
+## [7.8.1]
+- Transaction Simulatiom Session: fixed resource deserialization bug
+
+## [7.8.0]
 - New beta feature: Transaction Simulation Session
 
 ## [7.7.0]

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.8.0"
+version = "7.8.1"
 
 # Workspace inherited keys
 authors = { workspace = true }


### PR DESCRIPTION
This fixes a small yet critical bug in the transaction simulation library that caused resource reads to fail, breaking Transaction Simulation Session. It also bumps the CLI version so we can do another release soon