### PR TITLE
[move linter] fix FPs due to sint

### DIFF
--- a/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_numerical_extreme_comparison.rs
+++ b/third_party/move/tools/move-linter/src/model_ast_lints/unnecessary_numerical_extreme_comparison.rs
@@ -18,7 +18,6 @@ use move_model::{
     model::FunctionEnv,
     ty::Type,
 };
-use num::BigInt;
 use std::fmt;
 
 #[derive(Default)]
@@ -95,22 +94,22 @@ impl UnnecessaryNumericalExtremeComparison {
             unreachable!("number must be primitive")
         };
         let max = ty.get_max_value()?;
-        let zero = BigInt::from(0);
+        let min = ty.get_min_value()?;
         match (lhs, cmp, rhs) {
-            (_, Lt, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Gt, _) if n == &zero => {
-                // exp < 0 || 0 > exp
+            (_, Lt, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Gt, _) if n == &min => {
+                // exp < min || min > exp
                 Some(AlwaysFalse)
             },
-            (_, Ge, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Le, _) if n == &zero => {
-                // exp >= 0 || 0 <= exp
+            (_, Ge, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Le, _) if n == &min => {
+                // exp >= min || min <= exp
                 Some(AlwaysTrue)
             },
-            (_, Le, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Ge, _) if n == &zero => {
-                // exp <= 0 || 0 >= exp
+            (_, Le, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Ge, _) if n == &min => {
+                // exp <= min || min >= exp
                 Some(UseEqInstead)
             },
-            (_, Gt, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Lt, _) if n == &zero => {
-                // exp > 0 || 0 < exp
+            (_, Gt, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Lt, _) if n == &min => {
+                // exp > min || min < exp
                 Some(UseNeqInstead)
             },
             (_, Gt, ExpValue(_, Number(n))) | (ExpValue(_, Number(n)), Lt, _) if *n == max => {

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.exp
@@ -116,3 +116,111 @@ warning: [lint] Comparison is always false, consider rewriting the code to remov
    │
    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:58:13
+   │
+58 │         if (x + 1 > 127) { bar() };
+   │             ^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:62:13
+   │
+62 │         if ((*x + *y > 127) == true) { bar() };
+   │             ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Directly use the boolean expression, instead of comparing it with `true`.
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:62:13
+   │
+62 │         if ((*x + *y > 127) == true) { bar() };
+   │             ^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_boolean_identity_comparison)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_boolean_identity_comparison.
+
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:90:13
+   │
+90 │         if (x < I8_MIN || I8_MIN > x) { bar() };
+   │             ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:90:27
+   │
+90 │         if (x < I8_MIN || I8_MIN > x) { bar() };
+   │                           ^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:95:13
+   │
+95 │         if (foo(x) >= I8_MIN) { bar() };
+   │             ^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
+   ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:96:13
+   │
+96 │         if (I8_MIN <= foo(x)) { bar() };
+   │             ^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:100:13
+    │
+100 │         if (a > I8_MAX) { bar() };
+    │             ^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always false, consider rewriting the code to remove the redundant comparison
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:102:13
+    │
+102 │         if (I32_MAX < c) { bar() };
+    │             ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:105:13
+    │
+105 │         if (f <= I256_MAX) { bar() };
+    │             ^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:106:13
+    │
+106 │         if (I256_MAX >= f) { bar() };
+    │             ^^^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.
+
+warning: [lint] Comparison is always true, consider rewriting the code to remove the redundant comparison
+    ┌─ tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move:109:20
+    │
+109 │             assert a <= I8_MAX;
+    │                    ^^^^^^^^^^^
+    │
+    = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(unnecessary_numerical_extreme_comparison)]`.
+    = For more information, see https://aptos.dev/en/build/smart-contracts/linter#unnecessary_numerical_extreme_comparison.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/unnecessary_numerical_extreme_comparisons_warn.move
@@ -53,6 +53,73 @@ module 0xc0ffee::m {
     public fun test5(x: u8): bool {
         apply(|x| x > U8_MAX, x)
     }
+
+    public fun test6(x: i8) {
+        if (x + 1 > 127) { bar() };
+    }
+
+    public fun test7(x: &i8, y: &i8) {
+        if ((*x + *y > 127) == true) { bar() };
+    }
+
+        // 8-bit
+    const I8_MIN: i8 = -128;
+    const I8_MAX: i8 = 127;
+
+    // 16-bit
+    const I16_MIN: i16 = -32768;
+    const I16_MAX: i16 = 32767;
+
+    // 32-bit
+    const I32_MIN: i32 = -2147483648;
+    const I32_MAX: i32 = 2147483647;
+
+    // 64-bit
+    const I64_MIN: i64 = -9223372036854775808;
+    const I64_MAX: i64 = 9223372036854775807;
+
+    // 128-bit
+    const I128_MIN: i128 = -170141183460469231731687303715884105728;
+    const I128_MAX: i128 = 170141183460469231731687303715884105727;
+
+    // 256-bit (custom / nonstandard)
+    const I256_MIN: i256 = -57896044618658097711785492504343953926634992332820282019728792003956564819968;
+    const I256_MAX: i256 = 57896044618658097711785492504343953926634992332820282019728792003956564819967;
+
+    public fun test8(x: i8) {
+        if (x < I8_MIN || I8_MIN > x) { bar() };
+        if (foo(x) <= I8_MIN) { bar() };
+        if (I8_MIN >= foo(x)) { bar() };
+        if (foo(x) > I8_MIN) { bar() };
+        if (I8_MIN < foo(x)) { bar() };
+        if (foo(x) >= I8_MIN) { bar() };
+        if (I8_MIN <= foo(x)) { bar() };
+    }
+
+    public fun test9(a: i8, b: i16, c: i32, d: i64, e: i128, f: i256) {
+        if (a > I8_MAX) { bar() };
+        if (b >= I16_MAX) { bar() };
+        if (I32_MAX < c) { bar() };
+        if (I64_MAX <= d) { bar() };
+        if (e < I128_MAX) { bar() };
+        if (f <= I256_MAX) { bar() };
+        if (I256_MAX >= f) { bar() };
+        if (I128_MAX > e) { bar() };
+        spec {
+            assert a <= I8_MAX;
+        }
+    }
+
+    // simulate `abs`
+    public fun test_abs(x: i64): i64 {
+        // should not warn for `x >= 0`
+        if (x >= 0) {
+            x
+        } else {
+            -x
+        }
+    }
+
 }
 
 module 0xc0ffee::no_warn {

--- a/third_party/move/tools/move-linter/tests/testsuite.rs
+++ b/third_party/move/tools/move-linter/tests/testsuite.rs
@@ -25,7 +25,7 @@ fn test_runner(path: &Path) -> datatest_stable::Result<()> {
             "aptos_std=0x1".to_string(),
             "aptos_framework=0x1".to_string(),
         ],
-        language_version: Some(LanguageVersion::latest_stable()),
+        language_version: Some(LanguageVersion::latest()),
         compiler_version: Some(CompilerVersion::latest_stable()),
         experiments: vec![Experiment::LINT_CHECKS.to_string()],
         external_checks: vec![MoveLintChecks::make(BTreeMap::from([(


### PR DESCRIPTION
## Description
The `unnecessary_numerical_extreme_comparison` linter only considers unsigned int before, thus taking `0` as the lower bound. This breaks after signed int is added.

This PR updates the linter to consider signed int by changing the lower bound to `Type.ty.get_min_value()`.

## How Has This Been Tested?
- New linter test cases

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (Move Linter)
