### PR TITLE
[compiler]: gate signed int types with language version

### DIFF
--- a/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub_invalid.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/binary_sub_invalid.exp
@@ -1,118 +1,79 @@
 
 Diagnostics:
-error: no matching declaration of `-`
+error: cannot use `bool` with an operator which expects a value of type `integer`
   ┌─ tests/checking/typing/binary_sub_invalid.move:8:9
   │
 8 │         false - true;
-  │         ^^^^^^^^^^^^
-  │
-  = outruled candidate `-<T>(T, T): T` (cannot use `bool` with an operator which expects a value of type `integer`)
-  = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+  │         ^^^^^
 
-error: no matching declaration of `-`
-  ┌─ tests/checking/typing/binary_sub_invalid.move:9:9
+error: cannot use `bool` with an operator which expects a value of type `integer`
+  ┌─ tests/checking/typing/binary_sub_invalid.move:9:13
   │
 9 │         1 - false;
-  │         ^^^^^^^^^
-  │
-  = outruled candidate `-<T>(T, T): T` (cannot use `bool` with an operator which expects a value of type `integer`)
-  = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+  │             ^^^^^
 
-error: no matching declaration of `-`
+error: cannot use `bool` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:10:9
    │
 10 │         false - 1;
-   │         ^^^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `bool` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │         ^^^^^
 
-error: no matching declaration of `-`
+error: cannot use `address` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:11:9
    │
 11 │         @0x0 - @0x1;
-   │         ^^^^^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `address` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │         ^^^^
 
-error: no matching declaration of `-`
-   ┌─ tests/checking/typing/binary_sub_invalid.move:12:9
+error: cannot use `u128` with an operator which expects a value of type `u8`
+   ┌─ tests/checking/typing/binary_sub_invalid.move:12:20
    │
 12 │         (0: u8) - (1: u128);
-   │         ^^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `u128` with an operator which expects a value of type `u8`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │                    ^
 
-error: no matching declaration of `-`
+error: cannot use `R` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:13:9
    │
 13 │         r - r;
-   │         ^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `R` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │         ^
 
-error: no matching declaration of `-`
+error: cannot use `S` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:14:9
    │
 14 │         s - s;
-   │         ^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `S` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │         ^
 
-error: no matching declaration of `-`
-   ┌─ tests/checking/typing/binary_sub_invalid.move:15:9
+error: cannot use `bool` with an operator which expects a value of type `integer`
+   ┌─ tests/checking/typing/binary_sub_invalid.move:15:13
    │
 15 │         1 - false - @0x0 - 0;
-   │         ^^^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `bool` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │             ^^^^^
 
-error: no matching declaration of `-`
-   ┌─ tests/checking/typing/binary_sub_invalid.move:15:9
+error: cannot use `address` with an operator which expects a value of type `integer`
+   ┌─ tests/checking/typing/binary_sub_invalid.move:15:21
    │
 15 │         1 - false - @0x0 - 0;
-   │         ^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `address` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │                     ^^^^
 
-error: no matching declaration of `-`
+error: cannot use `()` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:16:9
    │
 16 │         () - ();
-   │         ^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `()` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │         ^^
 
-error: no matching declaration of `-`
-   ┌─ tests/checking/typing/binary_sub_invalid.move:17:9
+error: cannot use `()` with an operator which expects a value of type `integer`
+   ┌─ tests/checking/typing/binary_sub_invalid.move:17:13
    │
 17 │         1 - ();
-   │         ^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `()` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │             ^^
 
-error: no matching declaration of `-`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:18:9
    │
 18 │         (0, 1) - (0, 1, 2);
-   │         ^^^^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `(integer, integer)` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │         ^^^^^^
 
-error: no matching declaration of `-`
+error: cannot use `(integer, integer)` with an operator which expects a value of type `integer`
    ┌─ tests/checking/typing/binary_sub_invalid.move:19:9
    │
 19 │         (1, 2) - (0, 1);
-   │         ^^^^^^^^^^^^^^^
-   │
-   = outruled candidate `-<T>(T, T): T` (cannot use `(integer, integer)` with an operator which expects a value of type `integer`)
-   = outruled candidate `-<T>(T): T` (the function takes 1 argument but 2 were provided)
+   │         ^^^^^^

