### PR TITLE
Error handing when REST API for auxiliary info fails

### DIFF
--- a/aptos-move/aptos-validator-interface/src/rest_interface.rs
+++ b/aptos-move/aptos-validator-interface/src/rest_interface.rs
@@ -370,9 +370,17 @@ impl AptosValidatorInterface for RestDebuggerInterface {
         start: Version,
         limit: u64,
     ) -> Result<Vec<PersistedAuxiliaryInfo>> {
-        self.0
-            .get_persisted_auxiliary_infos(start, limit)
-            .await
-            .map_err(|e| anyhow!(e))
+        // TODO: Once testnet and mainnet are upgraded to v1.37, return error when the REST API fails.
+        // self.0
+        //  .get_persisted_auxiliary_infos(start, limit)
+        //  .await
+        //  .map_err(|e| anyhow!(e))
+        match self.0.get_persisted_auxiliary_infos(start, limit).await {
+            Ok(auxiliary_infos) => Ok(auxiliary_infos),
+            Err(_) => {
+                // Fallback to empty auxiliary info when REST API fails
+                Ok(vec![PersistedAuxiliaryInfo::None; limit as usize])
+            },
+        }
     }
 }

--- a/crates/aptos-metrics-core/src/thread_local.rs
+++ b/crates/aptos-metrics-core/src/thread_local.rs
@@ -108,7 +108,7 @@ impl<'a> ThreadLocalHistogramTimer<'a> {
     }
 }
 
-impl<'a> Drop for ThreadLocalHistogramTimer<'a> {
+impl Drop for ThreadLocalHistogramTimer<'_> {
     fn drop(&mut self) {
         self.parent
             .observe_with(self.labels, self.start.elapsed().as_secs_f64());


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
