### PR TITLE
fix and reenable jwk smoke tests

### DIFF
--- a/testsuite/smoke-test/src/jwks/jwk_consensus_basic.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_basic.rs
@@ -35,6 +35,9 @@ async fn jwk_consensus_basic() {
         .with_init_genesis_config(Arc::new(move |conf| {
             conf.epoch_duration_secs = epoch_duration_secs;
         }))
+        .with_init_genesis_stake(Arc::new(|_i, genesis_stake_amount| {
+            *genesis_stake_amount = 100_000_000_000_000;
+        }))
         .build_with_cli(0)
         .await;
     let client = swarm.validators().next().unwrap().rest_client();

--- a/testsuite/smoke-test/src/jwks/jwk_consensus_per_issuer.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_per_issuer.rs
@@ -26,13 +26,15 @@ use tokio::time::sleep;
 /// The validators should do JWK consensus per issuer:
 /// one problematic issuer should not block valid updates of other issuers.
 #[tokio::test]
-#[ignore]
 async fn jwk_consensus_per_issuer() {
     let epoch_duration_secs = 30;
 
     let (swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
         .with_num_fullnodes(1)
         .with_aptos()
+        .with_init_genesis_stake(Arc::new(|_i, genesis_stake_amount| {
+            *genesis_stake_amount = 100_000_000_000_000;
+        }))
         .with_init_genesis_config(Arc::new(move |conf| {
             conf.epoch_duration_secs = epoch_duration_secs;
         }))

--- a/testsuite/smoke-test/src/jwks/jwk_consensus_per_key.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_per_key.rs
@@ -26,13 +26,15 @@ use tokio::time::sleep;
 /// Validators should be able to reach consensus on key-level diffs
 /// even if providers are equivocating on the full key list.
 #[tokio::test]
-#[ignore]
 async fn jwk_consensus_per_key() {
     let epoch_duration_secs = 30;
 
     let (swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
         .with_num_fullnodes(1)
         .with_aptos()
+        .with_init_genesis_stake(Arc::new(|_i, genesis_stake_amount| {
+            *genesis_stake_amount = 100_000_000_000_000;
+        }))
         .with_init_genesis_config(Arc::new(move |conf| {
             conf.epoch_duration_secs = epoch_duration_secs;
             let mut features = Features::default();

--- a/testsuite/smoke-test/src/jwks/jwk_consensus_provider_change_mind.rs
+++ b/testsuite/smoke-test/src/jwks/jwk_consensus_provider_change_mind.rs
@@ -27,7 +27,6 @@ use tokio::time::sleep;
 /// even if a provider double-rotates its key in a very short period of time.
 /// First rotation may have been observed by some validators.
 #[tokio::test]
-#[ignore]
 async fn jwk_consensus_provider_change_mind() {
     // Big epoch duration to ensure epoch change does not help reset validators if they are stuck.
     let epoch_duration_secs = 1800;
@@ -35,6 +34,9 @@ async fn jwk_consensus_provider_change_mind() {
     let (swarm, mut cli, _faucet) = SwarmBuilder::new_local(4)
         .with_num_fullnodes(1)
         .with_aptos()
+        .with_init_genesis_stake(Arc::new(|_i, genesis_stake_amount| {
+            *genesis_stake_amount = 100_000_000_000_000;
+        }))
         .with_init_genesis_config(Arc::new(move |conf| {
             conf.epoch_duration_secs = epoch_duration_secs;
         }))


### PR DESCRIPTION
## Description

JWK consensus smoke tests assume (almost) evenly distributed stakes between 4 validators.
The default voting power was set to 10, which is too small after priority fees were enabled and distributed (which is why they became flaky and some were disabled).
Fixing and reenable tests.

## How Has This Been Tested?

Existing test suites.

## Key Areas to Review

n/a

## Type of Change

- [x] Tests

## Which Components or Systems Does This Change Impact?

n/a

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->