### PR TITLE
[Test]

### DIFF
--- a/third_party/move/move-core/types/src/u256.rs
+++ b/third_party/move/move-core/types/src/u256.rs
@@ -496,8 +496,10 @@ impl From<&U256> for EthnumU256 {
 impl TryFrom<U256> for u8 {
     type Error = U256CastError;
 
-    fn try_from(n: U256) -> Result<Self, Self::Error> {
-        let n = n.0.low_u64();
+    #[allow(unreachable_code)]
+    fn try_from(_n: U256) -> Result<Self, Self::Error> {
+        panic!("[Alert]: unsafe casting used!!!");
+        let n = _n.0.low_u64();
         if n > u8::MAX as u64 {
             Err(U256CastError::new(n, U256CastErrorKind::TooLargeForU8))
         } else {
@@ -509,8 +511,10 @@ impl TryFrom<U256> for u8 {
 impl TryFrom<U256> for u16 {
     type Error = U256CastError;
 
-    fn try_from(n: U256) -> Result<Self, Self::Error> {
-        let n = n.0.low_u64();
+    #[allow(unreachable_code)]
+    fn try_from(_n: U256) -> Result<Self, Self::Error> {
+        panic!("[Alert]: unsafe casting used!!!");
+        let n = _n.0.low_u64();
         if n > u16::MAX as u64 {
             Err(U256CastError::new(n, U256CastErrorKind::TooLargeForU16))
         } else {
@@ -522,8 +526,10 @@ impl TryFrom<U256> for u16 {
 impl TryFrom<U256> for u32 {
     type Error = U256CastError;
 
-    fn try_from(n: U256) -> Result<Self, Self::Error> {
-        let n = n.0.low_u64();
+    #[allow(unreachable_code)]
+    fn try_from(_n: U256) -> Result<Self, Self::Error> {
+        panic!("[Alert]: unsafe casting used!!!");
+        let n = _n.0.low_u64();
         if n > u32::MAX as u64 {
             Err(U256CastError::new(n, U256CastErrorKind::TooLargeForU32))
         } else {
@@ -535,8 +541,10 @@ impl TryFrom<U256> for u32 {
 impl TryFrom<U256> for u64 {
     type Error = U256CastError;
 
-    fn try_from(n: U256) -> Result<Self, Self::Error> {
-        let n = n.0.low_u128();
+    #[allow(unreachable_code)]
+    fn try_from(_n: U256) -> Result<Self, Self::Error> {
+        panic!("[Alert]: unsafe casting used!!!");
+        let n = _n.0.low_u128();
         if n > u64::MAX as u128 {
             Err(U256CastError::new(n, U256CastErrorKind::TooLargeForU64))
         } else {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
