### PR TITLE
[Aptos CLI] release 7.10.2

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 
+## [7.10.2]
+- Fix backward compatibility issue of enum-based option module
+
 ## [7.10.1]
 - Add support into Move 2.2 for builtin constant `__COMPILE_FOR_TESTING__` 
 - Update the default version of move formatter to 1.3.7

--- a/third_party/move/move-vm/runtime/src/config.rs
+++ b/third_party/move/move-vm/runtime/src/config.rs
@@ -75,7 +75,7 @@ impl Default for VMConfig {
             enable_enum_option: true,
             enable_layout_caches: true,
             propagate_dependency_limit_error: true,
-            enable_framework_for_option: true,
+            enable_framework_for_option: false,
         }
     }
 }

--- a/types/src/on_chain_config/aptos_features.rs
+++ b/types/src/on_chain_config/aptos_features.rs
@@ -258,7 +258,6 @@ impl FeatureFlag {
             FeatureFlag::ENABLE_TRUSTED_CODE,
             FeatureFlag::ENABLE_ENUM_OPTION,
             FeatureFlag::VM_BINARY_FORMAT_V9,
-            FeatureFlag::ENABLE_FRAMEWORK_FOR_OPTION,
         ]
     }
 }


### PR DESCRIPTION
## Description
Enum-based option has compatibility issues with old versions of framework that users might choose to use. This PR fixes the issues and release a new CLI.

## How Has This Been Tested?
- Manual testing

## Type of Change
- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)