### PR TITLE
introduce --exact filter options to `aptos move test`

### DIFF
--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -34,7 +34,10 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, use_latest_language: bool) 
     }
 
     let utc = UnitTestingConfig {
-        filter: std::env::var("TEST_FILTER").ok(),
+        filter_options: move_unit_test::FilterOptions {
+            filter: std::env::var("TEST_FILTER").ok(),
+            exact: false,
+        },
         report_statistics: matches!(std::env::var("REPORT_STATS"), Ok(s) if s.as_str() == "1"),
         ..Default::default()
     };

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -513,9 +513,8 @@ pub struct CompileScriptOutput {
 /// turned on.  Note, that move code warnings currently block tests from running.
 #[derive(Parser)]
 pub struct TestPackage {
-    /// A filter string to determine which unit tests to run
-    #[clap(long, short)]
-    pub filter: Option<String>,
+    #[clap(flatten)]
+    pub filter_options: move_unit_test::FilterOptions,
 
     /// A boolean value to skip warnings.
     #[clap(long)]
@@ -600,7 +599,7 @@ impl CliCommand<&'static str> for TestPackage {
             path.as_path(),
             config.clone(),
             UnitTestingConfig {
-                filter: self.filter.clone(),
+                filter_options: self.filter_options.clone(),
                 report_storage_on_error: self.dump_state,
                 ignore_compile_warnings: self.ignore_compile_warnings,
                 named_address_values: self
@@ -636,7 +635,7 @@ impl CliCommand<&'static str> for TestPackage {
             let summary = SummaryCoverage {
                 summarize_functions: false,
                 output_csv: false,
-                filter: self.filter,
+                filter_options: self.filter_options,
                 move_options: self.move_options,
             };
             summary.coverage()?;

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -854,7 +854,10 @@ impl CliTestFramework {
         TestPackage {
             instruction_execution_bound: 100_000,
             move_options: self.move_options(account_strs),
-            filter: filter.map(|str| str.to_string()),
+            filter_options: move_unit_test::FilterOptions {
+                filter: filter.map(|str| str.to_string()),
+                exact: false,
+            },
             ignore_compile_warnings: false,
             compute_coverage: false,
             dump_state: false,

--- a/third_party/move/tools/move-cli/src/base/test.rs
+++ b/third_party/move/tools/move-cli/src/base/test.rs
@@ -49,10 +49,10 @@ pub struct Test {
     /// Bound the amount of gas used by any one test.
     #[clap(name = "gas_limit", short = 'i', long = "gas_limit")]
     pub gas_limit: Option<u64>,
-    /// An optional filter string to determine which unit tests to run. A unit test will be run only if it
-    /// contains this string in its fully qualified (`<addr>::<module_name>::<fn_name>`) name.
-    #[clap(name = "filter")]
-    pub filter: Option<String>,
+
+    #[clap(flatten)]
+    pub filter_options: move_unit_test::FilterOptions,
+
     /// List all tests
     #[clap(name = "list", short = 'l', long = "list")]
     pub list: bool,
@@ -95,7 +95,7 @@ impl Test {
         let rerooted_path = reroot_path(path)?;
         let Self {
             gas_limit,
-            filter,
+            filter_options,
             list,
             num_threads,
             report_statistics,
@@ -105,7 +105,7 @@ impl Test {
             compute_coverage,
         } = self;
         let unit_test_config = UnitTestingConfig {
-            filter,
+            filter_options,
             list,
             num_threads,
             report_statistics,

--- a/third_party/move/tools/move-unit-test/src/filter.rs
+++ b/third_party/move/tools/move-unit-test/src/filter.rs
@@ -1,0 +1,68 @@
+use clap::Parser;
+
+#[derive(Debug, Parser, Clone, Default)]
+pub struct FilterOptions {
+    /// If specified, only run tests containing this string in their names
+    #[clap(long, short)]
+    pub filter: Option<String>,
+
+    /// Only execute the test module/test function if their `<module_name>[::<fn_name>]` fq name exactly matches provided `--filter` value
+    #[clap(long, hide = true)]
+    pub exact: bool,
+}
+
+impl FilterOptions {
+    pub fn matches(&self, fullname: &str) -> bool {
+        match self.filter.as_ref() {
+            None => true,
+            Some(filter_s) => {
+                if self.exact {
+                    fullname == filter_s
+                } else {
+                    fullname.contains(filter_s)
+                }
+            },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_filter_default_matches_everything() {
+        let opts = FilterOptions::default();
+        assert!(opts.matches("mod"));
+        assert!(opts.matches("mod::fun"));
+        assert!(opts.matches("1122"));
+    }
+
+    #[test]
+    fn test_filter_with_name() {
+        let opts = FilterOptions {
+            filter: Some("mod".into()),
+            exact: false,
+        };
+        assert!(opts.matches("mod"));
+        assert!(opts.matches("other_mod"));
+        assert!(opts.matches("main::mod"));
+        assert!(opts.matches("mod::fun"));
+
+        assert!(!opts.matches("other"));
+        assert!(!opts.matches("0x1"));
+    }
+
+    #[test]
+    fn test_filter_with_exact() {
+        let opts = FilterOptions {
+            filter: Some("mod".into()),
+            exact: true,
+        };
+        assert!(opts.matches("mod"));
+
+        assert!(!opts.matches("other_mod"));
+        assert!(!opts.matches("mod::fun"));
+        assert!(!opts.matches("main::mod"));
+    }
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
* Refactors `--filter` of `aptos move test` into a separate `move_unit_test::FilterOptions` struct to reduce code duplication. 
* Introduces undocumented `--exact` option, which controls whether `contains` or exact match is used for `--filter`. 

I also made `--exact` undocumented to not bloat the interface. This option is mostly needed for the IDE functionality, if it's considered useful later for the public - we could remove that `hide = true`. 

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->
I haven't found any tests for e2e testing of `aptos move test` specifically, so I introduced small unit tests just to check that matching works correctly. 
I assume `--filter` tested as part of the overall move testsuite. 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
