### PR TITLE
[Keyless] Add simple test for pepper and address generation.

### DIFF
--- a/keyless/pepper/service/src/tests/mod.rs
+++ b/keyless/pepper/service/src/tests/mod.rs
@@ -5,4 +5,4 @@ mod jwk_fetcher;
 mod pepper_request;
 mod request_handler;
 mod resource_fetcher;
-mod utils;
+pub mod utils;


### PR DESCRIPTION
## Description
This PR adds several simple tests for pepper and account address generation in the pepper service. These are currently missing, making it difficult to ensure backward compatibility and prevent breakages. To construct these values, I did the following:
1. Wrote the tests, ran them and saved the outputs as hard-coded test constants (as you see in the files here).
2. Checked out this commit of the codebase: https://github.com/aptos-labs/aptos-core/commit/b1ffc171bcf8dee3ba48c0c63686ae0a1feece49 (before any of my changes were made), and added equivalent versions of these tests to ensure the same values were produced. This was the case, thus verifying that no "trivial breakages" were detected.

## Testing Plan
New and existing test infrastructure.