### PR TITLE
[Hot State] Compute LRU in speculative state

### DIFF
--- a/execution/executor-types/src/transactions_with_output.rs
+++ b/execution/executor-types/src/transactions_with_output.rs
@@ -111,12 +111,11 @@ impl TransactionsToKeep {
                     .transaction_outputs
                     .iter()
                     .map(TransactionOutput::write_set);
-                let last_checkpoint_index = all_checkpoint_indices.last().copied();
                 StateUpdateRefs::index_write_sets(
                     first_version,
                     write_sets,
                     transactions_with_output.len(),
-                    last_checkpoint_index,
+                    all_checkpoint_indices,
                 )
             },
         }

--- a/execution/executor/src/workflow/do_get_execution_output.rs
+++ b/execution/executor/src/workflow/do_get_execution_output.rs
@@ -418,6 +418,7 @@ impl Parser {
         )?;
 
         let result_state = parent_state.update_with_memorized_reads(
+            base_state_view.persisted_hot_state(),
             base_state_view.persisted_state(),
             to_commit.state_update_refs(),
             base_state_view.memorized_reads(),

--- a/storage/aptosdb/src/backup/restore_utils.rs
+++ b/storage/aptosdb/src/backup/restore_utils.rs
@@ -268,7 +268,7 @@ pub(crate) fn save_transactions_impl(
 
     if kv_replay && first_version > 0 && state_store.get_usage(Some(first_version - 1)).is_ok() {
         let ledger_state = state_store.calculate_state_and_put_updates(
-            &StateUpdateRefs::index_write_sets(first_version, write_sets, write_sets.len(), None),
+            &StateUpdateRefs::index_write_sets(first_version, write_sets, write_sets.len(), vec![]),
             &mut ledger_db_batch.ledger_metadata_db_batches, // used for storing the storage usage
             state_kv_batches,
         )?;

--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::metrics::{COUNTER, GAUGE, OTHER_TIMERS_SECONDS};
+use anyhow::{ensure, Result};
 use aptos_infallible::Mutex;
 use aptos_logger::prelude::*;
 use aptos_metrics_core::{IntCounterVecHelper, IntGaugeVecHelper, TimerHelper};
@@ -15,11 +16,12 @@ use aptos_types::state_store::{
     state_slot::StateSlot,
     NUM_STATE_SHARDS,
 };
+#[cfg(test)]
+use aptos_types::transaction::Version;
 use arr_macro::arr;
-use dashmap::{
-    mapref::one::{Ref, RefMut},
-    DashMap,
-};
+use dashmap::{mapref::one::Ref, DashMap};
+#[cfg(test)]
+use std::collections::BTreeMap;
 use std::sync::{
     mpsc::{Receiver, SyncSender, TryRecvError},
     Arc,
@@ -37,7 +39,8 @@ where
 
 impl<K, V> Shard<K, V>
 where
-    K: Eq + std::hash::Hash,
+    K: Clone + Eq + std::hash::Hash,
+    V: Clone,
 {
     fn new(max_items: usize) -> Self {
         Self {
@@ -45,20 +48,12 @@ where
         }
     }
 
-    fn contains_key(&self, key: &K) -> bool {
-        self.inner.contains_key(key)
-    }
-
     fn get(&self, key: &K) -> Option<Ref<'_, K, V>> {
         self.inner.get(key)
     }
 
-    fn get_mut(&self, key: &K) -> Option<RefMut<'_, K, V>> {
-        self.inner.get_mut(key)
-    }
-
-    fn insert(&self, key: K, value: V) {
-        self.inner.insert(key, value);
+    fn insert(&self, key: K, value: V) -> Option<V> {
+        self.inner.insert(key, value)
     }
 
     fn remove(&self, key: &K) -> Option<(K, V)> {
@@ -68,6 +63,13 @@ where
     fn len(&self) -> usize {
         self.inner.len()
     }
+
+    #[cfg(test)]
+    fn iter(&self) -> impl Iterator<Item = (K, V)> + use<'_, K, V> {
+        self.inner
+            .iter()
+            .map(|entry| (entry.key().clone(), entry.value().clone()))
+    }
 }
 
 #[derive(Debug)]
@@ -75,21 +77,16 @@ pub struct HotStateBase<K = StateKey, V = StateSlot>
 where
     K: Eq + std::hash::Hash,
 {
-    /// After committing a new batch to `inner`, items are evicted so that
-    ///  1. total number of items doesn't exceed this number
-    max_items_per_shard: usize,
-
     shards: [Shard<K, V>; NUM_STATE_SHARDS],
 }
 
 impl<K, V> HotStateBase<K, V>
 where
-    K: Eq + std::hash::Hash,
+    K: Clone + Eq + std::hash::Hash,
     V: Clone,
 {
     fn new_empty(max_items_per_shard: usize) -> Self {
         Self {
-            max_items_per_shard,
             shards: arr![Shard::new(max_items_per_shard); 16],
         }
     }
@@ -148,6 +145,19 @@ impl HotState {
             .send(to_commit)
             .expect("Failed to queue for hot state commit.")
     }
+
+    /// Wait until the asynchronous commit finishes and the state reaches certain version.
+    #[cfg(test)]
+    pub fn wait_for_commit(&self, next_version: Version) {
+        while self.committed.lock().next_version() < next_version {
+            std::thread::sleep(std::time::Duration::from_millis(1));
+        }
+    }
+
+    #[cfg(test)]
+    pub fn get_all_entries(&self, shard_id: usize) -> BTreeMap<StateKey, StateSlot> {
+        self.base.shards[shard_id].iter().collect()
+    }
 }
 
 pub struct Committer {
@@ -163,7 +173,7 @@ pub struct Committer {
 }
 
 impl Committer {
-    pub fn spawn(base: Arc<HotStateBase>, committed: Arc<Mutex<State>>) -> SyncSender<State> {
+    fn spawn(base: Arc<HotStateBase>, committed: Arc<Mutex<State>>) -> SyncSender<State> {
         let (tx, rx) = std::sync::mpsc::sync_channel(MAX_HOT_STATE_COMMIT_BACKLOG);
         std::thread::spawn(move || Self::new(base, committed, rx).run());
 
@@ -187,7 +197,6 @@ impl Committer {
 
         while let Some(to_commit) = self.next_to_commit() {
             self.commit(&to_commit);
-            self.evict();
             *self.committed.lock() = to_commit;
 
             GAUGE.set_with(&["hot_state_items"], self.base.len() as i64);
@@ -229,305 +238,78 @@ impl Committer {
     fn commit(&mut self, to_commit: &State) {
         let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hot_state_commit"]);
 
-        let mut n_delete = 0;
-        let n_too_large = 0; // TODO(HotState): enforce this later.
-        let mut n_update = 0;
         let mut n_insert = 0;
+        let mut n_update = 0;
+        let mut n_evict = 0;
 
         let delta = to_commit.make_delta(&self.committed.lock());
         for shard_id in 0..NUM_STATE_SHARDS {
-            let mut updates: Vec<_> = delta.shards[shard_id].iter().collect();
-            // We will update the LRU next. Here we put the deletions at the beginning, then the
-            // older updates, and the newest updates are at the end.
-            updates.sort_unstable_by_key(|(_key, slot)| {
-                slot.hot_since_version_opt().map_or(-1, |v| v as i64)
-            });
-
-            let mut updater = LRUUpdater::new(
-                &self.base.shards[shard_id],
-                &mut self.heads[shard_id],
-                &mut self.tails[shard_id],
-                self.base.max_items_per_shard,
-            );
-
-            for (key, slot) in updates {
-                let has_old_entry = if let Some(old_slot) = self.base.get_state_slot(&key) {
-                    self.total_key_bytes -= key.size();
-                    self.total_value_bytes -= old_slot.size();
-                    true
-                } else {
-                    false
-                };
-
-                if slot.is_cold() {
-                    // deletion
-                    if has_old_entry {
-                        n_delete += 1;
-                        updater.delete(&key);
-                    }
-                } else {
-                    if has_old_entry {
+            for (key, slot) in delta.shards[shard_id].iter() {
+                if slot.is_hot() {
+                    let key_size = key.size();
+                    self.total_key_bytes += key_size;
+                    self.total_value_bytes += slot.size();
+                    if let Some(old_slot) = self.base.shards[shard_id].insert(key, slot) {
+                        self.total_key_bytes -= key_size;
+                        self.total_value_bytes -= old_slot.size();
                         n_update += 1;
                     } else {
                         n_insert += 1;
-                    };
-
-                    self.total_key_bytes += key.size();
-                    self.total_value_bytes += slot.size();
-
-                    updater.insert(key, slot);
+                    }
+                } else if let Some((key, old_slot)) = self.base.shards[shard_id].remove(&key) {
+                    self.total_key_bytes -= key.size();
+                    self.total_value_bytes -= old_slot.size();
+                    n_evict += 1;
                 }
             }
-        }
-
-        COUNTER.inc_with_by(&["hot_state_delete"], n_delete);
-        COUNTER.inc_with_by(&["hot_state_too_large"], n_too_large);
-        COUNTER.inc_with_by(&["hot_state_update"], n_update);
-        COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
-    }
-
-    fn evict(&mut self) {
-        let _timer = OTHER_TIMERS_SECONDS.timer_with(&["hot_state_evict"]);
-        let mut num_evicted = 0;
-
-        for shard_id in 0..NUM_STATE_SHARDS {
-            let mut updater = LRUUpdater::new(
-                &self.base.shards[shard_id],
-                &mut self.heads[shard_id],
-                &mut self.tails[shard_id],
-                self.base.max_items_per_shard,
+            self.heads[shard_id] = to_commit.latest_hot_key(shard_id);
+            self.tails[shard_id] = to_commit.oldest_hot_key(shard_id);
+            assert_eq!(
+                self.base.shards[shard_id].len(),
+                to_commit.num_hot_items(shard_id)
             );
-            let evicted = updater.evict();
-            num_evicted += evicted.len();
-            for (key, slot) in &evicted {
-                self.total_key_bytes -= key.size();
-                self.total_value_bytes -= slot.size();
+
+            debug_assert!(self.validate_lru(shard_id).is_ok());
+
+            COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
+            COUNTER.inc_with_by(&["hot_state_update"], n_update);
+            COUNTER.inc_with_by(&["hot_state_evict"], n_evict);
+        }
+    }
+
+    /// Traverses the entire map and checks if all the pointers are correctly linked.
+    fn validate_lru(&self, shard_id: usize) -> Result<()> {
+        let head = &self.heads[shard_id];
+        let tail = &self.tails[shard_id];
+        ensure!(head.is_some() == tail.is_some());
+        let shard = &self.base.shards[shard_id];
+
+        {
+            let mut num_visited = 0;
+            let mut current = head.clone();
+            while let Some(key) = current {
+                let entry = shard.get(&key).expect("Must exist.");
+                num_visited += 1;
+                ensure!(num_visited <= shard.len());
+                ensure!(entry.is_hot());
+                current = entry.next().cloned();
             }
-        }
-        COUNTER.inc_with_by(&["hot_state_evict"], num_evicted as u64);
-    }
-}
-
-struct LRUUpdater<'a, K, V>
-where
-    K: Eq + std::hash::Hash,
-{
-    shard: &'a Shard<K, V>,
-    head: &'a mut Option<K>,
-    tail: &'a mut Option<K>,
-    max_items: usize,
-}
-
-impl<'a, K, V> LRUUpdater<'a, K, V>
-where
-    K: Clone + std::fmt::Debug + Eq + std::hash::Hash,
-    V: Clone + std::fmt::Debug + THotStateSlot<Key = K>,
-{
-    fn new(
-        shard: &'a Shard<K, V>,
-        head: &'a mut Option<K>,
-        tail: &'a mut Option<K>,
-        max_items: usize,
-    ) -> Self {
-        Self {
-            shard,
-            head,
-            tail,
-            max_items,
-        }
-    }
-
-    fn insert(&mut self, key: K, value: V) {
-        if self.shard.contains_key(&key) {
-            self.delete(&key);
-        }
-        self.insert_to_front(key, value);
-    }
-
-    /// Deletes and returns the oldest entry.
-    fn delete_lru(&mut self) -> Option<(K, V)> {
-        let key = match &self.tail {
-            Some(k) => k.clone(),
-            None => return None,
-        };
-        let value = self.delete(&key).expect("Tail must exist.");
-        Some((key, value))
-    }
-
-    fn delete(&mut self, key: &K) -> Option<V> {
-        let old_entry = match self.shard.remove(key) {
-            Some((_k, e)) => e,
-            None => return None,
-        };
-
-        match old_entry.prev() {
-            Some(prev_key) => {
-                let mut prev_entry = self
-                    .shard
-                    .get_mut(prev_key)
-                    .expect("The previous key must exist");
-                prev_entry.set_next(old_entry.next().cloned());
-            },
-            None => {
-                // There is no newer entry. The current key was the head.
-                *self.head = old_entry.next().cloned();
-            },
+            ensure!(num_visited == shard.len());
         }
 
-        match old_entry.next() {
-            Some(next_key) => {
-                let mut next_entry = self
-                    .shard
-                    .get_mut(next_key)
-                    .expect("The next key must exist.");
-                next_entry.set_prev(old_entry.prev().cloned());
-            },
-            None => {
-                // There is no older entry. The current key was the tail.
-                *self.tail = old_entry.prev().cloned();
-            },
-        }
-
-        Some(old_entry)
-    }
-
-    fn insert_to_front(&mut self, key: K, mut value: V) {
-        assert_eq!(self.head.is_some(), self.tail.is_some());
-        match self.head.take() {
-            Some(head) => {
-                {
-                    // Release the reference to the old entry ASAP to avoid deadlock when inserting
-                    // the new entry below.
-                    let mut old_head_entry = self.shard.get_mut(&head).expect("Head must exist.");
-                    old_head_entry.set_prev(Some(key.clone()));
-                }
-                value.set_prev(None);
-                value.set_next(Some(head));
-                self.shard.insert(key.clone(), value);
-                *self.head = Some(key);
-            },
-            None => {
-                value.set_prev(None);
-                value.set_next(None);
-                self.shard.insert(key.clone(), value);
-                *self.head = Some(key.clone());
-                *self.tail = Some(key);
-            },
-        }
-    }
-
-    fn evict(&mut self) -> Vec<(K, V)> {
-        if !self.should_evict() {
-            return Vec::new();
-        }
-
-        let mut items = Vec::with_capacity(self.shard.len() - self.max_items);
-        while self.should_evict() {
-            items.push(self.delete_lru().unwrap());
-        }
-        items
-    }
-
-    fn should_evict(&self) -> bool {
-        self.shard.len() > self.max_items
-    }
-
-    #[cfg(test)]
-    fn collect_all(&self) -> Vec<(K, V)> {
-        assert_eq!(self.head.is_some(), self.tail.is_some());
-
-        let mut keys = Vec::new();
-        let mut values = Vec::new();
-
-        let mut current_key = self.head.clone();
-        while let Some(key) = current_key {
-            let entry = self.shard.get(&key).unwrap();
-            assert_eq!(entry.prev(), keys.last());
-            keys.push(key);
-            values.push(entry.clone());
-            current_key = entry.next().cloned();
-        }
-        itertools::zip_eq(keys, values).collect()
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::{LRUUpdater, Shard, THotStateSlot};
-    use lru::LruCache;
-    use proptest::{collection::vec, option, prelude::*};
-    use std::num::NonZeroUsize;
-
-    #[derive(Clone, Debug)]
-    struct TestSlot {
-        num: u64,
-        prev: Option<u32>,
-        next: Option<u32>,
-    }
-
-    impl TestSlot {
-        fn new(num: u64) -> Self {
-            Self {
-                num,
-                prev: None,
-                next: None,
+        {
+            let mut num_visited = 0;
+            let mut current = tail.clone();
+            while let Some(key) = current {
+                let entry = shard.get(&key).expect("Must exist.");
+                num_visited += 1;
+                ensure!(num_visited <= shard.len());
+                ensure!(entry.is_hot());
+                current = entry.prev().cloned();
             }
-        }
-    }
-
-    impl THotStateSlot for TestSlot {
-        type Key = u32;
-
-        fn prev(&self) -> Option<&Self::Key> {
-            self.prev.as_ref()
+            ensure!(num_visited == shard.len());
         }
 
-        fn next(&self) -> Option<&Self::Key> {
-            self.next.as_ref()
-        }
-
-        fn set_prev(&mut self, prev: Option<Self::Key>) {
-            self.prev = prev;
-        }
-
-        fn set_next(&mut self, next: Option<Self::Key>) {
-            self.next = next;
-        }
-    }
-
-    proptest! {
-        #[test]
-        fn test_hot_state_lru(
-            max_items in 1..10usize,
-            updates in vec((0..20u32, option::weighted(0.8, 0..1000u64)), 1..50),
-        ) {
-            let shard = Shard::new(max_items);
-            let mut head = None;
-            let mut tail = None;
-
-            let mut updater = LRUUpdater::new(&shard, &mut head, &mut tail, max_items);
-            let mut cache = LruCache::new(NonZeroUsize::new(max_items).unwrap());
-
-            for (key, value_opt) in updates {
-                match value_opt {
-                    Some(value) => {
-                        updater.insert(key, TestSlot::new(value));
-                        cache.put(key, value);
-                    }
-                    None => {
-                        updater.delete(&key);
-                        cache.pop(&key);
-                    }
-                }
-                updater.evict();
-
-                prop_assert_eq!(shard.len(), cache.len());
-                let items = updater.collect_all();
-                prop_assert_eq!(
-                    items.into_iter().map(|(k, v)| (k, v.num)).collect::<Vec<_>>(),
-                    cache.iter().map(|(k, v)| (*k, *v)).collect::<Vec<_>>(),
-                );
-            }
-        }
+        Ok(())
     }
 }

--- a/storage/aptosdb/src/state_store/mod.rs
+++ b/storage/aptosdb/src/state_store/mod.rs
@@ -591,20 +591,18 @@ impl StateStore {
                 .ledger_db
                 .transaction_info_db()
                 .get_transaction_info_iter(snapshot_next_version, write_sets.len())?;
-            let last_checkpoint_index = txn_info_iter
+            let all_checkpoint_indices = txn_info_iter
                 .into_iter()
                 .collect::<Result<Vec<_>>>()?
                 .into_iter()
-                .enumerate()
-                .filter(|(_idx, txn_info)| txn_info.has_state_checkpoint_hash())
-                .next_back()
-                .map(|(idx, _)| idx);
+                .positions(|txn_info| txn_info.has_state_checkpoint_hash())
+                .collect();
 
             let state_update_refs = StateUpdateRefs::index_write_sets(
                 state.next_version(),
                 &write_sets,
                 write_sets.len(),
-                last_checkpoint_index,
+                all_checkpoint_indices,
             );
             let current_state = out_current_state.lock().clone();
             let (hot_state, state) = out_persisted_state.get_state();
@@ -1358,7 +1356,7 @@ mod test_only {
                     .iter()
                     .map(|updates| updates.iter().map(|(k, op)| (k, op))),
                 num_versions,
-                Some(num_versions - 1),
+                vec![num_versions - 1],
             );
 
             let mut ledger_batch = SchemaBatch::new();

--- a/storage/aptosdb/src/state_store/persisted_state.rs
+++ b/storage/aptosdb/src/state_store/persisted_state.rs
@@ -42,6 +42,11 @@ impl PersistedState {
         self.summary.lock().clone()
     }
 
+    #[cfg(test)]
+    pub fn get_hot_state(&self) -> Arc<HotState> {
+        Arc::clone(&self.hot_state)
+    }
+
     pub fn get_state(&self) -> (Arc<dyn HotStateView>, State) {
         self.hot_state.get_committed()
     }

--- a/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
+++ b/storage/aptosdb/src/state_store/tests/speculative_state_workflow.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{db::test_helper::arb_key_universe, state_store::persisted_state::PersistedState};
+use crate::state_store::persisted_state::PersistedState;
 use aptos_block_executor::hot_state_op_accumulator::BlockHotStateOpAccumulator;
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_infallible::Mutex;
@@ -24,19 +24,22 @@ use aptos_types::{
         state_slot::StateSlot,
         state_storage_usage::StateStorageUsage,
         state_value::StateValue,
-        StateViewId, StateViewResult, TStateView,
+        StateViewId, StateViewResult, TStateView, NUM_STATE_SHARDS,
     },
     transaction::Version,
     write_set::{BaseStateOp, HotStateOp, WriteOp},
 };
 use itertools::Itertools;
 use lru::LruCache;
-use proptest::{collection::vec, prelude::*, sample::Index};
+use proptest::{
+    collection::{hash_set, vec},
+    prelude::*,
+    sample::Index,
+};
 use rayon::prelude::*;
 use std::{
     collections::{BTreeMap, BTreeSet, HashMap, HashSet},
     fmt::{Debug, Formatter},
-    num::NonZeroUsize,
     ops::Deref,
     sync::{
         mpsc::{channel, Receiver, Sender},
@@ -45,13 +48,15 @@ use std::{
     thread::spawn,
 };
 
-const NUM_KEYS: usize = 10;
-const HOT_STATE_MAX_ITEMS: usize = NUM_KEYS / 2;
-const MAX_PROMOTIONS_PER_BLOCK: usize = 10;
+const NUM_KEYS: usize = NUM_STATE_SHARDS * 6;
+const HOT_STATE_MAX_ITEMS_PER_SHARD: usize = NUM_KEYS / NUM_STATE_SHARDS / 2;
+
+// TODO(HotState): these are not used much at the moment.
+const MAX_PROMOTIONS_PER_BLOCK: usize = NUM_KEYS;
 const REFRESH_INTERVAL_VERSIONS: usize = 50;
 
 const TEST_CONFIG: HotStateConfig = HotStateConfig {
-    max_items_per_shard: HOT_STATE_MAX_ITEMS,
+    max_items_per_shard: HOT_STATE_MAX_ITEMS_PER_SHARD,
 };
 
 #[derive(Debug)]
@@ -84,7 +89,7 @@ impl Chunk {
                     first_version,
                     txn_outs.iter().map(|t| t.write_set.iter()),
                     txn_outs.len(),
-                    txn_outs.iter().rposition(|t| t.is_checkpoint),
+                    txn_outs.iter().positions(|t| t.is_checkpoint).collect(),
                 )
             },
         }
@@ -107,7 +112,15 @@ impl Debug for Chunk {
 }
 
 prop_compose! {
-    pub fn arb_user_block(
+    fn arb_keys(num_keys: usize)(
+        raw_keys in hash_set("[a-z0-9]{5}", num_keys),
+    ) -> Vec<StateKey> {
+        raw_keys.iter().map(|raw| StateKey::raw(raw.as_bytes())).collect_vec()
+    }
+}
+
+prop_compose! {
+    fn arb_user_block(
         keys: Vec<StateKey>,
         max_read_only_set_size: usize,
         max_write_set_size: usize,
@@ -154,7 +167,7 @@ prop_compose! {
 #[derive(Clone)]
 struct VersionState {
     usage: StateStorageUsage,
-    hot_state: LruCache<StateKey, StateSlot>,
+    hot_state: [LruCache<StateKey, StateSlot>; NUM_STATE_SHARDS],
     state: HashMap<StateKey, (Version, StateValue)>,
     summary: NaiveSmt,
     next_version: Version,
@@ -164,7 +177,7 @@ impl VersionState {
     fn new_empty() -> Self {
         Self {
             usage: StateStorageUsage::zero(),
-            hot_state: LruCache::new(NonZeroUsize::new(HOT_STATE_MAX_ITEMS).unwrap()),
+            hot_state: [(); NUM_STATE_SHARDS].map(|_| LruCache::unbounded()),
             state: HashMap::new(),
             summary: NaiveSmt::default(),
             next_version: 0,
@@ -176,6 +189,7 @@ impl VersionState {
         version: Version,
         writes: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
         promotions: impl IntoIterator<Item = &'a StateKey>,
+        is_checkpoint: bool,
     ) -> Self {
         assert_eq!(version, self.next_version);
 
@@ -184,13 +198,14 @@ impl VersionState {
         let mut smt_updates = vec![];
 
         for (k, v_opt) in writes {
+            let shard_id = k.get_shard_id();
             match v_opt {
                 None => {
                     let slot = StateSlot::HotVacant {
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
                     };
-                    hot_state.put(k.clone(), slot);
+                    hot_state[shard_id].put(k.clone(), slot);
                     state.remove(k);
                     smt_updates.push((k.hash(), None));
                 },
@@ -201,7 +216,7 @@ impl VersionState {
                         hot_since_version: version,
                         lru_info: LRUEntry::uninitialized(),
                     };
-                    hot_state.put(k.clone(), slot);
+                    hot_state[shard_id].put(k.clone(), slot);
                     state.insert(k.clone(), (version, v.clone()));
                     smt_updates.push((k.hash(), Some(v.hash())));
                 },
@@ -209,7 +224,9 @@ impl VersionState {
         }
 
         for k in promotions {
-            if let Some(slot) = hot_state.get_mut(k) {
+            assert!(is_checkpoint, "No promotions unless in checkpoints");
+            let shard_id = k.get_shard_id();
+            if let Some(slot) = hot_state[shard_id].get_mut(k) {
                 slot.refresh(version);
                 continue;
             }
@@ -225,7 +242,15 @@ impl VersionState {
                     lru_info: LRUEntry::uninitialized(),
                 },
             };
-            hot_state.put(k.clone(), slot);
+            hot_state[shard_id].put(k.clone(), slot);
+        }
+
+        if is_checkpoint {
+            for shard in hot_state.iter_mut() {
+                while shard.len() > HOT_STATE_MAX_ITEMS_PER_SHARD {
+                    shard.pop_lru();
+                }
+            }
         }
 
         let summary = self.summary.clone().update(&smt_updates);
@@ -249,7 +274,8 @@ impl TStateView for VersionState {
 
     fn get_state_slot(&self, key: &Self::Key) -> StateViewResult<StateSlot> {
         let from_cold = StateSlot::from_db_get(self.state.get(key).cloned());
-        let slot = match self.hot_state.peek(key) {
+        let shard_id = key.get_shard_id();
+        let slot = match self.hot_state[shard_id].peek(key) {
             Some(slot) => {
                 assert_eq!(slot.as_state_value_opt(), from_cold.as_state_value_opt());
                 slot.clone()
@@ -273,7 +299,7 @@ struct StateByVersion {
 }
 
 impl StateByVersion {
-    pub fn get_state(&self, version: Option<Version>) -> &Arc<VersionState> {
+    fn get_state(&self, version: Option<Version>) -> &VersionState {
         let next_version = version.map_or(0, |ver| ver + 1);
         &self.state_by_next_version[next_version as usize]
     }
@@ -288,12 +314,14 @@ impl StateByVersion {
         &mut self,
         writes: impl IntoIterator<Item = (&'a StateKey, Option<&'a StateValue>)>,
         promotions: impl IntoIterator<Item = &'a StateKey>,
+        is_checkpoint: bool,
     ) {
         self.state_by_next_version.push(Arc::new(
             self.state_by_next_version.last().unwrap().update(
                 self.next_version(),
                 writes,
                 promotions,
+                is_checkpoint,
             ),
         ));
     }
@@ -302,11 +330,45 @@ impl StateByVersion {
         self.state_by_next_version.len() as Version - 1
     }
 
+    fn assert_state_slot(slot1: &StateSlot, slot2: &StateSlot) {
+        match (slot1, slot2) {
+            (
+                StateSlot::HotVacant {
+                    hot_since_version: v1,
+                    ..
+                },
+                StateSlot::HotVacant {
+                    hot_since_version: v2,
+                    ..
+                },
+            ) => assert_eq!(v1, v2),
+            (
+                StateSlot::HotOccupied {
+                    value_version: vv1,
+                    value: v1,
+                    hot_since_version: h1,
+                    ..
+                },
+                StateSlot::HotOccupied {
+                    value_version: vv2,
+                    value: v2,
+                    hot_since_version: h2,
+                    ..
+                },
+            ) => {
+                assert_eq!(vv1, vv2);
+                assert_eq!(v1, v2);
+                assert_eq!(h1, h2);
+            },
+            (s1, s2) => assert_eq!(s1, s2),
+        }
+    }
+
     fn assert_state(&self, state: &State) {
         assert_eq!(state.usage(), self.get_state(state.version()).usage);
     }
 
-    pub fn assert_ledger_state(&self, ledger_state: &LedgerState) {
+    fn assert_ledger_state(&self, ledger_state: &LedgerState) {
         self.assert_state(ledger_state.last_checkpoint());
         self.assert_state(ledger_state.latest());
     }
@@ -320,16 +382,12 @@ impl StateByVersion {
         );
     }
 
-    pub fn assert_ledger_state_summary(&self, ledger_state_summary: &LedgerStateSummary) {
+    fn assert_ledger_state_summary(&self, ledger_state_summary: &LedgerStateSummary) {
         self.assert_state_summary(ledger_state_summary.last_checkpoint());
         self.assert_state_summary(ledger_state_summary.latest());
     }
 
-    pub fn assert_jmt_updates(
-        &self,
-        last_snapshot: &StateWithSummary,
-        snapshot: &StateWithSummary,
-    ) {
+    fn assert_jmt_updates(&self, last_snapshot: &StateWithSummary, snapshot: &StateWithSummary) {
         let base_state = self.get_state(last_snapshot.version()).clone();
         let result_state = self.get_state(snapshot.version()).clone();
         assert_eq!(
@@ -467,6 +525,7 @@ fn update_state(
         let memorized_reads = state_view.into_memorized_reads();
 
         let next_state = parent_state.update_with_memorized_reads(
+            hot_state.clone(),
             &persisted_state,
             block.update_refs(),
             &memorized_reads,
@@ -539,16 +598,43 @@ fn send_to_state_buffer(
         }
     }
 
+    // Make sure the final checkpoint is committed.
+    let final_state_with_summary: LedgerStateWithSummary = current_state.lock().clone();
+    assert!(final_state_with_summary.is_at_checkpoint());
+    let final_version = final_state_with_summary.version().unwrap();
+    if last_snapshot.version() != Some(final_version) {
+        let snapshot = final_state_with_summary.last_checkpoint();
+        state_by_version.assert_jmt_updates(&last_snapshot, snapshot);
+        to_buffered_state_commit.send(snapshot.clone()).unwrap();
+    }
+
     // inform downstream to quit
     drop(to_buffered_state_commit);
 }
 
 fn commit_state_buffer(
+    state_by_version: Arc<StateByVersion>,
     from_buffered_state_commit: Receiver<StateWithSummary>,
     persisted_state: PersistedState,
 ) {
     while let Ok(snapshot) = from_buffered_state_commit.recv() {
+        let next_version = snapshot.next_version();
         persisted_state.set(snapshot);
+
+        let hot_state = persisted_state.get_hot_state();
+        hot_state.wait_for_commit(next_version);
+
+        (0..NUM_STATE_SHARDS).into_par_iter().for_each(|shard_id| {
+            let all_entries = hot_state.get_all_entries(shard_id);
+            let naive_hot_state =
+                &state_by_version.get_state(Some(next_version - 1)).hot_state[shard_id];
+            assert_eq!(all_entries.len(), naive_hot_state.len());
+
+            for (key, slot) in &all_entries {
+                let slot2 = naive_hot_state.peek(key).unwrap();
+                StateByVersion::assert_state_slot(slot, slot2);
+            }
+        });
     }
 }
 
@@ -560,10 +646,16 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
             MAX_PROMOTIONS_PER_BLOCK,
             REFRESH_INTERVAL_VERSIONS,
         );
-        for txn in block_txns {
-            // No promotions except for block epilogue.
-            state_by_version
-                .append_version(txn.writes.iter().map(|(k, v)| (k, v.as_ref())), vec![]);
+        let num_txns = block_txns.len();
+        for (idx, txn) in block_txns.into_iter().enumerate() {
+            // No promotions except for block epilogue. Also note that in case of reconfig, there's
+            // no epilogue, but we still have a checkpoint and will run eviction on hot state.
+            let is_checkpoint = !append_epilogue && idx + 1 == num_txns;
+            state_by_version.append_version(
+                txn.writes.iter().map(|(k, v)| (k, v.as_ref())),
+                vec![],
+                is_checkpoint,
+            );
             op_accu.add_transaction(txn.writes.keys(), txn.reads.iter());
             all_txns.push(Txn {
                 reads: txn.reads,
@@ -580,7 +672,8 @@ fn naive_run_blocks(blocks: Vec<(Vec<UserTxn>, bool)>) -> (Vec<Txn>, StateByVers
         }
         if append_epilogue {
             let to_make_hot = op_accu.get_keys_to_make_hot();
-            state_by_version.append_version(vec![], to_make_hot.iter());
+            let is_checkpoint = true;
+            state_by_version.append_version(vec![], to_make_hot.iter(), is_checkpoint);
 
             let reads = to_make_hot.clone();
             let write_set = to_make_hot
@@ -657,9 +750,14 @@ fn replay_chunks_pipelined(chunks: Vec<Chunk>, state_by_version: Arc<StateByVers
     }
 
     {
+        let state_by_version = state_by_version.clone();
         let persisted_state = persisted_state.clone();
         threads.push(spawn(move || {
-            commit_state_buffer(from_buffered_state_commit, persisted_state);
+            commit_state_buffer(
+                state_by_version,
+                from_buffered_state_commit,
+                persisted_state,
+            );
         }));
     }
 
@@ -669,18 +767,25 @@ fn replay_chunks_pipelined(chunks: Vec<Chunk>, state_by_version: Arc<StateByVers
 }
 
 proptest! {
-    #![proptest_config(ProptestConfig::with_cases(100))]
+    #![proptest_config(ProptestConfig::with_cases(50))]
 
     #[test]
     fn test_speculative_state_workflow(
-        blocks in arb_key_universe(NUM_KEYS)
+        (mut blocks, last_block) in arb_keys(NUM_KEYS)
             .prop_flat_map(move |keys| {
-                vec((
-                    arb_user_block(keys, NUM_KEYS, NUM_KEYS, NUM_KEYS),
-                    prop_oneof![1=>Just(false), 9=>Just(true)]
-                ), 1..100)
+                (
+                    vec(
+                        (
+                            arb_user_block(keys.clone(), NUM_KEYS, NUM_KEYS, NUM_KEYS),
+                            prop_oneof![1=>Just(false), 9=>Just(true)]
+                        ),
+                        1..100
+                    ),
+                    arb_user_block(keys, NUM_KEYS, NUM_KEYS, NUM_KEYS)
+                )
             })
     ) {
+        blocks.push((last_block, /* is_checkpoint */ true));
 
         let (all_txns, state_by_version) = naive_run_blocks(blocks);
 

--- a/storage/storage-interface/src/state_store/hot_state.rs
+++ b/storage/storage-interface/src/state_store/hot_state.rs
@@ -142,7 +142,7 @@ impl<'a> HotStateLRU<'a> {
         Some(old_slot)
     }
 
-    fn get_slot(&self, key: &StateKey) -> Option<StateSlot> {
+    pub(crate) fn get_slot(&self, key: &StateKey) -> Option<StateSlot> {
         if let Some(slot) = self.pending.get(key) {
             return Some(slot.clone());
         }

--- a/storage/storage-interface/src/state_store/state.rs
+++ b/storage/storage-interface/src/state_store/state.rs
@@ -4,8 +4,9 @@
 use crate::{
     metrics::TIMER,
     state_store::{
+        hot_state::HotStateLRU,
         state_delta::StateDelta,
-        state_update_refs::{BatchedStateUpdateRefs, StateUpdateRefs},
+        state_update_refs::{BatchedStateUpdateRefs, PerVersionStateUpdateRefs, StateUpdateRefs},
         state_view::{
             cached_state_view::{
                 CachedStateView, PrimingPolicy, ShardedStateCache, StateCacheShard,
@@ -30,7 +31,7 @@ use arr_macro::arr;
 use derive_more::Deref;
 use itertools::Itertools;
 use rayon::prelude::*;
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, num::NonZeroUsize, sync::Arc};
 
 #[derive(Clone, Debug)]
 pub struct HotStateMetadata {
@@ -134,28 +135,32 @@ impl State {
         self.shards[0].is_descendant_of(&rhs.shards[0])
     }
 
-    pub(crate) fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    pub fn latest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
         self.hot_state_metadata[shard_id].latest.clone()
     }
 
-    pub(crate) fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
+    pub fn oldest_hot_key(&self, shard_id: usize) -> Option<StateKey> {
         self.hot_state_metadata[shard_id].oldest.clone()
     }
 
-    pub(crate) fn num_hot_items(&self, shard_id: usize) -> usize {
+    pub fn num_hot_items(&self, shard_id: usize) -> usize {
         self.hot_state_metadata[shard_id].num_items
     }
 
-    pub fn update(
+    fn update(
         &self,
+        persisted_hot_state: Arc<dyn HotStateView>,
         persisted: &State,
-        updates: &BatchedStateUpdateRefs,
+        batched_updates: &BatchedStateUpdateRefs,
+        per_version_updates: &PerVersionStateUpdateRefs,
+        all_checkpoint_versions: &[Version],
         state_cache: &ShardedStateCache,
     ) -> Self {
         let _timer = TIMER.timer_with(&["state__update"]);
 
         // 1. The update batch must begin at self.next_version().
-        assert_eq!(self.next_version(), updates.first_version);
+        assert_eq!(self.next_version(), batched_updates.first_version);
+        assert_eq!(self.next_version(), per_version_updates.first_version);
         // 2. The cache must be at a version equal or newer than `persisted`, otherwise
         //    updates between the cached version and the persisted version are potentially
         //    missed during the usage calculation.
@@ -170,43 +175,94 @@ impl State {
         assert!(self.next_version() >= state_cache.next_version());
 
         let overlay = self.make_delta(persisted);
-        let (shards, usage_delta_per_shard): (Vec<_>, Vec<_>) = (
+        let ((shards, new_metadata), usage_delta_per_shard): ((Vec<_>, Vec<_>), Vec<_>) = (
             state_cache.shards.as_slice(),
             overlay.shards.as_slice(),
-            updates.shards.as_slice(),
+            self.hot_state_metadata.as_slice(),
+            batched_updates.shards.as_slice(),
+            per_version_updates.shards.as_slice(),
         )
             .into_par_iter()
-            .map(|(cache, overlay, updates)| {
-                let new_items = updates
-                    .iter()
-                    .map(|(k, u)| {
-                        let slot = u
-                            .to_result_slot()
-                            .unwrap_or_else(|| Self::expect_old_slot(overlay, cache, k));
-                        ((*k).clone(), slot)
-                    })
-                    .collect_vec();
+            .map(
+                |(cache, overlay, hot_metadata, batched_updates, per_version)| {
+                    let mut lru = HotStateLRU::new(
+                        NonZeroUsize::new(self.hot_state_config.max_items_per_shard).unwrap(),
+                        Arc::clone(&persisted_hot_state),
+                        overlay,
+                        hot_metadata.latest.clone(),
+                        hot_metadata.oldest.clone(),
+                        hot_metadata.num_items,
+                    );
+                    let mut all_updates = per_version.iter();
+                    for ckpt_version in all_checkpoint_versions {
+                        for (key, update) in
+                            all_updates.take_while_ref(|(_k, u)| u.version <= *ckpt_version)
+                        {
+                            Self::apply_one_update(&mut lru, overlay, cache, key, update);
+                        }
+                        // Only evict at the checkpoints.
+                        lru.maybe_evict();
+                    }
+                    for (key, update) in all_updates {
+                        Self::apply_one_update(&mut lru, overlay, cache, key, update);
+                    }
 
-                (
+                    let (new_items, new_head, new_tail, new_num_items) = lru.into_updates();
+                    let new_items = new_items.into_iter().collect_vec();
+
                     // TODO(aldenhu): change interface to take iter of ref
-                    overlay.new_layer(&new_items),
-                    Self::usage_delta_for_shard(cache, overlay, updates),
-                )
-            })
+                    let new_layer = overlay.new_layer(&new_items);
+                    let new_metadata = HotStateMetadata {
+                        latest: new_head,
+                        oldest: new_tail,
+                        num_items: new_num_items,
+                    };
+                    let new_usage = Self::usage_delta_for_shard(cache, overlay, batched_updates);
+                    ((new_layer, new_metadata), new_usage)
+                },
+            )
             .unzip();
         let shards = Arc::new(shards.try_into().expect("Known to be 16 shards."));
+        let new_metadata = new_metadata.try_into().expect("Known to be 16 shards.");
         let usage = self.update_usage(usage_delta_per_shard);
 
-        // TODO(HotState): compute new hot state metadata.
-        let hot_state_metadata = arr![HotStateMetadata::new(); 16];
         // TODO(HotState): extract and pass new hot state onchain config if needed.
         State::new_with_updates(
-            updates.last_version(),
+            batched_updates.last_version(),
             shards,
-            hot_state_metadata,
+            new_metadata,
             usage,
             self.hot_state_config,
         )
+    }
+
+    fn apply_one_update(
+        lru: &mut HotStateLRU,
+        overlay: &LayeredMap<StateKey, StateSlot>,
+        read_cache: &StateCacheShard,
+        key: &StateKey,
+        update: &StateUpdateRef,
+    ) {
+        if update.state_op.is_value_write_op() {
+            lru.insert((*key).clone(), update.to_result_slot().unwrap());
+            return;
+        }
+
+        if let Some(mut slot) = lru.get_slot(key) {
+            lru.insert(
+                (*key).clone(),
+                if slot.is_hot() {
+                    slot.refresh(update.version);
+                    slot
+                } else {
+                    slot.to_hot(update.version)
+                },
+            );
+        } else {
+            let slot = Self::expect_old_slot(overlay, read_cache, key);
+            assert!(slot.is_cold());
+            lru.insert((*key).clone(), slot.to_hot(update.version));
+        }
     }
 
     fn update_usage(&self, usage_delta_per_shard: Vec<(i64, i64)>) -> StateStorageUsage {
@@ -308,14 +364,25 @@ impl LedgerState {
     /// have already been recorded.
     pub fn update_with_memorized_reads(
         &self,
+        persisted_hot_view: Arc<dyn HotStateView>,
         persisted_snapshot: &State,
         updates: &StateUpdateRefs,
         reads: &ShardedStateCache,
     ) -> LedgerState {
         let _timer = TIMER.timer_with(&["ledger_state__update"]);
 
-        let last_checkpoint = if let Some(updates) = updates.for_last_checkpoint_batched() {
-            self.latest().update(persisted_snapshot, updates, reads)
+        let last_checkpoint = if let Some(batched) = updates.for_last_checkpoint_batched() {
+            let per_version = updates
+                .for_last_checkpoint_per_version()
+                .expect("Both per-version and batched updates should exist.");
+            self.latest().update(
+                Arc::clone(&persisted_hot_view),
+                persisted_snapshot,
+                batched,
+                per_version,
+                updates.all_checkpoint_versions(),
+                reads,
+            )
         } else {
             self.last_checkpoint.clone()
         };
@@ -325,8 +392,18 @@ impl LedgerState {
         } else {
             &last_checkpoint
         };
-        let latest = if let Some(updates) = updates.for_latest_batched() {
-            base_of_latest.update(persisted_snapshot, updates, reads)
+        let latest = if let Some(batched) = updates.for_latest_batched() {
+            let per_version = updates
+                .for_latest_per_version()
+                .expect("Both per-version and batched updates should exist.");
+            base_of_latest.update(
+                persisted_hot_view,
+                persisted_snapshot,
+                batched,
+                per_version,
+                &[],
+                reads,
+            )
         } else {
             base_of_latest.clone()
         };
@@ -346,13 +423,14 @@ impl LedgerState {
         let state_view = CachedStateView::new_impl(
             StateViewId::Miscellaneous,
             reader,
-            hot_state,
+            Arc::clone(&hot_state),
             persisted_snapshot.clone(),
             self.latest().clone(),
         );
         state_view.prime_cache(updates, PrimingPolicy::All)?;
 
         let updated = self.update_with_memorized_reads(
+            hot_state,
             persisted_snapshot,
             updates,
             state_view.memorized_reads(),

--- a/storage/storage-interface/src/state_store/state_update_refs.rs
+++ b/storage/storage-interface/src/state_store/state_update_refs.rs
@@ -120,6 +120,7 @@ impl BatchedStateUpdateRefs<'_> {
 #[derive(Debug)]
 pub struct StateUpdateRefs<'kv> {
     pub per_version: PerVersionStateUpdateRefs<'kv>,
+    all_checkpoint_versions: Vec<Version>,
     /// Updates from the beginning of the block/chunk to the last checkpoint (if it exists).
     for_last_checkpoint: Option<(PerVersionStateUpdateRefs<'kv>, BatchedStateUpdateRefs<'kv>)>,
     /// Updates from the version after last checkpoint to last version (`None` if the last version
@@ -128,8 +129,20 @@ pub struct StateUpdateRefs<'kv> {
 }
 
 impl<'kv> StateUpdateRefs<'kv> {
+    pub(crate) fn all_checkpoint_versions(&self) -> &[Version] {
+        &self.all_checkpoint_versions
+    }
+
+    pub(crate) fn for_last_checkpoint_per_version(&self) -> Option<&PerVersionStateUpdateRefs<'_>> {
+        self.for_last_checkpoint.as_ref().map(|x| &x.0)
+    }
+
     pub(crate) fn for_last_checkpoint_batched(&self) -> Option<&BatchedStateUpdateRefs<'_>> {
         self.for_last_checkpoint.as_ref().map(|x| &x.1)
+    }
+
+    pub(crate) fn for_latest_per_version(&self) -> Option<&PerVersionStateUpdateRefs<'_>> {
+        self.for_latest.as_ref().map(|x| &x.0)
     }
 
     pub(crate) fn for_latest_batched(&self) -> Option<&BatchedStateUpdateRefs<'_>> {
@@ -140,7 +153,7 @@ impl<'kv> StateUpdateRefs<'kv> {
         first_version: Version,
         write_sets: impl IntoIterator<Item = &'kv WriteSet>,
         num_write_sets: usize,
-        last_checkpoint_index: Option<usize>,
+        all_checkpoint_indices: Vec<usize>,
     ) -> Self {
         Self::index(
             first_version,
@@ -148,7 +161,7 @@ impl<'kv> StateUpdateRefs<'kv> {
                 .into_iter()
                 .map(|write_set| write_set.base_op_iter()),
             num_write_sets,
-            last_checkpoint_index,
+            all_checkpoint_indices,
         )
     }
 
@@ -159,11 +172,12 @@ impl<'kv> StateUpdateRefs<'kv> {
         first_version: Version,
         updates_by_version: VersionIter,
         num_versions: usize,
-        last_checkpoint_index: Option<usize>,
+        all_checkpoint_indices: Vec<usize>,
     ) -> Self {
         if num_versions == 0 {
             return Self {
                 per_version: PerVersionStateUpdateRefs::new_empty(first_version),
+                all_checkpoint_versions: vec![],
                 for_last_checkpoint: None,
                 for_latest: None,
             };
@@ -171,6 +185,7 @@ impl<'kv> StateUpdateRefs<'kv> {
 
         let mut updates_by_version = updates_by_version.into_iter();
         let mut num_versions_for_last_checkpoint = 0;
+        let last_checkpoint_index = all_checkpoint_indices.last().copied();
 
         let for_last_checkpoint = last_checkpoint_index.map(|index| {
             num_versions_for_last_checkpoint = index + 1;
@@ -204,6 +219,10 @@ impl<'kv> StateUpdateRefs<'kv> {
                 for_last_checkpoint.as_ref().map(|x| &x.0),
                 for_latest.as_ref().map(|x| &x.0),
             ),
+            all_checkpoint_versions: all_checkpoint_indices
+                .into_iter()
+                .map(|index| first_version + index as Version)
+                .collect(),
             for_last_checkpoint,
             for_latest,
         }
@@ -331,9 +350,9 @@ mod tests {
         let v0 = write_set(&[("A", "A0")]);
         let v1 = write_set(&[("A", "A1"), ("B", "B1")]);
         let v2 = write_set(&[("C", "C2")]);
-        let last_checkpoint_index = Some(2);
+        let all_checkpoint_indices = vec![2];
         let ret =
-            StateUpdateRefs::index_write_sets(0, vec![&v0, &v1, &v2], 3, last_checkpoint_index);
+            StateUpdateRefs::index_write_sets(0, vec![&v0, &v1, &v2], 3, all_checkpoint_indices);
 
         let for_last_checkpoint = ret.for_last_checkpoint_batched().unwrap();
         assert_eq!(for_last_checkpoint.first_version, 0);
@@ -353,12 +372,12 @@ mod tests {
         let v1 = write_set(&[("A", "A1"), ("B", "B1")]);
         let v2 = write_set(&[("A", "A2"), ("B", "B2")]);
         let v3 = write_set(&[("B", "B3"), ("C", "C3")]);
-        let last_checkpoint_index = Some(1);
+        let all_checkpoint_indices = vec![1];
         let ret = StateUpdateRefs::index_write_sets(
             0,
             vec![&v0, &v1, &v2, &v3],
             4,
-            last_checkpoint_index,
+            all_checkpoint_indices,
         );
 
         let for_last_checkpoint = ret.for_last_checkpoint_batched().unwrap();
@@ -381,8 +400,9 @@ mod tests {
         let v0 = write_set(&[("A", "A0"), ("B", "B0")]);
         let v1 = write_set(&[("A", "A1")]);
         let v2 = write_set(&[("C", "C2")]);
-        let last_checkpoint = None;
-        let ret = StateUpdateRefs::index_write_sets(10, vec![&v0, &v1, &v2], 3, last_checkpoint);
+        let all_checkpoint_indices = vec![];
+        let ret =
+            StateUpdateRefs::index_write_sets(10, vec![&v0, &v1, &v2], 3, all_checkpoint_indices);
 
         assert!(ret.for_last_checkpoint_batched().is_none());
 

--- a/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
+++ b/storage/storage-interface/src/state_store/state_view/cached_state_view.rs
@@ -265,6 +265,10 @@ impl CachedStateView {
         &self.speculative.base
     }
 
+    pub fn persisted_hot_state(&self) -> Arc<dyn HotStateView> {
+        Arc::clone(&self.hot)
+    }
+
     pub fn memorized_reads(&self) -> &ShardedStateCache {
         &self.memorized
     }

--- a/storage/storage-interface/src/state_store/state_with_summary.rs
+++ b/storage/storage-interface/src/state_store/state_with_summary.rs
@@ -108,6 +108,10 @@ impl LedgerStateWithSummary {
         )
     }
 
+    pub fn is_at_checkpoint(&self) -> bool {
+        self.latest.next_version() == self.last_checkpoint.next_version()
+    }
+
     pub fn last_checkpoint(&self) -> &StateWithSummary {
         &self.last_checkpoint
     }

--- a/types/src/state_store/mod.rs
+++ b/types/src/state_store/mod.rs
@@ -80,15 +80,18 @@ pub trait TStateView {
     }
 
     /// Checks if a state keyed by the given state key exists in the hot state.
+    // TODO(HotState): not used.
     fn contains_hot_state_value(&self, _state_key: &Self::Key) -> bool {
         false
     }
 
     /// Number of free slots in hot state.
+    // TODO(HotState): not used.
     fn num_free_hot_slots(&self) -> [usize; NUM_STATE_SHARDS] {
         [0; NUM_STATE_SHARDS]
     }
 
+    // TODO(HotState): not used.
     fn get_shard_id(&self, _state_key: &Self::Key) -> usize {
         unimplemented!();
     }
@@ -100,6 +103,7 @@ pub trait TStateView {
     /// or `Some(None)` if the input key is already the newest.
     ///
     /// Returns `None` if the input key does not exist in hot state at all.
+    // TODO(HotState): not used.
     fn get_next_old_key(
         &self,
         _shard_id: usize,


### PR DESCRIPTION

Until now we had only been computing hot state (its insertions and evictions)
until a block is committed. However, we will eventually need consensus to agree
on the content of the hot state. This means that we need to compute it when a
block is proposed.

This commit finally implements the computation of LRU insertion and eviction in
the speculative state.

Main changes:
- We now use per-version updates instead of batched updates to run
  `State::update`. This is needed for LRU computation. Batched updates are still
  passed to the function for state usage computation, and we'll see if this can
  be cleaned up a bit later.
- The code in `storage/aptosdb/src/state_store/hot_state.rs` now simply accepts
  the updates from upstream, without computing the LRU on its own.

Added tests and validations.
