### PR TITLE
[Keyless] Add simple metrics for pepper service operation latencies.

### DIFF
--- a/keyless/pepper/service/src/external_resources/resource_fetcher.rs
+++ b/keyless/pepper/service/src/external_resources/resource_fetcher.rs
@@ -5,17 +5,21 @@ use crate::{
     external_resources::{
         groth16_vk::OnChainGroth16VerificationKey, keyless_config::OnChainKeylessConfiguration,
     },
-    utils,
+    metrics, utils,
 };
 use aptos_infallible::RwLock;
-use aptos_logger::{info, warn};
+use aptos_logger::{info, prelude::SampleRate, sample, warn};
 use serde::de::DeserializeOwned;
 use std::{sync::Arc, time::Duration};
+use tokio::time::Instant;
 
 // Cached resource constants
 const ENV_ONCHAIN_KEYLESS_CONFIG_URL: &str = "ONCHAIN_KEYLESS_CONFIG_URL";
 const ENV_ONCHAIN_GROTH16_VK_URL: &str = "ONCHAIN_GROTH16_VK_URL";
+const ONCHAIN_KEYLESS_CONFIG_RESOURCE_NAME: &str = "onchain_keyless_configuration";
+const ONCHAIN_GROTH16_VK_RESOURCE_NAME: &str = "onchain_groth16_verification_key";
 const RESOURCE_FETCH_INTERVAL_SECS: u64 = 10;
+const RESOURCE_FETCH_LOG_INTERVAL_SECS: u64 = 60;
 
 /// A struct that holds the cached resources and their refresh logic
 #[derive(Clone, Debug, Default)]
