### PR TITLE
[APTOS CLI] release 7.10.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,7 +304,7 @@ dependencies = [
 
 [[package]]
 name = "aptos"
-version = "7.10.0"
+version = "7.10.1"
 dependencies = [
  "anyhow",
  "aptos-api-types",

--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -3,6 +3,9 @@
 All notable changes to the Aptos CLI will be captured in this file. This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) and the format set out by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 # Unreleased
+
+## [7.10.1]
+- Add support into Move 2.2 for builtin constant `__COMPILE_FOR_TESTING__` 
 - Update the default version of move formatter to 1.3.7
 - Update the default version of move mutation test tool to 2.0.0
 

--- a/crates/aptos/Cargo.toml
+++ b/crates/aptos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "aptos"
 description = "Aptos tool for management of nodes and interacting with the blockchain"
-version = "7.10.0"
+version = "7.10.1"
 
 # Workspace inherited keys
 authors = { workspace = true }

--- a/third_party/move/move-model/src/builder/builtins.rs
+++ b/third_party/move/move-model/src/builder/builtins.rs
@@ -7,7 +7,10 @@
 use crate::{
     ast::{Operation, TraceKind, Value},
     builder::model_builder::{ConstEntry, EntryVisibility, ModelBuilder, SpecOrBuiltinFunEntry},
-    metadata::{lang_feature_versions::SINT_LANGUAGE_VERSION_VALUE, LanguageVersion},
+    metadata::{
+        lang_feature_versions::{COMPILE_FOR_TESTING_VALUE, SINT_LANGUAGE_VERSION_VALUE},
+        LanguageVersion,
+    },
     model::{Parameter, TypeParameter, TypeParameterKind},
     options::ModelBuilderOptions,
     ty::{Constraint, PrimitiveType, ReferenceKind, Type},
@@ -63,7 +66,10 @@ pub(crate) fn declare_builtins(trans: &mut ModelBuilder) {
     };
 
     {
-        if options.language_version.is_at_least(LanguageVersion::V2_3) {
+        if options
+            .language_version
+            .is_at_least(COMPILE_FOR_TESTING_VALUE)
+        {
             use EntryVisibility::SpecAndImpl;
             // Compiler builtin constants.
             trans.define_const(

--- a/third_party/move/move-model/src/metadata.rs
+++ b/third_party/move/move-model/src/metadata.rs
@@ -27,6 +27,7 @@ pub static COMPILATION_METADATA_KEY: &[u8] = "compilation_metadata".as_bytes();
 // Language versions enabling specific features
 pub mod lang_feature_versions {
     use crate::LanguageVersion;
+    pub const COMPILE_FOR_TESTING_VALUE: LanguageVersion = LanguageVersion::V2_2;
     pub const SINT_LANGUAGE_VERSION_VALUE: LanguageVersion = LanguageVersion::V2_3;
 }
 


### PR DESCRIPTION
## Description
This PR downgrades the gate on built-in constant `__COMPILE_FOR_TESTING__` from language v2.3 to v2.2. It also releases a new APTOS CLI version 7.10.1.

## How Has This Been Tested?
- Manual testing

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)
