### PR TITLE
[indexer-grpc] Do not panic when starting version is not set

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
@@ -60,7 +60,10 @@ impl FullnodeData for FullnodeDataService {
     ) -> Result<Response<Self::GetTransactionsFromNodeStream>, Status> {
         // Gets configs for the stream, partly from the request and partly from the node config
         let r = req.into_inner();
-        let starting_version = r.starting_version.expect("Starting version must be set");
+        let starting_version = match r.starting_version {
+            Some(version) => version,
+            None => return Err(Status::invalid_argument("Starting version must be set")),
+        };
         let processor_task_count = self.service_context.processor_task_count;
         let processor_batch_size = self.service_context.processor_batch_size;
         let output_batch_size = self.service_context.output_batch_size;

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
@@ -39,7 +39,10 @@ impl RawData for LocalnetDataService {
         // Some node metadata
         let context = self.service_context.context.clone();
         let r = req.into_inner();
-        let starting_version = r.starting_version.expect("Starting version must be set");
+        let starting_version = match r.starting_version {
+            Some(version) => version,
+            None => return Err(Status::invalid_argument("Starting version must be set")),
+        };
         let ending_version = if let Some(count) = r.transactions_count {
             starting_version.saturating_add(count)
         } else {


### PR DESCRIPTION
## Description
It's obviously bad that we panic the whole node when a bad request comes in, we should just return an error:

## How Has This Been Tested?
Run a localnet:
```
cargo run -p aptos -- node run-localnet --assume-yes --force-restart
```
Make a regular request:
```
grpcurl -d '{ "starting_version": 0 }' -max-msg-sz 30000000 -plaintext 127.0.0.1:50051 aptos.indexer.v1.RawData/GetTransactions
```
```
{
  "transactions": [
    {
      "timestamp": {},
      "info": {
        "hash": "yGnNekT3wEuDVsF8FvFj858rOMtJPqxl9ocaN1G0FJw=",
...
```
Make a request without the starting version:
```
grpcurl -max-msg-sz 30000000 -plaintext 127.0.0.1:50051 aptos.indexer.v1.RawData/GetTransactions
```
```
ERROR:
  Code: InvalidArgument
  Message: Starting version must be set
```

See that it no longer panics.

## Key Areas to Review
N/A

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
