### PR TITLE
[Executor] Remove use of verify_extends_ledger in chunk executor

### DIFF
--- a/execution/executor/src/chunk_executor/mod.rs
+++ b/execution/executor/src/chunk_executor/mod.rs
@@ -147,7 +147,7 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
             first_version: v.ok_or_else(|| anyhow!("first version is None"))?,
         };
         let chunk_verifier = Arc::new(StateSyncChunkVerifier {
-            txn_infos_with_proof,
+            transaction_infos: txn_infos_with_proof.transaction_infos,
             verified_target_li: verified_target_li.clone(),
             epoch_change_li: epoch_change_li.cloned(),
         });
@@ -191,7 +191,7 @@ impl<V: VMBlockExecutor> ChunkExecutorTrait for ChunkExecutor<V> {
             first_version: v.ok_or_else(|| anyhow!("first version is None"))?,
         };
         let chunk_verifier = Arc::new(StateSyncChunkVerifier {
-            txn_infos_with_proof,
+            transaction_infos: txn_infos_with_proof.transaction_infos,
             verified_target_li: verified_target_li.clone(),
             epoch_change_li: epoch_change_li.cloned(),
         });
@@ -360,10 +360,10 @@ impl<V: VMBlockExecutor> ChunkExecutorInner<V> {
         let ledger_update_output = DoLedgerUpdate::run(
             &output.execution_output,
             &state_checkpoint_output,
-            parent_accumulator.clone(),
+            parent_accumulator,
         )?;
 
-        chunk_verifier.verify_chunk_result(&parent_accumulator, &ledger_update_output)?;
+        chunk_verifier.verify_chunk_result(&ledger_update_output)?;
 
         let ledger_info_opt = chunk_verifier.maybe_select_chunk_ending_ledger_info(
             &ledger_update_output,


### PR DESCRIPTION

I don't think we need to verify anything here. Somewhere before this code we have verified that the
`TransactionInfo`s are the correct ones in the range `[first_version, first_version + N)` according
to the signed ledger info, so here all we need to do is to check if the `TransactionInfo`s produced
by local execution match what we fetched from peers.

In addition, this is essentially a no-op. If we check the implementation of [verify_extends_ledger](https://github.com/aptos-labs/aptos-core/blob/84df75576b9beccc33d001ed7fdec6426f257206/types/src/proof/definition.rs#L928C12-L928C33),
the purpose of the function is to verify that "proof + overlapping leaves == known root hash". Here
the caller knows that there's no overlapping (`num_txns_in_ledger` and `first_transaction_info_version`)
are both `first_version`, so this code is not useful anyway.