@@ -31,6 +35,7 @@ impl CachedResources {
         match utils::read_environment_variable(ENV_ONCHAIN_KEYLESS_CONFIG_URL) {
             Ok(url) => {
                 start_external_resource_refresh_loop(
+                    ONCHAIN_KEYLESS_CONFIG_RESOURCE_NAME.into(),
                     url,
                     self.on_chain_keyless_configuration.clone(),
                 );
@@ -46,7 +51,11 @@ impl CachedResources {
         // Start the Groth16 VK fetcher
         match utils::read_environment_variable(ENV_ONCHAIN_GROTH16_VK_URL) {
             Ok(url) => {
-                start_external_resource_refresh_loop(url, self.groth16_vk.clone());
+                start_external_resource_refresh_loop(
+                    ONCHAIN_GROTH16_VK_RESOURCE_NAME.into(),
+                    url,
+                    self.groth16_vk.clone(),
+                );
             },
             Err(error) => {
                 warn!(
@@ -87,6 +96,7 @@ impl CachedResources {
 
 /// Starts a background task that periodically fetches and caches the resource from the given URL
 fn start_external_resource_refresh_loop<T: DeserializeOwned + Send + Sync + 'static>(
+    resource_name: String,
     resource_url: String,
     local_cache: Arc<RwLock<Option<T>>>,
 ) {
@@ -106,32 +116,53 @@ fn start_external_resource_refresh_loop<T: DeserializeOwned + Send + Sync + 'sta
             tokio::time::sleep(refresh_interval).await;
 
             // Fetch the resource from the URL
-            let response = match client.get(resource_url.clone()).send().await {
-                Ok(response) => response,
+            let time_now = Instant::now();
+            let fetch_result = client.get(resource_url.clone()).send().await;
+            let fetch_time = time_now.elapsed();
+
+            // Update the fetch metrics
+            metrics::update_external_resource_fetch_metrics(
+                &resource_name,
+                fetch_result.is_ok(),
+                fetch_time,
+            );
+
+            // Process the fetch result
+            match fetch_result {
+                Ok(response) => {
+                    // Log the successful fetch
+                    sample!(
+                        SampleRate::Duration(Duration::from_secs(RESOURCE_FETCH_LOG_INTERVAL_SECS)),
+                        info!(
+                            "Successfully fetched resource {} from {} in {:?}",
+                            resource_name, resource_url, fetch_time
+                        )
+                    );
+
+                    // Parse the response into the expected resource
+                    let resource = match response.json::<T>().await {
+                        Ok(resource) => resource,
+                        Err(error) => {
+                            warn!(
+                                "Failed to parse resource from {}! Error: {}",
+                                resource_url, error
+                            );
+                            continue; // Retry in the next loop
+                        },
+                    };
+
+                    // Update the cache
+                    let mut cache = local_cache.write();
+                    *cache = Some(resource);
+                },
                 Err(error) => {
                     warn!(
-                        "Failed to fetch resource from {}! Error: {}",
-                        resource_url, error
+                        "Failed to fetch resource from {} in {:?}! Error: {}",
+                        resource_url, fetch_time, error
                     );
                     continue; // Retry in the next loop
                 },
-            };
-
-            // Parse the response into the expected resource
-            let resource = match response.json::<T>().await {
-                Ok(resource) => resource,
-                Err(error) => {
-                    warn!(
-                        "Failed to parse resource from {}! Error: {}",
-                        resource_url, error
-                    );
-                    continue; // Retry in the next loop
-                },
-            };
-
-            // Update the local cache
-            let mut cache = local_cache.write();
-            *cache = Some(resource);
+            }
         }
     });
 }

--- a/keyless/pepper/service/src/main.rs
+++ b/keyless/pepper/service/src/main.rs
@@ -20,7 +20,7 @@ use hyper::{
     service::{make_service_fn, service_fn},
     Server,
 };
-use std::{convert::Infallible, net::SocketAddr, ops::Deref, sync::Arc};
+use std::{convert::Infallible, net::SocketAddr, ops::Deref, sync::Arc, time::Instant};
 
 #[tokio::main]
 async fn main() {
@@ -60,7 +60,7 @@ fn start_metrics_server() {
 
         // Create a service function that handles the metrics requests
         let make_service = make_service_fn(|_conn| async {
-            Ok::<_, Infallible>(service_fn(metrics::handle_request))
+            Ok::<_, Infallible>(service_fn(metrics::handle_metrics_request))
         });
 
         // Bind the socket address, and start the server
@@ -85,17 +85,46 @@ async fn start_pepper_service(
 
     // Create the service function that handles the endpoint requests
     let make_service = make_service_fn(move |_conn| {
+        // Clone the required Arcs for the service function
         let vuf_keypair = vuf_keypair.clone();
         let jwk_cache = jwk_cache.clone();
         let cached_resources = cached_resources.clone();
+
         async move {
             Ok::<_, Infallible>(service_fn(move |request| {
-                request_handler::handle_request(
-                    request,
-                    vuf_keypair.clone(),
-                    jwk_cache.clone(),
-                    cached_resources.clone(),
-                )
+                // Get the request start time, method and request path
+                let request_start_time = Instant::now();
+                let request_method = request.method().clone();
+                let request_path = request.uri().path().to_owned();
+
+                // Clone the required Arcs for the request handler
+                let vuf_keypair = vuf_keypair.clone();
+                let jwk_cache = jwk_cache.clone();
+                let cached_resources = cached_resources.clone();
+
+                // Handle the request
+                async move {
+                    // Call the request handler
+                    let result = request_handler::handle_request(
+                        request,
+                        vuf_keypair.clone(),
+                        jwk_cache.clone(),
+                        cached_resources.clone(),
+                    )
+                    .await;
+
+                    // Update the request handling metrics
+                    if let Ok(response) = &result {
+                        metrics::update_request_handling_metrics(
+                            &request_path,
+                            request_method,
+                            response.status(),
+                            request_start_time,
+                        );
+                    }
+
+                    result
+                }
             }))
         }
     });

--- a/keyless/pepper/service/src/metrics.rs
+++ b/keyless/pepper/service/src/metrics.rs
@@ -1,40 +1,68 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
+use crate::request_handler::is_known_path;
 use aptos_inspection_service::utils::get_encoded_metrics;
 use aptos_metrics_core::{exponential_buckets, register_histogram_vec, HistogramVec, TextEncoder};
 use hyper::{header::CONTENT_TYPE, Body, Method, StatusCode};
 use once_cell::sync::Lazy;
-use std::convert::Infallible;
+use std::{
+    convert::Infallible,
+    time::{Duration, Instant},
+};
 
 // Default port for the metrics service
 pub const DEFAULT_METRICS_SERVER_PORT: u16 = 8080;
 
+// Invalid request path label
+const INVALID_PATH: &str = "invalid-path";
+
+// Buckets for tracking latencies
+static LATENCY_BUCKETS: Lazy<Vec<f64>> = Lazy::new(|| {
+    exponential_buckets(
+        /*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 24,
+    )
+    .unwrap()
+});
+
+// Histogram for tracking time taken to fetch external resources
+static EXTERNAL_RESOURCE_FETCH_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+    register_histogram_vec!(
+        "keyless_pepper_service_external_resource_fetch_seconds",
+        "Time taken to fetch external resources",
+        &["resource", "succeeded"],
+        LATENCY_BUCKETS.clone()
+    )
+    .unwrap()
+});
+
 // Histogram for tracking time taken to fetch JWKs by issuer and result
-pub static JWK_FETCH_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+static JWK_FETCH_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
         "keyless_pepper_service_jwk_fetch_seconds",
         "Time taken to fetch keyless pepper service jwks",
         &["issuer", "succeeded"],
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 24).unwrap()
+        LATENCY_BUCKETS.clone()
     )
     .unwrap()
 });
 
-pub static REQUEST_HANDLING_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
+// Histogram for tracking time taken to handle pepper service requests
+static REQUEST_HANDLING_SECONDS: Lazy<HistogramVec> = Lazy::new(|| {
     register_histogram_vec!(
-        "keyless_pepper_request_handling_seconds",
+        "keyless_pepper_service_request_handling_seconds",
         "Seconds taken to process pepper requests by scheme and result.",
-        &["pepper_scheme", "is_ok"],
-        exponential_buckets(/*start=*/ 1e-6, /*factor=*/ 2.0, /*count=*/ 24).unwrap()
+        &["request_endpoint", "request_method", "response_code"],
+        LATENCY_BUCKETS.clone()
     )
     .unwrap()
 });
 
-pub async fn handle_request(
-    req: hyper::Request<Body>,
+/// Handles incoming HTTP requests for the metrics server
+pub async fn handle_metrics_request(
+    request: hyper::Request<Body>,
 ) -> Result<hyper::Response<Body>, Infallible> {
-    let response = match (req.method(), req.uri().path()) {
+    let response = match (request.method(), request.uri().path()) {
         (&Method::GET, "/metrics") => {
             let buffer = get_encoded_metrics(TextEncoder::new());
             hyper::Response::builder()
@@ -50,4 +78,50 @@ pub async fn handle_request(
         },
     };
     Ok(response)
+}
+
+/// Updates the external resource fetch metrics with the given data
+pub fn update_external_resource_fetch_metrics(
+    resource_name: &str,
+    succeeded: bool,
+    elapsed: Duration,
+) {
+    EXTERNAL_RESOURCE_FETCH_SECONDS
+        .with_label_values(&[resource_name, &succeeded.to_string()])
+        .observe(elapsed.as_secs_f64());
+}
+
+/// Updates the JWK fetch metrics with the given data
+pub fn update_jwk_fetch_metrics(issuer: &str, succeeded: bool, elapsed: Duration) {
+    JWK_FETCH_SECONDS
+        .with_label_values(&[issuer, &succeeded.to_string()])
+        .observe(elapsed.as_secs_f64());
+}
+
+/// Updates the request handling metrics with the given data
+pub fn update_request_handling_metrics(
+    request_endpoint: &str,
+    request_method: Method,
+    response_code: StatusCode,
+    request_start_time: Instant,
+) {
+    // Calculate the elapsed time
+    let elapsed = request_start_time.elapsed();
+
+    // Determine the request endpoint to use in the metrics (i.e., replace
+    // invalid paths with a fixed label to avoid high cardinality).
+    let request_endpoint = if is_known_path(request_endpoint) {
+        request_endpoint
+    } else {
+        INVALID_PATH
+    };
+
+    // Update the metrics
+    REQUEST_HANDLING_SECONDS
+        .with_label_values(&[
+            request_endpoint,
+            request_method.as_str(),
+            &response_code.to_string(),
+        ])
+        .observe(elapsed.as_secs_f64());
 }

--- a/keyless/pepper/service/src/request_handler.rs
+++ b/keyless/pepper/service/src/request_handler.rs
@@ -28,10 +28,10 @@ pub const DEFAULT_PEPPER_SERVICE_PORT: u16 = 8000;
 // The list of endpoints/paths offered by the Pepper Service.
 // Note: if you update these paths, please also update the "ALL_PATHS" array below.
 pub const ABOUT_PATH: &str = "/about";
+pub const FETCH_PATH: &str = "/v0/fetch";
 pub const GROTH16_VK_PATH: &str = "/cached/groth16-vk";
 pub const JWK_PATH: &str = "/cached/jwk";
 pub const KEYLESS_CONFIG_PATH: &str = "/cached/keyless-config";
-pub const FETCH_PATH: &str = "/v0/fetch";
 pub const SIGNATURE_PATH: &str = "/v0/signature";
 pub const VERIFY_PATH: &str = "/v0/verify";
 pub const VUF_PUB_KEY_PATH: &str = "/v0/vuf-pub-key";
@@ -189,7 +189,7 @@ fn generate_bad_request_response(
 fn generate_cached_resource_response<T: Serialize>(
     origin: String,
     request_method: &Method,
-    path: &str,
+    request_path: &str,
     cached_resource: Option<T>,
 ) -> Result<Response<Body>, Infallible> {
     if let Some(cached_resource) = cached_resource {
@@ -203,7 +203,7 @@ fn generate_cached_resource_response<T: Serialize>(
         }
     } else {
         // The cached resource was not found, return a missing resource error
-        generate_not_found_response(origin, request_method, path)
+        generate_not_found_response(origin, request_method, request_path)
     }
 }
 
@@ -258,11 +258,11 @@ fn generate_method_not_allowed_response(origin: String) -> Result<Response<Body>
 fn generate_not_found_response(
     origin: String,
     request_method: &Method,
-    invalid_path: &str,
+    request_path: &str,
 ) -> Result<Response<Body>, Infallible> {
     let response_message = format!(
         "The request for '{}' with method '{}' was not found!",
-        invalid_path, request_method
+        request_path, request_method
     );
     generate_text_response(origin, StatusCode::NOT_FOUND, response_message)
 }
@@ -317,8 +317,9 @@ pub async fn handle_request(
     }
 
     // Handle any GET requests
+    let request_path = request.uri().path();
     if request_method == Method::GET {
-        match request.uri().path() {
+        match request_path {
             ABOUT_PATH => return generate_about_response(origin),
             GROTH16_VK_PATH => {
                 let groth16_vk = cached_resources.read_on_chain_groth16_vk();
@@ -352,7 +353,7 @@ pub async fn handle_request(
     // Handle any POST requests
     let (_, vuf_priv_key) = vuf_keypair.deref();
     if request_method == Method::POST {
-        match request.uri().path() {
+        match request_path {
             FETCH_PATH => {
                 return call_dedicated_request_handler(
                     origin,
@@ -391,15 +392,15 @@ pub async fn handle_request(
     }
 
     // If the request is to a known path but with an invalid method, return a method not allowed response
-    if is_known_path(request.uri().path()) {
+    if is_known_path(request_path) {
         return generate_method_not_allowed_response(origin);
     }
 
     // Otherwise, no matching route was found
-    generate_not_found_response(origin, request_method, request.uri().path())
+    generate_not_found_response(origin, request_method, request_path)
 }
 
 /// Returns true if the given URI path is a known path/endpoint
-fn is_known_path(uri_path: &str) -> bool {
+pub fn is_known_path(uri_path: &str) -> bool {
     ALL_PATHS.contains(&uri_path)
 }


### PR DESCRIPTION
## Description
This PR adds simple metrics for operations in the pepper service. These include:
1. Metrics for JWK fetching times and success rates.
2. Metrics for external resource fetching times and success rates (e.g., cached resources).
3. Metrics for request processing and response generation (e.g., request rates, methods, endpoints, errors, etc.)

## Testing Plan
Existing test infrastructure. More tests will be added soon.