### PR TITLE
Set block cache size to 36GB for replay-verify

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -188,6 +188,11 @@ pub struct RocksdbConfigs {
     pub shared_block_cache_size: usize,
 }
 
+impl RocksdbConfigs {
+    /// Default block cache size is 24GB.
+    pub const DEFAULT_BLOCK_CACHE_SIZE: usize = 24 * (1 << 30);
+}
+
 fn default_to_true() -> bool {
     true
 }
@@ -205,7 +210,7 @@ impl Default for RocksdbConfigs {
             enable_storage_sharding: true,
             high_priority_background_threads: 4,
             low_priority_background_threads: 2,
-            shared_block_cache_size: 24 * (1 << 30),
+            shared_block_cache_size: Self::DEFAULT_BLOCK_CACHE_SIZE,
         }
     }
 }

--- a/storage/backup/backup-cli/src/utils/mod.rs
+++ b/storage/backup/backup-cli/src/utils/mod.rs
@@ -87,8 +87,8 @@ pub struct RocksdbOpt {
     index_db_max_total_wal_size: u64,
     #[clap(long, hide(true), default_value_t = 16)]
     max_background_jobs: i32,
-    #[clap(long, hide(true), default_value_t = 1024)]
-    block_cache_size: u64,
+    #[clap(long, hide(true), default_value_t = RocksdbConfigs::DEFAULT_BLOCK_CACHE_SIZE)]
+    block_cache_size: usize,
 }
 
 impl From<RocksdbOpt> for RocksdbConfigs {
@@ -98,14 +98,12 @@ impl From<RocksdbOpt> for RocksdbConfigs {
                 max_open_files: opt.ledger_db_max_open_files,
                 max_total_wal_size: opt.ledger_db_max_total_wal_size,
                 max_background_jobs: opt.max_background_jobs,
-                block_cache_size: opt.block_cache_size,
                 ..Default::default()
             },
             state_merkle_db_config: RocksdbConfig {
                 max_open_files: opt.state_merkle_db_max_open_files,
                 max_total_wal_size: opt.state_merkle_db_max_total_wal_size,
                 max_background_jobs: opt.max_background_jobs,
-                block_cache_size: opt.block_cache_size,
                 ..Default::default()
             },
             enable_storage_sharding: opt.enable_storage_sharding,
@@ -113,16 +111,15 @@ impl From<RocksdbOpt> for RocksdbConfigs {
                 max_open_files: opt.state_kv_db_max_open_files,
                 max_total_wal_size: opt.state_kv_db_max_total_wal_size,
                 max_background_jobs: opt.max_background_jobs,
-                block_cache_size: opt.block_cache_size,
                 ..Default::default()
             },
             index_db_config: RocksdbConfig {
                 max_open_files: opt.index_db_max_open_files,
                 max_total_wal_size: opt.index_db_max_total_wal_size,
                 max_background_jobs: opt.max_background_jobs,
-                block_cache_size: opt.block_cache_size,
                 ..Default::default()
             },
+            shared_block_cache_size: opt.block_cache_size,
             ..Default::default()
         }
     }

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -233,7 +233,7 @@ class WorkerPod:
             "--timeout-secs",
             f"{self.config.timeout_secs}",
             "--block-cache-size",
-            "10737418240",
+            f"{36 * 1024 * 1024 * 1024}",
         ]
         # TODO(ibalajiarun): bump memory limit to 180GiB for heavy ranges
         if (


### PR DESCRIPTION

We noticed significant speedup for mainnet replay-verify (~3h -> ~2h) after
https://github.com/aptos-labs/aptos-core/pull/17812 was committed. Previously, ledger db, state kv
db and state merkle db each had 10GB of block cache (specified in
`testsuite/replay-verify/main.py`). After, we have a single block cache (24GB) for everything.

My feeling is that the 10GB block cache for state kv db was too small, because the archival nodes
have lots of more versions than validators.

For this PR:
- We do some cleanups. `block_cache_size` in the config has been deprecated, so we assign to
  `shared_block_cache_size` instead.
- Set the block cache size to 36GB. The number is a bit of guesstimate for now,
  based on 1) the total memory seems to be 100GB, so we have plenty 2) I ran a
  test with 48, it might've sped up a bit, but not a lot. We can tune this
  number later when we check RocksDB's logs and see what the cache hit rate
  looks like. (I'm not sure how to ssh into the replay-verify containers yet.)
