### PR TITLE
[compiler] fix EXTRANEOUS_ACQUIRES_ANNOTATION

### DIFF
--- a/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/module_generator.rs
@@ -1074,6 +1074,33 @@ impl ModuleContext<'_> {
 }
 
 impl ModuleContext<'_> {
+    /// Get the called functions from the same module by traversing the stackless bytecode.
+    fn get_same_module_called_functions(
+        &self,
+        module: &ModuleEnv,
+    ) -> BTreeMap<FunId, BTreeSet<FunId>> {
+        let mut called_functions_map = BTreeMap::new();
+        for fun in module.get_functions() {
+            if fun.is_inline() {
+                continue;
+            }
+            let mut called_functions = BTreeSet::new();
+            let target = self.targets.get_target(&fun, &FunctionVariant::Baseline);
+            for bc in target.get_bytecode() {
+                use Bytecode::*;
+                use Operation::*;
+                if let Call(_, _, Function(mid, fid, _), ..) = bc {
+                    // only add functions from the same module and not the function itself
+                    if *mid == module.get_id() && *fid != fun.get_id() {
+                        called_functions.insert(*fid);
+                    }
+                }
+            }
+            called_functions_map.insert(fun.get_id(), called_functions);
+        }
+        called_functions_map
+    }
+
     /// Acquires analysis. This is temporary until we have the full reference analysis.
     fn generate_acquires_map(&self, module: &ModuleEnv) -> BTreeMap<FunId, BTreeSet<StructId>> {
         // Compute map with direct usage of resources
@@ -1082,6 +1109,7 @@ impl ModuleContext<'_> {
             .filter(|f| !f.is_inline())
             .map(|f| (f.get_id(), self.get_direct_function_acquires(&f)))
             .collect::<BTreeMap<_, _>>();
+        let called_functions_map = self.get_same_module_called_functions(module);
         // Now run a fixed-point loop: add resources used by called functions until there are no
         // changes.
         loop {
@@ -1090,20 +1118,16 @@ impl ModuleContext<'_> {
                 if fun.is_inline() {
                     continue;
                 }
-                if let Some(callees) = fun.get_called_functions() {
-                    let mut usage = usage_map[&fun.get_id()].clone();
-                    let count = usage.len();
+                let mut usage = usage_map[&fun.get_id()].clone();
+                let count = usage.len();
+                for called_fun in called_functions_map[&fun.get_id()].iter() {
                     // Extend usage by that of callees from the same module. Acquires is only
                     // local to a module.
-                    for callee in callees {
-                        if callee.module_id == module.get_id() {
-                            usage.extend(usage_map[&callee.id].iter().cloned());
-                        }
-                    }
-                    if usage.len() > count {
-                        *usage_map.get_mut(&fun.get_id()).unwrap() = usage;
-                        changes = true;
-                    }
+                    usage.extend(usage_map[called_fun].iter().cloned());
+                }
+                if usage.len() > count {
+                    *usage_map.get_mut(&fun.get_id()).unwrap() = usage;
+                    changes = true;
                 }
             }
             if !changes {

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14396.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14396.exp
@@ -1,0 +1,27 @@
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module cafe.Module0 {
+struct S has copy, drop, store, key {
+	dummy_field: bool
+}
+
+public function1() /* def_idx: 0 */ {
+B0:
+	0: Ret
+B1:
+	1: Call function2()
+	2: Ret
+}
+public function2() /* def_idx: 1 */ {
+L0:	$t0: &S
+B0:
+	0: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 239])
+	1: ImmBorrowGlobal[0](S)
+	2: StLoc[0]($t0: &S)
+	3: MoveLoc[0]($t0: &S)
+	4: Pop
+	5: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14396.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14396.move
@@ -1,0 +1,12 @@
+module 0xCAFE::Module0 {
+    const ADDR: address = @0xBEEF;
+    struct S has copy, drop, store, key { }
+
+    public fun function1() acquires S {
+        return;
+        function2();
+    }
+    public fun function2() acquires S {
+        borrow_global<S>(ADDR);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14396.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/bug_14396.opt.exp
@@ -1,0 +1,22 @@
+
+============ disassembled file-format ==================
+// Move bytecode v8
+module cafe.Module0 {
+struct S has copy, drop, store, key {
+	dummy_field: bool
+}
+
+public function1() /* def_idx: 0 */ {
+B0:
+	0: Ret
+}
+public function2() /* def_idx: 1 */ {
+L0:	$t0: &S
+B0:
+	0: LdConst[0](Address: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 190, 239])
+	1: ImmBorrowGlobal[0](S)
+	2: Pop
+	3: Ret
+}
+}
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/assert_false_with_resource.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/assert_false_with_resource.exp
@@ -1,0 +1,103 @@
+// -- Model dump before first bytecode pipeline
+module 0x8675309::M1 {
+    struct R<T> {
+        x: u64,
+    }
+    public fun extract<T>(r: &mut R<T>,y: u64): R<T> {
+        {
+          let x: u64 = Sub<u64>(select M1::R.x<&mut R<T>>(r), y);
+          pack M1::R<T>(x)
+        }
+    }
+} // end 0x8675309::M1
+module 0x8675309::M {
+    use 0x8675309::M1::{R}; // resolved as: 0x8675309::M1
+    use 0x8675309::M1::{extract}; // resolved as: 0x8675309::M1
+    struct R1<T> {
+        x: M1::R<T>,
+    }
+    private fun f<T>(a: address): M1::R<T> {
+        {
+          let r: &mut R1<T> = BorrowGlobal(Mutable)<R1<T>>(a);
+          M1::extract<T>(Borrow(Mutable)(select M::R1.x<&mut R1<T>>(r)), 3)
+        }
+    }
+    public fun t0<T>(a: address): M1::R<T> {
+        if false {
+          Tuple()
+        } else {
+          Abort(0)
+        };
+        M::f<T>(a)
+    }
+} // end 0x8675309::M
+
+// -- Sourcified model before first bytecode pipeline
+module 0x8675309::M1 {
+    struct R<phantom T> has copy, drop, store, key {
+        x: u64,
+    }
+    public fun extract<T>(r: &mut R<T>, y: u64): R<T> {
+        let x = r.x - y;
+        R<T>{x: x}
+    }
+}
+module 0x8675309::M {
+    use 0x8675309::M1;
+    use 0x8675309::M1;
+    struct R1<phantom T> has key {
+        x: M1::R<T>,
+    }
+    fun f<T>(a: address): M1::R<T> {
+        let r = borrow_global_mut<R1<T>>(a);
+        M1::extract<T>(&mut r.x, 3)
+    }
+    public fun t0<T>(a: address): M1::R<T> {
+        if (false) () else abort 0;
+        f<T>(a)
+    }
+}
+
+
+Diagnostics:
+warning: If condition is always false, so then branch code eliminated as dead code
+   ┌─ tests/simplifier-elimination/assert_false_with_resource.move:30:17
+   │
+30 │         assert!(false, 0);
+   │         ------  ^^^^^
+   │         │       │
+   │         │       condition is always false
+   │         then branch eliminated
+
+// -- Model dump before second bytecode pipeline
+module 0x8675309::M1 {
+    struct R<T> {
+        x: u64,
+    }
+    public fun extract<T>(r: &mut R<T>,y: u64): R<T> {
+        {
+          let x: u64 = Sub<u64>(select M1::R.x<&mut R<T>>(r), y);
+          pack M1::R<T>(x)
+        }
+    }
+} // end 0x8675309::M1
+module 0x8675309::M {
+    use 0x8675309::M1::{R}; // resolved as: 0x8675309::M1
+    use 0x8675309::M1::{extract}; // resolved as: 0x8675309::M1
+    struct R1<T> {
+        x: M1::R<T>,
+    }
+    private fun f<T>(a: address): M1::R<T> {
+        {
+          let r: &mut R1<T> = BorrowGlobal(Mutable)<R1<T>>(a);
+          M1::extract<T>(Borrow(Mutable)(select M::R1.x<&mut R1<T>>(r)), 3)
+        }
+    }
+    public fun t0<T>(a: address): M1::R<T> {
+        Abort(0);
+        M::f<T>(a)
+    }
+} // end 0x8675309::M
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/assert_false_with_resource.move
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/assert_false_with_resource.move
@@ -1,0 +1,34 @@
+module 0x8675309::M1 {
+
+
+    struct R<phantom T> has key, store, copy, drop {
+       x: u64
+    }
+
+    public fun extract<T>(r: &mut R<T>, y: u64): R<T> {
+        let x = r.x - y;
+        R {x}
+    }
+
+}
+
+module 0x8675309::M {
+    use 0x8675309::M1::R;
+    use 0x8675309::M1::extract;
+
+    struct R1<phantom T> has key {
+       x: R<T>
+    }
+
+
+    fun f<T>(a: address): R<T> {
+        let r = borrow_global_mut<R1<T>>(a);
+        extract<T>(&mut r.x, 3)
+    }
+
+    public fun t0<T>(a: address): R<T> {
+        assert!(false, 0);
+        f(a)
+    }
+
+}


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

When optimization removes code, result of `get_called_functions` may contain function calls that have already been removed, which leads to incorrect computation of resources that are acquired indirectly. This PR fixes the issue by analyzing the stackless bytecode directly.

close #17801
close #14396

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Existing tests and new test cases.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
