### PR TITLE
[lint] Added random_modulo linter

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -329,6 +329,7 @@ dependencies = [
  "aptos-localnet",
  "aptos-logger",
  "aptos-move-debugger",
+ "aptos-move-linter",
  "aptos-network-checker",
  "aptos-node",
  "aptos-rest-client",
@@ -3133,6 +3134,22 @@ dependencies = [
  "move-unit-test",
  "move-vm-runtime",
  "tempfile",
+]
+
+[[package]]
+name = "aptos-move-linter"
+version = "0.1.0"
+dependencies = [
+ "codespan-reporting",
+ "datatest-stable",
+ "legacy-move-compiler",
+ "move-binary-format",
+ "move-compiler-v2",
+ "move-model",
+ "move-prover-test-utils",
+ "move-stackless-bytecode",
+ "num 0.4.1",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -392,6 +392,7 @@ aptos-localnet = { path = "crates/aptos-localnet" }
 aptos-log-derive = { path = "crates/aptos-log-derive" }
 aptos-logger = { path = "crates/aptos-logger" }
 aptos-memory-usage-tracker = { path = "aptos-move/aptos-memory-usage-tracker" }
+aptos-move-linter = { path = "aptos-move/aptos-move-linter" }
 aptos-mempool = { path = "mempool" }
 aptos-mempool-notifications = { path = "state-sync/inter-component/mempool-notifications" }
 aptos-memsocket = { path = "network/memsocket" }

--- a/aptos-move/aptos-move-linter/Cargo.toml
+++ b/aptos-move/aptos-move-linter/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "aptos-move-linter"
+description = "The Move Linter"
+version = "0.1.0"
+
+# Workspace inherited keys
+authors = { workspace = true }
+edition = { workspace = true }
+homepage = { workspace = true }
+license = { workspace = true }
+publish = { workspace = true }
+repository = { workspace = true }
+rust-version = { workspace = true }
+
+[dependencies]
+codespan-reporting = { workspace = true }
+legacy-move-compiler = { workspace = true }
+move-binary-format = { workspace = true }
+move-compiler-v2 = { workspace = true }
+move-model = { workspace = true }
+move-stackless-bytecode = { workspace = true }
+num = { workspace = true }
+once_cell = { workspace = true }
+
+[dev-dependencies]
+datatest-stable = { workspace = true }
+move-prover-test-utils = { workspace = true }
+
+[features]
+default = []
+
+[[test]]
+name = "testsuite"
+harness = false
+
+[lib]
+doctest = false

--- a/aptos-move/aptos-move-linter/src/lib.rs
+++ b/aptos-move/aptos-move-linter/src/lib.rs
@@ -1,0 +1,43 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+mod model_ast_lints;
+mod stackless_bytecode_lints;
+use move_compiler_v2::external_checks::{ExpChecker, ExternalChecks, StacklessBytecodeChecker};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+/// Holds collection of lint checks for Move.
+pub struct SecurityChecks {
+    config: BTreeMap<String, String>,
+}
+
+impl ExternalChecks for SecurityChecks {
+    fn get_exp_checkers(&self) -> Vec<Box<dyn ExpChecker>> {
+        model_ast_lints::get_default_linter_pipeline(&self.config)
+    }
+
+    fn get_stackless_bytecode_checkers(&self) -> Vec<Box<dyn StacklessBytecodeChecker>> {
+        stackless_bytecode_lints::get_default_linter_pipeline(&self.config)
+    }
+}
+
+impl SecurityChecks {
+    /// Make an instance of lint checks for Move, provided as `ExternalChecks`.
+    /// Will panic if the configuration is not valid.
+    pub fn make(config: BTreeMap<String, String>) -> Arc<dyn ExternalChecks> {
+        // Check whether the config map is valid.
+        // Currently, we expect it to contain a single key "checks" that can map to
+        // one of the three string values: "default", "strict", or "experimental".
+        if config.len() != 1 {
+            panic!("config should have a single key `checks`");
+        }
+        let checks_value = config
+            .get("checks")
+            .expect("config is missing the `checks` key");
+        if !matches!(checks_value.as_str(), "default" | "strict" | "experimental") {
+            panic!("Invalid value for `checks` key in the config, expected one of: `default`, `strict`, or `experimental`");
+        }
+        Arc::new(SecurityChecks { config })
+    }
+}

--- a/aptos-move/aptos-move-linter/src/model_ast_lints.rs
+++ b/aptos-move/aptos-move-linter/src/model_ast_lints.rs
@@ -1,0 +1,22 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module (and its submodules) contain various model-AST-based lint checks.
+
+use move_compiler_v2::external_checks::ExpChecker;
+use std::collections::BTreeMap;
+mod random_modulo;
+
+/// Returns a default pipeline of "expression linters" to run.
+pub fn get_default_linter_pipeline(config: &BTreeMap<String, String>) -> Vec<Box<dyn ExpChecker>> {
+    #[allow(unused_mut)]
+    let mut checks: Vec<Box<dyn ExpChecker>> = vec![Box::<random_modulo::RandomModulo>::default()];
+    let checks_category = config.get("checks").map_or("default", |s| s.as_str());
+    if checks_category == "strict" || checks_category == "experimental" {
+        // Push strict checks to `checks`.
+    }
+    if checks_category == "experimental" {
+        // Push experimental checks to `checks`.
+    }
+    checks
+}

--- a/aptos-move/aptos-move-linter/src/model_ast_lints/random_modulo.rs
+++ b/aptos-move/aptos-move-linter/src/model_ast_lints/random_modulo.rs
@@ -1,0 +1,65 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module implements an expression linter that checks for calls to
+//! aptos_framework::randomness::u*_integer() whose results are passed as the
+//! dividend to a modulo operation.
+
+use move_compiler_v2::external_checks::ExpChecker;
+use move_model::{
+    ast::{ExpData, Operation},
+    model::FunctionEnv,
+};
+use once_cell::sync::Lazy;
+use std::collections::HashMap;
+
+static FUNCTIONS: Lazy<HashMap<String, String>> = Lazy::new(|| {
+    let mut ret = HashMap::new();
+    for i in 0..6 {
+        let k = format!("randomness::u{}_integer", 8 << i);
+        let v = format!("u{}_range", 8 << i);
+        ret.insert(k, v);
+    }
+    ret
+});
+
+#[derive(Default)]
+pub struct RandomModulo;
+
+impl ExpChecker for RandomModulo {
+    fn get_name(&self) -> String {
+        "random_modulo".to_string()
+    }
+
+    fn visit_expr_pre(&mut self, function: &FunctionEnv, expr: &ExpData) {
+        let env = function.env();
+
+        let ExpData::Call(node_id, Operation::Mod, exps) = expr else {
+            return;
+        };
+
+        if exps.len() != 2 {
+            return;
+        }
+
+        let Some(first) = exps.first() else {
+            return;
+        };
+        let ExpData::Call(node_id2, f, args) = first as &ExpData else {
+            return;
+        };
+        if !matches!(f, Operation::MoveFunction(_, _)) {
+            return;
+        }
+        let s = f.display(env, *node_id2).to_string();
+        if !args.is_empty() {
+            return;
+        }
+
+        let Some(suggestion) = FUNCTIONS.get(&s) else {
+            return;
+        };
+
+        self.report(env, &env.get_node_loc(*node_id), format!("Using % to generate random numbers may introduce bias. Consider using {}(0, N) instead", suggestion).as_str());
+    }
+}

--- a/aptos-move/aptos-move-linter/src/stackless_bytecode_lints.rs
+++ b/aptos-move/aptos-move-linter/src/stackless_bytecode_lints.rs
@@ -1,0 +1,16 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module (and its submodules) contain various stackless-bytecode-based lint checks.
+//! Live variable analysis is a prerequisite for this lint processor.
+//! The lint checks also assume that all the correctness checks have already been performed.
+
+use move_compiler_v2::external_checks::StacklessBytecodeChecker;
+use std::collections::BTreeMap;
+
+/// Get default pipeline of "stackless bytecode linters" to run.
+pub fn get_default_linter_pipeline(
+    _config: &BTreeMap<String, String>,
+) -> Vec<Box<dyn StacklessBytecodeChecker>> {
+    vec![]
+}

--- a/aptos-move/aptos-move-linter/src/utils.rs
+++ b/aptos-move/aptos-move-linter/src/utils.rs
@@ -1,0 +1,36 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! This module holds utility functions for the Move linter.
+
+use move_model::ast::{ExpData, Operation};
+
+/// Returns `true` if two expressions represent the same simple access pattern.
+/// This compares nested `Select`, `Borrow`, and local variable references for structural equality.
+/// `Deref` calls can occur anywhere without affecting the result.
+/// Patterns that use global storage or non-builtin function (including vector operations)
+/// are not considered simple access patterns for the purpose of this function and return `false`.
+#[allow(dead_code)]
+pub(crate) fn is_simple_access_equal(expr1: &ExpData, expr2: &ExpData) -> bool {
+    match (expr1, expr2) {
+        (ExpData::Call(_, Operation::Deref, args), expr)
+        | (expr, ExpData::Call(_, Operation::Deref, args)) => {
+            is_simple_access_equal(&args[0], expr)
+        },
+        (ExpData::Call(_, op1, args1), ExpData::Call(_, op2, args2)) => {
+            op1 == op2
+                && matches!(
+                    op1,
+                    Operation::Select(_, _, _)
+                        | Operation::Borrow(_)
+                        | Operation::SelectVariants(_, _, _)
+                )
+                && args1
+                    .iter()
+                    .zip(args2.iter())
+                    .all(|(a1, a2)| is_simple_access_equal(a1, a2))
+        },
+        (ExpData::LocalVar(_, s1), ExpData::LocalVar(_, s2)) => s1 == s2,
+        _ => false,
+    }
+}

--- a/aptos-move/aptos-move-linter/tests/model_ast_lints/random_modulo.exp
+++ b/aptos-move/aptos-move-linter/tests/model_ast_lints/random_modulo.exp
@@ -1,0 +1,109 @@
+
+Diagnostics:
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u8_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:18:19
+   │
+18 │         let ret = (u8_integer() % 251) as u256;
+   │                   ^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u16_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:19:16
+   │
+19 │         ret += (u16_integer() % 65521) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u32_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:20:16
+   │
+20 │         ret += (u32_integer() % 2147483647) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u64_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:21:16
+   │
+21 │         ret += (u64_integer() % 2305843009213693951) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u128_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:22:16
+   │
+22 │         ret += (u128_integer() % 170141183460469231731687303715884105727) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u256_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:23:16
+   │
+23 │         ret += u256_integer() % 77194726158210796949047323339125271902179989777093709359638389338608753093290;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u8_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:28:19
+   │
+28 │         let ret = (u8_integer() % (u8_range(0, 251) ^ 0xAA)) as u256;
+   │                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u16_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:29:16
+   │
+29 │         ret += (u16_integer() % (u16_range(0, 65521) ^ 0xAAAA)) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u32_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:30:16
+   │
+30 │         ret += (u32_integer() % (u32_range(0, 2147483647) ^ 0xAAAAAAAA)) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u64_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:31:16
+   │
+31 │         ret += (u64_integer() % (u64_range(0, 2305843009213693951) ^ 0xAAAAAAAA)) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u128_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:32:16
+   │
+32 │         ret += (u128_integer() % (u128_range(0, 170141183460469231731687303715884105727) ^ 0xAAAAAAAAAAAAAAAA)) as u256;
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.
+
+warning: [lint] Using % to generate random numbers may introduce bias. Consider using u256_range(0, N) instead
+   ┌─ tests/model_ast_lints/random_modulo.move:33:16
+   │
+33 │         ret += u256_integer() % (u256_range(0, 77194726158210796949047323339125271902179989777093709359638389338608753093290) ^ 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
+   │                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(random_modulo)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#random_modulo.

--- a/aptos-move/aptos-move-linter/tests/model_ast_lints/random_modulo.move
+++ b/aptos-move/aptos-move-linter/tests/model_ast_lints/random_modulo.move
@@ -1,0 +1,36 @@
+module 0xc0ffee::m {
+    use aptos_framework::randomness::{
+        u8_integer,
+        u8_range,
+        u16_integer,
+        u16_range,
+        u32_integer,
+        u32_range,
+        u64_integer,
+        u64_range,
+        u128_integer,
+        u128_range,
+        u256_integer,
+        u256_range,
+    };
+
+    public fun test1_warn(): u256 {
+        let ret = (u8_integer() % 251) as u256;
+        ret += (u16_integer() % 65521) as u256;
+        ret += (u32_integer() % 2147483647) as u256;
+        ret += (u64_integer() % 2305843009213693951) as u256;
+        ret += (u128_integer() % 170141183460469231731687303715884105727) as u256;
+        ret += u256_integer() % 77194726158210796949047323339125271902179989777093709359638389338608753093290;
+        ret
+    }
+
+    public fun test2_warn(): u256 {
+        let ret = (u8_integer() % (u8_range(0, 251) ^ 0xAA)) as u256;
+        ret += (u16_integer() % (u16_range(0, 65521) ^ 0xAAAA)) as u256;
+        ret += (u32_integer() % (u32_range(0, 2147483647) ^ 0xAAAAAAAA)) as u256;
+        ret += (u64_integer() % (u64_range(0, 2305843009213693951) ^ 0xAAAAAAAA)) as u256;
+        ret += (u128_integer() % (u128_range(0, 170141183460469231731687303715884105727) ^ 0xAAAAAAAAAAAAAAAA)) as u256;
+        ret += u256_integer() % (u256_range(0, 77194726158210796949047323339125271902179989777093709359638389338608753093290) ^ 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA);
+        ret
+    }
+}

--- a/aptos-move/aptos-move-linter/tests/testsuite.rs
+++ b/aptos-move/aptos-move-linter/tests/testsuite.rs
@@ -1,0 +1,78 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_move_linter::SecurityChecks;
+use codespan_reporting::{diagnostic::Severity, term::termcolor::Buffer};
+use move_compiler_v2::{diagnostics::human::HumanEmitter, run_move_compiler, Experiment};
+use move_model::metadata::{CompilerVersion, LanguageVersion};
+use move_prover_test_utils::baseline_test;
+use std::{
+    collections::BTreeMap,
+    path::{Path, PathBuf},
+};
+
+/// Extension for expected output files.
+pub const EXP_EXT: &str = "exp";
+
+datatest_stable::harness!(test_runner, "tests", r".*\.move$");
+
+fn test_runner(path: &Path) -> datatest_stable::Result<()> {
+    let compiler_options = move_compiler_v2::Options {
+        sources: vec![path.display().to_string()],
+        dependencies: vec![
+            path_from_crate_root("../framework/aptos-stdlib/sources"),
+            path_from_crate_root("../framework/move-stdlib/sources"),
+            path_from_crate_root("../framework/aptos-framework/sources"),
+        ],
+        named_address_mapping: vec![
+            "std=0x1".to_string(),
+            "aptos_std=0x1".to_string(),
+            "aptos_framework=0x1".to_string(),
+            "vm=0x0".to_string(),
+            "vm_reserved=0x0".to_string(),
+            "core_resources=0x0".to_string(),
+            "aptos_fungible_asset=0x0".to_string(),
+            "aptos_token=0x0".to_string(),
+        ],
+        language_version: Some(LanguageVersion::latest_stable()),
+        compiler_version: Some(CompilerVersion::latest_stable()),
+        experiments: vec![Experiment::LINT_CHECKS.to_string()],
+        external_checks: vec![SecurityChecks::make(BTreeMap::from([(
+            "checks".to_string(),
+            "experimental".to_string(),
+        )]))],
+        ..Default::default()
+    };
+    let mut output = String::new();
+    let mut error_writer = Buffer::no_color();
+    let mut emitter = HumanEmitter::new(&mut error_writer);
+    match run_move_compiler(&mut emitter, compiler_options) {
+        Err(e) => {
+            output.push_str(&format!(
+                "Aborting with compilation errors:\n{:#}\n{}\n",
+                e,
+                String::from_utf8_lossy(&error_writer.into_inner())
+            ));
+        },
+        Ok((env, _)) => {
+            env.report_diag(&mut error_writer, Severity::Warning);
+            let diag = String::from_utf8_lossy(&error_writer.into_inner()).to_string();
+            if !diag.is_empty() {
+                output.push_str(&format!("\nDiagnostics:\n{}", diag));
+            } else {
+                output.push_str("\nNo errors or warnings!");
+            }
+        },
+    }
+    // Generate/check baseline.
+    let baseline_path = path.with_extension(EXP_EXT);
+    baseline_test::verify_or_update_baseline(baseline_path.as_path(), &output)?;
+    Ok(())
+}
+
+/// Returns a path relative to the crate root.
+fn path_from_crate_root(path: &str) -> String {
+    let mut buf = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    buf.push(path);
+    buf.to_string_lossy().to_string()
+}

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -36,6 +36,7 @@ aptos-ledger = { workspace = true }
 aptos-localnet = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-move-debugger = { workspace = true }
+aptos-move-linter = { workspace = true }
 aptos-network-checker = { workspace = true }
 aptos-node = { workspace = true }
 aptos-rest-client = { workspace = true }

--- a/crates/aptos/src/move_tool/lint.rs
+++ b/crates/aptos/src/move_tool/lint.rs
@@ -11,6 +11,7 @@ use async_trait::async_trait;
 use clap::Parser;
 use move_compiler_v2::Experiment;
 use move_linter::MoveLintChecks;
+use aptos_move_linter::SecurityChecks;
 use move_model::metadata::{CompilerVersion, LanguageVersion, LATEST_STABLE_LANGUAGE_VERSION};
 use move_package::source_package::std_lib::StdVersion;
 use std::{collections::BTreeMap, path::PathBuf, str::FromStr};
@@ -184,13 +185,15 @@ impl CliCommand<&'static str> for LintPackage {
         let build_config = BuiltPackage::create_build_config(&build_options)?;
         let resolved_graph =
             BuiltPackage::prepare_resolution_graph(package_path, build_config.clone())?;
+        let config = self.checks.unwrap_or_default().to_config();
         BuiltPackage::build_with_external_checks(
             resolved_graph,
             build_options,
             build_config,
-            vec![MoveLintChecks::make(
-                self.checks.unwrap_or_default().to_config(),
-            )],
+            vec![
+                MoveLintChecks::make(config.clone()),
+                SecurityChecks::make(config),
+            ],
         )?;
 
         Ok("succeeded")


### PR DESCRIPTION
## Description
This security check searches for calls to aptos_framework::randomness::u*_integer() whose results are passed as the dividend to a modulo operation, and suggests using aptos_framework::randomness::u*_range() instead.

## How Has This Been Tested?
Test cases have been added to the move lint unit tests.
Additionally, the linter has been run on the crates in the aptos-move/framework subdirectory, with the following results:
Crate | Result | Notes
-- | -- | --
aptos-experimental | No warnings |
aptos-framework | No warnings |
aptos-stdlib | No warnings |  
aptos-token | No warnings |  
aptos-token-objects | No warnings |  
move-stdlib | No warnings |  

## Key Areas to Review
The key change is to aptos-move/aptos-move-linter/src/model_ast_lints/random_modulo.rs as well as to the entire aptos-move/aptos-move-linter subdirectory.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Move linter
