### PR TITLE
allow overriding default framework cached build to skip rebuilding in debug and save on compilation time

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -801,6 +801,7 @@ dependencies = [
  "aptos-package-builder",
  "aptos-types",
  "bcs 0.1.4",
+ "build-rs",
  "move-core-types",
  "once_cell",
  "proptest",
@@ -6457,6 +6458,15 @@ checksum = "c48f0051a4b4c5e0b6d365cd04af53aeaa209e3cc15ec2cdb69e73cc87fbd0dc"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "build-rs"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cde4c9ce1d8e6e94b4c0ee341c000d79335b7c55b7d7979b36ca803c85c091ba"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -18886,9 +18896,9 @@ checksum = "6f2528f27a9eb2b21e69c95319b30bd0efd85d09c379741b0f78ea1d86be2416"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.12"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-linebreak"

--- a/aptos-move/framework/cached-packages/Cargo.toml
+++ b/aptos-move/framework/cached-packages/Cargo.toml
@@ -25,6 +25,7 @@ proptest-derive = { workspace = true, optional = true }
 [build-dependencies]
 anyhow = { workspace = true }
 aptos-framework = { workspace = true }
+build-rs = "0.3.2"
 
 [features]
 default = []

--- a/aptos-move/framework/cached-packages/build.rs
+++ b/aptos-move/framework/cached-packages/build.rs
@@ -3,7 +3,7 @@
 
 use anyhow::{Context, Result};
 use aptos_framework::ReleaseTarget;
-use std::{env::current_dir, path::PathBuf};
+use std::{env::current_dir, fs, path::PathBuf};
 
 fn main() -> Result<()> {
     // Set the below variable to skip the building step. This might be useful if the build
@@ -13,6 +13,7 @@ fn main() -> Result<()> {
         // Get the previous directory
         let mut prev_dir = current_dir;
         prev_dir.pop();
+        println!("cargo::rerun-if-changed=build.rs");
         println!(
             "cargo:rerun-if-changed={}",
             prev_dir
@@ -88,13 +89,44 @@ fn main() -> Result<()> {
             prev_dir.join("move-stdlib").join("Move.toml").display()
         );
 
-        let path =
-            PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR defined")).join("head.mrb");
-
-        ReleaseTarget::Head
-            .create_release(true, Some(path))
-            .context("Failed to create release")?;
+        rebuild_framework()?;
     }
 
     Ok(())
+}
+
+/// For debug builds, specify `APTOS_OVERRIDE_CACHED_PACKAGES_PATH` at compile time to override framework's `head.mrb` path.
+fn rebuild_framework() -> Result<()> {
+    let default_head_mrb_path =
+        PathBuf::from(std::env::var("OUT_DIR").expect("OUT_DIR defined")).join("head.mrb");
+
+    // need to use option_env! instead of `std::env::var()` to trigger recompilation step
+    let override_cached_packages_path =
+        option_env!("APTOS_OVERRIDE_CACHED_PACKAGES_PATH").map(|it| PathBuf::from(it));
+
+    let target_mrb_path = match override_cached_packages_path {
+        Some(override_cached_packages_path) => {
+            // we need to create dummy file at `default_head_mrb_path` for later `include_bytes!` to succeed
+            if !default_head_mrb_path.exists() {
+                fs::File::create(default_head_mrb_path).expect("OUT_DIR should be writeable");
+            }
+            build_rs::output::warning(&format!(
+                "APTOS_OVERRIDE_CACHED_PACKAGES_PATH is set, target framework override path = {}",
+                override_cached_packages_path.display(),
+            ));
+            if override_cached_packages_path.exists() {
+                build_rs::output::warning(&format!(
+                    "target framework `{}` path already exists",
+                    override_cached_packages_path.display()
+                ));
+                return Ok(());
+            }
+            override_cached_packages_path
+        }
+        None => default_head_mrb_path,
+    };
+
+    ReleaseTarget::Head
+        .create_release(true, Some(target_mrb_path))
+        .context("Failed to create release")
 }

--- a/aptos-move/framework/cached-packages/src/lib.rs
+++ b/aptos-move/framework/cached-packages/src/lib.rs
@@ -3,6 +3,8 @@
 
 use aptos_framework::ReleaseBundle;
 use once_cell::sync::Lazy;
+use std::fs;
+use std::path::PathBuf;
 
 pub mod aptos_framework_sdk_builder;
 pub mod aptos_stdlib;
@@ -15,7 +17,19 @@ const HEAD_RELEASE_BUNDLE_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"),
 const HEAD_RELEASE_BUNDLE_BYTES: &[u8] = include_bytes!(concat!(env!("OUT_DIR"), "\\head.mrb"));
 
 static HEAD_RELEASE_BUNDLE: Lazy<ReleaseBundle> = Lazy::new(|| {
-    bcs::from_bytes::<ReleaseBundle>(HEAD_RELEASE_BUNDLE_BYTES).expect("bcs succeeds")
+    let override_cached_packages_path =
+        option_env!("APTOS_OVERRIDE_CACHED_PACKAGES_PATH").map(|it| PathBuf::from(it));
+
+    let head_release_bundle_bytes = match override_cached_packages_path {
+        Some(override_cached_packages_path) => {
+            fs::read(override_cached_packages_path).expect(
+                "APTOS_OVERRIDE_CACHED_PACKAGES_PATH file should be created at the earlier compilation step"
+            )
+        },
+        None => Vec::from(HEAD_RELEASE_BUNDLE_BYTES),
+    };
+
+    bcs::from_bytes::<ReleaseBundle>(head_release_bundle_bytes.as_slice()).expect("bcs succeeds")
 });
 
 /// Returns the release bundle for the current code.


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Every time there's any change in the `move-compiler-v2` or other crates up the dep tree, `aptos-cached-packages` build.rs step is performed. 
It rebuilds the `MoveStdlib`/`AptosStdlib`/`AptosFramework` Move packages with the current compiler. The problem with debug builds is they are not optimized, so rebuilding takes a long time, ~80 seconds on my machine. 

This change allows specifying `APTOS_FRAMEWORK_BUILD_PATH=` environment variable while compiling to override the path of the cached framework, so if the file already exists it won't be recompiled. 

I limited the behaviour only to debug builds to prevent possible issues.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->


## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
