### PR TITLE
[Storage] Smooth out RocksDB compactions

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -122,7 +122,7 @@ pub struct RocksdbConfig {
     pub max_open_files: i32,
     /// Maximum size of the RocksDB write ahead log (WAL)
     pub max_total_wal_size: u64,
-    /// Maximum number of background threads for Rocks DB
+    /// Maximum number of background jobs for Rocks DB
     pub max_background_jobs: i32,
     /// Block cache size for Rocks DB
     pub block_cache_size: u64,
@@ -159,9 +159,8 @@ impl Default for RocksdbConfig {
             // For now we set the max total WAL size to be 1G. This config can be useful when column
             // families are updated at non-uniform frequencies.
             max_total_wal_size: 1u64 << 30,
-            // This includes threads for flashing and compaction. Rocksdb will decide the # of
-            // threads to use internally.
-            max_background_jobs: 16,
+            // This includes jobs for flush and compaction.
+            max_background_jobs: 4,
             block_cache_size: Self::DEFAULT_BLOCK_CACHE_SIZE,
             block_size: Self::DEFAULT_BLOCK_SIZE,
             // Count index/filter blocks in block cache usage by default.
@@ -186,6 +185,8 @@ pub struct RocksdbConfigs {
     pub index_db_config: RocksdbConfig,
     #[serde(default = "default_to_true")]
     pub enable_storage_sharding: bool,
+    pub high_priority_background_threads: i32,
+    pub low_priority_background_threads: i32,
 }
 
 fn default_to_true() -> bool {
@@ -206,6 +207,8 @@ impl Default for RocksdbConfigs {
                 ..Default::default()
             },
             enable_storage_sharding: true,
+            high_priority_background_threads: 4,
+            low_priority_background_threads: 4,
         }
     }
 }

