### PR TITLE
[Move framework] add modules supporting signed int into move-stdlib

### DIFF
--- a/aptos-move/framework/move-stdlib/doc/i128.md
+++ b/aptos-move/framework/move-stdlib/doc/i128.md
@@ -1,0 +1,1005 @@
+
+<a id="0x1_i128"></a>
+
+# Module `0x1::i128`
+
+Implements the <code><a href="i128.md#0x1_i128">i128</a></code> type. The type name <code><a href="i128.md#0x1_i128">i128</a></code> is a shortcut for the <code><b>struct</b> <a href="i128.md#0x1_i128_I128">I128</a></code> defined in this module. One can use <code>+</code>, <code>-</code>, <code>==</code>, etc. with <code><a href="i128.md#0x1_i128">i128</a></code>, which are mapped to Move functions in this module.
+
+
+-  [Struct `I128`](#0x1_i128_I128)
+-  [Constants](#@Constants_0)
+-  [Function `from`](#0x1_i128_from)
+-  [Function `neg_from`](#0x1_i128_neg_from)
+-  [Function `neg`](#0x1_i128_neg)
+-  [Function `wrapping_add`](#0x1_i128_wrapping_add)
+-  [Function `add`](#0x1_i128_add)
+-  [Function `wrapping_sub`](#0x1_i128_wrapping_sub)
+-  [Function `sub`](#0x1_i128_sub)
+-  [Function `mul`](#0x1_i128_mul)
+-  [Function `div`](#0x1_i128_div)
+-  [Function `mod`](#0x1_i128_mod)
+-  [Function `abs`](#0x1_i128_abs)
+-  [Function `abs_u128`](#0x1_i128_abs_u128)
+-  [Function `min`](#0x1_i128_min)
+-  [Function `max`](#0x1_i128_max)
+-  [Function `pow`](#0x1_i128_pow)
+-  [Function `pack`](#0x1_i128_pack)
+-  [Function `unpack`](#0x1_i128_unpack)
+-  [Function `bits`](#0x1_i128_bits)
+-  [Function `sign`](#0x1_i128_sign)
+-  [Function `zero`](#0x1_i128_zero)
+-  [Function `is_zero`](#0x1_i128_is_zero)
+-  [Function `is_neg`](#0x1_i128_is_neg)
+-  [Function `cmp`](#0x1_i128_cmp)
+-  [Function `eq`](#0x1_i128_eq)
+-  [Function `neq`](#0x1_i128_neq)
+-  [Function `gt`](#0x1_i128_gt)
+-  [Function `gte`](#0x1_i128_gte)
+-  [Function `lt`](#0x1_i128_lt)
+-  [Function `lte`](#0x1_i128_lte)
+-  [Function `twos_complement`](#0x1_i128_twos_complement)
+-  [Function `sign_internal`](#0x1_i128_sign_internal)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="0x1_i128_I128"></a>
+
+## Struct `I128`
+
+Implementation of the <code><a href="i128.md#0x1_i128">i128</a></code> primitive type. Do not use this type directly, instead use <code><a href="i128.md#0x1_i128">i128</a></code>.
+
+
+<pre><code><b>struct</b> <a href="i128.md#0x1_i128_I128">I128</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bits: u128</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_i128_MAX_U128"></a>
+
+(1 << 128) - 1
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_MAX_U128">MAX_U128</a>: u128 = 340282366920938463463374607431768211455;
+</code></pre>
+
+
+
+<a id="0x1_i128_EDIVISION_BY_ZERO"></a>
+
+Division by Zero is not allowed
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x1_i128_BITS_MAX_I128"></a>
+
+max number that a I128 could represent = (0 followed by 127 1s) = (1 << 127) - 1
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_BITS_MAX_I128">BITS_MAX_I128</a>: u128 = 170141183460469231731687303715884105727;
+</code></pre>
+
+
+
+<a id="0x1_i128_BITS_MIN_I128"></a>
+
+min number that a I128 could represent = (1 followed by 127 0s) = 1 << 127
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_BITS_MIN_I128">BITS_MIN_I128</a>: u128 = 170141183460469231731687303715884105728;
+</code></pre>
+
+
+
+<a id="0x1_i128_EOVERFLOW"></a>
+
+Arithmetic operation resulted in overflow (value outside the range [-2^127, 2^127 - 1])
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_i128_EQ"></a>
+
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_EQ">EQ</a>: u8 = 1;
+</code></pre>
+
+
+
+<a id="0x1_i128_GT"></a>
+
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_GT">GT</a>: u8 = 2;
+</code></pre>
+
+
+
+<a id="0x1_i128_LT"></a>
+
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_LT">LT</a>: u8 = 0;
+</code></pre>
+
+
+
+<a id="0x1_i128_TWO_POW_128"></a>
+
+1 << 128
+
+
+<pre><code><b>const</b> <a href="i128.md#0x1_i128_TWO_POW_128">TWO_POW_128</a>: u256 = 340282366920938463463374607431768211456;
+</code></pre>
+
+
+
+<a id="0x1_i128_from"></a>
+
+## Function `from`
+
+Creates an I128 from a u128, asserting that it's not greater than the maximum positive value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_from">from</a>(v: u128): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_from">from</a>(v: u128): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>assert</b>!(v &lt;= <a href="i128.md#0x1_i128_BITS_MAX_I128">BITS_MAX_I128</a>, <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>);
+    <a href="i128.md#0x1_i128_I128">I128</a> { bits: v }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_neg_from"></a>
+
+## Function `neg_from`
+
+Creates a negative I128 from a u128, asserting that it's not greater than the minimum negative value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_neg_from">neg_from</a>(v: u128): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_neg_from">neg_from</a>(v: u128): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>assert</b>!(v &lt;= <a href="i128.md#0x1_i128_BITS_MIN_I128">BITS_MIN_I128</a>, <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>);
+    <a href="i128.md#0x1_i128_I128">I128</a> { bits: <a href="i128.md#0x1_i128_twos_complement">twos_complement</a>(v) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_neg"></a>
+
+## Function `neg`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_neg">neg</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_neg">neg</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>if</b> (self.<a href="i128.md#0x1_i128_is_neg">is_neg</a>()) { self.<a href="i128.md#0x1_i128_abs">abs</a>() }
+    <b>else</b> {
+        <a href="i128.md#0x1_i128_neg_from">neg_from</a>(self.bits)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_wrapping_add"></a>
+
+## Function `wrapping_add`
+
+Performs wrapping addition on two I128 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_wrapping_add">wrapping_add</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_wrapping_add">wrapping_add</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <a href="i128.md#0x1_i128_I128">I128</a> { bits: (((self.bits <b>as</b> u256) + (num2.bits <b>as</b> u256)) % <a href="i128.md#0x1_i128_TWO_POW_128">TWO_POW_128</a> <b>as</b> u128) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_add"></a>
+
+## Function `add`
+
+Performs checked addition on two I128 numbers, abort on overflow
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_add">add</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_add">add</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>let</b> sum = self.<a href="i128.md#0x1_i128_wrapping_add">wrapping_add</a>(num2);
+    // overflow only <b>if</b>: (1) postive + postive = negative, OR (2) negative + negative = positive
+    <b>let</b> self_sign = self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>();
+    <b>let</b> overflow = self_sign == num2.<a href="i128.md#0x1_i128_sign">sign</a>() && self_sign != sum.<a href="i128.md#0x1_i128_sign">sign</a>();
+    <b>assert</b>!(!overflow, <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>);
+    sum
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_wrapping_sub"></a>
+
+## Function `wrapping_sub`
+
+Performs wrapping subtraction on two I128 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_wrapping_sub">wrapping_sub</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_wrapping_sub">wrapping_sub</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    self.<a href="i128.md#0x1_i128_wrapping_add">wrapping_add</a>(<a href="i128.md#0x1_i128_I128">I128</a> { bits: <a href="i128.md#0x1_i128_twos_complement">twos_complement</a>(num2.bits) })
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_sub"></a>
+
+## Function `sub`
+
+Performs checked subtraction on two I128 numbers, asserting on overflow
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_sub">sub</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_sub">sub</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>let</b> difference = self.<a href="i128.md#0x1_i128_wrapping_sub">wrapping_sub</a>(num2);
+    // overflow only <b>if</b>: (1) positive - negative = negative, OR (2) negative - positive = positive
+    <b>let</b> self_sign = self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>();
+    <b>let</b> overflow = self_sign != num2.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>() && self_sign != difference.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>();
+    <b>assert</b>!(!overflow, <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>);
+    difference
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_mul"></a>
+
+## Function `mul`
+
+Performs multiplication on two I128 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_mul">mul</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_mul">mul</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>let</b> product = (self.<a href="i128.md#0x1_i128_abs_u128">abs_u128</a>() <b>as</b> u256) * (num2.<a href="i128.md#0x1_i128_abs_u128">abs_u128</a>() <b>as</b> u256);
+    <b>if</b> (self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>() != num2.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>()) {
+        <b>assert</b>!(product &lt;= (<a href="i128.md#0x1_i128_BITS_MIN_I128">BITS_MIN_I128</a> <b>as</b> u256), <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>);
+        <a href="i128.md#0x1_i128_neg_from">neg_from</a>((product <b>as</b> u128))
+    } <b>else</b> {
+        <b>assert</b>!(product &lt;= (<a href="i128.md#0x1_i128_BITS_MAX_I128">BITS_MAX_I128</a> <b>as</b> u256), <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>);
+        <a href="i128.md#0x1_i128_from">from</a>((product <b>as</b> u128))
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_div"></a>
+
+## Function `div`
+
+Performs division on two I128 numbers
+Note that we mimic the behavior of solidity int division that it rounds towards 0 rather than rounds down
+- rounds towards 0: (-4) / 3 = -(4 / 3) = -1 (remainder = -1)
+- rounds down: (-4) / 3 = -2 (remainder = 2)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_div">div</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_div">div</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>assert</b>!(!num2.<a href="i128.md#0x1_i128_is_zero">is_zero</a>(), <a href="i128.md#0x1_i128_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>);
+    <b>let</b> result = self.<a href="i128.md#0x1_i128_abs_u128">abs_u128</a>() / num2.<a href="i128.md#0x1_i128_abs_u128">abs_u128</a>();
+    <b>if</b> (self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>() != num2.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>()) <a href="i128.md#0x1_i128_neg_from">neg_from</a>(result)
+    <b>else</b> <a href="i128.md#0x1_i128_from">from</a>(result)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_mod"></a>
+
+## Function `mod`
+
+Performs modulo on two I128 numbers
+a mod b = a - b * (a / b)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_mod">mod</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_mod">mod</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>let</b> quotient = self.<a href="i128.md#0x1_i128_div">div</a>(num2);
+    self.<a href="i128.md#0x1_i128_sub">sub</a>(num2.<a href="i128.md#0x1_i128_mul">mul</a>(quotient))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_abs"></a>
+
+## Function `abs`
+
+Returns the absolute value of an I128 number
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_abs">abs</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_abs">abs</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>let</b> bits = <b>if</b> (self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>() == 0) { self.bits }
+    <b>else</b> {
+        <b>assert</b>!(self.bits &gt; <a href="i128.md#0x1_i128_BITS_MIN_I128">BITS_MIN_I128</a>, <a href="i128.md#0x1_i128_EOVERFLOW">EOVERFLOW</a>);
+        <a href="i128.md#0x1_i128_twos_complement">twos_complement</a>(self.bits)
+    };
+    <a href="i128.md#0x1_i128_I128">I128</a> { bits }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_abs_u128"></a>
+
+## Function `abs_u128`
+
+Returns the absolute value of an I128 number as a u128
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_abs_u128">abs_u128</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_abs_u128">abs_u128</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): u128 {
+    <b>if</b> (self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>() == 0) self.bits
+    <b>else</b> <a href="i128.md#0x1_i128_twos_complement">twos_complement</a>(self.bits)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_min"></a>
+
+## Function `min`
+
+Returns the minimum of two I128 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, b: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(self: <a href="i128.md#0x1_i128_I128">I128</a>, b: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>if</b> (self.<a href="i128.md#0x1_i128_lt">lt</a>(b)) self <b>else</b> b
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_max"></a>
+
+## Function `max`
+
+Returns the maximum of two I128 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_max">max</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, b: <a href="i128.md#0x1_i128_I128">i128::I128</a>): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_max">max</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, b: <a href="i128.md#0x1_i128_I128">I128</a>): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>if</b> (self.<a href="i128.md#0x1_i128_gt">gt</a>(b)) self <b>else</b> b
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_pow"></a>
+
+## Function `pow`
+
+Raises an I128 number to a u64 power
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_pow">pow</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, exponent: u64): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_pow">pow</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, exponent: u64): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <b>if</b> (exponent == 0) {
+        <b>return</b> <a href="i128.md#0x1_i128_from">from</a>(1)
+    };
+    <b>let</b> result = <a href="i128.md#0x1_i128_from">from</a>(1);
+    <b>while</b> (exponent &gt; 0) {
+        <b>if</b> (exponent % 2 == 1) {
+            result = result.<a href="i128.md#0x1_i128_mul">mul</a>(self);
+        };
+        self = self.<a href="i128.md#0x1_i128_mul">mul</a>(self);
+        exponent /= 2;
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_pack"></a>
+
+## Function `pack`
+
+Creates an I128 from a u128 without any checks
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_pack">pack</a>(v: u128): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_pack">pack</a>(v: u128): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <a href="i128.md#0x1_i128_I128">I128</a> { bits: v }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_unpack"></a>
+
+## Function `unpack`
+
+Destroys an I128 and returns its internal bits
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_unpack">unpack</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_unpack">unpack</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): u128 {
+    self.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_bits"></a>
+
+## Function `bits`
+
+Get internal bits of I128
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_bits">bits</a>(self: &<a href="i128.md#0x1_i128_I128">i128::I128</a>): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_bits">bits</a>(self: &<a href="i128.md#0x1_i128_I128">I128</a>): u128 {
+    self.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_sign"></a>
+
+## Function `sign`
+
+Returns the sign of an I128 number (0 for positive, 1 for negative)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_sign">sign</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_sign">sign</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): u8 {
+    self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_zero"></a>
+
+## Function `zero`
+
+Creates and returns an I128 representing zero
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_zero">zero</a>(): <a href="i128.md#0x1_i128_I128">i128::I128</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_zero">zero</a>(): <a href="i128.md#0x1_i128_I128">I128</a> {
+    <a href="i128.md#0x1_i128_I128">I128</a> { bits: 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_is_zero"></a>
+
+## Function `is_zero`
+
+Checks if an I128 number is zero
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_is_zero">is_zero</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_is_zero">is_zero</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.bits == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_is_neg"></a>
+
+## Function `is_neg`
+
+Checks if an I128 number is negative
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_is_neg">is_neg</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_is_neg">is_neg</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>() == 1
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_cmp"></a>
+
+## Function `cmp`
+
+Compares two I128 numbers, returning LT, EQ, or GT
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp">cmp</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp">cmp</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): u8 {
+    <b>let</b> sign1 = self.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>();
+    <b>let</b> sign2 = num2.<a href="i128.md#0x1_i128_sign_internal">sign_internal</a>();
+
+    <b>if</b> (sign1 &gt; sign2) {
+        <a href="i128.md#0x1_i128_LT">LT</a>
+    } <b>else</b> <b>if</b> (sign1 &lt; sign2) {
+        <a href="i128.md#0x1_i128_GT">GT</a>
+    } <b>else</b> <b>if</b> (self.bits &gt; num2.bits) {
+        <a href="i128.md#0x1_i128_GT">GT</a>
+    } <b>else</b> <b>if</b> (self.<a href="i128.md#0x1_i128_bits">bits</a> &lt; num2.bits) {
+        <a href="i128.md#0x1_i128_LT">LT</a>
+    } <b>else</b> {
+        <a href="i128.md#0x1_i128_EQ">EQ</a>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_eq"></a>
+
+## Function `eq`
+
+Checks if two I128 numbers are equal
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_eq">eq</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_eq">eq</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.bits == num2.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_neq"></a>
+
+## Function `neq`
+
+Checks if two I128 numbers are not equal
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_neq">neq</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_neq">neq</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.bits != num2.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_gt"></a>
+
+## Function `gt`
+
+Checks if the first I128 number is greater than the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_gt">gt</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_gt">gt</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) == <a href="i128.md#0x1_i128_GT">GT</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_gte"></a>
+
+## Function `gte`
+
+Checks if the first I128 number is greater than or equal to the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_gte">gte</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_gte">gte</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) &gt;= <a href="i128.md#0x1_i128_EQ">EQ</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_lt"></a>
+
+## Function `lt`
+
+Checks if the first I128 number is less than the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_lt">lt</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_lt">lt</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) == <a href="i128.md#0x1_i128_LT">LT</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_lte"></a>
+
+## Function `lte`
+
+Checks if the first I128 number is less than or equal to the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_lte">lte</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>, num2: <a href="i128.md#0x1_i128_I128">i128::I128</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i128.md#0x1_i128_lte">lte</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>, num2: <a href="i128.md#0x1_i128_I128">I128</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) &lt;= <a href="i128.md#0x1_i128_EQ">EQ</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_twos_complement"></a>
+
+## Function `twos_complement`
+
+Two's complement in order to dervie negative representation of bits
+It is overflow-proof because we hardcode 2's complement of 0 to be 0
+Which is fine for our specific use case
+
+
+<pre><code><b>fun</b> <a href="i128.md#0x1_i128_twos_complement">twos_complement</a>(v: u128): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="i128.md#0x1_i128_twos_complement">twos_complement</a>(v: u128): u128 {
+    <b>if</b> (v == 0) 0 <b>else</b> <a href="i128.md#0x1_i128_MAX_U128">MAX_U128</a> - v + 1
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i128_sign_internal"></a>
+
+## Function `sign_internal`
+
+Returns the sign of an I128 number (0 for positive, 1 for negative)
+
+
+<pre><code><b>fun</b> <a href="i128.md#0x1_i128_sign_internal">sign_internal</a>(self: <a href="i128.md#0x1_i128_I128">i128::I128</a>): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="i128.md#0x1_i128_sign_internal">sign_internal</a>(self: <a href="i128.md#0x1_i128_I128">I128</a>): u8 {
+    ((self.bits / <a href="i128.md#0x1_i128_BITS_MIN_I128">BITS_MIN_I128</a>) <b>as</b> u8)
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/i64.md
+++ b/aptos-move/framework/move-stdlib/doc/i64.md
@@ -1,0 +1,1005 @@
+
+<a id="0x1_i64"></a>
+
+# Module `0x1::i64`
+
+Implements the <code><a href="i64.md#0x1_i64">i64</a></code> type. The type name <code><a href="i64.md#0x1_i64">i64</a></code> is a shortcut for the <code><b>struct</b> <a href="i64.md#0x1_i64_I64">I64</a></code> defined in this module. One can use <code>+</code>, <code>-</code>, <code>==</code>, etc. with <code><a href="i64.md#0x1_i64">i64</a></code>, which are mapped to Move functions in this module.
+
+
+-  [Struct `I64`](#0x1_i64_I64)
+-  [Constants](#@Constants_0)
+-  [Function `from`](#0x1_i64_from)
+-  [Function `neg_from`](#0x1_i64_neg_from)
+-  [Function `neg`](#0x1_i64_neg)
+-  [Function `wrapping_add`](#0x1_i64_wrapping_add)
+-  [Function `add`](#0x1_i64_add)
+-  [Function `wrapping_sub`](#0x1_i64_wrapping_sub)
+-  [Function `sub`](#0x1_i64_sub)
+-  [Function `mul`](#0x1_i64_mul)
+-  [Function `div`](#0x1_i64_div)
+-  [Function `mod`](#0x1_i64_mod)
+-  [Function `abs`](#0x1_i64_abs)
+-  [Function `abs_u64`](#0x1_i64_abs_u64)
+-  [Function `min`](#0x1_i64_min)
+-  [Function `max`](#0x1_i64_max)
+-  [Function `pow`](#0x1_i64_pow)
+-  [Function `pack`](#0x1_i64_pack)
+-  [Function `unpack`](#0x1_i64_unpack)
+-  [Function `bits`](#0x1_i64_bits)
+-  [Function `sign`](#0x1_i64_sign)
+-  [Function `zero`](#0x1_i64_zero)
+-  [Function `is_zero`](#0x1_i64_is_zero)
+-  [Function `is_neg`](#0x1_i64_is_neg)
+-  [Function `cmp`](#0x1_i64_cmp)
+-  [Function `eq`](#0x1_i64_eq)
+-  [Function `neq`](#0x1_i64_neq)
+-  [Function `gt`](#0x1_i64_gt)
+-  [Function `gte`](#0x1_i64_gte)
+-  [Function `lt`](#0x1_i64_lt)
+-  [Function `lte`](#0x1_i64_lte)
+-  [Function `twos_complement`](#0x1_i64_twos_complement)
+-  [Function `sign_internal`](#0x1_i64_sign_internal)
+
+
+<pre><code></code></pre>
+
+
+
+<a id="0x1_i64_I64"></a>
+
+## Struct `I64`
+
+Implementation of the <code><a href="i64.md#0x1_i64">i64</a></code> primitive type. Do not use this type directly, instead use <code><a href="i64.md#0x1_i64">i64</a></code>.
+
+
+<pre><code><b>struct</b> <a href="i64.md#0x1_i64_I64">I64</a> <b>has</b> <b>copy</b>, drop, store
+</code></pre>
+
+
+
+<details>
+<summary>Fields</summary>
+
+
+<dl>
+<dt>
+<code>bits: u64</code>
+</dt>
+<dd>
+
+</dd>
+</dl>
+
+
+</details>
+
+<a id="@Constants_0"></a>
+
+## Constants
+
+
+<a id="0x1_i64_MAX_U64"></a>
+
+(1 << 64) - 1
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_MAX_U64">MAX_U64</a>: u64 = 18446744073709551615;
+</code></pre>
+
+
+
+<a id="0x1_i64_EDIVISION_BY_ZERO"></a>
+
+Division by Zero is not allowed
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>: u64 = 2;
+</code></pre>
+
+
+
+<a id="0x1_i64_EOVERFLOW"></a>
+
+Arithmetic operation resulted in overflow (value outside the range [-2^63, 2^63 - 1])
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>: u64 = 1;
+</code></pre>
+
+
+
+<a id="0x1_i64_EQ"></a>
+
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_EQ">EQ</a>: u8 = 1;
+</code></pre>
+
+
+
+<a id="0x1_i64_GT"></a>
+
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_GT">GT</a>: u8 = 2;
+</code></pre>
+
+
+
+<a id="0x1_i64_LT"></a>
+
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_LT">LT</a>: u8 = 0;
+</code></pre>
+
+
+
+<a id="0x1_i64_BITS_MAX_I64"></a>
+
+max number that a I64 could represent = (0 followed by 63 1s) = (1 << 63) - 1
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_BITS_MAX_I64">BITS_MAX_I64</a>: u64 = 9223372036854775807;
+</code></pre>
+
+
+
+<a id="0x1_i64_BITS_MIN_I64"></a>
+
+min number that a I64 could represent = (1 followed by 63 0s) = 1 << 63
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_BITS_MIN_I64">BITS_MIN_I64</a>: u64 = 9223372036854775808;
+</code></pre>
+
+
+
+<a id="0x1_i64_TWO_POW_64"></a>
+
+1 << 64
+
+
+<pre><code><b>const</b> <a href="i64.md#0x1_i64_TWO_POW_64">TWO_POW_64</a>: u128 = 18446744073709551616;
+</code></pre>
+
+
+
+<a id="0x1_i64_from"></a>
+
+## Function `from`
+
+Creates an I64 from a u64, asserting that it's not greater than the maximum positive value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_from">from</a>(v: u64): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_from">from</a>(v: u64): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>assert</b>!(v &lt;= <a href="i64.md#0x1_i64_BITS_MAX_I64">BITS_MAX_I64</a>, <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>);
+    <a href="i64.md#0x1_i64_I64">I64</a> { bits: v }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_neg_from"></a>
+
+## Function `neg_from`
+
+Creates a negative I64 from a u64, asserting that it's not greater than the minimum negative value
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_neg_from">neg_from</a>(v: u64): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_neg_from">neg_from</a>(v: u64): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>assert</b>!(v &lt;= <a href="i64.md#0x1_i64_BITS_MIN_I64">BITS_MIN_I64</a>, <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>);
+    <a href="i64.md#0x1_i64_I64">I64</a> { bits: <a href="i64.md#0x1_i64_twos_complement">twos_complement</a>(v) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_neg"></a>
+
+## Function `neg`
+
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_neg">neg</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_neg">neg</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>if</b> (self.<a href="i64.md#0x1_i64_is_neg">is_neg</a>()) { self.<a href="i64.md#0x1_i64_abs">abs</a>() }
+    <b>else</b> {
+        <a href="i64.md#0x1_i64_neg_from">neg_from</a>(self.bits)
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_wrapping_add"></a>
+
+## Function `wrapping_add`
+
+Performs wrapping addition on two I64 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_wrapping_add">wrapping_add</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_wrapping_add">wrapping_add</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <a href="i64.md#0x1_i64_I64">I64</a> { bits: (((self.bits <b>as</b> u128) + (num2.bits <b>as</b> u128)) % <a href="i64.md#0x1_i64_TWO_POW_64">TWO_POW_64</a> <b>as</b> u64) }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_add"></a>
+
+## Function `add`
+
+Performs checked addition on two I64 numbers, abort on overflow
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_add">add</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_add">add</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>let</b> sum = self.<a href="i64.md#0x1_i64_wrapping_add">wrapping_add</a>(num2);
+    // overflow only <b>if</b>: (1) postive + postive = negative, OR (2) negative + negative = positive
+    <b>let</b> self_sign = self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>();
+    <b>let</b> overflow = self_sign == num2.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() && self_sign != sum.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>();
+    <b>assert</b>!(!overflow, <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>);
+    sum
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_wrapping_sub"></a>
+
+## Function `wrapping_sub`
+
+Performs wrapping subtraction on two I64 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_wrapping_sub">wrapping_sub</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_wrapping_sub">wrapping_sub</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    self.<a href="i64.md#0x1_i64_wrapping_add">wrapping_add</a>(<a href="i64.md#0x1_i64_I64">I64</a> { bits: <a href="i64.md#0x1_i64_twos_complement">twos_complement</a>(num2.bits) })
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_sub"></a>
+
+## Function `sub`
+
+Performs checked subtraction on two I64 numbers, asserting on overflow
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_sub">sub</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_sub">sub</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>let</b> difference = self.<a href="i64.md#0x1_i64_wrapping_sub">wrapping_sub</a>(num2);
+    // overflow only <b>if</b>: (1) positive - negative = negative, OR (2) negative - positive = positive
+    <b>let</b> self_sign = self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>();
+    <b>let</b> overflow = self_sign != num2.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() && self_sign != difference.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>();
+    <b>assert</b>!(!overflow, <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>);
+    difference
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_mul"></a>
+
+## Function `mul`
+
+Performs multiplication on two I64 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_mul">mul</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_mul">mul</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>let</b> product = (self.<a href="i64.md#0x1_i64_abs_u64">abs_u64</a>() <b>as</b> u128) * (num2.<a href="i64.md#0x1_i64_abs_u64">abs_u64</a>() <b>as</b> u128);
+    <b>if</b> (self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() != num2.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>()) {
+        <b>assert</b>!(product &lt;= (<a href="i64.md#0x1_i64_BITS_MIN_I64">BITS_MIN_I64</a> <b>as</b> u128), <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>);
+        <a href="i64.md#0x1_i64_neg_from">neg_from</a>((product <b>as</b> u64))
+    } <b>else</b> {
+        <b>assert</b>!(product &lt;= (<a href="i64.md#0x1_i64_BITS_MAX_I64">BITS_MAX_I64</a> <b>as</b> u128), <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>);
+        <a href="i64.md#0x1_i64_from">from</a>((product <b>as</b> u64))
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_div"></a>
+
+## Function `div`
+
+Performs division on two I64 numbers
+Note that we mimic the behavior of solidity int division that it rounds towards 0 rather than rounds down
+- rounds towards 0: (-4) / 3 = -(4 / 3) = -1 (remainder = -1)
+- rounds down: (-4) / 3 = -2 (remainder = 2)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_div">div</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_div">div</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>assert</b>!(!num2.<a href="i64.md#0x1_i64_is_zero">is_zero</a>(), <a href="i64.md#0x1_i64_EDIVISION_BY_ZERO">EDIVISION_BY_ZERO</a>);
+    <b>let</b> result = self.<a href="i64.md#0x1_i64_abs_u64">abs_u64</a>() / num2.<a href="i64.md#0x1_i64_abs_u64">abs_u64</a>();
+    <b>if</b> (self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() != num2.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>()) <a href="i64.md#0x1_i64_neg_from">neg_from</a>(result)
+    <b>else</b> <a href="i64.md#0x1_i64_from">from</a>(result)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_mod"></a>
+
+## Function `mod`
+
+Performs modulo on two I64 numbers
+a mod b = a - b * (a / b)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_mod">mod</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_mod">mod</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>let</b> quotient = self.<a href="i64.md#0x1_i64_div">div</a>(num2);
+    self.<a href="i64.md#0x1_i64_sub">sub</a>(num2.<a href="i64.md#0x1_i64_mul">mul</a>(quotient))
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_abs"></a>
+
+## Function `abs`
+
+Returns the absolute value of an I64 number
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_abs">abs</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_abs">abs</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>let</b> bits = <b>if</b> (self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() == 0) { self.bits }
+    <b>else</b> {
+        <b>assert</b>!(self.bits &gt; <a href="i64.md#0x1_i64_BITS_MIN_I64">BITS_MIN_I64</a>, <a href="i64.md#0x1_i64_EOVERFLOW">EOVERFLOW</a>);
+        <a href="i64.md#0x1_i64_twos_complement">twos_complement</a>(self.bits)
+    };
+    <a href="i64.md#0x1_i64_I64">I64</a> { bits }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_abs_u64"></a>
+
+## Function `abs_u64`
+
+Returns the absolute value of an I64 number as a u64
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_abs_u64">abs_u64</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_abs_u64">abs_u64</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): u64 {
+    <b>if</b> (self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() == 0) self.bits
+    <b>else</b> <a href="i64.md#0x1_i64_twos_complement">twos_complement</a>(self.bits)
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_min"></a>
+
+## Function `min`
+
+Returns the minimum of two I64 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, b: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <b>min</b>(self: <a href="i64.md#0x1_i64_I64">I64</a>, b: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>if</b> (self.<a href="i64.md#0x1_i64_lt">lt</a>(b)) self <b>else</b> b
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_max"></a>
+
+## Function `max`
+
+Returns the maximum of two I64 numbers
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_max">max</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, b: <a href="i64.md#0x1_i64_I64">i64::I64</a>): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_max">max</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, b: <a href="i64.md#0x1_i64_I64">I64</a>): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>if</b> (self.<a href="i64.md#0x1_i64_gt">gt</a>(b)) self <b>else</b> b
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_pow"></a>
+
+## Function `pow`
+
+Raises an I64 number to a u64 power
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_pow">pow</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, exponent: u64): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_pow">pow</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, exponent: u64): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <b>if</b> (exponent == 0) {
+        <b>return</b> <a href="i64.md#0x1_i64_from">from</a>(1)
+    };
+    <b>let</b> result = <a href="i64.md#0x1_i64_from">from</a>(1);
+    <b>while</b> (exponent &gt; 0)  {
+        <b>if</b> (exponent % 2 == 1) {
+            result = result.<a href="i64.md#0x1_i64_mul">mul</a>(self);
+        };
+        self = self.<a href="i64.md#0x1_i64_mul">mul</a>(self);
+        exponent /= 2;
+    };
+    result
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_pack"></a>
+
+## Function `pack`
+
+Creates an I64 from a u64 without any checks
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_pack">pack</a>(v: u64): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_pack">pack</a>(v: u64): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <a href="i64.md#0x1_i64_I64">I64</a> { bits: v }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_unpack"></a>
+
+## Function `unpack`
+
+Destroys an I64 and returns its internal bits
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_unpack">unpack</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_unpack">unpack</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): u64 {
+    self.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_bits"></a>
+
+## Function `bits`
+
+Get internal bits of I64
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_bits">bits</a>(self: &<a href="i64.md#0x1_i64_I64">i64::I64</a>): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_bits">bits</a>(self: &<a href="i64.md#0x1_i64_I64">I64</a>): u64 {
+    self.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_sign"></a>
+
+## Function `sign`
+
+Returns the sign of an I64 number (0 for positive, 1 for negative)
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_sign">sign</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_sign">sign</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): u8 {
+    self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>()
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_zero"></a>
+
+## Function `zero`
+
+Creates and returns an I64 representing zero
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_zero">zero</a>(): <a href="i64.md#0x1_i64_I64">i64::I64</a>
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_zero">zero</a>(): <a href="i64.md#0x1_i64_I64">I64</a> {
+    <a href="i64.md#0x1_i64_I64">I64</a> { bits: 0 }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_is_zero"></a>
+
+## Function `is_zero`
+
+Checks if an I64 number is zero
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_is_zero">is_zero</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_is_zero">is_zero</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.bits == 0
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_is_neg"></a>
+
+## Function `is_neg`
+
+Checks if an I64 number is negative
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_is_neg">is_neg</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_is_neg">is_neg</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>() == 1
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_cmp"></a>
+
+## Function `cmp`
+
+Compares two I64 numbers, returning LT, EQ, or GT
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp">cmp</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="cmp.md#0x1_cmp">cmp</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): u8 {
+    <b>let</b> sign1 = self.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>();
+    <b>let</b> sign2 = num2.<a href="i64.md#0x1_i64_sign_internal">sign_internal</a>();
+
+    <b>if</b> (sign1 &gt; sign2) {
+        <a href="i64.md#0x1_i64_LT">LT</a>
+    } <b>else</b> <b>if</b> (sign1 &lt; sign2) {
+        <a href="i64.md#0x1_i64_GT">GT</a>
+    } <b>else</b> <b>if</b> (self.bits &gt; num2.bits) {
+        <a href="i64.md#0x1_i64_GT">GT</a>
+    } <b>else</b> <b>if</b> (self.<a href="i64.md#0x1_i64_bits">bits</a> &lt; num2.bits)  {
+        <a href="i64.md#0x1_i64_LT">LT</a>
+    } <b>else</b> {
+        <a href="i64.md#0x1_i64_EQ">EQ</a>
+    }
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_eq"></a>
+
+## Function `eq`
+
+Checks if two I64 numbers are equal
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_eq">eq</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_eq">eq</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.bits == num2.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_neq"></a>
+
+## Function `neq`
+
+Checks if two I64 numbers are not equal
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_neq">neq</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_neq">neq</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.bits != num2.bits
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_gt"></a>
+
+## Function `gt`
+
+Checks if the first I64 number is greater than the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_gt">gt</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_gt">gt</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) == <a href="i64.md#0x1_i64_GT">GT</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_gte"></a>
+
+## Function `gte`
+
+Checks if the first I64 number is greater than or equal to the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_gte">gte</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_gte">gte</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) &gt;= <a href="i64.md#0x1_i64_EQ">EQ</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_lt"></a>
+
+## Function `lt`
+
+Checks if the first I64 number is less than the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_lt">lt</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_lt">lt</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) == <a href="i64.md#0x1_i64_LT">LT</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_lte"></a>
+
+## Function `lte`
+
+Checks if the first I64 number is less than or equal to the second
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_lte">lte</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>, num2: <a href="i64.md#0x1_i64_I64">i64::I64</a>): bool
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>public</b> <b>fun</b> <a href="i64.md#0x1_i64_lte">lte</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>, num2: <a href="i64.md#0x1_i64_I64">I64</a>): bool {
+    self.<a href="cmp.md#0x1_cmp">cmp</a>(num2) &lt;= <a href="i64.md#0x1_i64_EQ">EQ</a>
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_twos_complement"></a>
+
+## Function `twos_complement`
+
+Two's complement in order to dervie negative representation of bits
+It is overflow-proof because we hardcode 2's complement of 0 to be 0
+Which is fine for our specific use case
+
+
+<pre><code><b>fun</b> <a href="i64.md#0x1_i64_twos_complement">twos_complement</a>(v: u64): u64
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="i64.md#0x1_i64_twos_complement">twos_complement</a>(v: u64): u64 {
+    <b>if</b> (v == 0) 0 <b>else</b> <a href="i64.md#0x1_i64_MAX_U64">MAX_U64</a> - v + 1
+}
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_i64_sign_internal"></a>
+
+## Function `sign_internal`
+
+Returns the sign of an I64 number (0 for positive, 1 for negative)
+
+
+<pre><code><b>fun</b> <a href="i64.md#0x1_i64_sign_internal">sign_internal</a>(self: <a href="i64.md#0x1_i64_I64">i64::I64</a>): u8
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code>inline <b>fun</b> <a href="i64.md#0x1_i64_sign_internal">sign_internal</a>(self: <a href="i64.md#0x1_i64_I64">I64</a>): u8 {
+    ((self.bits / <a href="i64.md#0x1_i64_BITS_MIN_I64">BITS_MIN_I64</a>) <b>as</b> u8)
+}
+</code></pre>
+
+
+
+</details>
+
+
+[move-book]: https://aptos.dev/move/book/SUMMARY

--- a/aptos-move/framework/move-stdlib/doc/overview.md
+++ b/aptos-move/framework/move-stdlib/doc/overview.md
@@ -21,6 +21,8 @@ For on overview of the Move language, see the [Move Book][move-book].
 -  [`0x1::features`](features.md#0x1_features)
 -  [`0x1::fixed_point32`](fixed_point32.md#0x1_fixed_point32)
 -  [`0x1::hash`](hash.md#0x1_hash)
+-  [`0x1::i128`](i128.md#0x1_i128)
+-  [`0x1::i64`](i64.md#0x1_i64)
 -  [`0x1::mem`](mem.md#0x1_mem)
 -  [`0x1::option`](option.md#0x1_option)
 -  [`0x1::signer`](signer.md#0x1_signer)

--- a/aptos-move/framework/move-stdlib/sources/i128.move
+++ b/aptos-move/framework/move-stdlib/sources/i128.move
@@ -1,0 +1,249 @@
+/// Implements the `i128` type. The type name `i128` is a shortcut for the `struct I128` defined in this module. One can use `+`, `-`, `==`, etc. with `i128`, which are mapped to Move functions in this module.
+module std::i128 {
+    /// Arithmetic operation resulted in overflow (value outside the range [-2^127, 2^127 - 1])
+    const EOVERFLOW: u64 = 1;
+    /// Division by Zero is not allowed
+    const EDIVISION_BY_ZERO: u64 = 2;
+
+    /// min number that a I128 could represent = (1 followed by 127 0s) = 1 << 127
+    const BITS_MIN_I128: u128 = 0x80000000000000000000000000000000;
+
+    /// max number that a I128 could represent = (0 followed by 127 1s) = (1 << 127) - 1
+    const BITS_MAX_I128: u128 = 0x7fffffffffffffffffffffffffffffff;
+
+    /// (1 << 128) - 1
+    const MAX_U128: u128 = 0xffffffffffffffffffffffffffffffff;
+
+    /// 1 << 128
+    const TWO_POW_128: u256 = 0x100000000000000000000000000000000;
+
+    const LT: u8 = 0;
+    const EQ: u8 = 1;
+    const GT: u8 = 2;
+
+    /// Implementation of the `i128` primitive type. Do not use this type directly, instead use `i128`.
+    struct I128 has copy, drop, store {
+        bits: u128
+    }
+
+    /// Creates an I128 from a u128, asserting that it's not greater than the maximum positive value
+    public fun from(v: u128): I128 {
+        assert!(v <= BITS_MAX_I128, EOVERFLOW);
+        I128 { bits: v }
+    }
+
+    /// Creates a negative I128 from a u128, asserting that it's not greater than the minimum negative value
+    public fun neg_from(v: u128): I128 {
+        assert!(v <= BITS_MIN_I128, EOVERFLOW);
+        I128 { bits: twos_complement(v) }
+    }
+
+    public fun neg(self: I128): I128 {
+        if (self.is_neg()) { self.abs() }
+        else {
+            neg_from(self.bits)
+        }
+    }
+
+    /// Performs wrapping addition on two I128 numbers
+    public fun wrapping_add(self: I128, num2: I128): I128 {
+        I128 { bits: (((self.bits as u256) + (num2.bits as u256)) % TWO_POW_128 as u128) }
+    }
+
+    /// Performs checked addition on two I128 numbers, abort on overflow
+    public fun add(self: I128, num2: I128): I128 {
+        let sum = self.wrapping_add(num2);
+        // overflow only if: (1) postive + postive = negative, OR (2) negative + negative = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign == num2.sign() && self_sign != sum.sign();
+        assert!(!overflow, EOVERFLOW);
+        sum
+    }
+
+    /// Performs wrapping subtraction on two I128 numbers
+    public fun wrapping_sub(self: I128, num2: I128): I128 {
+        self.wrapping_add(I128 { bits: twos_complement(num2.bits) })
+    }
+
+    /// Performs checked subtraction on two I128 numbers, asserting on overflow
+    public fun sub(self: I128, num2: I128): I128 {
+        let difference = self.wrapping_sub(num2);
+        // overflow only if: (1) positive - negative = negative, OR (2) negative - positive = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign != num2.sign_internal() && self_sign != difference.sign_internal();
+        assert!(!overflow, EOVERFLOW);
+        difference
+    }
+
+    /// Performs multiplication on two I128 numbers
+    public fun mul(self: I128, num2: I128): I128 {
+        let product = (self.abs_u128() as u256) * (num2.abs_u128() as u256);
+        if (self.sign_internal() != num2.sign_internal()) {
+            assert!(product <= (BITS_MIN_I128 as u256), EOVERFLOW);
+            neg_from((product as u128))
+        } else {
+            assert!(product <= (BITS_MAX_I128 as u256), EOVERFLOW);
+            from((product as u128))
+        }
+    }
+
+    /// Performs division on two I128 numbers
+    /// Note that we mimic the behavior of solidity int division that it rounds towards 0 rather than rounds down
+    /// - rounds towards 0: (-4) / 3 = -(4 / 3) = -1 (remainder = -1)
+    /// - rounds down: (-4) / 3 = -2 (remainder = 2)
+    public fun div(self: I128, num2: I128): I128 {
+        assert!(!num2.is_zero(), EDIVISION_BY_ZERO);
+        let result = self.abs_u128() / num2.abs_u128();
+        if (self.sign_internal() != num2.sign_internal()) neg_from(result)
+        else from(result)
+    }
+
+    /// Performs modulo on two I128 numbers
+    /// a mod b = a - b * (a / b)
+    public fun mod(self: I128, num2: I128): I128 {
+        let quotient = self.div(num2);
+        self.sub(num2.mul(quotient))
+    }
+
+    /// Returns the absolute value of an I128 number
+    public fun abs(self: I128): I128 {
+        let bits = if (self.sign_internal() == 0) { self.bits }
+        else {
+            assert!(self.bits > BITS_MIN_I128, EOVERFLOW);
+            twos_complement(self.bits)
+        };
+        I128 { bits }
+    }
+
+    /// Returns the absolute value of an I128 number as a u128
+    public fun abs_u128(self: I128): u128 {
+        if (self.sign_internal() == 0) self.bits
+        else twos_complement(self.bits)
+    }
+
+    /// Returns the minimum of two I128 numbers
+    public fun min(self: I128, b: I128): I128 {
+        if (self.lt(b)) self else b
+    }
+
+    /// Returns the maximum of two I128 numbers
+    public fun max(self: I128, b: I128): I128 {
+        if (self.gt(b)) self else b
+    }
+
+    /// Raises an I128 number to a u64 power
+    public fun pow(self: I128, exponent: u64): I128 {
+        if (exponent == 0) {
+            return from(1)
+        };
+        let result = from(1);
+        while (exponent > 0) {
+            if (exponent % 2 == 1) {
+                result = result.mul(self);
+            };
+            self = self.mul(self);
+            exponent /= 2;
+        };
+        result
+    }
+
+    /// Creates an I128 from a u128 without any checks
+    public fun pack(v: u128): I128 {
+        I128 { bits: v }
+    }
+
+    /// Destroys an I128 and returns its internal bits
+    public fun unpack(self: I128): u128 {
+        self.bits
+    }
+
+    /// Get internal bits of I128
+    public fun bits(self: &I128): u128 {
+        self.bits
+    }
+
+    /// Returns the sign of an I128 number (0 for positive, 1 for negative)
+    public fun sign(self: I128): u8 {
+        self.sign_internal()
+    }
+
+    /// Creates and returns an I128 representing zero
+    public fun zero(): I128 {
+        I128 { bits: 0 }
+    }
+
+    /// Checks if an I128 number is zero
+    public fun is_zero(self: I128): bool {
+        self.bits == 0
+    }
+
+    /// Checks if an I128 number is negative
+    public fun is_neg(self: I128): bool {
+        self.sign_internal() == 1
+    }
+
+    /// Compares two I128 numbers, returning LT, EQ, or GT
+    public fun cmp(self: I128, num2: I128): u8 {
+        let sign1 = self.sign_internal();
+        let sign2 = num2.sign_internal();
+
+        if (sign1 > sign2) {
+            LT
+        } else if (sign1 < sign2) {
+            GT
+        } else if (self.bits > num2.bits) {
+            GT
+        } else if (self.bits < num2.bits) {
+            LT
+        } else {
+            EQ
+        }
+    }
+
+    /// Checks if two I128 numbers are equal
+    public fun eq(self: I128, num2: I128): bool {
+        self.bits == num2.bits
+    }
+
+    /// Checks if two I128 numbers are not equal
+    public fun neq(self: I128, num2: I128): bool {
+        self.bits != num2.bits
+    }
+
+    /// Checks if the first I128 number is greater than the second
+    public fun gt(self: I128, num2: I128): bool {
+        self.cmp(num2) == GT
+    }
+
+    /// Checks if the first I128 number is greater than or equal to the second
+    public fun gte(self: I128, num2: I128): bool {
+        self.cmp(num2) >= EQ
+    }
+
+    /// Checks if the first I128 number is less than the second
+    public fun lt(self: I128, num2: I128): bool {
+        self.cmp(num2) == LT
+    }
+
+    /// Checks if the first I128 number is less than or equal to the second
+    public fun lte(self: I128, num2: I128): bool {
+        self.cmp(num2) <= EQ
+    }
+
+    /// Get the sign and the absolute value of an I128 number
+    public fun into_inner(self: I128): (bool, u128) {
+        (self.sign_internal() == 0, self.abs_u128())
+    }
+
+    /// Two's complement in order to dervie negative representation of bits
+    /// It is overflow-proof because we hardcode 2's complement of 0 to be 0
+    /// Which is fine for our specific use case
+    inline fun twos_complement(v: u128): u128 {
+        if (v == 0) 0 else MAX_U128 - v + 1
+    }
+
+    /// Returns the sign of an I128 number (0 for positive, 1 for negative)
+    inline fun sign_internal(self: I128): u8 {
+        ((self.bits / BITS_MIN_I128) as u8)
+    }
+}

--- a/aptos-move/framework/move-stdlib/sources/i64.move
+++ b/aptos-move/framework/move-stdlib/sources/i64.move
@@ -1,0 +1,249 @@
+/// Implements the `i64` type. The type name `i64` is a shortcut for the `struct I64` defined in this module. One can use `+`, `-`, `==`, etc. with `i64`, which are mapped to Move functions in this module.
+module std::i64 {
+    /// Arithmetic operation resulted in overflow (value outside the range [-2^63, 2^63 - 1])
+    const EOVERFLOW: u64 = 1;
+    /// Division by Zero is not allowed
+    const EDIVISION_BY_ZERO: u64 = 2;
+
+    /// min number that a I64 could represent = (1 followed by 63 0s) = 1 << 63
+    const BITS_MIN_I64: u64 = 0x8000000000000000;
+
+    /// max number that a I64 could represent = (0 followed by 63 1s) = (1 << 63) - 1
+    const BITS_MAX_I64: u64 = 0x7fffffffffffffff;
+
+    /// (1 << 64) - 1
+    const MAX_U64: u64 = 0xffffffffffffffff;
+
+    /// 1 << 64
+    const TWO_POW_64: u128 = 0x10000000000000000;
+
+    const LT: u8 = 0;
+    const EQ: u8 = 1;
+    const GT: u8 = 2;
+
+    /// Implementation of the `i64` primitive type. Do not use this type directly, instead use `i64`.
+    struct I64 has copy, drop, store {
+        bits: u64
+    }
+
+    /// Creates an I64 from a u64, asserting that it's not greater than the maximum positive value
+    public fun from(v: u64): I64 {
+        assert!(v <= BITS_MAX_I64, EOVERFLOW);
+        I64 { bits: v }
+    }
+
+    /// Creates a negative I64 from a u64, asserting that it's not greater than the minimum negative value
+    public fun neg_from(v: u64): I64 {
+        assert!(v <= BITS_MIN_I64, EOVERFLOW);
+        I64 { bits: twos_complement(v) }
+    }
+
+    public fun neg(self: I64): I64 {
+        if (self.is_neg()) { self.abs() }
+        else {
+            neg_from(self.bits)
+        }
+    }
+
+    /// Performs wrapping addition on two I64 numbers
+    public fun wrapping_add(self: I64, num2: I64): I64 {
+        I64 { bits: (((self.bits as u128) + (num2.bits as u128)) % TWO_POW_64 as u64) }
+    }
+
+    /// Performs checked addition on two I64 numbers, abort on overflow
+    public fun add(self: I64, num2: I64): I64 {
+        let sum = self.wrapping_add(num2);
+        // overflow only if: (1) postive + postive = negative, OR (2) negative + negative = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign == num2.sign_internal() && self_sign != sum.sign_internal();
+        assert!(!overflow, EOVERFLOW);
+        sum
+    }
+
+    /// Performs wrapping subtraction on two I64 numbers
+    public fun wrapping_sub(self: I64, num2: I64): I64 {
+        self.wrapping_add(I64 { bits: twos_complement(num2.bits) })
+    }
+
+    /// Performs checked subtraction on two I64 numbers, asserting on overflow
+    public fun sub(self: I64, num2: I64): I64 {
+        let difference = self.wrapping_sub(num2);
+        // overflow only if: (1) positive - negative = negative, OR (2) negative - positive = positive
+        let self_sign = self.sign_internal();
+        let overflow = self_sign != num2.sign_internal() && self_sign != difference.sign_internal();
+        assert!(!overflow, EOVERFLOW);
+        difference
+    }
+
+    /// Performs multiplication on two I64 numbers
+    public fun mul(self: I64, num2: I64): I64 {
+        let product = (self.abs_u64() as u128) * (num2.abs_u64() as u128);
+        if (self.sign_internal() != num2.sign_internal()) {
+            assert!(product <= (BITS_MIN_I64 as u128), EOVERFLOW);
+            neg_from((product as u64))
+        } else {
+            assert!(product <= (BITS_MAX_I64 as u128), EOVERFLOW);
+            from((product as u64))
+        }
+    }
+
+    /// Performs division on two I64 numbers
+    /// Note that we mimic the behavior of solidity int division that it rounds towards 0 rather than rounds down
+    /// - rounds towards 0: (-4) / 3 = -(4 / 3) = -1 (remainder = -1)
+    /// - rounds down: (-4) / 3 = -2 (remainder = 2)
+    public fun div(self: I64, num2: I64): I64 {
+        assert!(!num2.is_zero(), EDIVISION_BY_ZERO);
+        let result = self.abs_u64() / num2.abs_u64();
+        if (self.sign_internal() != num2.sign_internal()) neg_from(result)
+        else from(result)
+    }
+
+    /// Performs modulo on two I64 numbers
+    /// a mod b = a - b * (a / b)
+    public fun mod(self: I64, num2: I64): I64 {
+        let quotient = self.div(num2);
+        self.sub(num2.mul(quotient))
+    }
+
+    /// Returns the absolute value of an I64 number
+    public fun abs(self: I64): I64 {
+        let bits = if (self.sign_internal() == 0) { self.bits }
+        else {
+            assert!(self.bits > BITS_MIN_I64, EOVERFLOW);
+            twos_complement(self.bits)
+        };
+        I64 { bits }
+    }
+
+    /// Returns the absolute value of an I64 number as a u64
+    public fun abs_u64(self: I64): u64 {
+        if (self.sign_internal() == 0) self.bits
+        else twos_complement(self.bits)
+    }
+
+    /// Returns the minimum of two I64 numbers
+    public fun min(self: I64, b: I64): I64 {
+        if (self.lt(b)) self else b
+    }
+
+    /// Returns the maximum of two I64 numbers
+    public fun max(self: I64, b: I64): I64 {
+        if (self.gt(b)) self else b
+    }
+
+    /// Raises an I64 number to a u64 power
+    public fun pow(self: I64, exponent: u64): I64 {
+        if (exponent == 0) {
+            return from(1)
+        };
+        let result = from(1);
+        while (exponent > 0)  {
+            if (exponent % 2 == 1) {
+                result = result.mul(self);
+            };
+            self = self.mul(self);
+            exponent /= 2;
+        };
+        result
+    }
+
+    /// Creates an I64 from a u64 without any checks
+    public fun pack(v: u64): I64 {
+        I64 { bits: v }
+    }
+
+    /// Destroys an I64 and returns its internal bits
+    public fun unpack(self: I64): u64 {
+        self.bits
+    }
+
+    /// Get internal bits of I64
+    public fun bits(self: &I64): u64 {
+        self.bits
+    }
+
+    /// Returns the sign of an I64 number (0 for positive, 1 for negative)
+    public fun sign(self: I64): u8 {
+        self.sign_internal()
+    }
+
+    /// Creates and returns an I64 representing zero
+    public fun zero(): I64 {
+        I64 { bits: 0 }
+    }
+
+    /// Checks if an I64 number is zero
+    public fun is_zero(self: I64): bool {
+        self.bits == 0
+    }
+
+    /// Checks if an I64 number is negative
+    public fun is_neg(self: I64): bool {
+        self.sign_internal() == 1
+    }
+
+    /// Compares two I64 numbers, returning LT, EQ, or GT
+    public fun cmp(self: I64, num2: I64): u8 {
+        let sign1 = self.sign_internal();
+        let sign2 = num2.sign_internal();
+
+        if (sign1 > sign2) {
+            LT
+        } else if (sign1 < sign2) {
+            GT
+        } else if (self.bits > num2.bits) {
+            GT
+        } else if (self.bits < num2.bits)  {
+            LT
+        } else {
+            EQ
+        }
+    }
+
+    /// Checks if two I64 numbers are equal
+    public fun eq(self: I64, num2: I64): bool {
+        self.bits == num2.bits
+    }
+
+    /// Checks if two I64 numbers are not equal
+    public fun neq(self: I64, num2: I64): bool {
+        self.bits != num2.bits
+    }
+
+    /// Checks if the first I64 number is greater than the second
+    public fun gt(self: I64, num2: I64): bool {
+        self.cmp(num2) == GT
+    }
+
+    /// Checks if the first I64 number is greater than or equal to the second
+    public fun gte(self: I64, num2: I64): bool {
+        self.cmp(num2) >= EQ
+    }
+
+    /// Checks if the first I64 number is less than the second
+    public fun lt(self: I64, num2: I64): bool {
+        self.cmp(num2) == LT
+    }
+
+    /// Checks if the first I64 number is less than or equal to the second
+    public fun lte(self: I64, num2: I64): bool {
+        self.cmp(num2) <= EQ
+    }
+
+    /// Get the sign and the absolute value of an I64 number
+    public fun into_inner(self: I64): (bool, u64) {
+        (self.sign_internal() == 0, self.abs_u64())
+    }
+
+    /// Two's complement in order to dervie negative representation of bits
+    /// It is overflow-proof because we hardcode 2's complement of 0 to be 0
+    /// Which is fine for our specific use case
+    inline fun twos_complement(v: u64): u64 {
+        if (v == 0) 0 else MAX_U64 - v + 1
+    }
+
+    /// Returns the sign of an I64 number (0 for positive, 1 for negative)
+    inline fun sign_internal(self: I64): u8 {
+        ((self.bits / BITS_MIN_I64) as u8)
+    }
+}

--- a/aptos-move/framework/move-stdlib/tests/i128_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/i128_tests.move
@@ -1,0 +1,210 @@
+#[test_only]
+module std::i128_tests {
+    use std::i128;
+
+    #[test]
+    fun test_from() {
+        assert!(i128::from(0).bits() == 0, 0);
+        assert!(i128::from(1).bits() == 1, 0);
+        assert!(i128::from(0x7fffffffffffffffffffffffffffffff).bits() == 0x7fffffffffffffffffffffffffffffff, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = i128::EOVERFLOW)]
+    fun test_from_overflow() {
+        i128::from(0x80000000000000000000000000000000);
+    }
+
+    #[test]
+    fun test_neg_from() {
+        assert!(i128::neg_from(0).bits() == 0, 0);
+        assert!(i128::neg_from(1).bits() == 0xffffffffffffffffffffffffffffffff, 0);
+        assert!(i128::neg_from(0x80000000000000000000000000000000).bits() == 0x80000000000000000000000000000000, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = i128::EOVERFLOW)]
+    fun test_neg_from_overflow() {
+        i128::neg_from(0x80000000000000000000000000000001);
+    }
+
+    #[test]
+    fun test_neg() {
+        assert!(i128::from(3).neg() == i128::neg_from(3), 0);
+    }
+
+    #[test]
+    fun test_add() {
+        assert!(i128::from(5).add(i128::neg_from(3)) == i128::from(2), 0);
+    }
+
+    #[test]
+    fun test_sub() {
+        assert!(i128::from(5).sub(i128::from(3)) == i128::from(2), 0);
+    }
+
+    #[test]
+    fun test_mul() {
+        assert!(i128::from(5).mul(i128::neg_from(3)) == i128::neg_from(15), 0);
+    }
+
+    #[test]
+    fun test_div() {
+        assert!(i128::from(3).div(i128::from(3)) == i128::from(1), 0);
+        assert!(i128::from(4).div(i128::from(3)) == i128::from(1), 0);
+        assert!(i128::from(5).div(i128::from(3)) == i128::from(1), 0);
+        assert!(i128::neg_from(3).div(i128::from(3)) == i128::neg_from(1), 0);
+        assert!(i128::neg_from(4).div(i128::from(3)) == i128::neg_from(1), 0);
+        assert!(i128::neg_from(5).div(i128::from(3)) == i128::neg_from(1), 0);
+    }
+
+    #[test]
+    fun test_wrapping_add() {
+        assert!(i128::from(5).wrapping_add(i128::from(3)) == i128::from(8), 0);
+        assert!(i128::from(0x7fffffffffffffffffffffffffffffff).wrapping_add(i128::from(1)).bits() == 0x80000000000000000000000000000000, 0);
+        assert!(i128::neg_from(1).wrapping_add(i128::from(1)) == i128::zero(), 0);
+    }
+
+    #[test]
+    fun test_wrapping_sub() {
+        assert!(i128::from(5).wrapping_sub(i128::from(3)) == i128::from(2), 0);
+        assert!(i128::neg_from(0x80000000000000000000000000000000).wrapping_sub(i128::from(1)).bits() == 0x7fffffffffffffffffffffffffffffff, 0);
+        assert!(i128::from(0).wrapping_sub(i128::from(1)) == i128::neg_from(1), 0);
+    }
+
+    #[test]
+    fun test_mod() {
+        assert!(i128::from(10).mod(i128::from(3)) == i128::from(1), 0);
+        assert!(i128::neg_from(10).mod(i128::from(3)) == i128::neg_from(1), 0);
+        assert!(i128::from(10).mod(i128::neg_from(3)) == i128::from(1), 0);
+        assert!(i128::neg_from(10).mod(i128::neg_from(3)) == i128::neg_from(1), 0);
+    }
+
+    #[test]
+    fun test_abs() {
+        assert!(i128::from(5).abs() == i128::from(5), 0);
+        assert!(i128::neg_from(5).abs() == i128::from(5), 0);
+        assert!(i128::zero().abs() == i128::zero(), 0);
+    }
+
+    #[test]
+    fun test_abs_u128() {
+        assert!(i128::from(5).abs_u128() == 5, 0);
+        assert!(i128::neg_from(5).abs_u128() == 5, 0);
+        assert!(i128::zero().abs_u128() == 0, 0);
+    }
+
+    #[test]
+    fun test_min_max() {
+        assert!(i128::from(5).min(i128::from(3)) == i128::from(3), 0);
+        assert!(i128::from(3).min(i128::from(5)) == i128::from(3), 0);
+        assert!(i128::neg_from(5).min(i128::from(3)) == i128::neg_from(5), 0);
+
+        assert!(i128::from(5).max(i128::from(3)) == i128::from(5), 0);
+        assert!(i128::from(3).max(i128::from(5)) == i128::from(5), 0);
+        assert!(i128::neg_from(5).max(i128::from(3)) == i128::from(3), 0);
+    }
+
+    #[test]
+    fun test_pow() {
+        assert!(i128::from(2).pow(0) == i128::from(1), 0);
+        assert!(i128::from(2).pow(3) == i128::from(8), 0);
+        assert!(i128::neg_from(2).pow(3) == i128::neg_from(8), 0);
+        assert!(i128::neg_from(2).pow(4) == i128::from(16), 0);
+    }
+
+    #[test]
+    fun test_pack_unpack() {
+        assert!(i128::pack(0).unpack() == 0, 0);
+        assert!(i128::pack(0xffffffffffffffffffffffffffffffff).unpack() == 0xffffffffffffffffffffffffffffffff, 0);
+        assert!(i128::pack(0x80000000000000000000000000000000).unpack() == 0x80000000000000000000000000000000, 0);
+    }
+
+    #[test]
+    fun test_bits() {
+        assert!(i128::from(5).bits() == 5, 0);
+        assert!(i128::neg_from(5).bits() == 0xfffffffffffffffffffffffffffffffb, 0);
+    }
+
+    #[test]
+    fun test_sign() {
+        assert!(i128::from(5).sign() == 0, 0);
+        assert!(i128::neg_from(5).sign() == 1, 0);
+        assert!(i128::zero().sign() == 0, 0);
+    }
+
+    #[test]
+    fun test_zero_is_zero() {
+        assert!(i128::zero().is_zero(), 0);
+        assert!(!i128::from(1).is_zero(), 0);
+        assert!(!i128::neg_from(1).is_zero(), 0);
+    }
+
+    #[test]
+    fun test_is_neg() {
+        assert!(!i128::from(5).is_neg(), 0);
+        assert!(i128::neg_from(5).is_neg(), 0);
+        assert!(!i128::zero().is_neg(), 0);
+    }
+
+    #[test]
+    fun test_cmp() {
+        assert!(i128::from(5).cmp(i128::from(3)) == 2, 0);
+        assert!(i128::from(3).cmp(i128::from(5)) == 0, 0);
+        assert!(i128::from(5).cmp(i128::from(5)) == 1, 0);
+        assert!(i128::neg_from(5).cmp(i128::from(5)) == 0, 0);
+        assert!(i128::from(5).cmp(i128::neg_from(5)) == 2, 0);
+    }
+
+    #[test]
+    fun test_eq() {
+        assert!(i128::from(5).eq(i128::from(5)), 0);
+        assert!(!i128::from(5).eq(i128::from(3)), 0);
+        assert!(!i128::from(5).eq(i128::neg_from(5)), 0);
+    }
+
+    #[test]
+    fun test_neq() {
+        assert!(!i128::from(5).neq(i128::from(5)), 0);
+        assert!(i128::from(5).neq(i128::from(3)), 0);
+        assert!(i128::from(5).neq(i128::neg_from(5)), 0);
+    }
+
+    #[test]
+    fun test_into_inner() {
+        let (pos, amt) = i128::from(5).into_inner();
+        assert!(pos && amt == 5);
+
+        let (pos, amt) = i128::neg_from(5).into_inner();
+        assert!(!pos && amt == 5);
+
+        let (pos, amt) = i128::neg_from(0).into_inner();
+        assert!(pos && amt == 0);
+    }
+
+    #[test]
+    fun test_gt_gte() {
+        assert!(i128::from(5).gt(i128::from(3)), 0);
+        assert!(!i128::from(3).gt(i128::from(5)), 0);
+        assert!(!i128::from(5).gt(i128::from(5)), 0);
+        assert!(i128::from(5).gt(i128::neg_from(5)), 0);
+
+        assert!(i128::from(5).gte(i128::from(3)), 0);
+        assert!(!i128::from(3).gte(i128::from(5)), 0);
+        assert!(i128::from(5).gte(i128::from(5)), 0);
+        assert!(i128::from(5).gte(i128::neg_from(5)), 0);
+    }
+
+    #[test]
+    fun test_lt_lte() {
+        assert!(!i128::from(5).lt(i128::from(3)), 0);
+        assert!(i128::from(3).lt(i128::from(5)), 0);
+        assert!(!i128::from(5).lt(i128::from(5)), 0);
+        assert!(i128::neg_from(5).lt(i128::from(5)), 0);
+
+        assert!(!i128::from(5).lte(i128::from(3)), 0);
+        assert!(i128::from(3).lte(i128::from(5)), 0);
+        assert!(i128::from(5).lte(i128::from(5)), 0);
+        assert!(i128::neg_from(5).lte(i128::from(5)), 0);
+    }
+}

--- a/aptos-move/framework/move-stdlib/tests/i64_tests.move
+++ b/aptos-move/framework/move-stdlib/tests/i64_tests.move
@@ -1,0 +1,211 @@
+#[test_only]
+module std::i64_tests {
+    use std::i64;
+
+    #[test]
+    fun test_from() {
+        assert!(i64::from(0).bits() == 0, 0);
+        assert!(i64::from(1).bits() == 1, 0);
+        assert!(i64::from(0x7fffffffffffffff).bits() == 0x7fffffffffffffff, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = i64::EOVERFLOW)]
+    fun test_from_overflow() {
+        i64::from(0x8000000000000000);
+    }
+
+    #[test]
+    fun test_neg_from() {
+        assert!(i64::neg_from(0).bits() == 0, 0);
+        assert!(i64::neg_from(1).bits() == 0xffffffffffffffff, 0);
+        assert!(i64::neg_from(0x8000000000000000).bits() == 0x8000000000000000, 0);
+    }
+
+    #[test]
+    #[expected_failure(abort_code = i64::EOVERFLOW)]
+    fun test_neg_from_overflow() {
+        i64::neg_from(0x8000000000000001);
+    }
+
+    #[test]
+    fun test_neg() {
+        assert!(i64::from(3).neg() == i64::neg_from(3), 0);
+    }
+
+    #[test]
+    fun test_add() {
+        assert!(i64::from(5).add(i64::neg_from(3)) == i64::from(2), 0);
+    }
+
+    #[test]
+    fun test_sub() {
+        assert!(i64::from(5).sub(i64::from(3)) == i64::from(2), 0);
+    }
+
+    #[test]
+    fun test_mul() {
+        assert!(i64::from(5).mul(i64::neg_from(3)) == i64::neg_from(15), 0);
+    }
+
+    #[test]
+    fun test_div() {
+        assert!(i64::from(3).div(i64::from(3)) == i64::from(1), 0);
+        assert!(i64::from(4).div(i64::from(3)) == i64::from(1), 0);
+        assert!(i64::from(5).div(i64::from(3)) == i64::from(1), 0);
+        assert!(i64::neg_from(3).div(i64::from(3)) == i64::neg_from(1), 0);
+        assert!(i64::neg_from(4).div(i64::from(3)) == i64::neg_from(1), 0);
+        assert!(i64::neg_from(5).div(i64::from(3)) == i64::neg_from(1), 0);
+    }
+
+    #[test]
+    fun test_wrapping_add() {
+        assert!(i64::from(5).wrapping_add(i64::from(3)) == i64::from(8), 0);
+        assert!(i64::from(0x7fffffffffffffff).wrapping_add(i64::from(1)).bits() == 0x8000000000000000, 0);
+        assert!(i64::neg_from(1).wrapping_add(i64::from(1)) == i64::zero(), 0);
+    }
+
+    #[test]
+    fun test_wrapping_sub() {
+        assert!(i64::from(5).wrapping_sub(i64::from(3)) == i64::from(2), 0);
+        assert!(i64::neg_from(0x8000000000000000).wrapping_sub(i64::from(1)).bits() == 0x7fffffffffffffff, 0);
+        assert!(i64::from(0).wrapping_sub(i64::from(1)) == i64::neg_from(1), 0);
+    }
+
+    #[test]
+    fun test_mod() {
+        assert!(i64::from(10).mod(i64::from(3)) == i64::from(1), 0);
+        assert!(i64::neg_from(10).mod(i64::from(3)) == i64::neg_from(1), 0);
+        assert!(i64::from(10).mod(i64::neg_from(3)) == i64::from(1), 0);
+        assert!(i64::neg_from(10).mod(i64::neg_from(3)) == i64::neg_from(1), 0);
+    }
+
+    #[test]
+    fun test_abs() {
+        assert!(i64::from(5).abs() == i64::from(5), 0);
+        assert!(i64::neg_from(5).abs() == i64::from(5), 0);
+        assert!(i64::zero().abs() == i64::zero(), 0);
+    }
+
+    #[test]
+    fun test_abs_u64() {
+        assert!(i64::from(5).abs_u64() == 5, 0);
+        assert!(i64::neg_from(5).abs_u64() == 5, 0);
+        assert!(i64::zero().abs_u64() == 0, 0);
+    }
+
+    #[test]
+    fun test_min_max() {
+        assert!(i64::from(5).min(i64::from(3)) == i64::from(3), 0);
+        assert!(i64::from(3).min(i64::from(5)) == i64::from(3), 0);
+        assert!(i64::neg_from(5).min(i64::from(3)) == i64::neg_from(5), 0);
+
+        assert!(i64::from(5).max(i64::from(3)) == i64::from(5), 0);
+        assert!(i64::from(3).max(i64::from(5)) == i64::from(5), 0);
+        assert!(i64::neg_from(5).max(i64::from(3)) == i64::from(3), 0);
+    }
+
+    #[test]
+    fun test_pow() {
+        assert!(i64::from(2).pow(0) == i64::from(1), 0);
+        assert!(i64::from(2).pow(3) == i64::from(8), 0);
+        assert!(i64::neg_from(2).pow(3) == i64::neg_from(8), 0);
+        assert!(i64::neg_from(2).pow(4) == i64::from(16), 0);
+    }
+
+    #[test]
+    fun test_pack_unpack() {
+        assert!(i64::pack(0).unpack() == 0, 0);
+        assert!(i64::pack(0xffffffffffffffff).unpack() == 0xffffffffffffffff, 0);
+        assert!(i64::pack(0x8000000000000000).unpack() == 0x8000000000000000, 0);
+    }
+
+    #[test]
+    fun test_bits() {
+        assert!(i64::from(5).bits() == 5, 0);
+        assert!(i64::neg_from(5).bits() == 0xfffffffffffffffb, 0);
+    }
+
+    #[test]
+    fun test_sign() {
+        assert!(i64::from(5).sign() == 0, 0);
+        assert!(i64::neg_from(5).sign() == 1, 0);
+        assert!(i64::zero().sign() == 0, 0);
+    }
+
+    #[test]
+    fun test_zero_is_zero() {
+        assert!(i64::zero().is_zero(), 0);
+        assert!(!i64::from(1).is_zero(), 0);
+        assert!(!i64::neg_from(1).is_zero(), 0);
+    }
+
+    #[test]
+    fun test_is_neg() {
+        assert!(!i64::from(5).is_neg(), 0);
+        assert!(i64::neg_from(5).is_neg(), 0);
+        assert!(!i64::zero().is_neg(), 0);
+    }
+
+    #[test]
+    fun test_cmp() {
+        assert!(i64::from(5).cmp(i64::from(3)) == 2, 0);
+        assert!(i64::from(3).cmp(i64::from(5)) == 0, 0);
+        assert!(i64::from(5).cmp(i64::from(5)) == 1, 0);
+        assert!(i64::neg_from(5).cmp(i64::from(5)) == 0, 0);
+        assert!(i64::from(5).cmp(i64::neg_from(5)) == 2, 0);
+        assert!(i64::neg_from(1).cmp(i64::neg_from(2)) == 2, 0);
+    }
+
+    #[test]
+    fun test_eq() {
+        assert!(i64::from(5).eq(i64::from(5)), 0);
+        assert!(!i64::from(5).eq(i64::from(3)), 0);
+        assert!(!i64::from(5).eq(i64::neg_from(5)), 0);
+    }
+
+    #[test]
+    fun test_neq() {
+        assert!(!i64::from(5).neq(i64::from(5)), 0);
+        assert!(i64::from(5).neq(i64::from(3)), 0);
+        assert!(i64::from(5).neq(i64::neg_from(5)), 0);
+    }
+
+    #[test]
+    fun test_into_inner() {
+        let (pos, amt) = i64::from(5).into_inner();
+        assert!(pos && amt == 5);
+
+        let (pos, amt) = i64::neg_from(5).into_inner();
+        assert!(!pos && amt == 5);
+
+        let (pos, amt) = i64::neg_from(0).into_inner();
+        assert!(pos && amt == 0);
+    }
+
+    #[test]
+    fun test_gt_gte() {
+        assert!(i64::from(5).gt(i64::from(3)), 0);
+        assert!(!i64::from(3).gt(i64::from(5)), 0);
+        assert!(!i64::from(5).gt(i64::from(5)), 0);
+        assert!(i64::from(5).gt(i64::neg_from(5)), 0);
+
+        assert!(i64::from(5).gte(i64::from(3)), 0);
+        assert!(!i64::from(3).gte(i64::from(5)), 0);
+        assert!(i64::from(5).gte(i64::from(5)), 0);
+        assert!(i64::from(5).gte(i64::neg_from(5)), 0);
+    }
+
+    #[test]
+    fun test_lt_lte() {
+        assert!(!i64::from(5).lt(i64::from(3)), 0);
+        assert!(i64::from(3).lt(i64::from(5)), 0);
+        assert!(!i64::from(5).lt(i64::from(5)), 0);
+        assert!(i64::neg_from(5).lt(i64::from(5)), 0);
+
+        assert!(!i64::from(5).lte(i64::from(3)), 0);
+        assert!(i64::from(3).lte(i64::from(5)), 0);
+        assert!(i64::from(5).lte(i64::from(5)), 0);
+        assert!(i64::neg_from(5).lte(i64::from(5)), 0);
+    }
+}


### PR DESCRIPTION
## Description
This PR adds Move modules, specs, and tests supporting signed int (`i64` and `i128`) into the framework under `move-stdlib`. The support is contributed by the community at https://github.com/aptos-labs/aptos-core/pull/16735. All addresses are updated from `aptos_experimental` to `std`.

Before deploying the updated framework, we need to:
- Update the specs as needed
- Land the compiler syntactic sugar
- Clean other potential concerns, especially security

## How Has This Been Tested?
- Prover with built-in specs
- Built-in test cases

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [x] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
