### PR TITLE
Bump target-cpu to x86-64-v3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -35,9 +35,23 @@ x = "run --package aptos-cargo-cli --bin aptos-cargo-cli --"
 [build]
 rustflags = ["--cfg", "tokio_unstable", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes"]
 
-# TODO(grao): Figure out whether we should enable othaer cpu features, and whether we should use a different way to configure them rather than list every single one here.
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["--cfg", "tokio_unstable", "-C", "link-arg=-fuse-ld=lld", "-C", "force-frame-pointers=yes", "-C", "force-unwind-tables=yes", "-C", "target-feature=+sse4.2"]
+rustflags = [
+  "--cfg",
+  "tokio_unstable",
+  "-C",
+  "link-arg=-fuse-ld=lld",
+  "-C",
+  "force-frame-pointers=yes",
+  "-C",
+  "force-unwind-tables=yes",
+  "-C",
+  "target-cpu=x86-64-v3",
+]
+
+# Need this for RocksDB to build until its build script is fixed.
+[env]
+CXXFLAGS_x86_64_unknown_linux_gnu = "-mpclmul"
 
 # 64 bit MSVC
 [target.x86_64-pc-windows-msvc]


### PR DESCRIPTION

Move the default CPU baseline from `x86-64` to `x86-64-v3`, enabling
AVX2/FMA/BMI1/2 and related instructions. This drops guaranteed support for very
old machines (e.g., Intel Sandy/Ivy Bridge); Haswell and newer are fine.

If older CPUs must be used, people can build things with

```
RUSTFLAGS="... -C target-cpu=x86-64-v2"
```

Benchmarks show improvements on most workloads, although not all of them (see
the updated TSV).
