### PR TITLE
[Prover] Fix upsert spec

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
+++ b/aptos-move/framework/aptos-framework/doc/big_ordered_map.md
@@ -3429,6 +3429,7 @@ Given a path to node (excluding the node itself), which is currently stored unde
 <b>ensures</b> [abstract] <a href="big_ordered_map.md#0x1_big_ordered_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), key) ==&gt; <a href="big_ordered_map.md#0x1_big_ordered_map_spec_len">spec_len</a>(<b>old</b>(self)) == <a href="big_ordered_map.md#0x1_big_ordered_map_spec_len">spec_len</a>(self);
 <b>ensures</b> [abstract] <b>forall</b> k: K: <a href="big_ordered_map.md#0x1_big_ordered_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), k) && k != key ==&gt; <a href="big_ordered_map.md#0x1_big_ordered_map_spec_get">spec_get</a>(<b>old</b>(self), k) == <a href="big_ordered_map.md#0x1_big_ordered_map_spec_get">spec_get</a>(self, k);
 <b>ensures</b> [abstract] <b>forall</b> k: K: <a href="big_ordered_map.md#0x1_big_ordered_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), k) ==&gt; <a href="big_ordered_map.md#0x1_big_ordered_map_spec_contains_key">spec_contains_key</a>(self, k);
+<b>ensures</b> [abstract] <b>forall</b> k: K: <a href="big_ordered_map.md#0x1_big_ordered_map_spec_contains_key">spec_contains_key</a>(self, k) ==&gt; (k == key || <a href="big_ordered_map.md#0x1_big_ordered_map_spec_contains_key">spec_contains_key</a>(<b>old</b>(self), k));
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.move
@@ -2346,6 +2346,7 @@ module aptos_std::big_ordered_map {
             assert spec_get(map, 4) == 6;
             assert option::spec_is_some(result_2);
             assert option::spec_borrow(result_2) == 5;
+            assert !spec_contains_key(map, 10);
         };
         spec {
             assert keys[0] == 1;

--- a/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/datastructures/big_ordered_map.spec.move
@@ -155,6 +155,7 @@ spec aptos_std::big_ordered_map {
         ensures [abstract] spec_contains_key(old(self), key) ==> spec_len(old(self)) == spec_len(self);
         ensures [abstract] forall k: K: spec_contains_key(old(self), k) && k != key ==> spec_get(old(self), k) == spec_get(self, k);
         ensures [abstract] forall k: K: spec_contains_key(old(self), k) ==> spec_contains_key(self, k);
+        ensures [abstract] forall k: K: spec_contains_key(self, k) ==> (k == key || spec_contains_key(old(self), k));
     }
 
     spec add_all {


### PR DESCRIPTION
## Description
`upsert` was missing invariant that ensures that arbitrary new keys are not added. This corrects that

## How Has This Been Tested?
Modified verification test of `upsert` to check for this.


## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): Move prover

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
