### PR TITLE
Enable trusted code in 1.37 testnet.

### DIFF
--- a/aptos-move/aptos-release-builder/data/proposals/enable-trusted-coded.yaml
+++ b/aptos-move/aptos-release-builder/data/proposals/enable-trusted-coded.yaml
@@ -1,0 +1,12 @@
+remote_endpoint: ~
+name: "v1.37-enable-trusted-code"
+proposals:
+  - name: enable_trusted_code
+    metadata:
+      title: "Proposal to enable trusted code (see also AIP 134)"
+      description: "See https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-134.md"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - enable_trusted_code


### PR DESCRIPTION
## Description

Enable trusted code

