### PR TITLE
[vm][DO NOT LAND] More instruction caches

### DIFF
--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -6,7 +6,7 @@ use move_binary_format::{
     errors::*,
     file_format::{
         FieldInstantiationIndex, SignatureIndex, StructDefInstantiationIndex,
-        StructVariantInstantiationIndex, VariantFieldInstantiationIndex,
+        StructVariantInstantiationIndex, VariantFieldInstantiationIndex, VariantIndex,
     },
 };
 use move_core_types::gas_algebra::NumTypeNodes;
@@ -38,8 +38,11 @@ impl RuntimeCacheTraits for AllRuntimeCaches {
 #[derive(Clone)]
 pub(crate) enum PerInstructionCache {
     Nothing,
+    VecPack,
     Pack(u16),
     PackGeneric(u16),
+    PackVariant(VariantIndex, u16),
+    PackVariantGeneric(VariantIndex, u16),
     Call(Rc<LoadedFunction>, Rc<RefCell<FrameTypeCache>>),
     CallGeneric(Rc<LoadedFunction>, Rc<RefCell<FrameTypeCache>>),
 }
@@ -235,5 +238,13 @@ impl FrameTypeCache {
             .per_instruction_cache
             .resize(function.code_size(), PerInstructionCache::Nothing);
         frame_cache
+    }
+
+    pub(crate) fn get_instruction_cache(&self, pc: u16) -> &PerInstructionCache {
+        &self.per_instruction_cache[pc as usize]
+    }
+
+    pub(crate) fn set_instruction_cache(&mut self, pc: u16, instr_cache: PerInstructionCache) {
+        self.per_instruction_cache[pc as usize] = instr_cache;
     }
 }


### PR DESCRIPTION
## Description

This PR adds more per-instruction caches for `PackVariant`, `PackVariantGeneric` and `VecPack` instructions. The caches cache type depth check, gas charges per callsite throughout interpreter.

That is, if `foo()` calls `PackVariant` at `pc = 23`, and `foo()` is called 20 times throughout the interpreter session, we charge gas and check depth for `PackVariant` at `pc = 23` only once. This is aligned with types/number of type nodes being already computed by the frame cache (and type clone is relatively cheap) and doing depth checks on first access per type is good enough (note that we already cache formulas but this is still expensive).

### Performance

tested on GCP, 1 thread to make runs stable, 6 runs each.

Recall that the baseline is 
- 272.68
- 272.23
- 275.56,
- 276.80
- 276.75
- 273.86
and the with #17592 is
- 288.16
- 291.92
- 291.33
- 291.04
- 292.79
- 289.34

New numbers with this PR:
- 287.37
- 290.81
- 293.93
- 291.52
- 292.90
- 292.17
=> no clear imperovement

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
