### PR TITLE
fix: print a nice error when there are no tests in the package and co…

### DIFF
--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -646,23 +646,28 @@ impl CliCommand<&'static str> for TestPackage {
 
         // Print coverage summary if --coverage is set
         if self.compute_coverage {
-            // TODO: config seems to be dead here.
-            config.test_mode = false;
-            let summary = SummaryCoverage {
-                summarize_functions: false,
-                output_csv: false,
-                filter: self.filter,
-                common: CoverageCommon::default(),
-                move_options: self.move_options,
-            };
-            summary.coverage()?;
+            if UnitTestResult::Success == result {
+                // TODO: config seems to be dead here.
+                config.test_mode = false;
+                let summary = SummaryCoverage {
+                    summarize_functions: false,
+                    output_csv: false,
+                    filter: self.filter,
+                    common: CoverageCommon::default(),
+                    move_options: self.move_options,
+                };
+                summary.coverage()?;
 
-            println!("Please use `aptos move coverage -h` for more detailed source or bytecode test coverage of this package");
+                println!("Please use `aptos move coverage -h` for more detailed source or bytecode test coverage of this package");
+            }
+        }
+        if UnitTestResult::NoTests == result {
+            println!("No tests found - coverage map not generated");
         }
 
         match result {
             UnitTestResult::Success => Ok("Success"),
-            UnitTestResult::Failure => Err(CliError::MoveTestError),
+            UnitTestResult::NoTests | UnitTestResult::Failure => Err(CliError::MoveTestError),
         }
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -666,8 +666,8 @@ impl CliCommand<&'static str> for TestPackage {
         }
 
         match result {
-            UnitTestResult::Success => Ok("Success"),
-            UnitTestResult::NoTests | UnitTestResult::Failure => Err(CliError::MoveTestError),
+            UnitTestResult::Success | UnitTestResult::NoTests => Ok("Success"),
+            UnitTestResult::Failure => Err(CliError::MoveTestError),
         }
     }
 }

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -660,9 +660,9 @@ impl CliCommand<&'static str> for TestPackage {
 
                 println!("Please use `aptos move coverage -h` for more detailed source or bytecode test coverage of this package");
             }
-        }
-        if UnitTestResult::NoTests == result {
-            println!("No tests found - coverage map not generated");
+            if UnitTestResult::NoTests == result {
+                println!("No tests found - coverage map not generated");
+            }
         }
 
         match result {

--- a/third_party/move/tools/move-unit-test/src/package_test.rs
+++ b/third_party/move/tools/move-unit-test/src/package_test.rs
@@ -36,6 +36,7 @@ compile_error!("Unsupported OS, currently we only support windows and unix famil
 #[derive(PartialEq, Eq, Debug)]
 pub enum UnitTestResult {
     Success,
+    NoTests,
     Failure,
 }
 
@@ -206,13 +207,17 @@ pub fn run_move_unit_tests_with_factory<W: Write + Send, F: UnitTestFactory + Se
         output_map_to_file(&coverage_map_path, &coverage_map)?;
     }
     cleanup_trace();
-    Ok(UnitTestResult::Success)
+    if no_tests {
+        Ok(UnitTestResult::NoTests)
+    } else {
+        Ok(UnitTestResult::Success)
+    }
 }
 
 impl From<UnitTestResult> for ExitStatus {
     fn from(result: UnitTestResult) -> Self {
         match result {
-            UnitTestResult::Success => ExitStatus::from_raw(0),
+            UnitTestResult::Success | UnitTestResult::NoTests => ExitStatus::from_raw(0),
             UnitTestResult::Failure => ExitStatus::from_raw(1),
         }
     }


### PR DESCRIPTION
…verage was requested

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

https://github.com/aptos-labs/aptos-core/issues/13593

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Manually ran `aptos move test --coverage` on a package with no tests. Output is now:
```
aptos move test --coverage --package-dir /home/jos/Projects/move-mutation-tools/move-mutator/tests/move-assets/basic_coin/                                                                                               ✔   8m 35s  󰌠 3.13.7  11:35:18
INCLUDING DEPENDENCY AptosStdlib
INCLUDING DEPENDENCY MoveStdlib
BUILDING basic_coin

Running Move unit tests
Test result: OK. Total tests: 0; passed: 0; failed: 0
No tests found - coverage map not generated
{
  "Result": "Success"
}
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to CLI/test tooling result handling and coverage generation gating; minimal risk beyond altering success/coverage behavior for empty test suites.
> 
> **Overview**
> Fixes `aptos move test --coverage` behavior for packages with zero unit tests by introducing a distinct `UnitTestResult::NoTests` outcome and treating it as a successful exit.
> 
> Coverage map generation and CLI coverage summarization are now skipped when no tests are present, and the CLI prints a clear message (`No tests found - coverage map not generated`) instead of attempting coverage processing.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbed0d4449e860993b0954503f980b2360f303f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->