### PR TITLE
[Storage] Use a single block cache for all major RocksDB instances

### DIFF
--- a/storage/aptosdb/src/db_debugger/common/mod.rs
+++ b/storage/aptosdb/src/db_debugger/common/mod.rs
@@ -27,6 +27,7 @@ pub struct DbDir {
 impl DbDir {
     pub fn open_state_merkle_db(&self) -> Result<StateMerkleDb> {
         let env = None;
+        let block_cache = None;
         StateMerkleDb::new(
             &StorageDirPaths::from_path(&self.db_dir),
             RocksdbConfigs {
@@ -34,6 +35,7 @@ impl DbDir {
                 ..Default::default()
             },
             env,
+            block_cache,
             false,
             0,
         )
@@ -42,6 +44,7 @@ impl DbDir {
     pub fn open_state_kv_db(&self) -> Result<StateKvDb> {
         let leger_db = self.open_ledger_db()?;
         let env = None;
+        let block_cache = None;
         StateKvDb::new(
             &StorageDirPaths::from_path(&self.db_dir),
             RocksdbConfigs {
@@ -49,6 +52,7 @@ impl DbDir {
                 ..Default::default()
             },
             env,
+            block_cache,
             true,
             leger_db.metadata_db_arc(),
         )
@@ -56,6 +60,7 @@ impl DbDir {
 
     pub fn open_ledger_db(&self) -> Result<LedgerDb> {
         let env = None;
+        let block_cache = None;
         LedgerDb::new(
             self.db_dir.as_path(),
             RocksdbConfigs {
@@ -63,6 +68,7 @@ impl DbDir {
                 ..Default::default()
             },
             env,
+            block_cache,
             true,
         )
     }

--- a/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_db_versions.rs
@@ -41,9 +41,13 @@ impl Cmd {
             enable_storage_sharding: self.sharding_config.enable_storage_sharding,
             ..Default::default()
         };
+        let env = None;
+        let block_cache = None;
         let (ledger_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
             &StorageDirPaths::from_path(&self.db_dir),
             rocksdb_config,
+            env,
+            block_cache,
             /*readonly=*/ true,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
         )?;

--- a/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
+++ b/storage/aptosdb/src/db_debugger/examine/print_raw_data_by_version.rs
@@ -26,10 +26,14 @@ impl Cmd {
             enable_storage_sharding: self.sharding_config.enable_storage_sharding,
             ..Default::default()
         };
+        let env = None;
+        let block_cache = None;
 
         let (ledger_db, _, _) = AptosDB::open_dbs(
             &StorageDirPaths::from_path(&self.db_dir),
             rocksdb_config,
+            env,
+            block_cache,
             /*readonly=*/ true,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
         )?;

--- a/storage/aptosdb/src/db_debugger/truncate/mod.rs
+++ b/storage/aptosdb/src/db_debugger/truncate/mod.rs
@@ -68,9 +68,13 @@ impl Cmd {
             enable_storage_sharding: self.sharding_config.enable_storage_sharding,
             ..Default::default()
         };
+        let env = None;
+        let block_cache = None;
         let (ledger_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
             &StorageDirPaths::from_path(&self.db_dir),
             rocksdb_config,
+            env,
+            block_cache,
             /*readonly=*/ false,
             /*max_num_nodes_per_lru_cache_shard=*/ 0,
         )?;
@@ -242,12 +246,16 @@ mod test {
 
             drop(db);
 
+            let env = None;
+            let block_cache = None;
             let (ledger_db, state_merkle_db, state_kv_db) = AptosDB::open_dbs(
                 &StorageDirPaths::from_path(tmp_dir.path()),
                 RocksdbConfigs {
                     enable_storage_sharding: input.1,
                     ..Default::default()
                 },
+                env,
+                block_cache,
                 /*readonly=*/ false,
                 /*max_num_nodes_per_lru_cache_shard=*/ 0,
             ).unwrap();

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -55,6 +55,7 @@ impl StateKvDb {
         db_paths: &StorageDirPaths,
         rocksdb_configs: RocksdbConfigs,
         env: Option<&Env>,
+        block_cache: Option<&Cache>,
         readonly: bool,
         ledger_db: Arc<DB>,
     ) -> Result<Self> {
@@ -69,15 +70,11 @@ impl StateKvDb {
             });
         }
 
-        let block_cache = Cache::new_hyper_clock_cache(
-            rocksdb_configs.state_kv_db_config.block_cache_size as usize,
-            /* estimated_entry_charge = */ 0,
-        );
         Self::open_sharded(
             db_paths,
             rocksdb_configs.state_kv_db_config,
             env,
-            Some(&block_cache),
+            block_cache,
             readonly,
         )
     }


### PR DESCRIPTION

Right now we have one larger block cache for state kv db (16GB) and some smaller
block caches for several other databases (1GB). This complicates configuration
and tuning a bit.

As far as I can tell, there's no obvious downside to using a single, shared
block cache for everything, unless we want to isolate one database from the
others. Benchmark should be mostly neutral. Therefore, using a single cache
would make it easier to reason about memory usage and configure cache size.
