### PR TITLE
[aptos node] disable feature flag move-vm-runtime/debugging by moving `move-cli` out of its depdency tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,7 @@ dependencies = [
  "fail",
  "futures",
  "hex",
+ "move-vm-runtime",
  "num_cpus",
  "rand 0.7.3",
  "rayon",

--- a/aptos-move/framework/Cargo.toml
+++ b/aptos-move/framework/Cargo.toml
@@ -49,7 +49,6 @@ libsecp256k1 = { workspace = true }
 log = { workspace = true }
 merlin = { workspace = true }
 move-binary-format = { workspace = true }
-move-cli = { workspace = true }
 move-command-line-common = { workspace = true }
 move-compiler-v2 = { workspace = true }
 move-core-types = { workspace = true }

--- a/aptos-move/framework/src/extended_checks.rs
+++ b/aptos-move/framework/src/extended_checks.rs
@@ -6,7 +6,6 @@ use aptos_types::vm::module_metadata::{
 };
 use legacy_move_compiler::shared::known_attributes;
 use move_binary_format::file_format::Visibility;
-use move_cli::base::test_validation;
 use move_core_types::{
     ability::{Ability, AbilitySet},
     account_address::AccountAddress,
@@ -89,14 +88,6 @@ pub fn run_extended_checks(env: &GlobalEnv) -> BTreeMap<ModuleId, RuntimeModuleM
     let mut checker = ExtendedChecker::new(env);
     checker.run();
     checker.output
-}
-
-/// Configures the move-cli unit test validation hook to run the extended checker.
-pub fn configure_extended_checks_for_unit_test() {
-    fn validate(env: &GlobalEnv) {
-        run_extended_checks(env);
-    }
-    test_validation::set_validation_hook(Box::new(validate));
 }
 
 #[derive(Debug)]

--- a/aptos-move/move-examples/tests/move_unit_tests.rs
+++ b/aptos-move/move-examples/tests/move_unit_tests.rs
@@ -8,7 +8,11 @@ use aptos_types::{
     on_chain_config::{aptos_test_feature_flags_genesis, Features, TimedFeaturesBuilder},
 };
 use aptos_vm::natives;
-use move_cli::base::test::{run_move_unit_tests, UnitTestResult};
+use move_cli::base::{
+    test::{run_move_unit_tests, UnitTestResult},
+    test_validation,
+};
+use move_model::model::GlobalEnv;
 use move_package::{source_package::std_lib::StdVersion, CompilerConfig};
 use move_unit_test::UnitTestingConfig;
 use move_vm_runtime::native_functions::NativeFunctionTable;
@@ -22,6 +26,14 @@ where
     let mut path = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     path.push(relative.into());
     path
+}
+
+/// Configures the move-cli unit test validation hook to run the extended checker.
+fn configure_extended_checks_for_unit_test() {
+    fn validate(env: &GlobalEnv) {
+        extended_checks::run_extended_checks(env);
+    }
+    test_validation::set_validation_hook(Box::new(validate));
 }
 
 pub fn run_tests_for_pkg(
@@ -58,7 +70,7 @@ pub fn run_tests_for_pkg(
 
 pub fn aptos_test_natives() -> NativeFunctionTable {
     natives::configure_for_unit_test();
-    extended_checks::configure_extended_checks_for_unit_test();
+    configure_extended_checks_for_unit_test();
     natives::aptos_natives(
         LATEST_GAS_FEATURE_VERSION,
         NativeGasParameters::zeros(),

--- a/aptos-node/Cargo.toml
+++ b/aptos-node/Cargo.toml
@@ -70,6 +70,7 @@ either = { workspace = true }
 fail = { workspace = true }
 futures = { workspace = true }
 hex = { workspace = true }
+move-vm-runtime = { workspace = true }
 num_cpus = { workspace = true }
 rand = { workspace = true }
 rayon = { workspace = true }

--- a/aptos-node/src/main.rs
+++ b/aptos-node/src/main.rs
@@ -15,6 +15,9 @@ fn main() {
     // Check that we are not including any Move test natives
     aptos_vm::natives::assert_no_test_natives(ERROR_MSG_BAD_FEATURE_FLAGS);
 
+    // Check that we do have the Move VM's tracing feature enabled
+    move_vm_runtime::tracing::assert_move_vm_tracing_feature_disabled(ERROR_MSG_BAD_FEATURE_FLAGS);
+
     // Start the node
     AptosNodeArgs::parse().run()
 }

--- a/aptos-node/src/utils.rs
+++ b/aptos-node/src/utils.rs
@@ -22,9 +22,9 @@ aptos-node was compiled with feature flags that shouldn't be enabled.
 This is caused by cargo's feature unification.
 When you compile two crates with a shared dependency, if one enables a feature flag for the dependency, then it is also enabled for the other crate.
 
-PLEASE RECOMPILE APTOS-NODE SEPARATELY using the following command:
-    cargo build --package aptos-node
-
+To resolve this issue, try the following methods:
+- Recompile `aptos-node` SEPARATELY
+- Check if a disallowed feature flag is enabled by a dependency in the build tree
 "#;
 
 /// Initializes a global rayon thread pool iff `create_global_rayon_pool` is true

--- a/crates/aptos/src/move_tool/aptos_debug_natives.rs
+++ b/crates/aptos/src/move_tool/aptos_debug_natives.rs
@@ -5,7 +5,16 @@ use aptos_framework::extended_checks;
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};
 use aptos_types::on_chain_config::{Features, TimedFeaturesBuilder};
 use aptos_vm::natives;
+use move_model::model::GlobalEnv;
 use move_vm_runtime::native_functions::NativeFunctionTable;
+
+/// Configures the move-cli unit test validation hook to run the extended checker.
+fn configure_extended_checks_for_unit_test() {
+    fn validate(env: &GlobalEnv) {
+        extended_checks::run_extended_checks(env);
+    }
+    move_cli::base::test_validation::set_validation_hook(Box::new(validate));
+}
 
 // move_stdlib has the testing feature enabled to include debug native functions
 pub fn aptos_debug_natives(
@@ -14,7 +23,7 @@ pub fn aptos_debug_natives(
 ) -> NativeFunctionTable {
     // As a side effect, also configure for unit testing
     natives::configure_for_unit_test();
-    extended_checks::configure_extended_checks_for_unit_test();
+    configure_extended_checks_for_unit_test();
     // Return all natives -- build with the 'testing' feature, therefore containing
     // debug related functions.
     natives::aptos_natives(

--- a/third_party/move/move-vm/runtime/src/tracing.rs
+++ b/third_party/move/move-vm/runtime/src/tracing.rs
@@ -2,11 +2,11 @@
 // Copyright (c) The Move Contributors
 // SPDX-License-Identifier: Apache-2.0
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 use crate::debug::DebugContext;
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 use crate::{interpreter::InterpreterDebugInterface, loader::LoadedFunction, RuntimeEnvironment};
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 use ::{
     move_binary_format::file_format::Bytecode,
     move_vm_types::values::Locals,
@@ -19,26 +19,26 @@ use ::{
     },
 };
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 const MOVE_VM_TRACING_ENV_VAR_NAME: &str = "MOVE_VM_TRACE";
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 const MOVE_VM_STEPPING_ENV_VAR_NAME: &str = "MOVE_VM_STEP";
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 static FILE_PATH: Lazy<String> = Lazy::new(|| {
     env::var(MOVE_VM_TRACING_ENV_VAR_NAME).unwrap_or_else(|_| "move_vm_trace.trace".to_string())
 });
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 pub static TRACING_ENABLED: Lazy<bool> =
     Lazy::new(|| env::var(MOVE_VM_TRACING_ENV_VAR_NAME).is_ok());
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 static DEBUGGING_ENABLED: Lazy<bool> =
     Lazy::new(|| env::var(MOVE_VM_STEPPING_ENV_VAR_NAME).is_ok());
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 pub static LOGGING_FILE_WRITER: Lazy<Mutex<std::io::BufWriter<File>>> = Lazy::new(|| {
     let file = OpenOptions::new()
         .create(true)
@@ -51,11 +51,11 @@ pub static LOGGING_FILE_WRITER: Lazy<Mutex<std::io::BufWriter<File>>> = Lazy::ne
     ))
 });
 
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 static DEBUG_CONTEXT: Lazy<Mutex<DebugContext>> = Lazy::new(|| Mutex::new(DebugContext::new()));
 
 // Only include in debug builds
-#[cfg(any(debug_assertions, feature = "debugging"))]
+#[cfg(feature = "debugging")]
 pub(crate) fn trace(
     function: &LoadedFunction,
     locals: &Locals,
@@ -91,7 +91,11 @@ pub(crate) fn trace(
 macro_rules! trace {
     ($function_desc:expr, $locals:expr, $pc:expr, $instr:tt, $resolver:expr, $interp:expr) => {
         // Only include this code in debug releases
-        #[cfg(any(debug_assertions, feature = "debugging"))]
+        #[cfg(feature = "debugging")]
         $crate::tracing::trace(&$function_desc, $locals, $pc, &$instr, $resolver, $interp)
     };
+}
+
+pub const fn assert_move_vm_tracing_feature_disabled(err_msg: &str) {
+    assert!(!cfg!(feature = "debugging"), "{}", err_msg)
 }


### PR DESCRIPTION
Right now `aptos-node` gets compiled with feature `move-vm-runtime/debugging` enabled, resulting in a few percent of perf loss. 
- This PR gets it fixed by moving the `move-cli` crate, which sets the feature flag, out of the dependency tree of `aptos-node`. 
- Additionally it also adds a check to prevent this flag cannot be accidentally enabled in the future.

I'm aware this is a dirty hack, and there are probably cleaner ways to handle this, but (1) we already have a similar check and we know it works (2) we have other important tasks to prioritize.