### PR TITLE
[vm] Remove static cache config in interpreter

### DIFF
--- a/aptos-move/aptos-vm-environment/src/prod_configs.rs
+++ b/aptos-move/aptos-vm-environment/src/prod_configs.rs
@@ -200,8 +200,7 @@ pub fn aptos_prod_vm_config(
         // manually where applicable.
         delayed_field_optimization_enabled: false,
         ty_builder,
-        use_call_tree_and_instruction_cache: features
-            .is_call_tree_and_instruction_vm_cache_enabled(),
+        enable_function_caches: features.is_call_tree_and_instruction_vm_cache_enabled(),
         enable_lazy_loading: features.is_lazy_loading_enabled(),
         enable_depth_checks,
         optimize_trusted_code: features.is_trusted_code_enabled(),

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -34,7 +34,7 @@ pub struct VMConfig {
     pub type_byte_cost: u64,
     pub delayed_field_optimization_enabled: bool,
     pub ty_builder: TypeBuilder,
-    pub use_call_tree_and_instruction_cache: bool,
+    pub enable_function_caches: bool,
     pub enable_lazy_loading: bool,
     pub enable_depth_checks: bool,
     /// Whether trusted code should be optimized, for example, excluding it from expensive
@@ -65,7 +65,7 @@ impl Default for VMConfig {
             type_byte_cost: 0,
             delayed_field_optimization_enabled: false,
             ty_builder: TypeBuilder::with_limits(128, 20),
-            use_call_tree_and_instruction_cache: true,
+            enable_function_caches: true,
             enable_lazy_loading: true,
             enable_depth_checks: true,
             optimize_trusted_code: false,

--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -14,25 +14,6 @@ use move_core_types::gas_algebra::NumTypeNodes;
 use move_vm_types::loaded_data::runtime_types::Type;
 use std::{cell::RefCell, collections::BTreeMap, rc::Rc};
 
-pub(crate) trait RuntimeCacheTraits {
-    fn caches_enabled() -> bool;
-}
-
-pub(crate) struct NoRuntimeCaches;
-pub(crate) struct AllRuntimeCaches;
-
-impl RuntimeCacheTraits for NoRuntimeCaches {
-    fn caches_enabled() -> bool {
-        false
-    }
-}
-
-impl RuntimeCacheTraits for AllRuntimeCaches {
-    fn caches_enabled() -> bool {
-        true
-    }
-}
-
 /// Variants for each individual instruction cache. Should make sure
 /// that the memory footprint of each variant is small. This is an
 /// enum that is expected to grow in the future.

--- a/third_party/move/move-vm/runtime/src/interpreter_caches.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter_caches.rs
@@ -7,7 +7,7 @@
 //! on the first call.
 
 use crate::{
-    frame_type_cache::{FrameTypeCache, RuntimeCacheTraits},
+    frame_type_cache::FrameTypeCache,
     loader::{FunctionPtr, GenericFunctionPtr},
     LoadedFunction,
 };
@@ -27,18 +27,14 @@ impl InterpreterFunctionCaches {
         }
     }
 
-    pub(crate) fn get_or_create_frame_cache<RTCaches: RuntimeCacheTraits>(
+    pub(crate) fn get_or_create_frame_cache(
         &mut self,
         function: &LoadedFunction,
     ) -> Rc<RefCell<FrameTypeCache>> {
-        if RTCaches::caches_enabled() {
-            if function.ty_args.is_empty() {
-                self.get_or_create_frame_cache_non_generic(function)
-            } else {
-                self.get_or_create_frame_cache_generic(function)
-            }
+        if function.ty_args.is_empty() {
+            self.get_or_create_frame_cache_non_generic(function)
         } else {
-            FrameTypeCache::make_rc()
+            self.get_or_create_frame_cache_generic(function)
         }
     }
 


### PR DESCRIPTION
## Description

We do not need static config for instruction caches - it makes 2 copies of interpreter loop, and it seems better to have the dynamic config to reduce code size while performance stays on par: branches are only taken at function calls which are common but not like every instruction is a call.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