--- a/third_party/move/move-compiler-v2/tests/more-v1/parser/expr_unary_negation.exp
+++ b/third_party/move/move-compiler-v2/tests/more-v1/parser/expr_unary_negation.exp
@@ -1,13 +1,7 @@
 
 Diagnostics:
-error: unable to infer instantiation of type `i8|i16|i32|i64|i128|i256` (consider providing type arguments or annotating the type)
-  ┌─ tests/more-v1/parser/expr_unary_negation.move:5:15
+error: the function takes 2 arguments but 1 were provided
+  ┌─ tests/more-v1/parser/expr_unary_negation.move:5:33
   │
 5 │     assert!(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
-  │               ^
-
-error: unable to infer instantiation of type `i8|i16|i32|i64|i128|i256` (consider providing type arguments or annotating the type)
-  ┌─ tests/more-v1/parser/expr_unary_negation.move:5:35
-  │
-5 │     assert!(((1 - -2) == 3) && (-(1 - 2) == 1), 100);
-  │                                   ^
+  │                                 ^^^^^^^^

--- a/third_party/move/move-model/src/builder/builtins.rs
+++ b/third_party/move/move-model/src/builder/builtins.rs
@@ -7,7 +7,7 @@
 use crate::{
     ast::{Operation, TraceKind, Value},
     builder::model_builder::{ConstEntry, EntryVisibility, ModelBuilder, SpecOrBuiltinFunEntry},
-    metadata::LanguageVersion,
+    metadata::{lang_feature_versions::SINT_LANGUAGE_VERSION_VALUE, LanguageVersion},
     model::{Parameter, TypeParameter, TypeParameterKind},
     options::ModelBuilderOptions,
     ty::{Constraint, PrimitiveType, ReferenceKind, Type},
@@ -582,26 +582,30 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
                 visibility: SpecAndImpl,
             },
         );
-
-        trans.define_spec_or_builtin_fun(
-            trans.unary_op_symbol(&PA::UnaryOp_::Negate),
-            SpecOrBuiltinFunEntry {
-                loc: loc.clone(),
-                oper: Operation::Negate,
-                type_params: vec![param_t_decl.clone()],
-                type_param_constraints: [(
-                    0,
-                    Constraint::SomeNumber(
-                        PrimitiveType::all_signed_int_types().into_iter().collect(),
-                    ),
-                )]
-                .into_iter()
-                .collect(),
-                params: vec![mk_param(trans, 1, param_t.clone())],
-                result_type: param_t.clone(),
-                visibility: SpecAndImpl,
-            },
-        );
+        if options
+            .language_version
+            .is_at_least(SINT_LANGUAGE_VERSION_VALUE)
+        {
+            trans.define_spec_or_builtin_fun(
+                trans.unary_op_symbol(&PA::UnaryOp_::Negate),
+                SpecOrBuiltinFunEntry {
+                    loc: loc.clone(),
+                    oper: Operation::Negate,
+                    type_params: vec![param_t_decl.clone()],
+                    type_param_constraints: [(
+                        0,
+                        Constraint::SomeNumber(
+                            PrimitiveType::all_signed_int_types().into_iter().collect(),
+                        ),
+                    )]
+                    .into_iter()
+                    .collect(),
+                    params: vec![mk_param(trans, 1, param_t.clone())],
+                    result_type: param_t.clone(),
+                    visibility: SpecAndImpl,
+                },
+            );
+        }
     }
 
     {

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -24,6 +24,12 @@ pub const LATEST_STABLE_COMPILER_VERSION: &str = LATEST_STABLE_COMPILER_VERSION_
 
 pub static COMPILATION_METADATA_KEY: &[u8] = "compilation_metadata".as_bytes();
 
+// Language versions enabling specific features
+pub mod lang_feature_versions {
+    use crate::LanguageVersion;
+    pub const SINT_LANGUAGE_VERSION_VALUE: LanguageVersion = LanguageVersion::V2_3;
+}
+
 // ================================================================================'
 // Metadata for compilation result (WORK IN PROGRESS)
 


### PR DESCRIPTION
## Description
This PR gates signed integer types with language version 2.3 in the compiler:
- Adds a gate when translating type string to type
- Adds a gate when translating a signed int literal
- Adds a gate on `negate`

## How Has This Been Tested?
- Existing compiler test cases
- Manual testing

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)
