### PR TITLE
enable lto=fat for release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -903,8 +903,9 @@ move-vm-test-utils = { path = "third_party/move/move-vm/test-utils", features = 
 move-vm-types = { path = "third_party/move/move-vm/types" }
 
 [profile.release]
-debug = true
+debug = "line-tables-only"
 overflow-checks = true
+lto = "fat"
 
 # The performance build is not currently recommended
 # for production deployments. It has not been widely tested.
@@ -926,12 +927,8 @@ codegen-units = 1
 
 [profile.ci]
 inherits = "release"
-debug = "line-tables-only"
 overflow-checks = true
 debug-assertions = true
-
-[profile.bench]
-debug = true
 
 [patch.crates-io]
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->
I've added some benchmarks on top of `aptos-vm-profiling`, I'll submit those shortly. 
From my quick tests, just enabling `lto=fat` instead of manual inlining achieves around ~13% improvement, specifically for "100 AptosCoin transfers" benchmark from `aptos-vm-profiling` the perf improves from 
(10 runs, so take either average or minimum)
```
[422.936023ms, 411.233841ms, 398.871034ms, 401.322705ms, 402.139115ms, 403.626349ms, 398.745256ms, 389.934855ms, 394.187919ms, 385.006846ms]
```
to this
```
[533.513846ms, 451.574982ms, 367.839742ms, 332.677758ms, 331.523456ms, 340.650192ms, 332.339084ms, 333.419974ms, 348.390954ms, 335.022509ms]
```
Basically 385ms -> 335ms improvement. 

Might me an alternative to 
https://github.com/aptos-labs/aptos-core/pull/17674

@vgao1996

> [!NOTE]  
> The compilation time jumps from the ~1m to 3.40m for the final binary in the `release` build. But this can be easily hidden in the separate build profile, so not a problem for the day-to-day builds. 

> [!NOTE]  
> `debug = line-tables-only` cuts the compilation times just a bit if one doesn't use the debugger. Should be no change in performance, or maybe even at improvement. 


