### PR TITLE
add `#[code]` attribute to `PartialVMError` contructor and helpers

### DIFF
--- a/third_party/move/move-binary-format/src/errors.rs
+++ b/third_party/move/move-binary-format/src/errors.rs
@@ -389,6 +389,7 @@ impl PartialVMError {
         )
     }
 
+    #[cold]
     pub fn finish(self, location: Location) -> VMError {
         let PartialVMError_ {
             major_status,
@@ -429,6 +430,7 @@ impl PartialVMError {
         }))
     }
 
+    #[cold]
     pub fn new(major_status: StatusCode) -> Self {
         debug_assert!(major_status != StatusCode::EXECUTED);
         let message = if major_status == StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR
@@ -493,6 +495,7 @@ impl PartialVMError {
         self
     }
 
+    #[cold]
     pub fn with_message(mut self, message: impl ToString) -> Self {
         let mut message = message.to_string();
         if self.0.major_status == StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR {


### PR DESCRIPTION
It marks most of the error handling as cold-path throughout the codebase, making LLVM put error handling code behind jump at the end of the function. 
For it to work, block needs to contain of the `#[cold]` function calls, so marked not just the contructor, but some builder methods too. 
Gives me 2-3% on microbenchmark. 

Marking other paths may give additional performance, but I couldn't find other high impacting places yet. 