### PR TITLE
[vm] Disable static checks for depth in favour of runtime checks

### DIFF
--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -39,7 +39,9 @@ impl RuntimeCacheTraits for AllRuntimeCaches {
 #[derive(Clone)]
 pub(crate) enum PerInstructionCache {
     Nothing,
+    #[allow(dead_code)]
     Pack(u16),
+    #[allow(dead_code)]
     PackGeneric(u16),
     Call(Rc<LoadedFunction>, Rc<RefCell<FrameTypeCache>>),
     CallGeneric(Rc<LoadedFunction>, Rc<RefCell<FrameTypeCache>>),

--- a/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_depth_checker.rs
@@ -52,10 +52,13 @@ where
 {
     /// Creates a new depth checker for the specified loader to query struct definitions if needed.
     pub(crate) fn new(struct_definition_loader: &'a T) -> Self {
-        let maybe_max_depth = struct_definition_loader
-            .runtime_environment()
-            .vm_config()
-            .max_value_nest_depth;
+        let vm_config = struct_definition_loader.runtime_environment().vm_config();
+        // Gate by other config which will be enabled in 1.38. Will be removed after it is enabled.
+        let maybe_max_depth = if vm_config.propagate_dependency_limit_error {
+            None
+        } else {
+            vm_config.max_value_nest_depth
+        };
         Self {
             struct_definition_loader,
             maybe_max_depth,

--- a/third_party/move/move-vm/transactional-tests/tests/lazy_loading/cyclic_structs.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/lazy_loading/cyclic_structs.exp
@@ -5,13 +5,13 @@ task 2 lines 21-33:  publish --verbose [module 0x66::list]
 task 3 lines 36-52:  publish --verbose [module 0x66::app]
 task 4 lines 55-55:  run 0x66::app::create_list --signers 0x42 --verbose
 Error: Function execution failed with VMError: {
-    message: Definition of struct 0x0000000000000000000000000000000000000000000000000000000000000066::list::List is recursive: failed to construct its depth formula,
-    major_status: RUNTIME_CYCLIC_MODULE_DEPENDENCY,
+    message: Depth of a layout exceeded the maximum of 128 during construction,
+    major_status: VM_MAX_VALUE_DEPTH_REACHED,
     sub_status: None,
-    location: 0x66::list,
+    location: 0x66::app,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 1)],
-    exec_state: Some(ExecutionState { stack_trace: [(Some(ModuleId { address: 0000000000000000000000000000000000000000000000000000000000000066, name: Identifier("app") }), FunctionDefinitionIndex(1), 1)] }),
+    offsets: [(FunctionDefinitionIndex(1), 3)],
+    exec_state: Some(ExecutionState { stack_trace: [] }),
 }
 task 5 lines 57-57:  run 0x66::app::list_exists --args @0x42 --verbose
 Error: Function execution failed with VMError: {

--- a/third_party/move/move-vm/transactional-tests/tests/recursion/runtime_layout_deeply_nested.exp
+++ b/third_party/move/move-vm/transactional-tests/tests/recursion/runtime_layout_deeply_nested.exp
@@ -7,7 +7,7 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 1)],
+    offsets: [(FunctionDefinitionIndex(8), 3)],
 }
 task 3 lines 89-96:  run --signers 0x3 [import 0x42.M;]
 Error: Script execution failed with VMError: {
@@ -15,5 +15,5 @@ Error: Script execution failed with VMError: {
     sub_status: None,
     location: 0x42::M,
     indices: [],
-    offsets: [(FunctionDefinitionIndex(0), 1)],
+    offsets: [(FunctionDefinitionIndex(9), 4)],
 }


### PR DESCRIPTION
## Description

For 1.38, disable depth checks based on types. We have runtime checks on values now on every usage, and memory consumption tracker that traverses values. With function values, we already rely on those.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
