### PR TITLE
[Executor] Move unused deps

### DIFF
--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -24,7 +24,6 @@ aptos-experimental-runtimes = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
-aptos-sdk = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-types = { workspace = true }
 aptos-vm = { workspace = true }
@@ -44,6 +43,7 @@ aptos-db = { workspace = true }
 aptos-db-indexer = { workspace = true, features = ["fuzzing"] }
 aptos-executor-test-helpers = { workspace = true }
 aptos-indexer-grpc-table-info = { workspace = true }
+aptos-sdk = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-temppath = { workspace = true }
 aptos-transaction-simulation = { workspace = true }


### PR DESCRIPTION

Cuts about 50~60 packages in dependency for executor-benchmark.
