### PR TITLE
[chore] Gas version bump for 1.38 release

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -72,7 +72,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_37;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_38;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -104,4 +104,5 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_35: u64 = 39;
     pub const RELEASE_V1_36: u64 = 40;
     pub const RELEASE_V1_37: u64 = 41;
+    pub const RELEASE_V1_38: u64 = 42;
 }


### PR DESCRIPTION
Bump gas version to 1.38 on main branch