### PR TITLE
aptos-executor: move aptos-indexer-grpc-table-info to `[dev-dependencies]`

### DIFF
--- a/execution/executor/Cargo.toml
+++ b/execution/executor/Cargo.toml
@@ -21,7 +21,6 @@ aptos-drop-helper = { workspace = true }
 aptos-executor-service = { workspace = true }
 aptos-executor-types = { workspace = true }
 aptos-experimental-runtimes = { workspace = true }
-aptos-indexer-grpc-table-info = { workspace = true }
 aptos-infallible = { workspace = true }
 aptos-logger = { workspace = true }
 aptos-metrics-core = { workspace = true }
@@ -44,6 +43,7 @@ aptos-config = { workspace = true }
 aptos-db = { workspace = true }
 aptos-db-indexer = { workspace = true, features = ["fuzzing"] }
 aptos-executor-test-helpers = { workspace = true }
+aptos-indexer-grpc-table-info = { workspace = true }
 aptos-storage-interface = { workspace = true }
 aptos-temppath = { workspace = true }
 aptos-transaction-simulation = { workspace = true }


### PR DESCRIPTION
Noticed while benchmarking. `aptos-indexer-grpc-table-info` is used only in tests, but pulls `aptos-indexer-grpc-fullnode` tree which is pretty sizeable. 
Cuts number of packages in dependency tree: 1116 -> 965.  