### PR TITLE
[Keyless] Add verify() call to pepper base logic.

### DIFF
--- a/keyless/pepper/service/src/dedicated_handlers/handlers.rs
+++ b/keyless/pepper/service/src/dedicated_handlers/handlers.rs
@@ -8,6 +8,7 @@ use crate::{
     dedicated_handlers::pepper_request::handle_pepper_request,
     error::PepperServiceError,
     external_resources::{jwk_fetcher, jwk_fetcher::JWKCache, resource_fetcher::CachedResources},
+    vuf_keypair::VUFKeypair,
 };
 use aptos_crypto::ed25519::Ed25519PublicKey;
 use aptos_keyless_pepper_common::{
@@ -40,7 +41,7 @@ pub trait HandlerTrait<TRequest, TResponse>: Send + Sync {
     // TODO: is there a way we can remove the vuf_private_key param here?
     async fn handle_request(
         &self,
-        vuf_private_key: Arc<ark_bls12_381::Fr>,
+        vuf_keypair: Arc<VUFKeypair>,
         jwk_cache: JWKCache,
         cached_resources: CachedResources,
         request: TRequest,
@@ -56,7 +57,7 @@ pub struct V0DelegatedFetchHandler;
 impl HandlerTrait<PepperRequestV2, PepperResponse> for V0DelegatedFetchHandler {
     async fn handle_request(
         &self,
-        vuf_private_key: Arc<ark_bls12_381::Fr>,
+        vuf_keypair: Arc<VUFKeypair>,
         jwk_cache: JWKCache,
         cached_resources: CachedResources,
         request: PepperRequestV2,
@@ -79,7 +80,7 @@ impl HandlerTrait<PepperRequestV2, PepperResponse> for V0DelegatedFetchHandler {
 
         // Fetch the pepper
         let (_pepper_base, pepper, address) = handle_pepper_request(
-            vuf_private_key,
+            vuf_keypair,
             jwk_cache,
             cached_resources,
             jwt,
@@ -109,7 +110,7 @@ pub struct V0FetchHandler;
 impl HandlerTrait<PepperRequest, PepperResponse> for V0FetchHandler {
     async fn handle_request(
         &self,
-        vuf_private_key: Arc<ark_bls12_381::Fr>,
+        vuf_keypair: Arc<VUFKeypair>,
         jwk_cache: JWKCache,
         cached_resources: CachedResources,
         request: PepperRequest,
@@ -128,7 +129,7 @@ impl HandlerTrait<PepperRequest, PepperResponse> for V0FetchHandler {
 
         // Fetch the pepper
         let (_pepper_base, pepper, address) = handle_pepper_request(
-            vuf_private_key,
+            vuf_keypair,
             jwk_cache,
             cached_resources,
             jwt,
@@ -158,7 +159,7 @@ pub struct V0SignatureHandler;
 impl HandlerTrait<PepperRequest, SignatureResponse> for V0SignatureHandler {
     async fn handle_request(
         &self,
-        vuf_private_key: Arc<ark_bls12_381::Fr>,
+        vuf_keypair: Arc<VUFKeypair>,
         jwk_cache: JWKCache,
         cached_resources: CachedResources,
         request: PepperRequest,
@@ -177,7 +178,7 @@ impl HandlerTrait<PepperRequest, SignatureResponse> for V0SignatureHandler {
 
         // Fetch the pepper base (i.e., VUF signature)
         let (pepper_base, _pepper, _address) = handle_pepper_request(
-            vuf_private_key,
+            vuf_keypair,
             jwk_cache,
             cached_resources,
             jwt,
@@ -207,7 +208,7 @@ pub struct V0VerifyHandler;
 impl HandlerTrait<VerifyRequest, VerifyResponse> for V0VerifyHandler {
     async fn handle_request(
         &self,
-        _: Arc<ark_bls12_381::Fr>,
+        _: Arc<VUFKeypair>,
         jwk_cache: JWKCache,
         cached_resources: CachedResources,
         request: VerifyRequest,

--- a/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
+++ b/keyless/pepper/service/src/dedicated_handlers/pepper_request.rs
@@ -8,6 +8,7 @@ use crate::{
     error::PepperServiceError,
     external_resources::{jwk_fetcher, jwk_fetcher::JWKCache, resource_fetcher::CachedResources},
     metrics,
+    vuf_keypair::VUFKeypair,
 };
 use aptos_keyless_pepper_common::{
     jwt::Claims,
@@ -28,7 +29,6 @@ use aptos_types::{
 };
 use jsonwebtoken::{Algorithm::RS256, DecodingKey, TokenData, Validation};
 use std::{
-    ops::Deref,
     sync::Arc,
     time::{Instant, SystemTime, UNIX_EPOCH},
 };
@@ -47,7 +47,7 @@ const EMAIL_UID_KEY: &str = "email";
 
 /// Handles the given pepper request, returning the pepper base, pepper and account address
 pub async fn handle_pepper_request(
-    vuf_private_key: Arc<ark_bls12_381::Fr>,
+    vuf_keypair: Arc<VUFKeypair>,
     jwk_cache: JWKCache,
     cached_resources: CachedResources,
     jwt: String,
@@ -104,7 +104,7 @@ pub async fn handle_pepper_request(
 
         // Derive the pepper and account address
         let derivation_result =
-            derive_pepper_and_account_address(vuf_private_key, derivation_path, &pepper_input);
+            derive_pepper_and_account_address(vuf_keypair, derivation_path, &pepper_input);
 
         // Update the derivation metrics
         metrics::update_pepper_derivation_metrics(derivation_result.is_ok(), derivation_start_time);
@@ -142,7 +142,7 @@ fn create_account_address(
 
 /// Creates the pepper base using the VUF private key and the pepper input
 fn create_pepper_base(
-    vuf_private_key: Arc<ark_bls12_381::Fr>,
+    vuf_keypair: Arc<VUFKeypair>,
     pepper_input: &PepperInput,
 ) -> Result<Vec<u8>, PepperServiceError> {
     // Serialize the pepper input using BCS
@@ -155,14 +155,13 @@ fn create_pepper_base(
 
     // Generate the pepper base and proof using the VUF
     let (pepper_base, vuf_proof) =
-        vuf::bls12381_g1_bls::Bls12381G1Bls::eval(vuf_private_key.deref(), &input_bytes).map_err(
-            |error| {
+        vuf::bls12381_g1_bls::Bls12381G1Bls::eval(vuf_keypair.vuf_private_key(), &input_bytes)
+            .map_err(|error| {
                 PepperServiceError::InternalError(format!(
                     "Failed to evaluate bls12381_g1_bls VUF: {}",
                     error
                 ))
-            },
-        )?;
+            })?;
 
     // Verify that the proof is empty
     if !vuf_proof.is_empty() {
@@ -170,6 +169,18 @@ fn create_pepper_base(
             "The VUF proof is not empty! This shouldn't happen.".to_string(),
         ));
     }
+
+    // Verify the pepper base output (this ensures we only ever return valid outputs,
+    // and protects against various security issues, e.g., fault based side channels).
+    vuf::bls12381_g1_bls::Bls12381G1Bls::verify(
+        vuf_keypair.vuf_public_key(),
+        &input_bytes,
+        &pepper_base,
+        &vuf_proof,
+    )
+    .map_err(|error| {
+        PepperServiceError::InternalError(format!("VUF verification failed: {}", error))
+    })?;
 
     Ok(pepper_base)
 }
@@ -244,12 +255,12 @@ fn derive_pepper(
 
 /// Derives the pepper base, pepper bytes and account address
 fn derive_pepper_and_account_address(
-    vuf_private_key: Arc<ark_bls12_381::Fr>,
+    vuf_keypair: Arc<VUFKeypair>,
     derivation_path: Option<String>,
     pepper_input: &PepperInput,
 ) -> Result<(Vec<u8>, Vec<u8>, AccountAddress), PepperServiceError> {
     // Create the pepper base using the vuf private key and the pepper input
-    let pepper_base = create_pepper_base(vuf_private_key, pepper_input)?;
+    let pepper_base = create_pepper_base(vuf_keypair, pepper_input)?;
 
     // Derive the pepper using the verified derivation path and the pepper base
     let verified_derivation_path = get_verified_derivation_path(derivation_path)?;
@@ -452,8 +463,6 @@ fn verify_public_key_expiry_date_secs(
 mod tests {
     use super::*;
     use crate::{accounts::account_managers::AccountRecoveryManager, tests::utils};
-    use aptos_keyless_pepper_common::vuf::slip_10::ed25519_dalek::Digest;
-    use ark_ff::PrimeField;
 
     // Test token data constants
     const TEST_TOKEN_ISSUER: &str = "token_issuer";
@@ -491,6 +500,45 @@ mod tests {
     const TEST_SUB_OVERRIDE_DERIVED_PEPPER_HEX: &str =
         "21a8d5768336a41a5872351c806d56cca994b0acbe7f054afeed22bee06ef2";
     const TEST_SUB_OVERRIDE_PEPPER_BASE_HEX: &str = "b14111748bc9bde79f0a7edea91b06432800107c448dbe9cc89b47a49ec5094e2fe8976790f6574c7eb9abdc7c5b1df5";
+
+    #[test]
+    fn test_create_pepper_base() {
+        // Create a test pepper input
+        let pepper_input = PepperInput {
+            iss: TEST_TOKEN_ISSUER.into(),
+            uid_key: SUB_UID_KEY.into(),
+            uid_val: TEST_TOKEN_SUB.into(),
+            aud: TEST_TOKEN_AUD.into(),
+        };
+
+        // Create a test VUF keypair
+        let vuf_keypair = utils::create_vuf_keypair(Some(TEST_SUB_VUF_PRIVATE_KEY_SEED));
+
+        // Create the pepper base
+        let pepper_base = create_pepper_base(vuf_keypair.clone(), &pepper_input).unwrap();
+
+        // Verify the pepper base matches the expected value
+        assert_eq!(
+            hex::encode(pepper_base),
+            TEST_SUB_PEPPER_BASE_HEX.to_string()
+        );
+
+        // Create an invalid keypair where the public and private keys do not match
+        let invalid_private_key = *utils::create_vuf_keypair(None).vuf_private_key();
+        let invalid_vuf_keypair = VUFKeypair::new(
+            invalid_private_key,
+            *vuf_keypair.vuf_public_key(),
+            vuf_keypair.vuf_public_key_json().clone(),
+        );
+
+        // Create the pepper base using the invalid keypair. This should fail with
+        // a verification error, because the public and private keys don't match.
+        let pepper_service_error =
+            create_pepper_base(Arc::new(invalid_vuf_keypair), &pepper_input).unwrap_err();
+        assert!(pepper_service_error
+            .to_string()
+            .contains("VUF verification failed"));
+    }
 
     #[test]
     fn test_get_uid_key_and_value() {
@@ -547,12 +595,12 @@ mod tests {
         .await
         .unwrap();
 
-        // Get the VUF private key
-        let vuf_private_key = get_test_vuf_private_key(TEST_SUB_VUF_PRIVATE_KEY_SEED);
+        // Get the VUF keypair
+        let vuf_keypair = utils::create_vuf_keypair(Some(TEST_SUB_VUF_PRIVATE_KEY_SEED));
 
         // Verify the pepper base, derived pepper and account address
         verify_base_pepper_and_address_generation(
-            vuf_private_key,
+            vuf_keypair,
             &pepper_input,
             TEST_SUB_PEPPER_BASE_HEX,
             TEST_SUB_DERIVED_PEPPER_HEX,
@@ -583,12 +631,12 @@ mod tests {
         .await
         .unwrap();
 
-        // Get the VUF private key
-        let vuf_private_key = get_test_vuf_private_key(TEST_EMAIL_VUF_PRIVATE_KEY_SEED);
+        // Get the VUF keypair
+        let vuf_keypair = utils::create_vuf_keypair(Some(TEST_EMAIL_VUF_PRIVATE_KEY_SEED));
 
         // Verify the pepper base, derived pepper and account address
         verify_base_pepper_and_address_generation(
-            vuf_private_key,
+            vuf_keypair,
             &pepper_input,
             TEST_EMAIL_PEPPER_BASE_HEX,
             TEST_EMAIL_DERIVED_PEPPER_HEX,
@@ -618,12 +666,12 @@ mod tests {
         .await
         .unwrap();
 
-        // Get the VUF private key
-        let vuf_private_key = get_test_vuf_private_key(TEST_SUB_VUF_PRIVATE_KEY_SEED);
+        // Get the VUF keypair
+        let vuf_keypair = utils::create_vuf_keypair(Some(TEST_SUB_VUF_PRIVATE_KEY_SEED));
 
         // Verify the pepper base, derived pepper and account address
         verify_base_pepper_and_address_generation(
-            vuf_private_key,
+            vuf_keypair,
             &pepper_input,
             TEST_SUB_PEPPER_BASE_HEX,
             TEST_SUB_DERIVED_PEPPER_HEX,
@@ -658,12 +706,12 @@ mod tests {
         .await
         .unwrap();
 
-        // Get the VUF private key
-        let vuf_private_key = get_test_vuf_private_key(TEST_SUB_VUF_PRIVATE_KEY_SEED);
+        // Get the VUF keypair
+        let vuf_keypair = utils::create_vuf_keypair(Some(TEST_SUB_VUF_PRIVATE_KEY_SEED));
 
         // Verify the pepper base, derived pepper and account address
         verify_base_pepper_and_address_generation(
-            vuf_private_key,
+            vuf_keypair,
             &pepper_input,
             TEST_SUB_OVERRIDE_PEPPER_BASE_HEX,
             TEST_SUB_OVERRIDE_DERIVED_PEPPER_HEX,
@@ -688,19 +736,9 @@ mod tests {
         }
     }
 
-    /// Returns the test VUF private key from the given seed
-    fn get_test_vuf_private_key(seed: [u8; 32]) -> Arc<ark_bls12_381::Fr> {
-        // Derive the VUF private key from the seed
-        let mut sha3_hasher = sha3::Sha3_512::new();
-        sha3_hasher.update(seed);
-        let vuf_private_key =
-            ark_bls12_381::Fr::from_be_bytes_mod_order(sha3_hasher.finalize().as_slice());
-        Arc::new(vuf_private_key)
-    }
-
     /// Verifies the generated pepper base, derived pepper and account address against the expected values
     fn verify_base_pepper_and_address_generation(
-        vuf_private_key: Arc<ark_bls12_381::Fr>,
+        vuf_keypair: Arc<VUFKeypair>,
         pepper_input: &PepperInput,
         expected_pepper_base_hex: &str,
         expected_derived_pepper_hex: &str,
@@ -708,7 +746,7 @@ mod tests {
     ) {
         // Derive the pepper base, pepper and account address
         let (pepper_base, derived_pepper_bytes, address) =
-            derive_pepper_and_account_address(vuf_private_key, None, pepper_input).unwrap();
+            derive_pepper_and_account_address(vuf_keypair, None, pepper_input).unwrap();
 
         // Verify the pepper base, derived pepper and account address
         assert_eq!(hex::encode(pepper_base), expected_pepper_base_hex);

--- a/keyless/pepper/service/src/lib.rs
+++ b/keyless/pepper/service/src/lib.rs
@@ -8,7 +8,7 @@ pub mod external_resources;
 pub mod metrics;
 pub mod request_handler;
 pub mod utils;
-pub mod vuf_pub_key;
+pub mod vuf_keypair;
 
 #[cfg(test)]
 mod tests;

--- a/keyless/pepper/service/src/main.rs
+++ b/keyless/pepper/service/src/main.rs
@@ -18,7 +18,8 @@ use aptos_keyless_pepper_service::{
     metrics::DEFAULT_METRICS_SERVER_PORT,
     request_handler,
     request_handler::DEFAULT_PEPPER_SERVICE_PORT,
-    utils, vuf_pub_key,
+    utils, vuf_keypair,
+    vuf_keypair::VUFKeypair,
 };
 use aptos_logger::{error, info, warn};
 use clap::Parser;
@@ -125,11 +126,14 @@ async fn main() {
 
     // Fetch the VUF public and private keypair (this will load the private key into memory)
     info!("Fetching the VUF public and private keypair for the pepper service...");
-    let (vuf_public_key, vuf_private_key) = vuf_pub_key::get_pepper_service_vuf_keypair(
+    let vuf_keypair = vuf_keypair::get_pepper_service_vuf_keypair(
         args.vuf_private_key_hex,
         args.vuf_private_key_seed_hex,
     );
-    info!("Retrieved the VUF public key: {:?}", vuf_public_key);
+    info!(
+        "Retrieved the VUF public key: {:?}",
+        vuf_keypair.vuf_public_key_json()
+    );
 
     // Collect the account recovery managers
     info!("Collecting the account recovery managers...");
@@ -168,7 +172,7 @@ async fn main() {
     let jwk_cache = jwk_fetcher::start_jwk_fetchers(args.jwk_issuers_override.clone());
 
     // Start the pepper service
-    let vuf_keypair = Arc::new((vuf_public_key, Arc::new(vuf_private_key)));
+    let vuf_keypair = Arc::new(vuf_keypair);
     start_pepper_service(
         args.pepper_service_port,
         vuf_keypair,
@@ -202,7 +206,7 @@ fn start_metrics_server() {
 // Starts the pepper service
 async fn start_pepper_service(
     pepper_service_port: u16,
-    vuf_keypair: Arc<(String, Arc<ark_bls12_381::Fr>)>,
+    vuf_keypair: Arc<VUFKeypair>,
     jwk_cache: JWKCache,
     cached_resources: CachedResources,
     account_recovery_managers: Arc<AccountRecoveryManagers>,

--- a/keyless/pepper/service/src/tests/pepper_request.rs
+++ b/keyless/pepper/service/src/tests/pepper_request.rs
@@ -31,8 +31,8 @@ use std::{
 
 #[tokio::test]
 async fn request_ephemeral_public_key_expired() {
-    // Generate a VUF private key
-    let (_, vuf_private_key) = utils::create_vuf_public_private_keypair();
+    // Generate a VUF keypair
+    let vuf_keypair = utils::create_vuf_keypair(None);
 
     // Create a JWK cache and resource cache
     let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
@@ -53,7 +53,7 @@ async fn request_ephemeral_public_key_expired() {
 
     // Handle the pepper request
     let pepper_result = handle_pepper_request(
-        vuf_private_key,
+        vuf_keypair,
         jwk_cache,
         cached_resources,
         jwt,
@@ -77,8 +77,8 @@ async fn request_ephemeral_public_key_expired() {
 
 #[tokio::test]
 async fn request_ephemeral_public_key_expiry_too_large() {
-    // Generate a VUF private key
-    let (_, vuf_private_key) = utils::create_vuf_public_private_keypair();
+    // Generate a VUF keypair
+    let vuf_keypair = utils::create_vuf_keypair(None);
 
     // Create a JWK cache and resource cache
     let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
@@ -99,7 +99,7 @@ async fn request_ephemeral_public_key_expiry_too_large() {
 
     // Handle the pepper request
     let pepper_result = handle_pepper_request(
-        vuf_private_key,
+        vuf_keypair,
         jwk_cache,
         cached_resources,
         jwt,
@@ -123,8 +123,8 @@ async fn request_ephemeral_public_key_expiry_too_large() {
 
 #[tokio::test]
 async fn request_invalid_oath_nonce() {
-    // Generate a VUF private key
-    let (_, vuf_private_key) = utils::create_vuf_public_private_keypair();
+    // Generate a VUF keypair
+    let vuf_keypair = utils::create_vuf_keypair(None);
 
     // Create a JWK cache and resource cache
     let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
@@ -145,7 +145,7 @@ async fn request_invalid_oath_nonce() {
 
     // Handle the pepper request
     let pepper_result = handle_pepper_request(
-        vuf_private_key,
+        vuf_keypair,
         jwk_cache,
         cached_resources,
         jwt,
@@ -169,8 +169,8 @@ async fn request_invalid_oath_nonce() {
 
 #[tokio::test]
 async fn request_invalid_jwt() {
-    // Generate a VUF private key
-    let (_, vuf_private_key) = utils::create_vuf_public_private_keypair();
+    // Generate a VUF keypair
+    let vuf_keypair = utils::create_vuf_keypair(None);
 
     // Create a JWK cache and resource cache
     let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
@@ -181,7 +181,7 @@ async fn request_invalid_jwt() {
 
     // Handle the pepper request
     let pepper_result = handle_pepper_request(
-        vuf_private_key,
+        vuf_keypair,
         jwk_cache,
         cached_resources,
         "invalid jwt string".into(),
@@ -202,8 +202,8 @@ async fn request_invalid_jwt() {
 
 #[tokio::test]
 async fn request_invalid_jwt_signature() {
-    // Generate a VUF private key
-    let (_, vuf_private_key) = utils::create_vuf_public_private_keypair();
+    // Generate a VUF keypair
+    let vuf_keypair = utils::create_vuf_keypair(None);
 
     // Create a JWK cache and resource cache
     let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
@@ -242,7 +242,7 @@ async fn request_invalid_jwt_signature() {
 
     // Handle the pepper request
     let pepper_result = handle_pepper_request(
-        vuf_private_key,
+        vuf_keypair,
         jwk_cache,
         cached_resources,
         jwt,
@@ -263,8 +263,8 @@ async fn request_invalid_jwt_signature() {
 
 #[tokio::test]
 async fn request_max_exp_data_secs_overflowed() {
-    // Generate a VUF private key
-    let (_, vuf_private_key) = utils::create_vuf_public_private_keypair();
+    // Generate a VUF keypair
+    let vuf_keypair = utils::create_vuf_keypair(None);
 
     // Create a JWK cache and resource cache
     let jwk_cache = Arc::new(Mutex::new(HashMap::new()));
@@ -285,7 +285,7 @@ async fn request_max_exp_data_secs_overflowed() {
 
     // Handle the pepper request
     let pepper_result = handle_pepper_request(
-        vuf_private_key,
+        vuf_keypair,
         jwk_cache,
         cached_resources,
         jwt,

--- a/keyless/pepper/service/src/tests/request_handler.rs
+++ b/keyless/pepper/service/src/tests/request_handler.rs
@@ -12,6 +12,7 @@ use crate::{
         VUF_PUB_KEY_PATH,
     },
     tests::utils,
+    vuf_keypair::VUFKeypair,
 };
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},
@@ -284,7 +285,7 @@ async fn test_get_keyless_config_request() {
 #[tokio::test]
 async fn test_get_vuf_pub_key_request() {
     // Generate a test VUF public private keypair
-    let vuf_keypair = utils::create_vuf_public_private_keypair();
+    let vuf_keypair = utils::create_vuf_keypair(None);
 
     // Send a GET request to the vuf public key endpoint
     let response = send_request_to_path(
@@ -305,8 +306,7 @@ async fn test_get_vuf_pub_key_request() {
     let response_vuf_public_key = get_public_key_from_json(&body_string);
 
     // Get the expected public key from the keypair
-    let (vuf_public_key_json, _) = vuf_keypair;
-    let vuf_public_key = get_public_key_from_json(&vuf_public_key_json);
+    let vuf_public_key = get_public_key_from_json(vuf_keypair.vuf_public_key_json());
 
     // Verify the public key is correct
     assert_eq!(response_vuf_public_key, vuf_public_key);
@@ -508,7 +508,7 @@ async fn send_request_to_path(
     method: Method,
     endpoint: &str,
     body: Body,
-    vuf_keypair: Option<(String, Arc<ark_bls12_381::Fr>)>,
+    vuf_keypair: Option<Arc<VUFKeypair>>,
     jwk_cache: Option<JWKCache>,
     cached_resources: Option<CachedResources>,
 ) -> Response<Body> {
@@ -526,8 +526,7 @@ async fn send_request_to_path(
         .unwrap();
 
     // Get or create a VUF public private keypair
-    let vuf_keypair =
-        Arc::new(vuf_keypair.unwrap_or_else(utils::create_vuf_public_private_keypair));
+    let vuf_keypair = vuf_keypair.unwrap_or_else(|| utils::create_vuf_keypair(None));
 
     // Get or create a JWK cache
     let jwk_cache = jwk_cache.unwrap_or_else(|| Arc::new(Mutex::new(HashMap::new())));

--- a/keyless/pepper/service/src/tests/utils.rs
+++ b/keyless/pepper/service/src/tests/utils.rs
@@ -6,15 +6,11 @@ use crate::{
         account_managers::AccountRecoveryManagers, account_recovery_db::AccountRecoveryDBInterface,
     },
     error::PepperServiceError,
+    vuf_keypair::{get_pepper_service_vuf_public_key_and_json, VUFKeypair},
 };
-use aptos_keyless_pepper_common::{
-    vuf::{bls12381_g1_bls::Bls12381G1Bls, slip_10::ed25519_dalek::Digest, VUF},
-    PepperInput, PepperV0VufPubKey,
-};
+use aptos_keyless_pepper_common::{vuf::slip_10::ed25519_dalek::Digest, PepperInput};
 use aptos_time_service::TimeService;
-use ark_ec::CurveGroup;
 use ark_ff::PrimeField;
-use ark_serialize::CanonicalSerialize;
 use std::{sync::Arc, time::Duration};
 
 /// A mock implementation of the account recovery DB that does nothing
@@ -38,10 +34,10 @@ pub async fn advance_time_secs(time_service: TimeService, seconds: u64) {
         .await;
 }
 
-/// Generates a random VUF public and private keypair for testing purposes
-pub fn create_vuf_public_private_keypair() -> (String, Arc<ark_bls12_381::Fr>) {
-    // Generate a random VUF seed
-    let private_key_seed = rand::random::<[u8; 32]>();
+/// Generates a random VUF keypair for testing purposes
+pub fn create_vuf_keypair(private_key_seed: Option<[u8; 32]>) -> Arc<VUFKeypair> {
+    // Get or generate a seed for the private key
+    let private_key_seed = private_key_seed.unwrap_or(rand::random::<[u8; 32]>());
 
     // Derive the VUF private key from the seed
     let mut sha3_hasher = sha3::Sha3_512::new();
@@ -49,21 +45,13 @@ pub fn create_vuf_public_private_keypair() -> (String, Arc<ark_bls12_381::Fr>) {
     let vuf_private_key =
         ark_bls12_381::Fr::from_be_bytes_mod_order(sha3_hasher.finalize().as_slice());
 
-    // Derive the VUF public key from the private key
-    let vuf_public_key = Bls12381G1Bls::pk_from_sk(&vuf_private_key).unwrap();
+    // Get the VUF public key and its JSON representation
+    let (vuf_public_key, vuf_public_key_json) =
+        get_pepper_service_vuf_public_key_and_json(&vuf_private_key);
 
-    // Create the pepper public key object
-    let mut public_key_buf = vec![];
-    vuf_public_key
-        .into_affine()
-        .serialize_compressed(&mut public_key_buf)
-        .unwrap();
-    let pepper_vuf_public_key = PepperV0VufPubKey::new(public_key_buf);
-
-    // Transform the public key object to a pretty JSON string
-    let vuf_public_key_string = serde_json::to_string_pretty(&pepper_vuf_public_key).unwrap();
-
-    (vuf_public_key_string, Arc::new(vuf_private_key))
+    // Return the VUF keypair
+    let vuf_keypair = VUFKeypair::new(vuf_private_key, vuf_public_key, vuf_public_key_json);
+    Arc::new(vuf_keypair)
 }
 
 /// Returns an empty account managers and overrides instance


### PR DESCRIPTION
## Description
This PR updates the pepper fetching logic in the pepper service to verify the generated pepper base. This helps to ensure that only valid results are returned to clients.

## Testing Plan
New and existing test infrastructure.
