### PR TITLE
aggresstive inlining in the Move VM interpreter loop

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3470,6 +3470,7 @@ dependencies = [
  "futures",
  "hex",
  "move-vm-runtime",
+ "move-vm-types",
  "num_cpus",
  "rand 0.7.3",
  "rayon",

--- a/aptos-move/aptos-gas-meter/src/algebra.rs
+++ b/aptos-move/aptos-gas-meter/src/algebra.rs
@@ -187,6 +187,7 @@ where
         Ok(())
     }
 
+    #[inline(always)]
     fn charge_execution(
         &mut self,
         abstract_amount: impl GasExpression<VMGasParameters, Unit = InternalGasUnit> + Debug,

--- a/aptos-move/aptos-gas-meter/src/algebra.rs
+++ b/aptos-move/aptos-gas-meter/src/algebra.rs
@@ -111,6 +111,7 @@ impl<T> StandardGasAlgebra<'_, T>
 where
     T: BlockSynchronizationKillSwitch,
 {
+    #[inline(always)]
     fn charge(&mut self, amount: InternalGas) -> (InternalGas, PartialVMResult<()>) {
         match self.balance.checked_sub(amount) {
             Some(new_balance) => {

--- a/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
+++ b/aptos-move/aptos-gas-schedule/src/gas_schedule/misc.rs
@@ -143,6 +143,7 @@ where
 /// overflowing.
 macro_rules! check_depth_impl {
     () => {
+        #[inline(always)]
         fn check_depth(&self, depth: u64) -> PartialVMResult<()> {
             if self
                 .max_value_nest_depth

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -78,6 +78,7 @@ macro_rules! delegate {
     ($(
         fn $fn: ident $(<$($lt: lifetime),*>)? (&self $(, $arg: ident : $ty: ty)* $(,)?) -> $ret_ty: ty;
     )*) => {
+        #[inline(always)]
         $(fn $fn $(<$($lt)*>)? (&self, $($arg: $ty),*) -> $ret_ty {
             self.base.$fn($($arg),*)
         })*
@@ -88,6 +89,7 @@ macro_rules! delegate_mut {
     ($(
         fn $fn: ident $(<$($lt: lifetime),*>)? (&mut self $(, $arg: ident : $ty: ty)* $(,)?) -> $ret_ty: ty;
     )*) => {
+        #[inline(always)]
         $(fn $fn $(<$($lt)*>)? (&mut self, $($arg: $ty),*) -> $ret_ty {
             self.base.$fn($($arg),*)
         })*

--- a/aptos-move/aptos-native-interface/src/context.rs
+++ b/aptos-move/aptos-native-interface/src/context.rs
@@ -71,6 +71,7 @@ impl<'b, 'c> SafeNativeContext<'_, 'b, 'c, '_> {
     /// In other words, this function **MUST** always be called **BEFORE** executing **any**
     /// gas-metered operation or library call within a native function.
     #[must_use = "must always propagate the error returned by this function to the native function that called it using the ? operator"]
+    #[inline(always)]
     pub fn charge(
         &mut self,
         abstract_amount: impl GasExpression<NativeGasParameters, Unit = InternalGasUnit>,

--- a/aptos-move/aptos-vm-profiling/src/profile_aptos_vm.rs
+++ b/aptos-move/aptos-vm-profiling/src/profile_aptos_vm.rs
@@ -46,6 +46,8 @@ fn build_binaries() -> Result<()> {
         .arg("build")
         .arg("--profile")
         .arg(BUILD_PROFILE)
+        .arg("--features")
+        .arg("move-vm-types/force-inline move-vm-runtime/force-inline")
         .arg("-p")
         .arg("aptos-vm-profiling")
         .arg("--bin")

--- a/aptos-move/aptos-vm-profiling/src/profile_move_vm.rs
+++ b/aptos-move/aptos-vm-profiling/src/profile_move_vm.rs
@@ -93,6 +93,8 @@ fn build_binaries() -> Result<()> {
         .arg("build")
         .arg("--profile")
         .arg(BUILD_PROFILE)
+        .arg("--features")
+        .arg("move-vm-types/force-inline move-vm-runtime/force-inline")
         .arg("-p")
         .arg("aptos-vm-profiling")
         .arg("--bin")

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -70,7 +70,8 @@ either = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
-move-vm-runtime = { workspace = true }
+move-vm-runtime = { workspace = true, features = ["force-inline"] }
+move-vm-types = { workspace = true, features = ["force-inline"] }
 num_cpus = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }
@@ -99,4 +100,4 @@ tokio-console = ["aptos-logger/tokio-console", "aptos-config/tokio-console"]
 smoke-test = ["aptos-jwk-consensus/smoke-test", "aptos-dkg-runtime/smoke-test"]
 
 [package.metadata.cargo-machete]
-ignored = ["aptos-crypto"]
+ignored = ["aptos-crypto", "move-vm-types"]

--- a/third_party/move/move-core/types/src/account_address.rs
+++ b/third_party/move/move-core/types/src/account_address.rs
@@ -116,6 +116,7 @@ impl AccountAddress {
     ///
     /// For more details see the v1 address standard defined as part of AIP-40:
     /// <https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-40.md>
+    #[inline(always)]
     pub fn is_special(&self) -> bool {
         self.0[..Self::LENGTH - 1].iter().all(|x| *x == 0) && self.0[Self::LENGTH - 1] < 0b10000
     }

--- a/third_party/move/move-core/types/src/function.rs
+++ b/third_party/move/move-core/types/src/function.rs
@@ -65,6 +65,7 @@ impl ClosureMask {
 
     /// Returns true if the i'th argument is captured. If `i` is out of range, false will
     /// be returned.
+    #[inline(always)]
     pub fn is_captured(&self, i: usize) -> bool {
         i < Self::MAX_ARGS && self.0 & (1 << i) != 0
     }

--- a/third_party/move/move-vm/metrics/src/lib.rs
+++ b/third_party/move/move-vm/metrics/src/lib.rs
@@ -15,6 +15,7 @@ pub trait Timer {
 }
 
 impl Timer for HistogramVec {
+    #[inline]
     fn timer_with_label(&self, label: &str) -> HistogramTimer {
         self.with_label_values(&[label]).start_timer()
     }

--- a/third_party/move/move-vm/runtime/Cargo.toml
+++ b/third_party/move/move-vm/runtime/Cargo.toml
@@ -55,6 +55,7 @@ testing = []
 stacktrace = []
 # Enable this features for tests that check bytecode verification.
 disable_verifier_cache = []
+force-inline = []
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(fuzzing)'] }

--- a/third_party/move/move-vm/runtime/src/access_control.rs
+++ b/third_party/move/move-vm/runtime/src/access_control.rs
@@ -20,6 +20,7 @@ pub struct AccessControlState {
 
 impl AccessControlState {
     /// Enters a function, applying its access specifier to the state.
+    #[inline(always)]
     pub(crate) fn enter_function(
         &mut self,
         env: &impl AccessSpecifierEnv,
@@ -46,6 +47,7 @@ impl AccessControlState {
     }
 
     /// Exit function, restoring access state before entering.
+    #[inline(always)]
     pub(crate) fn exit_function(&mut self, fun: &LoadedFunction) -> PartialVMResult<()> {
         if !matches!(fun.access_specifier(), AccessSpecifier::Any) {
             if self.specifier_stack.is_empty() {

--- a/third_party/move/move-vm/runtime/src/access_control.rs
+++ b/third_party/move/move-vm/runtime/src/access_control.rs
@@ -20,7 +20,7 @@ pub struct AccessControlState {
 
 impl AccessControlState {
     /// Enters a function, applying its access specifier to the state.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn enter_function(
         &mut self,
         env: &impl AccessSpecifierEnv,
@@ -47,7 +47,7 @@ impl AccessControlState {
     }
 
     /// Exit function, restoring access state before entering.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn exit_function(&mut self, fun: &LoadedFunction) -> PartialVMResult<()> {
         if !matches!(fun.access_specifier(), AccessSpecifier::Any) {
             if self.specifier_stack.is_empty() {

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -131,6 +131,7 @@ impl Frame {
         function_instantiation_handle_at
     );
 
+    #[inline(always)]
     pub(crate) fn make_new_frame<RTTCheck: RuntimeTypeCheck>(
         gas_meter: &mut impl GasMeter,
         call_type: CallType,
@@ -258,6 +259,7 @@ impl Frame {
         )
     }
 
+    #[inline(always)]
     pub(crate) fn get_field_ty(&self, idx: FieldHandleIndex) -> PartialVMResult<&Type> {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -269,6 +271,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn get_generic_field_ty(
         &self,
         idx: FieldInstantiationIndex,
@@ -414,6 +417,7 @@ impl Frame {
         )
     }
 
+    #[inline(always)]
     pub(crate) fn field_offset(&self, idx: FieldHandleIndex) -> usize {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -422,6 +426,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn field_instantiation_offset(&self, idx: FieldInstantiationIndex) -> usize {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -439,6 +444,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn field_instantiation_count(&self, idx: StructDefInstantiationIndex) -> u16 {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -447,6 +453,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn field_handle_to_struct(&self, idx: FieldHandleIndex) -> Type {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -458,6 +465,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn field_instantiation_to_struct(
         &self,
         idx: FieldInstantiationIndex,

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -179,6 +179,7 @@ impl Frame {
         self.call_type
     }
 
+    #[inline(always)]
     pub(crate) fn local_ty_at(&self, idx: usize) -> &Type {
         &self.local_tys[idx]
     }

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -184,6 +184,7 @@ impl Frame {
         &self.local_tys[idx]
     }
 
+    #[inline(always)]
     pub(crate) fn check_local_tys_have_drop_ability(&self) -> PartialVMResult<()> {
         for (idx, ty) in self.local_tys.iter().enumerate() {
             if !self.locals.is_invalid(idx)? {
@@ -198,6 +199,7 @@ impl Frame {
         !self.function.function.is_trusted
     }
 
+    #[inline(always)]
     pub(crate) fn constant_at(&self, idx: ConstantPoolIndex) -> &Constant {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -206,6 +208,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn get_struct_ty(&self, idx: StructDefinitionIndex) -> Type {
         use LoadedFunctionOwner::*;
         let struct_ty = match self.function.owner() {
@@ -313,6 +316,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn get_struct(&self, idx: StructDefinitionIndex) -> &Arc<StructType> {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -426,6 +430,7 @@ impl Frame {
         }
     }
 
+    #[inline(always)]
     pub(crate) fn field_count(&self, idx: StructDefinitionIndex) -> u16 {
         use LoadedFunctionOwner::*;
         match self.function.owner() {

--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -131,7 +131,7 @@ impl Frame {
         function_instantiation_handle_at
     );
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn make_new_frame<RTTCheck: RuntimeTypeCheck>(
         gas_meter: &mut impl GasMeter,
         call_type: CallType,
@@ -180,12 +180,12 @@ impl Frame {
         self.call_type
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn local_ty_at(&self, idx: usize) -> &Type {
         &self.local_tys[idx]
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn check_local_tys_have_drop_ability(&self) -> PartialVMResult<()> {
         for (idx, ty) in self.local_tys.iter().enumerate() {
             if !self.locals.is_invalid(idx)? {
@@ -195,12 +195,12 @@ impl Frame {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn untrusted_code(&self) -> bool {
         !self.function.function.is_trusted
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn constant_at(&self, idx: ConstantPoolIndex) -> &Constant {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -209,7 +209,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_struct_ty(&self, idx: StructDefinitionIndex) -> Type {
         use LoadedFunctionOwner::*;
         let struct_ty = match self.function.owner() {
@@ -259,7 +259,7 @@ impl Frame {
         )
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_field_ty(&self, idx: FieldHandleIndex) -> PartialVMResult<&Type> {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -271,7 +271,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_generic_field_ty(
         &self,
         idx: FieldInstantiationIndex,
@@ -319,7 +319,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_struct(&self, idx: StructDefinitionIndex) -> &Arc<StructType> {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -417,7 +417,7 @@ impl Frame {
         )
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_offset(&self, idx: FieldHandleIndex) -> usize {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -426,7 +426,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_instantiation_offset(&self, idx: FieldInstantiationIndex) -> usize {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -435,7 +435,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_count(&self, idx: StructDefinitionIndex) -> u16 {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -444,7 +444,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_instantiation_count(&self, idx: StructDefInstantiationIndex) -> u16 {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -453,7 +453,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_handle_to_struct(&self, idx: FieldHandleIndex) -> Type {
         use LoadedFunctionOwner::*;
         match self.function.owner() {
@@ -465,7 +465,7 @@ impl Frame {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_instantiation_to_struct(
         &self,
         idx: FieldInstantiationIndex,

--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -84,7 +84,7 @@ pub(crate) struct FrameTypeCache {
 }
 
 impl FrameTypeCache {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn get_or<K: Copy + Ord + Eq, V, F>(
         map: &mut BTreeMap<K, V>,
         idx: K,
@@ -102,7 +102,7 @@ impl FrameTypeCache {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_field_type_and_struct_type(
         &mut self,
         idx: FieldInstantiationIndex,
@@ -140,7 +140,7 @@ impl FrameTypeCache {
         Ok(((field_ty, *field_ty_count), (struct_ty, *struct_ty_count)))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_struct_type(
         &mut self,
         idx: StructDefInstantiationIndex,
@@ -154,7 +154,7 @@ impl FrameTypeCache {
         Ok((ty, *ty_count))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_struct_variant_type(
         &mut self,
         idx: StructVariantInstantiationIndex,
@@ -173,7 +173,7 @@ impl FrameTypeCache {
         Ok((ty, *ty_count))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_struct_fields_types(
         &mut self,
         idx: StructDefInstantiationIndex,
@@ -195,7 +195,7 @@ impl FrameTypeCache {
         )?)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_struct_variant_fields_types(
         &mut self,
         idx: StructVariantInstantiationIndex,
@@ -217,7 +217,7 @@ impl FrameTypeCache {
         )?)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn get_signature_index_type(
         &mut self,
         idx: SignatureIndex,

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -809,7 +809,7 @@ where
     }
 
     // Check whether the values on the operand stack have the expected return types.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_return_tys<RTTCheck: RuntimeTypeCheck>(
         &self,
         current_frame: &mut Frame,
@@ -846,7 +846,7 @@ where
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn set_new_call_frame<
         RTTCheck: RuntimeTypeCheck,
         RTRCheck: RuntimeRefCheck,
@@ -902,7 +902,7 @@ where
     ///
     /// Native functions do not push a frame at the moment and as such errors from a native
     /// function are incorrectly attributed to the caller.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn make_call_frame<
         RTTCheck: RuntimeTypeCheck,
         RTRCheck: RuntimeRefCheck,
@@ -1773,7 +1773,7 @@ impl Stack {
 
     /// Push a `Value` on the stack if the max stack size has not been reached. Abort execution
     /// otherwise.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn push(&mut self, value: Value) -> PartialVMResult<()> {
         if self.value.len() < OPERAND_STACK_SIZE_LIMIT {
             self.value.push(value);
@@ -1784,7 +1784,7 @@ impl Stack {
     }
 
     /// Pop a `Value` off the stack or abort execution if the stack is empty.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn pop(&mut self) -> PartialVMResult<Value> {
         self.value
             .pop()
@@ -1794,7 +1794,7 @@ impl Stack {
     /// Pop a `Value` of a given type off the stack. Abort if the value is not of the given
     /// type or if the stack is empty.
     // Note(inline): expensive to inline, adds a few seconds of compile time
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn pop_as<T>(&mut self) -> PartialVMResult<T>
     where
         Value: VMValueCast<T>,
@@ -1803,7 +1803,7 @@ impl Stack {
     }
 
     /// Pop n values off the stack.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn popn(&mut self, n: u16) -> PartialVMResult<Vec<Value>> {
         let remaining_stack_size = self
             .value
@@ -1814,7 +1814,7 @@ impl Stack {
         Ok(args)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn last_n(&self, n: usize) -> PartialVMResult<impl ExactSizeIterator<Item = &Value> + Clone> {
         if self.value.len() < n {
             return Err(
@@ -1829,7 +1829,7 @@ impl Stack {
 
     /// Push a type on the stack if the max stack size has not been reached. Abort execution
     /// otherwise.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn push_ty(&mut self, ty: Type) -> PartialVMResult<()> {
         if self.types.len() < OPERAND_STACK_SIZE_LIMIT {
             self.types.push(ty);
@@ -1840,7 +1840,7 @@ impl Stack {
     }
 
     /// Pop a type off the stack or abort execution if the stack is empty.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn pop_ty(&mut self) -> PartialVMResult<Type> {
         self.types.pop().ok_or_else(|| {
             PartialVMError::new(StatusCode::EMPTY_VALUE_STACK)
@@ -1848,7 +1848,7 @@ impl Stack {
         })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn top_ty(&mut self) -> PartialVMResult<&Type> {
         self.types.last().ok_or_else(|| {
             PartialVMError::new(StatusCode::EMPTY_VALUE_STACK)
@@ -1857,7 +1857,7 @@ impl Stack {
     }
 
     /// Pop n types off the stack.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn popn_tys(&mut self, n: u16) -> PartialVMResult<Vec<Type>> {
         let remaining_stack_size = self.types.len().checked_sub(n as usize).ok_or_else(|| {
             PartialVMError::new(StatusCode::EMPTY_VALUE_STACK)
@@ -1890,7 +1890,7 @@ impl Stack {
         Ok(&self.types[(len - n)..])
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn check_balance(&self) -> PartialVMResult<()> {
         if self.types.len() != self.value.len() {
             return Err(
@@ -1914,7 +1914,7 @@ impl CallStack {
     }
 
     /// Push a `Frame` on the call stack.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn push(&mut self, frame: Frame) -> Result<(), Frame> {
         if self.0.len() < CALL_STACK_SIZE_LIMIT {
             self.0.push(frame);
@@ -1925,7 +1925,7 @@ impl CallStack {
     }
 
     /// Pop a `Frame` off the call stack.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn pop(&mut self) -> Option<Frame> {
         self.0.pop()
     }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1790,6 +1790,8 @@ impl Stack {
 
     /// Pop a `Value` of a given type off the stack. Abort if the value is not of the given
     /// type or if the stack is empty.
+    // Note(inline): expensive to inline, adds a few seconds of compile time
+    #[inline(always)]
     fn pop_as<T>(&mut self) -> PartialVMResult<T>
     where
         Value: VMValueCast<T>,

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1800,6 +1800,7 @@ impl Stack {
     }
 
     /// Pop n values off the stack.
+    #[inline(always)]
     fn popn(&mut self, n: u16) -> PartialVMResult<Vec<Value>> {
         let remaining_stack_size = self
             .value
@@ -1810,6 +1811,7 @@ impl Stack {
         Ok(args)
     }
 
+    #[inline(always)]
     fn last_n(&self, n: usize) -> PartialVMResult<impl ExactSizeIterator<Item = &Value> + Clone> {
         if self.value.len() < n {
             return Err(
@@ -1852,6 +1854,7 @@ impl Stack {
     }
 
     /// Pop n types off the stack.
+    #[inline(always)]
     pub(crate) fn popn_tys(&mut self, n: u16) -> PartialVMResult<Vec<Type>> {
         let remaining_stack_size = self.types.len().checked_sub(n as usize).ok_or_else(|| {
             PartialVMError::new(StatusCode::EMPTY_VALUE_STACK)

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1911,6 +1911,7 @@ impl CallStack {
     }
 
     /// Push a `Frame` on the call stack.
+    #[inline(always)]
     fn push(&mut self, frame: Frame) -> Result<(), Frame> {
         if self.0.len() < CALL_STACK_SIZE_LIMIT {
             self.0.push(frame);
@@ -1921,6 +1922,7 @@ impl CallStack {
     }
 
     /// Pop a `Frame` off the call stack.
+    #[inline(always)]
     fn pop(&mut self) -> Option<Frame> {
         self.0.pop()
     }

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -809,6 +809,7 @@ where
     }
 
     // Check whether the values on the operand stack have the expected return types.
+    #[inline(always)]
     fn check_return_tys<RTTCheck: RuntimeTypeCheck>(
         &self,
         current_frame: &mut Frame,
@@ -845,6 +846,7 @@ where
         Ok(())
     }
 
+    #[inline(always)]
     fn set_new_call_frame<
         RTTCheck: RuntimeTypeCheck,
         RTRCheck: RuntimeRefCheck,
@@ -900,6 +902,7 @@ where
     ///
     /// Native functions do not push a frame at the moment and as such errors from a native
     /// function are incorrectly attributed to the caller.
+    #[inline(always)]
     fn make_call_frame<
         RTTCheck: RuntimeTypeCheck,
         RTRCheck: RuntimeRefCheck,

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1770,6 +1770,7 @@ impl Stack {
 
     /// Push a `Value` on the stack if the max stack size has not been reached. Abort execution
     /// otherwise.
+    #[inline(always)]
     fn push(&mut self, value: Value) -> PartialVMResult<()> {
         if self.value.len() < OPERAND_STACK_SIZE_LIMIT {
             self.value.push(value);
@@ -1780,6 +1781,7 @@ impl Stack {
     }
 
     /// Pop a `Value` off the stack or abort execution if the stack is empty.
+    #[inline(always)]
     fn pop(&mut self) -> PartialVMResult<Value> {
         self.value
             .pop()
@@ -1820,6 +1822,7 @@ impl Stack {
 
     /// Push a type on the stack if the max stack size has not been reached. Abort execution
     /// otherwise.
+    #[inline(always)]
     pub(crate) fn push_ty(&mut self, ty: Type) -> PartialVMResult<()> {
         if self.types.len() < OPERAND_STACK_SIZE_LIMIT {
             self.types.push(ty);
@@ -1830,6 +1833,7 @@ impl Stack {
     }
 
     /// Pop a type off the stack or abort execution if the stack is empty.
+    #[inline(always)]
     pub(crate) fn pop_ty(&mut self) -> PartialVMResult<Type> {
         self.types.pop().ok_or_else(|| {
             PartialVMError::new(StatusCode::EMPTY_VALUE_STACK)
@@ -1837,6 +1841,7 @@ impl Stack {
         })
     }
 
+    #[inline(always)]
     pub(crate) fn top_ty(&mut self) -> PartialVMResult<&Type> {
         self.types.last().ok_or_else(|| {
             PartialVMError::new(StatusCode::EMPTY_VALUE_STACK)
@@ -1877,6 +1882,7 @@ impl Stack {
         Ok(&self.types[(len - n)..])
     }
 
+    #[inline(always)]
     pub(crate) fn check_balance(&self) -> PartialVMResult<()> {
         if self.types.len() != self.value.len() {
             return Err(

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -121,6 +121,7 @@ impl LoadedFunction {
 
     /// Returns a reference to parent [Module] owning the function. Returns an invariant violation
     /// error if the function comes from a script.
+    #[inline(always)]
     pub fn owner_as_module(&self) -> VMResult<&Module> {
         match &self.owner {
             LoadedFunctionOwner::Module(module) => Ok(module.as_ref()),
@@ -406,6 +407,7 @@ impl LoadedFunction {
     }
 
     /// Returns the module id or, if it is a script, the pseudo module id for scripts.
+    #[inline(always)]
     pub fn module_or_script_id(&self) -> &ModuleId {
         match &self.owner {
             LoadedFunctionOwner::Module(m) => Module::self_id(m),
@@ -481,6 +483,7 @@ impl LoadedFunction {
         self.function.is_native()
     }
 
+    #[inline(always)]
     pub fn get_native(&self) -> PartialVMResult<&UnboxedNativeFunction> {
         self.function.get_native()
     }

--- a/third_party/move/move-vm/runtime/src/loader/function.rs
+++ b/third_party/move/move-vm/runtime/src/loader/function.rs
@@ -121,7 +121,7 @@ impl LoadedFunction {
 
     /// Returns a reference to parent [Module] owning the function. Returns an invariant violation
     /// error if the function comes from a script.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn owner_as_module(&self) -> VMResult<&Module> {
         match &self.owner {
             LoadedFunctionOwner::Module(module) => Ok(module.as_ref()),
@@ -407,7 +407,7 @@ impl LoadedFunction {
     }
 
     /// Returns the module id or, if it is a script, the pseudo module id for scripts.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn module_or_script_id(&self) -> &ModuleId {
         match &self.owner {
             LoadedFunctionOwner::Module(m) => Module::self_id(m),
@@ -483,7 +483,7 @@ impl LoadedFunction {
         self.function.is_native()
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn get_native(&self) -> PartialVMResult<&UnboxedNativeFunction> {
         self.function.get_native()
     }

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -487,18 +487,22 @@ impl Module {
         &self.id
     }
 
+    #[inline(always)]
     pub(crate) fn struct_at(&self, idx: StructDefinitionIndex) -> &Arc<StructType> {
         &self.structs[idx.0 as usize].definition_struct_type
     }
 
+    #[inline(always)]
     pub(crate) fn struct_instantiation_at(&self, idx: u16) -> &StructInstantiation {
         &self.struct_instantiations[idx as usize]
     }
 
+    #[inline(always)]
     pub(crate) fn struct_variant_at(&self, idx: StructVariantHandleIndex) -> &StructVariantInfo {
         &self.struct_variant_infos[idx.0 as usize]
     }
 
+    #[inline(always)]
     pub(crate) fn struct_variant_instantiation_at(
         &self,
         idx: StructVariantInstantiationIndex,
@@ -506,38 +510,47 @@ impl Module {
         &self.struct_variant_instantiation_infos[idx.0 as usize]
     }
 
+    #[inline(always)]
     pub(crate) fn function_at(&self, idx: u16) -> &FunctionHandle {
         &self.function_refs[idx as usize]
     }
 
+    #[inline(always)]
     pub(crate) fn function_instantiation_at(&self, idx: u16) -> &[Type] {
         &self.function_instantiations[idx as usize].instantiation
     }
 
+    #[inline(always)]
     pub(crate) fn function_instantiation_handle_at(&self, idx: u16) -> &FunctionHandle {
         &self.function_instantiations[idx as usize].handle
     }
 
+    #[inline(always)]
     pub(crate) fn field_count(&self, idx: u16) -> u16 {
         self.structs[idx as usize].field_count
     }
 
+    #[inline(always)]
     pub(crate) fn field_instantiation_count(&self, idx: u16) -> u16 {
         self.struct_instantiations[idx as usize].field_count
     }
 
+    #[inline(always)]
     pub(crate) fn field_offset(&self, idx: FieldHandleIndex) -> usize {
         self.field_handles[idx.0 as usize].offset
     }
 
+    #[inline(always)]
     pub(crate) fn field_instantiation_offset(&self, idx: FieldInstantiationIndex) -> usize {
         self.field_instantiations[idx.0 as usize].offset
     }
 
+    #[inline(always)]
     pub(crate) fn variant_field_info_at(&self, idx: VariantFieldHandleIndex) -> &VariantFieldInfo {
         &self.variant_field_infos[idx.0 as usize]
     }
 
+    #[inline(always)]
     pub(crate) fn variant_field_instantiation_info_at(
         &self,
         idx: VariantFieldInstantiationIndex,
@@ -545,6 +558,7 @@ impl Module {
         &self.variant_field_instantiation_infos[idx.0 as usize]
     }
 
+    #[inline(always)]
     pub(crate) fn single_type_at(&self, idx: SignatureIndex) -> &Type {
         self.single_signature_token_map.get(&idx).unwrap()
     }

--- a/third_party/move/move-vm/runtime/src/loader/modules.rs
+++ b/third_party/move/move-vm/runtime/src/loader/modules.rs
@@ -487,22 +487,22 @@ impl Module {
         &self.id
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn struct_at(&self, idx: StructDefinitionIndex) -> &Arc<StructType> {
         &self.structs[idx.0 as usize].definition_struct_type
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn struct_instantiation_at(&self, idx: u16) -> &StructInstantiation {
         &self.struct_instantiations[idx as usize]
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn struct_variant_at(&self, idx: StructVariantHandleIndex) -> &StructVariantInfo {
         &self.struct_variant_infos[idx.0 as usize]
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn struct_variant_instantiation_at(
         &self,
         idx: StructVariantInstantiationIndex,
@@ -510,47 +510,47 @@ impl Module {
         &self.struct_variant_instantiation_infos[idx.0 as usize]
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn function_at(&self, idx: u16) -> &FunctionHandle {
         &self.function_refs[idx as usize]
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn function_instantiation_at(&self, idx: u16) -> &[Type] {
         &self.function_instantiations[idx as usize].instantiation
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn function_instantiation_handle_at(&self, idx: u16) -> &FunctionHandle {
         &self.function_instantiations[idx as usize].handle
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_count(&self, idx: u16) -> u16 {
         self.structs[idx as usize].field_count
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_instantiation_count(&self, idx: u16) -> u16 {
         self.struct_instantiations[idx as usize].field_count
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_offset(&self, idx: FieldHandleIndex) -> usize {
         self.field_handles[idx.0 as usize].offset
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn field_instantiation_offset(&self, idx: FieldInstantiationIndex) -> usize {
         self.field_instantiations[idx.0 as usize].offset
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn variant_field_info_at(&self, idx: VariantFieldHandleIndex) -> &VariantFieldInfo {
         &self.variant_field_infos[idx.0 as usize]
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn variant_field_instantiation_info_at(
         &self,
         idx: VariantFieldInstantiationIndex,
@@ -558,7 +558,7 @@ impl Module {
         &self.variant_field_instantiation_infos[idx.0 as usize]
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn single_type_at(&self, idx: SignatureIndex) -> &Type {
         self.single_signature_token_map.get(&idx).unwrap()
     }

--- a/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
+++ b/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
@@ -108,6 +108,7 @@ impl ReentrancyChecker {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn exit_function(
         &mut self,
         caller_module: &ModuleId,

--- a/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
+++ b/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
@@ -60,6 +60,7 @@ impl CallType {
 }
 
 impl ReentrancyChecker {
+    #[inline(always)]
     pub fn enter_function(
         &mut self,
         caller_module: Option<&ModuleId>,

--- a/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
+++ b/third_party/move/move-vm/runtime/src/reentrancy_checker.rs
@@ -60,7 +60,7 @@ impl CallType {
 }
 
 impl ReentrancyChecker {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn enter_function(
         &mut self,
         caller_module: Option<&ModuleId>,
@@ -108,7 +108,7 @@ impl ReentrancyChecker {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn exit_function(
         &mut self,
         caller_module: &ModuleId,

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -45,6 +45,7 @@ pub(crate) trait RuntimeTypeCheck {
 
     /// Performs a runtime check of the caller is allowed to call the callee for any type of call,
     /// including native dynamic dispatch or calling a closure.
+    #[inline(always)]
     fn check_call_visibility(
         caller: &LoadedFunction,
         callee: &LoadedFunction,
@@ -107,6 +108,7 @@ pub(crate) trait RuntimeTypeCheck {
     ) -> PartialVMResult<()>;
 }
 
+#[inline(always)]
 fn verify_pack<'a>(
     operand_stack: &mut Stack,
     field_count: u16,
@@ -260,6 +262,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
         false
     }
 
+    #[inline(always)]
     fn check_cross_module_regular_call_visibility(
         _caller: &LoadedFunction,
         _callee: &LoadedFunction,
@@ -888,6 +891,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
         false
     }
 
+    #[inline(always)]
     fn check_cross_module_regular_call_visibility(
         caller: &LoadedFunction,
         callee: &LoadedFunction,
@@ -985,6 +989,7 @@ impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
         true
     }
 
+    #[inline(always)]
     fn check_cross_module_regular_call_visibility(
         caller: &LoadedFunction,
         callee: &LoadedFunction,

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -222,6 +222,7 @@ pub(crate) struct FullRuntimeTypeCheck;
 pub(crate) struct UntrustedOnlyRuntimeTypeCheck;
 
 impl RuntimeTypeCheck for NoRuntimeTypeCheck {
+    #[inline(always)]
     fn pre_execution_type_stack_transition(
         _frame: &Frame,
         _operand_stack: &mut Stack,
@@ -231,6 +232,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
         Ok(())
     }
 
+    #[inline(always)]
     fn post_execution_type_stack_transition(
         _frame: &Frame,
         _operand_stack: &mut Stack,
@@ -240,6 +242,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
         Ok(())
     }
 
+    #[inline(always)]
     fn check_operand_stack_balance(
         _for_fun: &Function,
         _operand_stack: &Stack,
@@ -268,6 +271,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
 impl RuntimeTypeCheck for FullRuntimeTypeCheck {
     /// Note that most of the checks should happen after instruction execution, because gas charging will happen during
     /// instruction execution and we want to avoid running code without charging proper gas as much as possible.
+    #[inline(always)]
     fn pre_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -399,6 +403,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
     /// This function and `pre_execution_type_stack_transition` should
     /// constitute the full type stack transition for the paranoid
     /// mode.
+    #[inline(always)]
     fn post_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -865,6 +870,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
         Ok(())
     }
 
+    #[inline(always)]
     fn check_operand_stack_balance(
         _for_fun: &Function,
         operand_stack: &Stack,
@@ -922,6 +928,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
 }
 
 impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
+    #[inline(always)]
     fn pre_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -940,6 +947,7 @@ impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
         }
     }
 
+    #[inline(always)]
     fn post_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -958,6 +966,7 @@ impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
         }
     }
 
+    #[inline(always)]
     fn check_operand_stack_balance(
         _for_fun: &Function,
         _operand_stack: &Stack,

--- a/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
+++ b/third_party/move/move-vm/runtime/src/runtime_type_checks.rs
@@ -45,7 +45,7 @@ pub(crate) trait RuntimeTypeCheck {
 
     /// Performs a runtime check of the caller is allowed to call the callee for any type of call,
     /// including native dynamic dispatch or calling a closure.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_call_visibility(
         caller: &LoadedFunction,
         callee: &LoadedFunction,
@@ -108,7 +108,7 @@ pub(crate) trait RuntimeTypeCheck {
     ) -> PartialVMResult<()>;
 }
 
-#[inline(always)]
+#[cfg_attr(feature = "force-inline", inline(always))]
 fn verify_pack<'a>(
     operand_stack: &mut Stack,
     field_count: u16,
@@ -224,7 +224,7 @@ pub(crate) struct FullRuntimeTypeCheck;
 pub(crate) struct UntrustedOnlyRuntimeTypeCheck;
 
 impl RuntimeTypeCheck for NoRuntimeTypeCheck {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn pre_execution_type_stack_transition(
         _frame: &Frame,
         _operand_stack: &mut Stack,
@@ -234,7 +234,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn post_execution_type_stack_transition(
         _frame: &Frame,
         _operand_stack: &mut Stack,
@@ -244,7 +244,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_operand_stack_balance(
         _for_fun: &Function,
         _operand_stack: &Stack,
@@ -252,17 +252,17 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn should_perform_checks(_for_fun: &Function) -> bool {
         false
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn is_partial_checker() -> bool {
         false
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_cross_module_regular_call_visibility(
         _caller: &LoadedFunction,
         _callee: &LoadedFunction,
@@ -274,7 +274,7 @@ impl RuntimeTypeCheck for NoRuntimeTypeCheck {
 impl RuntimeTypeCheck for FullRuntimeTypeCheck {
     /// Note that most of the checks should happen after instruction execution, because gas charging will happen during
     /// instruction execution and we want to avoid running code without charging proper gas as much as possible.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn pre_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -406,7 +406,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
     /// This function and `pre_execution_type_stack_transition` should
     /// constitute the full type stack transition for the paranoid
     /// mode.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn post_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -873,7 +873,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_operand_stack_balance(
         _for_fun: &Function,
         operand_stack: &Stack,
@@ -881,17 +881,17 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
         operand_stack.check_balance()
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn should_perform_checks(_for_fun: &Function) -> bool {
         true
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn is_partial_checker() -> bool {
         false
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_cross_module_regular_call_visibility(
         caller: &LoadedFunction,
         callee: &LoadedFunction,
@@ -932,7 +932,7 @@ impl RuntimeTypeCheck for FullRuntimeTypeCheck {
 }
 
 impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn pre_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -951,7 +951,7 @@ impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn post_execution_type_stack_transition(
         frame: &Frame,
         operand_stack: &mut Stack,
@@ -970,7 +970,7 @@ impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_operand_stack_balance(
         _for_fun: &Function,
         _operand_stack: &Stack,
@@ -984,12 +984,12 @@ impl RuntimeTypeCheck for UntrustedOnlyRuntimeTypeCheck {
         !for_fun.is_trusted
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn is_partial_checker() -> bool {
         true
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check_cross_module_regular_call_visibility(
         caller: &LoadedFunction,
         callee: &LoadedFunction,

--- a/third_party/move/move-vm/runtime/src/storage/environment.rs
+++ b/third_party/move/move-vm/runtime/src/storage/environment.rs
@@ -238,7 +238,7 @@ impl RuntimeEnvironment {
     }
 
     /// Returns an error is module's address and name do not match the expected values.
-    #[inline]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_module_address_and_name(
         &self,
         module: &CompiledModule,

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
@@ -116,6 +116,7 @@ impl<Ctx> WithRuntimeEnvironment for UnsyncModuleStorageImpl<'_, Ctx>
 where
     Ctx: ModuleBytesStorage + WithRuntimeEnvironment,
 {
+    #[inline(always)]
     fn runtime_environment(&self) -> &RuntimeEnvironment {
         self.ctx.runtime_environment()
     }

--- a/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
+++ b/third_party/move/move-vm/runtime/src/storage/implementations/unsync_module_storage.rs
@@ -116,7 +116,7 @@ impl<Ctx> WithRuntimeEnvironment for UnsyncModuleStorageImpl<'_, Ctx>
 where
     Ctx: ModuleBytesStorage + WithRuntimeEnvironment,
 {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn runtime_environment(&self) -> &RuntimeEnvironment {
         self.ctx.runtime_environment()
     }

--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -66,6 +66,7 @@ where
     /// Checks the depth of a type. If the type is too deep, returns an error. Note that the type
     /// must be non-generic, i.e., all type substitutions must be performed. If needed, the check
     /// traverses multiple modules where inner structs and their fields are defined.
+    #[inline(always)]
     pub(crate) fn check_depth_of_type(
         &self,
         gas_meter: &mut impl DependencyGasMeter,

--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -66,7 +66,7 @@ where
     /// Checks the depth of a type. If the type is too deep, returns an error. Note that the type
     /// must be non-generic, i.e., all type substitutions must be performed. If needed, the check
     /// traverses multiple modules where inner structs and their fields are defined.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub(crate) fn check_depth_of_type(
         &self,
         gas_meter: &mut impl DependencyGasMeter,

--- a/third_party/move/move-vm/runtime/src/storage/verified_module_cache.rs
+++ b/third_party/move/move-vm/runtime/src/storage/verified_module_cache.rs
@@ -53,7 +53,7 @@ lazy_static! {
         VerifiedModuleCache::empty();
 }
 
-#[inline(always)]
+#[cfg_attr(feature = "force-inline", inline(always))]
 fn verifier_cache_enabled() -> bool {
     cfg_if! {
         if #[cfg(feature = "disable_verifier_cache")] {

--- a/third_party/move/move-vm/types/Cargo.toml
+++ b/third_party/move/move-vm/types/Cargo.toml
@@ -40,3 +40,4 @@ rand = { workspace = true }
 default = []
 testing = []
 fuzzing = ["proptest", "move-binary-format/fuzzing"]
+force-inline = []

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -449,6 +449,7 @@ impl Type {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn paranoid_check_is_u64_ty(&self) -> PartialVMResult<()> {
         if !matches!(self, Self::U64) {
             let msg = format!("Expected U64 type, got {}", self);
@@ -475,6 +476,7 @@ impl Type {
         paranoid_failure!(msg)
     }
 
+    #[inline(always)]
     pub fn paranoid_check_has_ability(&self, ability: Ability) -> PartialVMResult<()> {
         if !self.abilities()?.has_ability(ability) {
             let msg = format!("Type {} does not have expected ability {}", self, ability);
@@ -504,6 +506,7 @@ impl Type {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn paranoid_check_assignable(&self, expected_ty: &Self) -> PartialVMResult<()> {
         let ok = match (expected_ty, self) {
             (
@@ -538,6 +541,7 @@ impl Type {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn paranoid_check_is_vec_ty(&self, expected_elem_ty: &Self) -> PartialVMResult<()> {
         if let Self::Vector(elem_ty) = self {
             return elem_ty.paranoid_check_eq(expected_elem_ty);
@@ -547,6 +551,7 @@ impl Type {
         paranoid_failure!(msg)
     }
 
+    #[inline(always)]
     pub fn paranoid_check_is_vec_ref_ty<const IS_MUT: bool>(
         &self,
         expected_elem_ty: &Self,
@@ -602,6 +607,7 @@ impl Type {
         Ok(self.get_vec_ref_elem_ty())
     }
 
+    #[inline(always)]
     fn get_vec_ref_elem_ty(&self) -> Self {
         match self {
             Self::Reference(inner_ty) | Self::MutableReference(inner_ty) => match inner_ty.as_ref()
@@ -890,52 +896,54 @@ impl TypeBuilder {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_bool_ty(&self) -> Type {
         Type::Bool
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_u8_ty(&self) -> Type {
         Type::U8
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_u16_ty(&self) -> Type {
         Type::U16
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_u32_ty(&self) -> Type {
         Type::U32
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_u64_ty(&self) -> Type {
         Type::U64
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_u128_ty(&self) -> Type {
         Type::U128
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_u256_ty(&self) -> Type {
         Type::U256
     }
 
+    #[inline(always)]
     pub fn create_address_ty(&self) -> Type {
         Type::Address
     }
 
+    #[inline(always)]
     pub fn create_signer_ty(&self) -> Type {
         Type::Signer
     }
 
     /// Creates a (possibly mutable) reference type from the given inner type.
     /// Returns an error if the type size or depth are too large.
-    #[inline]
+    #[inline(always)]
     pub fn create_ref_ty(&self, inner_ty: &Type, is_mut: bool) -> PartialVMResult<Type> {
         let mut count = 1;
         let check = |c: &mut u64, d: u64| self.check(c, d);
@@ -960,7 +968,7 @@ impl TypeBuilder {
 
     /// Creates a vector type with the given element type, returning an error
     /// if the type size or depth are too large.
-    #[inline]
+    #[inline(always)]
     pub fn create_vec_ty(&self, elem_ty: &Type) -> PartialVMResult<Type> {
         let mut count = 1;
         let check = |c: &mut u64, d: u64| self.check(c, d);
@@ -978,7 +986,7 @@ impl TypeBuilder {
         Ok(Type::Vector(TriompheArc::new(elem_ty)))
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn create_struct_ty(&self, idx: StructNameIndex, ability: AbilityInfo) -> Type {
         Type::Struct { idx, ability }
     }
@@ -1057,6 +1065,7 @@ impl TypeBuilder {
         self.subst_impl(ty, ty_args, &mut count, 1, check)
     }
 
+    #[inline]
     fn check(&self, count: &mut u64, depth: u64) -> PartialVMResult<()> {
         if *count >= self.max_ty_size {
             return Err(

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -495,6 +495,7 @@ impl Type {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn paranoid_check_eq(&self, expected_ty: &Self) -> PartialVMResult<()> {
         if self != expected_ty {
             let msg = format!("Expected type {}, got {}", expected_ty, self);

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -700,6 +700,9 @@ impl Type {
         }
     }
 
+    // Note(inline): Recursive function, but `#[inline(always)]` seems to improve perf slightly
+    //               and doesn't add much compile time.
+    #[inline(always)]
     pub fn abilities(&self) -> PartialVMResult<AbilitySet> {
         match self {
             Type::Bool

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -145,6 +145,7 @@ impl StructType {
     /// must be None. Otherwise if its a variant struct, the variant for which the fields
     /// are requested must be given. For non-matching parameters, the function returns
     /// an empty list.
+    #[inline(always)]
     pub fn fields(&self, variant: Option<VariantIndex>) -> PartialVMResult<&[(Identifier, Type)]> {
         match (&self.layout, variant) {
             (StructLayout::Single(fields), None) => Ok(fields.as_slice()),
@@ -485,6 +486,7 @@ impl Type {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn paranoid_check_abilities(&self, expected_abilities: AbilitySet) -> PartialVMResult<()> {
         let abilities = self.abilities()?;
         if !expected_abilities.is_subset(abilities) {
@@ -581,6 +583,7 @@ impl Type {
 
     /// Returns an error if the type is not a (mutable) vector reference. Otherwise, returns
     /// a (mutable) reference to its element type.
+    #[inline(always)]
     pub fn paranoid_check_and_get_vec_elem_ref_ty<const IS_MUT: bool>(
         &self,
         expected_elem_ty: &Self,
@@ -599,6 +602,7 @@ impl Type {
 
     /// Returns an error if the type is not a (mutable) vector reference. Otherwise, returns
     /// its element type.
+    #[inline(always)]
     pub fn paranoid_check_and_get_vec_elem_ty<const IS_MUT: bool>(
         &self,
         expected_elem_ty: &Self,
@@ -619,7 +623,7 @@ impl Type {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn paranoid_freeze_ref_ty(self) -> PartialVMResult<Type> {
         match self {
             Type::MutableReference(ty) => Ok(Type::Reference(ty)),
@@ -630,7 +634,7 @@ impl Type {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn paranoid_read_ref(self) -> PartialVMResult<Type> {
         match self {
             Type::Reference(inner_ty) | Type::MutableReference(inner_ty) => {
@@ -644,7 +648,7 @@ impl Type {
         }
     }
 
-    #[inline]
+    #[inline(always)]
     pub fn paranoid_write_ref(&self, val_ty: &Type) -> PartialVMResult<()> {
         if let Type::MutableReference(inner_ty) = self {
             val_ty.paranoid_check_assignable(inner_ty)?;
@@ -655,6 +659,7 @@ impl Type {
         }
     }
 
+    #[inline(always)]
     pub fn paranoid_check_ref_eq(
         &self,
         expected_inner_ty: &Self,
@@ -763,6 +768,7 @@ impl Type {
     ///   - `u64` has one node
     ///   - `vector<u64>` has two nodes -- one for the vector and one for the element type u64.
     ///   - `Foo<u64, Bar<u8, bool>>` has 5 nodes.
+    #[inline(always)]
     pub fn num_nodes(&self) -> usize {
         self.preorder_traversal().count()
     }
@@ -1035,6 +1041,7 @@ impl TypeBuilder {
 
     /// Creates a type for a Move constant. Note that constant types can be
     /// more restrictive and therefore have their own creation API.
+    #[inline(always)]
     pub fn create_constant_ty(&self, const_tok: &SignatureToken) -> PartialVMResult<Type> {
         let mut count = 0;
         self.create_constant_ty_impl(const_tok, &mut count, 1)
@@ -1065,7 +1072,7 @@ impl TypeBuilder {
         self.subst_impl(ty, ty_args, &mut count, 1, check)
     }
 
-    #[inline]
+    #[inline(always)]
     fn check(&self, count: &mut u64, depth: u64) -> PartialVMResult<()> {
         if *count >= self.max_ty_size {
             return Err(

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -145,7 +145,7 @@ impl StructType {
     /// must be None. Otherwise if its a variant struct, the variant for which the fields
     /// are requested must be given. For non-matching parameters, the function returns
     /// an empty list.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn fields(&self, variant: Option<VariantIndex>) -> PartialVMResult<&[(Identifier, Type)]> {
         match (&self.layout, variant) {
             (StructLayout::Single(fields), None) => Ok(fields.as_slice()),
@@ -450,7 +450,7 @@ impl Type {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_is_u64_ty(&self) -> PartialVMResult<()> {
         if !matches!(self, Self::U64) {
             let msg = format!("Expected U64 type, got {}", self);
@@ -477,7 +477,7 @@ impl Type {
         paranoid_failure!(msg)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_has_ability(&self, ability: Ability) -> PartialVMResult<()> {
         if !self.abilities()?.has_ability(ability) {
             let msg = format!("Type {} does not have expected ability {}", self, ability);
@@ -486,7 +486,7 @@ impl Type {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_abilities(&self, expected_abilities: AbilitySet) -> PartialVMResult<()> {
         let abilities = self.abilities()?;
         if !expected_abilities.is_subset(abilities) {
@@ -499,7 +499,7 @@ impl Type {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_eq(&self, expected_ty: &Self) -> PartialVMResult<()> {
         if self != expected_ty {
             let msg = format!("Expected type {}, got {}", expected_ty, self);
@@ -508,7 +508,7 @@ impl Type {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_assignable(&self, expected_ty: &Self) -> PartialVMResult<()> {
         let ok = match (expected_ty, self) {
             (
@@ -543,7 +543,7 @@ impl Type {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_is_vec_ty(&self, expected_elem_ty: &Self) -> PartialVMResult<()> {
         if let Self::Vector(elem_ty) = self {
             return elem_ty.paranoid_check_eq(expected_elem_ty);
@@ -553,7 +553,7 @@ impl Type {
         paranoid_failure!(msg)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_is_vec_ref_ty<const IS_MUT: bool>(
         &self,
         expected_elem_ty: &Self,
@@ -583,7 +583,7 @@ impl Type {
 
     /// Returns an error if the type is not a (mutable) vector reference. Otherwise, returns
     /// a (mutable) reference to its element type.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_and_get_vec_elem_ref_ty<const IS_MUT: bool>(
         &self,
         expected_elem_ty: &Self,
@@ -602,7 +602,7 @@ impl Type {
 
     /// Returns an error if the type is not a (mutable) vector reference. Otherwise, returns
     /// its element type.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_and_get_vec_elem_ty<const IS_MUT: bool>(
         &self,
         expected_elem_ty: &Self,
@@ -611,7 +611,7 @@ impl Type {
         Ok(self.get_vec_ref_elem_ty())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn get_vec_ref_elem_ty(&self) -> Self {
         match self {
             Self::Reference(inner_ty) | Self::MutableReference(inner_ty) => match inner_ty.as_ref()
@@ -623,7 +623,7 @@ impl Type {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_freeze_ref_ty(self) -> PartialVMResult<Type> {
         match self {
             Type::MutableReference(ty) => Ok(Type::Reference(ty)),
@@ -634,7 +634,7 @@ impl Type {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_read_ref(self) -> PartialVMResult<Type> {
         match self {
             Type::Reference(inner_ty) | Type::MutableReference(inner_ty) => {
@@ -648,7 +648,7 @@ impl Type {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_write_ref(&self, val_ty: &Type) -> PartialVMResult<()> {
         if let Type::MutableReference(inner_ty) = self {
             val_ty.paranoid_check_assignable(inner_ty)?;
@@ -659,7 +659,7 @@ impl Type {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn paranoid_check_ref_eq(
         &self,
         expected_inner_ty: &Self,
@@ -700,9 +700,9 @@ impl Type {
         }
     }
 
-    // Note(inline): Recursive function, but `#[inline(always)]` seems to improve perf slightly
+    // Note(inline): Recursive function, but `#[cfg_attr(feature = "force-inline", inline(always))]` seems to improve perf slightly
     //               and doesn't add much compile time.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn abilities(&self) -> PartialVMResult<AbilitySet> {
         match self {
             Type::Bool
@@ -771,7 +771,7 @@ impl Type {
     ///   - `u64` has one node
     ///   - `vector<u64>` has two nodes -- one for the vector and one for the element type u64.
     ///   - `Foo<u64, Bar<u8, bool>>` has 5 nodes.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn num_nodes(&self) -> usize {
         self.preorder_traversal().count()
     }
@@ -905,54 +905,54 @@ impl TypeBuilder {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_bool_ty(&self) -> Type {
         Type::Bool
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_u8_ty(&self) -> Type {
         Type::U8
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_u16_ty(&self) -> Type {
         Type::U16
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_u32_ty(&self) -> Type {
         Type::U32
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_u64_ty(&self) -> Type {
         Type::U64
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_u128_ty(&self) -> Type {
         Type::U128
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_u256_ty(&self) -> Type {
         Type::U256
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_address_ty(&self) -> Type {
         Type::Address
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_signer_ty(&self) -> Type {
         Type::Signer
     }
 
     /// Creates a (possibly mutable) reference type from the given inner type.
     /// Returns an error if the type size or depth are too large.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_ref_ty(&self, inner_ty: &Type, is_mut: bool) -> PartialVMResult<Type> {
         let mut count = 1;
         let check = |c: &mut u64, d: u64| self.check(c, d);
@@ -977,7 +977,7 @@ impl TypeBuilder {
 
     /// Creates a vector type with the given element type, returning an error
     /// if the type size or depth are too large.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_vec_ty(&self, elem_ty: &Type) -> PartialVMResult<Type> {
         let mut count = 1;
         let check = |c: &mut u64, d: u64| self.check(c, d);
@@ -995,14 +995,14 @@ impl TypeBuilder {
         Ok(Type::Vector(TriompheArc::new(elem_ty)))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_struct_ty(&self, idx: StructNameIndex, ability: AbilityInfo) -> Type {
         Type::Struct { idx, ability }
     }
 
     /// Creates a fully-instantiated struct type, performing the type substitution.
     /// Returns an error if the type size or depth are too large.
-    #[inline]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_struct_instantiation_ty(
         &self,
         struct_ty: &StructType,
@@ -1044,7 +1044,7 @@ impl TypeBuilder {
 
     /// Creates a type for a Move constant. Note that constant types can be
     /// more restrictive and therefore have their own creation API.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn create_constant_ty(&self, const_tok: &SignatureToken) -> PartialVMResult<Type> {
         let mut count = 0;
         self.create_constant_ty_impl(const_tok, &mut count, 1)
@@ -1075,7 +1075,7 @@ impl TypeBuilder {
         self.subst_impl(ty, ty_args, &mut count, 1, check)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn check(&self, count: &mut u64, depth: u64) -> PartialVMResult<()> {
         if *count >= self.max_ty_size {
             return Err(

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -300,6 +300,7 @@ pub struct TypePreorderTraversalIter<'a> {
 impl<'a> Iterator for TypePreorderTraversalIter<'a> {
     type Item = &'a Type;
 
+    #[inline(always)]
     fn next(&mut self) -> Option<Self::Item> {
         use Type::*;
 

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -1703,6 +1703,7 @@ impl Locals {
         )))
     }
 
+    #[inline(always)]
     pub fn copy_loc(&self, idx: usize) -> PartialVMResult<Value> {
         self.copy_loc_impl(idx, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
     }
@@ -1713,6 +1714,7 @@ impl Locals {
         self.copy_loc_impl(idx, Some(max_depth))
     }
 
+    #[inline(always)]
     fn copy_loc_impl(&self, idx: usize, max_depth: Option<u64>) -> PartialVMResult<Value> {
         let v = self.0.borrow();
         match v.get(idx) {
@@ -1729,6 +1731,7 @@ impl Locals {
         }
     }
 
+    #[inline(always)]
     fn swap_loc(&mut self, idx: usize, x: Value) -> PartialVMResult<Value> {
         let mut v = self.0.borrow_mut();
         match v.get_mut(idx) {
@@ -1741,6 +1744,7 @@ impl Locals {
         }
     }
 
+    #[inline(always)]
     pub fn move_loc(&mut self, idx: usize) -> PartialVMResult<Value> {
         match self.swap_loc(idx, Value(ValueImpl::Invalid))? {
             Value(ValueImpl::Invalid) => Err(PartialVMError::new(
@@ -1751,6 +1755,7 @@ impl Locals {
         }
     }
 
+    #[inline(always)]
     pub fn store_loc(&mut self, idx: usize, x: Value) -> PartialVMResult<()> {
         self.swap_loc(idx, x)?;
         Ok(())
@@ -1778,6 +1783,7 @@ impl Locals {
         res.into_iter()
     }
 
+    #[inline(always)]
     pub fn is_invalid(&self, idx: usize) -> PartialVMResult<bool> {
         let v = self.0.borrow();
         match v.get(idx) {

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -1943,6 +1943,9 @@ impl Value {
  *   the conversion will succeed. An error will be raised in case of a violation.
  *
  **************************************************************************************/
+// Note(inline): Kinda expensive to inline all the cast functions.
+//               Together they add a few seconds of compile time.
+
 pub trait VMValueCast<T> {
     fn cast(self) -> PartialVMResult<T>;
 }
@@ -1950,6 +1953,7 @@ pub trait VMValueCast<T> {
 macro_rules! impl_vm_value_cast {
     ($ty:ty, $tc:ident) => {
         impl VMValueCast<$ty> for Value {
+            #[inline(always)]
             fn cast(self) -> PartialVMResult<$ty> {
                 match self.0 {
                     ValueImpl::$tc(x) => Ok(x),
@@ -1973,6 +1977,7 @@ impl_vm_value_cast!(ContainerRef, ContainerRef);
 impl_vm_value_cast!(IndexedRef, IndexedRef);
 
 impl VMValueCast<DelayedFieldID> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<DelayedFieldID> {
         match self.0 {
             ValueImpl::DelayedFieldID { id } => Ok(id),
@@ -1987,6 +1992,7 @@ impl VMValueCast<DelayedFieldID> for Value {
 }
 
 impl VMValueCast<IntegerValue> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<IntegerValue> {
         match self.0 {
             ValueImpl::U8(x) => Ok(IntegerValue::U8(x)),
@@ -2002,6 +2008,7 @@ impl VMValueCast<IntegerValue> for Value {
 }
 
 impl VMValueCast<Reference> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<Reference> {
         match self.0 {
             ValueImpl::ContainerRef(r) => Ok(Reference(ReferenceImpl::ContainerRef(r))),
@@ -2013,6 +2020,7 @@ impl VMValueCast<Reference> for Value {
 }
 
 impl VMValueCast<Container> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<Container> {
         match self.0 {
             ValueImpl::Container(c) => Ok(c),
@@ -2023,6 +2031,7 @@ impl VMValueCast<Container> for Value {
 }
 
 impl VMValueCast<Struct> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<Struct> {
         match self.0 {
             ValueImpl::Container(Container::Struct(r)) => Ok(Struct {
@@ -2035,12 +2044,14 @@ impl VMValueCast<Struct> for Value {
 }
 
 impl VMValueCast<StructRef> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<StructRef> {
         Ok(StructRef(VMValueCast::cast(self)?))
     }
 }
 
 impl VMValueCast<Vec<u8>> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<Vec<u8>> {
         match self.0 {
             ValueImpl::Container(Container::VecU8(r)) => take_unique_ownership(r),
@@ -2051,6 +2062,7 @@ impl VMValueCast<Vec<u8>> for Value {
 }
 
 impl VMValueCast<Vec<u64>> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<Vec<u64>> {
         match self.0 {
             ValueImpl::Container(Container::VecU64(r)) => take_unique_ownership(r),
@@ -2061,6 +2073,7 @@ impl VMValueCast<Vec<u64>> for Value {
 }
 
 impl VMValueCast<Vec<Value>> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<Vec<Value>> {
         match self.0 {
             ValueImpl::Container(Container::Vec(c)) => {
@@ -2088,6 +2101,7 @@ impl VMValueCast<Vec<Value>> for Value {
 }
 
 impl VMValueCast<SignerRef> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<SignerRef> {
         match self.0 {
             ValueImpl::ContainerRef(r) => Ok(SignerRef(r)),
@@ -2098,6 +2112,7 @@ impl VMValueCast<SignerRef> for Value {
 }
 
 impl VMValueCast<VectorRef> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<VectorRef> {
         match self.0 {
             ValueImpl::ContainerRef(r) => Ok(VectorRef(r)),
@@ -2108,6 +2123,7 @@ impl VMValueCast<VectorRef> for Value {
 }
 
 impl VMValueCast<Vector> for Value {
+    #[inline(always)]
     fn cast(self) -> PartialVMResult<Vector> {
         match self.0 {
             ValueImpl::Container(c) => Ok(Vector(c)),

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -329,6 +329,7 @@ impl ContainerRef {
         }
     }
 
+    #[inline(always)]
     fn mark_dirty(&self) {
         if let Self::Global { status, .. } = self {
             *status.borrow_mut() = GlobalDataStatus::Dirty
@@ -1086,6 +1087,7 @@ impl IndexedRef {
 }
 
 impl ReferenceImpl {
+    #[inline(always)]
     fn read_ref(self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Value> {
         match self {
             Self::ContainerRef(r) => r.read_ref(depth, max_depth),
@@ -1235,6 +1237,7 @@ impl IndexedRef {
 }
 
 impl ReferenceImpl {
+    #[inline(always)]
     fn write_ref(self, x: Value) -> PartialVMResult<()> {
         match self {
             Self::ContainerRef(r) => r.write_ref(x),
@@ -1244,6 +1247,7 @@ impl ReferenceImpl {
 }
 
 impl Reference {
+    #[inline(always)]
     pub fn write_ref(self, x: Value) -> PartialVMResult<()> {
         self.0.write_ref(x)
     }
@@ -2888,6 +2892,7 @@ impl VectorRef {
         Ok(res)
     }
 
+    #[inline(always)]
     pub fn swap(&self, idx1: usize, idx2: usize) -> PartialVMResult<()> {
         let c = self.0.container();
 
@@ -5127,6 +5132,7 @@ fn try_get_variant_field_layouts<'a>(
     None
 }
 
+#[inline(always)]
 fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
     if max_depth.map_or(false, |max_depth| depth > max_depth) {
         return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -274,7 +274,7 @@ pub struct Locals(Rc<RefCell<Vec<ValueImpl>>>);
  **************************************************************************************/
 
 impl Container {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn len(&self) -> usize {
         match self {
             Self::Vec(r) => r.borrow().len(),
@@ -310,7 +310,7 @@ impl Container {
  *
  **************************************************************************************/
 
-#[inline(always)]
+#[cfg_attr(feature = "force-inline", inline(always))]
 fn take_unique_ownership<T: Debug>(r: Rc<RefCell<T>>) -> PartialVMResult<T> {
     match Rc::try_unwrap(r) {
         Ok(cell) => Ok(cell.into_inner()),
@@ -329,7 +329,7 @@ impl ContainerRef {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn mark_dirty(&self) {
         if let Self::Global { status, .. } = self {
             *status.borrow_mut() = GlobalDataStatus::Dirty
@@ -391,9 +391,9 @@ impl ValueImpl {
  *
  **************************************************************************************/
 impl ValueImpl {
-    // Note(inline): recursive function, but `#[inline(always)]` seems to improve perf slightly
+    // Note(inline): recursive function, but `#[cfg_attr(feature = "force-inline", inline(always))]` seems to improve perf slightly
     //               and doesn't add much compile time.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn copy_value(&self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Self> {
         use ValueImpl::*;
 
@@ -489,7 +489,7 @@ impl Container {
 }
 
 impl IndexedRef {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn copy_by_ref(&self) -> Self {
         Self {
             idx: self.idx,
@@ -499,7 +499,7 @@ impl IndexedRef {
 }
 
 impl ContainerRef {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn copy_by_ref(&self) -> Self {
         match self {
             Self::Local(container) => Self::Local(container.copy_by_ref()),
@@ -536,7 +536,7 @@ impl Value {
  **************************************************************************************/
 
 impl ValueImpl {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         use ValueImpl::*;
 
@@ -789,7 +789,7 @@ impl Container {
 }
 
 impl ContainerRef {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         // Note: the depth passed in accounts for the container.
         check_depth(depth, max_depth)?;
@@ -810,7 +810,7 @@ impl ContainerRef {
 }
 
 impl IndexedRef {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         use Container::*;
 
@@ -1025,7 +1025,7 @@ impl IndexedRef {
 }
 
 impl Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn equals(&self, other: &Self) -> PartialVMResult<bool> {
         self.0
             .equals(&other.0, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
@@ -1058,7 +1058,7 @@ impl Value {
  **************************************************************************************/
 
 impl ContainerRef {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn read_ref(self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Value> {
         Ok(Value(ValueImpl::Container(
             self.container().copy_value(depth, max_depth)?,
@@ -1091,7 +1091,7 @@ impl IndexedRef {
 }
 
 impl ReferenceImpl {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn read_ref(self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Value> {
         match self {
             Self::ContainerRef(r) => r.read_ref(depth, max_depth),
@@ -1112,7 +1112,7 @@ impl StructRef {
 }
 
 impl Reference {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn read_ref(self) -> PartialVMResult<Value> {
         self.0.read_ref(1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
     }
@@ -1241,7 +1241,7 @@ impl IndexedRef {
 }
 
 impl ReferenceImpl {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn write_ref(self, x: Value) -> PartialVMResult<()> {
         match self {
             Self::ContainerRef(r) => r.write_ref(x),
@@ -1251,7 +1251,7 @@ impl ReferenceImpl {
 }
 
 impl Reference {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn write_ref(self, x: Value) -> PartialVMResult<()> {
         self.0.write_ref(x)
     }
@@ -1502,7 +1502,7 @@ impl Reference {
  **************************************************************************************/
 
 impl ContainerRef {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn borrow_elem(&self, idx: usize) -> PartialVMResult<ValueImpl> {
         let len = self.container().len();
         if idx >= len {
@@ -1629,7 +1629,7 @@ impl StructRef {
 }
 
 impl Locals {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn borrow_loc(&self, idx: usize) -> PartialVMResult<Value> {
         let v = self.0.borrow();
         if idx >= v.len() {
@@ -1717,14 +1717,14 @@ impl SignerRef {
  *
  **************************************************************************************/
 impl Locals {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn new(n: usize) -> Self {
         Self(Rc::new(RefCell::new(
             iter::repeat_with(|| ValueImpl::Invalid).take(n).collect(),
         )))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn copy_loc(&self, idx: usize) -> PartialVMResult<Value> {
         self.copy_loc_impl(idx, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
     }
@@ -1735,7 +1735,7 @@ impl Locals {
         self.copy_loc_impl(idx, Some(max_depth))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn copy_loc_impl(&self, idx: usize, max_depth: Option<u64>) -> PartialVMResult<Value> {
         let v = self.0.borrow();
         match v.get(idx) {
@@ -1752,7 +1752,7 @@ impl Locals {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn swap_loc(&mut self, idx: usize, x: Value) -> PartialVMResult<Value> {
         let mut v = self.0.borrow_mut();
         match v.get_mut(idx) {
@@ -1765,7 +1765,7 @@ impl Locals {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn move_loc(&mut self, idx: usize) -> PartialVMResult<Value> {
         match self.swap_loc(idx, Value(ValueImpl::Invalid))? {
             Value(ValueImpl::Invalid) => Err(PartialVMError::new(
@@ -1776,7 +1776,7 @@ impl Locals {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn store_loc(&mut self, idx: usize, x: Value) -> PartialVMResult<()> {
         self.swap_loc(idx, x)?;
         Ok(())
@@ -1784,7 +1784,7 @@ impl Locals {
 
     /// Drop all Move values onto a different Vec to avoid leaking memory.
     /// References are excluded since they may point to invalid data.
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn drop_all_values(&mut self) -> impl Iterator<Item = (usize, Value)> + use<> {
         let mut locals = self.0.borrow_mut();
         let mut res = vec![];
@@ -1805,7 +1805,7 @@ impl Locals {
         res.into_iter()
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn is_invalid(&self, idx: usize) -> PartialVMResult<bool> {
         let v = self.0.borrow();
         match v.get(idx) {
@@ -1883,21 +1883,21 @@ impl Value {
         )))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn struct_(s: Struct) -> Self {
         Self(ValueImpl::Container(Container::Struct(Rc::new(
             RefCell::new(s.fields),
         ))))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn vector_u8(it: impl IntoIterator<Item = u8>) -> Self {
         Self(ValueImpl::Container(Container::VecU8(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn vector_u16(it: impl IntoIterator<Item = u16>) -> Self {
         Self(ValueImpl::Container(Container::VecU16(Rc::new(
             RefCell::new(it.into_iter().collect()),
@@ -1911,35 +1911,35 @@ impl Value {
         ))))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn vector_u64(it: impl IntoIterator<Item = u64>) -> Self {
         Self(ValueImpl::Container(Container::VecU64(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn vector_u128(it: impl IntoIterator<Item = u128>) -> Self {
         Self(ValueImpl::Container(Container::VecU128(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn vector_u256(it: impl IntoIterator<Item = u256::U256>) -> Self {
         Self(ValueImpl::Container(Container::VecU256(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn vector_bool(it: impl IntoIterator<Item = bool>) -> Self {
         Self(ValueImpl::Container(Container::VecBool(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn vector_address(it: impl IntoIterator<Item = AccountAddress>) -> Self {
         Self(ValueImpl::Container(Container::VecAddress(Rc::new(
             RefCell::new(it.into_iter().collect()),
@@ -1984,7 +1984,7 @@ pub trait VMValueCast<T> {
 macro_rules! impl_vm_value_cast {
     ($ty:ty, $tc:ident) => {
         impl VMValueCast<$ty> for Value {
-            #[inline(always)]
+            #[cfg_attr(feature = "force-inline", inline(always))]
             fn cast(self) -> PartialVMResult<$ty> {
                 match self.0 {
                     ValueImpl::$tc(x) => Ok(x),
@@ -2008,7 +2008,7 @@ impl_vm_value_cast!(ContainerRef, ContainerRef);
 impl_vm_value_cast!(IndexedRef, IndexedRef);
 
 impl VMValueCast<DelayedFieldID> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<DelayedFieldID> {
         match self.0 {
             ValueImpl::DelayedFieldID { id } => Ok(id),
@@ -2023,7 +2023,7 @@ impl VMValueCast<DelayedFieldID> for Value {
 }
 
 impl VMValueCast<IntegerValue> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<IntegerValue> {
         match self.0 {
             ValueImpl::U8(x) => Ok(IntegerValue::U8(x)),
@@ -2039,7 +2039,7 @@ impl VMValueCast<IntegerValue> for Value {
 }
 
 impl VMValueCast<Reference> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<Reference> {
         match self.0 {
             ValueImpl::ContainerRef(r) => Ok(Reference(ReferenceImpl::ContainerRef(r))),
@@ -2051,7 +2051,7 @@ impl VMValueCast<Reference> for Value {
 }
 
 impl VMValueCast<Container> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<Container> {
         match self.0 {
             ValueImpl::Container(c) => Ok(c),
@@ -2062,7 +2062,7 @@ impl VMValueCast<Container> for Value {
 }
 
 impl VMValueCast<Struct> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<Struct> {
         match self.0 {
             ValueImpl::Container(Container::Struct(r)) => Ok(Struct {
@@ -2075,14 +2075,14 @@ impl VMValueCast<Struct> for Value {
 }
 
 impl VMValueCast<StructRef> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<StructRef> {
         Ok(StructRef(VMValueCast::cast(self)?))
     }
 }
 
 impl VMValueCast<Vec<u8>> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<Vec<u8>> {
         match self.0 {
             ValueImpl::Container(Container::VecU8(r)) => take_unique_ownership(r),
@@ -2093,7 +2093,7 @@ impl VMValueCast<Vec<u8>> for Value {
 }
 
 impl VMValueCast<Vec<u64>> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<Vec<u64>> {
         match self.0 {
             ValueImpl::Container(Container::VecU64(r)) => take_unique_ownership(r),
@@ -2104,7 +2104,7 @@ impl VMValueCast<Vec<u64>> for Value {
 }
 
 impl VMValueCast<Vec<Value>> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<Vec<Value>> {
         match self.0 {
             ValueImpl::Container(Container::Vec(c)) => {
@@ -2132,7 +2132,7 @@ impl VMValueCast<Vec<Value>> for Value {
 }
 
 impl VMValueCast<SignerRef> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<SignerRef> {
         match self.0 {
             ValueImpl::ContainerRef(r) => Ok(SignerRef(r)),
@@ -2143,7 +2143,7 @@ impl VMValueCast<SignerRef> for Value {
 }
 
 impl VMValueCast<VectorRef> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<VectorRef> {
         match self.0 {
             ValueImpl::ContainerRef(r) => Ok(VectorRef(r)),
@@ -2154,7 +2154,7 @@ impl VMValueCast<VectorRef> for Value {
 }
 
 impl VMValueCast<Vector> for Value {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn cast(self) -> PartialVMResult<Vector> {
         match self.0 {
             ValueImpl::Container(c) => Ok(Vector(c)),
@@ -2731,7 +2731,7 @@ pub const VEC_UNPACK_PARITY_MISMATCH: u64 = NFE_VECTOR_ERROR_BASE + 3;
 
 // TODO: this check seems to be obsolete if paranoid mode is on,
 //   and should either be removed or move over to runtime_type_checks?
-#[inline(always)]
+#[cfg_attr(feature = "force-inline", inline(always))]
 fn check_elem_layout(ty: &Type, v: &Container) -> PartialVMResult<()> {
     match (ty, v) {
         (Type::U8, Container::VecU8(_))
@@ -2779,7 +2779,7 @@ fn check_elem_layout(ty: &Type, v: &Container) -> PartialVMResult<()> {
 }
 
 impl VectorRef {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn length_as_usize(&self) -> PartialVMResult<usize> {
         let c: &Container = self.0.container();
 
@@ -2798,12 +2798,12 @@ impl VectorRef {
         Ok(len)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn len(&self) -> PartialVMResult<Value> {
         Ok(Value::u64(self.length_as_usize()? as u64))
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn push_back(&self, e: Value) -> PartialVMResult<()> {
         let c = self.0.container();
 
@@ -2824,7 +2824,7 @@ impl VectorRef {
         Ok(())
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn borrow_elem(&self, idx: usize) -> PartialVMResult<Value> {
         let c = self.0.container();
         if idx >= c.len() {
@@ -2843,7 +2843,7 @@ impl VectorRef {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn pop(&self) -> PartialVMResult<Value> {
         let c = self.0.container();
 
@@ -2898,7 +2898,7 @@ impl VectorRef {
         Ok(res)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn swap(&self, idx1: usize, idx2: usize) -> PartialVMResult<()> {
         let c = self.0.container();
 
@@ -3004,7 +3004,7 @@ impl VectorRef {
 }
 
 impl Vector {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn pack(type_param: &Type, elements: Vec<Value>) -> PartialVMResult<Value> {
         let container = match type_param {
             Type::U8 => Value::vector_u8(
@@ -3079,7 +3079,7 @@ impl Vector {
         Self::pack(type_param, vec![])
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn unpack_unchecked(self) -> PartialVMResult<Vec<Value>> {
         let elements: Vec<_> = match self.0 {
             Container::VecU8(r) => take_unique_ownership(r)?
@@ -3124,7 +3124,7 @@ impl Vector {
         Ok(elements)
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn unpack(self, expected_num: u64) -> PartialVMResult<Vec<Value>> {
         let elements = self.unpack_unchecked()?;
         if expected_num as usize == elements.len() {
@@ -3306,7 +3306,7 @@ impl Struct {
         }
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn unpack(self) -> PartialVMResult<impl Iterator<Item = Value>> {
         Ok(self.fields.into_iter().map(Value))
     }
@@ -4477,7 +4477,7 @@ impl Value {
         })
     }
 
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn deserialize_constant(constant: &Constant) -> Option<Value> {
         let layout = Self::constant_sig_token_to_layout(&constant.type_)?;
         // INVARIANT:
@@ -4691,7 +4691,7 @@ impl Struct {
 }
 
 impl Vector {
-    #[inline(always)]
+    #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn elem_views(&self) -> impl ExactSizeIterator<Item = impl ValueView + '_> + Clone {
         struct ElemView<'b> {
             container: &'b Container,
@@ -5138,7 +5138,7 @@ fn try_get_variant_field_layouts<'a>(
     None
 }
 
-#[inline(always)]
+#[cfg_attr(feature = "force-inline", inline(always))]
 fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
     if max_depth.map_or(false, |max_depth| depth > max_depth) {
         return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -390,6 +390,9 @@ impl ValueImpl {
  *
  **************************************************************************************/
 impl ValueImpl {
+    // Note(inline): recursive function, but `#[inline(always)]` seems to improve perf slightly
+    //               and doesn't add much compile time.
+    #[inline(always)]
     fn copy_value(&self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Self> {
         use ValueImpl::*;
 
@@ -464,6 +467,7 @@ impl Container {
         })
     }
 
+    // Note(inline): expensive to inline, +10s compile time
     fn copy_by_ref(&self) -> Self {
         match self {
             Self::Vec(r) => Self::Vec(Rc::clone(r)),
@@ -1049,6 +1053,7 @@ impl Value {
  **************************************************************************************/
 
 impl ContainerRef {
+    #[inline(always)]
     fn read_ref(self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Value> {
         Ok(Value(ValueImpl::Container(
             self.container().copy_value(depth, max_depth)?,
@@ -1101,6 +1106,7 @@ impl StructRef {
 }
 
 impl Reference {
+    #[inline(always)]
     pub fn read_ref(self) -> PartialVMResult<Value> {
         self.0.read_ref(1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
     }
@@ -3289,6 +3295,7 @@ impl Struct {
         }
     }
 
+    #[inline(always)]
     pub fn unpack(self) -> PartialVMResult<impl Iterator<Item = Value>> {
         Ok(self.fields.into_iter().map(Value))
     }
@@ -4459,6 +4466,7 @@ impl Value {
         })
     }
 
+    #[inline(always)]
     pub fn deserialize_constant(constant: &Constant) -> Option<Value> {
         let layout = Self::constant_sig_token_to_layout(&constant.type_)?;
         // INVARIANT:

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -274,6 +274,7 @@ pub struct Locals(Rc<RefCell<Vec<ValueImpl>>>);
  **************************************************************************************/
 
 impl Container {
+    #[inline(always)]
     fn len(&self) -> usize {
         match self {
             Self::Vec(r) => r.borrow().len(),
@@ -309,6 +310,7 @@ impl Container {
  *
  **************************************************************************************/
 
+#[inline(always)]
 fn take_unique_ownership<T: Debug>(r: Rc<RefCell<T>>) -> PartialVMResult<T> {
     match Rc::try_unwrap(r) {
         Ok(cell) => Ok(cell.into_inner()),
@@ -482,6 +484,7 @@ impl Container {
 }
 
 impl IndexedRef {
+    #[inline(always)]
     fn copy_by_ref(&self) -> Self {
         Self {
             idx: self.idx,
@@ -491,6 +494,7 @@ impl IndexedRef {
 }
 
 impl ContainerRef {
+    #[inline(always)]
     fn copy_by_ref(&self) -> Self {
         match self {
             Self::Local(container) => Self::Local(container.copy_by_ref()),
@@ -1484,6 +1488,7 @@ impl Reference {
  **************************************************************************************/
 
 impl ContainerRef {
+    #[inline(always)]
     fn borrow_elem(&self, idx: usize) -> PartialVMResult<ValueImpl> {
         let len = self.container().len();
         if idx >= len {
@@ -1610,6 +1615,7 @@ impl StructRef {
 }
 
 impl Locals {
+    #[inline(always)]
     pub fn borrow_loc(&self, idx: usize) -> PartialVMResult<Value> {
         let v = self.0.borrow();
         if idx >= v.len() {
@@ -1861,54 +1867,64 @@ impl Value {
         )))
     }
 
+    #[inline(always)]
     pub fn struct_(s: Struct) -> Self {
         Self(ValueImpl::Container(Container::Struct(Rc::new(
             RefCell::new(s.fields),
         ))))
     }
 
+    #[inline(always)]
     pub fn vector_u8(it: impl IntoIterator<Item = u8>) -> Self {
         Self(ValueImpl::Container(Container::VecU8(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
+    #[inline(always)]
     pub fn vector_u16(it: impl IntoIterator<Item = u16>) -> Self {
         Self(ValueImpl::Container(Container::VecU16(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
+
+    #[inline(always)]
     pub fn vector_u32(it: impl IntoIterator<Item = u32>) -> Self {
         Self(ValueImpl::Container(Container::VecU32(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
+    #[inline(always)]
     pub fn vector_u64(it: impl IntoIterator<Item = u64>) -> Self {
         Self(ValueImpl::Container(Container::VecU64(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
+    #[inline(always)]
     pub fn vector_u128(it: impl IntoIterator<Item = u128>) -> Self {
         Self(ValueImpl::Container(Container::VecU128(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
+    #[inline(always)]
     pub fn vector_u256(it: impl IntoIterator<Item = u256::U256>) -> Self {
         Self(ValueImpl::Container(Container::VecU256(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
+    #[inline(always)]
     pub fn vector_bool(it: impl IntoIterator<Item = bool>) -> Self {
         Self(ValueImpl::Container(Container::VecBool(Rc::new(
             RefCell::new(it.into_iter().collect()),
         ))))
     }
 
+    #[inline(always)]
     pub fn vector_address(it: impl IntoIterator<Item = AccountAddress>) -> Self {
         Self(ValueImpl::Container(Container::VecAddress(Rc::new(
             RefCell::new(it.into_iter().collect()),
@@ -4646,6 +4662,7 @@ impl Struct {
 }
 
 impl Vector {
+    #[inline(always)]
     pub fn elem_views(&self) -> impl ExactSizeIterator<Item = impl ValueView + '_> + Clone {
         struct ElemView<'b> {
             container: &'b Container,

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -1888,7 +1888,6 @@ impl Value {
         ))))
     }
 
-
     #[inline(always)]
     pub fn vector_u32(it: impl IntoIterator<Item = u32>) -> Self {
         Self(ValueImpl::Container(Container::VecU32(Rc::new(
@@ -2712,8 +2711,11 @@ pub const INDEX_OUT_OF_BOUNDS: u64 = NFE_VECTOR_ERROR_BASE + 1;
 pub const POP_EMPTY_VEC: u64 = NFE_VECTOR_ERROR_BASE + 2;
 pub const VEC_UNPACK_PARITY_MISMATCH: u64 = NFE_VECTOR_ERROR_BASE + 3;
 
+// Note(inline): Inlining all vector functions adds ~10s to compile time.
+
 // TODO: this check seems to be obsolete if paranoid mode is on,
 //   and should either be removed or move over to runtime_type_checks?
+#[inline(always)]
 fn check_elem_layout(ty: &Type, v: &Container) -> PartialVMResult<()> {
     match (ty, v) {
         (Type::U8, Container::VecU8(_))
@@ -2761,6 +2763,7 @@ fn check_elem_layout(ty: &Type, v: &Container) -> PartialVMResult<()> {
 }
 
 impl VectorRef {
+    #[inline(always)]
     pub fn length_as_usize(&self) -> PartialVMResult<usize> {
         let c: &Container = self.0.container();
 
@@ -2779,10 +2782,12 @@ impl VectorRef {
         Ok(len)
     }
 
+    #[inline(always)]
     pub fn len(&self) -> PartialVMResult<Value> {
         Ok(Value::u64(self.length_as_usize()? as u64))
     }
 
+    #[inline(always)]
     pub fn push_back(&self, e: Value) -> PartialVMResult<()> {
         let c = self.0.container();
 
@@ -2803,6 +2808,7 @@ impl VectorRef {
         Ok(())
     }
 
+    #[inline(always)]
     pub fn borrow_elem(&self, idx: usize) -> PartialVMResult<Value> {
         let c = self.0.container();
         if idx >= c.len() {
@@ -2821,6 +2827,7 @@ impl VectorRef {
         }
     }
 
+    #[inline(always)]
     pub fn pop(&self) -> PartialVMResult<Value> {
         let c = self.0.container();
 
@@ -2980,6 +2987,7 @@ impl VectorRef {
 }
 
 impl Vector {
+    #[inline(always)]
     pub fn pack(type_param: &Type, elements: Vec<Value>) -> PartialVMResult<Value> {
         let container = match type_param {
             Type::U8 => Value::vector_u8(
@@ -3054,6 +3062,7 @@ impl Vector {
         Self::pack(type_param, vec![])
     }
 
+    #[inline(always)]
     pub fn unpack_unchecked(self) -> PartialVMResult<Vec<Value>> {
         let elements: Vec<_> = match self.0 {
             Container::VecU8(r) => take_unique_ownership(r)?
@@ -3098,6 +3107,7 @@ impl Vector {
         Ok(elements)
     }
 
+    #[inline(always)]
     pub fn unpack(self, expected_num: u64) -> PartialVMResult<Vec<Value>> {
         let elements = self.unpack_unchecked()?;
         if expected_num as usize == elements.len() {

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -536,6 +536,7 @@ impl Value {
  **************************************************************************************/
 
 impl ValueImpl {
+    #[inline(always)]
     fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         use ValueImpl::*;
 
@@ -788,6 +789,7 @@ impl Container {
 }
 
 impl ContainerRef {
+    #[inline(always)]
     fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         // Note: the depth passed in accounts for the container.
         check_depth(depth, max_depth)?;
@@ -808,6 +810,7 @@ impl ContainerRef {
 }
 
 impl IndexedRef {
+    #[inline(always)]
     fn equals(&self, other: &Self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<bool> {
         use Container::*;
 
@@ -1022,6 +1025,7 @@ impl IndexedRef {
 }
 
 impl Value {
+    #[inline(always)]
     pub fn equals(&self, other: &Self) -> PartialVMResult<bool> {
         self.0
             .equals(&other.0, 1, Some(DEFAULT_MAX_VM_VALUE_NESTED_DEPTH))
@@ -1713,6 +1717,7 @@ impl SignerRef {
  *
  **************************************************************************************/
 impl Locals {
+    #[inline(always)]
     pub fn new(n: usize) -> Self {
         Self(Rc::new(RefCell::new(
             iter::repeat_with(|| ValueImpl::Invalid).take(n).collect(),
@@ -1779,6 +1784,7 @@ impl Locals {
 
     /// Drop all Move values onto a different Vec to avoid leaking memory.
     /// References are excluded since they may point to invalid data.
+    #[inline(always)]
     pub fn drop_all_values(&mut self) -> impl Iterator<Item = (usize, Value)> + use<> {
         let mut locals = self.0.borrow_mut();
         let mut res = vec![];

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -4496,6 +4496,7 @@ impl Value {
 // Locals may contain reference values that points to the same cotnainer through Rc, hencing forming
 // a cycle. Therefore values need to be manually taken out of the Locals in order to not leak memory.
 impl Drop for Locals {
+    #[cfg_attr(feature = "force-inline", inline(always))]
     fn drop(&mut self) {
         _ = self.drop_all_values();
     }


### PR DESCRIPTION
The Move VM's interpreter loop calls many small helper functions. This PR ensures calls to these functions are always inlined, reduction function call overhead significantly. 