### PR TITLE
[consensus] refactor: self-send local timeout directly to round manager

### DIFF
--- a/consensus/src/twins/twins_node.rs
+++ b/consensus/src/twins/twins_node.rs
@@ -140,8 +140,6 @@ impl SMRNode {
 
         let time_service = Arc::new(ClockTimeService::new(runtime.handle().clone()));
 
-        let (timeout_sender, timeout_receiver) =
-            aptos_channels::new(1_024, &counters::PENDING_ROUND_TIMEOUTS);
         let (self_sender, self_receiver) =
             aptos_channels::new_unbounded(&counters::PENDING_SELF_MESSAGES);
 
@@ -153,7 +151,6 @@ impl SMRNode {
             time_service,
             self_sender,
             consensus_network_client,
-            timeout_sender,
             quorum_store_to_mempool_sender,
             execution_client.clone(),
             storage.clone(),
@@ -169,7 +166,7 @@ impl SMRNode {
             NetworkTask::new(network_service_events, self_receiver);
 
         runtime.spawn(network_task.start());
-        runtime.spawn(epoch_mgr.start(timeout_receiver, network_receiver));
+        runtime.spawn(epoch_mgr.start(network_receiver));
 
         let (commit_cb_sender, commit_cb_receiver) = mpsc::unbounded::<LedgerInfoWithSignatures>();
         runtime.spawn(async move {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
The current local timeout goes through epoch manager, which is unnecessary. 
## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
