### PR TITLE
[compiler] change default byte version of lang v2.3 to v9

### DIFF
--- a/third_party/move/move-binary-format/src/file_format_common.rs
+++ b/third_party/move/move-binary-format/src/file_format_common.rs
@@ -563,6 +563,9 @@ pub const VERSION_DEFAULT: u32 = VERSION_8;
 /// Mark which version is the default version if compiling Move 2.
 pub const VERSION_DEFAULT_LANG_V2: u32 = VERSION_8;
 
+/// Mark which version is the default version if compiling with language version 2.3
+pub const VERSION_DEFAULT_LANG_V2_3: u32 = VERSION_9;
+
 // Mark which oldest version is supported.
 pub const VERSION_MIN: u32 = VERSION_5;
 

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -3,7 +3,9 @@
 
 use anyhow::bail;
 use legacy_move_compiler::shared::LanguageVersion as CompilerLanguageVersion;
-use move_binary_format::file_format_common::{VERSION_DEFAULT, VERSION_DEFAULT_LANG_V2};
+use move_binary_format::file_format_common::{
+    VERSION_DEFAULT, VERSION_DEFAULT_LANG_V2, VERSION_DEFAULT_LANG_V2_3,
+};
 use move_command_line_common::env;
 use serde::{Deserialize, Serialize};
 use std::{
@@ -289,10 +291,10 @@ impl LanguageVersion {
     pub fn infer_bytecode_version(&self, version: Option<u32>) -> u32 {
         env::get_bytecode_version_from_env(version).unwrap_or(match self {
             LanguageVersion::V1 => VERSION_DEFAULT,
-            LanguageVersion::V2_0
-            | LanguageVersion::V2_1
-            | LanguageVersion::V2_2
-            | LanguageVersion::V2_3 => VERSION_DEFAULT_LANG_V2,
+            LanguageVersion::V2_0 | LanguageVersion::V2_1 | LanguageVersion::V2_2 => {
+                VERSION_DEFAULT_LANG_V2
+            },
+            LanguageVersion::V2_3 => VERSION_DEFAULT_LANG_V2_3,
         })
     }
 


### PR DESCRIPTION
## Description
This PR changes the default bytecode version to V9 when using language version v2.3.

By default, `aptos move compile` will use language version v2.2 and bytecode version V8.

## How Has This Been Tested?
Manual testing.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)