### PR TITLE
[compiler-v2] Enable inlining optimization in transactional tests

### DIFF
--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/nested_loop_labels.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/nested_loop_labels.exp
@@ -1,0 +1,95 @@
+// -- Model dump before first bytecode pipeline
+module 0xc0ffee::m {
+    private fun inner(x: u64): u64 {
+        loop {
+          x: u64 = Add<u64>(x, 10);
+          break;
+          Tuple()
+        };
+        x
+    }
+    private fun outer(x: u64): u64 {
+        loop {
+          m::inner(x);
+          x: u64 = Add<u64>(x, 1);
+          break;
+          Tuple()
+        };
+        x
+    }
+} // end 0xc0ffee::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0xc0ffee::m {
+    fun inner(x: u64): u64 {
+        loop {
+            x = x + 10;
+            break;
+        };
+        x
+    }
+    fun outer(x: u64): u64 {
+        loop {
+            inner(x);
+            x = x + 1;
+            break;
+        };
+        x
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0xc0ffee::m {
+    private fun inner(x: u64): u64 {
+        loop {
+          x: u64 = Add<u64>(x, 10);
+          break;
+          Tuple()
+        };
+        x
+    }
+    private fun outer(x: u64): u64 {
+        loop {
+          {
+            let (x: u64): (u64) = Tuple(x);
+            loop {
+              x: u64 = Add<u64>(x, 10);
+              break;
+              Tuple()
+            };
+            x
+          };
+          x: u64 = Add<u64>(x, 1);
+          break;
+          Tuple()
+        };
+        x
+    }
+} // end 0xc0ffee::m
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module c0ffee.m {
+
+
+inner(x: u64): u64 /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](x: u64)
+	1: LdU64(10)
+	2: Add
+	3: Ret
+}
+outer(x: u64): u64 /* def_idx: 1 */ {
+B0:
+	0: CopyLoc[0](x: u64)
+	1: LdU64(10)
+	2: Add
+	3: Pop
+	4: MoveLoc[0](x: u64)
+	5: LdU64(1)
+	6: Add
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/nested_loop_labels.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/nested_loop_labels.move
@@ -1,0 +1,18 @@
+module 0xc0ffee::m {
+    fun outer(x: u64): u64 {
+        'a: loop {
+            inner(x);
+            x = x + 1;
+            break 'a;
+        };
+        x
+    }
+
+    fun inner(x: u64): u64 {
+        'a: loop {
+            x = x + 10;
+            break 'a;
+        };
+        x
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/wildcard.exp
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/wildcard.exp
@@ -1,0 +1,112 @@
+// -- Model dump before first bytecode pipeline
+module 0x42::test {
+    struct T<A,B> {
+        x: A,
+        y: B,
+    }
+    struct S<A,B,C> {
+        0: A,
+        1: B,
+        2: C,
+    }
+    private fun proj_0<A,B,C>(self: S<A, B, C>): A {
+        {
+          let test::S<A, B, C>{ 0: x, 1: _, 2: _ } = self;
+          x
+        }
+    }
+    private fun test_proj_0(): u8 {
+        {
+          let x: S<u8, address, bool> = pack test::S<u8, address, bool>(42, 0x1, true);
+          test::proj_0<u8, address, bool>(x)
+        }
+    }
+} // end 0x42::test
+
+// -- Sourcified model before first bytecode pipeline
+module 0x42::test {
+    struct T<A, B> has drop {
+        x: A,
+        y: B,
+    }
+    struct S<A, B, C> has drop {
+        0: A,
+        1: B,
+        2: C,
+    }
+    fun proj_0<A, B: drop, C: drop>(self: S<A, B, C>): A {
+        let S<A,B,C>(x, _, _) = self;
+        x
+    }
+    fun test_proj_0(): u8 {
+        let x = S<u8,address,bool>(42u8, @0x1, true);
+        proj_0<u8,address,bool>(x)
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x42::test {
+    struct T<A,B> {
+        x: A,
+        y: B,
+    }
+    struct S<A,B,C> {
+        0: A,
+        1: B,
+        2: C,
+    }
+    private fun proj_0<A,B,C>(self: S<A, B, C>): A {
+        {
+          let test::S<A, B, C>{ 0: x, 1: _, 2: _ } = self;
+          x
+        }
+    }
+    private fun test_proj_0(): u8 {
+        {
+          let x: S<u8, address, bool> = pack test::S<u8, address, bool>(42, 0x1, true);
+          {
+            let (self: S<u8, address, bool>): (S<u8, address, bool>) = Tuple(x);
+            {
+              let test::S<u8, address, bool>{ 0: x, 1: _, 2: _ } = self;
+              x
+            }
+          }
+        }
+    }
+} // end 0x42::test
+
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module 42.test {
+struct T<A, B> has drop {
+	x: A,
+	y: B
+}
+struct S<A, B, C> has drop {
+	_0: A,
+	_1: B,
+	_2: C
+}
+
+proj_0<A, B: drop, C: drop>(self: S<A, B, C>): A /* def_idx: 0 */ {
+B0:
+	0: MoveLoc[0](self: S<A, B, C>)
+	1: UnpackGeneric[0](S<A, B, C>)
+	2: Pop
+	3: Pop
+	4: Ret
+}
+test_proj_0(): u8 /* def_idx: 1 */ {
+B0:
+	0: LdU8(42)
+	1: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1])
+	2: LdTrue
+	3: PackGeneric[1](S<u8, address, bool>)
+	4: UnpackGeneric[1](S<u8, address, bool>)
+	5: Pop
+	6: Pop
+	7: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/inlining-optimization/wildcard.move
+++ b/third_party/move/move-compiler-v2/tests/inlining-optimization/wildcard.move
@@ -1,0 +1,18 @@
+module 0x42::test {
+	struct S<A, B, C>(A, B, C) has drop;
+
+	struct T<A, B> has drop {
+		x: A,
+		y: B
+	}
+
+	fun proj_0<A, B: drop, C: drop>(self: S<A, B, C>): A {
+		let S(x, ..) = self;
+		x
+	}
+
+	fun test_proj_0(): u8 {
+		let x = S(42, @0x1, true);
+		x.proj_0()
+	}
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/constants/large_vectors.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/constants/large_vectors.opt-extra.exp
@@ -1,0 +1,6 @@
+processed 3 tasks
+task 0 lines 1-15:  publish [module 0xc0ffee::m {]
+task 1 lines 17-17:  run 0xc0ffee::m::large_vec_1
+return values: 1027
+task 2 lines 19-19:  run 0xc0ffee::m::large_vec_2
+return values: 1025

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/for_loop_nested_break.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/for_loop_nested_break.opt-extra.exp
@@ -1,0 +1,9 @@
+processed 1 task
+task 0 lines 1-14:  run --gas-budget 700 [script {]
+Error: Script execution failed with VMError: {
+    major_status: OUT_OF_GAS,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 25)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/for_loop_non_terminating.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/control_flow/for_loop_non_terminating.opt-extra.exp
@@ -1,0 +1,9 @@
+processed 1 task
+task 0 lines 1-11:  run --gas-budget 700 [script {]
+Error: Script execution failed with VMError: {
+    major_status: OUT_OF_GAS,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 9)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/lazy_assert.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/lazy_assert.opt-extra.exp
@@ -1,0 +1,11 @@
+processed 3 tasks
+task 0 lines 1-7:  run [script {]
+task 1 lines 9-15:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 2)],
+}
+task 2 lines 17-23:  run [script {]

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/short_circuiting_invalid.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/short_circuiting_invalid.opt-extra.exp
@@ -1,0 +1,42 @@
+processed 6 tasks
+task 0 lines 1-8:  publish [module 0x42::X {]
+task 1 lines 10-16:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(42),
+    location: 0x42::X,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+task 2 lines 19-25:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(42),
+    location: 0x42::X,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+task 3 lines 27-33:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(42),
+    location: 0x42::X,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+task 4 lines 35-41:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(42),
+    location: 0x42::X,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 1)],
+}
+task 5 lines 43-48:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(0),
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 3)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/struct_arguments.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/evaluation_order/struct_arguments.opt-extra.exp
@@ -1,0 +1,50 @@
+processed 7 tasks
+task 0 lines 3-55:  publish [module 0x42::M {]
+task 1 lines 57-64:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::M,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 2)],
+}
+task 2 lines 66-73:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::M,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 2)],
+}
+task 3 lines 75-82:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::M,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 2)],
+}
+task 4 lines 84-91:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::M,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 2)],
+}
+task 5 lines 93-110:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ARITHMETIC_ERROR,
+    sub_status: None,
+    location: 0x42::M,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(6), 2)],
+}
+task 6 lines 112-119:  run --signers 0x1 [script {]
+Error: Script execution failed with VMError: {
+    major_status: RESOURCE_ALREADY_EXISTS,
+    sub_status: None,
+    location: 0x42::M,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(7), 15)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/inlining/bug_11223.opt-extra.exp
@@ -1,0 +1,14 @@
+processed 1 task
+task 0 lines 1-14:  publish --print-bytecode [module 0xcafe::vectors {]
+
+== BEGIN Bytecode ==
+// Bytecode version v8
+module 0xcafe::vectors
+// Function definition at index 0
+#[persistent] entry public fun guess_flips_break2(l0: vector<u8>): u64
+    borrow_loc l0
+    vec_len <u8>
+    ret
+
+
+== END Bytecode ==

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14243_stack_size.opt-extra.exp
@@ -1,0 +1,28 @@
+processed 1 task
+task 0 lines 2-14:  print-bytecode --input=module [module 0xc0ffee::m {]
+// Bytecode version v8
+module 0xc0ffee::m
+// Function definition at index 0
+fun id_mut<T0>(l0: &mut T0): &mut T0
+    move_loc l0
+    ret
+
+// Function definition at index 1
+fun t0()
+    local l0: u64
+    local l1: &mut u64
+    ld_u64 0
+    st_loc l0
+    mut_borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    // @5
+    read_ref
+    pop
+    move_loc l1
+    read_ref
+    pop
+    // @10
+    ret
+
+

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.baseline.exp
@@ -1,0 +1,9 @@
+processed 8 tasks
+task 0 lines 1-144:  publish [module 0xc0ffee::m {]
+task 1 lines 146-146:  run 0xc0ffee::m::main
+task 2 lines 148-162:  publish [module 0xCAFE::m1 {]
+task 3 lines 164-164:  run 0xCAFE::m1::main
+task 4 lines 166-183:  publish [module 0xCAFE::m2 {]
+task 5 lines 185-185:  run 0xCAFE::m2::main
+task 6 lines 187-201:  publish [module 0xc0ffee::m3 {]
+task 7 lines 203-203:  run 0xc0ffee::m3::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.no-optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.no-optimize.exp
@@ -1,0 +1,9 @@
+processed 8 tasks
+task 0 lines 1-144:  publish [module 0xc0ffee::m {]
+task 1 lines 146-146:  run 0xc0ffee::m::main
+task 2 lines 148-162:  publish [module 0xCAFE::m1 {]
+task 3 lines 164-164:  run 0xCAFE::m1::main
+task 4 lines 166-183:  publish [module 0xCAFE::m2 {]
+task 5 lines 185-185:  run 0xCAFE::m2::main
+task 6 lines 187-201:  publish [module 0xc0ffee::m3 {]
+task 7 lines 203-203:  run 0xc0ffee::m3::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.opt-extra.exp
@@ -1,0 +1,27 @@
+processed 8 tasks
+task 0 lines 1-144:  publish [module 0xc0ffee::m {]
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `BORROWFIELD_TYPE_MISMATCH_ERROR`:
+Error message: none
+   ┌─ TEMPFILE:48:9
+   │
+48 │         &mut p.q.r
+   │         ^^^^^^^^^^
+   │
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+
+task 1 lines 146-146:  run 0xc0ffee::m::main
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 2 lines 148-162:  publish [module 0xCAFE::m1 {]
+task 3 lines 164-164:  run 0xCAFE::m1::main
+task 4 lines 166-183:  publish [module 0xCAFE::m2 {]
+task 5 lines 185-185:  run 0xCAFE::m2::main
+task 6 lines 187-201:  publish [module 0xc0ffee::m3 {]
+task 7 lines 203-203:  run 0xc0ffee::m3::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.optimize.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/bug_14817_extended.optimize.exp
@@ -1,0 +1,9 @@
+processed 8 tasks
+task 0 lines 1-144:  publish [module 0xc0ffee::m {]
+task 1 lines 146-146:  run 0xc0ffee::m::main
+task 2 lines 148-162:  publish [module 0xCAFE::m1 {]
+task 3 lines 164-164:  run 0xCAFE::m1::main
+task 4 lines 166-183:  publish [module 0xCAFE::m2 {]
+task 5 lines 185-185:  run 0xCAFE::m2::main
+task 6 lines 187-201:  publish [module 0xc0ffee::m3 {]
+task 7 lines 203-203:  run 0xc0ffee::m3::main

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/misc/build_with_warnings.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/misc/build_with_warnings.opt-extra.exp
@@ -1,0 +1,26 @@
+processed 2 tasks
+task 0 lines 1-10:  publish --print-bytecode [module 0x42::m {]
+warning: Unused value of parameter `x`. Consider removing the parameter, or prefixing with an underscore (e.g., `_x`), or binding to `_`
+  ┌─ TEMPFILE:3:20
+  │
+3 │     public fun foo(x: u64): u64 {
+  │                    ^
+
+
+== BEGIN Bytecode ==
+// Bytecode version v8
+module 0x42::m
+// Function definition at index 0
+#[persistent] public fun bar()
+    ret
+    ld_u64 1
+    abort
+
+// Function definition at index 1
+#[persistent] public fun foo(l0: u64): u64
+    ld_u64 2
+    ret
+
+
+== END Bytecode ==
+task 1 lines 12-12:  run 0x42::m::bar

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/assert_one.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/assert_one.opt-extra.exp
@@ -1,0 +1,10 @@
+processed 2 tasks
+task 0 lines 1-19:  publish [module 0x42::Test {]
+task 1 lines 21-34:  run [script {]
+Error: Script execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(14566554180833181696),
+    location: script,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 27)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy.opt-extra.exp
@@ -1,0 +1,16 @@
+processed 5 tasks
+task 0 lines 1-6:  publish [module 0x42::callee {]
+task 1 lines 8-40:  publish [module 0x42::caller {]
+task 2 lines 43-43:  run 0x42::caller::init --signers 0x42
+task 3 lines 45-45:  run 0x42::caller::callback_ok
+return values: true
+task 4 lines 47-47:  run 0x42::caller::callback_fails --verbose
+Error: Function execution failed with VMError: {
+    message: Resource `0x42::caller::R` cannot be accessed because of active reentrancy of defining module.,
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::caller,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("caller") }), FunctionDefinitionIndex(1), 5)] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_local.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_local.opt-extra.exp
@@ -1,0 +1,13 @@
+processed 3 tasks
+task 0 lines 1-16:  publish [module 0x42::tests {]
+task 1 lines 18-18:  run 0x42::tests::init --signers 0x42
+task 2 lines 20-20:  run 0x42::tests::local_access_via_lambda_fails --verbose
+Error: Function execution failed with VMError: {
+    message: Resource `0x42::tests::R` cannot be accessed because of active reentrancy of defining module.,
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::tests,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(2), 1)],
+    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000042, name: Identifier("tests") }), FunctionDefinitionIndex(1), 4)] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_module_lock.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_module_lock.opt-extra.exp
@@ -1,0 +1,14 @@
+processed 4 tasks
+task 0 lines 1-6:  publish [module 0x42::callee {]
+task 1 lines 8-32:  publish [module 0x42::caller {]
+task 2 lines 35-35:  run 0x42::caller::init --signers 0x42
+task 3 lines 37-37:  run 0x42::caller::callback_not_ok --verbose
+Error: Function execution failed with VMError: {
+    message: Reentrancy disallowed: reentering `0000000000000000000000000000000000000000000000000000000000000042::caller` via function `do_something` (module lock is active),
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::caller,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_nested.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/closures/reentrancy_nested.opt-extra.exp
@@ -1,0 +1,31 @@
+processed 8 tasks
+task 0 lines 1-17:  publish [module 0x42::worker1 {]
+task 1 lines 19-36:  publish [module 0x42::worker2 {]
+task 2 lines 38-69:  publish [module 0x42::tests {]
+task 3 lines 71-73:  run 0x42::tests::init --signers 0x42 [// task 4]
+task 4 lines 74-76:  run 0x42::tests::direct_failure [// task 5]
+Error: Function execution failed with VMError: {
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::tests,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 1)],
+}
+task 5 lines 77-79:  run 0x42::tests::worker1_failure [// task 6]
+Error: Function execution failed with VMError: {
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::worker1,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+}
+task 6 lines 80-82:  run 0x42::tests::worker2_failure [// task 7]
+Error: Function execution failed with VMError: {
+    major_status: RUNTIME_DISPATCH_ERROR,
+    sub_status: None,
+    location: 0x42::worker2,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 1)],
+}
+task 7 lines 83-83:  run 0x42::tests::worker2_ok
+return values: true

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select.opt-extra.exp
@@ -1,0 +1,16 @@
+processed 5 tasks
+task 0 lines 1-35:  publish [module 0x42::m {]
+task 1 lines 37-37:  run 0x42::m::test_get_x_v1
+return values: 43
+task 2 lines 39-39:  run 0x42::m::test_get_x_v2
+return values: 43
+task 3 lines 41-41:  run 0x42::m::test_get_y_v1
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(33),
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 15)],
+}
+task 4 lines 43-43:  run 0x42::m::test_get_y_v2
+return values: true

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_field_select_different_offsets.opt-extra.exp
@@ -1,0 +1,26 @@
+processed 7 tasks
+task 0 lines 1-40:  publish [module 0x42::m {]
+task 1 lines 42-42:  run 0x42::m::test_get_x_v1
+return values: 43
+task 2 lines 44-44:  run 0x42::m::test_get_x_v2
+return values: 43
+task 3 lines 46-46:  run 0x42::m::test_get_x_v3
+return values: 43
+task 4 lines 48-48:  run 0x42::m::test_get_y_v1
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(3), 4)],
+}
+task 5 lines 50-50:  run 0x42::m::test_get_y_v2
+return values: true
+task 6 lines 52-52:  run 0x42::m::test_get_y_v3
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 5)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/enum_scoping.opt-extra.exp
@@ -1,0 +1,23 @@
+processed 2 tasks
+task 0 lines 1-43:  publish [module 0x42::m {]
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+   ┌─ TEMPFILE:20:21
+   │
+20 │             let x = 4;
+   │                     ^
+
+warning: This assignment/binding to the left-hand-side variable `b` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_b`), or renaming to `_`
+   ┌─ TEMPFILE:35:13
+   │
+35 │             Two{i, b} => 3,
+   │             ^^^^^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `i` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_i`), or renaming to `_`
+   ┌─ TEMPFILE:35:13
+   │
+35 │             Two{i, b} => 3,
+   │             ^^^^^^^^^
+
+
+task 1 lines 45-45:  run 0x42::m::t1_check_scoping
+return values: 3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/fv_as_keys.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/fv_as_keys.opt-extra.exp
@@ -1,0 +1,87 @@
+processed 23 tasks
+task 0 lines 2-89:  publish [module 0x99::test_struct {]
+task 1 lines 91-91:  run --verbose --signers 0x1 -- 0x99::test_struct::init
+task 2 lines 93-93:  run --verbose --signers 0x1 -- 0x99::test_struct::test_exist
+task 3 lines 95-95:  run --verbose --signers 0x1 -- 0x99::test_struct::test_not_exist_1
+task 4 lines 97-97:  run --verbose --signers 0x1 -- 0x99::test_struct::test_not_exist_2
+task 5 lines 99-101:  run --verbose --signers 0x1 -- 0x99::test_struct::test_not_exist_3 [//expect to fail]
+task 6 lines 102-102:  run --verbose --signers 0x1 -- 0x99::test_struct::test_bad_borrow_from
+Error: Function execution failed with VMError: {
+    message: Failed to borrow global resource from 0000000000000000000000000000000000000000000000000000000000000001,
+    major_status: MISSING_DATA,
+    sub_status: None,
+    location: 0x99::test_struct,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(4), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 7 lines 104-106:  run --verbose --signers 0x1 -- 0x99::test_struct::test_borrow_from [//expect to fail]
+task 8 lines 107-107:  run --verbose --signers 0x1 -- 0x99::test_struct::test_bad_move_from
+Error: Function execution failed with VMError: {
+    message: Failed to move resource from 0000000000000000000000000000000000000000000000000000000000000001,
+    major_status: MISSING_DATA,
+    sub_status: None,
+    location: 0x99::test_struct,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 9 lines 109-111:  run --verbose --signers 0x1 -- 0x99::test_struct::test_move_from [// expected to fail as the functon value has been removed above]
+task 10 lines 112-115:  run --verbose --signers 0x1 -- 0x99::test_struct::test_borrow_from [/// Test cases for function values wrapped in enums as keys]
+Error: Function execution failed with VMError: {
+    message: Failed to borrow global resource from 0000000000000000000000000000000000000000000000000000000000000001,
+    major_status: MISSING_DATA,
+    sub_status: None,
+    location: 0x99::test_struct,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(6), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 11 lines 116-225:  publish [module 0x99::test_enum {]
+task 12 lines 227-229:  run --verbose --signers 0x1 -- 0x99::test_enum::init [//expect to fail]
+task 13 lines 230-230:  run --verbose --signers 0x1 -- 0x99::test_enum::bad_init
+Error: Function execution failed with VMError: {
+    message: Failed to move resource into 0000000000000000000000000000000000000000000000000000000000000001,
+    major_status: RESOURCE_ALREADY_EXISTS,
+    sub_status: None,
+    location: 0x99::test_enum,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(1), 5)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 14 lines 232-232:  run --verbose --signers 0x1 -- 0x99::test_enum::test_exist
+task 15 lines 234-234:  run --verbose --signers 0x1 -- 0x99::test_enum::test_not_exist_1
+task 16 lines 236-236:  run --verbose --signers 0x1 -- 0x99::test_enum::test_not_exist_2
+task 17 lines 238-240:  run --verbose --signers 0x1 -- 0x99::test_enum::test_not_exist_3 [//expect to fail]
+task 18 lines 241-241:  run --verbose --signers 0x1 -- 0x99::test_enum::test_bad_borrow_from
+Error: Function execution failed with VMError: {
+    message: Failed to borrow global resource from 0000000000000000000000000000000000000000000000000000000000000001,
+    major_status: MISSING_DATA,
+    sub_status: None,
+    location: 0x99::test_enum,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 19 lines 243-245:  run --verbose --signers 0x1 -- 0x99::test_enum::test_borrow_from [//expect to fail]
+task 20 lines 246-246:  run --verbose --signers 0x1 -- 0x99::test_enum::test_bad_move_from
+Error: Function execution failed with VMError: {
+    message: Failed to move resource from 0000000000000000000000000000000000000000000000000000000000000001,
+    major_status: MISSING_DATA,
+    sub_status: None,
+    location: 0x99::test_enum,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(6), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}
+task 21 lines 248-250:  run --verbose --signers 0x1 -- 0x99::test_enum::test_move_from [// expected to fail as the functon value has been removed above]
+task 22 lines 251-251:  run --verbose --signers 0x1 -- 0x99::test_enum::test_move_from
+Error: Function execution failed with VMError: {
+    message: Failed to move resource from 0000000000000000000000000000000000000000000000000000000000000001,
+    major_status: MISSING_DATA,
+    sub_status: None,
+    location: 0x99::test_enum,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(9), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/print_bytecode.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/print_bytecode.opt-extra.exp
@@ -1,0 +1,18 @@
+processed 2 tasks
+task 0 lines 1-4:  print-bytecode [script {]
+// Bytecode version v8
+script
+// Function definition at index 0
+entry public fun main()
+    ret
+
+
+task 1 lines 6-11:  print-bytecode --input=module [module 0x3::N {]
+// Bytecode version v8
+module 0x3::N
+// Function definition at index 0
+#[persistent] entry public fun ex(l0: signer, l1: u64)
+    ld_u64 0
+    abort
+
+

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_14223_unused_non_droppable.opt-extra.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/optimization/bug_14223_unused_non_droppable.opt-extra.exp
@@ -1,0 +1,10 @@
+processed 2 tasks
+task 0 lines 1-10:  publish [module 0xCAFE::m {]
+task 1 lines 12-12:  run 0xCAFE::m::f
+Error: Function execution failed with VMError: {
+    major_status: ABORTED,
+    sub_status: Some(1),
+    location: 0xcafe::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(0), 4)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -78,6 +78,21 @@ const TEST_CONFIGS: &[TestConfig] = &[
         exclude: COMMON_EXCLUSIONS,
         cross_compile: false,
     },
+    // Test enabling inlining optimization, across package inlining, and extra optimizations.
+    TestConfig {
+        name: "opt-extra",
+        runner: |p| run(p, get_config_by_name("opt-extra")),
+        experiments: &[
+            (Experiment::INLINING_OPTIMIZATION, true),
+            (Experiment::ACROSS_PACKAGE_INLINING, true),
+            (Experiment::OPTIMIZE, true),
+            (Experiment::OPTIMIZE_EXTRA, true),
+        ],
+        language_version: LanguageVersion::latest(),
+        include: &[], // all tests except those excluded below
+        exclude: COMMON_EXCLUSIONS,
+        cross_compile: false,
+    },
     // Test `/operator_eval/` with language version 1 and 2
     TestConfig {
         name: "operator-eval-lang-1",
@@ -159,6 +174,8 @@ const SEPARATE_BASELINE: &[&str] = &[
     "no-v1-comparison/enum/enum_scoping.move",
     // Different error messages depending on optimizations or not
     "no-v1-comparison/fv_as_keys.move",
+    // needed until bug #17615 is fixed
+    "misc/bug_14817_extended.move",
 ];
 
 fn get_config_by_name(name: &str) -> TestConfig {


### PR DESCRIPTION
## Description

In this PR, we enable inlining optimization as a config in the compiler's transactional tests. Thus, in addition to running under no-optimize and optimize configs, they all also run under the newly added config and compare outputs.

There are also fixes for:
1. When `#[module_lock] attribute is present, if we perform inlining, we can have more lenient semantics because across-modules calls. While this is safe, to prevent change in semantics, we do not perform inlining when such an attribute is present.
2. When resource access control specifiers (`reads` or `writes`) are present, call sites to those functions should not be inlined because their dynamic access control checks won't be run when they are inlined away.

Also added some more tests, e.g., when the same loop labels are present in the caller and the callee.

## How Has This Been Tested?

- added new tests
- existing transactional tests, new `.exp` files have been created when the output could differ because of optimization: I have verified that for all the new `.exp` files, the outputs are either the same as the corresponding `optimize.exp`, or differ only in locations specified in the outputs (the locations can differ because the code produced is different).

## Type of Change
- [x] Bug fix
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler