### PR TITLE
[benchmarks] Update calibration table to include monotonic counter

### DIFF
--- a/testsuite/single_node_performance.py
+++ b/testsuite/single_node_performance.py
@@ -261,7 +261,7 @@ TESTS = [
     RunGroupConfig(key=RunGroupKey("vector-trim-append-len3000-size1"), included_in=Flow.CONTINUOUS),
     RunGroupConfig(key=RunGroupKey("vector-remove-insert-len3000-size1"), included_in=Flow.CONTINUOUS),
 
-    # waived because of missing monothonic counter native.
+    # waived because of missing monotonic counter native.
     RunGroupConfig(key=RunGroupKey("order-book-no-matches1-market"), included_in=Flow.ORDER_BOOK, waived=True),
     RunGroupConfig(key=RunGroupKey("order-book-balanced-matches25-pct1-market"), included_in=Flow.ORDER_BOOK, waived=True),
     RunGroupConfig(key=RunGroupKey("order-book-balanced-matches80-pct1-market"), included_in=Flow.ORDER_BOOK, waived=True),
@@ -270,6 +270,7 @@ TESTS = [
     RunGroupConfig(key=RunGroupKey("order-book-balanced-matches25-pct50-markets"), included_in=Flow.ORDER_BOOK | Flow.CONTINUOUS, waived=True),
     RunGroupConfig(key=RunGroupKey("order-book-balanced-matches80-pct50-markets"), included_in=Flow.ORDER_BOOK | Flow.CONTINUOUS, waived=True),
     RunGroupConfig(key=RunGroupKey("order-book-balanced-size-skewed80-pct50-markets"), included_in=Flow.ORDER_BOOK | Flow.CONTINUOUS, waived=True),
+    RunGroupConfig(key=RunGroupKey("monotonic-counter-single"), included_in=Flow.CONTINUOUS, waived=True),
 
     RunGroupConfig(expected_tps=50000, key=RunGroupKey("coin_transfer_connected_components", executor_type="sharded"), key_extra=RunGroupKeyExtra(sharding_traffic_flags="--connected-tx-grps 5000", transaction_type_override=""), included_in=Flow.REPRESENTATIVE, waived=True),
     RunGroupConfig(expected_tps=50000, key=RunGroupKey("coin_transfer_hotspot", executor_type="sharded"), key_extra=RunGroupKeyExtra(sharding_traffic_flags="--hotspot-probability 0.8", transaction_type_override=""), included_in=Flow.REPRESENTATIVE, waived=True),
@@ -281,8 +282,7 @@ TESTS = [
     RunGroupConfig(expected_tps=6800, key=RunGroupKey("token-v2-ambassador-mint"), included_in=Flow.MAINNET_LARGE_DB),
     RunGroupConfig(expected_tps=17000 if NUM_ACCOUNTS < 5000000 else 28000, key=RunGroupKey("coin_transfer_connected_components", executor_type="sharded"), key_extra=RunGroupKeyExtra(sharding_traffic_flags="--connected-tx-grps 5000", transaction_type_override=""), included_in=Flow.MAINNET | Flow.MAINNET_LARGE_DB, waived=True),
     RunGroupConfig(expected_tps=27000 if NUM_ACCOUNTS < 5000000 else 23000, key=RunGroupKey("coin_transfer_hotspot", executor_type="sharded"), key_extra=RunGroupKeyExtra(sharding_traffic_flags="--hotspot-probability 0.8", transaction_type_override=""), included_in=Flow.MAINNET | Flow.MAINNET_LARGE_DB, waived=True),
-    RunGroupConfig(key=RunGroupKey("monotonic-counter-single"), included_in=Flow.CONTINUOUS),
-] + [ 
+] + [
     # no-commit throughput of different executor, used on continuous flow
     RunGroupConfig(
         key=RunGroupKey(

--- a/testsuite/single_node_performance_values.tsv
+++ b/testsuite/single_node_performance_values.tsv
@@ -48,3 +48,8 @@ order-book-no-matches50-markets	1	VM	6	0.989	1.025	4749.0
 order-book-balanced-matches25-pct50-markets	1	VM	6	0.997	1.012	5095.3
 order-book-balanced-matches80-pct50-markets	1	VM	6	0.978	1.041	5916.8
 order-book-balanced-size-skewed80-pct50-markets	1	VM	6	0.949	1.015	5161.0
+monotonic-counter-single	1	VM	6	0.972	1.020	5170.4
+no_commit_apt-fa-transfer	1	VM	6	0.978	1.017	26381.7
+no_commit_apt-fa-transfer	1	NativeVM	6	0.979	1.014	44067.9
+no_commit_apt-fa-transfer	1	AptosVMSpeculative	6	0.990	1.016	9462.4
+no_commit_apt-fa-transfer	1	NativeSpeculative	6	0.992	1.020	97922.8


### PR DESCRIPTION
## Description

Single node benchmark fails on Continuous flow (full test) to fetch calibration numbers for monotonic counter because it is not in the table.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
