### PR TITLE
[CLI][compiler] A few changes on experiments flag for compiler optimization

### DIFF
--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1248,7 +1248,7 @@ pub struct MovePackageOptions {
     pub optimize: Option<OptimizationLevel>,
 
     /// Experiments
-    #[clap(long, hide(true))]
+    #[clap(long, hide(true), num_args = 1.., value_delimiter = ',')]
     pub experiments: Vec<String>,
 
     /// ...or --bytecode BYTECODE_VERSION

--- a/crates/transaction-generator-lib/src/publishing/prebuild_packages.rs
+++ b/crates/transaction-generator-lib/src/publishing/prebuild_packages.rs
@@ -57,9 +57,19 @@ pub struct PrebuiltPackageConfig {
     pub latest_language: bool,
     /// If true, will use the local Aptos framework.
     pub use_local_std: bool,
+    /// Experiments for compiler optimization.
+    pub experiments: Vec<String>,
 }
 
 impl PrebuiltPackageConfig {
+    pub fn new(latest_language: bool, use_local_std: bool, experiments: Vec<String>) -> Self {
+        Self {
+            latest_language,
+            use_local_std,
+            experiments,
+        }
+    }
+
     /// Returns built options corresponding to the prebuilt config.
     pub fn build_options(&self) -> BuildOptions {
         let mut build_options = BuildOptions::move_2();
@@ -69,6 +79,9 @@ impl PrebuiltPackageConfig {
         }
         if self.use_local_std {
             build_options.override_std = Some(StdVersion::Local(get_local_framework_path()));
+        }
+        for exp in &self.experiments {
+            build_options = build_options.with_experiment(exp);
         }
         build_options
     }

--- a/testsuite/benchmark-workloads/package-generator/src/main.rs
+++ b/testsuite/benchmark-workloads/package-generator/src/main.rs
@@ -27,6 +27,9 @@ struct Args {
     /// If true, uses local aptos-framework from aptos-core.
     #[clap(long)]
     use_local_std: bool,
+    /// Experiments for compiler optimization.
+    #[clap(long, num_args = 1.., value_delimiter = ',')]
+    experiments: Vec<String>,
 }
 
 /// Recursively traverses a directory to extract paths of all Move packages inside it.
@@ -63,10 +66,8 @@ fn main() -> anyhow::Result<()> {
             .into_iter()
             .map(|p| (p, true)),
     ) {
-        let config = PrebuiltPackageConfig {
-            latest_language,
-            use_local_std,
-        };
+        let config =
+            PrebuiltPackageConfig::new(latest_language, use_local_std, args.experiments.clone());
         visit(&package_path, &config, &mut all_package_paths)?;
     }
 

--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -117,6 +117,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(false),
         },
         Experiment {
+            name: Experiment::INLINING_OPTIMIZATION_TO_NON_PRIMARY_TARGETS.to_string(),
+            description: "Turns on or off restricting inlining optimization to primary target modules".to_string(),
+            default: Given(false),
+        },
+        Experiment {
             name: Experiment::SPEC_CHECK.to_string(),
             description: "Turns on or off specification checks".to_string(),
             default: Inherited(Experiment::CHECKS.to_string()),
@@ -319,6 +324,8 @@ impl Experiment {
     pub const FLUSH_WRITES_OPTIMIZATION: &'static str = "flush-writes-optimization";
     pub const INLINING: &'static str = "inlining";
     pub const INLINING_OPTIMIZATION: &'static str = "inlining-optimization";
+    pub const INLINING_OPTIMIZATION_TO_NON_PRIMARY_TARGETS: &'static str =
+        "inlining-optimization-to-non-primary-targets";
     pub const KEEP_INLINE_FUNS: &'static str = "keep-inline-funs";
     pub const KEEP_UNINIT_ANNOTATIONS: &'static str = "keep-uninit-annotations";
     pub const LAMBDA_LIFTING_INLINE: &'static str = "lambda-lifting-inline";

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -472,9 +472,15 @@ pub fn env_optimization_pipeline<'a, 'b>(options: &'a Options) -> EnvProcessorPi
     // those simplifications can take advantage of the inlining.
     let do_inlining_optimization = options.experiment_on(Experiment::INLINING_OPTIMIZATION);
     if do_inlining_optimization {
+        // This allows inlining a call that comes from a different package
         let across_package = options.experiment_on(Experiment::ACROSS_PACKAGE_INLINING);
+        // This allows performing an inlining optimization to a function that does not belong to the primary target package
+        let allow_non_primary_targets =
+            options.experiment_on(Experiment::INLINING_OPTIMIZATION_TO_NON_PRIMARY_TARGETS);
         env_pipeline.add("inlining optimization", {
-            move |env: &mut GlobalEnv| inlining_optimization::optimize(env, across_package)
+            move |env: &mut GlobalEnv| {
+                inlining_optimization::optimize(env, across_package, allow_non_primary_targets)
+            }
         });
     }
     if options.experiment_on(Experiment::AST_SIMPLIFY_FULL) {


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR:

1) fixes "--experiments" option for Aptos CLI";
2) adds "--experiments" to benchmark generator for pre-built; 
3) adds an experiment flag `allow-inlining-optimization-to-non-primary-targets` which allows inlining optimization for non-primary targets.


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

Manual tests.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
