### PR TITLE
Update a few packages to latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -660,7 +660,7 @@ dependencies = [
  "tokio",
  "tokio-io-timeout",
  "tokio-stream",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "warp",
 ]
 
@@ -2495,7 +2495,7 @@ dependencies = [
  "tempfile",
  "tokio",
  "tokio-stream",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -2526,7 +2526,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tonic 0.12.3",
  "tracing",
  "url",
@@ -3238,7 +3238,7 @@ dependencies = [
  "pin-project 1.1.3",
  "serde",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "url",
 ]
 
@@ -3288,7 +3288,7 @@ dependencies = [
  "tokio",
  "tokio-retry",
  "tokio-stream",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -3738,7 +3738,7 @@ dependencies = [
  "futures",
  "pin-project 1.1.3",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -5089,7 +5089,7 @@ dependencies = [
  "rand 0.7.3",
  "tempfile",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "url",
  "uuid 1.11.0",
 ]
@@ -6388,7 +6388,7 @@ dependencies = [
  "serde_urlencoded",
  "thiserror",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "url",
  "winapi 0.3.9",
 ]
@@ -7115,7 +7115,7 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
 ]
 
 [[package]]
@@ -9908,7 +9908,7 @@ dependencies = [
  "prost-types 0.11.9",
  "thiserror",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -10030,7 +10030,7 @@ dependencies = [
  "indexmap 2.7.0",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -10049,7 +10049,7 @@ dependencies = [
  "indexmap 2.7.0",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tracing",
 ]
 
@@ -10964,6 +10964,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "io-uring"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "046fa2d4d00aea763528b4950358d0ead425372445dc8ff86312b3c69ff7727b"
+dependencies = [
+ "bitflags 2.9.1",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11515,9 +11526,9 @@ checksum = "db13adb97ab515a3691f56e4dbab09283d0b86cb45abd991d8634a9d6f501760"
 
 [[package]]
 name = "libc"
-version = "0.2.155"
+version = "0.2.176"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+checksum = "58f929b4d672ea937a23a1ab494143d968337a5f47e56d0815df1e0890ddf174"
 
 [[package]]
 name = "libfuzzer-sys"
@@ -14549,7 +14560,7 @@ dependencies = [
  "tokio",
  "tokio-rustls 0.25.0",
  "tokio-stream",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tracing",
  "wildmatch",
 ]
@@ -15654,9 +15665,9 @@ checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
 
 [[package]]
 name = "rayon"
-version = "1.9.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e4963ed1bc86e4f3ee217022bd855b297cef07fb9eac5dfa1f788b220b49b3bd"
+checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
 dependencies = [
  "either",
  "rayon-core",
@@ -15664,9 +15675,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.12.1"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -15690,7 +15701,7 @@ dependencies = [
  "ryu",
  "sha1_smol",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "url",
 ]
 
@@ -15843,7 +15854,7 @@ dependencies = [
  "tokio",
  "tokio-native-tls",
  "tokio-rustls 0.24.1",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -15890,7 +15901,7 @@ dependencies = [
  "sync_wrapper 1.0.1",
  "tokio",
  "tokio-rustls 0.26.0",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -17358,6 +17369,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "socket2"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "233504af464074f9d066d7b5416c5f9b894a5862a6506e306f7b816cdd6f1807"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "solang-parser"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18119,28 +18140,30 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.40.0"
+version = "1.47.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2b070231665d27ad9ec9b8df639893f46727666c6767db40317fbe920a5d998"
+checksum = "89e49afdadebb872d3145a5638b59eb0691ea23e46ca484037cfab3b76b95038"
 dependencies = [
  "backtrace",
  "bytes",
+ "io-uring",
  "libc",
  "mio 1.0.2",
  "parking_lot 0.12.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.5.5",
+ "slab",
+ "socket2 0.6.0",
  "tokio-macros",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "tokio-io-timeout"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b74022ada614a1b4834de765f9bb43877f910cc8ce4be40e89042c9223a8bf"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
 dependencies = [
  "pin-project-lite",
  "tokio",
@@ -18148,9 +18171,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.4.0"
+version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
+checksum = "6e06d43f1345a3bcd39f6a56dbb7dcab2ba47e68e8ac134855e7e2bdbaf8cab8"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -18189,7 +18212,7 @@ dependencies = [
  "rand 0.8.5",
  "socket2 0.5.5",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "whoami",
 ]
 
@@ -18270,9 +18293,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-test"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89b3cbabd3ae862100094ae433e1def582cf86451b4e9bf83aa7ac1d8a7d719"
+checksum = "2468baabc3311435b55dd935f702f42cd1b8abb7e754fb7dfb16bd36aa88f9f7"
 dependencies = [
  "async-stream",
  "bytes",
@@ -18312,9 +18335,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.10"
+version = "0.7.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419f34732d9eb6ee4c3578b7989078579b7f039cbbb9ca2c4da015749371e15"
+checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
 dependencies = [
  "bytes",
  "futures-core",
@@ -18322,7 +18345,6 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -18533,7 +18555,7 @@ dependencies = [
  "rand 0.8.5",
  "slab",
  "tokio",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -19243,7 +19265,7 @@ dependencies = [
  "tokio-rustls 0.24.1",
  "tokio-stream",
  "tokio-tungstenite",
- "tokio-util 0.7.10",
+ "tokio-util 0.7.16",
  "tower-service",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -735,7 +735,7 @@ rand = "0.7.3"
 rand_core = "0.5.1"
 random_word = "0.3.0"
 rapidhash = "1.4.0"
-rayon = "1.5.2"
+rayon = "1.11.0"
 redis = { version = "0.22.3", features = [
     "tokio-comp",
     "script",
@@ -810,13 +810,13 @@ tracing-subscriber = { version = "0.3.17", features = ["json", "env-filter"] }
 triomphe = "0.1.14"
 trybuild = "1.0.80"
 try_match = "0.4.2"
-tokio = { version = "1.35.1", features = ["full"] }
-tokio-io-timeout = "1.2.0"
+tokio = { version = "1.47.1", features = ["full"] }
+tokio-io-timeout = "1.2.1"
 tokio-retry = "0.3.0"
 tokio-scoped = { version = "0.2.0" }
-tokio-stream = { version = "0.1.14", features = ["fs"] }
-tokio-test = "0.4.1"
-tokio-util = { version = "0.7.2", features = ["compat", "codec"] }
+tokio-stream = { version = "0.1.17", features = ["fs"] }
+tokio-test = "0.4.4"
+tokio-util = { version = "0.7.16", features = ["compat", "codec"] }
 toml = "0.7.4"
 tonic = { version = "0.12.3", features = [
     "tls-roots",

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -101,7 +101,7 @@ async fn test_batch_request_exists() {
             .into(),
     );
 
-    let (_, subscriber_rx) = oneshot::channel();
+    let (_subscriber_tx, subscriber_rx) = oneshot::channel();
     let result = batch_requester
         .request_batch(
             *batch.digest(),
@@ -191,7 +191,7 @@ async fn test_batch_request_not_exists_not_expired() {
     );
 
     let request_start = Instant::now();
-    let (_, subscriber_rx) = oneshot::channel();
+    let (_subscriber_tx, subscriber_rx) = oneshot::channel();
     let result = batch_requester
         .request_batch(
             *batch.digest(),
@@ -236,7 +236,7 @@ async fn test_batch_request_not_exists_expired() {
     );
 
     let request_start = Instant::now();
-    let (_, subscriber_rx) = oneshot::channel();
+    let (_subscriber_tx, subscriber_rx) = oneshot::channel();
     let result = batch_requester
         .request_batch(
             *batch.digest(),


### PR DESCRIPTION

Had to fix one bug in quorum store tests: the sender should not be dropped,
otherwise it causes the code in `request_batch` to enter a different branch and
panic. Someone probably should check if [this code](https://github.com/aptos-labs/aptos-core/blob/f60b78276066fbabcc4c8f48fbe11e0b984d3bf1/consensus/src/quorum_store/batch_requester.rs#L158-L169) needs fixing.
The receiver should not be polled again if an error has occurred.
