### PR TITLE
Allow scheduling replay-verify shards on T2D

### DIFF
--- a/testsuite/replay-verify/replay-verify-worker-template.yaml
+++ b/testsuite/replay-verify/replay-verify-worker-template.yaml
@@ -43,6 +43,7 @@ spec:
             - key: cloud.google.com/machine-family
               operator: In
               values:
+              - "t2d"
               - "c3d"
             - key: node-restriction.kubernetes.io/aptos-workload
               operator: In


### PR DESCRIPTION
## Description

Add T2D to the allowed machine families for replay-verify.