### PR TITLE
[Mempool] Add health check to peer prioritization logic.

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -54,6 +54,8 @@ pub struct MempoolConfig {
     pub max_broadcasts_per_peer: usize,
     /// Maximum number of inbound network messages to the Mempool application
     pub max_network_channel_size: usize,
+    /// The maximum amount of time a node can be out of sync before being considered unhealthy
+    pub max_sync_lag_before_unhealthy_secs: usize,
     /// The interval to take a snapshot of the mempool to logs, only used when trace logging is enabled
     pub mempool_snapshot_interval_secs: u64,
     /// The maximum amount of time to wait for an ACK of Mempool submission to an upstream node.
@@ -114,6 +116,7 @@ impl Default for MempoolConfig {
             shared_mempool_ack_timeout_ms: 2_000,
             shared_mempool_max_concurrent_inbound_syncs: 4,
             max_broadcasts_per_peer: 20,
+            max_sync_lag_before_unhealthy_secs: 300, // 5 minutes
             max_network_channel_size: 1024,
             mempool_snapshot_interval_secs: 180,
             capacity: 2_000_000,

--- a/mempool/src/shared_mempool/network.rs
+++ b/mempool/src/shared_mempool/network.rs
@@ -267,6 +267,7 @@ impl<NetworkClient: NetworkClientInterface<MempoolSyncMsg>> MempoolNetworkInterf
             self.num_committed_txns_received_since_peers_updated
                 .load(Ordering::Relaxed),
         );
+
         // Resetting the counter
         self.num_mempool_txns_received_since_peers_updated = 0;
         self.num_committed_txns_received_since_peers_updated

--- a/peer-monitoring-service/types/src/response.rs
+++ b/peer-monitoring-service/types/src/response.rs
@@ -91,7 +91,7 @@ pub struct ServerProtocolVersionResponse {
 }
 
 /// A response for the node information request
-#[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
+#[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct NodeInformationResponse {
     pub build_information: BTreeMap<String, String>, // The build information of the node
     pub highest_synced_epoch: u64,                   // The highest synced epoch of the node


### PR DESCRIPTION
## Description
This PR adds a simple health check to the mempool peer prioritization logic. Now, when peers are ordered (to determine which peers to forward transactions to), any peers that are deemed unhealthy are deprioritized.

We define peer health as the amount of synchronization lag a node is experiencing (e.g., if the sync lag threshold is 10 seconds, a peer that has only synced data 11 seconds behind the current time is determined to be unhealthy). 

The exact threshold is configurable, and defaults to ~5 minutes (i.e., any peers that are experiencing sync lag greater than 5 minutes are determined to be unhealthy). This should be sufficient to tolerate any transient sync lag spikes, while still ensuring valid transaction routing behaviour.

## Testing Plan
New and existing test infrastructure.
