### PR TITLE
Move unit test for monotonically increasing counter native function

### DIFF
--- a/aptos-move/framework/aptos-framework/doc/transaction_context.md
+++ b/aptos-move/framework/aptos-framework/doc/transaction_context.md
@@ -41,6 +41,7 @@
 -  [Function `inner_entry_function_payload`](#0x1_transaction_context_inner_entry_function_payload)
 -  [Function `monotonically_increasing_counter`](#0x1_transaction_context_monotonically_increasing_counter)
 -  [Function `monotonically_increasing_counter_internal`](#0x1_transaction_context_monotonically_increasing_counter_internal)
+-  [Function `monotonically_increasing_counter_internal_for_test_only`](#0x1_transaction_context_monotonically_increasing_counter_internal_for_test_only)
 -  [Specification](#@Specification_1)
     -  [Function `get_txn_hash`](#@Specification_1_get_txn_hash)
     -  [Function `get_transaction_hash`](#@Specification_1_get_transaction_hash)
@@ -59,6 +60,7 @@
     -  [Function `entry_function_payload_internal`](#@Specification_1_entry_function_payload_internal)
     -  [Function `multisig_payload_internal`](#@Specification_1_multisig_payload_internal)
     -  [Function `monotonically_increasing_counter_internal`](#@Specification_1_monotonically_increasing_counter_internal)
+    -  [Function `monotonically_increasing_counter_internal_for_test_only`](#@Specification_1_monotonically_increasing_counter_internal_for_test_only)
 
 
 <pre><code><b>use</b> <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error">0x1::error</a>;
@@ -997,6 +999,7 @@ Returns a monotonically increasing counter value that combines timestamp, transa
 session counter, and local counter into a 128-bit value.
 Format: <code>&lt;reserved_byte (8 bits)&gt; || timestamp_us (64 bits) || transaction_index (32 bits) || session_counter (8 bits) || local_counter (16 bits)</code>
 The function aborts if the local counter overflows (after 65535 calls in a single session).
+When compiled for testing, this function bypasses feature checks and returns a simplified counter value.
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter">monotonically_increasing_counter</a>(): u128
@@ -1009,10 +1012,12 @@ The function aborts if the local counter overflows (after 65535 calls in a singl
 
 
 <pre><code><b>public</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter">monotonically_increasing_counter</a>(): u128 {
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_transaction_context_extension_enabled">features::transaction_context_extension_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_context.md#0x1_transaction_context_ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED">ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED</a>));
-    <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_monotonically_increasing_counter_enabled">features::is_monotonically_increasing_counter_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_context.md#0x1_transaction_context_EMONOTONICALLY_INCREASING_COUNTER_NOT_ENABLED">EMONOTONICALLY_INCREASING_COUNTER_NOT_ENABLED</a>));
-    <b>let</b> timestamp_us = <a href="timestamp.md#0x1_timestamp_now_microseconds">timestamp::now_microseconds</a>();
-    <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal">monotonically_increasing_counter_internal</a>(timestamp_us)
+    <b>if</b> (__COMPILE_FOR_TESTING__) {
+        <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal_for_test_only">monotonically_increasing_counter_internal_for_test_only</a>()
+    } <b>else</b> {
+        <b>assert</b>!(<a href="../../aptos-stdlib/../move-stdlib/doc/features.md#0x1_features_is_monotonically_increasing_counter_enabled">features::is_monotonically_increasing_counter_enabled</a>(), <a href="../../aptos-stdlib/../move-stdlib/doc/error.md#0x1_error_invalid_state">error::invalid_state</a>(<a href="transaction_context.md#0x1_transaction_context_EMONOTONICALLY_INCREASING_COUNTER_NOT_ENABLED">EMONOTONICALLY_INCREASING_COUNTER_NOT_ENABLED</a>));
+        <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal">monotonically_increasing_counter_internal</a>(<a href="timestamp.md#0x1_timestamp_now_microseconds">timestamp::now_microseconds</a>())
+    }
 }
 </code></pre>
 
@@ -1036,6 +1041,31 @@ The function aborts if the local counter overflows (after 65535 calls in a singl
 
 
 <pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal">monotonically_increasing_counter_internal</a>(timestamp_us: u64): u128;
+</code></pre>
+
+
+
+</details>
+
+<a id="0x1_transaction_context_monotonically_increasing_counter_internal_for_test_only"></a>
+
+## Function `monotonically_increasing_counter_internal_for_test_only`
+
+Test-only version of monotonically_increasing_counter that returns increasing values
+without requiring a user transaction context. This allows unit tests to verify
+the monotonically increasing behavior.
+
+
+<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal_for_test_only">monotonically_increasing_counter_internal_for_test_only</a>(): u128
+</code></pre>
+
+
+
+<details>
+<summary>Implementation</summary>
+
+
+<pre><code><b>native</b> <b>fun</b> <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal_for_test_only">monotonically_increasing_counter_internal_for_test_only</a>(): u128;
 </code></pre>
 
 
@@ -1371,6 +1401,22 @@ The function aborts if the local counter overflows (after 65535 calls in a singl
 
 
 <pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal">monotonically_increasing_counter_internal</a>(timestamp_us: u64): u128
+</code></pre>
+
+
+
+
+<pre><code><b>pragma</b> opaque;
+</code></pre>
+
+
+
+<a id="@Specification_1_monotonically_increasing_counter_internal_for_test_only"></a>
+
+### Function `monotonically_increasing_counter_internal_for_test_only`
+
+
+<pre><code><b>fun</b> <a href="transaction_context.md#0x1_transaction_context_monotonically_increasing_counter_internal_for_test_only">monotonically_increasing_counter_internal_for_test_only</a>(): u128
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.move
@@ -193,13 +193,21 @@ module aptos_framework::transaction_context {
     /// session counter, and local counter into a 128-bit value.
     /// Format: `<reserved_byte (8 bits)> || timestamp_us (64 bits) || transaction_index (32 bits) || session_counter (8 bits) || local_counter (16 bits)`
     /// The function aborts if the local counter overflows (after 65535 calls in a single session).
+    /// When compiled for testing, this function bypasses feature checks and returns a simplified counter value.
     public fun monotonically_increasing_counter(): u128 {
-        assert!(features::transaction_context_extension_enabled(), error::invalid_state(ETRANSACTION_CONTEXT_EXTENSION_NOT_ENABLED));
-        assert!(features::is_monotonically_increasing_counter_enabled(), error::invalid_state(EMONOTONICALLY_INCREASING_COUNTER_NOT_ENABLED));
-        let timestamp_us = timestamp::now_microseconds();
-        monotonically_increasing_counter_internal(timestamp_us)
+        if (__COMPILE_FOR_TESTING__) {
+            monotonically_increasing_counter_internal_for_test_only()
+        } else {
+            assert!(features::is_monotonically_increasing_counter_enabled(), error::invalid_state(EMONOTONICALLY_INCREASING_COUNTER_NOT_ENABLED));
+            monotonically_increasing_counter_internal(timestamp::now_microseconds())
+        }
     }
     native fun monotonically_increasing_counter_internal(timestamp_us: u64): u128;
+
+    /// Test-only version of monotonically_increasing_counter that returns increasing values
+    /// without requiring a user transaction context. This allows unit tests to verify
+    /// the monotonically increasing behavior.
+    native fun monotonically_increasing_counter_internal_for_test_only(): u128;
 
     #[test_only]
     public fun new_entry_function_payload(
@@ -294,5 +302,16 @@ module aptos_framework::transaction_context {
     fun test_call_multisig_payload() {
         // expected to fail with the error code of `invalid_state(E_TRANSACTION_CONTEXT_NOT_AVAILABLE)`
         let _multisig = multisig_payload();
+    }
+
+    #[test]
+    fun test_monotonically_increasing_counter() {
+        let counter1 = monotonically_increasing_counter();
+        let counter2 = monotonically_increasing_counter();
+        let counter3 = monotonically_increasing_counter();
+
+        // Verify that the increment is exactly 1 (since only local_counter changes in test mode)
+        assert!(counter2 == counter1 + 1, 2);
+        assert!(counter3 == counter2 + 1, 3);
     }
 }

--- a/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_context.spec.move
@@ -113,4 +113,9 @@ spec aptos_framework::transaction_context {
         //TODO: temporary mockup
         pragma opaque;
     }
+
+    spec monotonically_increasing_counter_internal_for_test_only(): u128 {
+        //TODO: temporary mockup
+        pragma opaque;
+    }
 }

--- a/aptos-move/framework/tests/move_unit_test.rs
+++ b/aptos-move/framework/tests/move_unit_test.rs
@@ -39,6 +39,7 @@ fn run_tests_for_pkg(path_to_pkg: impl Into<String>, use_latest_language: bool) 
         full_model_generation: true, // Run extended checks also on test code
         ..Default::default()
     };
+
     if use_latest_language {
         let latest_build_options = BuildOptions::default().set_latest_language();
         build_config.compiler_config.bytecode_version = latest_build_options.bytecode_version;


### PR DESCRIPTION
## Description
Run the `test_monotonically_increasing_counter` test using
```
TEST_FILTER="test_monotonically_increasing_counter" cargo test -p aptos-framework move_framework_unit_tests
```


## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
