### PR TITLE
[vm] Generic per-interpreter function frame caches

### DIFF
--- a/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
+++ b/aptos-move/aptos-vm/src/move_vm_ext/session/user_transaction_sessions/user.rs
@@ -28,7 +28,7 @@ use move_core_types::{
 use move_vm_runtime::{
     dispatch_loader, module_traversal::TraversalContext, FunctionDefinitionLoader,
     InstantiatedFunctionLoader, LegacyLoaderConfig, LoadedFunction, LoadedFunctionOwner,
-    ModuleStorage, StagingModuleStorage,
+    ModuleStorage, StagingModuleStorage, WithRuntimeEnvironment,
 };
 
 #[derive(Deref, DerefMut)]
@@ -152,9 +152,12 @@ impl<'r> UserSession<'r> {
                         ) {
                             verifier::module_init::verify_init_module_function(&function)?;
 
+                            let ty_args_id =
+                                loader.runtime_environment().ty_pool().intern_ty_args(&[]);
                             let loaded_function = LoadedFunction {
                                 owner: LoadedFunctionOwner::Module(module),
                                 ty_args: vec![],
+                                ty_args_id,
                                 function,
                             };
                             session.execute_loaded_function(

--- a/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
+++ b/aptos-move/aptos-vm/src/verifier/transaction_arg_validation.rs
@@ -611,10 +611,15 @@ fn load_constructor_function(
 
     Type::verify_ty_arg_abilities(function.ty_param_abilities(), &ty_args)
         .map_err(|e| e.finish(Location::Module(module_id.clone())))?;
+    let ty_args_id = loader
+        .runtime_environment()
+        .ty_pool()
+        .intern_ty_args(&ty_args);
 
     Ok(LoadedFunction {
         owner: LoadedFunctionOwner::Module(module),
         ty_args,
+        ty_args_id,
         function,
     })
 }

--- a/aptos-move/block-executor/src/counters.rs
+++ b/aptos-move/block-executor/src/counters.rs
@@ -403,3 +403,19 @@ pub static HOT_STATE_OP_ACCUMULATOR_COUNTER: Lazy<IntCounterVec> = Lazy::new(|| 
     )
     .unwrap()
 });
+
+pub static NUM_INTERNED_TYPES: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "num_interned_types",
+        "Number of interned types cached in execution environment"
+    )
+    .unwrap()
+});
+
+pub static NUM_INTERNED_TYPE_VECS: Lazy<IntGauge> = Lazy::new(|| {
+    register_int_gauge!(
+        "num_interned_type_vecs",
+        "Number of interned type vectors cached in execution environment"
+    )
+    .unwrap()
+});

--- a/aptos-move/block-executor/src/executor.rs
+++ b/aptos-move/block-executor/src/executor.rs
@@ -2528,7 +2528,7 @@ where
             module_cache_manager_guard
                 .environment()
                 .runtime_environment()
-                .flush_struct_name_and_tag_caches();
+                .flush_all_caches();
             module_cache_manager_guard.module_cache_mut().flush();
 
             info!("parallel execution requiring fallback");

--- a/aptos-move/e2e-benchmark/data/calibration_values.tsv
+++ b/aptos-move/e2e-benchmark/data/calibration_values.tsv
@@ -1,43 +1,43 @@
-Loop { loop_count: Some(100000), loop_type: NoOp }	6	0.990	1.040	34731.8
-Loop { loop_count: Some(10000), loop_type: Arithmetic }	6	0.988	1.018	21679.8
-CreateObjects { num_objects: 10, object_payload_size: 0 }	6	0.989	1.007	104.0
-CreateObjects { num_objects: 10, object_payload_size: 10240 }	6	0.998	1.037	7793.9
-CreateObjects { num_objects: 100, object_payload_size: 0 }	6	0.984	1.011	957.7
-CreateObjects { num_objects: 100, object_payload_size: 10240 }	6	0.992	1.038	9076.4
-InitializeVectorPicture { length: 128 }	6	0.989	1.022	138.6
-VectorPicture { length: 128 }	6	0.994	1.024	33.3
-VectorPictureRead { length: 128 }	6	0.997	1.016	32.3
-InitializeVectorPicture { length: 30720 }	6	0.992	1.025	23963.8
-VectorPicture { length: 30720 }	6	0.996	1.006	4529.6
-VectorPictureRead { length: 30720 }	6	0.996	1.029	4546.9
-SmartTablePicture { length: 30720, num_points_per_txn: 200 }	6	0.997	1.067	18712.4
-SmartTablePicture { length: 1048576, num_points_per_txn: 300 }	6	0.989	1.058	33129.7
-ResourceGroupsSenderWriteTag { string_length: 1024 }	6	0.990	1.008	16.0
-ResourceGroupsSenderMultiChange { string_length: 1024 }	6	0.982	1.004	29.9
-TokenV1MintAndTransferFT	6	0.994	1.021	304.1
-TokenV1MintAndTransferNFTSequential	6	1.000	1.016	441.4
-TokenV2AmbassadorMint { numbered: true }	6	0.982	1.005	318.5
-LiquidityPoolSwap { is_stable: true }	6	0.987	1.005	487.1
-LiquidityPoolSwap { is_stable: false }	6	0.988	1.018	453.7
-CoinInitAndMint	6	0.991	1.009	415.2
-FungibleAssetMint	6	0.987	1.014	158.4
-IncGlobalMilestoneAggV2 { milestone_every: 1 }	6	0.989	1.018	24.1
-IncGlobalMilestoneAggV2 { milestone_every: 2 }	6	0.996	1.016	14.3
-EmitEvents { count: 1000 }	6	0.998	1.013	5429.7
-APTTransferWithPermissionedSigner	6	0.989	1.005	541.6
-APTTransferWithMasterSigner	6	0.987	1.014	65.6
-VectorTrimAppend { vec_len: 3000, element_len: 1, index: 0, repeats: 0 }	6	0.994	1.029	4573.0
-VectorTrimAppend { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	6	0.982	1.038	18783.0
-VectorTrimAppend { vec_len: 3000, element_len: 1, index: 2990, repeats: 1000 }	6	0.994	1.017	9480.2
-VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	6	0.995	1.017	14981.6
-VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 2998, repeats: 1000 }	6	0.987	1.030	10492.5
-VectorRangeMove { vec_len: 3000, element_len: 1, index: 1000, move_len: 500, repeats: 1000 }	6	0.996	1.018	21485.1
-VectorTrimAppend { vec_len: 100, element_len: 100, index: 0, repeats: 0 }	6	0.998	1.046	236.3
-VectorTrimAppend { vec_len: 100, element_len: 100, index: 10, repeats: 1000 }	6	0.993	1.012	5638.4
-VectorRangeMove { vec_len: 100, element_len: 100, index: 50, move_len: 10, repeats: 1000 }	6	0.995	1.000	3882.1
-MapInsertRemove { len: 100, repeats: 100, map_type: OrderedMap }	6	0.993	1.031	5608.2
-MapInsertRemove { len: 100, repeats: 100, map_type: SimpleMap }	6	0.993	1.065	18222.3
-MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 4, leaf_max_degree: 4 } }	6	0.992	1.023	33261.7
-MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 1024, leaf_max_degree: 1024 } }	6	0.991	1.022	7719.9
-MapInsertRemove { len: 1000, repeats: 100, map_type: OrderedMap }	6	0.991	1.036	28612.4
-OrderBook { state: OrderBookState { order_idx: 0 }, num_markets: 1, overlap_ratio: 0.0, buy_frequency: 0.5, max_sell_size: 1, max_buy_size: 1 }	6	0.984	1.007	385.2
+Loop { loop_count: Some(100000), loop_type: NoOp }	10	0.996	1.097	34731.8
+Loop { loop_count: Some(10000), loop_type: Arithmetic }	10	0.993	1.079	21679.8
+CreateObjects { num_objects: 10, object_payload_size: 0 }	10	0.989	1.020	104.5
+CreateObjects { num_objects: 10, object_payload_size: 10240 }	10	0.988	1.083	7838.9
+CreateObjects { num_objects: 100, object_payload_size: 0 }	10	0.989	1.021	966.8
+CreateObjects { num_objects: 100, object_payload_size: 10240 }	10	0.993	1.087	9111.1
+InitializeVectorPicture { length: 128 }	10	0.990	1.064	138.3
+VectorPicture { length: 128 }	10	0.991	1.027	34.2
+VectorPictureRead { length: 128 }	10	0.996	1.022	32.6
+InitializeVectorPicture { length: 30720 }	10	0.989	1.082	23878.7
+VectorPicture { length: 30720 }	10	0.998	1.015	4607.8
+VectorPictureRead { length: 30720 }	10	0.992	1.015	4607.8
+SmartTablePicture { length: 30720, num_points_per_txn: 200 }	10	0.994	1.096	18501.4
+SmartTablePicture { length: 1048576, num_points_per_txn: 300 }	10	0.991	1.109	32605.3
+ResourceGroupsSenderWriteTag { string_length: 1024 }	10	0.969	1.013	15.9
+ResourceGroupsSenderMultiChange { string_length: 1024 }	10	0.976	1.010	29.8
+TokenV1MintAndTransferFT	10	0.992	1.032	308.6
+TokenV1MintAndTransferNFTSequential	10	0.990	1.021	443.8
+TokenV2AmbassadorMint { numbered: true }	10	0.984	1.002	314.4
+LiquidityPoolSwap { is_stable: true }	10	0.988	1.022	469.0
+LiquidityPoolSwap { is_stable: false }	10	0.983	1.017	435.8
+CoinInitAndMint	10	0.991	1.003	397.1
+FungibleAssetMint	10	0.990	1.064	152.9
+IncGlobalMilestoneAggV2 { milestone_every: 1 }	10	0.990	1.019	24.9
+IncGlobalMilestoneAggV2 { milestone_every: 2 }	10	0.987	1.023	14.5
+EmitEvents { count: 1000 }	10	0.984	1.024	5449.3
+APTTransferWithPermissionedSigner	10	0.985	1.013	475.2
+APTTransferWithMasterSigner	10	0.989	1.021	65.7
+VectorTrimAppend { vec_len: 3000, element_len: 1, index: 0, repeats: 0 }	10	0.990	1.136	4573.0
+VectorTrimAppend { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	10	0.966	1.098	18536.4
+VectorTrimAppend { vec_len: 3000, element_len: 1, index: 2990, repeats: 1000 }	10	0.991	1.053	9444.7
+VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 100, repeats: 1000 }	10	0.994	1.036	15009.6
+VectorRemoveInsert { vec_len: 3000, element_len: 1, index: 2998, repeats: 1000 }	10	0.991	1.062	10473.4
+VectorRangeMove { vec_len: 3000, element_len: 1, index: 1000, move_len: 500, repeats: 1000 }	10	0.993	1.027	21562.8
+VectorTrimAppend { vec_len: 100, element_len: 100, index: 0, repeats: 0 }	10	0.993	1.072	237.2
+VectorTrimAppend { vec_len: 100, element_len: 100, index: 10, repeats: 1000 }	10	0.989	1.031	5689.1
+VectorRangeMove { vec_len: 100, element_len: 100, index: 50, move_len: 10, repeats: 1000 }	10	0.998	1.045	3882.1
+MapInsertRemove { len: 100, repeats: 100, map_type: OrderedMap }	10	0.981	1.048	5668.8
+MapInsertRemove { len: 100, repeats: 100, map_type: SimpleMap }	10	0.998	1.110	18014.6
+MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 4, leaf_max_degree: 4 } }	10	0.991	1.035	31782.9
+MapInsertRemove { len: 100, repeats: 100, map_type: BigOrderedMap { inner_max_degree: 1024, leaf_max_degree: 1024 } }	10	0.993	1.049	7647.1
+MapInsertRemove { len: 1000, repeats: 100, map_type: OrderedMap }	10	0.984	1.042	28717.2
+OrderBook { state: OrderBookState { order_idx: 0 }, num_markets: 1, overlap_ratio: 0.0, buy_frequency: 0.5, max_sell_size: 1, max_buy_size: 1 }	10	0.990	1.019	391.5

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -32,6 +32,7 @@ use move_vm_types::{
         runtime_access_specifier::{AccessSpecifierEnv, AddressSpecifierFunction},
         runtime_types::{AbilityInfo, StructType, Type, TypeBuilder},
     },
