### PR TITLE
adding workspace start_node test - genesis issue with fv and 2.2 / v8 move version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5062,6 +5062,7 @@ dependencies = [
  "aptos-indexer-processor-sdk",
  "aptos-localnet",
  "aptos-node",
+ "aptos-temppath",
  "aptos-types",
  "bollard",
  "clap 4.5.21",

--- a/aptos-move/aptos-workspace-server/Cargo.toml
+++ b/aptos-move/aptos-workspace-server/Cargo.toml
@@ -38,3 +38,6 @@ uuid = { workspace = true }
 # indexer deps
 aptos-indexer-processor-sdk = { workspace = true }
 processor = { workspace = true }
+
+[dev-dependencies]
+aptos-temppath = { workspace = true }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
