### PR TITLE
[compiler] Add warning for capturing option values

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_1.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_1.exp
@@ -1,0 +1,63 @@
+
+Diagnostics:
+warning: capturing option values is currently not supported
+   ┌─ tests/checking-lang-v2.2/lambda/capturing_option_1.move:11:66
+   │
+11 │         let f: ||option::Option<u64> has copy+drop+store = || id(v);
+   │                                                                  ^
+
+warning: capturing option values is currently not supported
+   ┌─ tests/checking-lang-v2.2/lambda/capturing_option_1.move:16:67
+   │
+16 │         let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+   │                                                                   ^
+
+// -- Model dump before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    private entry fun entry_func() {
+        {
+          let v: 0x1::option::Option<u64> = option::none<u64>();
+          {
+            let _f: ||0x1::option::Option<u64> has copy + drop + store = closure#1m::id(v);
+            Tuple()
+          }
+        }
+    }
+    public fun id(x: 0x1::option::Option<u64>): 0x1::option::Option<u64> {
+        x
+    }
+    private fun init_module(account: &signer) {
+        {
+          let v: 0x1::option::Option<u64> = option::none<u64>();
+          {
+            let f: ||0x1::option::Option<u64> has copy + drop + store = closure#1m::id(v);
+            MoveTo<FunctionStore>(account, pack m::FunctionStore(f));
+            Tuple()
+          }
+        }
+    }
+} // end 0x99::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore has key {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    entry fun entry_func() {
+        let v = 0x1::option::none<u64>();
+        let _f: ||0x1::option::Option<u64> has copy + drop + store = || id(v);
+    }
+    public fun id(x: 0x1::option::Option<u64>): 0x1::option::Option<u64> {
+        x
+    }
+    fun init_module(account: &signer) {
+        let v = 0x1::option::none<u64>();
+        let f: ||0x1::option::Option<u64> has copy + drop + store = || id(v);
+        move_to<FunctionStore>(FunctionStore{f: f}, account);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_1.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_1.move
@@ -1,0 +1,18 @@
+module 0x99::m {
+    use std::option;
+    struct FunctionStore has key {
+        f: ||option::Option<u64> has copy+drop+store,
+    }
+    public fun id(x: option::Option<u64>): option::Option<u64> {
+        x
+    }
+    fun init_module(account: &signer) {
+        let v = option::none();
+        let f: ||option::Option<u64> has copy+drop+store = || id(v);
+        move_to(account, FunctionStore { f });
+    }
+    entry fun entry_func() {
+        let v = option::none();
+        let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_2.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_2.exp
@@ -1,0 +1,48 @@
+
+Diagnostics:
+warning: capturing option values is currently not supported
+   ┌─ tests/checking-lang-v2.2/lambda/capturing_option_2.move:14:67
+   │
+14 │         let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+   │                                                                   ^
+
+// -- Model dump before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    struct OptionStore {
+        o: 0x1::option::Option<u64>,
+    }
+    private entry fun entry_func() {
+        {
+          let v: OptionStore = pack m::OptionStore(option::none<u64>());
+          {
+            let _f: ||0x1::option::Option<u64> has copy + drop + store = closure#1m::id(v);
+            Tuple()
+          }
+        }
+    }
+    public fun id(x: OptionStore): 0x1::option::Option<u64> {
+        select m::OptionStore.o<OptionStore>(x)
+    }
+} // end 0x99::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore has key {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    struct OptionStore has copy, drop, store {
+        o: 0x1::option::Option<u64>,
+    }
+    entry fun entry_func() {
+        let v = OptionStore{o: 0x1::option::none<u64>()};
+        let _f: ||0x1::option::Option<u64> has copy + drop + store = || id(v);
+    }
+    public fun id(x: OptionStore): 0x1::option::Option<u64> {
+        x.o
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_2.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_2.move
@@ -1,0 +1,16 @@
+module 0x99::m {
+    use std::option;
+    struct OptionStore has copy,drop,store {
+        o: option::Option<u64>,
+    }
+    struct FunctionStore has key {
+        f: ||option::Option<u64> has copy+drop+store,
+    }
+    public fun id(x: OptionStore): option::Option<u64> {
+        x.o
+    }
+    entry fun entry_func() {
+        let v = OptionStore { o: option::none() };
+        let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_3.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_3.exp
@@ -1,0 +1,44 @@
+
+Diagnostics:
+warning: capturing option values is currently not supported
+   ┌─ tests/checking-lang-v2.2/lambda/capturing_option_3.move:12:67
+   │
+12 │         let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+   │                                                                   ^
+
+// -- Model dump before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    use std::vector;
+    struct FunctionStore {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    private entry fun entry_func() {
+        {
+          let v: vector<0x1::option::Option<u64>> = vector::empty<0x1::option::Option<u64>>();
+          {
+            let _f: ||0x1::option::Option<u64> has copy + drop + store = closure#1m::id(v);
+            Tuple()
+          }
+        }
+    }
+    public fun id(_x: vector<0x1::option::Option<u64>>): 0x1::option::Option<u64> {
+        option::none<u64>()
+    }
+} // end 0x99::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    use std::vector;
+    struct FunctionStore has key {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    entry fun entry_func() {
+        let v = 0x1::vector::empty<0x1::option::Option<u64>>();
+        let _f: ||0x1::option::Option<u64> has copy + drop + store = || id(v);
+    }
+    public fun id(_x: vector<0x1::option::Option<u64>>): 0x1::option::Option<u64> {
+        0x1::option::none<u64>()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_3.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_3.move
@@ -1,0 +1,14 @@
+module 0x99::m {
+    use std::option;
+    use std::vector;
+    struct FunctionStore has key {
+        f: ||option::Option<u64> has copy+drop+store,
+    }
+    public fun id(_x: vector<option::Option<u64>>): option::Option<u64> {
+        option::none()
+    }
+    entry fun entry_func() {
+        let v = vector::empty();
+        let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_4.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_4.exp
@@ -1,0 +1,69 @@
+
+Diagnostics:
+warning: capturing option values is currently not supported
+   ┌─ tests/checking-lang-v2.2/lambda/capturing_option_4.move:14:66
+   │
+14 │         let f: ||option::Option<u64> has copy+drop+store = || id(v);
+   │                                                                  ^
+
+warning: capturing option values is currently not supported
+   ┌─ tests/checking-lang-v2.2/lambda/capturing_option_4.move:19:67
+   │
+19 │         let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+   │                                                                   ^
+
+// -- Model dump before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    struct Store<T> {
+        o: T,
+    }
+    private entry fun entry_func() {
+        {
+          let v: Store<0x1::option::Option<u64>> = pack m::Store<0x1::option::Option<u64>>(option::none<u64>());
+          {
+            let _f: ||0x1::option::Option<u64> has copy + drop + store = closure#1m::id<0x1::option::Option<u64>>(v);
+            Tuple()
+          }
+        }
+    }
+    public fun id<T>(x: Store<T>): T {
+        select m::Store.o<Store<T>>(x)
+    }
+    private fun init_module(account: &signer) {
+        {
+          let v: Store<0x1::option::Option<u64>> = pack m::Store<0x1::option::Option<u64>>(option::none<u64>());
+          {
+            let f: ||0x1::option::Option<u64> has copy + drop + store = closure#1m::id<0x1::option::Option<u64>>(v);
+            MoveTo<FunctionStore>(account, pack m::FunctionStore(f));
+            Tuple()
+          }
+        }
+    }
+} // end 0x99::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore has key {
+        f: ||0x1::option::Option<u64> has copy + drop + store,
+    }
+    struct Store<T: copy + drop + store> has copy, drop, store {
+        o: T,
+    }
+    entry fun entry_func() {
+        let v = Store<0x1::option::Option<u64>>{o: 0x1::option::none<u64>()};
+        let _f: ||0x1::option::Option<u64> has copy + drop + store = || id<0x1::option::Option<u64>>(v);
+    }
+    public fun id<T: copy + drop + store>(x: Store<T>): T {
+        x.o
+    }
+    fun init_module(account: &signer) {
+        let v = Store<0x1::option::Option<u64>>{o: 0x1::option::none<u64>()};
+        let f: ||0x1::option::Option<u64> has copy + drop + store = || id<0x1::option::Option<u64>>(v);
+        move_to<FunctionStore>(FunctionStore{f: f}, account);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_4.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_4.move
@@ -1,0 +1,21 @@
+module 0x99::m {
+    use std::option;
+    struct Store<T: store+drop+copy> has copy,drop,store {
+        o: T,
+    }
+    struct FunctionStore has key {
+        f: ||option::Option<u64> has copy+drop+store,
+    }
+    public fun id<T: store+drop+copy>(x: Store<T>): T {
+        x.o
+    }
+    fun init_module(account: &signer) {
+        let v = Store { o: option::none() };
+        let f: ||option::Option<u64> has copy+drop+store = || id(v);
+        move_to(account, FunctionStore { f });
+    }
+    entry fun entry_func() {
+        let v = Store { o: option::none() };
+        let _f: ||option::Option<u64> has copy+drop+store = || id(v);
+    }
+ }

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_5_no_warning.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_5_no_warning.exp
@@ -1,0 +1,55 @@
+// -- Model dump before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore {
+        f: ||u64 has copy + drop + store,
+    }
+    private entry fun entry_func() {
+        {
+          let v: |0x1::option::Option<u64>|u64 has copy + drop + store = closure#0m::id2();
+          {
+            let _f: ||u64 has copy + drop + store = closure#1m::id(v);
+            Tuple()
+          }
+        }
+    }
+    public fun id(f: |0x1::option::Option<u64>|u64 has copy + drop + store): u64 {
+        (f)(option::some<u64>(3))
+    }
+    public fun id2(_v: 0x1::option::Option<u64>): u64 {
+        3
+    }
+    private fun init_module(account: &signer) {
+        {
+          let v: |0x1::option::Option<u64>|u64 has copy + drop + store = closure#0m::id2();
+          {
+            let f: ||u64 has copy + drop + store = closure#1m::id(v);
+            MoveTo<FunctionStore>(account, pack m::FunctionStore(f));
+            Tuple()
+          }
+        }
+    }
+} // end 0x99::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore has key {
+        f: ||u64 has copy + drop + store,
+    }
+    entry fun entry_func() {
+        let v: |0x1::option::Option<u64>|u64 has copy + drop + store = |arg0| id2(arg0);
+        let _f: ||u64 has copy + drop + store = || id(v);
+    }
+    public fun id(f: |0x1::option::Option<u64>|u64 has copy + drop + store): u64 {
+        f(0x1::option::some<u64>(3))
+    }
+    public fun id2(_v: 0x1::option::Option<u64>): u64 {
+        3
+    }
+    fun init_module(account: &signer) {
+        let v: |0x1::option::Option<u64>|u64 has copy + drop + store = |arg0| id2(arg0);
+        let f: ||u64 has copy + drop + store = || id(v);
+        move_to<FunctionStore>(FunctionStore{f: f}, account);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_5_no_warning.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_5_no_warning.move
@@ -1,0 +1,21 @@
+module 0x99::m {
+    use std::option;
+    struct FunctionStore has key {
+        f: ||u64 has copy+drop+store,
+    }
+    public fun id(f: |option::Option<u64>| u64 has copy+drop+store): u64 {
+        f(option::some(3))
+    }
+    public fun id2(_v: option::Option<u64>): u64 {
+        3
+    }
+    fun init_module(account: &signer) {
+        let v :|option::Option<u64>|u64 has copy+drop+store = id2;
+        let f: ||u64 has copy+drop+store = || id(v);
+        move_to(account, FunctionStore { f });
+    }
+    entry fun entry_func() {
+        let v :|option::Option<u64>|u64 has copy+drop+store = id2;
+        let _f: ||u64 has copy+drop+store = || id(v);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_6_phantom.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_6_phantom.exp
@@ -1,0 +1,40 @@
+// -- Model dump before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore {
+        f: ||u64 has copy + drop + store,
+    }
+    struct OptionStore<T> {
+        o: u64,
+    }
+    private entry fun entry_func() {
+        {
+          let v: OptionStore<0x1::option::Option<u64>> = pack m::OptionStore<0x1::option::Option<u64>>(3);
+          {
+            let _f: ||u64 has copy + drop + store = closure#1m::id(v);
+            Tuple()
+          }
+        }
+    }
+    public fun id(x: OptionStore<0x1::option::Option<u64>>): u64 {
+        select m::OptionStore.o<OptionStore<0x1::option::Option<u64>>>(x)
+    }
+} // end 0x99::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x99::m {
+    use std::option;
+    struct FunctionStore has key {
+        f: ||u64 has copy + drop + store,
+    }
+    struct OptionStore<phantom T> has copy, drop, store {
+        o: u64,
+    }
+    entry fun entry_func() {
+        let v = OptionStore<0x1::option::Option<u64>>{o: 3};
+        let _f: ||u64 has copy + drop + store = || id(v);
+    }
+    public fun id(x: OptionStore<0x1::option::Option<u64>>): u64 {
+        x.o
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_6_phantom.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_6_phantom.move
@@ -1,0 +1,16 @@
+module 0x99::m {
+    use std::option;
+    struct OptionStore<phantom T> has copy,drop,store {
+        o: u64,
+    }
+    struct FunctionStore has key {
+        f: ||u64 has copy+drop+store,
+    }
+    public fun id(x: OptionStore<option::Option<u64>>): u64 {
+        x.o
+    }
+    entry fun entry_func() {
+        let v = OptionStore { o: 3 };
+        let _f: ||u64 has copy+drop+store = || id(v);
+    }
+}

--- a/third_party/move/move-model/src/model.rs
+++ b/third_party/move/move-model/src/model.rs
@@ -3734,6 +3734,10 @@ impl<'env> ModuleEnv<'env> {
     pub fn is_cmp(&self) -> bool {
         self.is_module_in_std("cmp")
     }
+
+    pub fn is_option(&self) -> bool {
+        self.is_module_in_std("option")
+    }
 }
 
 // =================================================================================================
@@ -4143,6 +4147,11 @@ impl<'env> StructEnv<'env> {
             }
         }
         None
+    }
+
+    /// Whether the current struct/enum is Option
+    pub fn is_option_type(&self) -> bool {
+        self.module_env.is_option() && self.get_full_name_str() == "option::Option"
     }
 }
 

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_bin_op.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/equal_operands_in_bin_op.exp
@@ -118,18 +118,18 @@ warning: [lint] This operation always evaluates to `false`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#equal_operands_in_bin_op.
 
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
-   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:68:13
+   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:69:13
    │
-68 │         if (b || b) { // This should trigger `simpler_boolean_expression` instead of `equal_operands_in_bin_op`
+69 │         if (b || b) { // This should trigger `simpler_boolean_expression` instead of `equal_operands_in_bin_op`
    │             ^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
 
 warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
-   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:72:13
+   ┌─ tests/model_ast_lints/equal_operands_in_bin_op.move:73:13
    │
-72 │         if (b && b) { // This should trigger `simpler_boolean_expression` instead of `equal_operands_in_bin_op`
+73 │         if (b && b) { // This should trigger `simpler_boolean_expression` instead of `equal_operands_in_bin_op`
    │             ^^^^^^
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds to logic to generate warning when trying to capture a value that contains option in a closure.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

5 unit tests care added

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