+    ty_interner::{InternedTypePool, TypeVecId},
     values::Locals,
 };
 use std::{cell::RefCell, rc::Rc, sync::Arc};
@@ -72,6 +73,7 @@ macro_rules! build_loaded_function {
             traversal_context: &mut TraversalContext,
             idx: $idx_ty,
             verified_ty_args: Vec<Type>,
+            ty_args_id: TypeVecId,
         ) -> PartialVMResult<LoadedFunction> {
             match self.function.owner() {
                 LoadedFunctionOwner::Module(module) => {
@@ -81,6 +83,7 @@ macro_rules! build_loaded_function {
                             (Ok(LoadedFunction {
                                 owner: LoadedFunctionOwner::Module(module.clone()),
                                 ty_args: verified_ty_args,
+                                ty_args_id,
                                 function: function.clone(),
                             }))
                         },
@@ -92,6 +95,7 @@ macro_rules! build_loaded_function {
                                 module,
                                 name,
                                 verified_ty_args,
+                                ty_args_id,
                             ),
                     }
                 },
@@ -110,6 +114,7 @@ macro_rules! build_loaded_function {
                                 module,
                                 name,
                                 verified_ty_args,
+                                ty_args_id,
                             ),
                     }
                 },
@@ -485,11 +490,12 @@ impl Frame {
 
     pub(crate) fn instantiate_generic_function(
         &self,
+        ty_pool: &InternedTypePool,
         gas_meter: Option<&mut impl GasMeter>,
         idx: FunctionInstantiationIndex,
-    ) -> PartialVMResult<Vec<Type>> {
+    ) -> PartialVMResult<(Vec<Type>, TypeVecId)> {
         use LoadedFunctionOwner::*;
-        let instantiation = match self.function.owner() {
+        let (instantiation, ty_args_id) = match self.function.owner() {
             Module(module) => module.function_instantiation_at(idx.0),
             Script(script) => script.function_instantiation_at(idx.0),
         };
@@ -506,7 +512,13 @@ impl Frame {
             .iter()
             .map(|ty| self.ty_builder.create_ty_with_subst(ty, ty_args))
             .collect::<PartialVMResult<Vec<_>>>()?;
-        Ok(instantiation)
+        let ty_args_id = match ty_args_id {
+            Some(ty_args_id) => ty_args_id,
+            // We can hit this case where original type args were only a partial instantiation.
+            None => ty_pool.intern_ty_args(&instantiation),
+        };
+
+        Ok((instantiation, ty_args_id))
     }
 
     pub(crate) fn build_loaded_function_from_name_and_ty_args(
@@ -517,6 +529,7 @@ impl Frame {
         module_id: &ModuleId,
         function_name: &IdentStr,
         verified_ty_args: Vec<Type>,
+        ty_args_id: TypeVecId,
     ) -> PartialVMResult<LoadedFunction> {
         let (module, function) = loader
             .load_function_definition(gas_meter, traversal_context, module_id, function_name)
@@ -524,6 +537,7 @@ impl Frame {
         Ok(LoadedFunction {
             owner: LoadedFunctionOwner::Module(module),
             ty_args: verified_ty_args,
+            ty_args_id,
             function,
         })
     }

--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -5,9 +5,8 @@ use crate::{frame::Frame, LoadedFunction};
 use move_binary_format::{
     errors::*,
     file_format::{
-        FieldInstantiationIndex, FunctionInstantiationIndex, SignatureIndex,
-        StructDefInstantiationIndex, StructVariantInstantiationIndex,
-        VariantFieldInstantiationIndex,
+        FieldInstantiationIndex, SignatureIndex, StructDefInstantiationIndex,
+        StructVariantInstantiationIndex, VariantFieldInstantiationIndex,
     },
 };
 use move_core_types::gas_algebra::NumTypeNodes;
@@ -63,13 +62,6 @@ pub(crate) struct FrameTypeCache {
     variant_field_instantiation:
         BTreeMap<VariantFieldInstantiationIndex, ((Type, NumTypeNodes), (Type, NumTypeNodes))>,
     single_sig_token_type: BTreeMap<SignatureIndex, (Type, NumTypeNodes)>,
-    /// Recursive frame cache for a function that is called from the
-    /// current frame. It is indexed by FunctionInstantiationIndex or
-    /// FunctionHandleIndex for non-generic functions. Note that
-    /// whenever a function with the same `index` is called, the
-    /// structures stored in that function's frame cache do not change.
-    pub(crate) generic_sub_frame_cache:
-        BTreeMap<FunctionInstantiationIndex, (Rc<LoadedFunction>, Rc<RefCell<FrameTypeCache>>)>,
     /// Stores a variant for each individual instruction in the
     /// function's bytecode. We keep the size of the variant to be
     /// small. The caches are indexed by the index of the given

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -51,6 +51,7 @@ use move_vm_types::{
     loaded_data::{runtime_access_specifier::AccessInstance, runtime_types::Type},
     natives::function::NativeResult,
     resolver::ResourceResolver,
+    ty_interner::InternedTypePool,
     values::{
         self, AbstractFunction, Closure, GlobalValue, IntegerValue, Locals, Reference, SignerRef,
         Struct, StructRef, VMValueCast, Value, Vector, VectorRef,
@@ -61,7 +62,7 @@ use once_cell::sync::Lazy;
 use std::{
     cell::RefCell,
     cmp::min,
-    collections::{btree_map, BTreeSet, VecDeque},
+    collections::{BTreeSet, VecDeque},
     fmt::{Debug, Write},
     rc::Rc,
     str::FromStr,
@@ -144,6 +145,8 @@ pub(crate) struct InterpreterImpl<'ctx, LoaderImpl> {
     call_stack: CallStack,
     /// VM configuration used by the interpreter.
     vm_config: &'ctx VMConfig,
+    /// Pool of interned types.
+    ty_pool: &'ctx InternedTypePool,
     /// The access control state.
     access_control: AccessControlState,
     /// Reentrancy checker.
@@ -228,6 +231,7 @@ where
             operand_stack: Stack::new(),
             call_stack: CallStack::new(),
             vm_config: loader.runtime_environment().vm_config(),
+            ty_pool: loader.runtime_environment().ty_pool(),
             access_control: AccessControlState::default(),
             reentrancy_checker: ReentrancyChecker::default(),
             loader,
@@ -316,8 +320,8 @@ where
         current_frame: &Frame,
         idx: FunctionInstantiationIndex,
     ) -> VMResult<LoadedFunction> {
-        let ty_args = current_frame
-            .instantiate_generic_function(Some(gas_meter), idx)
+        let (ty_args, ty_args_id) = current_frame
+            .instantiate_generic_function(self.ty_pool, Some(gas_meter), idx)
             .map_err(|e| set_err_info!(current_frame, e))?;
         let function = current_frame
             .build_loaded_function_from_instantiation_and_ty_args(
@@ -326,6 +330,7 @@ where
                 traversal_context,
                 idx,
                 ty_args,
+                ty_args_id,
             )
             .map_err(|e| self.set_location(e))?;
         Ok(function)
@@ -340,6 +345,7 @@ where
         current_frame: &Frame,
         fh_idx: FunctionHandleIndex,
     ) -> VMResult<LoadedFunction> {
+        let ty_args_id = self.ty_pool.intern_ty_args(&[]);
         let function = current_frame
             .build_loaded_function_from_handle_and_ty_args(
                 self.loader,
@@ -347,6 +353,7 @@ where
                 traversal_context,
                 fh_idx,
                 vec![],
+                ty_args_id,
             )
             .map_err(|e| self.set_location(e))?;
         Ok(function)
@@ -617,39 +624,21 @@ where
                         {
                             (Rc::clone(function), Rc::clone(frame_cache))
                         } else {
-                            match current_frame_cache.generic_sub_frame_cache.entry(idx) {
-                                btree_map::Entry::Occupied(entry) => {
-                                    let entry = entry.get();
-                                    current_frame_cache.per_instruction_cache
-                                        [current_frame.pc as usize] =
-                                        PerInstructionCache::CallGeneric(
-                                            Rc::clone(&entry.0),
-                                            Rc::clone(&entry.1),
-                                        );
-
-                                    (Rc::clone(&entry.0), Rc::clone(&entry.1))
-                                },
-                                btree_map::Entry::Vacant(entry) => {
-                                    let function =
-                                        Rc::new(self.load_generic_function_no_visibility_checks(
-                                            gas_meter,
-                                            traversal_context,
-                                            &current_frame,
-                                            idx,
-                                        )?);
-                                    // TODO(caches): remove the generic sub frame cache.
-                                    let frame_cache = function_caches
-                                        .get_or_create_frame_cache_generic(&function);
-                                    entry.insert((Rc::clone(&function), Rc::clone(&frame_cache)));
-                                    current_frame_cache.per_instruction_cache
-                                        [current_frame.pc as usize] =
-                                        PerInstructionCache::CallGeneric(
-                                            Rc::clone(&function),
-                                            Rc::clone(&frame_cache),
-                                        );
-                                    (function, frame_cache)
-                                },
-                            }
+                            let function =
+                                Rc::new(self.load_generic_function_no_visibility_checks(
+                                    gas_meter,
+                                    traversal_context,
+                                    &current_frame,
+                                    idx,
+                                )?);
+                            let frame_cache =
+                                function_caches.get_or_create_frame_cache_generic(&function);
+                            current_frame_cache.per_instruction_cache[current_frame.pc as usize] =
+                                PerInstructionCache::CallGeneric(
+                                    Rc::clone(&function),
+                                    Rc::clone(&frame_cache),
+                                );
+                            (function, frame_cache)
                         }
                     } else {
                         let function = Rc::new(self.load_generic_function_no_visibility_checks(
@@ -1154,6 +1143,7 @@ where
             } => {
                 gas_meter.charge_native_function(cost, Option::<std::iter::Empty<&Value>>::None)?;
 
+                let ty_args_id = self.ty_pool.intern_ty_args(&ty_args);
                 let target_func = current_frame.build_loaded_function_from_name_and_ty_args(
                     self.loader,
                     gas_meter,
@@ -1161,6 +1151,7 @@ where
                     &module_name,
                     &func_name,
                     ty_args,
+                    ty_args_id,
                 )?;
 
                 RTTCheck::check_call_visibility(
@@ -2265,21 +2256,7 @@ impl Frame {
                                 Ok(field_count)
                             };
 
-                        let field_count = if RTCaches::caches_enabled() {
-                            let cached_field_count =
-                                &frame_cache.per_instruction_cache[self.pc as usize];
-                            if let PerInstructionCache::Pack(field_count) = cached_field_count {
-                                *field_count
-                            } else {
-                                let field_count = get_field_count_charge_gas_and_check_depth()?;
-                                frame_cache.per_instruction_cache[self.pc as usize] =
-                                    PerInstructionCache::Pack(field_count);
-                                field_count
-                            }
-                        } else {
-                            get_field_count_charge_gas_and_check_depth()?
-                        };
-
+                        let field_count = get_field_count_charge_gas_and_check_depth()?;
                         gas_meter.charge_pack(
                             false,
                             interpreter.operand_stack.last_n(field_count as usize)?,
@@ -2333,25 +2310,7 @@ impl Frame {
                                 )?;
                                 Ok(self.field_instantiation_count(*si_idx))
                             };
-
-                        let field_count = if RTCaches::caches_enabled() {
-                            let cached_field_count =
-                                &frame_cache.per_instruction_cache[self.pc as usize];
-
-                            if let PerInstructionCache::PackGeneric(field_count) =
-                                cached_field_count
-                            {
-                                *field_count
-                            } else {
-                                let field_count =
-                                    get_field_count_charge_gas_and_check_depth(frame_cache)?;
-                                frame_cache.per_instruction_cache[self.pc as usize] =
-                                    PerInstructionCache::PackGeneric(field_count);
-                                field_count
-                            }
-                        } else {
-                            get_field_count_charge_gas_and_check_depth(frame_cache)?
-                        };
+                        let field_count = get_field_count_charge_gas_and_check_depth(frame_cache)?;
 
                         gas_meter.charge_pack(
                             true,
@@ -2489,6 +2448,7 @@ impl Frame {
                                 .last_n(mask.captured_count() as usize)?,
                         )?;
 
+                        let ty_args_id = interpreter.ty_pool.intern_ty_args(&[]);
                         let function = self
                             .build_loaded_function_from_handle_and_ty_args(
                                 interpreter.loader,
@@ -2496,6 +2456,7 @@ impl Frame {
                                 traversal_context,
                                 *fh_idx,
                                 vec![],
+                                ty_args_id,
                             )
                             .map(Rc::new)?;
                         RTTCheck::check_pack_closure_visibility(&self.function, &function)?;
@@ -2527,8 +2488,11 @@ impl Frame {
                                 .last_n(mask.captured_count() as usize)?,
                         )?;
 
-                        let ty_args =
-                            self.instantiate_generic_function(Some(gas_meter), *fi_idx)?;
+                        let (ty_args, ty_args_id) = self.instantiate_generic_function(
+                            interpreter.ty_pool,
+                            Some(gas_meter),
+                            *fi_idx,
+                        )?;
                         let function = self
                             .build_loaded_function_from_instantiation_and_ty_args(
                                 interpreter.loader,
@@ -2536,6 +2500,7 @@ impl Frame {
                                 traversal_context,
                                 *fi_idx,
                                 ty_args,
+                                ty_args_id,
                             )
                             .map(Rc::new)?;
                         RTTCheck::check_pack_closure_visibility(&self.function, &function)?;

--- a/third_party/move/move-vm/runtime/src/interpreter_caches.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter_caches.rs
@@ -1,43 +1,29 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+//! Interpreter caches keep a record of cached data for each function call observed during
+//! execution (e.g., caching [FrameTypeCache]). As a result, when calling function `foo<u64>`
+//! at multiple call-sites, cached information from `foo<u64>` is re-used and only computed once
+//! on the first call.
+
 use crate::{
     frame_type_cache::{FrameTypeCache, RuntimeCacheTraits},
-    Function, LoadedFunction,
+    loader::{FunctionPtr, GenericFunctionPtr},
+    LoadedFunction,
 };
-use std::{
-    cell::RefCell,
-    collections::HashMap,
-    hash::{Hash, Hasher},
-    rc::Rc,
-    sync::Arc,
-};
-
-/// Stable pointer identity for a [Function] within a single interpreter invocation.
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub(crate) struct FunctionPtr(*const Function);
-
-impl FunctionPtr {
-    pub(crate) fn from_loaded_function(function: &LoadedFunction) -> Self {
-        FunctionPtr(Arc::as_ptr(&function.function))
-    }
-}
-
-impl Hash for FunctionPtr {
-    fn hash<H: Hasher>(&self, state: &mut H) {
-        state.write_usize(self.0 as usize);
-    }
-}
+use std::{cell::RefCell, collections::HashMap, rc::Rc};
 
 /// Interpreter-level caches for function data (single-threaded)
 pub struct InterpreterFunctionCaches {
     function_instruction_caches: HashMap<FunctionPtr, Rc<RefCell<FrameTypeCache>>>,
+    generic_function_instruction_caches: HashMap<GenericFunctionPtr, Rc<RefCell<FrameTypeCache>>>,
 }
 
 impl InterpreterFunctionCaches {
     pub fn new() -> Self {
         Self {
             function_instruction_caches: HashMap::new(),
+            generic_function_instruction_caches: HashMap::new(),
         }
     }
 
@@ -75,7 +61,12 @@ impl InterpreterFunctionCaches {
         &mut self,
         function: &LoadedFunction,
     ) -> Rc<RefCell<FrameTypeCache>> {
-        // TODO(caches): cache per instantiation!
-        FrameTypeCache::make_rc_for_function(function)
+        debug_assert!(!function.ty_args().is_empty());
+
+        let ptr = GenericFunctionPtr::from_loaded_function(function);
+        self.generic_function_instruction_caches
+            .entry(ptr)
+            .or_insert_with(|| FrameTypeCache::make_rc_for_function(function))
+            .clone()
     }
 }

--- a/third_party/move/move-vm/runtime/src/loader/mod.rs
+++ b/third_party/move/move-vm/runtime/src/loader/mod.rs
@@ -7,7 +7,8 @@ mod access_specifier_loader;
 mod function;
 pub use function::{Function, LoadedFunction, LoadedFunctionOwner};
 pub(crate) use function::{
-    FunctionHandle, FunctionInstantiation, LazyLoadedFunction, LazyLoadedFunctionState,
+    FunctionHandle, FunctionInstantiation, FunctionPtr, GenericFunctionPtr, LazyLoadedFunction,
+    LazyLoadedFunctionState,
 };
 
 mod modules;
@@ -20,4 +21,4 @@ pub use script::Script;
 mod single_signature_loader;
 
 mod type_loader;
-use type_loader::intern_type;
+use type_loader::convert_tok_to_type;

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -6,7 +6,7 @@ use crate::{
     loader::{
         function::{Function, FunctionHandle, FunctionInstantiation},
         single_signature_loader::load_single_signatures_for_module,
-        type_loader::intern_type,
+        type_loader::{convert_tok_to_type, convert_toks_to_types},
     },
     native_functions::NativeFunctions,
 };
@@ -27,9 +27,12 @@ use move_core_types::{
     vm_status::StatusCode,
 };
 use move_vm_metrics::{Timer, VM_TIMER};
-use move_vm_types::loaded_data::{
-    runtime_types::{StructIdentifier, StructLayout, StructType, Type},
-    struct_name_indexing::{StructNameIndex, StructNameIndexMap},
+use move_vm_types::{
+    loaded_data::{
+        runtime_types::{StructIdentifier, StructLayout, StructType, Type},
+        struct_name_indexing::{StructNameIndex, StructNameIndexMap},
+    },
+    ty_interner::{InternedTypePool, TypeVecId},
 };
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap},
@@ -153,6 +156,7 @@ impl Module {
         size: usize,
         module: Arc<CompiledModule>,
         struct_name_index_map: &StructNameIndexMap,
+        ty_pool: &InternedTypePool,
     ) -> PartialVMResult<Self> {
         let _timer = VM_TIMER.timer_with_label("Module::new");
 
@@ -176,6 +180,7 @@ impl Module {
         let mut function_map = HashMap::new();
         let mut struct_map = HashMap::new();
         let mut signature_table = vec![];
+        let mut is_fully_instantiated_signature = vec![];
 
         let mut struct_idxs = vec![];
         let mut struct_names = vec![];
@@ -196,13 +201,13 @@ impl Module {
 
         // Build signature table
         for signatures in module.signatures() {
-            signature_table.push(
-                signatures
-                    .0
-                    .iter()
-                    .map(|sig| intern_type(BinaryIndexedView::Module(&module), sig, &struct_idxs))
-                    .collect::<PartialVMResult<Vec<_>>>()?,
-            )
+            let (tys, is_fully_instantiated) = convert_toks_to_types(
+                BinaryIndexedView::Module(&module),
+                &signatures.0,
+                &struct_idxs,
+            )?;
+            signature_table.push(tys);
+            is_fully_instantiated_signature.push(is_fully_instantiated);
         }
 
         for (idx, struct_def) in module.struct_defs().iter().enumerate() {
@@ -289,9 +294,17 @@ impl Module {
 
         for func_inst in module.function_instantiations() {
             let handle = function_refs[func_inst.handle.0 as usize].clone();
+            let idx = func_inst.type_parameters.0 as usize;
+            let instantiation = signature_table[idx].clone();
+            let ty_args_id = if is_fully_instantiated_signature[idx] {
+                Some(ty_pool.intern_ty_args(&instantiation))
+            } else {
+                None
+            };
             function_instantiations.push(FunctionInstantiation {
                 handle,
-                instantiation: signature_table[func_inst.type_parameters.0 as usize].clone(),
+                instantiation,
+                ty_args_id,
             });
         }
 
@@ -475,7 +488,7 @@ impl Module {
         field: &FieldDefinition,
         struct_name_table: &[StructNameIndex],
     ) -> PartialVMResult<(Identifier, Type)> {
-        let ty = intern_type(
+        let ty = convert_tok_to_type(
             BinaryIndexedView::Module(module),
             &field.signature.0,
             struct_name_table,
@@ -516,8 +529,9 @@ impl Module {
     }
 
     #[cfg_attr(feature = "force-inline", inline(always))]
-    pub(crate) fn function_instantiation_at(&self, idx: u16) -> &[Type] {
-        &self.function_instantiations[idx as usize].instantiation
+    pub(crate) fn function_instantiation_at(&self, idx: u16) -> (&[Type], Option<TypeVecId>) {
+        let instantiation = &self.function_instantiations[idx as usize];
+        (&instantiation.instantiation, instantiation.ty_args_id)
     }
 
     #[cfg_attr(feature = "force-inline", inline(always))]

--- a/third_party/move/move-vm/runtime/src/loader/script.rs
+++ b/third_party/move/move-vm/runtime/src/loader/script.rs
@@ -2,9 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use super::{
-    intern_type, single_signature_loader::load_single_signatures_for_script, Function,
+    convert_tok_to_type, single_signature_loader::load_single_signatures_for_script, Function,
     FunctionHandle, FunctionInstantiation,
 };
+use crate::loader::type_loader::convert_toks_to_types;
 use move_binary_format::{
     access::ScriptAccess,
     binary_views::BinaryIndexedView,
@@ -12,10 +13,13 @@ use move_binary_format::{
     file_format::{CompiledScript, FunctionDefinitionIndex, Signature, SignatureIndex, Visibility},
 };
 use move_core_types::{ident_str, language_storage::ModuleId};
-use move_vm_types::loaded_data::{
-    runtime_access_specifier::AccessSpecifier,
-    runtime_types::{StructIdentifier, Type},
-    struct_name_indexing::StructNameIndexMap,
+use move_vm_types::{
+    loaded_data::{
+        runtime_access_specifier::AccessSpecifier,
+        runtime_types::{StructIdentifier, Type},
+        struct_name_indexing::StructNameIndexMap,
+    },
+    ty_interner::{InternedTypePool, TypeVecId},
 };
 use std::{collections::BTreeMap, ops::Deref, sync::Arc};
 
@@ -44,6 +48,7 @@ impl Script {
     pub(crate) fn new(
         script: Arc<CompiledScript>,
         struct_name_index_map: &StructNameIndexMap,
+        ty_pool: &InternedTypePool,
     ) -> PartialVMResult<Self> {
         let mut struct_names = vec![];
         for struct_handle in script.struct_handles() {
@@ -74,17 +79,20 @@ impl Script {
         let mut function_instantiations = vec![];
         for func_inst in script.function_instantiations() {
             let handle = function_refs[func_inst.handle.0 as usize].clone();
-            let mut instantiation = vec![];
-            for ty in &script.signature_at(func_inst.type_parameters).0 {
-                instantiation.push(intern_type(
-                    BinaryIndexedView::Script(&script),
-                    ty,
-                    &struct_names,
-                )?);
-            }
+            let (instantiation, is_fully_instantiated) = convert_toks_to_types(
+                BinaryIndexedView::Script(&script),
+                &script.signature_at(func_inst.type_parameters).0,
+                &struct_names,
+            )?;
+            let ty_args_id = if is_fully_instantiated {
+                Some(ty_pool.intern_ty_args(&instantiation))
+            } else {
+                None
+            };
             function_instantiations.push(FunctionInstantiation {
                 handle,
                 instantiation,
+                ty_args_id,
             });
         }
 
@@ -94,7 +102,7 @@ impl Script {
         let param_tys = parameters
             .0
             .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .map(|tok| convert_tok_to_type(BinaryIndexedView::Script(&script), tok, &struct_names))
             .collect::<PartialVMResult<Vec<_>>>()?;
         let locals = Signature(
             parameters
@@ -107,7 +115,7 @@ impl Script {
         let local_tys = locals
             .0
             .iter()
-            .map(|tok| intern_type(BinaryIndexedView::Script(&script), tok, &struct_names))
+            .map(|tok| convert_tok_to_type(BinaryIndexedView::Script(&script), tok, &struct_names))
             .collect::<PartialVMResult<Vec<_>>>()?;
         let ty_param_abilities = script.type_parameters.clone();
 
@@ -155,8 +163,9 @@ impl Script {
         &self.function_instantiations[idx as usize].handle
     }
 
-    pub(crate) fn function_instantiation_at(&self, idx: u16) -> &[Type] {
-        &self.function_instantiations[idx as usize].instantiation
+    pub(crate) fn function_instantiation_at(&self, idx: u16) -> (&[Type], Option<TypeVecId>) {
+        let instantiation = &self.function_instantiations[idx as usize];
+        (&instantiation.instantiation, instantiation.ty_args_id)
     }
 
     pub(crate) fn single_type_at(&self, idx: SignatureIndex) -> &Type {

--- a/third_party/move/move-vm/runtime/src/loader/single_signature_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/single_signature_loader.rs
@@ -1,7 +1,7 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-use super::type_loader::intern_type;
+use super::type_loader::convert_tok_to_type;
 use move_binary_format::{
     access::ModuleAccess,
     binary_views::BinaryIndexedView,
@@ -99,7 +99,7 @@ impl<'a> SingleSignatureMap<'a> {
             );
         }
 
-        let ty = intern_type(self.view, &sig_toks[0], self.struct_idxs)?;
+        let ty = convert_tok_to_type(self.view, &sig_toks[0], self.struct_idxs)?;
         self.index_to_type.insert(idx, ty);
         Ok(())
     }

--- a/third_party/move/move-vm/runtime/src/loader/type_loader.rs
+++ b/third_party/move/move-vm/runtime/src/loader/type_loader.rs
@@ -11,55 +11,102 @@ use move_vm_types::loaded_data::{
 use triomphe::Arc as TriompheArc;
 
 /// Converts a signature token into the in memory type representation used by the MoveVM.
-pub fn intern_type(
+pub fn convert_tok_to_type(
     module: BinaryIndexedView,
     tok: &SignatureToken,
     struct_name_table: &[StructNameIndex],
 ) -> PartialVMResult<Type> {
-    let list = |toks: &[SignatureToken]| {
-        toks.iter()
-            .map(|tok| intern_type(module, tok, struct_name_table))
-            .collect::<PartialVMResult<Vec<_>>>()
-    };
+    Ok(convert_tok_to_type_impl(module, tok, struct_name_table)?.0)
+}
+
+/// Converts a stream of signature tokens into the in memory type representation used by the
+/// MoveVM. Also returns true if all tokens are non-generic (contain 0 type parameters).
+pub fn convert_toks_to_types(
+    module: BinaryIndexedView,
+    toks: &[SignatureToken],
+    struct_name_table: &[StructNameIndex],
+) -> PartialVMResult<(Vec<Type>, bool)> {
+    convert_toks_to_types_impl(module, toks, struct_name_table)
+}
+
+fn convert_toks_to_types_impl(
+    module: BinaryIndexedView,
+    toks: &[SignatureToken],
+    struct_name_table: &[StructNameIndex],
+) -> PartialVMResult<(Vec<Type>, bool)> {
+    let mut tys = Vec::with_capacity(toks.len());
+    let mut all_fully_instantiated = true;
+    for tok in toks {
+        let (ty, is_fully_instantiated) = convert_tok_to_type_impl(module, tok, struct_name_table)?;
+        tys.push(ty);
+        all_fully_instantiated &= is_fully_instantiated;
+    }
+    Ok((tys, all_fully_instantiated))
+}
+
+/// Returns the type, and true if this type is fully instantiated, and false otherwise.
+fn convert_tok_to_type_impl(
+    module: BinaryIndexedView,
+    tok: &SignatureToken,
+    struct_name_table: &[StructNameIndex],
+) -> PartialVMResult<(Type, bool)> {
     let res = match tok {
-        SignatureToken::Bool => Type::Bool,
-        SignatureToken::U8 => Type::U8,
-        SignatureToken::U16 => Type::U16,
-        SignatureToken::U32 => Type::U32,
-        SignatureToken::U64 => Type::U64,
-        SignatureToken::U128 => Type::U128,
-        SignatureToken::U256 => Type::U256,
-        SignatureToken::Address => Type::Address,
-        SignatureToken::Signer => Type::Signer,
-        SignatureToken::TypeParameter(idx) => Type::TyParam(*idx),
+        SignatureToken::Bool => (Type::Bool, true),
+        SignatureToken::U8 => (Type::U8, true),
+        SignatureToken::U16 => (Type::U16, true),
+        SignatureToken::U32 => (Type::U32, true),
+        SignatureToken::U64 => (Type::U64, true),
+        SignatureToken::U128 => (Type::U128, true),
+        SignatureToken::U256 => (Type::U256, true),
+        SignatureToken::Address => (Type::Address, true),
+        SignatureToken::Signer => (Type::Signer, true),
+        SignatureToken::TypeParameter(idx) => (Type::TyParam(*idx), false),
         SignatureToken::Vector(inner_tok) => {
-            let inner_type = intern_type(module, inner_tok, struct_name_table)?;
-            Type::Vector(TriompheArc::new(inner_type))
+            let (inner_type, is_fully_instantiated) =
+                convert_tok_to_type_impl(module, inner_tok, struct_name_table)?;
+            (
+                Type::Vector(TriompheArc::new(inner_type)),
+                is_fully_instantiated,
+            )
         },
-        SignatureToken::Function(args, results, abilities) => Type::Function {
-            args: list(args)?,
-            results: list(results)?,
-            abilities: *abilities,
+        SignatureToken::Function(args, results, abilities) => {
+            let (args, args_fully_instantiated) =
+                convert_toks_to_types_impl(module, args, struct_name_table)?;
+            let (results, results_fully_instantiated) =
+                convert_toks_to_types_impl(module, results, struct_name_table)?;
+            let ty = Type::Function {
+                args,
+                results,
+                abilities: *abilities,
+            };
+            (ty, args_fully_instantiated && results_fully_instantiated)
         },
         SignatureToken::Reference(inner_tok) => {
-            let inner_type = intern_type(module, inner_tok, struct_name_table)?;
-            Type::Reference(Box::new(inner_type))
+            let (inner_type, is_fully_instantiated) =
+                convert_tok_to_type_impl(module, inner_tok, struct_name_table)?;
+            (Type::Reference(Box::new(inner_type)), is_fully_instantiated)
         },
         SignatureToken::MutableReference(inner_tok) => {
-            let inner_type = intern_type(module, inner_tok, struct_name_table)?;
-            Type::MutableReference(Box::new(inner_type))
+            let (inner_type, is_fully_instantiated) =
+                convert_tok_to_type_impl(module, inner_tok, struct_name_table)?;
+            (
+                Type::MutableReference(Box::new(inner_type)),
+                is_fully_instantiated,
+            )
         },
         SignatureToken::Struct(sh_idx) => {
             let struct_handle = module.struct_handle_at(*sh_idx);
-            Type::Struct {
+            let ty = Type::Struct {
                 idx: struct_name_table[sh_idx.0 as usize],
                 ability: AbilityInfo::struct_(struct_handle.abilities),
-            }
+            };
+            (ty, true)
         },
         SignatureToken::StructInstantiation(sh_idx, tys) => {
-            let type_args: Vec<_> = list(tys)?;
+            let (type_args, type_args_fully_instantiated) =
+                convert_toks_to_types_impl(module, tys, struct_name_table)?;
             let struct_handle = module.struct_handle_at(*sh_idx);
-            Type::StructInstantiation {
+            let ty = Type::StructInstantiation {
                 idx: struct_name_table[sh_idx.0 as usize],
                 ty_args: TriompheArc::new(type_args),
                 ability: AbilityInfo::generic_struct(
@@ -70,7 +117,8 @@ pub fn intern_type(
                         .map(|ty| ty.is_phantom)
                         .collect(),
                 ),
-            }
+            };
+            (ty, type_args_fully_instantiated)
         },
     };
     Ok(res)

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -30,7 +30,10 @@ use move_vm_metrics::{Timer, VERIFIED_MODULE_CACHE_SIZE, VM_TIMER};
 use move_vm_types::loaded_data::{
     runtime_types::StructIdentifier, struct_name_indexing::StructNameIndex,
 };
-use move_vm_types::loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndexMap};
+use move_vm_types::{
+    loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndexMap},
+    ty_interner::InternedTypePool,
+};
 use std::sync::Arc;
 
 const OPTION_MODULE_BYTES: &[u8] = include_bytes!("option.mv");
@@ -61,6 +64,9 @@ pub struct RuntimeEnvironment {
     /// Caches struct tags for instantiated types. This cache can be used concurrently and
     /// speculatively because type tag information does not change with module publishes.
     ty_tag_cache: Arc<TypeTagCache>,
+
+    /// Pool of interned type representations. Same lifetime as struct index map.
+    interned_ty_pool: Arc<InternedTypePool>,
 }
 
 impl RuntimeEnvironment {
@@ -99,12 +105,18 @@ impl RuntimeEnvironment {
             natives,
             struct_name_index_map: Arc::new(StructNameIndexMap::empty()),
             ty_tag_cache: Arc::new(TypeTagCache::empty()),
+            interned_ty_pool: Arc::new(InternedTypePool::new()),
         }
     }
 
     /// Returns the config currently used by this runtime environment.
     pub fn vm_config(&self) -> &VMConfig {
         &self.vm_config
+    }
+
+    /// Returns the type pool for interning that is currently used by this runtime environment.
+    pub fn ty_pool(&self) -> &InternedTypePool {
+        &self.interned_ty_pool
     }
 
     /// Enables delayed field optimization for this environment.
@@ -140,8 +152,12 @@ impl RuntimeEnvironment {
                 .iter()
                 .map(|module| module.as_ref().as_ref()),
         )?;
-        Script::new(locally_verified_script.0, self.struct_name_index_map())
-            .map_err(|err| err.finish(Location::Script))
+        Script::new(
+            locally_verified_script.0,
+            self.struct_name_index_map(),
+            self.ty_pool(),
+        )
+        .map_err(|err| err.finish(Location::Script))
     }
 
     /// Creates a locally verified compiled module by running:
@@ -191,6 +207,7 @@ impl RuntimeEnvironment {
             locally_verified_module.1,
             locally_verified_module.0,
             self.struct_name_index_map(),
+            self.ty_pool(),
         );
 
         // Note: loader V1 implementation does not set locations for this error.
@@ -208,6 +225,7 @@ impl RuntimeEnvironment {
             locally_verified_module.1,
             locally_verified_module.0,
             self.struct_name_index_map(),
+            self.ty_pool(),
         )
         .map_err(|err| err.finish(Location::Undefined))
     }
@@ -324,9 +342,10 @@ impl RuntimeEnvironment {
 
     /// Flushes the global caches with struct name indices and struct tags. Note that when calling
     /// this function, modules that still store indices into struct name cache must also be flushed.
-    pub fn flush_struct_name_and_tag_caches(&self) {
+    pub fn flush_all_caches(&self) {
         self.ty_tag_cache.flush();
         self.struct_name_index_map.flush();
+        self.interned_ty_pool.flush();
     }
 
     /// Flushes the global verified module cache. Should be used when verifier configuration has
@@ -392,6 +411,7 @@ impl Clone for RuntimeEnvironment {
             natives: self.natives.clone(),
             struct_name_index_map: Arc::clone(&self.struct_name_index_map),
             ty_tag_cache: Arc::clone(&self.ty_tag_cache),
+            interned_ty_pool: Arc::clone(&self.interned_ty_pool),
         }
     }
 }

--- a/third_party/move/move-vm/runtime/src/storage/loader/traits.rs
+++ b/third_party/move/move-vm/runtime/src/storage/loader/traits.rs
@@ -95,7 +95,7 @@ impl LegacyLoaderConfig {
 }
 
 /// Private helper trait common for eager and lazy loaders when instantiating a function.
-pub(crate) trait InstantiatedFunctionLoaderHelper {
+pub(crate) trait InstantiatedFunctionLoaderHelper: WithRuntimeEnvironment {
     /// Loads a single type argument for the function instantiation, converting the type tag into
     /// a runtime type instance.
     fn load_ty_arg(
@@ -132,10 +132,15 @@ pub(crate) trait InstantiatedFunctionLoaderHelper {
 
         Type::verify_ty_arg_abilities(function.ty_param_abilities(), &ty_args)
             .map_err(|e| e.finish(Location::Module(module.self_id().clone())))?;
+        let ty_args_id = self
+            .runtime_environment()
+            .ty_pool()
+            .intern_ty_args(&ty_args);
 
         Ok(LoadedFunction {
             owner: LoadedFunctionOwner::Module(module),
             ty_args,
+            ty_args_id,
             function,
         })
     }
@@ -157,10 +162,15 @@ pub(crate) trait InstantiatedFunctionLoaderHelper {
         let main = script.entry_point();
         Type::verify_ty_arg_abilities(main.ty_param_abilities(), &ty_args)
             .map_err(|err| err.finish(Location::Script))?;
+        let ty_args_id = self
+            .runtime_environment()
+            .ty_pool()
+            .intern_ty_args(&ty_args);
 
         Ok(LoadedFunction {
             owner: LoadedFunctionOwner::Script(script),
             ty_args,
+            ty_args_id,
             function: main,
         })
     }

--- a/third_party/move/move-vm/types/src/lib.rs
+++ b/third_party/move/move-vm/types/src/lib.rs
@@ -39,6 +39,7 @@ pub mod gas;
 pub mod loaded_data;
 pub mod natives;
 pub mod resolver;
+pub mod ty_interner;
 pub mod value_serde;
 pub mod value_traversal;
 pub mod values;

--- a/third_party/move/move-vm/types/src/loaded_data/struct_name_indexing.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/struct_name_indexing.rs
@@ -20,13 +20,13 @@ macro_rules! panic_error {
 /// Represents a unique identifier for the struct name. Note that this index has no public
 /// constructor - the only way to construct it is via [StructNameIndexMap].
 #[derive(Debug, Copy, Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct StructNameIndex(usize);
+pub struct StructNameIndex(u32);
 
 impl StructNameIndex {
     /// Creates a new index for testing purposes only. For production, indices must always be
     /// created by the data structure that uses them to intern struct names.
     #[cfg(any(test, feature = "testing"))]
-    pub fn new(idx: usize) -> Self {
+    pub fn new(idx: u32) -> Self {
         Self(idx)
     }
 }
@@ -39,7 +39,7 @@ impl std::fmt::Display for StructNameIndex {
 
 #[derive(Clone)]
 struct IndexMap<T: Clone + Ord> {
-    forward_map: BTreeMap<T, usize>,
+    forward_map: BTreeMap<T, u32>,
     backward_map: Vec<Arc<T>>,
 }
 
@@ -89,7 +89,7 @@ impl StructNameIndexMap {
                 return Ok(StructNameIndex(*idx));
             }
 
-            let idx = index_map.backward_map.len();
+            let idx = index_map.backward_map.len() as u32;
             index_map.backward_map.push(backward_value);
             index_map.forward_map.insert(forward_key, idx);
             idx
@@ -102,7 +102,7 @@ impl StructNameIndexMap {
         index_map: &'a parking_lot::RwLockReadGuard<IndexMap<StructIdentifier>>,
         idx: StructNameIndex,
     ) -> PartialVMResult<&'a Arc<StructIdentifier>> {
-        index_map.backward_map.get(idx.0).ok_or_else(|| {
+        index_map.backward_map.get(idx.0 as usize).ok_or_else(|| {
             let msg = format!(
                 "Index out of bounds when accessing struct name reference \
                      at index {}, backward map length: {}",

--- a/third_party/move/move-vm/types/src/ty_interner.rs
+++ b/third_party/move/move-vm/types/src/ty_interner.rs
@@ -1,0 +1,563 @@
+// Copyright (c) The Move Contributors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Data structures and caches for interning types as unique compact identifiers. The lifetime of
+//! these caches is tied to the code cache, and is managed externally.
+
+use crate::loaded_data::{runtime_types::Type, struct_name_indexing::StructNameIndex};
+use parking_lot::RwLock;
+use std::collections::HashMap;
+use triomphe::Arc;
+
+/// Compactly represents a loaded type.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct TypeId(u32);
+
+/// Compactly represents a vector of types.
+#[repr(transparent)]
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+pub struct TypeVecId(u32);
+
+/// Partially-interned representation containing top-level information.
+#[derive(Copy, Clone, Eq, PartialEq, Hash, Debug)]
+enum TypeRepr {
+    Bool,
+    U8,
+    U16,
+    U32,
+    U64,
+    U128,
+    U256,
+    Address,
+    Signer,
+    Vector(TypeId),
+    Reference(TypeId),
+    MutableReference(TypeId),
+    Struct {
+        idx: StructNameIndex,
+        ty_args: TypeVecId,
+    },
+    Function {
+        args: TypeVecId,
+        results: TypeVecId,
+    },
+}
+
+struct InternMap<T, I> {
+    interned: HashMap<T, I>,
+    data: Vec<T>,
+}
+
+impl<T, I> Default for InternMap<T, I> {
+    fn default() -> Self {
+        Self {
+            interned: HashMap::new(),
+            data: Vec::with_capacity(16),
+        }
+    }
+}
+
+impl<T, I> InternMap<T, I> {
+    fn clear(&mut self) {
+        self.interned.clear();
+        self.data.clear();
+    }
+}
+
+/// Interns single types.
+struct TypeInterner {
+    inner: RwLock<InternMap<TypeRepr, TypeId>>,
+}
+
+impl Default for TypeInterner {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(InternMap::default()),
+        }
+    }
+}
+
+impl TypeInterner {
+    fn intern(&self, repr: TypeRepr) -> TypeId {
+        if let Some(id) = self.inner.read().interned.get(&repr) {
+            return *id;
+        }
+
+        let mut inner = self.inner.write();
+        if let Some(id) = inner.interned.get(&repr) {
+            return *id;
+        }
+
+        let id = TypeId(inner.data.len() as u32);
+        inner.data.push(repr);
+        inner.interned.insert(repr, id);
+        id
+    }
+}
+
+/// Interns vector of types (e.g., list of type arguments).
+struct TypeVecInterner {
+    inner: RwLock<InternMap<Arc<[TypeId]>, TypeVecId>>,
+}
+
+impl Default for TypeVecInterner {
+    fn default() -> Self {
+        Self {
+            inner: RwLock::new(InternMap::default()),
+        }
+    }
+}
+
+impl TypeVecInterner {
+    fn intern(&self, tys: &[TypeId]) -> TypeVecId {
+        if let Some(id) = self.inner.read().interned.get(tys) {
+            return *id;
+        }
+
+        let tys_arced: Arc<[TypeId]> = Arc::from(tys);
+        let tys_arced_key = tys_arced.clone();
+
+        let mut inner = self.inner.write();
+        if let Some(id) = inner.interned.get(tys) {
+            return *id;
+        }
+
+        let id = TypeVecId(inner.data.len() as u32);
+        inner.data.push(tys_arced);
+        inner.interned.insert(tys_arced_key, id);
+        id
+    }
+
+    fn intern_vec(&self, tys: Vec<TypeId>) -> TypeVecId {
+        if let Some(id) = self.inner.read().interned.get(tys.as_slice()) {
+            return *id;
+        }
+
+        let tys: Arc<[TypeId]> = tys.into();
+        let tys_key = tys.clone();
+
+        let mut inner = self.inner.write();
+        if let Some(id) = inner.interned.get(&tys) {
+            return *id;
+        }
+
+        let id = TypeVecId(inner.data.len() as u32);
+        inner.data.push(tys);
+        inner.interned.insert(tys_key, id);
+        id
+    }
+}
+
+/// Pool of all interned types. Users can query interned representations ([TypeId] for single types
+/// or [TypeVecId] for vector of types) based on provided runtime types. Context does not manage
+/// memory nor limit the number of types to intern - this has to be managed externally by the
+/// client (to ensure eviction of interned data is safe).
+pub struct InternedTypePool {
+    ty_interner: TypeInterner,
+    ty_vec_interner: TypeVecInterner,
+}
+
+impl InternedTypePool {
+    /// Creates a new interning context. Context is warmed-up with common types.
+    #[allow(clippy::new_without_default)]
+    pub fn new() -> Self {
+        let ty_interner = TypeInterner::default();
+        let ty_vec_interner = TypeVecInterner::default();
+        let ctx = Self {
+            ty_interner,
+            ty_vec_interner,
+        };
+        ctx.warmup();
+        ctx
+    }
+
+    /// Returns how many distinct types are instantiated.
+    pub fn num_interned_tys(&self) -> usize {
+        self.ty_interner.inner.read().data.len()
+    }
+
+    /// Returns how many distinct vectors of types are instantiated.
+    pub fn num_interned_ty_vecs(&self) -> usize {
+        self.ty_vec_interner.inner.read().data.len()
+    }
+
+    /// Clears all interned data, and then warm-ups the cache for common types. Should be called if
+    /// type IDs are no longer used, e.g., when flushing module cache at block boundaries.
+    pub fn flush(&self) {
+        self.flush_impl();
+        self.warmup();
+    }
+
+    /// Flushes all cached data without warming up the cache.
+    fn flush_impl(&self) {
+        let mut ty_interner = self.ty_interner.inner.write();
+        ty_interner.clear();
+        drop(ty_interner);
+
+        let mut ty_vec_interner = self.ty_vec_interner.inner.write();
+        ty_vec_interner.clear();
+        drop(ty_vec_interner);
+    }
+
+    /// Interns common type representations.
+    fn warmup(&self) {
+        self.ty_interner.intern(TypeRepr::Bool);
+        let u8_id = self.ty_interner.intern(TypeRepr::U8);
+        self.ty_interner.intern(TypeRepr::U16);
+        self.ty_interner.intern(TypeRepr::U32);
+        let u64_id = self.ty_interner.intern(TypeRepr::U64);
+        self.ty_interner.intern(TypeRepr::U128);
+        self.ty_interner.intern(TypeRepr::U256);
+        self.ty_interner.intern(TypeRepr::Address);
+        self.ty_interner.intern(TypeRepr::Signer);
+
+        self.ty_vec_interner.intern(&[]);
+        self.ty_vec_interner.intern(&[u8_id]);
+        self.ty_vec_interner.intern(&[u64_id]);
+    }
+
+    /// Given a vector if fully-instantiated type arguments, returns the corresponding [TypeVecId].
+    ///
+    /// Panics if there are non-instantiated type arguments.
+    pub fn intern_ty_args(&self, ty_args: &[Type]) -> TypeVecId {
+        let ty_args = ty_args
+            .iter()
+            .map(|t| self.instantiate_and_intern(t, &[]))
+            .collect::<Vec<_>>();
+        self.ty_vec_interner.intern_vec(ty_args)
+    }
+
+    /// Given a type containing type parameters, and a fully-interned type arguments, performs
+    /// type substitution with interning.
+    pub fn instantiate_and_intern(&self, ty: &Type, subst: &[TypeId]) -> TypeId {
+        use Type::*;
+        match ty {
+            Bool => self.ty_interner.intern(TypeRepr::Bool),
+            U8 => self.ty_interner.intern(TypeRepr::U8),
+            U16 => self.ty_interner.intern(TypeRepr::U16),
+            U32 => self.ty_interner.intern(TypeRepr::U32),
+            U64 => self.ty_interner.intern(TypeRepr::U64),
+            U128 => self.ty_interner.intern(TypeRepr::U128),
+            U256 => self.ty_interner.intern(TypeRepr::U256),
+            Address => self.ty_interner.intern(TypeRepr::Address),
+            Signer => self.ty_interner.intern(TypeRepr::Signer),
+            TyParam(idx) => subst[*idx as usize],
+            Vector(elem_ty) => {
+                let id = self.instantiate_and_intern(elem_ty, subst);
+                self.vec_of(id)
+            },
+            Reference(inner_ty) => {
+                let id = self.instantiate_and_intern(inner_ty, subst);
+                self.ref_of(id)
+            },
+            MutableReference(inner_ty) => {
+                let id = self.instantiate_and_intern(inner_ty, subst);
+                self.ref_mut_of(id)
+            },
+            Struct { idx, .. } => self.struct_of(*idx),
+            StructInstantiation { idx, ty_args, .. } => {
+                let ty_args = ty_args
+                    .iter()
+                    .map(|t| self.instantiate_and_intern(t, subst))
+                    .collect::<Vec<_>>();
+                self.instantiated_struct_of(*idx, ty_args)
+            },
+            Function { args, results, .. } => {
+                let args = args
+                    .iter()
+                    .map(|t| self.instantiate_and_intern(t, subst))
+                    .collect::<Vec<_>>();
+                let results = results
+                    .iter()
+                    .map(|t| self.instantiate_and_intern(t, subst))
+                    .collect::<Vec<_>>();
+                self.ty_interner.intern(TypeRepr::Function {
+                    args: self.ty_vec_interner.intern_vec(args),
+                    results: self.ty_vec_interner.intern_vec(results),
+                })
+            },
+        }
+    }
+
+    fn ref_of(&self, t: TypeId) -> TypeId {
+        self.ty_interner.intern(TypeRepr::Reference(t))
+    }
+
+    fn ref_mut_of(&self, t: TypeId) -> TypeId {
+        self.ty_interner.intern(TypeRepr::MutableReference(t))
+    }
+
+    fn vec_of(&self, t: TypeId) -> TypeId {
+        self.ty_interner.intern(TypeRepr::Vector(t))
+    }
+
+    fn struct_of(&self, idx: StructNameIndex) -> TypeId {
+        self.ty_interner.intern(TypeRepr::Struct {
+            idx,
+            ty_args: self.ty_vec_interner.intern(&[]),
+        })
+    }
+
+    fn instantiated_struct_of(&self, idx: StructNameIndex, ty_args: Vec<TypeId>) -> TypeId {
+        let ty_args = self.ty_vec_interner.intern_vec(ty_args);
+        self.ty_interner.intern(TypeRepr::Struct { idx, ty_args })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::loaded_data::{runtime_types::AbilityInfo, struct_name_indexing::StructNameIndex};
+    use move_core_types::ability::AbilitySet;
+    use std::{collections::HashSet, thread};
+
+    #[test]
+    fn test_primitive_types() {
+        let ctx = InternedTypePool::new();
+
+        let tys = [
+            Type::Bool,
+            Type::U8,
+            Type::U16,
+            Type::U32,
+            Type::U64,
+            Type::U128,
+            Type::U256,
+            Type::Address,
+            Type::Signer,
+        ];
+
+        for ty in &tys {
+            let id1 = ctx.instantiate_and_intern(ty, &[]);
+            let id2 = ctx.instantiate_and_intern(ty, &[]);
+            assert_eq!(id1, id2);
+        }
+    }
+
+    #[test]
+    fn test_vector_types() {
+        let ctx = InternedTypePool::new();
+
+        let vec_u8 = Type::Vector(Arc::new(Type::U8));
+        let vec_u64 = Type::Vector(Arc::new(Type::U64));
+
+        let u8_id = ctx.instantiate_and_intern(&Type::U8, &[]);
+        let vec_u8_id1 = ctx.instantiate_and_intern(&vec_u8, &[]);
+        let vec_u8_id2 = ctx.instantiate_and_intern(&vec_u8, &[]);
+        let vec_u64_id = ctx.instantiate_and_intern(&vec_u64, &[]);
+
+        assert_eq!(vec_u8_id1, vec_u8_id2);
+        assert_ne!(vec_u8_id1, vec_u64_id);
+        assert_ne!(vec_u8_id1, u8_id);
+    }
+
+    #[test]
+    fn test_reference_types() {
+        let ctx = InternedTypePool::new();
+
+        let u64_ref = Type::Reference(Box::new(Type::U64));
+        let u64_mut_ref = Type::MutableReference(Box::new(Type::U64));
+        let u8_ref = Type::Reference(Box::new(Type::U8));
+
+        let u64_ref_id1 = ctx.instantiate_and_intern(&u64_ref, &[]);
+        let u64_ref_id2 = ctx.instantiate_and_intern(&u64_ref, &[]);
+        let u64_mut_ref_id = ctx.instantiate_and_intern(&u64_mut_ref, &[]);
+        let u8_ref_id = ctx.instantiate_and_intern(&u8_ref, &[]);
+
+        assert_eq!(u64_ref_id1, u64_ref_id2);
+        assert_ne!(u64_ref_id1, u64_mut_ref_id);
+        assert_ne!(u64_ref_id1, u8_ref_id);
+    }
+
+    #[test]
+    fn test_struct_types() {
+        let ctx = InternedTypePool::new();
+
+        let struct_type = Type::Struct {
+            idx: StructNameIndex::new(0),
+            ability: AbilityInfo::struct_(AbilitySet::EMPTY),
+        };
+
+        let id1 = ctx.instantiate_and_intern(&struct_type, &[]);
+        let id2 = ctx.instantiate_and_intern(&struct_type, &[]);
+
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_structs() {
+        let ctx = InternedTypePool::new();
+
+        let struct_ty = Type::StructInstantiation {
+            idx: StructNameIndex::new(0),
+            ty_args: Arc::new(vec![Type::U64, Type::Bool]),
+            // Irrelevant for tests.
+            ability: AbilityInfo::struct_(AbilitySet::EMPTY),
+        };
+
+        let id1 = ctx.instantiate_and_intern(&struct_ty, &[]);
+        let id2 = ctx.instantiate_and_intern(&struct_ty, &[]);
+        assert_eq!(id1, id2);
+
+        let struct_inst2 = Type::StructInstantiation {
+            idx: StructNameIndex::new(0),
+            ty_args: Arc::new(vec![Type::Bool, Type::U64]),
+            // Irrelevant for tests.
+            ability: AbilityInfo::struct_(AbilitySet::EMPTY),
+        };
+
+        let id3 = ctx.instantiate_and_intern(&struct_inst2, &[]);
+        assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn test_function_types() {
+        let ctx = InternedTypePool::new();
+
+        let func_ty = Type::Function {
+            args: vec![Type::U64, Type::Bool],
+            results: vec![Type::U8],
+            abilities: AbilitySet::EMPTY,
+        };
+
+        let id1 = ctx.instantiate_and_intern(&func_ty, &[]);
+        let id2 = ctx.instantiate_and_intern(&func_ty, &[]);
+
+        assert_eq!(id1, id2);
+
+        let func_ty = Type::Function {
+            args: vec![Type::U64],
+            results: vec![Type::U8],
+            abilities: AbilitySet::EMPTY,
+        };
+
+        let id3 = ctx.instantiate_and_intern(&func_ty, &[]);
+        assert_ne!(id1, id3);
+
+        let func_ty = Type::Function {
+            args: vec![Type::U64],
+            results: vec![Type::U8],
+            abilities: AbilitySet::ALL,
+        };
+        let id4 = ctx.instantiate_and_intern(&func_ty, &[]);
+        assert_eq!(id3, id4);
+    }
+
+    #[test]
+    fn test_deeply_nested_type() {
+        let ctx = InternedTypePool::new();
+
+        let mut ty = Type::U64;
+        for _ in 0..10 {
+            ty = Type::Vector(Arc::new(ty));
+        }
+
+        let id1 = ctx.instantiate_and_intern(&ty, &[]);
+        let id2 = ctx.instantiate_and_intern(&ty, &[]);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_type_parameter_substitution() {
+        let ctx = InternedTypePool::new();
+
+        let u64_id = ctx.instantiate_and_intern(&Type::U64, &[]);
+        let substituted_id = ctx.instantiate_and_intern(&Type::TyParam(0), &[u64_id]);
+        assert_eq!(substituted_id, u64_id);
+    }
+
+    #[test]
+    fn test_empty_type_vectors() {
+        let ctx = InternedTypePool::new();
+        let id1 = ctx.intern_ty_args(&[]);
+        let id2 = ctx.intern_ty_args(&[]);
+        assert_eq!(id1, id2);
+    }
+
+    #[test]
+    fn test_type_vector_consistency() {
+        let ctx = InternedTypePool::new();
+
+        let u64_ty = Type::U64;
+        let bool_ty = Type::Bool;
+
+        let mut tys = vec![u64_ty, bool_ty];
+        let id1 = ctx.intern_ty_args(&tys);
+        let id2 = ctx.intern_ty_args(&tys);
+        assert_eq!(id1, id2);
+
+        tys.reverse();
+        let id3 = ctx.intern_ty_args(&tys);
+        assert_ne!(id1, id3);
+    }
+
+    #[test]
+    fn test_flush_clears_cache() {
+        let ctx = InternedTypePool::new();
+
+        ctx.intern_ty_args(&[Type::U64]);
+        ctx.instantiate_and_intern(&Type::U64, &[]);
+
+        let initial_ty_count = ctx.num_interned_tys();
+        let initial_ty_vec_count = ctx.num_interned_ty_vecs();
+
+        assert!(initial_ty_count > 0);
+        assert!(initial_ty_vec_count > 0);
+
+        ctx.flush_impl();
+
+        assert_eq!(ctx.num_interned_tys(), 0);
+        assert_eq!(ctx.num_interned_ty_vecs(), 0);
+    }
+
+    #[test]
+    fn test_concurrent_interning_same_type() {
+        let ctx = Arc::new(InternedTypePool::new());
+
+        let mut handles = Vec::new();
+        for _ in 0..10 {
+            let ctx = Arc::clone(&ctx);
+            let handle = thread::spawn(move || ctx.instantiate_and_intern(&Type::U64, &[]));
+            handles.push(handle);
+        }
+
+        let mut ids = HashSet::new();
+        for handle in handles {
+            let id = handle.join().unwrap();
+            ids.insert(id);
+        }
+        assert_eq!(ids.len(), 1);
+    }
+
+    #[test]
+    fn test_concurrent_interning_different_types() {
+        let ctx = Arc::new(InternedTypePool::new());
+        let tys = Arc::new(vec![
+            Type::Bool,
+            Type::U8,
+            Type::U16,
+            Type::U32,
+            Type::U64,
+            Type::U128,
+            Type::U256,
+            Type::Address,
+            Type::Signer,
+        ]);
+
+        let mut handles = Vec::new();
+        for i in 0..tys.len() {
+            let tys = Arc::clone(&tys);
+            let ctx = Arc::clone(&ctx);
+            let handle = thread::spawn(move || ctx.instantiate_and_intern(&tys[i], &[]));
+            handles.push(handle);
+        }
+
+        let mut ids = HashSet::new();
+        for handle in handles {
+            let id = handle.join().unwrap();
+            ids.insert(id);
+        }
+        assert_eq!(ids.len(), tys.len());
+    }
+}

--- a/types/src/block_executor/config.rs
+++ b/types/src/block_executor/config.rs
@@ -18,6 +18,10 @@ pub struct BlockExecutorModuleCacheLocalConfig {
     /// The maximum size (in terms of entries) of struct name re-indexing map stored in the runtime
     /// environment.
     pub max_struct_name_index_map_num_entries: usize,
+    /// The maximum number of types to intern.
+    pub max_interned_tys: usize,
+    /// The maximum number of type vectors to intern.
+    pub max_interned_ty_vecs: usize,
 }
 
 impl Default for BlockExecutorModuleCacheLocalConfig {
@@ -28,6 +32,10 @@ impl Default for BlockExecutorModuleCacheLocalConfig {
             // of writing this comment, 13.11.24).
             max_module_cache_size_in_bytes: 1024 * 1024 * 1024,
             max_struct_name_index_map_num_entries: 1_000_000,
+            // Each entry is 4 + 2 * 8 = 20 bytes. This allows ~200 Mb of distinct types.
+            max_interned_tys: 10 * 1024 * 1024,
+            // Use slightly less for vectors of types.
+            max_interned_ty_vecs: 4 * 1024 * 1024,
         }
     }
 }


### PR DESCRIPTION
## Description

Per-interpreter cache for generic functions. For every call-site, we cache the loaded function and its frame cache. If not there, we intern the function's type argument vector and load the frame from the cache entry. In practice, interning is done at load time and is not too expensive while it allows us to
1. Drop generic function frame caches when interpreter is done.
2. Re-use instantiated types, and other metadata.
3. Maybe share caches across re-executions in Block-STM!

### Performance

Tests results in 3-5% speedup.

## How Has This Been Tested?

Existing tests + new tests for fingerprint calculation.

## Key Areas to Review

Ensure hashing of type arguments is correct and is collision-resistant (via different salt on different machines)

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [x] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
