### PR TITLE
[Telemetry] Improve environment variable handling.

### DIFF
--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -46,48 +46,66 @@ static TELEMETRY_TOKEN: Lazy<String> = Lazy::new(|| {
     format!("TOKEN_{:?}", token)
 });
 
+/// Returns true iff the given environment variable is set to true. Note: true
+/// values are "true", "t", "1", "yes" or "y" (all case-insensitive). Any other
+/// values are considered false (including when the variable is not set).
+#[inline]
+fn is_env_variable_true(env_variable: &str) -> bool {
+    match env::var(env_variable) {
+        Ok(value) => {
+            matches!(
+                value.to_lowercase().as_str(),
+                "true" | "t" | "1" | "yes" | "y"
+            )
+        },
+        Err(_) => false,
+    }
+}
+
 /// Returns true iff telemetry is disabled
 #[inline]
 pub fn telemetry_is_disabled() -> bool {
-    env::var(ENV_APTOS_DISABLE_TELEMETRY).is_ok()
+    is_env_variable_true(ENV_APTOS_DISABLE_TELEMETRY)
 }
 
 /// Flag to force enabling/disabling of telemetry
 #[inline]
 fn force_enable_telemetry() -> bool {
-    env::var(ENV_APTOS_FORCE_ENABLE_TELEMETRY).is_ok()
+    is_env_variable_true(ENV_APTOS_FORCE_ENABLE_TELEMETRY)
 }
 
 /// Flag to control enabling/disabling prometheus push metrics
 #[inline]
 fn enable_prometheus_push_metrics() -> bool {
     force_enable_telemetry()
-        || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_TELEMETRY_PUSH_METRICS).is_ok())
+        || !(telemetry_is_disabled()
+            || is_env_variable_true(ENV_APTOS_DISABLE_TELEMETRY_PUSH_METRICS))
 }
 
 #[inline]
 fn enable_prometheus_node_metrics() -> bool {
-    env::var(ENV_APTOS_DISABLE_PROMETHEUS_NODE_METRICS).is_err()
+    !is_env_variable_true(ENV_APTOS_DISABLE_PROMETHEUS_NODE_METRICS)
 }
 
 /// Flag to control enabling/disabling push logs
 #[inline]
 fn enable_push_logs() -> bool {
     force_enable_telemetry()
-        || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_TELEMETRY_PUSH_LOGS).is_ok())
+        || !(telemetry_is_disabled() || is_env_variable_true(ENV_APTOS_DISABLE_TELEMETRY_PUSH_LOGS))
 }
 
 /// Flag to control enabling/disabling telemetry push events
 #[inline]
 fn enable_push_custom_events() -> bool {
     force_enable_telemetry()
-        || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_TELEMETRY_PUSH_EVENTS).is_ok())
+        || !(telemetry_is_disabled()
+            || is_env_variable_true(ENV_APTOS_DISABLE_TELEMETRY_PUSH_EVENTS))
 }
 
 #[inline]
 fn enable_log_env_polling() -> bool {
     force_enable_telemetry()
-        || !(telemetry_is_disabled() || env::var(ENV_APTOS_DISABLE_LOG_ENV_POLLING).is_ok())
+        || !(telemetry_is_disabled() || is_env_variable_true(ENV_APTOS_DISABLE_LOG_ENV_POLLING))
 }
 
 /// Starts the telemetry service and returns the execution runtime.


### PR DESCRIPTION
## Description
This PR improves environment variable handling for telemetry. Currently, if an environment variable is set to false (e.g., `ENV_APTOS_DISABLE_TELEMETRY=false`), the code treats the variable as true (because it only checks for the presence of the variable). Instead, we now check for "truth" values, e.g., `true`, `1`, `yes`, etc.

## Testing Plan
Manual verification.