### PR TITLE
[gas] cache value sizes for read_ref and copy_loc

### DIFF
--- a/aptos-move/aptos-gas-meter/src/lib.rs
+++ b/aptos-move/aptos-gas-meter/src/lib.rs
@@ -10,4 +10,4 @@ mod traits;
 
 pub use algebra::StandardGasAlgebra;
 pub use meter::StandardGasMeter;
-pub use traits::{AptosGasMeter, GasAlgebra};
+pub use traits::{AptosGasMeter, CacheValueSizes, GasAlgebra};

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -1,7 +1,9 @@
 // Copyright © Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use aptos_gas_algebra::{Fee, FeePerGasUnit, Gas, GasExpression, GasScalingFactor, Octa};
+use aptos_gas_algebra::{
+    AbstractValueSize, Fee, FeePerGasUnit, Gas, GasExpression, GasScalingFactor, Octa,
+};
 use aptos_gas_schedule::{gas_feature_versions::RELEASE_V1_30, VMGasParameters};
 use aptos_types::{
     contract_event::ContractEvent, state_store::state_key::StateKey, write_set::WriteOpSize,
@@ -263,4 +265,18 @@ pub trait AptosGasMeter: MoveGasMeter {
             .inject_balance(extra_balance)
             .map_err(|e| e.finish(Location::Undefined))
     }
+}
+
+pub trait CacheValueSizes: AptosGasMeter {
+    fn charge_read_ref_cached(
+        &mut self,
+        stack_size: AbstractValueSize,
+        heap_size: AbstractValueSize,
+    ) -> PartialVMResult<()>;
+
+    fn charge_copy_loc_cached(
+        &mut self,
+        stack_size: AbstractValueSize,
+        heap_size: AbstractValueSize,
+    ) -> PartialVMResult<()>;
 }


### PR DESCRIPTION
This gets rid of the double-traversal of value during `read_ref` and `copy_loc` by introducing a new gas meter trait that allows the size to be reused. Brings us about 3% extra TPS.