### PR TITLE
chore: fix busted pre-commit call

### DIFF
--- a/scripts/dev_setup.sh
+++ b/scripts/dev_setup.sh
@@ -1071,7 +1071,7 @@ if [[ "$SKIP_PRE_COMMIT" == "false" ]]; then
   fi
 
   # For now best effort install, will need to improve later
-  if command -v pre-commit; then
+  if command -v pre-commit &>/dev/null; then
     pre-commit install
   else
     ~/.local/bin/pre-commit install


### PR DESCRIPTION
## Description

Turns out the `pre-commit` call was missing quotes - Bash wasn’t happy about it and threw a “command not found” error when the command wasn’t found.
Added the quotes, works fine now.

## How Has This Been Tested?

Ran the command locally - no more Bash errors, and hooks trigger as expected.

## Key Areas to Review

Just make sure the quoting fix doesn’t break any existing automation or scripts.

## Type of Change

* [x] Bug fix

## Which Components or Systems Does This Change Impact?

* [x] Developer Infrastructure

## Checklist

* [x] I have read and followed the [[CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md)](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
* [x] I have performed a self-review of my own code
* [ ] I have commented my code, particularly in hard-to-understand areas
* [x] I identified and added all stakeholders and component owners affected by this change as reviewers
* [x] I tested both happy and unhappy path of the functionality
* [ ] I have made corresponding changes to the documentation