### PR TITLE
[Storage Service] Remove auxiliary data support.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -12,7 +12,7 @@ use serde_yaml::Value;
 
 // Whether to enable size and time-aware chunking (for non-production networks).
 // Note: once this becomes stable, we should enable it for all networks (e.g., Mainnet).
-const ENABLE_SIZE_AND_TIME_AWARE_CHUNKING: bool = false;
+const ENABLE_SIZE_AND_TIME_AWARE_CHUNKING: bool = true;
 
 // The maximum message size per state sync message
 const SERVER_MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
@@ -832,7 +832,6 @@ mod tests {
         );
     }
 
-    #[ignore] // TODO: revert when size and time-aware chunking is healthy
     #[test]
     fn test_optimize_storage_service_devnet() {
         // Create a node config with size and time-aware chunking disabled
@@ -862,7 +861,6 @@ mod tests {
         assert!(storage_service_config.enable_size_and_time_aware_chunking);
     }
 
-    #[ignore] // TODO: revert when size and time-aware chunking is healthy
     #[test]
     fn test_optimize_storage_service_mainnet() {
         // Create a node config with size and time-aware chunking disabled

--- a/state-sync/storage-service/server/src/tests/mock.rs
+++ b/state-sync/storage-service/server/src/tests/mock.rs
@@ -45,9 +45,9 @@ use aptos_types::{
         state_value::{StateValue, StateValueChunkWithProof},
     },
     transaction::{
-        AccountOrderedTransactionsWithProof, PersistedAuxiliaryInfo, Transaction,
-        TransactionAuxiliaryData, TransactionInfo, TransactionListWithProofV2,
-        TransactionOutputListWithProofV2, TransactionWithProof, Version,
+        AccountOrderedTransactionsWithProof, PersistedAuxiliaryInfo, Transaction, TransactionInfo,
+        TransactionListWithProofV2, TransactionOutputListWithProofV2, TransactionWithProof,
+        Version,
     },
     write_set::WriteSet,
     PeerId,
@@ -396,12 +396,6 @@ mock! {
             start_version: Version,
             limit: u64,
         ) -> aptos_storage_interface::Result<Box<dyn Iterator<Item = aptos_storage_interface::Result<WriteSet>>>>;
-
-        fn get_auxiliary_data_iterator(
-            &self,
-            start_version: Version,
-            limit: u64,
-        ) -> aptos_storage_interface::Result<Box<dyn Iterator<Item = aptos_storage_interface::Result<TransactionAuxiliaryData>>>>;
 
         fn get_transaction_accumulator_range_proof(
             &self,

--- a/state-sync/storage-service/server/src/tests/utils.rs
+++ b/state-sync/storage-service/server/src/tests/utils.rs
@@ -612,19 +612,6 @@ pub fn expect_get_transaction_outputs(
         .returning(move |_, _| Ok(Box::new(events_iterator.clone())))
         .in_sequence(&mut expectation_sequence);
 
-    // Expect a call to get an auxiliary data iterator
-    let auxiliary_data_iterator = output_list_with_proof
-        .clone()
-        .transactions_and_outputs
-        .into_iter()
-        .map(|(_, output)| Ok(output.auxiliary_data().clone()));
-    mock_db
-        .expect_get_auxiliary_data_iterator()
-        .times(1)
-        .with(eq(start_version), eq(num_items))
-        .returning(move |_, _| Ok(Box::new(auxiliary_data_iterator.clone())))
-        .in_sequence(&mut expectation_sequence);
-
     // Expect a call to get a persisted auxiliary info iterator
     let persisted_auxiliary_info_iterator = persisted_auxiliary_infos.clone().into_iter().map(Ok);
     mock_db

--- a/storage/aptosdb/src/db/aptosdb_reader.rs
+++ b/storage/aptosdb/src/db/aptosdb_reader.rs
@@ -545,26 +545,6 @@ impl DbReader for AptosDB {
         })
     }
 
-    fn get_auxiliary_data_iterator(
-        &self,
-        start_version: Version,
-        limit: u64,
-    ) -> Result<Box<dyn Iterator<Item = Result<TransactionAuxiliaryData>> + '_>> {
-        gauged_api("get_auxiliary_data_iterator", || {
-            error_if_too_many_requested(limit, MAX_REQUEST_LIMIT)?;
-            self.error_if_ledger_pruned("Transaction", start_version)?;
-
-            let iter = self
-                .ledger_db
-                .transaction_auxiliary_data_db()
-                .get_transaction_auxiliary_data_iter(start_version, limit as usize)?;
-            Ok(Box::new(iter)
-                as Box<
-                    dyn Iterator<Item = Result<TransactionAuxiliaryData>> + '_,
-                >)
-        })
-    }
-
     fn get_transaction_accumulator_range_proof(
         &self,
         first_version: Version,

--- a/storage/storage-interface/src/lib.rs
+++ b/storage/storage-interface/src/lib.rs
@@ -239,13 +239,6 @@ pub trait DbReader: Send + Sync {
             limit: u64,
         ) -> Result<Box<dyn Iterator<Item = Result<WriteSet>> + '_>>;
 
-        /// Returns an iterator of transaction auxiliary data starting from the given version.
-        fn get_auxiliary_data_iterator(
-            &self,
-            start_version: Version,
-            limit: u64,
-        ) -> Result<Box<dyn Iterator<Item = Result<TransactionAuxiliaryData>> + '_>>;
-
         fn get_transaction_accumulator_range_proof(
             &self,
             start_version: Version,


### PR DESCRIPTION
## Description
This PR removes auxiliary data support from the storage service in state sync. This feature is no longer supported, and caused issues with the new size and time-aware chunking logic.

## Testing Plan
Existing test infrastructure.
