### PR TITLE
Enable stats for jemalloc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -650,6 +650,7 @@ ipnet = "2.5.0"
 itertools = "0.13"
 jemallocator = { package = "tikv-jemallocator", version = "0.6.0", features = [
     "profiling",
+    "stats",
     "unprefixed_malloc_on_supported_platforms",
 ] }
 jemalloc-ctl = { package = "tikv-jemalloc-ctl", version = "0.6.0" }


### PR DESCRIPTION

The old version (0.5.4) had a bug where the stats were on even when the feature
was not enabled, so after upgrading to 0.6 we need to turn it on manually.