--- a/storage/aptosdb/src/db/mod.rs
+++ b/storage/aptosdb/src/db/mod.rs
@@ -11,7 +11,7 @@ use crate::{
 use aptos_config::config::{PrunerConfig, RocksdbConfigs, StorageDirPaths};
 use aptos_db_indexer::{db_indexer::InternalIndexerDB, Indexer};
 use aptos_logger::prelude::*;
-use aptos_schemadb::batch::SchemaBatch;
+use aptos_schemadb::{batch::SchemaBatch, Env};
 use aptos_storage_interface::{db_ensure as ensure, AptosDbError, Result};
 use aptos_types::{ledger_info::LedgerInfoWithSignatures, transaction::Version};
 use std::{path::Path, sync::Arc, time::Instant};
@@ -107,16 +107,28 @@ impl AptosDB {
         readonly: bool,
         max_num_nodes_per_lru_cache_shard: usize,
     ) -> Result<(LedgerDb, StateMerkleDb, StateKvDb)> {
-        let ledger_db = LedgerDb::new(db_paths.ledger_db_root_path(), rocksdb_configs, readonly)?;
+        let mut env =
+            Env::new().map_err(|err| AptosDbError::OtherRocksDbError(err.into_string()))?;
+        env.set_high_priority_background_threads(rocksdb_configs.high_priority_background_threads);
+        env.set_low_priority_background_threads(rocksdb_configs.low_priority_background_threads);
+
+        let ledger_db = LedgerDb::new(
+            db_paths.ledger_db_root_path(),
+            rocksdb_configs,
+            Some(&env),
+            readonly,
+        )?;
         let state_kv_db = StateKvDb::new(
             db_paths,
             rocksdb_configs,
+            Some(&env),
             readonly,
             ledger_db.metadata_db_arc(),
         )?;
         let state_merkle_db = StateMerkleDb::new(
             db_paths,
             rocksdb_configs,
+            Some(&env),
             readonly,
             max_num_nodes_per_lru_cache_shard,
         )?;

--- a/storage/aptosdb/src/db_debugger/common/mod.rs
+++ b/storage/aptosdb/src/db_debugger/common/mod.rs
@@ -26,12 +26,14 @@ pub struct DbDir {
 
 impl DbDir {
     pub fn open_state_merkle_db(&self) -> Result<StateMerkleDb> {
+        let env = None;
         StateMerkleDb::new(
             &StorageDirPaths::from_path(&self.db_dir),
             RocksdbConfigs {
                 enable_storage_sharding: self.sharding_config.enable_storage_sharding,
                 ..Default::default()
             },
+            env,
             false,
             0,
         )
@@ -39,24 +41,28 @@ impl DbDir {
 
     pub fn open_state_kv_db(&self) -> Result<StateKvDb> {
         let leger_db = self.open_ledger_db()?;
+        let env = None;
         StateKvDb::new(
             &StorageDirPaths::from_path(&self.db_dir),
             RocksdbConfigs {
                 enable_storage_sharding: self.sharding_config.enable_storage_sharding,
                 ..Default::default()
             },
+            env,
             true,
             leger_db.metadata_db_arc(),
         )
     }
 
     pub fn open_ledger_db(&self) -> Result<LedgerDb> {
+        let env = None;
         LedgerDb::new(
             self.db_dir.as_path(),
             RocksdbConfigs {
                 enable_storage_sharding: self.sharding_config.enable_storage_sharding,
                 ..Default::default()
             },
+            env,
             true,
         )
     }

--- a/storage/aptosdb/src/db_debugger/validation.rs
+++ b/storage/aptosdb/src/db_debugger/validation.rs
@@ -118,7 +118,8 @@ pub fn verify_state_kvs(
 ) -> Result<()> {
     println!("Validating db statekeys");
     let storage_dir = StorageDirPaths::from_path(db_root_path);
-    let state_kv_db = StateKvDb::open_sharded(&storage_dir, RocksdbConfig::default(), None, false)?;
+    let state_kv_db =
+        StateKvDb::open_sharded(&storage_dir, RocksdbConfig::default(), None, None, false)?;
 
     //read all statekeys from internal db and store them in mem
     let mut all_internal_keys = HashSet::new();

--- a/storage/aptosdb/src/state_kv_db.rs
+++ b/storage/aptosdb/src/state_kv_db.rs
@@ -24,7 +24,7 @@ use aptos_metrics_core::TimerHelper;
 use aptos_rocksdb_options::gen_rocksdb_options;
 use aptos_schemadb::{
     batch::{SchemaBatch, WriteBatch},
-    Cache, ReadOptions, DB,
+    Cache, Env, ReadOptions, DB,
 };
 use aptos_storage_interface::Result;
 use aptos_types::{
@@ -54,6 +54,7 @@ impl StateKvDb {
     pub(crate) fn new(
         db_paths: &StorageDirPaths,
         rocksdb_configs: RocksdbConfigs,
+        env: Option<&Env>,
         readonly: bool,
         ledger_db: Arc<DB>,
     ) -> Result<Self> {
@@ -75,6 +76,7 @@ impl StateKvDb {
         Self::open_sharded(
             db_paths,
             rocksdb_configs.state_kv_db_config,
+            env,
             Some(&block_cache),
             readonly,
         )
@@ -83,6 +85,7 @@ impl StateKvDb {
     pub(crate) fn open_sharded(
         db_paths: &StorageDirPaths,
         state_kv_db_config: RocksdbConfig,
+        env: Option<&Env>,
         block_cache: Option<&Cache>,
         readonly: bool,
     ) -> Result<Self> {
@@ -93,6 +96,7 @@ impl StateKvDb {
             state_kv_metadata_db_path.clone(),
             STATE_KV_METADATA_DB_NAME,
             &state_kv_db_config,
+            env,
             block_cache,
             readonly,
             /* is_hot = */ false,
@@ -111,6 +115,7 @@ impl StateKvDb {
                     shard_root_path,
                     shard_id,
                     &state_kv_db_config,
+                    env,
                     block_cache,
                     readonly,
                     /* is_hot = */ false,
@@ -136,6 +141,7 @@ impl StateKvDb {
                             shard_root_path,
                             shard_id,
                             &state_kv_db_config,
+                            env,
                             block_cache,
                             readonly,
                             /* is_hot = */ true,
@@ -227,6 +233,7 @@ impl StateKvDb {
             &StorageDirPaths::from_path(db_root_path),
             RocksdbConfig::default(),
             None,
+            None,
             false,
         )?;
         let cp_state_kv_db_path = cp_root_path.as_ref().join(STATE_KV_DB_FOLDER_NAME);
@@ -303,6 +310,7 @@ impl StateKvDb {
         db_root_path: P,
         shard_id: usize,
         state_kv_db_config: &RocksdbConfig,
+        env: Option<&Env>,
         block_cache: Option<&Cache>,
         readonly: bool,
         is_hot: bool,
@@ -316,6 +324,7 @@ impl StateKvDb {
             Self::db_shard_path(db_root_path, shard_id, is_hot),
             &db_name,
             state_kv_db_config,
+            env,
             block_cache,
             readonly,
             is_hot,
@@ -326,6 +335,7 @@ impl StateKvDb {
         path: PathBuf,
         name: &str,
         state_kv_db_config: &RocksdbConfig,
+        env: Option<&Env>,
         block_cache: Option<&Cache>,
         readonly: bool,
         is_hot: bool,
@@ -335,7 +345,7 @@ impl StateKvDb {
         } else {
             DB::open_cf
         };
-        let rocksdb_opts = gen_rocksdb_options(state_kv_db_config, readonly);
+        let rocksdb_opts = gen_rocksdb_options(state_kv_db_config, env, readonly);
         let cfds = if is_hot {
             gen_hot_state_kv_shard_cfds
         } else {

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -123,6 +123,7 @@ impl From<RocksdbOpt> for RocksdbConfigs {
                 block_cache_size: opt.block_cache_size,
                 ..Default::default()
             },
+            ..Default::default()
         }
     }
 }

--- a/storage/indexer/src/db_ops.rs
+++ b/storage/indexer/src/db_ops.rs
@@ -12,11 +12,12 @@ const INTERNAL_INDEXER_DB_NAME: &str = "internal_indexer_db";
 const TABLE_INFO_DB_NAME: &str = "index_async_v2_db";
 
 pub fn open_db<P: AsRef<Path>>(db_path: P, rocksdb_config: &RocksdbConfig) -> Result<DB> {
+    let env = None;
     Ok(DB::open(
         db_path,
         TABLE_INFO_DB_NAME,
         column_families(),
-        &gen_rocksdb_options(rocksdb_config, false),
+        &gen_rocksdb_options(rocksdb_config, env, false),
     )?)
 }
 
@@ -24,11 +25,12 @@ pub fn open_internal_indexer_db<P: AsRef<Path>>(
     db_path: P,
     rocksdb_config: &RocksdbConfig,
 ) -> Result<DB> {
+    let env = None;
     Ok(DB::open(
         db_path,
         INTERNAL_INDEXER_DB_NAME,
         internal_indexer_column_families(),
-        &gen_rocksdb_options(rocksdb_config, false),
+        &gen_rocksdb_options(rocksdb_config, env, false),
     )?)
 }
 

--- a/storage/indexer/src/lib.rs
+++ b/storage/indexer/src/lib.rs
@@ -61,12 +61,13 @@ impl Indexer {
         rocksdb_config: RocksdbConfig,
     ) -> Result<Self> {
         let db_path = db_root_path.as_ref().join(INDEX_DB_NAME);
+        let env = None;
 
         let db = DB::open(
             db_path,
             "index_db",
             column_families(),
-            &gen_rocksdb_options(&rocksdb_config, false),
+            &gen_rocksdb_options(&rocksdb_config, env, false),
         )?;
 
         let next_version = db

--- a/storage/rocksdb-options/src/lib.rs
+++ b/storage/rocksdb-options/src/lib.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use aptos_config::config::{RocksDBStatsLevel, RocksdbConfig};
-use rocksdb::{statistics::StatsLevel, Options};
+use rocksdb::{statistics::StatsLevel, Env, Options};
 
 // TODO: Clean this up. It is currently separated into its own crate
 // to avoid circular dependencies, because it depends on aptos-config (which
@@ -19,11 +19,13 @@ fn convert_stats_level(level: RocksDBStatsLevel) -> StatsLevel {
     }
 }
 
-pub fn gen_rocksdb_options(config: &RocksdbConfig, readonly: bool) -> Options {
+pub fn gen_rocksdb_options(config: &RocksdbConfig, env: Option<&Env>, readonly: bool) -> Options {
     let mut db_opts = Options::default();
+    if let Some(env) = env {
+        db_opts.set_env(env);
+    }
     db_opts.set_max_open_files(config.max_open_files);
     db_opts.set_max_total_wal_size(config.max_total_wal_size);
-    db_opts.set_max_background_jobs(config.max_background_jobs);
 
     if let Some(level) = config.stats_level {
         db_opts.enable_statistics();

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -36,7 +36,7 @@ use batch::{IntoRawBatch, NativeBatch, WriteBatch};
 use iterator::{ScanDirection, SchemaIterator};
 /// Type alias to `rocksdb::ReadOptions`. See [`rocksdb doc`](https://github.com/pingcap/rust-rocksdb/blob/master/src/rocksdb_options.rs)
 pub use rocksdb::{
-    BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Options, ReadOptions,
+    BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Env, Options, ReadOptions,
     SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use rocksdb::{ErrorKind, WriteOptions};


### PR DESCRIPTION

The default number of low-pri threads used by RocksDB seems a bit too high. We
have `max_background_job = 16`, so that seems to end up creating 4 high-pri
threads and 12 low-pri threads.

This change reduces the number of low-pri threads (for compaction) to 4 and
limits the speed of compaction. Also reduce `max_background_jobs`, since we
don't have that many threads anyway, and this might avoid one DB to pile up too
many jobs.
