### PR TITLE
[move compiler] [CSE Step 2] common subexpression elimination

### DIFF
--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -163,6 +163,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(false),
         },
         Experiment {
+            name: Experiment::COMMON_SUBEXP_ELIMINATION.to_string(),
+            description: "Whether to run common subexpression elimination".to_string(),
+            default: Inherited(Experiment::OPTIMIZE_WAITING_FOR_COMPARE_TESTS.to_string()),
+        },
+        Experiment {
             name: Experiment::CFG_SIMPLIFICATION.to_string(),
             description: "Whether to do the control flow graph simplification".to_string(),
             default: Inherited(Experiment::OPTIMIZE.to_string()),
@@ -327,6 +332,7 @@ impl Experiment {
     pub const CFG_SIMPLIFICATION: &'static str = "cfg-simplification";
     pub const CHECKS: &'static str = "checks";
     pub const CMP_REWRITE: &'static str = "cmp-rewrite";
+    pub const COMMON_SUBEXP_ELIMINATION: &'static str = "common-subexp-elimination";
     pub const COMPILE_FOR_TESTING: &'static str = "compile-for-testing";
     pub const DEAD_CODE_ELIMINATION: &'static str = "dead-code-elimination";
     pub const DUPLICATE_STRUCT_PARAMS_CHECK: &'static str = "duplicate-struct-params-check";

--- a/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/ability_processor.rs
@@ -280,6 +280,7 @@ impl Transformer<'_> {
                     self.check_explicit_copy(id, src);
                     self.builder.emit(Assign(id, dst, src, AssignKind::Copy))
                 },
+                AssignKind::Dup => self.builder.emit(Assign(id, dst, src, AssignKind::Dup)),
                 AssignKind::Move => {
                     self.check_explicit_move(code_offset, id, src);
                     self.builder.emit(Assign(id, dst, src, AssignKind::Move))

--- a/third_party/move/move-compiler-v2/src/pipeline/common_subexp_elimination.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/common_subexp_elimination.rs
@@ -1,0 +1,1893 @@
+// Copyright (c) Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Implements the "common subexpression elimination" (CSE) transformation
+//!
+//! Prerequisites:
+//! - Variable liveness information is available
+//! - Reaching definition information is available
+//! - Flush writes information is available
+//!
+//! Side effects:
+//! - Certain instructions are rewritten/removed
+//! - Annotations are cleared
+//! - AbilityProcessor need to run after this to check variable abilities and insert Copy/Move as needed
+//!
+//! Motivating Example:
+//! ```Move
+//! 1. fun test(data: S, a: u64, b: u64): u64 {
+//! 2.       if (data.x != 0) {
+//! 3.           a / data.x
+//! 4.       } else {
+//! 5.           data.x + 1
+//! 6.       }
+//! 7.   }
+//! ```
+//! At the stackless bytecode level, `data.x` is translated into a seq of `BorrowLoc` + `BorrowField` + `ReadRef` instructions.
+//! *Without* CSE, all occurance of the same expression `data.x` (line 2, line 3, line 5) will be translated into the seq above,
+//! despite `data.x` at line 3 and line 5 share the same result of line 2 and the computations are not necessary.
+//!
+//! CSE aims to eliminate such repeated computations by reusing the result of previous computations.
+//! Specifically, in the example above, assuming the `BorrowLoc` + `BorrowField` + `ReadRef` sequence at line 2 is assigned to temp `t1`,
+//! then the occurrences at line 3 and line 5 can both be replaced by `t1`, eliminating the repeated computations.
+//! The optimized bytecode would look like:
+//!
+//!  0: $t6 := borrow_local($t0)
+//!  1: $t7 := borrow_field<0x8675::M::S>.x($t6)
+//!  2: $t5 := read_ref($t7) // `data.x` at line 2 assigned to $t5
+//!  3: $t8 := 0
+//!  4: $t4 := !=($t5, $t8)
+//!  5: if ($t4) goto 6 else goto 11
+//!  6: label L0
+//!  7: $t9 := move($t1)
+//!  8: $t10 := copy($t5)
+//!  9: $t3 := /($t9, $t10) // line 3 reuses $t5
+//!  10: label L2
+//!  11: return $t3
+//!  12: label L1
+//!  13: $t16 := 1
+//!  14: $t11 := copy($t5)
+//!  15: $t3 := +($t11, $t16) // line 5 reuses $t5
+//!  16: goto 9
+//!
+//! ============================ Implementation Details ============================
+//!
+//! Step 1: Build the Control Flow Graph (CFG) and Domination Tree of a target function.
+//!
+//! Step 2: Traverse the Domination Tree in preorder, and for each basic block, for each instruction:
+//! - If the instruction is *PURE*, canonicalize the expression into an `Expr` structure
+//!   - `Expr` contains the operation, arguments, defined temps, and code offset
+//!   - Arguments (`ExprArg`) can be constants, variables (temps), or nested `Expr`s
+//!      - Motivation to nest expression: consider the expression `ReadRef(BorrowField(BorrowLoc(x)))`, we want to
+//!        represent it as a single one rather than three separate ones, so that we can eliminate
+//!        the entire sequence at once upon reoccurance.
+//!      - Conditions to nest `t1 = Op1(t0); t2 = Op2(t1);` as `Op2(Op1(t0))`:
+//!         - The definition at `Op1` is the only definition of `t1` that can reach `Op2`
+//!         - `t1` is only used once and exactly by `Op2`.
+//!      - For commutative operations, the arguments are sorted to get a canonical order
+//!   - `Expr` caches an `ExprKey` (the canonical pattern) for efficient map lookups
+//! - Why pre-order traversal: ensure that all dominating blocks have been processed before the dominated ones,
+//!   hencing not missing opportunities for replacement
+//!
+//! Step 3: Check if the `Expr` from Step 2 has a matching pattern (same `ExprKey`) seen before in a dominating block.
+//! Given a seen-before `Expr` (annotated as `src_expr`) matching the current expression (annotated as `dest_expr`),
+//! and assuming the two expressions have the following formats:
+//!   - `src_expr`: `(src_temp1, src_temp2, ...) = src_op(src_ope1, src_ope2, ...)` defined at `src_inst`, where `src_ope1` and `src_ope2` can be nested expressions
+//!   - `dest_expr`: `(dest_temp1, dest_temp2, ...) = dest_op(dest_ope1, dest_ope2, ...)` defined at `dest_inst`, where `dest_ope1` and `dest_ope2` can be nested expressions
+//! reusing the results of `src_expr` to replace `dest_expr` can incur safety issues, which we defail below with corresponding solutions:
+//!
+//! Safety 1: execution may reach `dest_inst` without going through `src_inst` first
+//! - This can lead to using incorrect values at `dest_inst`
+//! - Solution: check that `src_expr` dominates `dest_expr`
+//!
+//! Safety 2: type issues
+//! - `src_temps` and `dest_temps` can have different mutability when both are references (stackless bytecode does not encode mutability status)
+//!   - This can lead to type conflict when copying `src_temp` to `dest_temp`
+//!   - Solution: check that when `src_temps` and `dest_temps` have identical types
+//! - `stc_temps` can be mutably borrowed
+//!   - This can create reference safety violations when copying `src_temps` to `dest_temps`
+//!   - Solution: check that none of `src_temps` are mutably borrowed
+//!
+//! Safety 3: `src_temps` may not be copyable
+//! - This can lead to ability violations when copying `src_temps` to `dest_temps`
+//! - Solution: check that all `src_temps` are copyable
+//!
+//! Safety 4: `src_temps` may be re-defined before reaching `dest_expr`
+//! - This can lead to using incorrect values at `dest_expr`
+//! - Solution: check that the definitions at `src_expr` are the only definitions of `src_temps` that can reach `dest_expr`
+//!
+//! Safety 5: resources accessed by `src_expr` (via `BorrowGlobal` and `Exists`) may be changed before reaching `dest_expr`
+//! - This can lead to accessing different resource status/values at `dest_expr`
+//! - Solution: check that the resources accessed by `src_expr` are not changed before reaching `dest_expr`
+//!
+//! Safety 6: leaf temps used in `src_expr` (i.e., `src_t1, src_t2, ...`) may be changed before reaching `dest_expr`
+//! - This means that `dest_expr` may produce different results from `src_expr`
+//! - Solution: check that leaf temps used in `src_expr` are safe to reuse at `dest_expr`
+//!   1. Leaf temps used in `src_expr` are identical to those used in `dest_expr`
+//!   2. None of the leaf temps used in `src_expr` are possibly re-defined in a path between `src_expr` and `dest_expr` (without going through `src_expr` again)
+//!   3. None of the leaf temps used in `src_expr` are mutable references
+//!      - In special cases (e.g., the leaf temp is directly from function argument), our reaching definition cannot trace the memory underneath,
+//!        and we may miss possible modifications to the memory states via the mutable reference.
+//!
+//! Besides safety, we also need to ensure that the replacement can bring performance gains. See comments above `gain_perf` for details
+//!
+//! Step 4: for each `src_expr` passing the conditions to replace `dest_expr` in Step 3, we check gather necessary information to perform replacement like below:
+//!
+//! Example:
+//! ```Move
+//! 1. src_temp = pure_computation_1(t0)      // src_inst
+//! 2. ...
+//! 3. use(src_temp)
+//! 4. dest_temp = pure_computation_1(t0)      // dest_inst
+//! 5. ...
+//! 6. use(dest_temp)
+//! ```
+//! ==>
+//! ```Move
+//! 1. src_temp = pure_computation_1(t0)      // src_inst
+//! 2. ...
+//! 3. use(src_temp)
+//! 4. dest_temp = copy(src_temp)      // inserted copy
+//! 5. ...
+//! 6. use(dest_temp)
+//! ```
+//!
+//! Step 5: After processing all basic blocks, we perform the recorded replacements and eliminate the marked code.
+//!
+//! ============================ Extensions ============================
+//!
+//! In principle, the algorithm above is designed to handle PURE instructions, defined as blow
+//! - the results only depend on the inputs
+//! - has no side effects on `memory` (including write via references), control flow (including `abort`), or external state (global storage)
+//! - recomputing it multiple times yields no semantic effect.
+//!
+//! Yet, we found that some non-pure instructions can be safely handled under certain conditions.
+//!
+//! Group 1: operations that are pure if no arithmetic errors like overflows happen (`+`, `-`, `*`, `/`, `%`, etc):
+//! - their side effects (i.e., aborts) are safe because those, if happening, are guaranteed to happen earlier in the `src_inst`
+//!
+//! Group 2: operations that are pure if no type errors happen (`UnpackVariant`):
+//! - their side effects (i.e., aborts) are safe because those, if happening, are guaranteed to happen earlier in the `src_inst`
+//!
+//! Group 3: local borrow operations: `BorrowLoc`, `BorrowField`, `BorrowVariantField`
+//! - In principle, borrow operations are not pure as they depend on memory states.
+//! - Yet, our `Safety 6` guarantees that the memory underneath are not changed and, hence, their "pureness".
+//! - We also note that borrowing constants (e.g., `&42`) cannot be reused, as the same constant will actually reside at different memory locations.
+//!
+//! Group 4: `Assign`
+//! - It can be treated as pure when the assign kind is `Copy` or `Inferred` (TODO(#18203): reasoning more about `Inferred`)
+//!
+//! Group 5: `readref`
+//! - `readref` also depends on memory states
+//! - But similar to local borrow operations, our `Safety 6` guarantees that the memory states are not changed.
+//!
+//! Group 6: `Function` calls
+//! - A function call can be treated as pure if the callee
+//!   - Does not modify any memory via mutable references
+//!   - Does not access global resources
+//!
+//! Group 7: `BorrowGlobal` and `Exists`
+//! - They can be treated as pure as our `Safety 5` guarantees that the resources accessed are not modified between `src_inst` and `dst_inst`
+//!
+//! To add support for other instructions, please extend `BytecodeSanitizer` to enable support and extend the safety rules accordingly.
+
+use crate::{
+    bytecode_generator::generate_bytecode,
+    pipeline::{
+        flush_writes_processor::FlushWritesAnnotation,
+        livevar_analysis_processor::{LiveVarAnnotation, LiveVarInfo},
+        reaching_def_analysis_processor::ReachingDefAnnotation,
+        reference_safety::Object,
+    },
+};
+use im::ordset::OrdSet;
+use log::info;
+use move_binary_format::file_format::CodeOffset;
+use move_core_types::account_address::AccountAddress;
+use move_model::{
+    ast::{Address, TempIndex},
+    model::{FunId, FunctionEnv, ModuleId, QualifiedId},
+    ty::Type,
+    well_known::{BORROW_NAME, EMPTY_NAME, LENGTH_NAME, VECTOR_MODULE},
+};
+use move_stackless_bytecode::{
+    function_data_builder::FunctionDataBuilder,
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    graph::{DomRelation, Graph},
+    stackless_bytecode::{AssignKind, Bytecode, Constant, Operation},
+    stackless_control_flow_graph::{BlockId, StacklessControlFlowGraph},
+};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fmt::{self, Formatter},
+};
+
+/// Enum to represent an expression operation.
+#[derive(Clone, PartialEq, Eq, Debug, PartialOrd, Ord)]
+pub enum ExprOp {
+    Op(Operation),
+    Load,
+    Assign(AssignKind),
+}
+
+/// Argument in an expression key (for pattern matching).
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum ArgKey {
+    Const(Constant),
+    Var(TempIndex),
+    Expr(Box<ExprKey>),
+}
+
+/// Canonicalized expression pattern used as a map key for identifying common subexpressions.
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct ExprKey {
+    op: ExprOp,
+    args: Vec<ArgKey>,
+}
+
+/// Argument in an expression definition (for analysis).
+#[derive(Clone, Debug)]
+pub enum ExprArg {
+    Const(Constant),
+    Var(TempIndex),
+    Expr(Box<Expr>),
+}
+
+/// A definition of an expression at a specific code location.
+///
+/// Contains both:
+/// - `key`: the cached canonical pattern (for efficient map lookups)
+/// - `args`: full argument info with nested definitions (for analysis)
+/// - `temps`: the temporaries defined by this expression
+/// - `offset`: the code offset where this expression is defined
+///
+/// Consider the following example:
+/// ```Move
+///  1. t1 = pure_computation_1(t0)
+///  2. t2 = pure_computation_1(t0)
+/// ```
+/// Both lines have the same `ExprKey` (op = pure_computation_1, args = [Var(t0)]),
+/// but different `Expr`s:
+/// - Line 1: Expr { key: ..., temps: [t1], offset: 1 }
+/// - Line 2: Expr { key: ..., temps: [t2], offset: 2 }
+#[derive(Clone, Debug)]
+pub struct Expr {
+    /// The cached canonical expression pattern (for map lookups)
+    key: ExprKey,
+    /// The operation
+    op: ExprOp,
+    /// Full arguments with nested definitions (for analysis)
+    args: Vec<ExprArg>,
+    /// Temps defined by this expression
+    temps: Vec<TempIndex>,
+    /// Code offset where this expression is defined
+    offset: CodeOffset,
+}
+
+impl Expr {
+    pub fn new(op: ExprOp, args: Vec<ExprArg>, temps: Vec<TempIndex>, offset: CodeOffset) -> Self {
+        let key = ExprKey {
+            op: op.clone(),
+            args: args.iter().map(|a| a.to_arg_key()).collect(),
+        };
+        Self {
+            key,
+            op,
+            args,
+            temps,
+            offset,
+        }
+    }
+
+    /// Get the cached expression key for map lookups
+    pub fn key(&self) -> &ExprKey {
+        &self.key
+    }
+
+    /// Get the operation
+    pub fn op(&self) -> &ExprOp {
+        &self.op
+    }
+
+    /// Get the arguments
+    pub fn args(&self) -> &[ExprArg] {
+        &self.args
+    }
+
+    /// Get the temps defined by this expression
+    pub fn temps(&self) -> &[TempIndex] {
+        &self.temps
+    }
+
+    /// Get the code offset
+    pub fn offset(&self) -> CodeOffset {
+        self.offset
+    }
+
+    /// Collect all leaf nodes (temps and constants) in this expression tree
+    pub fn collect_leaves(&self) -> (Vec<(TempIndex, CodeOffset)>, Vec<(Constant, CodeOffset)>) {
+        let mut temps = Vec::new();
+        let mut consts = Vec::new();
+        for arg in self.args.iter() {
+            match arg {
+                ExprArg::Var(temp) => temps.push((*temp, self.offset)),
+                ExprArg::Expr(boxed_expr) => {
+                    let (nested_temps, nested_consts) = boxed_expr.collect_leaves();
+                    temps.extend(nested_temps.into_iter());
+                    consts.extend(nested_consts.into_iter());
+                },
+                ExprArg::Const(c) => consts.push((c.clone(), self.offset)),
+            }
+        }
+        (temps, consts)
+    }
+
+    /// Collect all bytecode offsets constituting this expression, including nested ones
+    pub fn collect_exps(&self) -> Vec<CodeOffset> {
+        let mut exps = vec![self.offset];
+        for arg in self.args.iter() {
+            if let ExprArg::Expr(arg_expr) = arg {
+                exps.extend(arg_expr.collect_exps().into_iter());
+            }
+        }
+        exps
+    }
+
+    /// Creates a format object for an expression in context of a function target.
+    pub fn display<'env>(
+        &'env self,
+        func_target: &'env FunctionTarget<'env>,
+        verbose: bool,
+    ) -> ExprDisplay<'env> {
+        ExprDisplay {
+            expr_def: self,
+            func_target,
+            verbose,
+        }
+    }
+}
+
+/// A display object for an `Expr`.
+pub struct ExprDisplay<'env> {
+    expr_def: &'env Expr,
+    func_target: &'env FunctionTarget<'env>,
+    verbose: bool,
+}
+
+impl fmt::Display for ExprDisplay<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let args_str = self
+            .expr_def
+            .args()
+            .iter()
+            .map(|arg| format!("{}", arg.display(self.func_target, false)))
+            .collect::<Vec<_>>()
+            .join(", ");
+
+        if self.verbose {
+            write!(
+                f,
+                "`{}()` @ ",
+                self.func_target.func_env.get_full_name_str()
+            )?;
+
+            let loc = self
+                .func_target
+                .get_bytecode_loc_at_offset(self.expr_def.offset());
+            let file_name = self
+                .func_target
+                .global_env()
+                .get_file(loc.file_id())
+                .to_string_lossy()
+                .to_string();
+            let file_loc = self.func_target.global_env().get_location(&loc);
+
+            if let Some(file_loc) = file_loc {
+                write!(f, "{}: {},{}: ", file_name, file_loc.line, file_loc.column)?;
+            } else {
+                write!(f, "{}: <unknown>: ", file_name)?;
+            }
+        }
+
+        write!(f, "[L{}: ", self.expr_def.offset())?;
+        match self.expr_def.op() {
+            ExprOp::Load => write!(f, "load({})", args_str)?,
+            ExprOp::Assign(kind) => write!(f, "assign[{:?}]({})", kind, args_str)?,
+            ExprOp::Op(op) => write!(f, "{}({})", op.display(self.func_target), args_str)?,
+        };
+        write!(f, "]")?;
+        Ok(())
+    }
+}
+
+impl ExprArg {
+    /// Convert to an `ArgKey` for pattern matching
+    fn to_arg_key(&self) -> ArgKey {
+        match self {
+            ExprArg::Const(c) => ArgKey::Const(c.clone()),
+            ExprArg::Var(v) => ArgKey::Var(*v),
+            ExprArg::Expr(e) => ArgKey::Expr(Box::new(e.key().clone())),
+        }
+    }
+
+    pub fn display<'env>(
+        &'env self,
+        func_target: &'env FunctionTarget<'env>,
+        verbose: bool,
+    ) -> ExprArgDisplay<'env> {
+        ExprArgDisplay {
+            expr_arg: self,
+            func_target,
+            verbose,
+        }
+    }
+}
+
+/// A display object for an `ExprArg`.
+pub struct ExprArgDisplay<'env> {
+    expr_arg: &'env ExprArg,
+    func_target: &'env FunctionTarget<'env>,
+    verbose: bool,
+}
+
+impl fmt::Display for ExprArgDisplay<'_> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let str = match self.expr_arg {
+            ExprArg::Const(c) => format!("{}", c),
+            ExprArg::Var(idx) => format!("t{}", idx),
+            ExprArg::Expr(expr) => format!("{}", expr.display(self.func_target, self.verbose)),
+        };
+        write!(f, "{}", str)?;
+        Ok(())
+    }
+}
+
+/// The processor to perform Common Subexpression Elimination (CSE)
+pub struct CommonSubexpElimination {
+    aggressive_mode: bool,
+}
+
+impl CommonSubexpElimination {
+    pub fn new(aggressive_mode: bool) -> Self {
+        Self { aggressive_mode }
+    }
+}
+
+/// Implements the CSE transformation as a FunctionTargetProcessor
+impl FunctionTargetProcessor for CommonSubexpElimination {
+    /// Entry point
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+        let target = FunctionTarget::new(func_env, &data);
+        // CSE depends on variable liveness analysis, reaching definition analysis, and flush writes analysis!!!
+        let (Some(live_var_annotation), Some(reach_def_annotation), Some(flush_writes_annotation)) = (
+            target.get_annotations().get::<LiveVarAnnotation>(),
+            target.get_annotations().get::<ReachingDefAnnotation>(),
+            target.get_annotations().get::<FlushWritesAnnotation>(),
+        ) else {
+            return data;
+        };
+        let analyzer = CSEAnalyzer::new(
+            target,
+            live_var_annotation,
+            reach_def_annotation,
+            flush_writes_annotation,
+            self.aggressive_mode,
+        );
+        let mut new_data = analyzer.transform();
+        new_data.annotations.clear();
+        new_data
+    }
+
+    fn name(&self) -> String {
+        "CommonSubexpElimination".to_string()
+    }
+}
+
+/// Context for CSE analysis containing CFG, domination info, and analysis state.
+struct AnalysisContext<'a> {
+    // CFG and domination info
+    code: &'a [Bytecode],
+    forward_cfg: StacklessControlFlowGraph,
+    backward_cfg: StacklessControlFlowGraph,
+    dom_relation: DomRelation<u16>,
+    post_dom_relation: DomRelation<u16>,
+
+    // Analysis state
+    /// Maps from temps to the vector of expression definitions that define them
+    tempid_to_exprdef: BTreeMap<Vec<TempIndex>, Vec<Expr>>,
+    /// Maps from expression key to the vector of definitions that share the key
+    expr_table: BTreeMap<ExprKey, Vec<Expr>>,
+    /// Replacements: dest_offset -> [(dest_temp, (src_offset, src_temp))]
+    expr_replacements: BTreeMap<CodeOffset, Vec<(TempIndex, (CodeOffset, TempIndex))>>,
+    /// Code offsets to eliminate
+    eliminate_code: BTreeSet<CodeOffset>,
+}
+
+impl<'a> AnalysisContext<'a> {
+    fn new(code: &'a [Bytecode]) -> Self {
+        let forward_cfg = StacklessControlFlowGraph::new_forward(code);
+        let graph = Graph::new(
+            forward_cfg.entry_block(),
+            forward_cfg.blocks(),
+            forward_cfg.edges(),
+        );
+        let dom_relation = DomRelation::new(&graph);
+
+        let backward_cfg = StacklessControlFlowGraph::new_backward(code, true);
+        let backward_graph = Graph::new(
+            backward_cfg.entry_block(),
+            backward_cfg.blocks(),
+            backward_cfg.edges(),
+        );
+        let post_dom_relation = DomRelation::new(&backward_graph);
+
+        Self {
+            code,
+            forward_cfg,
+            backward_cfg,
+            dom_relation,
+            post_dom_relation,
+            tempid_to_exprdef: BTreeMap::new(),
+            expr_table: BTreeMap::new(),
+            expr_replacements: BTreeMap::new(),
+            eliminate_code: BTreeSet::new(),
+        }
+    }
+}
+
+struct CSEAnalyzer<'env> {
+    target: FunctionTarget<'env>,
+    live_var_annotation: &'env LiveVarAnnotation,
+    reach_def_annotation: &'env ReachingDefAnnotation,
+    flush_writes_annotation: &'env FlushWritesAnnotation,
+    aggressive_mode: bool,
+}
+
+impl CSEAnalyzer<'_> {
+    fn new<'env>(
+        target: FunctionTarget<'env>,
+        live_var_annotation: &'env LiveVarAnnotation,
+        reach_def_annotation: &'env ReachingDefAnnotation,
+        flush_writes_annotation: &'env FlushWritesAnnotation,
+        aggressive_mode: bool,
+    ) -> CSEAnalyzer<'env> {
+        CSEAnalyzer {
+            target,
+            live_var_annotation,
+            reach_def_annotation,
+            flush_writes_annotation,
+            aggressive_mode,
+        }
+    }
+
+    fn transform(&self) -> FunctionData {
+        let mut ctx = self.analyze();
+        self.apply(&mut ctx)
+    }
+
+    /// Phase 1: Analyze the function and identify all CSE opportunities.
+    fn analyze(&self) -> AnalysisContext<'_> {
+        let mut ctx = AnalysisContext::new(self.target.get_bytecode());
+
+        // Traverse the domination tree in preorder
+        let block_ids: Vec<_> = ctx.dom_relation.traverse_preorder().into_iter().collect();
+        for block_id in block_ids {
+            self.analyze_block(&mut ctx, block_id);
+        }
+
+        ctx
+    }
+
+    /// Analyze a single basic block for CSE opportunities.
+    fn analyze_block(&self, ctx: &mut AnalysisContext, block_id: BlockId) {
+        let bbl_range = ctx.forward_cfg.code_range(block_id);
+        let bbl = &ctx.code[bbl_range.clone()];
+        for (offset, inst) in bbl_range.clone().zip(bbl) {
+            // get a canonicalized representation of the current expression
+            let Some(expr_def) = self.canonicalize_expr(ctx, inst, offset as CodeOffset) else {
+                continue;
+            };
+
+            // cache the mapping from defined temps to `Expr`
+            ctx.tempid_to_exprdef
+                .entry(expr_def.temps.clone())
+                .or_default()
+                .push(expr_def.clone());
+
+            // get the top-most expression that shares the same key and qualifies for replacement
+            // why top-most: maximize the chances of reusing the same expression in multiple places
+            if let Some(src_expr) = self.get_qualified_replacement(ctx, &expr_def) {
+                // record the replacement info
+                if self.collect_replace_info(
+                    &src_expr,
+                    &expr_def,
+                    &mut ctx.expr_replacements,
+                    &mut ctx.eliminate_code,
+                ) {
+                    continue;
+                }
+            }
+            // if not to be replaced, record the `Expr` for checking future re-occurrences
+            ctx.expr_table
+                .entry(expr_def.key.clone())
+                .or_default()
+                .push(expr_def);
+        }
+    }
+
+    /// Phase 2: Apply the analysis results to produce transformed bytecode.
+    fn apply(&self, ctx: &mut AnalysisContext) -> FunctionData {
+        self.perform_replacement(&mut ctx.expr_replacements, &mut ctx.eliminate_code)
+    }
+
+    /// Create a canonical `Expr` for the bytecode `inst` at `offset`.
+    ///
+    /// - Nested expressions: if an argument temp has a single def that reaches here
+    ///   and is used only here, we inline it as a nested `Expr` (see file header for details)
+    /// - Commutative ops: arguments are sorted for canonical ordering
+    fn canonicalize_expr(
+        &self,
+        ctx: &AnalysisContext,
+        inst: &Bytecode,
+        offset: CodeOffset,
+    ) -> Option<Expr> {
+        let sanitizer = BytecodeSanitizer::new_from_bytecode(inst);
+        if !sanitizer.is_allowed(self.aggressive_mode, &self.target) {
+            return None;
+        }
+
+        // Check if temp defined at def_offset can be inlined at use_offset:
+        // 1. Single definition reaches use (value is unambiguous)
+        // 2. Single use at this location (safe to eliminate the temp)
+        let can_inline = |def_offset, temp, use_offset| {
+            self.single_def_reach(ctx, def_offset, temp, use_offset)
+                && self.single_use_at(def_offset, temp, use_offset)
+        };
+
+        // Try to find a recent expr for `temp` that can be inlined at `offset`
+        let try_inline = |temp: TempIndex| -> ExprArg {
+            ctx.tempid_to_exprdef
+                .get(&vec![temp])
+                .and_then(|exprs| {
+                    exprs
+                        .iter()
+                        .rev()
+                        .find(|e| can_inline(e.offset, temp, offset))
+                        .map(|e| ExprArg::Expr(Box::new(e.clone())))
+                })
+                .unwrap_or(ExprArg::Var(temp))
+        };
+
+        let expr = match inst {
+            Bytecode::Load(_, dest, constant) => Some(Expr::new(
+                ExprOp::Load,
+                vec![ExprArg::Const(constant.clone())],
+                vec![*dest],
+                offset,
+            )),
+
+            Bytecode::Assign(_, dest, src, kind) => Some(Expr::new(
+                ExprOp::Assign(*kind),
+                vec![try_inline(*src)],
+                vec![*dest],
+                offset,
+            )),
+
+            Bytecode::Call(_, dests, op, srcs, _) => {
+                // TODO(#18203): handle AbortAction
+                let mut args: Vec<_> = srcs.iter().map(|t| try_inline(*t)).collect();
+
+                // Sort arguments for commutative ops to get canonical form
+                if op.is_commutative() {
+                    args.sort_by_cached_key(|a| a.to_arg_key());
+                }
+
+                Some(Expr::new(
+                    ExprOp::Op(op.clone()),
+                    args,
+                    dests.clone(),
+                    offset,
+                ))
+            },
+
+            // Control flow and spec instructions don't define temps
+            Bytecode::Branch(..)
+            | Bytecode::Ret(..)
+            | Bytecode::Abort(..)
+            | Bytecode::Jump(..)
+            | Bytecode::Label(..)
+            | Bytecode::Nop(..)
+            | Bytecode::SaveMem(..)
+            | Bytecode::SaveSpecVar(..)
+            | Bytecode::SpecBlock(..)
+            | Bytecode::Prop(..) => None,
+        };
+
+        expr.filter(|e| sanitizer.sanitize(e, &self.target))
+    }
+
+    /// Get a qualified replacement for the expression definition `target_expr`
+    fn get_qualified_replacement(&self, ctx: &AnalysisContext, target_expr: &Expr) -> Option<Expr> {
+        // check all previous occurrences of the same expression pattern and return the first qualified one
+        if let Some(src_exprs) = ctx.expr_table.get(&target_expr.key) {
+            for src_expr in src_exprs.iter() {
+                if self.is_qualified_replacement(ctx, src_expr, target_expr) {
+                    return Some(src_expr.clone());
+                }
+            }
+        }
+        None
+    }
+
+    /// Check if `dest_expr` can be replaced by copying the result of `src_expr`.
+    ///
+    /// ```text
+    /// Before:                              After:
+    /// src_temp = expr(t0)                  src_temp = expr(t0)
+    /// ...                                  ...
+    /// dest_temp = expr(t0)                 dest_temp = copy(src_temp)
+    /// ```
+    ///
+    /// Safety conditions:
+    /// 1. Dominance: src must dominate dest in control flow
+    /// 2. Type safety: temps have same types and src is not mutably borrowed
+    /// 3. Copyability: src temps have the Copy ability
+    /// 4. Temp reuse: src temp has single definition reaching dest, not a mutable ref
+    /// 5. Resources: global resources in src are unchanged when reaching dest
+    /// 6. Leaf temps: input variables in src are unchanged when reaching dest
+    /// 7. Performance: replacement is beneficial (see `gain_perf`)
+    ///
+    fn is_qualified_replacement(
+        &self,
+        ctx: &AnalysisContext,
+        src_expr: &Expr,
+        dest_expr: &Expr,
+    ) -> bool {
+        // 1. Dominance
+        if !Self::src_dominate_dst(ctx, src_expr.offset, dest_expr.offset) {
+            return false;
+        }
+
+        // 2, 3, 4: Check each temp for type safety, copyability, and safe reuse
+        for (src_temp, dest_temp) in src_expr.temps.iter().zip(&dest_expr.temps) {
+            let src_ty = self.get_local_type(src_temp);
+
+            // 2a. Same type
+            if src_ty != self.get_local_type(dest_temp) {
+                return false;
+            }
+
+            // 2b. Not mutably borrowed at any use site
+            if let Some(live_var) = self.get_usage_of(src_temp, src_expr.offset) {
+                if live_var
+                    .usage_offsets()
+                    .iter()
+                    .any(|site| self.is_mutable_borrow(*site))
+                {
+                    return false;
+                }
+            }
+
+            // 3. Has Copy ability
+            let abilities = self
+                .target
+                .global_env()
+                .type_abilities(src_ty, &self.target.get_type_parameters());
+            if !abilities.has_copy() {
+                return false;
+            }
+
+            // 4a. Not a mutable reference
+            if src_ty.is_mutable_reference() {
+                return false;
+            }
+
+            // 4b. Single definition reaches dest (no redefinition on any path)
+            if !self.single_def_reach(ctx, src_expr.offset, *src_temp, dest_expr.offset) {
+                return false;
+            }
+        }
+
+        // 5. Global resources unchanged between src and dest
+        if !self.resources_safe_to_reuse(ctx, src_expr, dest_expr) {
+            return false;
+        }
+
+        // 6. Leaf temps unchanged between src and dest
+        if !self.leaf_temps_safe_to_reuse(ctx, src_expr, dest_expr) {
+            return false;
+        }
+
+        // 7. Performance benefit
+        self.gain_perf(ctx, src_expr, dest_expr, false)
+    }
+
+    /// Check if global resources in src_expr are safe to reuse at dest_expr.
+    /// Only BorrowGlobal and Exists access global resources in a reusable way
+    /// (MoveFrom/MoveTo are destructive and not candidates for CSE).
+    fn resources_safe_to_reuse(
+        &self,
+        ctx: &AnalysisContext,
+        src_expr: &Expr,
+        dest_expr: &Expr,
+    ) -> bool {
+        use Operation::{BorrowGlobal, Exists};
+
+        // Check if both operations access global resources
+        if let (
+            ExprOp::Op(BorrowGlobal(src_mid, src_fid, _) | Exists(src_mid, src_fid, _)),
+            ExprOp::Op(BorrowGlobal(dest_mid, dest_fid, _) | Exists(dest_mid, dest_fid, _)),
+        ) = (&src_expr.op, &dest_expr.op)
+        {
+            let src_res = src_mid.qualified(*src_fid);
+            if src_res != dest_mid.qualified(*dest_fid) {
+                return false;
+            }
+            if !Self::src_dominate_dst(ctx, src_expr.offset, dest_expr.offset) {
+                return false;
+            }
+            if self.obj_killed_between(
+                Object::Global(src_res),
+                src_expr.offset,
+                dest_expr.offset,
+                &ctx.forward_cfg,
+            ) {
+                return false;
+            }
+        }
+
+        // Recursively check nested expressions
+        for (src_arg, dest_arg) in src_expr.args.iter().zip(&dest_expr.args) {
+            if let (ExprArg::Expr(src_nested), ExprArg::Expr(dest_nested)) = (src_arg, dest_arg) {
+                if !self.resources_safe_to_reuse(ctx, src_nested, dest_nested) {
+                    return false;
+                }
+            }
+        }
+        true
+    }
+
+    /// Check if leaf temps in src_expr are safe to reuse at dest_expr.
+    /// Walks both expression trees in parallel, checking at each leaf:
+    /// - Same temp in both trees
+    /// - src dominates dest
+    /// - Temp not killed between src and dest
+    /// - Temp is not a mutable reference
+    fn leaf_temps_safe_to_reuse(
+        &self,
+        ctx: &AnalysisContext,
+        src_expr: &Expr,
+        dest_expr: &Expr,
+    ) -> bool {
+        for (src_arg, dest_arg) in src_expr.args.iter().zip(&dest_expr.args) {
+            match (src_arg, dest_arg) {
+                (ExprArg::Var(src_temp), ExprArg::Var(dest_temp)) => {
+                    if src_temp != dest_temp {
+                        return false;
+                    }
+                    if !Self::src_dominate_dst(ctx, src_expr.offset, dest_expr.offset) {
+                        return false;
+                    }
+                    if self.obj_killed_between(
+                        Object::Local(*src_temp),
+                        src_expr.offset,
+                        dest_expr.offset,
+                        &ctx.forward_cfg,
+                    ) {
+                        return false;
+                    }
+                    if self.get_local_type(src_temp).is_mutable_reference() {
+                        return false;
+                    }
+                },
+                (ExprArg::Expr(src_nested), ExprArg::Expr(dest_nested)) => {
+                    if !self.leaf_temps_safe_to_reuse(ctx, src_nested, dest_nested) {
+                        return false;
+                    }
+                },
+                _ => {},
+            }
+        }
+
+        true
+    }
+
+    /// Collect information needed for performing the replacement
+    /// Given `src_temps = src_expr` that will replace `dest_temps = dest_expr`,
+    /// record the replacement info in the format of `dest_expr.offset: dest_temp -> (src_expr.offset, src_temp)`
+    fn collect_replace_info(
+        &self,
+        src_expr: &Expr,
+        dest_expr: &Expr,
+        expr_replacements: &mut BTreeMap<CodeOffset, Vec<(TempIndex, (CodeOffset, TempIndex))>>,
+        eliminate_code: &mut BTreeSet<CodeOffset>,
+    ) -> bool {
+        // get the temps defined by src_expr (to replace) and dest_expr (be replaced)
+        let src_temps = &src_expr.temps;
+        let dest_temps = &dest_expr.temps;
+
+        // it's a lazy impl at present to only support expressions defining a single temp
+        // TODO(#18203): extend to support multiple temps
+        if src_temps.len() != 1 {
+            return false;
+        }
+
+        // If any nested expression in `src_expr` has been recorded for elimination, we cannot do the replacement
+        if src_expr
+            .collect_exps()
+            .iter()
+            .any(|offset| expr_replacements.contains_key(offset))
+        {
+            return false;
+        }
+
+        // record the replacement info
+        for (src_temp, dest_temp) in src_temps.iter().zip(dest_temps.iter()) {
+            expr_replacements
+                .entry(dest_expr.offset)
+                .or_default()
+                .push((*dest_temp, (src_expr.offset, *src_temp)));
+
+            info!(
+                "CSE: replacing \n \t {} ===> \t {}\n",
+                dest_expr.display(&self.target, true),
+                src_expr.display(&self.target, true),
+            );
+        }
+
+        // We also need to collect the code to be eliminated: including `dest_expr` and all its nested expressions
+        let to_be_eliminated = dest_expr.collect_exps();
+        // Any nested expression that is not `dest_expr` itself does not need to be replaced.
+        // Example: `src_expr` and `dest_expr` are both `op(inner_op1(t1), inner_op2(t2), ...)`
+        // We replace `dest_expr` as a whole, so nested `inner_op1(t1)` and `inner_op2(t2)` are not replaced separately.
+        for offset in to_be_eliminated.iter() {
+            if offset != &dest_expr.offset {
+                expr_replacements.remove(offset);
+            }
+        }
+        eliminate_code.extend(to_be_eliminated);
+        true
+    }
+
+    /// Perform the actual replacement in the bytecode
+    ///
+    /// Given the following stackless bytecode:
+    /// ```Move stackless bytecode without CSE
+    /// 1. t1 = pure_computation_1()
+    /// 2. ...
+    /// 3. use1(t1, ...)
+    /// 4. t2 = pure_computation_1()
+    /// 5. ...
+    /// 6. use2(t2, ...)
+    /// ```
+    /// intuitively, we should simply replace line 6 with `use2(t1, ...)`, resulting in:
+    /// ```Move stackless bytecode after intuitive CSE
+    /// 1. t1 = pure_computation_1()
+    /// 2. ...
+    /// 3. use1(t1, ...)
+    /// 4. ...
+    /// 5. use2(t1, ...)
+    /// ```
+    ///
+    /// This transformation, after translating to the file format bytecode, however can often downgrade the performance.
+    /// Let's consider the following example in file format bytecode:
+    ///
+    /// ```Move File Format Bytecode without CSE
+    /// 1. PURE_COMPUTATION_1 // defines `t1` and keeps `t1` on stack
+    /// 2. OP1 ...  // defines another temp on the stack (`t2`), without consuming `t1` or flushing it out of stack
+    /// 3. OP2 ...  // defines another temp on the stack (`t3`), without consuming `t1` and `t2` or flushing them out of stack
+    /// 4. USE1     // the original use of `t1`, consuming three temps on stack: [`t1`, `t2`, `t3`]
+    /// 5. PURE_COMPUTATION_1 // the redundant computation to be replaced, defines `t4` and keeps `t4` on stack
+    /// 6. USE2    // the original use of `t4`, consuming `t4` on the stack
+    /// ```
+    ///
+    /// If in CSE, we add a reuse of `t1` at line 6, the file format generator will flush `t1` after line 1,
+    /// and then copy it back to the stack before line 4.
+    /// Before the copy, it will find that the stack becomes [`t2`, `t3`], missing `t1`.
+    /// To restore the stack layout, it has to
+    /// - pop `t2` and `t3` off the stack,
+    /// - copy `t1` back to the stack,
+    /// - push `t2` and `t3` back to the stack.
+    /// and eventually have file format bytecode like below:
+    ///
+    /// ```Move File Format Bytecode
+    /// 1. PURE_COMPUTATION_1 // defines `t1` and keeps `t1` on stack
+    /// 2. STLOC t1 // flush t1 off stack to a local
+    /// 3. OP1 ...  // defines another temp on the stack (`t2`)
+    /// 4. OP2 ...  // defines another temp on the stack (`t3`)
+    /// 5. STLOC t3 // pop t3 to a local
+    /// 6. STLOC t2 // pop t2 to a local
+    /// 7. COPYLOC t1 // copy t1 back to stack
+    /// 8. COPYLOC t2 // copy t2 back to stack
+    /// 9. COPYLOC t3 // copy t3 back to stack
+    /// 10. USE1  // the original use of `t1`, taking three temps on stack: [`t1`, `t2`, `t3`]
+    /// 11. COPYLOC t1
+    /// 12. USE2  // the original use of `t4`, taking `t1` on stack
+    /// ```
+    /// To avoid this problem, we need to make a reuse of `t1` while not affecting the stack layout before its original use.
+    /// Similarly, we should also avoid affecting the stack layout before the original use of `t4` (`t4` represents the result of the replaced expression).
+    ///
+    /// As such, we will transform the stackless bytecode to:
+    ///
+    /// ```Move stackless bytecode after our deployed CSE
+    /// 1. t1 = pure_computation_1()
+    /// 2. t1 = dup(t1)
+    ///    // flush the value of `t1` from the stack to a local and meanwhile keep `t1` on the stack for its original use.
+    ///    // This ensures the stack layout before `use1` is not affected
+    ///    // Note: we do not need to do this if `t1` is going to be flushed without CSE
+    /// 3. ...
+    /// 4. use1(t1, ...)
+    /// 5. t2 = dup(t1) // copy the value of `t1` from the local to the stack to work as `t4`. This ensures the stack layout before `use2` is not affected
+    /// 6. ...
+    /// 7. use2(t2, ...)
+    ///
+    fn perform_replacement(
+        &self,
+        expr_replacements: &mut BTreeMap<CodeOffset, Vec<(TempIndex, (CodeOffset, TempIndex))>>,
+        eliminate_code: &mut BTreeSet<CodeOffset>,
+    ) -> FunctionData {
+        let mut builder = FunctionDataBuilder::new(self.target.func_env, self.target.data.clone());
+        let code = std::mem::take(&mut builder.data.code);
+
+        // collect the set of `src_expr`s whose temps need a `dup`
+        // specifically, if the temp defined at `src_expr` will not be flushed without CSE,
+        // we need to `dup` it to keep a copy on stack for its original use
+        // Remark: `expr_replacements` records the replacement info in the format of
+        //   `dest_expr.offset: dest_temp -> (src_expr.offset, src_temp)`
+        let dup_set = expr_replacements
+            .values()
+            .flatten()
+            .filter_map(|(_, (src_offset, src_temp))| {
+                if self.def_needs_flush(src_offset, src_temp) {
+                    None
+                } else {
+                    Some(*src_offset)
+                }
+            })
+            .collect::<BTreeSet<CodeOffset>>();
+
+        // iterate through the original code and perform replacements and eliminations
+        for (offset, inst) in code.into_iter().enumerate() {
+            let code_offset = offset as CodeOffset;
+            let id = inst.get_attr_id();
+
+            // if replacement found, perform it
+            if let Some(replacements) = expr_replacements.get(&code_offset) {
+                assert!(
+                    replacements.len() == 1 && eliminate_code.contains(&code_offset),
+                    "only one replacement supported for now and the code must be recorded for elimination"
+                );
+
+                // if the `src_temp` needs a `dup`, we replace the `dest_expr` with a `dup` of `src_temp`
+                // otherwise, we simply replace it with an `Assign` from `src_temp`
+                let assign_kind = if dup_set.contains(&replacements[0].1 .0) {
+                    AssignKind::Dup
+                } else {
+                    AssignKind::Inferred
+                };
+                builder.emit(Bytecode::Assign(
+                    id,
+                    replacements[0].0,
+                    replacements[0].1 .1,
+                    assign_kind,
+                ));
+
+                // record that the replacement has been done
+                // and the elimination has been performed
+                expr_replacements.remove(&code_offset);
+                eliminate_code.remove(&code_offset);
+                continue;
+            }
+
+            // if no replacement found, we try to see if it needs to be eliminated
+            // if so, simply skip it
+            if eliminate_code.remove(&code_offset) {
+                continue;
+            }
+            // otherwise, we emit the original instruction
+            let temp = inst.dests();
+            builder.emit(inst);
+            // if this is a `src_expr` whose temp needs a `dup`, we emit a `dup` instruction as well
+            if dup_set.contains(&code_offset) {
+                let new_id = builder.new_attr_with_cloned_info(id);
+                builder.emit(Bytecode::Assign(new_id, temp[0], temp[0], AssignKind::Dup));
+            }
+        }
+
+        // finally, check all replacements and eliminations have been performed
+        assert!(
+            expr_replacements.is_empty() && eliminate_code.is_empty(),
+            "all replacements must have been completed {:?}",
+            expr_replacements
+        );
+        builder.data
+    }
+
+    /// get the bytecode at the given offset
+    fn get_bytecode_at(&self, offset: &CodeOffset) -> &Bytecode {
+        &self.target.get_bytecode()[*offset as usize]
+    }
+
+    /// get the usage info of a temp at a given bytecode offset
+    fn get_usage_of(&self, temp: &TempIndex, offset: CodeOffset) -> Option<&LiveVarInfo> {
+        self.live_var_annotation.get_info_at(offset).after.get(temp)
+    }
+
+    /// get the type of a local temp
+    fn get_local_type(&self, temp: &TempIndex) -> &Type {
+        self.target.get_local_type(*temp)
+    }
+
+    /// check if `src` dominates `dst`
+    fn src_dominate_dst(ctx: &AnalysisContext, src: CodeOffset, dst: CodeOffset) -> bool {
+        let src_bbl = ctx.forward_cfg.enclosing_block(src);
+        let dst_bbl = ctx.forward_cfg.enclosing_block(dst);
+        if src_bbl == dst_bbl {
+            // same block, check offset
+            src < dst
+        } else {
+            // different blocks, check domination
+            ctx.dom_relation.is_dominated_by(dst_bbl, src_bbl)
+        }
+    }
+
+    /// check if `dst` post-dominates `src`
+    fn dst_post_dominate_src(ctx: &AnalysisContext, src: CodeOffset, dst: CodeOffset) -> bool {
+        let src_bbl = ctx.backward_cfg.enclosing_block(src);
+        let dst_bbl = ctx.backward_cfg.enclosing_block(dst);
+        if src_bbl == dst_bbl {
+            // same block, check offset
+            src < dst
+        } else {
+            // different blocks, check domination
+            ctx.post_dom_relation.is_dominated_by(src_bbl, dst_bbl)
+        }
+    }
+
+    /// check if a temp defined at offset will be flushed before its use
+    fn def_needs_flush(&self, offset: &CodeOffset, temp: &TempIndex) -> bool {
+        self.target.get_pinned_temps(true).contains(temp)
+            || self
+                .flush_writes_annotation
+                .0
+                .get(offset)
+                .is_some_and(|temps| temps.contains(temp))
+    }
+
+    /// check if the instruction at offset creates a mutable borrow
+    fn is_mutable_borrow(&self, offset: CodeOffset) -> bool {
+        let inst = self.get_bytecode_at(&offset);
+        inst.is_borrowing()
+            && inst
+                .dests()
+                .iter()
+                .any(|t| self.get_local_type(t).is_mutable_reference())
+    }
+
+    /// Checks if the definition of `src_temp` at `src_inst` is only used once and exactly at `dest_inst`.
+    fn single_use_at(
+        &self,
+        src_inst: CodeOffset,
+        src_temp: TempIndex,
+        dest_inst: CodeOffset,
+    ) -> bool {
+        self.get_usage_of(&src_temp, src_inst)
+            .is_some_and(|uses| uses.usage_offsets() == OrdSet::unit(dest_inst))
+    }
+
+    /// Checks if the definition of `src_temp` is the only definition of `src_inst` that can reach `dest_inst`.
+    fn single_def_reach(
+        &self,
+        ctx: &AnalysisContext,
+        src_inst: CodeOffset,
+        src_temp: TempIndex,
+        dest_inst: CodeOffset,
+    ) -> bool {
+        Self::src_dominate_dst(ctx, src_inst, dest_inst)
+            && self
+                .reach_def_annotation
+                .get_info_at(dest_inst)
+                .map
+                .get(&Object::Local(src_temp))
+                .is_some_and(|defs| defs == &BTreeSet::from([src_inst]))
+    }
+
+    /// Checks if `obj` is possibly re-defined in a path between `src` and `dest` (without going through `src` again)
+    fn obj_killed_between(
+        &self,
+        obj: Object,
+        src_inst: CodeOffset,
+        dest_inst: CodeOffset,
+        cfg: &StacklessControlFlowGraph,
+    ) -> bool {
+        let Some(reaching_defs) = self
+            .reach_def_annotation
+            .get_info_at(dest_inst)
+            .map
+            .get(&obj)
+        else {
+            // TODO(#18203): this would only happen if `obj` is a function parameter; so add a check later
+            return false;
+        };
+
+        // DFS to check if there is a path from `start` to `end` without going through `blocker`
+        let can_reach_without = |start, end, blocker| {
+            let mut stack = vec![start];
+            let mut visited = BTreeSet::new();
+            visited.insert(start);
+
+            while let Some(cur) = stack.pop() {
+                if cur == end {
+                    return true;
+                }
+                for succ in cfg.successor_insts(cur) {
+                    if succ == blocker || visited.contains(&succ) {
+                        continue;
+                    }
+                    visited.insert(succ);
+                    stack.push(succ);
+                }
+            }
+            false
+        };
+
+        // Check if any definition site is reachable on a path from src to dest without looping through src
+        reaching_defs.iter().any(|def_site| {
+            // src -> def_site -> dest exists without going through src again
+            can_reach_without(src_inst, *def_site, src_inst)
+                && can_reach_without(*def_site, dest_inst, src_inst)
+        })
+    }
+
+    /// Check if replacing `dest_expr` with `src_expr` can gain performance
+    /// In general, we need to consider two types of costs:
+    /// - new_cost: new instructions introduced by the replacements
+    /// - gain: the cost saved by eliminating `dest_expr`
+    ///
+    /// Here, we take a conservative estimation of the perf gain:
+    /// - new_cost: maximize
+    /// - gain: minimize
+    ///
+    /// The calculation of `new_cost` needs to happen at the file format level. Yet, we only have the stackless bytecode here.
+    /// As a workaround, we estimate the cost based on how the stackless bytecode would be translated to file format bytecode.
+    ///
+    /// Based on the comments above `perform_replacement`:
+    /// - If `src_temp` defined at `src_expr` is going to be flushed anyway,
+    ///   we only need to copy `src_temp` at `dest_expr` for reuse, usually via a `CopyLoc` instruction.
+    /// - If `src_temp` defined at `src_expr` is not going to be flushed,
+    ///   we need to flush `src_temp` at `src_expr` (via a `StLoc` instruction),
+    ///   `dup` it back to the stack for its original uses (via a `CopyLoc` instruction),
+    ///   and also `dup` it back to the stack at `dest_expr` for reuse (via a `CopyLoc` instruction).
+    ///
+    /// We have two modes to estimate the costs:
+    /// - instruction count mode: each bytecode instruction has a unit cost of 1, except for those very expensive ones like `Call` and `BorrowGlobal`
+    /// - gas cost mode: each bytecode instruction has a cost based on gas metrics
+    ///   - TODO(#18203): this is based on gas metrics defined in `aptos-move/aptos-gas-schedule/src/gas_schedule/instr.rs`.
+    ///   - Once we have a more accurate gas model, we need to refine the estimation here.
+    ///
+    pub fn gain_perf(
+        &self,
+        ctx: &AnalysisContext,
+        src_expr: &Expr,
+        dest_expr: &Expr,
+        use_gas_cost: bool,
+    ) -> bool {
+        let mut new_cost = 0;
+        let mut gain = 0;
+        let mut risk = 0;
+        let mut post_dominate = true;
+
+        // helper to get the cost of copying a local temp
+        let get_copy_loc_cost = |temp: &TempIndex| {
+            if use_gas_cost {
+                let temp_size = self
+                    .get_local_type(temp)
+                    .estimate_size(self.target.global_env(), Self::VEC_SIZE);
+                Self::COPY_LOC_COST + Self::BYTE_COST * temp_size
+            } else {
+                1
+            }
+        };
+
+        // helper to get the cost of storing a local temp
+        let get_st_loc_cost = || {
+            if use_gas_cost {
+                Self::ST_LOC_COST
+            } else {
+                1
+            }
+        };
+
+        for src_temp in src_expr.temps.iter() {
+            // part 4: we always need to make a copy of each `src_temp` at `dest_expr` for reuse
+            let copy_src_temp_cost = get_copy_loc_cost(src_temp);
+            new_cost += copy_src_temp_cost;
+
+            // if `src_temp` is going to be flushed anyway, no extra cost is introduced
+            if self.def_needs_flush(&src_expr.offset, src_temp) {
+                continue;
+            }
+
+            // check if `dest_expr` post-dominates `src_expr`
+            if !Self::dst_post_dominate_src(ctx, src_expr.offset, dest_expr.offset) {
+                post_dominate = false;
+            }
+
+            // part 1: flushing `src_temp` from the stack
+            let st_loc_cost = get_st_loc_cost();
+            new_cost += st_loc_cost;
+            risk += st_loc_cost;
+
+            // part 2: dup `src_temp` back to the stack for its original uses
+            let Some(usage) = self.get_usage_of(src_temp, src_expr.offset) else {
+                continue;
+            };
+
+            let use_cost = usage.usage_offsets().len() * get_copy_loc_cost(src_temp);
+            new_cost += use_cost;
+            risk += use_cost;
+        }
+
+        // here we calculate the gain from eliminating the bytecode instructions defining dest_expr
+        // we take the minimum cost of each instruction as the gain
+        for offset in dest_expr.collect_exps().iter() {
+            if let Some(inst) = self.target.get_bytecode().get(*offset as usize) {
+                let code_cost = self.bytecode_cost(inst);
+                if use_gas_cost {
+                    gain += code_cost.min_gas;
+                } else {
+                    gain += code_cost.min_inst_num;
+                }
+            }
+        }
+
+        // if any `dest_expr` does not post-dominate `src_expr`, we need to consider the risk level
+        // (i.e., the extra cost on paths which does not go through `dest_expr`);
+        // otherwise, we only need to compare gain and new_cost
+        if !post_dominate {
+            risk <= Self::RISK_LEVEL && gain > new_cost + Self::MIN_GAP
+        } else {
+            gain > new_cost + Self::MIN_GAP
+        }
+    }
+}
+
+struct BytecodeCost {
+    min_inst_num: usize,
+    _max_inst_num: usize,
+    min_gas: usize,
+    _max_gas: usize,
+}
+
+impl CSEAnalyzer<'_> {
+    const ABORT_COST: usize = 220;
+    const ARITH_LOGIC_COST: usize = 588;
+    const BORROW_FIELD_COST: usize = 735;
+    const BORROW_GLOBAL_COST: usize = 1838;
+    const BORROW_LOC_COST: usize = 220;
+    const BORROW_VARIANT_FIELD_COST: usize = 835;
+    const BRANCH_COST: usize = 441;
+    // extra cost for each byte in instruction arguments
+    // TODO(#18203): tune this value
+    const BYTE_COST: usize = 14;
+    const CAST_COST: usize = 441;
+    const COPY_LOC_COST: usize = 294;
+    const DROP_RELEASE_COST: usize = 441;
+    const EQUALITY_COST: usize = 367;
+    const EXISTS_COST: usize = 919;
+    const FREEZE_REF_COST: usize = 36;
+    const FUN_CALL_COST: usize = 3676;
+    const JUMP_COST: usize = 294;
+    const LABEL_COST: usize = 0;
+    const LD_CONST_COST: usize = 2389;
+    const LD_U8_COST: usize = 220;
+    // A minimum gain to justify the replacement
+    // TODO(#18203): tune this value
+    const MIN_GAP: usize = 0;
+    const MOVE_FROM_COST: usize = 1286;
+    const MOVE_LOC_COST: usize = 441;
+    const MOVE_TO_COST: usize = 1838;
+    const NOP_COST: usize = 36;
+    const PACK_UNPACK_CLOSURE_COST: usize = 808;
+    const READ_REF_COST: usize = 735;
+    const RET_COST: usize = 220;
+    // A risk level we can afford when any `dest_expr` does not post-dominate `src_expr`
+    // Here, `risk level` means the extra cost we may introduce in paths not going through `dest_expr`
+    // Currently, we do not take any risk
+    // TODO(#18203): tune this value
+    const RISK_LEVEL: usize = 2;
+    const SPEC_COST: usize = 0;
+    const ST_LOC_COST: usize = 441;
+    const TEST_VARIANT_COST: usize = 535;
+    const VEC_BORROW_COST: usize = 1213;
+    const VEC_ELE_COST: usize = 147;
+    const VEC_EMPTY_COST: usize = 2205;
+    const VEC_LEN_COST: usize = 808;
+    const VEC_PACK_COST: usize = 2205;
+    // default size for vector types
+    // TODO(#18203): tune this value
+    const VEC_SIZE: usize = 1;
+    const WRITE_REF_COST: usize = 735;
+
+    /// Estimate the bytecode cost of an instruction
+    /// based on its number of instructions and gas metric
+    /// The returned tuple represents (min_inst_num, _max_inst_num, min_gas, _max_gas)
+    fn bytecode_cost(&self, code: &Bytecode) -> BytecodeCost {
+        match code {
+            // min: nothing happens
+            // max: StLoc + CopyLoc/MoveLoc
+            Bytecode::Assign(..) => BytecodeCost {
+                min_inst_num: 0,
+                _max_inst_num: 2,
+                min_gas: 0,
+                _max_gas: Self::MOVE_LOC_COST + Self::ST_LOC_COST,
+            },
+            // min: LdU8
+            // max: LdConst
+            Bytecode::Load(..) => BytecodeCost {
+                min_inst_num: 1,
+                _max_inst_num: 1,
+                min_gas: Self::LD_U8_COST,
+                _max_gas: Self::LD_CONST_COST,
+            },
+            // BrTrue or BrFalse
+            Bytecode::Branch(..) => BytecodeCost {
+                min_inst_num: 1,
+                _max_inst_num: 1,
+                min_gas: Self::BRANCH_COST,
+                _max_gas: Self::BRANCH_COST,
+            },
+            Bytecode::Jump(..) => BytecodeCost {
+                min_inst_num: 1,
+                _max_inst_num: 1,
+                min_gas: Self::JUMP_COST,
+                _max_gas: Self::JUMP_COST,
+            },
+            Bytecode::Label(..) => BytecodeCost {
+                min_inst_num: 0,
+                _max_inst_num: 0,
+                min_gas: Self::LABEL_COST,
+                _max_gas: Self::LABEL_COST,
+            },
+            Bytecode::Nop(..) => BytecodeCost {
+                min_inst_num: 1,
+                _max_inst_num: 1,
+                min_gas: Self::NOP_COST,
+                _max_gas: Self::NOP_COST,
+            },
+            Bytecode::Abort(..) => BytecodeCost {
+                min_inst_num: 1,
+                _max_inst_num: 1,
+                min_gas: Self::ABORT_COST,
+                _max_gas: Self::ABORT_COST,
+            },
+            Bytecode::SpecBlock(..)
+            | Bytecode::Prop(..)
+            | Bytecode::SaveMem(..)
+            | Bytecode::SaveSpecVar(..) => BytecodeCost {
+                min_inst_num: 0,
+                _max_inst_num: 0,
+                min_gas: Self::SPEC_COST,
+                _max_gas: Self::SPEC_COST,
+            },
+            Bytecode::Ret(..) => BytecodeCost {
+                min_inst_num: 1,
+                _max_inst_num: 1,
+                min_gas: Self::RET_COST,
+                _max_gas: Self::RET_COST,
+            },
+            Bytecode::Call(_, dests, op, _, _) => {
+                match op {
+                    Operation::Function(mid, fid, _) => {
+                        // Several functions are compiled into special bytecodes instead of normal call/ret
+                        let global_env = self.target.global_env();
+                        let module_env = global_env.get_module(*mid);
+                        let module_addr = module_env.self_address();
+                        let module_name = global_env
+                            .symbol_pool()
+                            .string(module_env.get_name().name());
+                        let func_name = global_env
+                            .symbol_pool()
+                            .string(module_env.get_function(*fid).get_name());
+                        match (module_addr, module_name.as_str(), func_name.as_str()) {
+                            (
+                                Address::Numerical(AccountAddress::ONE),
+                                VECTOR_MODULE,
+                                LENGTH_NAME,
+                            ) => BytecodeCost {
+                                min_inst_num: 1,
+                                _max_inst_num: 1,
+                                min_gas: Self::VEC_LEN_COST,
+                                _max_gas: Self::VEC_LEN_COST,
+                            },
+                            (
+                                Address::Numerical(AccountAddress::ONE),
+                                VECTOR_MODULE,
+                                BORROW_NAME,
+                            ) => BytecodeCost {
+                                min_inst_num: 1,
+                                _max_inst_num: 1,
+                                min_gas: Self::VEC_BORROW_COST,
+                                _max_gas: Self::VEC_BORROW_COST,
+                            },
+                            (
+                                Address::Numerical(AccountAddress::ONE),
+                                VECTOR_MODULE,
+                                EMPTY_NAME,
+                            ) => BytecodeCost {
+                                min_inst_num: 1,
+                                _max_inst_num: 1,
+                                min_gas: Self::VEC_EMPTY_COST,
+                                _max_gas: Self::VEC_EMPTY_COST,
+                            },
+                            // min: Call + at least 2 inst (?) + Ret
+                            // max: unknown
+                            _ => BytecodeCost {
+                                min_inst_num: 4,
+                                _max_inst_num: usize::MAX,
+                                min_gas: Self::FUN_CALL_COST + Self::RET_COST,
+                                _max_gas: usize::MAX,
+                            },
+                        }
+                    },
+                    Operation::Invoke => BytecodeCost {
+                        min_inst_num: 4,
+                        _max_inst_num: usize::MAX,
+                        min_gas: Self::FUN_CALL_COST + Self::RET_COST,
+                        _max_gas: usize::MAX,
+                    },
+                    Operation::Pack(..)
+                    | Operation::Closure(..)
+                    | Operation::PackVariant(..)
+                    | Operation::Unpack(..)
+                    | Operation::UnpackVariant(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::PACK_UNPACK_CLOSURE_COST,
+                        _max_gas: usize::MAX,
+                    },
+                    Operation::MoveTo(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::MOVE_TO_COST,
+                        _max_gas: Self::MOVE_TO_COST,
+                    },
+                    Operation::MoveFrom(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::MOVE_FROM_COST,
+                        _max_gas: Self::MOVE_FROM_COST,
+                    },
+                    Operation::Exists(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::EXISTS_COST,
+                        _max_gas: Self::EXISTS_COST,
+                    },
+                    Operation::TestVariant(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::TEST_VARIANT_COST,
+                        _max_gas: Self::TEST_VARIANT_COST,
+                    },
+                    Operation::BorrowLoc => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::BORROW_LOC_COST,
+                        _max_gas: Self::BORROW_LOC_COST,
+                    },
+                    Operation::BorrowField(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::BORROW_FIELD_COST,
+                        _max_gas: Self::BORROW_FIELD_COST,
+                    },
+                    Operation::BorrowVariantField(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::BORROW_VARIANT_FIELD_COST,
+                        _max_gas: Self::BORROW_VARIANT_FIELD_COST,
+                    },
+                    Operation::BorrowGlobal(..) => BytecodeCost {
+                        min_inst_num: 3, // too much?
+                        _max_inst_num: 3,
+                        min_gas: Self::BORROW_GLOBAL_COST,
+                        _max_gas: Self::BORROW_GLOBAL_COST,
+                    },
+                    // deemed as `Move`?
+                    Operation::Drop | Operation::Release => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::DROP_RELEASE_COST,
+                        _max_gas: Self::DROP_RELEASE_COST,
+                    },
+                    Operation::ReadRef => {
+                        let dest_size = dests
+                            .iter()
+                            .map(|t| {
+                                self.get_local_type(t)
+                                    .estimate_size(self.target.global_env(), Self::VEC_SIZE)
+                            })
+                            .sum::<usize>();
+                        BytecodeCost {
+                            min_inst_num: 1,
+                            _max_inst_num: 1,
+                            min_gas: Self::READ_REF_COST + Self::BYTE_COST * dest_size,
+                            _max_gas: usize::MAX,
+                        }
+                    },
+                    Operation::WriteRef => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::WRITE_REF_COST,
+                        _max_gas: Self::WRITE_REF_COST,
+                    },
+                    Operation::FreezeRef(..) => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::FREEZE_REF_COST,
+                        _max_gas: Self::FREEZE_REF_COST,
+                    },
+                    Operation::Vector => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::VEC_PACK_COST + Self::VEC_ELE_COST * Self::VEC_SIZE,
+                        _max_gas: usize::MAX,
+                    },
+                    Operation::CastU8
+                    | Operation::CastU16
+                    | Operation::CastU32
+                    | Operation::CastU64
+                    | Operation::CastU128
+                    | Operation::CastU256
+                    | Operation::CastI8
+                    | Operation::CastI16
+                    | Operation::CastI32
+                    | Operation::CastI64
+                    | Operation::CastI128
+                    | Operation::CastI256 => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::CAST_COST,
+                        _max_gas: Self::CAST_COST,
+                    },
+                    Operation::Not
+                    | Operation::Negate
+                    | Operation::Add
+                    | Operation::Sub
+                    | Operation::Mul
+                    | Operation::Div
+                    | Operation::Mod
+                    | Operation::BitOr
+                    | Operation::BitAnd
+                    | Operation::Xor
+                    | Operation::Shl
+                    | Operation::Shr
+                    | Operation::Or
+                    | Operation::And
+                    | Operation::Le
+                    | Operation::Lt
+                    | Operation::Ge
+                    | Operation::Gt => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::ARITH_LOGIC_COST,
+                        _max_gas: Self::ARITH_LOGIC_COST,
+                    },
+                    Operation::Eq | Operation::Neq => BytecodeCost {
+                        min_inst_num: 1,
+                        _max_inst_num: 1,
+                        min_gas: Self::EQUALITY_COST,
+                        _max_gas: Self::EQUALITY_COST,
+                    },
+                    Operation::OpaqueCallBegin(..)
+                    | Operation::OpaqueCallEnd(..)
+                    | Operation::IsParent(..)
+                    | Operation::WriteBack(..)
+                    | Operation::UnpackRef
+                    | Operation::PackRef
+                    | Operation::UnpackRefDeep
+                    | Operation::PackRefDeep
+                    | Operation::GetField(..)
+                    | Operation::GetVariantField(..)
+                    | Operation::GetGlobal(..)
+                    | Operation::Uninit
+                    | Operation::Havoc(..)
+                    | Operation::Stop
+                    | Operation::TraceLocal(..)
+                    | Operation::TraceReturn(..)
+                    | Operation::TraceAbort
+                    | Operation::TraceExp(..)
+                    | Operation::TraceGlobalMem(..)
+                    | Operation::EmitEvent
+                    | Operation::EventStoreDiverge => BytecodeCost {
+                        min_inst_num: 0,
+                        _max_inst_num: 0,
+                        min_gas: usize::MAX,
+                        _max_gas: usize::MAX,
+                    },
+                }
+            },
+        }
+    }
+}
+
+/// Data structure to help determine the qualification of instructions for CSE
+enum BytecodeSanitizer {
+    Pure,
+    PureIfNoArithError,
+    PureIfNoTypeError,
+    LocalBorrow,
+    ReadRef,
+    Assign,
+    Function(ModuleId, FunId),
+    GlobalBorrow,
+    Exists,
+    Forbidden,
+}
+
+impl BytecodeSanitizer {
+    /// Create a BytecodeSanitizer from a bytecode instruction
+    /// It can be extended to support other impure instructions
+    pub fn new_from_bytecode(inst: &Bytecode) -> Self {
+        use BytecodeSanitizer::*;
+        match inst {
+            i if i.is_pure() => Pure,
+            i if i.pure_if_no_arith_error() => PureIfNoArithError,
+            i if i.pure_if_no_type_error() => PureIfNoTypeError,
+            i if i.is_loc_borrowing() => LocalBorrow,
+            Bytecode::Assign(_, _, _, AssignKind::Copy | AssignKind::Inferred) => Assign,
+            Bytecode::Call(_, _, Operation::ReadRef, _, _) => ReadRef,
+            Bytecode::Call(_, _, Operation::Exists(..), _, _) => Exists,
+            Bytecode::Call(_, _, Operation::BorrowGlobal(..), _, _) => GlobalBorrow,
+            Bytecode::Call(_, _, Operation::Function(mid, fid, _), _, _) => Function(*mid, *fid),
+            _ => Forbidden,
+        }
+    }
+
+    /// Check if the instruction is allowed to consider for CSE
+    /// See the doc comments of different types for details
+    pub fn is_allowed(&self, aggressive_mode: bool, function_target: &FunctionTarget) -> bool {
+        match self {
+            BytecodeSanitizer::Pure => true,
+            BytecodeSanitizer::PureIfNoArithError => aggressive_mode,
+            BytecodeSanitizer::PureIfNoTypeError => aggressive_mode,
+            BytecodeSanitizer::LocalBorrow => aggressive_mode,
+            BytecodeSanitizer::ReadRef => aggressive_mode,
+            BytecodeSanitizer::Assign => aggressive_mode,
+            BytecodeSanitizer::Function(mid, fid) => {
+                aggressive_mode && Self::is_child_allowed(function_target, mid, fid)
+            },
+            BytecodeSanitizer::GlobalBorrow => aggressive_mode,
+            BytecodeSanitizer::Exists => aggressive_mode,
+
+            BytecodeSanitizer::Forbidden => false,
+        }
+    }
+
+    /// Recursively check if the called function is allowed to consider for CSE
+    /// Condition 1: the called function do not modify its parent's memories
+    /// Condition 2: the called function and its deccendents do not access global storages
+    pub fn is_child_allowed(function_target: &FunctionTarget, mid: &ModuleId, fid: &FunId) -> bool {
+        let global_env = function_target.global_env();
+        let module_env = global_env.get_module(*mid);
+        let func_env = module_env.get_function(*fid);
+
+        // helper check if the bytecode of a function accesses global storage
+        let code_access_global = |qualified_fid: QualifiedId<FunId>| {
+            let code = generate_bytecode(global_env, qualified_fid).code;
+            code.is_empty() // no code available, conservatively assuming it accesses global storage
+                    || code.iter().any(|inst| {
+                        matches!(
+                            inst,
+                            Bytecode::Call(_, _, Operation::BorrowGlobal(..), _, _)
+                                | Bytecode::Call(_, _, Operation::MoveFrom(..), _, _)
+                                | Bytecode::Call(_, _, Operation::MoveTo(..), _, _)
+                                | Bytecode::Call(_, _, Operation::Exists(..), _, _)
+                        )
+                    })
+        };
+
+        // Checks if any bytecode in the function or its transitive callees accesses global storage
+        let accesses_global_resource =
+            |func_env: &FunctionEnv, qualified_fid: QualifiedId<FunId>| {
+                if code_access_global(qualified_fid) {
+                    return true;
+                }
+                // now we need to check all the functions called or used (possibly called through `Invoke`) transitively by this function.
+                func_env
+                    .get_transitive_closure_of_used_functions()
+                    .iter()
+                    .any(|child_fid| {
+                        let child_module_env = global_env.get_module(child_fid.module_id);
+                        let child_func_env = child_module_env.get_function(child_fid.id);
+                        // child is not native or inline, and its code accesses global storage
+                        !child_func_env.is_native()
+                            && !child_func_env.is_inline()
+                            && code_access_global(*child_fid)
+                    })
+            };
+
+        !func_env.is_mutating()
+            && (func_env.is_native() // native functions do not access global storage
+                || !accesses_global_resource(&func_env, mid.qualified(*fid)))
+    }
+
+    /// Further sanitize the non-pure expression represented by `expr_def` in the context of `function_target`
+    /// See the doc comments of different types for details
+    pub fn sanitize(&self, expr_def: &Expr, function_target: &FunctionTarget) -> bool {
+        match self {
+            BytecodeSanitizer::Pure => true,
+            BytecodeSanitizer::PureIfNoArithError => true,
+            BytecodeSanitizer::PureIfNoTypeError => true,
+            BytecodeSanitizer::LocalBorrow => {
+                let no_leaf_consts =
+                    |consts: &Vec<(Constant, CodeOffset)>, _: &FunctionTarget| consts.is_empty();
+                Self::sanitize_leaf_consts(expr_def, function_target, no_leaf_consts)
+            },
+            BytecodeSanitizer::ReadRef => true,
+            BytecodeSanitizer::Assign => true,
+            BytecodeSanitizer::Function(..) => true,
+            BytecodeSanitizer::GlobalBorrow => true,
+            BytecodeSanitizer::Exists => true,
+            BytecodeSanitizer::Forbidden => false,
+        }
+    }
+
+    // Helper to sanitize all leaf temps in `expr_def` with a given predicate
+    #[allow(dead_code)]
+    fn sanitize_leaf_temps<F>(
+        expr_def: &Expr,
+        function_target: &FunctionTarget,
+        predicate: F,
+    ) -> bool
+    where
+        F: Fn(&Vec<(TempIndex, CodeOffset)>, &FunctionTarget) -> bool,
+    {
+        predicate(&expr_def.collect_leaves().0, function_target)
+    }
+
+    // Helper to sanitize all leaf constants in `expr_def` with a given predicate
+    fn sanitize_leaf_consts<F>(
+        expr_def: &Expr,
+        function_target: &FunctionTarget,
+        predicate: F,
+    ) -> bool
+    where
+        F: Fn(&Vec<(Constant, CodeOffset)>, &FunctionTarget) -> bool,
+    {
+        predicate(&expr_def.collect_leaves().1, function_target)
+    }
+
+    /// Sanitize the expr, after expanding the args, with a given predicate
+    #[allow(dead_code)]
+    fn sanitize_exprs<F>(expr_def: &Expr, target: &FunctionTarget, predicate: F) -> bool
+    where
+        F: Fn(&Vec<ExprOp>, &FunctionTarget) -> bool,
+    {
+        // collect the expressions involved in the `expr` in a depth-first order
+        fn dfs(expr: &Expr, visited: &mut Vec<ExprOp>) {
+            visited.push(expr.op().clone());
+            for arg in expr.args().iter() {
+                if let ExprArg::Expr(arg_expr) = arg {
+                    dfs(arg_expr.as_ref(), visited);
+                }
+            }
+        }
+
+        let mut expr_seq_dfs = Vec::new();
+        dfs(expr_def, &mut expr_seq_dfs);
+
+        predicate(&expr_seq_dfs, target)
+    }
+}

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -12,6 +12,7 @@ use crate::pipeline::{
 use move_stackless_bytecode::function_target::FunctionTarget;
 
 pub mod ability_processor;
+pub mod common_subexp_elimination;
 pub mod control_flow_graph_simplifier;
 pub mod dead_store_elimination;
 pub mod exit_state_analysis;

--- a/third_party/move/move-compiler-v2/src/pipeline/reaching_def_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reaching_def_analysis_processor.rs
@@ -340,6 +340,13 @@ impl TransferFunctions for ReachingDefAnalysis<'_> {
                         state.kill(Object::Local(*dest));
                         state.def(Object::Local(*dest), offset);
                     },
+                    AssignKind::Dup => {
+                        // `Dup` a value itself is intended, so we do not consider it a kill and re-gen here
+                        if dest != src {
+                            state.kill(Object::Local(*dest));
+                            state.def(Object::Local(*dest), offset);
+                        }
+                    },
                     AssignKind::Move => {
                         state.kill(Object::Local(*dest));
                         state.def(Object::Local(*dest), offset);

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety/reference_safety_processor_v2.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety/reference_safety_processor_v2.rs
@@ -1530,7 +1530,7 @@ impl LifetimeAnalysisStep<'_, '_> {
         if self.is_ref(src) {
             match kind {
                 AssignKind::Move => self.state.move_ref(dest, src),
-                AssignKind::Copy => self.state.copy_ref(dest, src),
+                AssignKind::Copy | AssignKind::Dup => self.state.copy_ref(dest, src),
                 AssignKind::Inferred => {
                     if self.state.label_for_temp_with_children(src).is_none()
                         && !self.alive.after.contains_key(&src)

--- a/third_party/move/move-compiler-v2/src/pipeline/reference_safety/reference_safety_processor_v3.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reference_safety/reference_safety_processor_v3.rs
@@ -757,7 +757,7 @@ impl LifetimeAnalysisStep<'_, '_> {
         }
         let value = match kind {
             AssignKind::Move => self.move_(src),
-            AssignKind::Copy => self.copy(src),
+            AssignKind::Copy | AssignKind::Dup => self.copy(src),
             AssignKind::Inferred => self.move_or_copy(src, &[], &[dest]),
             AssignKind::Store => panic!("unexpected assign kind"),
         };

--- a/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/borrowed_from_one_path.exp
@@ -607,6 +607,198 @@ fun m::f($t0: u8, $t1: &vector<u64>): u64 {
      # refs: []
      #
   6: $t7 := borrow_global<0x42::m::R>($t8)
+     # flush: $t3
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #7 via [struct `m::R`] at line 12
+     #
+  7: $t3 := borrow_field<0x42::m::R>.data($t7)
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `m::R`] at line 12
+     #
+  8: goto 11
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  9: label L1
+     # flush: $t3
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+ 10: $t3 := infer($t1)
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `m::R`] at line 12
+     #
+ 11: label L2
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `m::R`] at line 12
+     #
+ 12: $t10 := infer($t3)
+     # live vars: $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `m::R`] at line 12
+     #
+ 13: $t11 := 0
+     # live vars: $t10, $t11
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `m::R`] at line 12
+     #
+ 14: $t9 := vector::borrow<u64>($t10, $t11)
+     # live vars: $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #9 via [struct `m::R`] at line 16
+     #
+ 15: $t2 := read_ref($t9)
+     # live vars: $t2
+     # refs: []
+     #
+ 16: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::f($t0: u8, $t1: &vector<u64>): u64 {
+     var $t2: u64
+     var $t3: &vector<u64>
+     var $t4: bool
+     var $t5: u8
+     var $t6: u8
+     var $t7: &0x42::m::R
+     var $t8: address
+     var $t9: &u64
+     var $t10: &vector<u64>
+     var $t11: u64
+     # live vars: $t0, $t1
+  0: $t5 := infer($t0)
+     # live vars: $t1, $t5
+  1: $t6 := 0
+     # live vars: $t1, $t5, $t6
+  2: $t4 := ==($t5, $t6)
+     # live vars: $t1, $t4
+  3: if ($t4) goto 4 else goto 9
+     # live vars: $t1
+  4: label L0
+     # live vars:
+  5: $t8 := 0x1
+     # live vars: $t8
+  6: $t7 := borrow_global<0x42::m::R>($t8)
+     # live vars: $t7
+  7: $t3 := borrow_field<0x42::m::R>.data($t7)
+     # live vars: $t3
+  8: goto 11
+     # live vars: $t1
+  9: label L1
+     # live vars: $t1
+ 10: $t3 := infer($t1)
+     # live vars: $t3
+ 11: label L2
+     # live vars: $t3
+ 12: $t10 := infer($t3)
+     # live vars: $t10
+ 13: $t11 := 0
+     # live vars: $t10, $t11
+ 14: $t9 := vector::borrow<u64>($t10, $t11)
+     # live vars: $t9
+ 15: $t2 := read_ref($t9)
+     # live vars: $t2
+ 16: return $t2
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun m::f($t0: u8, $t1: &vector<u64>): u64 {
+     var $t2: u64
+     var $t3: &vector<u64>
+     var $t4: bool
+     var $t5: u8
+     var $t6: u8
+     var $t7: &0x42::m::R
+     var $t8: address
+     var $t9: &u64
+     var $t10: &vector<u64>
+     var $t11: u64
+     # live vars: $t0, $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t5 := infer($t0)
+     # live vars: $t1, $t5
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t6 := 0
+     # live vars: $t1, $t5, $t6
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := ==($t5, $t6)
+     # live vars: $t1, $t4
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: if ($t4) goto 4 else goto 9
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: label L0
+     # live vars:
+     # refs: []
+     #
+  5: $t8 := 0x1
+     # live vars: $t8
+     # refs: []
+     #
+  6: $t7 := borrow_global<0x42::m::R>($t8)
      # live vars: $t7
      # refs: [$t7 => #7]
      # #7

--- a/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/by_reference.exp
@@ -2233,6 +2233,635 @@ fun <SELF>_0::check() {
      # refs: []
      #
  36: $t13 := 0
+     # flush: $t12, $t14
+     # live vars: $t13
+     # refs: []
+     #
+ 37: $t12 := borrow_local($t13)
+     # live vars: $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => (mut) #12 via [value] at line 13
+     #
+ 38: $t14 := 1
+     # live vars: $t12, $t14
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => (mut) #12 via [value] at line 13
+     #
+ 39: write_ref($t12, $t14)
+     # live vars: $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => (mut) #12 via [value] at line 13
+     #
+ 40: $t16 := [104, 101, 108, 108, 111]
+     # flush: $t15, $t17
+     # live vars: $t12, $t16
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => (mut) #12 via [value] at line 13
+     #
+ 41: $t15 := borrow_local($t16)
+     # live vars: $t12, $t15
+     # refs: [$t12 => #12, $t15 => #15]
+     # #12
+     #   <no edges>
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #12 via [value] at line 13
+     #   => (mut) #15 via [value] at line 15
+     #
+ 42: $t17 := [98, 121, 101]
+     # live vars: $t12, $t15, $t17
+     # refs: [$t12 => #12, $t15 => #15]
+     # #12
+     #   <no edges>
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #12 via [value] at line 13
+     #   => (mut) #15 via [value] at line 15
+     #
+ 43: write_ref($t15, $t17)
+     # live vars: $t12, $t15
+     # refs: [$t12 => #12, $t15 => #15]
+     # #12
+     #   <no edges>
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #12 via [value] at line 13
+     #   => (mut) #15 via [value] at line 15
+     #
+ 44: $t19 := read_ref($t12)
+     # live vars: $t15, $t19
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 45: $t20 := 1
+     # live vars: $t15, $t19, $t20
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 46: $t18 := ==($t19, $t20)
+     # live vars: $t15, $t18
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 47: if ($t18) goto 48 else goto 50
+     # live vars: $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 48: label L12
+     # live vars: $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 49: goto 53
+     # live vars: $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 50: label L13
+     # live vars:
+     # refs: []
+     #
+ 51: $t21 := 42
+     # live vars: $t21
+     # refs: []
+     #
+ 52: abort($t21)
+     # live vars: $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 53: label L14
+     # live vars: $t15
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => (mut) #15 via [value] at line 15
+     #
+ 54: $t23 := read_ref($t15)
+     # live vars: $t23
+     # refs: []
+     #
+ 55: $t24 := [98, 121, 101]
+     # live vars: $t23, $t24
+     # refs: []
+     #
+ 56: $t22 := ==($t23, $t24)
+     # live vars: $t22
+     # refs: []
+     #
+ 57: if ($t22) goto 58 else goto 60
+     # live vars:
+     # refs: []
+     #
+ 58: label L15
+     # live vars:
+     # refs: []
+     #
+ 59: goto 63
+     # live vars:
+     # refs: []
+     #
+ 60: label L16
+     # live vars:
+     # refs: []
+     #
+ 61: $t25 := 42
+     # live vars: $t25
+     # refs: []
+     #
+ 62: abort($t25)
+     # live vars:
+     # refs: []
+     #
+ 63: label L17
+     # live vars:
+     # refs: []
+     #
+ 64: $t26 := true
+     # live vars: $t26
+     # refs: []
+     #
+ 65: if ($t26) goto 66 else goto 68
+     # live vars:
+     # refs: []
+     #
+ 66: label L18
+     # live vars:
+     # refs: []
+     #
+ 67: goto 71
+     # live vars:
+     # refs: []
+     #
+ 68: label L19
+     # live vars:
+     # refs: []
+     #
+ 69: $t27 := 42
+     # live vars: $t27
+     # refs: []
+     #
+ 70: abort($t27)
+     # live vars:
+     # refs: []
+     #
+ 71: label L20
+     # live vars:
+     # refs: []
+     #
+ 72: $t28 := true
+     # live vars: $t28
+     # refs: []
+     #
+ 73: if ($t28) goto 74 else goto 76
+     # live vars:
+     # refs: []
+     #
+ 74: label L21
+     # live vars:
+     # refs: []
+     #
+ 75: goto 79
+     # live vars:
+     # refs: []
+     #
+ 76: label L22
+     # live vars:
+     # refs: []
+     #
+ 77: $t29 := 42
+     # live vars: $t29
+     # refs: []
+     #
+ 78: abort($t29)
+     # live vars:
+     # refs: []
+     #
+ 79: label L23
+     # live vars:
+     # refs: []
+     #
+ 80: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun <SELF>_0::check() {
+     var $t0: bool
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: vector<u8>
+     var $t10: vector<u8>
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: bool
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: bool
+     var $t23: vector<u8>
+     var $t24: vector<u8>
+     var $t25: u64
+     var $t26: bool
+     var $t27: u64
+     var $t28: bool
+     var $t29: u64
+     # live vars:
+  0: $t0 := true
+     # live vars: $t0
+  1: if ($t0) goto 2 else goto 4
+     # live vars:
+  2: label L0
+     # live vars:
+  3: goto 7
+     # live vars:
+  4: label L1
+     # live vars:
+  5: $t1 := 42
+     # live vars: $t1
+  6: abort($t1)
+     # live vars:
+  7: label L2
+     # live vars:
+  8: $t2 := true
+     # live vars: $t2
+  9: if ($t2) goto 10 else goto 12
+     # live vars:
+ 10: label L3
+     # live vars:
+ 11: goto 15
+     # live vars:
+ 12: label L4
+     # live vars:
+ 13: $t3 := 42
+     # live vars: $t3
+ 14: abort($t3)
+     # live vars:
+ 15: label L5
+     # live vars:
+ 16: $t5 := 0
+     # live vars: $t5
+ 17: $t6 := 0
+     # live vars: $t5, $t6
+ 18: $t4 := ==($t5, $t6)
+     # live vars: $t4
+ 19: if ($t4) goto 20 else goto 22
+     # live vars:
+ 20: label L6
+     # live vars:
+ 21: goto 25
+     # live vars:
+ 22: label L7
+     # live vars:
+ 23: $t7 := 42
+     # live vars: $t7
+ 24: abort($t7)
+     # live vars:
+ 25: label L8
+     # live vars:
+ 26: $t9 := [104, 101, 108, 108, 111]
+     # live vars: $t9
+ 27: $t10 := [104, 101, 108, 108, 111]
+     # live vars: $t9, $t10
+ 28: $t8 := ==($t9, $t10)
+     # live vars: $t8
+ 29: if ($t8) goto 30 else goto 32
+     # live vars:
+ 30: label L9
+     # live vars:
+ 31: goto 35
+     # live vars:
+ 32: label L10
+     # live vars:
+ 33: $t11 := 42
+     # live vars: $t11
+ 34: abort($t11)
+     # live vars:
+ 35: label L11
+     # live vars:
+ 36: $t13 := 0
+     # live vars: $t13
+ 37: $t12 := borrow_local($t13)
+     # live vars: $t12
+ 38: $t14 := 1
+     # live vars: $t12, $t14
+ 39: write_ref($t12, $t14)
+     # live vars: $t12
+ 40: $t16 := [104, 101, 108, 108, 111]
+     # live vars: $t12, $t16
+ 41: $t15 := borrow_local($t16)
+     # live vars: $t12, $t15
+ 42: $t17 := [98, 121, 101]
+     # live vars: $t12, $t15, $t17
+ 43: write_ref($t15, $t17)
+     # live vars: $t12, $t15
+ 44: $t19 := read_ref($t12)
+     # live vars: $t15, $t19
+ 45: $t20 := 1
+     # live vars: $t15, $t19, $t20
+ 46: $t18 := ==($t19, $t20)
+     # live vars: $t15, $t18
+ 47: if ($t18) goto 48 else goto 50
+     # live vars: $t15
+ 48: label L12
+     # live vars: $t15
+ 49: goto 53
+     # live vars: $t15
+ 50: label L13
+     # live vars:
+ 51: $t21 := 42
+     # live vars: $t21
+ 52: abort($t21)
+     # live vars: $t15
+ 53: label L14
+     # live vars: $t15
+ 54: $t23 := read_ref($t15)
+     # live vars: $t23
+ 55: $t24 := [98, 121, 101]
+     # live vars: $t23, $t24
+ 56: $t22 := ==($t23, $t24)
+     # live vars: $t22
+ 57: if ($t22) goto 58 else goto 60
+     # live vars:
+ 58: label L15
+     # live vars:
+ 59: goto 63
+     # live vars:
+ 60: label L16
+     # live vars:
+ 61: $t25 := 42
+     # live vars: $t25
+ 62: abort($t25)
+     # live vars:
+ 63: label L17
+     # live vars:
+ 64: $t26 := true
+     # live vars: $t26
+ 65: if ($t26) goto 66 else goto 68
+     # live vars:
+ 66: label L18
+     # live vars:
+ 67: goto 71
+     # live vars:
+ 68: label L19
+     # live vars:
+ 69: $t27 := 42
+     # live vars: $t27
+ 70: abort($t27)
+     # live vars:
+ 71: label L20
+     # live vars:
+ 72: $t28 := true
+     # live vars: $t28
+ 73: if ($t28) goto 74 else goto 76
+     # live vars:
+ 74: label L21
+     # live vars:
+ 75: goto 79
+     # live vars:
+ 76: label L22
+     # live vars:
+ 77: $t29 := 42
+     # live vars: $t29
+ 78: abort($t29)
+     # live vars:
+ 79: label L23
+     # live vars:
+ 80: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun <SELF>_0::check() {
+     var $t0: bool
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: bool
+     var $t9: vector<u8>
+     var $t10: vector<u8>
+     var $t11: u64
+     var $t12: &mut u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: &mut vector<u8>
+     var $t16: vector<u8>
+     var $t17: vector<u8>
+     var $t18: bool
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: bool
+     var $t23: vector<u8>
+     var $t24: vector<u8>
+     var $t25: u64
+     var $t26: bool
+     var $t27: u64
+     var $t28: bool
+     var $t29: u64
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := true
+     # live vars: $t0
+     # refs: []
+     #
+  1: if ($t0) goto 2 else goto 4
+     # live vars:
+     # refs: []
+     #
+  2: label L0
+     # live vars:
+     # refs: []
+     #
+  3: goto 7
+     # live vars:
+     # refs: []
+     #
+  4: label L1
+     # live vars:
+     # refs: []
+     #
+  5: $t1 := 42
+     # live vars: $t1
+     # refs: []
+     #
+  6: abort($t1)
+     # live vars:
+     # refs: []
+     #
+  7: label L2
+     # live vars:
+     # refs: []
+     #
+  8: $t2 := true
+     # live vars: $t2
+     # refs: []
+     #
+  9: if ($t2) goto 10 else goto 12
+     # live vars:
+     # refs: []
+     #
+ 10: label L3
+     # live vars:
+     # refs: []
+     #
+ 11: goto 15
+     # live vars:
+     # refs: []
+     #
+ 12: label L4
+     # live vars:
+     # refs: []
+     #
+ 13: $t3 := 42
+     # live vars: $t3
+     # refs: []
+     #
+ 14: abort($t3)
+     # live vars:
+     # refs: []
+     #
+ 15: label L5
+     # live vars:
+     # refs: []
+     #
+ 16: $t5 := 0
+     # live vars: $t5
+     # refs: []
+     #
+ 17: $t6 := 0
+     # live vars: $t5, $t6
+     # refs: []
+     #
+ 18: $t4 := ==($t5, $t6)
+     # live vars: $t4
+     # refs: []
+     #
+ 19: if ($t4) goto 20 else goto 22
+     # live vars:
+     # refs: []
+     #
+ 20: label L6
+     # live vars:
+     # refs: []
+     #
+ 21: goto 25
+     # live vars:
+     # refs: []
+     #
+ 22: label L7
+     # live vars:
+     # refs: []
+     #
+ 23: $t7 := 42
+     # live vars: $t7
+     # refs: []
+     #
+ 24: abort($t7)
+     # live vars:
+     # refs: []
+     #
+ 25: label L8
+     # live vars:
+     # refs: []
+     #
+ 26: $t9 := [104, 101, 108, 108, 111]
+     # live vars: $t9
+     # refs: []
+     #
+ 27: $t10 := [104, 101, 108, 108, 111]
+     # live vars: $t9, $t10
+     # refs: []
+     #
+ 28: $t8 := ==($t9, $t10)
+     # live vars: $t8
+     # refs: []
+     #
+ 29: if ($t8) goto 30 else goto 32
+     # live vars:
+     # refs: []
+     #
+ 30: label L9
+     # live vars:
+     # refs: []
+     #
+ 31: goto 35
+     # live vars:
+     # refs: []
+     #
+ 32: label L10
+     # live vars:
+     # refs: []
+     #
+ 33: $t11 := 42
+     # live vars: $t11
+     # refs: []
+     #
+ 34: abort($t11)
+     # live vars:
+     # refs: []
+     #
+ 35: label L11
+     # live vars:
+     # refs: []
+     #
+ 36: $t13 := 0
      # live vars: $t13
      # refs: []
      #

--- a/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/copy_ability_tuple.exp
@@ -405,6 +405,126 @@ public fun M::g($t0: &signer) {
      #   <no edges>
      #
   1: $t1 := pack 0x42::M::R($t2)
+     # flush: $t3
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t3 := 3
+     # flush: $t1, $t3
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: ($t1, $t3) := M::f($t1)
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t4 := infer($t0)
+     # live vars: $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: move_to<0x42::M::R>($t4, $t1)
+     # live vars:
+     # refs: []
+     #
+  6: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun M::f($t0: 0x42::M::R): (0x42::M::R, u64) {
+     var $t1: 0x42::M::R
+     var $t2: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t2 := 0
+     # live vars: $t1, $t2
+  2: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::g($t0: &signer) {
+     var $t1: 0x42::M::R
+     var $t2: u64
+     var $t3: u64
+     var $t4: &signer
+     # live vars: $t0
+  0: $t2 := 1
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x42::M::R($t2)
+     # live vars: $t0, $t1
+  2: $t3 := 3
+     # live vars: $t0, $t1
+  3: ($t1, $t3) := M::f($t1)
+     # live vars: $t0, $t1
+  4: $t4 := infer($t0)
+     # live vars: $t1, $t4
+  5: move_to<0x42::M::R>($t4, $t1)
+     # live vars:
+  6: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+public fun M::f($t0: 0x42::M::R): (0x42::M::R, u64) {
+     var $t1: 0x42::M::R
+     var $t2: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t2 := 0
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  2: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun M::g($t0: &signer) {
+     var $t1: 0x42::M::R
+     var $t2: u64
+     var $t3: u64
+     var $t4: &signer
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := 1
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := pack 0x42::M::R($t2)
      # live vars: $t0, $t1
      # refs: [$t0 => #0]
      # #0

--- a/third_party/move/move-compiler-v2/tests/ability-transform/dead_but_borrowed.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/dead_but_borrowed.exp
@@ -179,6 +179,52 @@ fun explicate_drop::test0(): u8 {
   3: return $t0
 }
 
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun explicate_drop::test0(): u8 {
+     var $t0: u8
+     var $t1: &u8
+     var $t2: u8
+     # live vars:
+  0: $t2 := 42
+     # live vars: $t2
+  1: $t1 := borrow_local($t2)
+     # live vars: $t1
+  2: $t0 := read_ref($t1)
+     # live vars: $t0
+  3: return $t0
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun explicate_drop::test0(): u8 {
+     var $t0: u8
+     var $t1: &u8
+     var $t2: u8
+     # live vars:
+     # refs: []
+     #
+  0: $t2 := 42
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := borrow_local($t2)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => #1 via [value] at line 4
+     #
+  2: $t0 := read_ref($t1)
+     # live vars: $t0
+     # refs: []
+     #
+  3: return $t0
+}
+
 ============ after AbortAnalysisProcessor: ================
 
 [variant baseline]

--- a/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/destroy_after_call.exp
@@ -342,6 +342,105 @@ fun m::g() {
      var $t1: &mut u64
      var $t2: &mut u64
      var $t3: &u64
+     # flush: $t0
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := 22
+     # live vars: $t0
+     # refs: []
+     #
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `v`] at line 7
+     #
+  2: $t2 := m::f($t1)
+     # flush: $t1
+     # live vars: $t0, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [local `v`] at line 8
+     #
+  3: $t1 := infer($t2)
+     # flush: $t3
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t3 := borrow_local($t0)
+     # live vars:
+     # refs: []
+     #
+  5: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::f($t0: &mut u64): &mut u64 {
+     var $t1: &mut u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::g() {
+     var $t0: u64
+     var $t1: &mut u64
+     var $t2: &mut u64
+     var $t3: &u64
+     # live vars:
+  0: $t0 := 22
+     # live vars: $t0
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  2: $t2 := m::f($t1)
+     # live vars: $t0, $t2
+  3: $t1 := infer($t2)
+     # live vars: $t0
+  4: $t3 := borrow_local($t0)
+     # live vars:
+  5: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun m::f($t0: &mut u64): &mut u64 {
+     var $t1: &mut u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::g() {
+     var $t0: u64
+     var $t1: &mut u64
+     var $t2: &mut u64
+     var $t3: &u64
      # live vars:
      # refs: []
      #

--- a/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/drop_after_loop.exp
@@ -714,6 +714,250 @@ fun m::drop_after_loop() {
      var $t6: u64
      var $t7: u64
      var $t8: u64
+     # flush: $t0
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := 1
+     # flush: $t1
+     # live vars: $t0
+     # refs: []
+     #
+  1: $t1 := borrow_local($t0)
+     # flush: $t2
+     # live vars: $t0, $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  2: $t2 := true
+     # live vars: $t0, $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  3: label L0
+     # live vars: $t0, $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  4: if ($t2) goto 5 else goto 11
+     # live vars: $t0, $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  5: label L2
+     # live vars: $t0, $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  6: $t3 := 2
+     # live vars: $t0, $t1, $t3
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  7: write_ref($t1, $t3)
+     # live vars: $t0, $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  8: $t4 := false
+     # flush: $t2
+     # live vars: $t0, $t1, $t4
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+  9: $t2 := infer($t4)
+     # live vars: $t0, $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+ 10: goto 13
+     # live vars: $t0, $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+ 11: label L3
+     # live vars: $t0
+     # refs: []
+     #
+ 12: goto 15
+     # live vars: $t0, $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+ 13: label L4
+     # live vars: $t0, $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   => (mut) #1 via [local `l`] at line 4
+     #
+ 14: goto 3
+     # live vars: $t0
+     # refs: []
+     #
+ 15: label L1
+     # live vars: $t0
+     # refs: []
+     #
+ 16: $t6 := infer($t0)
+     # live vars: $t6
+     # refs: []
+     #
+ 17: $t7 := 2
+     # live vars: $t6, $t7
+     # refs: []
+     #
+ 18: $t5 := ==($t6, $t7)
+     # live vars: $t5
+     # refs: []
+     #
+ 19: if ($t5) goto 20 else goto 22
+     # live vars:
+     # refs: []
+     #
+ 20: label L5
+     # live vars:
+     # refs: []
+     #
+ 21: goto 25
+     # live vars:
+     # refs: []
+     #
+ 22: label L6
+     # live vars:
+     # refs: []
+     #
+ 23: $t8 := 0
+     # live vars: $t8
+     # refs: []
+     #
+ 24: abort($t8)
+     # live vars:
+     # refs: []
+     #
+ 25: label L7
+     # live vars:
+     # refs: []
+     #
+ 26: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::drop_after_loop() {
+     var $t0: u64
+     var $t1: &mut u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := borrow_local($t0)
+     # live vars: $t0, $t1
+  2: $t2 := true
+     # live vars: $t0, $t1, $t2
+  3: label L0
+     # live vars: $t0, $t1, $t2
+  4: if ($t2) goto 5 else goto 11
+     # live vars: $t0, $t1
+  5: label L2
+     # live vars: $t0, $t1
+  6: $t3 := 2
+     # live vars: $t0, $t1, $t3
+  7: write_ref($t1, $t3)
+     # live vars: $t0, $t1
+  8: $t4 := false
+     # live vars: $t0, $t1, $t4
+  9: $t2 := infer($t4)
+     # live vars: $t0, $t1, $t2
+ 10: goto 13
+     # live vars: $t0, $t1
+ 11: label L3
+     # live vars: $t0
+ 12: goto 15
+     # live vars: $t0, $t1, $t2
+ 13: label L4
+     # live vars: $t0, $t1, $t2
+ 14: goto 3
+     # live vars: $t0
+ 15: label L1
+     # live vars: $t0
+ 16: $t6 := infer($t0)
+     # live vars: $t6
+ 17: $t7 := 2
+     # live vars: $t6, $t7
+ 18: $t5 := ==($t6, $t7)
+     # live vars: $t5
+ 19: if ($t5) goto 20 else goto 22
+     # live vars:
+ 20: label L5
+     # live vars:
+ 21: goto 25
+     # live vars:
+ 22: label L6
+     # live vars:
+ 23: $t8 := 0
+     # live vars: $t8
+ 24: abort($t8)
+     # live vars:
+ 25: label L7
+     # live vars:
+ 26: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun m::drop_after_loop() {
+     var $t0: u64
+     var $t1: &mut u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: bool
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
      # live vars:
      # refs: []
      #

--- a/third_party/move/move-compiler-v2/tests/ability-transform/drop_at_branch.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/drop_at_branch.exp
@@ -211,6 +211,70 @@ fun explicate_drop::drop_at_branch($t0: bool): u8 {
      # refs: []
      #
   1: label L0
+     # flush: $t1
+     # live vars:
+     # refs: []
+     #
+  2: $t1 := 1
+     # live vars: $t1
+     # refs: []
+     #
+  3: goto 6
+     # live vars:
+     # refs: []
+     #
+  4: label L1
+     # flush: $t1
+     # live vars:
+     # refs: []
+     #
+  5: $t1 := 0
+     # live vars: $t1
+     # refs: []
+     #
+  6: label L2
+     # live vars: $t1
+     # refs: []
+     #
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun explicate_drop::drop_at_branch($t0: bool): u8 {
+     var $t1: u8
+     # live vars: $t0
+  0: if ($t0) goto 1 else goto 4
+     # live vars:
+  1: label L0
+     # live vars:
+  2: $t1 := 1
+     # live vars: $t1
+  3: goto 6
+     # live vars:
+  4: label L1
+     # live vars:
+  5: $t1 := 0
+     # live vars: $t1
+  6: label L2
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun explicate_drop::drop_at_branch($t0: bool): u8 {
+     var $t1: u8
+     # live vars: $t0
+     # refs: []
+     #
+  0: if ($t0) goto 1 else goto 4
+     # live vars:
+     # refs: []
+     #
+  1: label L0
      # live vars:
      # refs: []
      #

--- a/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/foreach_mut_expanded.exp
@@ -1116,6 +1116,346 @@ fun m::test_for_each_mut() {
      var $t14: vector<u64>
      var $t15: vector<u64>
      var $t16: u64
+     # flush: $t0
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := ["1", "2", "3"]
+     # flush: $t1
+     # live vars: $t0
+     # refs: []
+     #
+  1: $t1 := 0
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  2: $t3 := borrow_local($t0)
+     # flush: $t2
+     # live vars: $t0, $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `v`] at line 8
+     #
+  3: $t2 := vector::length<u64>($t3)
+     # flush: $t4
+     # live vars: $t0, $t1, $t2
+     # refs: []
+     #
+  4: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+  5: label L0
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+  6: $t6 := infer($t1)
+     # live vars: $t0, $t1, $t2, $t4, $t6
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+  7: $t5 := <($t6, $t2)
+     # live vars: $t0, $t1, $t2, $t4, $t5
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+  8: if ($t5) goto 9 else goto 19
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+  9: label L2
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 10: $t8 := infer($t4)
+     # flush: $t9
+     # live vars: $t0, $t1, $t2, $t4, $t8
+     # refs: [$t4 => #4, $t8 => #8]
+     # #4
+     #   => (mut) #8 via [] at line 11
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 11: $t7 := vector::borrow_mut<u64>($t8, $t1)
+     # live vars: $t0, $t1, $t2, $t4, $t7
+     # refs: [$t4 => #4, $t7 => #7]
+     # #4
+     #   -> (mut) #7 via [] at line 11
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 12: $t9 := 2
+     # live vars: $t0, $t1, $t2, $t4, $t7, $t9
+     # refs: [$t4 => #4, $t7 => #7]
+     # #4
+     #   -> (mut) #7 via [] at line 11
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 13: write_ref($t7, $t9)
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 14: $t11 := infer($t1)
+     # live vars: $t0, $t2, $t4, $t11
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 15: $t12 := 1
+     # live vars: $t0, $t2, $t4, $t11, $t12
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 16: $t10 := +($t11, $t12)
+     # flush: $t1
+     # live vars: $t0, $t2, $t4, $t10
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 17: $t1 := infer($t10)
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 18: goto 21
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 19: label L3
+     # live vars: $t0
+     # refs: []
+     #
+ 20: goto 23
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 21: label L4
+     # live vars: $t0, $t1, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `v`] at line 9
+     #
+ 22: goto 5
+     # live vars: $t0
+     # refs: []
+     #
+ 23: label L1
+     # live vars: $t0
+     # refs: []
+     #
+ 24: $t14 := infer($t0)
+     # live vars: $t14
+     # refs: []
+     #
+ 25: $t15 := ["2", "3", "4"]
+     # live vars: $t14, $t15
+     # refs: []
+     #
+ 26: $t13 := ==($t14, $t15)
+     # live vars: $t13
+     # refs: []
+     #
+ 27: if ($t13) goto 28 else goto 30
+     # live vars:
+     # refs: []
+     #
+ 28: label L5
+     # live vars:
+     # refs: []
+     #
+ 29: goto 33
+     # live vars:
+     # refs: []
+     #
+ 30: label L6
+     # live vars:
+     # refs: []
+     #
+ 31: $t16 := 0
+     # live vars: $t16
+     # refs: []
+     #
+ 32: abort($t16)
+     # live vars:
+     # refs: []
+     #
+ 33: label L7
+     # live vars:
+     # refs: []
+     #
+ 34: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test_for_each_mut() {
+     var $t0: vector<u64>
+     var $t1: u64
+     var $t2: u64
+     var $t3: &vector<u64>
+     var $t4: &mut vector<u64>
+     var $t5: bool
+     var $t6: u64
+     var $t7: &mut u64
+     var $t8: &mut vector<u64>
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: vector<u64>
+     var $t15: vector<u64>
+     var $t16: u64
+     # live vars:
+  0: $t0 := ["1", "2", "3"]
+     # live vars: $t0
+  1: $t1 := 0
+     # live vars: $t0, $t1
+  2: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  3: $t2 := vector::length<u64>($t3)
+     # live vars: $t0, $t1, $t2
+  4: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t2, $t4
+  5: label L0
+     # live vars: $t0, $t1, $t2, $t4
+  6: $t6 := infer($t1)
+     # live vars: $t0, $t1, $t2, $t4, $t6
+  7: $t5 := <($t6, $t2)
+     # live vars: $t0, $t1, $t2, $t4, $t5
+  8: if ($t5) goto 9 else goto 19
+     # live vars: $t0, $t1, $t2, $t4
+  9: label L2
+     # live vars: $t0, $t1, $t2, $t4
+ 10: $t8 := infer($t4)
+     # live vars: $t0, $t1, $t2, $t4, $t8
+ 11: $t7 := vector::borrow_mut<u64>($t8, $t1)
+     # live vars: $t0, $t1, $t2, $t4, $t7
+ 12: $t9 := 2
+     # live vars: $t0, $t1, $t2, $t4, $t7, $t9
+ 13: write_ref($t7, $t9)
+     # live vars: $t0, $t1, $t2, $t4
+ 14: $t11 := infer($t1)
+     # live vars: $t0, $t2, $t4, $t11
+ 15: $t12 := 1
+     # live vars: $t0, $t2, $t4, $t11, $t12
+ 16: $t10 := +($t11, $t12)
+     # live vars: $t0, $t2, $t4, $t10
+ 17: $t1 := infer($t10)
+     # live vars: $t0, $t1, $t2, $t4
+ 18: goto 21
+     # live vars: $t0, $t1, $t2, $t4
+ 19: label L3
+     # live vars: $t0
+ 20: goto 23
+     # live vars: $t0, $t1, $t2, $t4
+ 21: label L4
+     # live vars: $t0, $t1, $t2, $t4
+ 22: goto 5
+     # live vars: $t0
+ 23: label L1
+     # live vars: $t0
+ 24: $t14 := infer($t0)
+     # live vars: $t14
+ 25: $t15 := ["2", "3", "4"]
+     # live vars: $t14, $t15
+ 26: $t13 := ==($t14, $t15)
+     # live vars: $t13
+ 27: if ($t13) goto 28 else goto 30
+     # live vars:
+ 28: label L5
+     # live vars:
+ 29: goto 33
+     # live vars:
+ 30: label L6
+     # live vars:
+ 31: $t16 := 0
+     # live vars: $t16
+ 32: abort($t16)
+     # live vars:
+ 33: label L7
+     # live vars:
+ 34: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun m::test_for_each_mut() {
+     var $t0: vector<u64>
+     var $t1: u64
+     var $t2: u64
+     var $t3: &vector<u64>
+     var $t4: &mut vector<u64>
+     var $t5: bool
+     var $t6: u64
+     var $t7: &mut u64
+     var $t8: &mut vector<u64>
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: bool
+     var $t14: vector<u64>
+     var $t15: vector<u64>
+     var $t16: u64
      # live vars:
      # refs: []
      #

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_return.exp
@@ -242,6 +242,79 @@ public fun m::singleton<#0>($t0: #0): vector<#0> {
      var $t1: vector<#0>
      var $t2: vector<#0>
      var $t3: &mut vector<#0>
+     # flush: $t2
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := vector($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := borrow_local($t2)
+     # live vars: $t2, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => (mut) #3 via [local `v`] at line 6
+     #
+  2: m::g<#0>($t3)
+     # live vars: $t2
+     # refs: []
+     #
+  3: $t1 := infer($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun m::g<#0>($t0: &mut vector<#0>) {
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::singleton<#0>($t0: #0): vector<#0> {
+     var $t1: vector<#0>
+     var $t2: vector<#0>
+     var $t3: &mut vector<#0>
+     # live vars: $t0
+  0: $t2 := vector($t0)
+     # live vars: $t2
+  1: $t3 := borrow_local($t2)
+     # live vars: $t2, $t3
+  2: m::g<#0>($t3)
+     # live vars: $t2
+  3: $t1 := infer($t2)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun m::g<#0>($t0: &mut vector<#0>) {
+     # live vars: $t0
+  0: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+public fun m::singleton<#0>($t0: #0): vector<#0> {
+     var $t1: vector<#0>
+     var $t2: vector<#0>
+     var $t3: &mut vector<#0>
      # live vars: $t0
      # refs: []
      #

--- a/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/ability-transform/mutate_vector.exp
@@ -390,6 +390,128 @@ public fun m::new_scalar_from_u8($t0: u8): 0x42::m::Scalar {
      var $t4: &mut vector<u8>
      var $t5: &mut 0x42::m::Scalar
      var $t6: u64
+     # flush: $t2
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := m::scalar_zero()
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  1: $t5 := borrow_local($t2)
+     # live vars: $t0, $t2, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => (mut) #5 via [local `s`] at line 11
+     #
+  2: $t4 := borrow_field<0x42::m::Scalar>.data($t5)
+     # live vars: $t0, $t2, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `s`, field `data`] at line 11
+     #
+  3: $t6 := 0
+     # flush: $t0
+     # live vars: $t0, $t2, $t4, $t6
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `s`, field `data`] at line 11
+     #
+  4: $t3 := vector::borrow_mut<u8>($t4, $t6)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [local `s`, field `data`] at line 11
+     #
+  5: write_ref($t3, $t0)
+     # live vars: $t2
+     # refs: []
+     #
+  6: $t1 := infer($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  7: return $t1
+}
+
+
+[variant baseline]
+public fun m::scalar_zero(): 0x42::m::Scalar {
+     var $t0: 0x42::m::Scalar
+     var $t1: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := [0]
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := pack 0x42::m::Scalar($t1)
+     # live vars: $t0
+     # refs: []
+     #
+  2: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun m::new_scalar_from_u8($t0: u8): 0x42::m::Scalar {
+     var $t1: 0x42::m::Scalar
+     var $t2: 0x42::m::Scalar
+     var $t3: &mut u8
+     var $t4: &mut vector<u8>
+     var $t5: &mut 0x42::m::Scalar
+     var $t6: u64
+     # live vars: $t0
+  0: $t2 := m::scalar_zero()
+     # live vars: $t0, $t2
+  1: $t5 := borrow_local($t2)
+     # live vars: $t0, $t2, $t5
+  2: $t4 := borrow_field<0x42::m::Scalar>.data($t5)
+     # live vars: $t0, $t2, $t4
+  3: $t6 := 0
+     # live vars: $t0, $t2, $t4, $t6
+  4: $t3 := vector::borrow_mut<u8>($t4, $t6)
+     # live vars: $t0, $t2, $t3
+  5: write_ref($t3, $t0)
+     # live vars: $t2
+  6: $t1 := infer($t2)
+     # live vars: $t1
+  7: return $t1
+}
+
+
+[variant baseline]
+public fun m::scalar_zero(): 0x42::m::Scalar {
+     var $t0: 0x42::m::Scalar
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := [0]
+     # live vars: $t1
+  1: $t0 := pack 0x42::m::Scalar($t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+public fun m::new_scalar_from_u8($t0: u8): 0x42::m::Scalar {
+     var $t1: 0x42::m::Scalar
+     var $t2: 0x42::m::Scalar
+     var $t3: &mut u8
+     var $t4: &mut vector<u8>
+     var $t5: &mut 0x42::m::Scalar
+     var $t6: u64
      # live vars: $t0
      # refs: []
      #

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/eager_push_01.opt.exp
@@ -13,13 +13,16 @@ fun one(): u64
 
 // Function definition at index 2
 #[persistent] public fun test(l0: u64)
+    local l1: u64
     move_loc l0
     call one
-    call one
-    call one
-    call one
+    st_loc l1
+    copy_loc l1
+    copy_loc l1
     // @5
-    call one
+    copy_loc l1
+    copy_loc l1
+    copy_loc l1
     call bar
     ret
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.opt.exp
@@ -255,7 +255,8 @@ l0: move_loc l2
 // Function definition at index 1
 fun test_v1()
     local l0: m::Data
-    local l1: &m::Data
+    local l1: bool
+    local l2: &m::Data
     ld_u64 43
     call m::pack$Data$V1
     st_loc l0
@@ -265,39 +266,35 @@ fun test_v1()
     read_ref
     ld_u64 43
     eq
-    br_false l0
-    borrow_loc l0
-    // @10
     st_loc l1
     copy_loc l1
+    // @10
+    br_false l0
+    borrow_loc l0
+    st_loc l2
+    copy_loc l2
     call m::test_variant$Data$V1
-    br_true l1
-    move_loc l1
     // @15
+    br_true l1
+    move_loc l2
     pop
     ld_u64 14566554180833181697
     abort
-l1: move_loc l1
-    call m::borrow$Data$0$0
     // @20
-    read_ref
-    ld_u64 43
-    eq
-    br_false l2
-    mut_borrow_loc l0
-    // @25
-    freeze_ref
+l1: move_loc l2
     call m::borrow$Data$0$0
     read_ref
     ld_u64 43
     eq
-    // @30
+    // @25
+    br_false l2
+    copy_loc l1
     br_false l3
     ret
 l3: ld_u64 3
+    // @30
     abort
 l2: ld_u64 2
-    // @35
     abort
 l0: ld_u64 1
     abort

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.opt.exp
@@ -88,21 +88,20 @@ use 0x42::m1
     call m1::pack$Result$Ok<u64, u64>
     st_loc l0
     copy_loc l0
-    ld_u64 42
+    copy_loc l0
     // @5
-    call m1::pack$Result$Ok<u64, u64>
     eq
     br_false l0
     move_loc l0
     call m1::unpack$Result$Err<u64, u64>
-    // @10
     ld_u64 42
+    // @10
     eq
     br_false l1
     ret
 l1: ld_u64 2
-    // @15
     abort
+    // @15
 l0: ld_u64 1
     abort
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.opt.exp
@@ -242,21 +242,20 @@ l0: ld_u64 3
     call m1::pack$Result$Ok<u64, u64>
     st_loc l0
     copy_loc l0
-    ld_u64 42
+    copy_loc l0
     // @5
-    call m1::pack$Result$Ok<u64, u64>
     eq
     br_false l0
     move_loc l0
     call m1::unpack$Result$Ok<u64, u64>
-    // @10
     ld_u64 42
+    // @10
     eq
     br_false l1
     ret
 l1: ld_u64 2
-    // @15
     abort
+    // @15
 l0: ld_u64 1
     abort
 

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.opt.exp
@@ -303,6 +303,7 @@ l0: ld_u64 11
     local l2: &m1::S<u64>
     local l3: &m1::T<u64>
     local l4: &m1::T<u64>
+    local l5: bool
     ld_u64 9
     call m1::pack$T<u64>
     st_loc l0
@@ -339,42 +340,38 @@ l0: ld_u64 11
     ld_u64 9
     eq
     // @30
+    st_loc l5
+    copy_loc l5
     br_false l2
-    borrow_loc l1
-    call m1::borrow$S$1<u64>
-    call m1::borrow$T$0<u64>
-    read_ref
-    // @35
-    ld_u64 9
-    eq
+    copy_loc l5
     br_false l3
+    // @35
     borrow_loc l1
     st_loc l2
-    // @40
     copy_loc l2
     call m1::borrow$S$0<u64>
     move_loc l2
+    // @40
     call m1::borrow$S$1<u64>
     pop
-    // @45
     read_ref
     ld_u64 8
     eq
+    // @45
     br_false l4
     ret
-    // @50
 l4: ld_u64 15
     abort
 l3: ld_u64 15
+    // @50
     abort
 l2: ld_u64 14
-    // @55
     abort
 l1: ld_u64 12
     abort
+    // @55
 l0: move_loc l3
     pop
-    // @60
     ld_u64 11
     abort
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_01.on.exp
@@ -31,6 +31,53 @@ fun m::take2($t0: u64, $t1: u64) {
 public fun m::test() {
      var $t0: u64
      var $t1: u64
+     var $t2: u64
+     # flush: $t1
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t1)
+     # live vars: $t0, $t1
+  2: $t2 := infer($t0)
+     # live vars: $t1, $t2
+  3: m::take2($t2, $t1)
+     # live vars:
+  4: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
      var $t2: u64 [unused]
      # flush: $t1
      # live vars:

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_02.on.exp
@@ -31,6 +31,53 @@ fun m::take2($t0: u64, $t1: u64) {
 public fun m::test() {
      var $t0: u64
      var $t1: u64
+     var $t2: u64
+     # flush: $t0, $t1
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t1)
+     # live vars: $t0, $t1
+  2: $t2 := infer($t1)
+     # live vars: $t0, $t2
+  3: m::take2($t2, $t0)
+     # live vars:
+  4: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
      var $t2: u64 [unused]
      # flush: $t0, $t1
      # live vars:

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_03.on.exp
@@ -31,6 +31,53 @@ fun m::take2($t0: u64, $t1: u64) {
 public fun m::test() {
      var $t0: u64
      var $t1: u64
+     var $t2: u64
+     # flush: $t0
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t1)
+     # live vars: $t0
+  2: $t2 := infer($t0)
+     # live vars: $t0, $t2
+  3: m::take2($t2, $t0)
+     # live vars:
+  4: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
      var $t2: u64 [unused]
      # flush: $t0
      # live vars:

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_04.on.exp
@@ -31,6 +31,53 @@ fun m::take2($t0: u64, $t1: u64) {
 public fun m::test() {
      var $t0: u64
      var $t1: u64
+     var $t2: u64
+     # flush: $t1
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t0)
+     # live vars: $t1
+  2: $t2 := infer($t1)
+     # live vars: $t1, $t2
+  3: m::take2($t2, $t1)
+     # live vars:
+  4: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
      var $t2: u64 [unused]
      # flush: $t1
      # live vars:

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_05.on.exp
@@ -42,6 +42,50 @@ public fun m::test() {
   3: return ()
 }
 
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+fun m::take1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     # flush: $t1
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: m::take1($t0)
+     # live vars: $t1
+  2: m::take1($t1)
+     # live vars:
+  3: return ()
+}
+
 
 ============ disassembled file-format ==================
 // Bytecode version v10

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_06.on.exp
@@ -20,6 +20,40 @@ fun m::take2($t0: u64, $t1: u64) {
 [variant baseline]
 public fun m::test($t0: u64) {
      var $t1: u64
+     var $t2: u64
+     # flush: $t1
+     # live vars: $t0
+  0: $t1 := m::one()
+     # live vars: $t0, $t1
+  1: $t2 := infer($t0)
+     # live vars: $t1, $t2
+  2: m::take2($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::take2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
      var $t2: u64 [unused]
      # flush: $t1
      # live vars: $t0

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_07.on.exp
@@ -2,6 +2,51 @@
 
 [variant baseline]
 fun m::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t1 := m::one()
+     # live vars: $t1
+  1: $t2 := m::foo($t1)
+     # live vars: $t2
+  2: $t1 := infer($t2)
+     # live vars: $t1
+  3: $t0 := infer($t1)
+     # live vars: $t0
+  4: return $t0
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64 [unused]
      var $t3: u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/def_use_08.on.exp
@@ -32,6 +32,58 @@ public fun m::test() {
      var $t1: u64
      var $t2: u64
      var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # flush: $t0
+     # live vars:
+  0: ($t0, $t1, $t2, $t3) := m::foo()
+     # live vars: $t0, $t1, $t2, $t3
+  1: $t4 := infer($t1)
+     # live vars: $t0, $t2, $t3, $t4
+  2: $t5 := infer($t2)
+     # live vars: $t0, $t3, $t4, $t5
+  3: $t6 := infer($t3)
+     # live vars: $t0, $t4, $t5, $t6
+  4: m::take($t4, $t5, $t6, $t0)
+     # live vars:
+  5: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::foo(): (u64, u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: $t3 := 4
+     # live vars: $t0, $t1, $t2, $t3
+  4: return ($t0, $t1, $t2, $t3)
+}
+
+
+[variant baseline]
+fun m::take($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64 [unused]
      var $t6: u64 [unused]

--- a/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_11.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_11.on.exp
@@ -3,6 +3,103 @@
 [variant baseline]
 fun m::consume($t0: u64, $t1: &u64) {
      # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: vector<u64>) {
+     var $t1: u64
+     var $t2: &vector<u64>
+     var $t3: &vector<u64>
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     var $t8: &u64
+     var $t9: &u64
+     var $t10: &vector<u64>
+     var $t11: &u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     # flush: $t1
+     # live vars: $t0
+  0: $t1 := m::one()
+     # live vars: $t0, $t1
+  1: $t3 := borrow_local($t0)
+     # flush: $t2
+     # live vars: $t1, $t3
+  2: $t2 := infer($t3)
+     # flush: $t4
+     # live vars: $t1, $t2
+  3: $t4 := 0
+     # live vars: $t1, $t2, $t4
+  4: label L0
+     # live vars: $t1, $t2, $t4
+  5: $t6 := infer($t4)
+     # live vars: $t1, $t2, $t4, $t6
+  6: $t7 := vector::length<u64>($t2)
+     # live vars: $t1, $t2, $t4, $t6, $t7
+  7: $t5 := <($t6, $t7)
+     # live vars: $t1, $t2, $t4, $t5
+  8: if ($t5) goto 9 else goto 21
+     # live vars: $t1, $t2, $t4
+  9: label L2
+     # live vars: $t1, $t2, $t4
+ 10: $t10 := infer($t2)
+     # live vars: $t1, $t2, $t4, $t10
+ 11: $t9 := vector::borrow<u64>($t10, $t4)
+     # live vars: $t1, $t2, $t4, $t9
+ 12: $t8 := infer($t9)
+     # flush: $t11
+     # live vars: $t1, $t2, $t4, $t8
+ 13: $t11 := infer($t8)
+     # live vars: $t1, $t2, $t4, $t11
+ 14: $t12 := infer($t1)
+     # live vars: $t1, $t2, $t4, $t11, $t12
+ 15: m::consume($t12, $t11)
+     # live vars: $t1, $t2, $t4
+ 16: $t14 := infer($t4)
+     # live vars: $t1, $t2, $t14
+ 17: $t15 := 1
+     # live vars: $t1, $t2, $t14, $t15
+ 18: $t13 := +($t14, $t15)
+     # flush: $t4
+     # live vars: $t1, $t2, $t13
+ 19: $t4 := infer($t13)
+     # live vars: $t1, $t2, $t4
+ 20: goto 23
+     # live vars: $t1, $t2, $t4
+ 21: label L3
+     # live vars:
+ 22: goto 25
+     # live vars: $t1, $t2, $t4
+ 23: label L4
+     # live vars: $t1, $t2, $t4
+ 24: goto 4
+     # live vars:
+ 25: label L1
+     # live vars:
+ 26: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: &u64) {
+     # live vars: $t0, $t1
   0: drop($t1)
      # live vars:
   1: return ()

--- a/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.off.exp
@@ -87,29 +87,30 @@ fun test(l0: u64): u64
     call one
     // @30
     call id
-    call one
-    call id
     st_loc l10
+    copy_loc l10
+    copy_loc l10
     st_loc l11
     // @35
+    pop
     st_loc l8
     st_loc l9
     move_loc l6
     move_loc l5
-    move_loc l4
     // @40
+    move_loc l4
     move_loc l9
     move_loc l8
-    move_loc l11
     move_loc l10
-    call cons_7
+    move_loc l11
     // @45
+    call cons_7
     st_loc l9
     move_loc l7
     move_loc l9
     call cons_2_another
-    move_loc l1
     // @50
+    move_loc l1
     ret
 l0: ld_u64 42
     abort

--- a/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/framework_reduced_12.on.exp
@@ -5,6 +5,175 @@ fun m::bytes($t0: &u64): vector<u8> {
      var $t1: vector<u8>
      # live vars: $t0
   0: $t1 := ["1", "2"]
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::cons_2($t0: u64, $t1: &mut u64): u64 {
+     var $t2: u64
+     # live vars: $t0, $t1
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: return $t2
+}
+
+
+[variant baseline]
+fun m::cons_2_another($t0: &u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::cons_7($t0: vector<u8>, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64): u64 {
+     var $t7: u64
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: $t7 := 0
+     # live vars: $t7
+  1: return $t7
+}
+
+
+[variant baseline]
+fun m::id($t0: u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::test($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: vector<u8>
+     var $t4: &u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: &vector<u8>
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &mut u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &mut u64
+     var $t18: u64
+     var $t19: &u64
+     var $t20: u64
+     var $t21: vector<u8>
+     var $t22: u64
+     var $t23: u64
+     var $t24: u64
+     var $t25: u64
+     var $t26: u64
+     var $t27: u64
+     var $t28: u64
+     var $t29: u64
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := m::id($t0)
+     # live vars: $t0, $t2
+  1: $t4 := borrow_local($t0)
+     # flush: $t3
+     # live vars: $t0, $t2, $t4
+  2: $t3 := m::bytes($t4)
+     # live vars: $t0, $t2, $t3
+  3: $t7 := borrow_local($t3)
+     # live vars: $t0, $t2, $t3, $t7
+  4: $t6 := vector::length<u8>($t7)
+     # live vars: $t0, $t2, $t3, $t6
+  5: $t8 := 2
+     # live vars: $t0, $t2, $t3, $t6, $t8
+  6: $t5 := ==($t6, $t8)
+     # live vars: $t0, $t2, $t3, $t5
+  7: if ($t5) goto 8 else goto 10
+     # live vars: $t0, $t2, $t3
+  8: label L0
+     # live vars: $t0, $t2, $t3
+  9: goto 13
+     # live vars: $t0, $t2, $t3
+ 10: label L1
+     # live vars:
+ 11: $t9 := 42
+     # live vars: $t9
+ 12: abort($t9)
+     # live vars: $t0, $t2, $t3
+ 13: label L2
+     # flush: $t10
+     # live vars: $t0, $t2, $t3
+ 14: $t10 := 0
+     # live vars: $t0, $t2, $t3, $t10
+ 15: $t12 := infer($t0)
+     # live vars: $t0, $t2, $t3, $t10, $t12
+ 16: $t13 := borrow_local($t10)
+     # live vars: $t0, $t2, $t3, $t10, $t12, $t13
+ 17: $t11 := m::cons_2($t12, $t13)
+     # live vars: $t0, $t2, $t3, $t10, $t11
+ 18: $t14 := m::id($t11)
+     # live vars: $t0, $t2, $t3, $t10, $t14
+ 19: $t16 := infer($t0)
+     # live vars: $t2, $t3, $t10, $t14, $t16
+ 20: $t17 := borrow_local($t10)
+     # live vars: $t2, $t3, $t10, $t14, $t16, $t17
+ 21: $t15 := m::cons_2($t16, $t17)
+     # live vars: $t2, $t3, $t10, $t14, $t15
+ 22: $t18 := m::id($t15)
+     # live vars: $t2, $t3, $t10, $t14, $t18
+ 23: $t19 := borrow_local($t2)
+     # live vars: $t2, $t3, $t10, $t14, $t18, $t19
+ 24: $t21 := infer($t3)
+     # live vars: $t2, $t10, $t14, $t18, $t19, $t21
+ 25: $t22 := 0
+     # live vars: $t2, $t10, $t14, $t18, $t19, $t21, $t22
+ 26: $t23 := infer($t10)
+     # live vars: $t2, $t14, $t18, $t19, $t21, $t22, $t23
+ 27: $t24 := infer($t14)
+     # live vars: $t2, $t18, $t19, $t21, $t22, $t23, $t24
+ 28: $t25 := infer($t18)
+     # live vars: $t2, $t19, $t21, $t22, $t23, $t24, $t25
+ 29: $t27 := m::one()
+     # live vars: $t2, $t19, $t21, $t22, $t23, $t24, $t25, $t27
+ 30: $t26 := m::id($t27)
+     # live vars: $t2, $t19, $t21, $t22, $t23, $t24, $t25, $t26
+ 31: $t29 := m::one()
+     # live vars: $t2, $t19, $t21, $t22, $t23, $t24, $t25, $t26, $t29
+ 32: $t28 := m::id($t29)
+     # live vars: $t2, $t19, $t21, $t22, $t23, $t24, $t25, $t26, $t28
+ 33: $t20 := m::cons_7($t21, $t22, $t23, $t24, $t25, $t26, $t28)
+     # live vars: $t2, $t19, $t20
+ 34: m::cons_2_another($t19, $t20)
+     # live vars: $t2
+ 35: $t1 := infer($t2)
+     # live vars: $t1
+ 36: return $t1
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::bytes($t0: &u64): vector<u8> {
+     var $t1: vector<u8>
+     # live vars: $t0
+  0: $t1 := ["1", "2"]
      # live vars: $t0, $t1
   1: drop($t0)
      # live vars: $t1
@@ -88,8 +257,8 @@ fun m::test($t0: u64): u64 {
      var $t25: u64 [unused]
      var $t26: u64 [unused]
      var $t27: u64
-     var $t28: u64 [unused]
-     var $t29: u64
+     var $t28: u64
+     var $t29: u64 [unused]
      # flush: $t2
      # live vars: $t0
   0: $t2 := m::id($t0)
@@ -145,14 +314,16 @@ fun m::test($t0: u64): u64 {
  23: $t8 := move($t8)
      # live vars: $t2, $t4, $t6, $t8, $t21, $t22, $t23
  24: $t27 := m::one()
+     # flush: $t27
      # live vars: $t2, $t4, $t6, $t8, $t21, $t22, $t23, $t27
  25: $t27 := m::id($t27)
+     # flush: $t27
      # live vars: $t2, $t4, $t6, $t8, $t21, $t22, $t23, $t27
- 26: $t29 := m::one()
-     # live vars: $t2, $t4, $t6, $t8, $t21, $t22, $t23, $t27, $t29
- 27: $t29 := m::id($t29)
-     # live vars: $t2, $t4, $t6, $t8, $t21, $t22, $t23, $t27, $t29
- 28: $t6 := m::cons_7($t21, $t22, $t23, $t6, $t8, $t27, $t29)
+ 26: $t27 := dup($t27)
+     # live vars: $t2, $t4, $t6, $t8, $t21, $t22, $t23, $t27
+ 27: $t28 := dup($t27)
+     # live vars: $t2, $t4, $t6, $t8, $t21, $t22, $t23, $t27, $t28
+ 28: $t6 := m::cons_7($t21, $t22, $t23, $t6, $t8, $t27, $t28)
      # live vars: $t2, $t4, $t6
  29: m::cons_2_another($t4, $t6)
      # live vars: $t2
@@ -213,6 +384,7 @@ fun test(l0: u64): u64
     local l3: u64
     local l4: u64
     local l5: u64
+    local l6: u64
     copy_loc l0
     call id
     st_loc l1
@@ -250,11 +422,12 @@ fun test(l0: u64): u64
     call one
     // @30
     call id
-    call one
-    call id
+    st_loc l6
+    copy_loc l6
+    copy_loc l6
     call cons_7
-    call cons_2_another
     // @35
+    call cons_2_another
     move_loc l1
     ret
 l0: ld_u64 42

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.off.exp
@@ -21,14 +21,36 @@ module 0xc0ffee::m
     local l5: u64
     local l6: u64
     call one
-    call one
-    call one
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    // @10
+    st_loc l1
+    st_loc l2
+    st_loc l3
+    st_loc l4
+    st_loc l5
+    // @15
+    pop
+    st_loc l6
+    move_loc l0
+    move_loc l5
+    move_loc l4
+    // @20
+    move_loc l3
+    move_loc l2
+    move_loc l1
+    move_loc l6
     call consume
+    // @25
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_01.on.exp
@@ -26,12 +26,12 @@ public fun m::test() {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
-     var $t10: u64 [unused]
-     var $t11: u64 [unused]
-     var $t12: u64 [unused]
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
      # live vars:
   0: $t0 := m::one()
      # live vars: $t0
@@ -44,24 +44,90 @@ public fun m::test() {
   4: $t4 := m::one()
      # live vars: $t0, $t1, $t2, $t3, $t4
   5: $t5 := m::one()
+     # flush: $t6
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5
   6: $t6 := m::one()
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
-  7: $t0 := move($t0)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
-  8: $t1 := move($t1)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
-  9: $t2 := move($t2)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
- 10: $t3 := move($t3)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
- 11: $t4 := move($t4)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
- 12: $t5 := move($t5)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
- 13: m::consume($t0, $t1, $t2, $t3, $t4, $t5, $t6)
+  7: $t7 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6, $t7
+  8: $t8 := infer($t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6, $t7, $t8
+  9: $t9 := infer($t2)
+     # live vars: $t3, $t4, $t5, $t6, $t7, $t8, $t9
+ 10: $t10 := infer($t3)
+     # live vars: $t4, $t5, $t6, $t7, $t8, $t9, $t10
+ 11: $t11 := infer($t4)
+     # live vars: $t5, $t6, $t7, $t8, $t9, $t10, $t11
+ 12: $t12 := infer($t5)
+     # live vars: $t6, $t7, $t8, $t9, $t10, $t11, $t12
+ 13: m::consume($t7, $t8, $t9, $t10, $t11, $t12, $t6)
      # live vars:
  14: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+public fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # flush: $t6
+     # live vars: $t0
+  2: $t6 := dup($t0)
+     # flush: $t0
+     # live vars: $t0, $t6
+  3: $t0 := move($t0)
+     # flush: $t0
+     # live vars: $t0, $t6
+  4: $t0 := dup($t0)
+     # live vars: $t0, $t6
+  5: $t8 := dup($t0)
+     # live vars: $t0, $t6, $t8
+  6: $t9 := dup($t0)
+     # live vars: $t0, $t6, $t8, $t9
+  7: $t10 := dup($t0)
+     # live vars: $t0, $t6, $t8, $t9, $t10
+  8: $t11 := dup($t0)
+     # live vars: $t0, $t6, $t8, $t9, $t10, $t11
+  9: $t12 := dup($t0)
+     # live vars: $t0, $t6, $t8, $t9, $t10, $t11, $t12
+ 10: m::consume($t0, $t8, $t9, $t10, $t11, $t12, $t6)
+     # live vars:
+ 11: return ()
 }
 
 
@@ -81,19 +147,21 @@ module 0xc0ffee::m
 #[persistent] public fun test()
     local l0: u64
     local l1: u64
-    local l2: u64
-    local l3: u64
-    local l4: u64
-    local l5: u64
-    local l6: u64
     call one
-    call one
-    call one
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    st_loc l1
     // @5
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    // @10
+    copy_loc l0
+    copy_loc l0
+    move_loc l1
     call consume
     ret
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_02.on.exp
@@ -36,6 +36,65 @@ public fun m::test() {
      var $t2: u64
      var $t3: u64
      var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     # flush: $t4
+     # live vars:
+  0: ($t0, $t1, $t2, $t3, $t4) := m::foo()
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  1: $t5 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5
+  2: $t6 := infer($t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6
+  3: $t7 := infer($t2)
+     # live vars: $t3, $t4, $t5, $t6, $t7
+  4: $t8 := infer($t3)
+     # live vars: $t4, $t5, $t6, $t7, $t8
+  5: m::consume($t5, $t6, $t7, $t8, $t4)
+     # live vars:
+  6: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo(): (u64, u64, u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: $t3 := 4
+     # live vars: $t0, $t1, $t2, $t3
+  4: $t4 := 5
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  5: return ($t0, $t1, $t2, $t3, $t4)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
      var $t5: u64 [unused]
      var $t6: u64 [unused]
      var $t7: u64 [unused]

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.off.exp
@@ -24,14 +24,17 @@ fun one(): u64
     local l4: u64
     local l5: u64
     call one
-    call one
-    call one
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
-    call one
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     call consume_2
     call consume_4
+    // @10
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_03.on.exp
@@ -32,36 +32,111 @@ public fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
      # live vars:
   0: $t0 := m::one()
      # live vars: $t0
   1: $t1 := m::one()
      # live vars: $t0, $t1
   2: $t2 := m::one()
+     # flush: $t3
      # live vars: $t0, $t1, $t2
   3: $t3 := m::one()
      # live vars: $t0, $t1, $t2, $t3
   4: $t4 := m::one()
+     # flush: $t5
      # live vars: $t0, $t1, $t2, $t3, $t4
   5: $t5 := m::one()
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  6: $t4 := move($t4)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  7: m::consume_2($t4, $t5)
+  6: $t6 := infer($t4)
+     # live vars: $t0, $t1, $t2, $t3, $t5, $t6
+  7: m::consume_2($t6, $t5)
      # live vars: $t0, $t1, $t2, $t3
-  8: $t0 := move($t0)
-     # live vars: $t0, $t1, $t2, $t3
-  9: $t1 := move($t1)
-     # live vars: $t0, $t1, $t2, $t3
- 10: $t2 := move($t2)
-     # live vars: $t0, $t1, $t2, $t3
- 11: m::consume_4($t0, $t1, $t2, $t3)
+  8: $t7 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t7
+  9: $t8 := infer($t1)
+     # live vars: $t2, $t3, $t7, $t8
+ 10: $t9 := infer($t2)
+     # live vars: $t3, $t7, $t8, $t9
+ 11: m::consume_4($t7, $t8, $t9, $t3)
      # live vars:
  12: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_4($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # flush: $t1
+     # live vars: $t0
+  2: $t1 := dup($t0)
+     # flush: $t2
+     # live vars: $t0, $t1
+  3: $t2 := dup($t0)
+     # flush: $t3
+     # live vars: $t0, $t1, $t2
+  4: $t3 := dup($t0)
+     # live vars: $t0, $t1, $t2, $t3
+  5: $t4 := dup($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  6: $t5 := dup($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  7: $t4 := move($t4)
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  8: m::consume_2($t4, $t5)
+     # live vars: $t0, $t1, $t2, $t3
+  9: $t0 := move($t0)
+     # live vars: $t0, $t1, $t2, $t3
+ 10: $t1 := move($t1)
+     # live vars: $t0, $t1, $t2, $t3
+ 11: $t2 := move($t2)
+     # live vars: $t0, $t1, $t2, $t3
+ 12: m::consume_4($t0, $t1, $t2, $t3)
+     # live vars:
+ 13: return ()
 }
 
 
@@ -90,13 +165,23 @@ fun one(): u64
     local l4: u64
     local l5: u64
     call one
-    call one
-    call one
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    st_loc l1
     // @5
-    call one
+    copy_loc l0
+    st_loc l2
+    copy_loc l0
+    st_loc l3
+    copy_loc l0
+    // @10
+    copy_loc l0
     call consume_2
+    move_loc l1
+    move_loc l2
+    move_loc l3
+    // @15
     call consume_4
     ret
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_04.on.exp
@@ -41,6 +41,88 @@ public fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     # flush: $t3
+     # live vars:
+  0: ($t0, $t1, $t2, $t3) := m::four()
+     # flush: $t5
+     # live vars: $t0, $t1, $t2, $t3
+  1: ($t4, $t5) := m::two()
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  2: $t6 := infer($t4)
+     # live vars: $t0, $t1, $t2, $t3, $t5, $t6
+  3: m::consume_2($t6, $t5)
+     # live vars: $t0, $t1, $t2, $t3
+  4: $t7 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t7
+  5: $t8 := infer($t1)
+     # live vars: $t2, $t3, $t7, $t8
+  6: $t9 := infer($t2)
+     # live vars: $t3, $t7, $t8, $t9
+  7: m::consume_4($t7, $t8, $t9, $t3)
+     # live vars:
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::two(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 5
+     # live vars: $t0
+  1: $t1 := 6
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_4($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::four(): (u64, u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: $t3 := 4
+     # live vars: $t0, $t1, $t2, $t3
+  4: return ($t0, $t1, $t2, $t3)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
      var $t6: u64 [unused]
      var $t7: u64 [unused]
      var $t8: u64 [unused]

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.off.exp
@@ -18,12 +18,19 @@ fun one(): u64
     local l2: u64
     local l3: u64
     call one
-    call one
-    call one
-    call one
-    call consume_2
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
+    copy_loc l0
     call consume_2
+    st_loc l3
+    move_loc l0
+    move_loc l3
+    // @10
+    call consume_2
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/in_order_use_05.on.exp
@@ -23,26 +23,80 @@ public fun m::test() {
      var $t1: u64
      var $t2: u64
      var $t3: u64
-     var $t4: u64 [unused]
-     var $t5: u64 [unused]
+     var $t4: u64
+     var $t5: u64
      # live vars:
   0: $t0 := m::one()
+     # flush: $t1
      # live vars: $t0
   1: $t1 := m::one()
      # live vars: $t0, $t1
   2: $t2 := m::one()
+     # flush: $t3
      # live vars: $t0, $t1, $t2
   3: $t3 := m::one()
      # live vars: $t0, $t1, $t2, $t3
-  4: $t2 := move($t2)
-     # live vars: $t0, $t1, $t2, $t3
-  5: m::consume_2($t2, $t3)
+  4: $t4 := infer($t2)
+     # live vars: $t0, $t1, $t3, $t4
+  5: m::consume_2($t4, $t3)
      # live vars: $t0, $t1
-  6: $t0 := move($t0)
-     # live vars: $t0, $t1
-  7: m::consume_2($t0, $t1)
+  6: $t5 := infer($t0)
+     # live vars: $t1, $t5
+  7: m::consume_2($t5, $t1)
      # live vars:
   8: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # flush: $t1
+     # live vars: $t0
+  2: $t1 := dup($t0)
+     # live vars: $t0, $t1
+  3: $t2 := dup($t0)
+     # live vars: $t0, $t1, $t2
+  4: $t3 := dup($t0)
+     # live vars: $t0, $t1, $t2, $t3
+  5: $t2 := move($t2)
+     # live vars: $t0, $t1, $t2, $t3
+  6: m::consume_2($t2, $t3)
+     # live vars: $t0, $t1
+  7: $t0 := move($t0)
+     # live vars: $t0, $t1
+  8: m::consume_2($t0, $t1)
+     # live vars:
+  9: return ()
 }
 
 
@@ -65,12 +119,17 @@ fun one(): u64
     local l2: u64
     local l3: u64
     call one
-    call one
-    call one
-    call one
-    call consume_2
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    st_loc l1
     // @5
+    copy_loc l0
+    copy_loc l0
     call consume_2
+    move_loc l1
+    call consume_2
+    // @10
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_01.on.exp
@@ -3,6 +3,102 @@
 [variant baseline]
 fun m::foo($t0: u64): (u64, u64) {
      var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t0, $t1
+  1: $t3 := infer($t0)
+     # live vars: $t1, $t3
+  2: $t4 := 1
+     # live vars: $t1, $t3, $t4
+  3: $t2 := -($t3, $t4)
+     # live vars: $t1, $t2
+  4: return ($t1, $t2)
+}
+
+
+[variant baseline]
+public fun m::test1($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: label L0
+     # flush: $t0
+     # live vars: $t0
+  1: ($t1, $t0) := m::foo($t0)
+     # live vars: $t0, $t1
+  2: $t3 := infer($t1)
+     # live vars: $t0, $t3
+  3: $t4 := 0
+     # live vars: $t0, $t3, $t4
+  4: $t2 := ==($t3, $t4)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 9
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 12
+     # live vars: $t0
+  8: goto 10
+     # live vars: $t0
+  9: label L3
+     # live vars: $t0
+ 10: label L4
+     # live vars: $t0
+ 11: goto 0
+     # live vars:
+ 12: label L1
+     # live vars:
+ 13: return ()
+}
+
+
+[variant baseline]
+public fun m::test2($t0: u64) {
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: label L0
+     # flush: $t0
+     # live vars: $t0
+  1: ($t0, $t1) := m::foo($t0)
+     # live vars: $t0, $t1
+  2: $t3 := infer($t1)
+     # live vars: $t0, $t3
+  3: $t4 := 0
+     # live vars: $t0, $t3, $t4
+  4: $t2 := ==($t3, $t4)
+     # live vars: $t0, $t2
+  5: if ($t2) goto 6 else goto 9
+     # live vars: $t0
+  6: label L2
+     # live vars:
+  7: goto 12
+     # live vars: $t0
+  8: goto 10
+     # live vars: $t0
+  9: label L3
+     # live vars: $t0
+ 10: label L4
+     # live vars: $t0
+ 11: goto 0
+     # live vars:
+ 12: label L1
+     # live vars:
+ 13: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::foo($t0: u64): (u64, u64) {
+     var $t1: u64
      var $t2: u64 [unused]
      var $t3: u64 [unused]
      var $t4: u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/loop_02.on.exp
@@ -2,6 +2,67 @@
 
 [variant baseline]
 fun m::inc($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: bool
+     var $t3: u64
+     var $t4: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := 0
+     # live vars: $t0
+  1: label L0
+     # live vars: $t0
+  2: $t1 := m::inc($t0)
+     # flush: $t0
+     # live vars: $t1
+  3: $t0 := infer($t1)
+     # live vars: $t0
+  4: $t3 := infer($t0)
+     # live vars: $t0, $t3
+  5: $t4 := 10
+     # live vars: $t0, $t3, $t4
+  6: $t2 := >($t3, $t4)
+     # live vars: $t0, $t2
+  7: if ($t2) goto 8 else goto 11
+     # live vars: $t0
+  8: label L2
+     # live vars:
+  9: goto 14
+     # live vars: $t0
+ 10: goto 12
+     # live vars: $t0
+ 11: label L3
+     # live vars: $t0
+ 12: label L4
+     # live vars: $t0
+ 13: goto 1
+     # live vars:
+ 14: label L1
+     # live vars:
+ 15: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::inc($t0: u64): u64 {
      var $t1: u64 [unused]
      var $t2: u64 [unused]
      var $t3: u64

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.off.exp
@@ -21,31 +21,17 @@ module 0xc0ffee::m
     local l5: u64
     local l6: u64
     call one
-    call one
-    call one
-    call one
-    call one
-    // @5
-    call one
-    call one
     st_loc l0
-    st_loc l1
-    st_loc l2
-    // @10
-    st_loc l3
-    st_loc l4
-    st_loc l5
-    st_loc l6
-    move_loc l5
-    // @15
-    move_loc l4
-    move_loc l3
-    move_loc l2
-    move_loc l1
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    // @5
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     move_loc l0
-    // @20
-    move_loc l6
     call consume
+    // @10
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_01.on.exp
@@ -26,12 +26,12 @@ public fun m::test() {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
-     var $t10: u64 [unused]
-     var $t11: u64 [unused]
-     var $t12: u64 [unused]
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
      # flush: $t0
      # live vars:
   0: $t0 := m::one()
@@ -47,6 +47,73 @@ public fun m::test() {
   5: $t5 := m::one()
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5
   6: $t6 := m::one()
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  7: $t7 := infer($t1)
+     # live vars: $t0, $t2, $t3, $t4, $t5, $t6, $t7
+  8: $t8 := infer($t2)
+     # live vars: $t0, $t3, $t4, $t5, $t6, $t7, $t8
+  9: $t9 := infer($t3)
+     # live vars: $t0, $t4, $t5, $t6, $t7, $t8, $t9
+ 10: $t10 := infer($t4)
+     # live vars: $t0, $t5, $t6, $t7, $t8, $t9, $t10
+ 11: $t11 := infer($t5)
+     # live vars: $t0, $t6, $t7, $t8, $t9, $t10, $t11
+ 12: $t12 := infer($t6)
+     # live vars: $t0, $t7, $t8, $t9, $t10, $t11, $t12
+ 13: m::consume($t7, $t8, $t9, $t10, $t11, $t12, $t0)
+     # live vars:
+ 14: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+public fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64, $t6: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
+  0: return ()
+}
+
+
+[variant baseline]
+public fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64 [unused]
+     var $t9: u64 [unused]
+     var $t10: u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64 [unused]
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := copy($t0)
+     # live vars: $t0, $t1
+  2: $t2 := copy($t0)
+     # live vars: $t0, $t1, $t2
+  3: $t3 := copy($t0)
+     # live vars: $t0, $t1, $t2, $t3
+  4: $t4 := copy($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  5: $t5 := copy($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  6: $t6 := copy($t0)
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
   7: $t1 := move($t1)
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5, $t6
@@ -89,13 +156,13 @@ module 0xc0ffee::m
     local l6: u64
     call one
     st_loc l0
-    call one
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
-    call one
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     move_loc l0
     call consume
     // @10

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.off.exp
@@ -14,20 +14,13 @@ fun one(): u64
 // Function definition at index 2
 #[persistent] public fun test()
     local l0: u64
-    local l1: u64
-    local l2: u64
-    call one
     call one
     st_loc l0
-    st_loc l1
-    copy_loc l1
-    // @5
-    st_loc l2
+    copy_loc l0
+    copy_loc l0
     move_loc l0
-    move_loc l2
-    move_loc l1
+    // @5
     call consume
-    // @10
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_02.on.exp
@@ -21,13 +21,53 @@ fun m::one(): u64 {
 public fun m::test() {
      var $t0: u64
      var $t1: u64
-     var $t2: u64 [unused]
+     var $t2: u64
      var $t3: u64
      # flush: $t0
      # live vars:
   0: $t0 := m::one()
      # live vars: $t0
   1: $t1 := m::one()
+     # live vars: $t0, $t1
+  2: $t2 := infer($t1)
+     # live vars: $t0, $t2
+  3: $t3 := infer($t0)
+     # live vars: $t0, $t2, $t3
+  4: m::consume($t2, $t3, $t0)
+     # live vars:
+  5: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64) {
+     # live vars: $t0, $t1, $t2
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := copy($t0)
      # live vars: $t0, $t1
   2: $t1 := move($t1)
      # live vars: $t0, $t1
@@ -56,7 +96,7 @@ fun one(): u64
     local l0: u64
     call one
     st_loc l0
-    call one
+    copy_loc l0
     copy_loc l0
     move_loc l0
     // @5

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_03.on.exp
@@ -24,6 +24,47 @@ fun m::one_one(): (u64, u64) {
 public fun m::test() {
      var $t0: u64
      var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # flush: $t0
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # live vars: $t0, $t1
+  1: $t2 := infer($t1)
+     # live vars: $t0, $t2
+  2: $t3 := infer($t0)
+     # live vars: $t0, $t2, $t3
+  3: m::consume($t2, $t3, $t0)
+     # live vars:
+  4: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64) {
+     # live vars: $t0, $t1, $t2
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
      var $t2: u64 [unused]
      var $t3: u64
      # flush: $t0

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.off.exp
@@ -15,15 +15,19 @@ fun one(): u64
 #[persistent] public fun test()
     local l0: u64
     local l1: u64
-    call one
+    local l2: u64
     call one
     st_loc l0
+    copy_loc l0
+    copy_loc l0
     st_loc l1
-    copy_loc l1
     // @5
-    move_loc l0
+    st_loc l2
     move_loc l1
+    move_loc l2
+    move_loc l0
     call consume
+    // @10
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_04.on.exp
@@ -22,13 +22,53 @@ public fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
+     var $t3: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::one()
+     # live vars: $t0, $t1
+  2: $t2 := infer($t0)
+     # live vars: $t0, $t1, $t2
+  3: $t3 := infer($t1)
+     # live vars: $t0, $t2, $t3
+  4: m::consume($t2, $t3, $t0)
+     # live vars:
+  5: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64) {
+     # live vars: $t0, $t1, $t2
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
      var $t3: u64 [unused]
      # flush: $t0
      # live vars:
   0: $t0 := m::one()
      # flush: $t1
      # live vars: $t0
-  1: $t1 := m::one()
+  1: $t1 := copy($t0)
      # live vars: $t0, $t1
   2: $t2 := copy($t0)
      # live vars: $t0, $t1, $t2
@@ -58,7 +98,7 @@ fun one(): u64
     local l1: u64
     call one
     st_loc l0
-    call one
+    copy_loc l0
     st_loc l1
     copy_loc l0
     // @5

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.off.exp
@@ -15,32 +15,21 @@ fun one(): u64
 fun test()
     local l0: u64
     local l1: u64
-    local l2: u64
-    local l3: u64
-    local l4: u64
-    local l5: u64
-    call one
     call one
     st_loc l0
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
+    move_loc l0
     // @5
     call one
-    call one
-    st_loc l2
-    st_loc l3
-    st_loc l4
-    // @10
-    st_loc l5
     st_loc l1
-    move_loc l0
-    move_loc l1
-    move_loc l5
-    // @15
-    move_loc l4
-    move_loc l3
-    move_loc l2
+    copy_loc l1
+    copy_loc l1
+    copy_loc l1
+    // @10
+    copy_loc l1
     call consume
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_05.on.exp
@@ -21,6 +21,54 @@ fun m::one(): u64 {
 fun m::test() {
      var $t0: u64
      var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars:
+  0: $t0 := m::one()
+     # live vars: $t0
+  1: $t1 := m::one()
+     # live vars: $t0, $t1
+  2: $t2 := infer($t0)
+     # live vars: $t1, $t2
+  3: $t3 := m::one()
+     # live vars: $t1, $t2, $t3
+  4: $t4 := m::one()
+     # live vars: $t1, $t2, $t3, $t4
+  5: $t5 := m::one()
+     # live vars: $t1, $t2, $t3, $t4, $t5
+  6: $t6 := m::one()
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6
+  7: m::consume($t1, $t2, $t3, $t4, $t5, $t6)
+     # live vars:
+  8: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
      var $t2: u64 [unused]
      var $t3: u64
      var $t4: u64
@@ -29,22 +77,29 @@ fun m::test() {
      # flush: $t0
      # live vars:
   0: $t0 := m::one()
+     # flush: $t0
      # live vars: $t0
-  1: $t1 := m::one()
+  1: $t0 := dup($t0)
+     # live vars: $t0
+  2: $t1 := dup($t0)
      # live vars: $t0, $t1
-  2: $t0 := move($t0)
+  3: $t0 := move($t0)
+     # flush: $t3
      # live vars: $t0, $t1
-  3: $t3 := m::one()
+  4: $t3 := m::one()
+     # flush: $t3
      # live vars: $t0, $t1, $t3
-  4: $t4 := m::one()
+  5: $t3 := dup($t3)
+     # live vars: $t0, $t1, $t3
+  6: $t4 := dup($t3)
      # live vars: $t0, $t1, $t3, $t4
-  5: $t5 := m::one()
+  7: $t5 := dup($t3)
      # live vars: $t0, $t1, $t3, $t4, $t5
-  6: $t6 := m::one()
+  8: $t6 := dup($t3)
      # live vars: $t0, $t1, $t3, $t4, $t5, $t6
-  7: m::consume($t1, $t0, $t3, $t4, $t5, $t6)
+  9: m::consume($t1, $t0, $t3, $t4, $t5, $t6)
      # live vars:
-  8: return ()
+ 10: return ()
 }
 
 
@@ -63,16 +118,22 @@ fun one(): u64
 // Function definition at index 2
 fun test()
     local l0: u64
+    local l1: u64
     call one
     st_loc l0
-    call one
+    copy_loc l0
+    copy_loc l0
     move_loc l0
-    call one
     // @5
     call one
-    call one
-    call one
+    st_loc l1
+    copy_loc l1
+    copy_loc l1
+    copy_loc l1
+    // @10
+    copy_loc l1
     call consume
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.off.exp
@@ -8,13 +8,16 @@ fun consume(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64)
 
 // Function definition at index 1
 fun multi(): (u64, u64, u64, u64, u64, u64)
+    local l0: u64
     call one
-    call one
-    call one
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
-    call one
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     ret
 
 // Function definition at index 2
@@ -39,11 +42,11 @@ fun test()
     pop
     pop
     pop
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
     // @10
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
     st_loc l2
     st_loc l3
     st_loc l4

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_06.on.exp
@@ -51,30 +51,117 @@ fun m::test() {
      var $t4: u64
      var $t5: u64
      var $t6: u64
-     var $t7: u64 [unused]
+     var $t7: u64
      var $t8: u64
      var $t9: u64
      var $t10: u64
      var $t11: u64
-     # flush: $t0, $t1, $t2, $t3, $t4, $t5
+     # flush: $t1, $t2, $t3, $t4, $t5
      # live vars:
   0: ($t0, $t1, $t2, $t3, $t4, $t5) := m::multi()
      # live vars: $t0
   1: $t6 := m::one()
      # live vars: $t0, $t6
-  2: $t0 := move($t0)
-     # live vars: $t0, $t6
+  2: $t7 := infer($t0)
+     # live vars: $t6, $t7
   3: $t8 := m::one()
-     # live vars: $t0, $t6, $t8
+     # live vars: $t6, $t7, $t8
   4: $t9 := m::one()
-     # live vars: $t0, $t6, $t8, $t9
+     # live vars: $t6, $t7, $t8, $t9
   5: $t10 := m::one()
-     # live vars: $t0, $t6, $t8, $t9, $t10
+     # live vars: $t6, $t7, $t8, $t9, $t10
   6: $t11 := m::one()
-     # live vars: $t0, $t6, $t8, $t9, $t10, $t11
-  7: m::consume($t6, $t0, $t8, $t9, $t10, $t11)
+     # live vars: $t6, $t7, $t8, $t9, $t10, $t11
+  7: m::consume($t6, $t7, $t8, $t9, $t10, $t11)
      # live vars:
   8: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64, $t5: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::multi(): (u64, u64, u64, u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # live vars: $t0
+  2: $t1 := dup($t0)
+     # live vars: $t0, $t1
+  3: $t2 := dup($t0)
+     # live vars: $t0, $t1, $t2
+  4: $t3 := dup($t0)
+     # live vars: $t0, $t1, $t2, $t3
+  5: $t4 := dup($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  6: $t5 := dup($t0)
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  7: return ($t0, $t1, $t2, $t3, $t4, $t5)
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64 [unused]
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     # flush: $t1, $t2, $t3, $t4, $t5
+     # live vars:
+  0: ($t0, $t1, $t2, $t3, $t4, $t5) := m::multi()
+     # flush: $t6
+     # live vars: $t0
+  1: $t6 := m::one()
+     # flush: $t6
+     # live vars: $t0, $t6
+  2: $t6 := dup($t6)
+     # live vars: $t0, $t6
+  3: $t0 := move($t0)
+     # live vars: $t0, $t6
+  4: $t8 := dup($t6)
+     # live vars: $t0, $t6, $t8
+  5: $t9 := dup($t6)
+     # live vars: $t0, $t6, $t8, $t9
+  6: $t10 := dup($t6)
+     # live vars: $t0, $t6, $t8, $t9, $t10
+  7: $t11 := dup($t6)
+     # live vars: $t0, $t6, $t8, $t9, $t10, $t11
+  8: m::consume($t6, $t0, $t8, $t9, $t10, $t11)
+     # live vars:
+  9: return ()
 }
 
 
@@ -87,13 +174,16 @@ fun consume(l0: u64, l1: u64, l2: u64, l3: u64, l4: u64, l5: u64)
 
 // Function definition at index 1
 fun multi(): (u64, u64, u64, u64, u64, u64)
+    local l0: u64
     call one
-    call one
-    call one
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
-    call one
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     ret
 
 // Function definition at index 2
@@ -104,6 +194,11 @@ fun one(): u64
 // Function definition at index 3
 fun test()
     local l0: u64
+    local l1: u64
+    local l2: u64
+    local l3: u64
+    local l4: u64
+    local l5: u64
     call multi
     pop
     pop
@@ -111,14 +206,26 @@ fun test()
     pop
     // @5
     pop
+    call one
     st_loc l0
-    call one
-    move_loc l0
-    call one
+    copy_loc l0
+    copy_loc l0
     // @10
-    call one
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
+    st_loc l2
+    st_loc l3
+    st_loc l4
+    // @15
+    st_loc l5
+    st_loc l1
+    move_loc l0
+    move_loc l1
+    move_loc l5
+    // @20
+    move_loc l4
+    move_loc l3
+    move_loc l2
     call consume
     ret
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.off.exp
@@ -22,21 +22,32 @@ fun one(): u64
     local l2: u64
     local l3: u64
     local l4: u64
-    local l5: u64
-    call one
-    call one
-    call one
-    call one
-    call one
-    // @5
     call one
     st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    // @5
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     st_loc l1
-    call consume_4
-    move_loc l1
+    st_loc l2
     // @10
-    move_loc l0
+    pop
+    st_loc l3
+    st_loc l4
+    copy_loc l0
+    move_loc l2
+    // @15
+    move_loc l1
+    move_loc l4
+    call consume_4
+    copy_loc l0
+    move_loc l3
+    // @20
     call consume_2
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_07.on.exp
@@ -32,36 +32,107 @@ public fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
      # live vars:
   0: $t0 := m::one()
      # live vars: $t0
   1: $t1 := m::one()
      # live vars: $t0, $t1
   2: $t2 := m::one()
+     # flush: $t3
      # live vars: $t0, $t1, $t2
   3: $t3 := m::one()
      # live vars: $t0, $t1, $t2, $t3
   4: $t4 := m::one()
+     # flush: $t5
      # live vars: $t0, $t1, $t2, $t3, $t4
   5: $t5 := m::one()
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  6: $t0 := move($t0)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  7: $t1 := move($t1)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  8: $t2 := move($t2)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  9: m::consume_4($t0, $t1, $t2, $t3)
+  6: $t6 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6
+  7: $t7 := infer($t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6, $t7
+  8: $t8 := infer($t2)
+     # live vars: $t3, $t4, $t5, $t6, $t7, $t8
+  9: m::consume_4($t6, $t7, $t8, $t3)
      # live vars: $t4, $t5
- 10: $t4 := move($t4)
-     # live vars: $t4, $t5
- 11: m::consume_2($t4, $t5)
+ 10: $t9 := infer($t4)
+     # live vars: $t5, $t9
+ 11: m::consume_2($t9, $t5)
      # live vars:
  12: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_4($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64 [unused]
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # flush: $t3
+     # live vars: $t0
+  2: $t3 := dup($t0)
+     # live vars: $t0, $t3
+  3: $t5 := dup($t0)
+     # flush: $t0
+     # live vars: $t0, $t3, $t5
+  4: $t0 := move($t0)
+     # flush: $t0
+     # live vars: $t0, $t3, $t5
+  5: $t0 := dup($t0)
+     # live vars: $t0, $t3, $t5
+  6: $t7 := dup($t0)
+     # live vars: $t0, $t3, $t5, $t7
+  7: $t8 := dup($t0)
+     # live vars: $t0, $t3, $t5, $t7, $t8
+  8: m::consume_4($t0, $t7, $t8, $t3)
+     # live vars: $t0, $t5
+  9: $t0 := dup($t0)
+     # live vars: $t0, $t5
+ 10: m::consume_2($t0, $t5)
+     # live vars:
+ 11: return ()
 }
 
 
@@ -86,23 +157,25 @@ fun one(): u64
     local l0: u64
     local l1: u64
     local l2: u64
-    local l3: u64
-    local l4: u64
-    local l5: u64
-    call one
-    call one
-    call one
-    call one
-    call one
-    // @5
     call one
     st_loc l0
+    copy_loc l0
+    copy_loc l0
     st_loc l1
-    call consume_4
+    // @5
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     move_loc l1
     // @10
+    call consume_4
+    st_loc l2
     move_loc l0
+    move_loc l2
     call consume_2
+    // @15
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_08.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_08.on.exp
@@ -41,6 +41,88 @@ public fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     # flush: $t3
+     # live vars:
+  0: ($t0, $t1, $t2, $t3) := m::four()
+     # flush: $t5
+     # live vars: $t0, $t1, $t2, $t3
+  1: ($t4, $t5) := m::two()
+     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
+  2: $t6 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6
+  3: $t7 := infer($t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6, $t7
+  4: $t8 := infer($t2)
+     # live vars: $t3, $t4, $t5, $t6, $t7, $t8
+  5: m::consume_4($t6, $t7, $t8, $t3)
+     # live vars: $t4, $t5
+  6: $t9 := infer($t4)
+     # live vars: $t5, $t9
+  7: m::consume_2($t9, $t5)
+     # live vars:
+  8: return ()
+}
+
+
+[variant baseline]
+fun m::two(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 5
+     # live vars: $t0
+  1: $t1 := 6
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_4($t0: u64, $t1: u64, $t2: u64, $t3: u64) {
+     # live vars: $t0, $t1, $t2, $t3
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::four(): (u64, u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: $t3 := 4
+     # live vars: $t0, $t1, $t2, $t3
+  4: return ($t0, $t1, $t2, $t3)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
      var $t6: u64 [unused]
      var $t7: u64 [unused]
      var $t8: u64 [unused]

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.off.exp
@@ -22,28 +22,32 @@ fun one(): u64
     local l2: u64
     local l3: u64
     local l4: u64
-    local l5: u64
-    call one
-    call one
-    call one
-    call one
-    call one
-    // @5
     call one
     st_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    // @5
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     st_loc l1
+    // @10
     st_loc l2
     st_loc l3
-    // @10
+    pop
     st_loc l4
+    move_loc l0
+    // @15
     move_loc l3
     move_loc l2
     move_loc l1
-    move_loc l0
-    // @15
-    call consume_5
     move_loc l4
+    call consume_5
+    // @20
     call consume_1
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_09.on.exp
@@ -32,13 +32,12 @@ public fun m::test() {
      var $t3: u64
      var $t4: u64
      var $t5: u64
-     var $t6: u64 [unused]
-     var $t7: u64 [unused]
-     var $t8: u64 [unused]
-     var $t9: u64 [unused]
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
      # live vars:
   0: $t0 := m::one()
-     # flush: $t1
      # live vars: $t0
   1: $t1 := m::one()
      # live vars: $t0, $t1
@@ -47,22 +46,92 @@ public fun m::test() {
   3: $t3 := m::one()
      # live vars: $t0, $t1, $t2, $t3
   4: $t4 := m::one()
+     # flush: $t5
      # live vars: $t0, $t1, $t2, $t3, $t4
   5: $t5 := m::one()
      # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  6: $t0 := move($t0)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  7: $t2 := move($t2)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  8: $t3 := move($t3)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
-  9: $t4 := move($t4)
-     # live vars: $t0, $t1, $t2, $t3, $t4, $t5
- 10: m::consume_5($t0, $t2, $t3, $t4, $t5)
+  6: $t6 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5, $t6
+  7: $t7 := infer($t2)
+     # live vars: $t1, $t3, $t4, $t5, $t6, $t7
+  8: $t8 := infer($t3)
+     # live vars: $t1, $t4, $t5, $t6, $t7, $t8
+  9: $t9 := infer($t4)
+     # live vars: $t1, $t5, $t6, $t7, $t8, $t9
+ 10: m::consume_5($t6, $t7, $t8, $t9, $t5)
      # live vars: $t1
  11: m::consume_1($t1)
      # live vars:
  12: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_5($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # live vars: $t0
+  2: $t1 := dup($t0)
+     # flush: $t5
+     # live vars: $t0, $t1
+  3: $t5 := dup($t0)
+     # flush: $t0
+     # live vars: $t0, $t1, $t5
+  4: $t0 := move($t0)
+     # flush: $t0
+     # live vars: $t0, $t1, $t5
+  5: $t0 := dup($t0)
+     # live vars: $t0, $t1, $t5
+  6: $t7 := dup($t0)
+     # live vars: $t0, $t1, $t5, $t7
+  7: $t8 := dup($t0)
+     # live vars: $t0, $t1, $t5, $t7, $t8
+  8: $t9 := dup($t0)
+     # live vars: $t0, $t1, $t5, $t7, $t8, $t9
+  9: m::consume_5($t0, $t7, $t8, $t9, $t5)
+     # live vars: $t1
+ 10: m::consume_1($t1)
+     # live vars:
+ 11: return ()
 }
 
 
@@ -86,22 +155,22 @@ fun one(): u64
 #[persistent] public fun test()
     local l0: u64
     local l1: u64
-    local l2: u64
-    local l3: u64
-    local l4: u64
-    local l5: u64
-    call one
     call one
     st_loc l0
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
-    call one
-    call one
-    call consume_5
-    move_loc l0
-    call consume_1
+    st_loc l1
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @10
+    move_loc l1
+    call consume_5
+    call consume_1
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.off.exp
@@ -21,15 +21,15 @@ fun one(): u64
     local l1: u64
     local l2: u64
     call one
-    call one
-    call one
     st_loc l0
-    st_loc l1
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
-    call consume_1
-    move_loc l1
     move_loc l0
+    call consume_1
     call consume_2
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_10.on.exp
@@ -29,22 +29,74 @@ public fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
-     # flush: $t0
+     var $t3: u64
      # live vars:
   0: $t0 := m::one()
      # live vars: $t0
   1: $t1 := m::one()
+     # flush: $t2
      # live vars: $t0, $t1
   2: $t2 := m::one()
      # live vars: $t0, $t1, $t2
   3: m::consume_1($t0)
      # live vars: $t1, $t2
-  4: $t1 := move($t1)
-     # live vars: $t1, $t2
-  5: m::consume_2($t1, $t2)
+  4: $t3 := infer($t1)
+     # live vars: $t2, $t3
+  5: m::consume_2($t3, $t2)
      # live vars:
   6: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64 [unused]
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # live vars: $t0
+  2: $t1 := dup($t0)
+     # live vars: $t0, $t1
+  3: $t2 := dup($t0)
+     # live vars: $t0, $t1, $t2
+  4: m::consume_1($t0)
+     # live vars: $t1, $t2
+  5: $t1 := move($t1)
+     # live vars: $t1, $t2
+  6: m::consume_2($t1, $t2)
+     # live vars:
+  7: return ()
 }
 
 
@@ -71,12 +123,14 @@ fun one(): u64
     local l2: u64
     call one
     st_loc l0
-    call one
-    call one
-    move_loc l0
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
+    move_loc l0
     call consume_1
     call consume_2
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_11.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_11.on.exp
@@ -26,6 +26,53 @@ public fun m::test() {
      var $t1: u64
      var $t2: u64
      var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # flush: $t2, $t3
+     # live vars: $t0, $t1
+  1: ($t2, $t3) := m::one_one()
+     # live vars: $t0, $t1, $t2, $t3
+  2: $t4 := infer($t1)
+     # live vars: $t0, $t2, $t3, $t4
+  3: m::consume_2($t4, $t2)
+     # live vars: $t0, $t3
+  4: $t5 := infer($t0)
+     # live vars: $t3, $t5
+  5: m::consume_2($t5, $t3)
+     # live vars:
+  6: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64 [unused]
      # live vars:

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_12.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_12.on.exp
@@ -33,6 +33,60 @@ public fun m::test() {
      var $t1: u64
      var $t2: u64
      var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars:
+  0: ($t0, $t1) := m::one_one()
+     # flush: $t3
+     # live vars: $t0, $t1
+  1: ($t2, $t3) := m::one_one()
+     # live vars: $t0, $t1, $t2, $t3
+  2: $t4 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t4
+  3: $t5 := infer($t2)
+     # live vars: $t1, $t3, $t4, $t5
+  4: m::consume_3($t4, $t5, $t3)
+     # live vars: $t1
+  5: m::consume_1($t1)
+     # live vars:
+  6: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_3($t0: u64, $t1: u64, $t2: u64) {
+     # live vars: $t0, $t1, $t2
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one_one(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 1
+     # live vars: $t0, $t1
+  2: return ($t0, $t1)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
      var $t4: u64 [unused]
      var $t5: u64 [unused]
      # flush: $t1

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.off.exp
@@ -21,13 +21,20 @@ fun one(): u64
     local l1: u64
     local l2: u64
     call one
-    call one
-    call one
     st_loc l0
-    call consume_2
+    copy_loc l0
+    copy_loc l0
+    copy_loc l0
     // @5
+    st_loc l1
+    st_loc l2
     move_loc l0
+    move_loc l2
+    call consume_2
+    // @10
+    move_loc l1
     call consume_1
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_13.on.exp
@@ -29,22 +29,75 @@ public fun m::test() {
      var $t0: u64
      var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
+     var $t3: u64
      # live vars:
   0: $t0 := m::one()
+     # flush: $t1
      # live vars: $t0
   1: $t1 := m::one()
-     # flush: $t2
      # live vars: $t0, $t1
   2: $t2 := m::one()
      # live vars: $t0, $t1, $t2
-  3: $t0 := move($t0)
-     # live vars: $t0, $t1, $t2
-  4: m::consume_2($t0, $t1)
+  3: $t3 := infer($t0)
+     # live vars: $t1, $t2, $t3
+  4: m::consume_2($t3, $t1)
      # live vars: $t2
   5: m::consume_1($t2)
      # live vars:
   6: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64 [unused]
+     # flush: $t0
+     # live vars:
+  0: $t0 := m::one()
+     # flush: $t0
+     # live vars: $t0
+  1: $t0 := dup($t0)
+     # flush: $t1
+     # live vars: $t0
+  2: $t1 := dup($t0)
+     # live vars: $t0, $t1
+  3: $t2 := dup($t0)
+     # live vars: $t0, $t1, $t2
+  4: $t0 := move($t0)
+     # live vars: $t0, $t1, $t2
+  5: m::consume_2($t0, $t1)
+     # live vars: $t2
+  6: m::consume_1($t2)
+     # live vars:
+  7: return ()
 }
 
 
@@ -68,15 +121,19 @@ fun one(): u64
 #[persistent] public fun test()
     local l0: u64
     local l1: u64
-    local l2: u64
-    call one
-    call one
     call one
     st_loc l0
-    call consume_2
+    copy_loc l0
+    copy_loc l0
+    st_loc l1
     // @5
+    copy_loc l0
     move_loc l0
+    move_loc l1
+    call consume_2
     call consume_1
+    // @10
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.off.exp
@@ -18,16 +18,13 @@ fun one(): u64
 // Function definition at index 3
 #[persistent] public fun test(l0: u64)
     local l1: u64
-    local l2: u64
-    call one
     call one
     st_loc l1
-    st_loc l2
+    copy_loc l1
     move_loc l0
-    // @5
-    move_loc l2
-    call consume_2
     move_loc l1
+    // @5
+    call consume_2
     call consume_1
     ret
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_14.on.exp
@@ -28,12 +28,58 @@ fun m::one(): u64 {
 public fun m::test($t0: u64) {
      var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
+     var $t3: u64
      # flush: $t1
      # live vars: $t0
   0: $t1 := m::one()
      # live vars: $t0, $t1
   1: $t2 := m::one()
+     # live vars: $t0, $t1, $t2
+  2: $t3 := infer($t0)
+     # live vars: $t1, $t2, $t3
+  3: m::consume_2($t3, $t1)
+     # live vars: $t2
+  4: m::consume_1($t2)
+     # live vars:
+  5: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64 [unused]
+     # flush: $t1
+     # live vars: $t0
+  0: $t1 := m::one()
+     # live vars: $t0, $t1
+  1: $t2 := copy($t1)
      # live vars: $t0, $t1, $t2
   2: $t0 := move($t0)
      # live vars: $t0, $t1, $t2
@@ -66,7 +112,7 @@ fun one(): u64
     local l1: u64
     call one
     st_loc l1
-    call one
+    copy_loc l1
     move_loc l0
     move_loc l1
     // @5

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.off.exp
@@ -20,11 +20,18 @@ fun one(): u64
     local l1: u64
     local l2: u64
     call one
-    call one
+    st_loc l1
+    copy_loc l1
+    copy_loc l1
     move_loc l0
-    call consume_1
-    call consume_2
     // @5
+    call consume_1
+    st_loc l2
+    move_loc l1
+    move_loc l2
+    call consume_2
+    // @10
+    pop
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/out_of_order_use_15.on.exp
@@ -28,19 +28,70 @@ fun m::one(): u64 {
 public fun m::test($t0: u64) {
      var $t1: u64
      var $t2: u64
-     var $t3: u64 [unused]
+     var $t3: u64
      # live vars: $t0
   0: $t1 := m::one()
+     # flush: $t2
      # live vars: $t0, $t1
   1: $t2 := m::one()
      # live vars: $t0, $t1, $t2
   2: m::consume_1($t0)
      # live vars: $t1, $t2
-  3: $t1 := move($t1)
-     # live vars: $t1, $t2
-  4: m::consume_2($t1, $t2)
+  3: $t3 := infer($t1)
+     # live vars: $t2, $t3
+  4: m::consume_2($t3, $t2)
      # live vars:
   5: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume_1($t0: u64) {
+     # live vars: $t0
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::consume_2($t0: u64, $t1: u64) {
+     # live vars: $t0, $t1
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64 [unused]
+     # flush: $t1
+     # live vars: $t0
+  0: $t1 := m::one()
+     # flush: $t1
+     # live vars: $t0, $t1
+  1: $t1 := dup($t1)
+     # flush: $t2
+     # live vars: $t0, $t1
+  2: $t2 := dup($t1)
+     # live vars: $t0, $t1, $t2
+  3: m::consume_1($t0)
+     # live vars: $t1, $t2
+  4: $t1 := move($t1)
+     # live vars: $t1, $t2
+  5: m::consume_2($t1, $t2)
+     # live vars:
+  6: return ()
 }
 
 
@@ -65,11 +116,15 @@ fun one(): u64
     local l1: u64
     local l2: u64
     call one
-    call one
+    st_loc l1
+    copy_loc l1
+    copy_loc l1
+    st_loc l2
+    // @5
     move_loc l0
     call consume_1
+    move_loc l2
     call consume_2
-    // @5
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/tuples_in_order_use_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/tuples_in_order_use_01.on.exp
@@ -36,6 +36,65 @@ public fun m::test() {
      var $t2: u64
      var $t3: u64
      var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     # flush: $t4
+     # live vars:
+  0: ($t0, $t1, $t2, $t3, $t4) := m::foo()
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  1: $t5 := infer($t0)
+     # live vars: $t1, $t2, $t3, $t4, $t5
+  2: $t6 := infer($t1)
+     # live vars: $t2, $t3, $t4, $t5, $t6
+  3: $t7 := infer($t2)
+     # live vars: $t3, $t4, $t5, $t6, $t7
+  4: $t8 := infer($t3)
+     # live vars: $t4, $t5, $t6, $t7, $t8
+  5: m::consume($t5, $t6, $t7, $t8, $t4)
+     # live vars:
+  6: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::consume($t0: u64, $t1: u64, $t2: u64, $t3: u64, $t4: u64) {
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo(): (u64, u64, u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: $t3 := 4
+     # live vars: $t0, $t1, $t2, $t3
+  4: $t4 := 5
+     # live vars: $t0, $t1, $t2, $t3, $t4
+  5: return ($t0, $t1, $t2, $t3, $t4)
+}
+
+
+[variant baseline]
+public fun m::test() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
      var $t5: u64 [unused]
      var $t6: u64 [unused]
      var $t7: u64 [unused]

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.off.exp
@@ -12,27 +12,18 @@ fun one(): u64
     local l0: u64
     local l1: u64
     call one
-    call one
-    call one
     st_loc l0
-    st_loc l1
-    // @5
-    pop
-    move_loc l1
+    copy_loc l0
     move_loc l0
     ret
 
 // Function definition at index 2
 #[persistent] public fun test2(): (u64, u64)
     local l0: u64
-    local l1: u64
-    call one
-    call one
     call one
     st_loc l0
-    pop
-    // @5
-    move_loc l0
+    copy_loc l0
+    copy_loc l0
     ret
 
 // Function definition at index 3
@@ -40,14 +31,14 @@ fun one(): u64
     local l0: u64
     local l1: u64
     call one
-    call one
-    call one
     st_loc l0
-    pop
-    // @5
+    copy_loc l0
+    copy_loc l0
     st_loc l1
-    move_loc l0
+    // @5
+    pop
     move_loc l1
+    move_loc l0
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_01.on.exp
@@ -12,8 +12,8 @@ fun m::one(): u64 {
 
 [variant baseline]
 public fun m::test1(): (u64, u64) {
-     var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t0: u64
+     var $t1: u64
      var $t2: u64
      var $t3: u64
      var $t4: u64
@@ -25,16 +25,18 @@ public fun m::test1(): (u64, u64) {
      # live vars: $t3
   2: $t4 := m::one()
      # live vars: $t3, $t4
-  3: $t3 := move($t3)
-     # live vars: $t3, $t4
-  4: return ($t3, $t4)
+  3: $t0 := infer($t3)
+     # live vars: $t0, $t4
+  4: $t1 := infer($t4)
+     # live vars: $t0, $t1
+  5: return ($t0, $t1)
 }
 
 
 [variant baseline]
 public fun m::test2(): (u64, u64) {
-     var $t0: u64 [unused]
-     var $t1: u64 [unused]
+     var $t0: u64
+     var $t1: u64
      var $t2: u64
      var $t3: u64
      var $t4: u64
@@ -46,9 +48,88 @@ public fun m::test2(): (u64, u64) {
      # live vars: $t2
   2: $t4 := m::one()
      # live vars: $t2, $t4
-  3: $t2 := move($t2)
+  3: $t0 := infer($t2)
+     # live vars: $t0, $t4
+  4: $t1 := infer($t4)
+     # live vars: $t0, $t1
+  5: return ($t0, $t1)
+}
+
+
+[variant baseline]
+public fun m::test3(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+  0: $t2 := m::one()
+     # flush: $t3
+     # live vars: $t2
+  1: $t3 := m::one()
+     # live vars: $t2
+  2: $t4 := m::one()
      # live vars: $t2, $t4
-  4: return ($t2, $t4)
+  3: $t0 := infer($t4)
+     # live vars: $t0, $t2
+  4: $t1 := infer($t2)
+     # live vars: $t0, $t1
+  5: return ($t0, $t1)
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test1(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64 [unused]
+     # flush: $t2
+     # live vars:
+  0: $t2 := m::one()
+     # live vars: $t2
+  1: $t3 := copy($t2)
+     # live vars: $t2, $t3
+  2: $t3 := move($t3)
+     # live vars: $t2, $t3
+  3: return ($t3, $t2)
+}
+
+
+[variant baseline]
+public fun m::test2(): (u64, u64) {
+     var $t0: u64 [unused]
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64 [unused]
+     var $t4: u64 [unused]
+     # live vars:
+  0: $t2 := m::one()
+     # live vars: $t2
+  1: $t2 := dup($t2)
+     # flush: $t2
+     # live vars: $t2
+  2: $t2 := move($t2)
+     # flush: $t2
+     # live vars: $t2
+  3: $t2 := dup($t2)
+     # live vars: $t2
+  4: $t1 := dup($t2)
+     # live vars: $t1, $t2
+  5: return ($t2, $t1)
 }
 
 
@@ -57,16 +138,16 @@ public fun m::test3(): (u64, u64) {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
      var $t2: u64
-     var $t3: u64
+     var $t3: u64 [unused]
      var $t4: u64
      # flush: $t2
      # live vars:
   0: $t2 := m::one()
-     # flush: $t3
+     # flush: $t2
      # live vars: $t2
-  1: $t3 := m::one()
+  1: $t2 := dup($t2)
      # live vars: $t2
-  2: $t4 := m::one()
+  2: $t4 := dup($t2)
      # live vars: $t2, $t4
   3: $t4 := move($t4)
      # live vars: $t2, $t4
@@ -87,19 +168,18 @@ fun one(): u64
     local l0: u64
     local l1: u64
     call one
-    pop
-    call one
-    call one
+    st_loc l0
+    copy_loc l0
+    move_loc l0
     ret
 
 // Function definition at index 2
 #[persistent] public fun test2(): (u64, u64)
     local l0: u64
-    local l1: u64
     call one
-    call one
-    pop
-    call one
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
     ret
 
 // Function definition at index 3
@@ -108,10 +188,12 @@ fun one(): u64
     local l1: u64
     call one
     st_loc l0
-    call one
-    pop
-    call one
+    copy_loc l0
+    copy_loc l0
+    st_loc l1
     // @5
+    pop
+    move_loc l1
     move_loc l0
     ret
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.off.exp
@@ -15,24 +15,21 @@ fun one(): u64
 #[persistent] public fun test(): (u64, u64)
     local l0: u64
     local l1: u64
-    local l2: bool
-    local l3: u64
-    call one
-    call one
+    local l2: u64
     call one
     st_loc l0
-    ld_u64 0
+    copy_loc l0
+    copy_loc l0
+    st_loc l1
     // @5
+    ld_u64 0
     eq
-    st_loc l2
-    st_loc l3
-    move_loc l2
     br_true l0
-    // @10
     branch l1
 l0: call bar
-l1: move_loc l3
-    move_loc l0
+    // @10
+l1: move_loc l0
+    move_loc l1
     ret
 
 

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_02.on.exp
@@ -19,6 +19,69 @@ fun m::one(): u64 {
 
 [variant baseline]
 public fun m::test(): (u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: bool
+     var $t6: u64
+     var $t7: u64
+     # flush: $t2
+     # live vars:
+  0: $t2 := m::one()
+     # live vars: $t2
+  1: $t3 := m::one()
+     # flush: $t4
+     # live vars: $t2, $t3
+  2: $t4 := m::one()
+     # live vars: $t2, $t3, $t4
+  3: $t6 := infer($t3)
+     # live vars: $t2, $t4, $t6
+  4: $t7 := 0
+     # live vars: $t2, $t4, $t6, $t7
+  5: $t5 := ==($t6, $t7)
+     # live vars: $t2, $t4, $t5
+  6: if ($t5) goto 7 else goto 10
+     # live vars: $t2, $t4
+  7: label L0
+     # live vars: $t2, $t4
+  8: m::bar()
+     # live vars: $t2, $t4
+  9: goto 11
+     # live vars: $t2, $t4
+ 10: label L1
+     # live vars: $t2, $t4
+ 11: label L2
+     # live vars: $t2, $t4
+ 12: $t0 := infer($t2)
+     # live vars: $t0, $t4
+ 13: $t1 := infer($t4)
+     # live vars: $t0, $t1
+ 14: return ($t0, $t1)
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::bar() {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::one(): u64 {
+     var $t0: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+public fun m::test(): (u64, u64) {
      var $t0: u64 [unused]
      var $t1: u64 [unused]
      var $t2: u64
@@ -31,10 +94,10 @@ public fun m::test(): (u64, u64) {
      # live vars:
   0: $t2 := m::one()
      # live vars: $t2
-  1: $t3 := m::one()
+  1: $t3 := copy($t2)
      # flush: $t4
      # live vars: $t2, $t3
-  2: $t4 := m::one()
+  2: $t4 := copy($t2)
      # live vars: $t2, $t3, $t4
   3: $t3 := move($t3)
      # live vars: $t2, $t3, $t4
@@ -78,8 +141,8 @@ fun one(): u64
     local l1: u64
     call one
     st_loc l0
-    call one
-    call one
+    copy_loc l0
+    copy_loc l0
     st_loc l1
     // @5
     ld_u64 0

--- a/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/unused_flush_early_03.on.exp
@@ -29,6 +29,106 @@ public fun m::test1() {
      var $t1: u64
      var $t2: u64
      var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: bool
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     # flush: $t1, $t2
+     # live vars:
+  0: ($t0, $t1, $t2) := m::foo()
+     # live vars: $t0, $t1, $t2
+  1: $t4 := infer($t0)
+     # live vars: $t1, $t2, $t4
+  2: $t5 := 0
+     # live vars: $t1, $t2, $t4, $t5
+  3: $t3 := ==($t4, $t5)
+     # live vars: $t1, $t2, $t3
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t1, $t2
+  5: label L0
+     # live vars: $t1, $t2
+  6: m::bar()
+     # live vars: $t1, $t2
+  7: goto 9
+     # live vars: $t1, $t2
+  8: label L1
+     # live vars: $t1, $t2
+  9: label L2
+     # live vars: $t1, $t2
+ 10: $t7 := infer($t1)
+     # live vars: $t2, $t7
+ 11: $t8 := 0
+     # live vars: $t2, $t7, $t8
+ 12: $t6 := ==($t7, $t8)
+     # live vars: $t2, $t6
+ 13: if ($t6) goto 14 else goto 17
+     # live vars: $t2
+ 14: label L3
+     # live vars: $t2
+ 15: m::bar()
+     # live vars: $t2
+ 16: goto 18
+     # live vars: $t2
+ 17: label L4
+     # live vars: $t2
+ 18: label L5
+     # live vars: $t2
+ 19: $t10 := infer($t2)
+     # live vars: $t10
+ 20: $t11 := 0
+     # live vars: $t10, $t11
+ 21: $t9 := ==($t10, $t11)
+     # live vars: $t9
+ 22: if ($t9) goto 23 else goto 26
+     # live vars:
+ 23: label L6
+     # live vars:
+ 24: m::bar()
+     # live vars:
+ 25: goto 27
+     # live vars:
+ 26: label L7
+     # live vars:
+ 27: label L8
+     # live vars:
+ 28: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::bar() {
+     # live vars:
+  0: return ()
+}
+
+
+[variant baseline]
+fun m::foo(): (u64, u64, u64) {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+  0: $t0 := 1
+     # live vars: $t0
+  1: $t1 := 2
+     # live vars: $t0, $t1
+  2: $t2 := 3
+     # live vars: $t0, $t1, $t2
+  3: return ($t0, $t1, $t2)
+}
+
+
+[variant baseline]
+public fun m::test1() {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
      var $t4: u64 [unused]
      var $t5: u64
      var $t6: bool [unused]

--- a/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.on.exp
+++ b/third_party/move/move-compiler-v2/tests/flush-writes/write_ref_01.on.exp
@@ -15,6 +15,23 @@ public fun m::test($t0: u64) {
   3: return ()
 }
 
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+public fun m::test($t0: u64) {
+     var $t1: &mut u64
+     var $t2: u64
+     # flush: $t2
+     # live vars: $t0
+  0: $t1 := borrow_local($t0)
+     # live vars: $t1
+  1: $t2 := 42
+     # live vars: $t1, $t2
+  2: write_ref($t1, $t2)
+     # live vars:
+  3: return ()
+}
+
 
 ============ disassembled file-format ==================
 // Bytecode version v10

--- a/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/bug_9717_looponly.exp
@@ -531,6 +531,124 @@ public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
      # live vars: $t0, $t2, $t3
   2: label L0
      # live vars: $t0, $t2, $t3
+  3: $t5 := infer($t2)
+     # live vars: $t0, $t2, $t3, $t5
+  4: $t6 := vector::length<u8>($t3)
+     # live vars: $t0, $t2, $t3, $t5, $t6
+  5: $t4 := <($t5, $t6)
+     # live vars: $t0, $t2, $t3, $t4
+  6: if ($t4) goto 7 else goto 35
+     # live vars: $t0, $t2, $t3
+  7: label L2
+     # live vars: $t0, $t2, $t3
+  8: $t10 := infer($t3)
+     # live vars: $t0, $t2, $t3, $t10
+  9: $t9 := vector::borrow<u8>($t10, $t2)
+     # live vars: $t0, $t2, $t3, $t9
+ 10: $t8 := read_ref($t9)
+     # live vars: $t0, $t2, $t3, $t8
+ 11: $t11 := 0
+     # live vars: $t0, $t2, $t3, $t8, $t11
+ 12: $t7 := !=($t8, $t11)
+     # live vars: $t0, $t2, $t3, $t7
+ 13: if ($t7) goto 14 else goto 17
+     # live vars: $t0, $t2, $t3
+ 14: label L5
+     # live vars: $t0, $t3
+ 15: goto 39
+     # live vars: $t0, $t2, $t3
+ 16: goto 18
+     # live vars: $t0, $t2, $t3
+ 17: label L6
+     # live vars: $t0, $t2, $t3
+ 18: label L7
+     # live vars: $t0, $t2, $t3
+ 19: $t13 := infer($t2)
+     # live vars: $t0, $t3, $t13
+ 20: $t14 := 1
+     # live vars: $t0, $t3, $t13, $t14
+ 21: $t12 := +($t13, $t14)
+     # live vars: $t0, $t3, $t12
+ 22: $t2 := infer($t12)
+     # live vars: $t0, $t2, $t3
+ 23: $t18 := infer($t3)
+     # live vars: $t0, $t2, $t3, $t18
+ 24: $t17 := vector::borrow<u8>($t18, $t2)
+     # live vars: $t0, $t2, $t3, $t17
+ 25: $t16 := read_ref($t17)
+     # live vars: $t0, $t2, $t3, $t16
+ 26: $t19 := 5
+     # live vars: $t0, $t2, $t3, $t16, $t19
+ 27: $t15 := ==($t16, $t19)
+     # live vars: $t0, $t2, $t3, $t15
+ 28: if ($t15) goto 29 else goto 32
+     # live vars: $t0, $t2, $t3
+ 29: label L8
+     # live vars: $t0, $t3
+ 30: goto 39
+     # live vars: $t0, $t2, $t3
+ 31: goto 33
+     # live vars: $t0, $t2, $t3
+ 32: label L9
+     # live vars: $t0, $t2, $t3
+ 33: label L10
+     # live vars: $t0, $t2, $t3
+ 34: goto 37
+     # live vars: $t0, $t2, $t3
+ 35: label L3
+     # live vars: $t0, $t3
+ 36: goto 39
+     # live vars: $t0, $t2, $t3
+ 37: label L4
+     # live vars: $t0, $t2, $t3
+ 38: goto 2
+     # live vars: $t0, $t3
+ 39: label L1
+     # live vars: $t0, $t3
+ 40: $t20 := copy($t0)
+     # live vars: $t0, $t3
+ 41: $t21 := infer($t0)
+     # live vars: $t3
+ 42: $t22 := infer($t3)
+     # live vars: $t22
+ 43: $t1 := vector::length<u8>($t22)
+     # live vars: $t1
+ 44: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+public fun vectors::guess_flips_break2($t0: vector<u8>): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &vector<u8>
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: u8
+     var $t9: &u8
+     var $t10: &vector<u8>
+     var $t11: u8
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: bool
+     var $t16: u8
+     var $t17: &u8
+     var $t18: &vector<u8>
+     var $t19: u8
+     var $t20: vector<u8>
+     var $t21: vector<u8>
+     var $t22: &vector<u8>
+     # live vars: $t0
+  0: $t2 := 0
+     # live vars: $t0, $t2
+  1: $t3 := borrow_local($t0)
+     # live vars: $t0, $t2, $t3
+  2: label L0
+     # live vars: $t0, $t2, $t3
   3: $t5 := copy($t2)
      # live vars: $t0, $t2, $t3, $t5
   4: $t6 := vector::length<u8>($t3)

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline.exp
@@ -943,6 +943,211 @@ fun m::foo(): u64 {
      # live vars: $t1
   1: $t2 := borrow_local($t1)
      # live vars: $t2
+  2: $t4 := infer($t2)
+     # live vars: $t2, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t4, $t5
+  4: $t7 := freeze_ref(implicit)($t4)
+     # live vars: $t2, $t4, $t5, $t7
+  5: $t6 := vector::length<u64>($t7)
+     # live vars: $t2, $t4, $t5, $t6
+  6: label L0
+     # live vars: $t2, $t4, $t5, $t6
+  7: $t9 := infer($t5)
+     # live vars: $t2, $t4, $t5, $t6, $t9
+  8: $t8 := <($t9, $t6)
+     # live vars: $t2, $t4, $t5, $t6, $t8
+  9: if ($t8) goto 10 else goto 29
+     # live vars: $t2, $t4, $t5, $t6
+ 10: label L2
+     # live vars: $t2, $t4, $t5, $t6
+ 11: $t14 := freeze_ref(implicit)($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t14
+ 12: $t13 := vector::borrow<u64>($t14, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t13
+ 13: $t12 := infer($t13)
+     # live vars: $t2, $t4, $t5, $t6, $t12
+ 14: $t15 := read_ref($t12)
+     # live vars: $t2, $t4, $t5, $t6, $t15
+ 15: $t16 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t15, $t16
+ 16: $t11 := >($t15, $t16)
+     # live vars: $t2, $t4, $t5, $t6, $t11
+ 17: $t10 := !($t11)
+     # live vars: $t2, $t4, $t5, $t6, $t10
+ 18: if ($t10) goto 19 else goto 22
+     # live vars: $t2, $t4, $t5, $t6
+ 19: label L5
+     # live vars: $t2, $t4, $t5, $t6
+ 20: goto 33
+     # live vars: $t2, $t4, $t5, $t6
+ 21: goto 23
+     # live vars: $t2, $t4, $t5, $t6
+ 22: label L6
+     # live vars: $t2, $t4, $t5, $t6
+ 23: label L7
+     # live vars: $t2, $t4, $t5, $t6
+ 24: $t18 := infer($t5)
+     # live vars: $t2, $t4, $t6, $t18
+ 25: $t19 := 1
+     # live vars: $t2, $t4, $t6, $t18, $t19
+ 26: $t17 := +($t18, $t19)
+     # live vars: $t2, $t4, $t6, $t17
+ 27: $t5 := infer($t17)
+     # live vars: $t2, $t4, $t5, $t6
+ 28: goto 31
+     # live vars: $t2, $t4, $t5, $t6
+ 29: label L3
+     # live vars: $t2, $t4, $t5, $t6
+ 30: goto 33
+     # live vars: $t2, $t4, $t5, $t6
+ 31: label L4
+     # live vars: $t2, $t4, $t5, $t6
+ 32: goto 6
+     # live vars: $t2, $t4, $t5, $t6
+ 33: label L1
+     # live vars: $t2, $t4, $t5, $t6
+ 34: $t20 := infer($t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 35: $t22 := infer($t5)
+     # live vars: $t2, $t4, $t6, $t20, $t22
+ 36: $t23 := 1
+     # live vars: $t2, $t4, $t6, $t20, $t22, $t23
+ 37: $t21 := +($t22, $t23)
+     # live vars: $t2, $t4, $t6, $t20, $t21
+ 38: $t5 := infer($t21)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 39: label L8
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 40: $t25 := infer($t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t25
+ 41: $t24 := <($t25, $t6)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t24
+ 42: if ($t24) goto 43 else goto 67
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 43: label L10
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 44: $t29 := freeze_ref(implicit)($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t29
+ 45: $t28 := vector::borrow<u64>($t29, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t28
+ 46: $t27 := infer($t28)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t27
+ 47: $t30 := read_ref($t27)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t30
+ 48: $t31 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t30, $t31
+ 49: $t26 := >($t30, $t31)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t26
+ 50: if ($t26) goto 51 else goto 60
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 51: label L13
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 52: $t32 := infer($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t32
+ 53: $t33 := infer($t20)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t32, $t33
+ 54: vector::swap<u64>($t32, $t33, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 55: $t35 := infer($t20)
+     # live vars: $t2, $t4, $t5, $t6, $t35
+ 56: $t36 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t35, $t36
+ 57: $t34 := +($t35, $t36)
+     # live vars: $t2, $t4, $t5, $t6, $t34
+ 58: $t20 := infer($t34)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 59: goto 61
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 60: label L14
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 61: label L15
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 62: $t38 := infer($t5)
+     # live vars: $t2, $t4, $t6, $t20, $t38
+ 63: $t39 := 1
+     # live vars: $t2, $t4, $t6, $t20, $t38, $t39
+ 64: $t37 := +($t38, $t39)
+     # live vars: $t2, $t4, $t6, $t20, $t37
+ 65: $t5 := infer($t37)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 66: goto 69
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 67: label L11
+     # live vars: $t2, $t20
+ 68: goto 71
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 69: label L12
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 70: goto 39
+     # live vars: $t2, $t20
+ 71: label L9
+     # live vars: $t2, $t20
+ 72: $t3 := infer($t20)
+     # live vars: $t2
+ 73: $t41 := freeze_ref(implicit)($t2)
+     # live vars: $t41
+ 74: $t42 := 0
+     # live vars: $t41, $t42
+ 75: $t40 := vector::borrow<u64>($t41, $t42)
+     # live vars: $t40
+ 76: $t0 := read_ref($t40)
+     # live vars: $t0
+ 77: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo(): u64 {
+     var $t0: u64
+     var $t1: vector<u64>
+     var $t2: &mut vector<u64>
+     var $t3: u64
+     var $t4: &mut vector<u64>
+     var $t5: u64
+     var $t6: u64
+     var $t7: &vector<u64>
+     var $t8: bool
+     var $t9: u64
+     var $t10: bool
+     var $t11: bool
+     var $t12: &u64
+     var $t13: &u64
+     var $t14: &vector<u64>
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: bool
+     var $t25: u64
+     var $t26: bool
+     var $t27: &u64
+     var $t28: &u64
+     var $t29: &vector<u64>
+     var $t30: u64
+     var $t31: u64
+     var $t32: &mut vector<u64>
+     var $t33: u64
+     var $t34: u64
+     var $t35: u64
+     var $t36: u64
+     var $t37: u64
+     var $t38: u64
+     var $t39: u64
+     var $t40: &u64
+     var $t41: &vector<u64>
+     var $t42: u64
+     # live vars:
+  0: $t1 := ["1", "2", "3"]
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t2
   2: $t4 := copy($t2)
      # live vars: $t2, $t4
   3: $t5 := 0

--- a/third_party/move/move-compiler-v2/tests/live-var/mut_inline_typed.exp
+++ b/third_party/move/move-compiler-v2/tests/live-var/mut_inline_typed.exp
@@ -943,6 +943,211 @@ fun m::foo(): u64 {
      # live vars: $t1
   1: $t2 := borrow_local($t1)
      # live vars: $t2
+  2: $t4 := infer($t2)
+     # live vars: $t2, $t4
+  3: $t5 := 0
+     # live vars: $t2, $t4, $t5
+  4: $t7 := freeze_ref(implicit)($t4)
+     # live vars: $t2, $t4, $t5, $t7
+  5: $t6 := vector::length<u64>($t7)
+     # live vars: $t2, $t4, $t5, $t6
+  6: label L0
+     # live vars: $t2, $t4, $t5, $t6
+  7: $t9 := infer($t5)
+     # live vars: $t2, $t4, $t5, $t6, $t9
+  8: $t8 := <($t9, $t6)
+     # live vars: $t2, $t4, $t5, $t6, $t8
+  9: if ($t8) goto 10 else goto 29
+     # live vars: $t2, $t4, $t5, $t6
+ 10: label L2
+     # live vars: $t2, $t4, $t5, $t6
+ 11: $t14 := freeze_ref(implicit)($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t14
+ 12: $t13 := vector::borrow<u64>($t14, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t13
+ 13: $t12 := infer($t13)
+     # live vars: $t2, $t4, $t5, $t6, $t12
+ 14: $t15 := read_ref($t12)
+     # live vars: $t2, $t4, $t5, $t6, $t15
+ 15: $t16 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t15, $t16
+ 16: $t11 := >($t15, $t16)
+     # live vars: $t2, $t4, $t5, $t6, $t11
+ 17: $t10 := !($t11)
+     # live vars: $t2, $t4, $t5, $t6, $t10
+ 18: if ($t10) goto 19 else goto 22
+     # live vars: $t2, $t4, $t5, $t6
+ 19: label L5
+     # live vars: $t2, $t4, $t5, $t6
+ 20: goto 33
+     # live vars: $t2, $t4, $t5, $t6
+ 21: goto 23
+     # live vars: $t2, $t4, $t5, $t6
+ 22: label L6
+     # live vars: $t2, $t4, $t5, $t6
+ 23: label L7
+     # live vars: $t2, $t4, $t5, $t6
+ 24: $t18 := infer($t5)
+     # live vars: $t2, $t4, $t6, $t18
+ 25: $t19 := 1
+     # live vars: $t2, $t4, $t6, $t18, $t19
+ 26: $t17 := +($t18, $t19)
+     # live vars: $t2, $t4, $t6, $t17
+ 27: $t5 := infer($t17)
+     # live vars: $t2, $t4, $t5, $t6
+ 28: goto 31
+     # live vars: $t2, $t4, $t5, $t6
+ 29: label L3
+     # live vars: $t2, $t4, $t5, $t6
+ 30: goto 33
+     # live vars: $t2, $t4, $t5, $t6
+ 31: label L4
+     # live vars: $t2, $t4, $t5, $t6
+ 32: goto 6
+     # live vars: $t2, $t4, $t5, $t6
+ 33: label L1
+     # live vars: $t2, $t4, $t5, $t6
+ 34: $t20 := infer($t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 35: $t22 := infer($t5)
+     # live vars: $t2, $t4, $t6, $t20, $t22
+ 36: $t23 := 1
+     # live vars: $t2, $t4, $t6, $t20, $t22, $t23
+ 37: $t21 := +($t22, $t23)
+     # live vars: $t2, $t4, $t6, $t20, $t21
+ 38: $t5 := infer($t21)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 39: label L8
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 40: $t25 := infer($t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t25
+ 41: $t24 := <($t25, $t6)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t24
+ 42: if ($t24) goto 43 else goto 67
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 43: label L10
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 44: $t29 := freeze_ref(implicit)($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t29
+ 45: $t28 := vector::borrow<u64>($t29, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t28
+ 46: $t27 := infer($t28)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t27
+ 47: $t30 := read_ref($t27)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t30
+ 48: $t31 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t30, $t31
+ 49: $t26 := >($t30, $t31)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t26
+ 50: if ($t26) goto 51 else goto 60
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 51: label L13
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 52: $t32 := infer($t4)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t32
+ 53: $t33 := infer($t20)
+     # live vars: $t2, $t4, $t5, $t6, $t20, $t32, $t33
+ 54: vector::swap<u64>($t32, $t33, $t5)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 55: $t35 := infer($t20)
+     # live vars: $t2, $t4, $t5, $t6, $t35
+ 56: $t36 := 1
+     # live vars: $t2, $t4, $t5, $t6, $t35, $t36
+ 57: $t34 := +($t35, $t36)
+     # live vars: $t2, $t4, $t5, $t6, $t34
+ 58: $t20 := infer($t34)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 59: goto 61
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 60: label L14
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 61: label L15
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 62: $t38 := infer($t5)
+     # live vars: $t2, $t4, $t6, $t20, $t38
+ 63: $t39 := 1
+     # live vars: $t2, $t4, $t6, $t20, $t38, $t39
+ 64: $t37 := +($t38, $t39)
+     # live vars: $t2, $t4, $t6, $t20, $t37
+ 65: $t5 := infer($t37)
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 66: goto 69
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 67: label L11
+     # live vars: $t2, $t20
+ 68: goto 71
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 69: label L12
+     # live vars: $t2, $t4, $t5, $t6, $t20
+ 70: goto 39
+     # live vars: $t2, $t20
+ 71: label L9
+     # live vars: $t2, $t20
+ 72: $t3 := infer($t20)
+     # live vars: $t2
+ 73: $t41 := freeze_ref(implicit)($t2)
+     # live vars: $t41
+ 74: $t42 := 0
+     # live vars: $t41, $t42
+ 75: $t40 := vector::borrow<u64>($t41, $t42)
+     # live vars: $t40
+ 76: $t0 := read_ref($t40)
+     # live vars: $t0
+ 77: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::foo(): u64 {
+     var $t0: u64
+     var $t1: vector<u64>
+     var $t2: &mut vector<u64>
+     var $t3: u64
+     var $t4: &mut vector<u64>
+     var $t5: u64
+     var $t6: u64
+     var $t7: &vector<u64>
+     var $t8: bool
+     var $t9: u64
+     var $t10: bool
+     var $t11: bool
+     var $t12: &u64
+     var $t13: &u64
+     var $t14: &vector<u64>
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+     var $t19: u64
+     var $t20: u64
+     var $t21: u64
+     var $t22: u64
+     var $t23: u64
+     var $t24: bool
+     var $t25: u64
+     var $t26: bool
+     var $t27: &u64
+     var $t28: &u64
+     var $t29: &vector<u64>
+     var $t30: u64
+     var $t31: u64
+     var $t32: &mut vector<u64>
+     var $t33: u64
+     var $t34: u64
+     var $t35: u64
+     var $t36: u64
+     var $t37: u64
+     var $t38: u64
+     var $t39: u64
+     var $t40: &u64
+     var $t41: &vector<u64>
+     var $t42: u64
+     # live vars:
+  0: $t1 := ["1", "2", "3"]
+     # live vars: $t1
+  1: $t2 := borrow_local($t1)
+     # live vars: $t2
   2: $t4 := copy($t2)
      # live vars: $t2, $t4
   3: $t5 := 0

--- a/third_party/move/move-model/bytecode/src/borrow_analysis.rs
+++ b/third_party/move/move-model/bytecode/src/borrow_analysis.rs
@@ -684,7 +684,7 @@ impl TransferFunctions for BorrowAnalysis<'_> {
                             state.del_node(&src_node)
                         }
                     },
-                    AssignKind::Copy | AssignKind::Store => {
+                    AssignKind::Copy | AssignKind::Dup | AssignKind::Store => {
                         if self.func_target.get_local_type(*src).is_mutable_reference() {
                             assert!(self
                                 .func_target

--- a/third_party/move/move-model/bytecode/src/function_target.rs
+++ b/third_party/move/move-model/bytecode/src/function_target.rs
@@ -147,6 +147,15 @@ impl<'env> FunctionTarget<'env> {
         }
     }
 
+    /// Returns the location of the bytecode at the given offset.
+    pub fn get_bytecode_loc_at_offset(&self, offset: CodeOffset) -> Loc {
+        if let Some(bytecode) = self.data.code.get(offset as usize) {
+            self.get_bytecode_loc(bytecode.get_attr_id())
+        } else {
+            self.func_env.module_env.env.internal_loc()
+        }
+    }
+
     /// Returns the debug comment, if any, associated with the given attribute.
     pub fn get_debug_comment(&self, attr_id: AttrId) -> Option<&String> {
         self.data.debug_comments.get(&attr_id)

--- a/third_party/move/move-model/bytecode/src/graph.rs
+++ b/third_party/move/move-model/bytecode/src/graph.rs
@@ -137,7 +137,7 @@ impl<T: Ord + Copy + Debug> Graph<T> {
     }
 }
 
-struct DomRelation<T: Ord + Copy + Debug> {
+pub struct DomRelation<T: Ord + Copy + Debug> {
     node_to_postorder_num: BTreeMap<T, usize>,
     postorder_num_to_node: Vec<T>,
     idom_tree: BTreeMap<usize, usize>,
@@ -260,6 +260,37 @@ impl<T: Ord + Copy + Debug> DomRelation<T> {
             }
         }
         finger1
+    }
+
+    /// Function to traverse the dominator tree in preorder
+    pub fn traverse_preorder(&self) -> Vec<T> {
+        // build the parent-children map based on domination relation
+        let mut children_map = BTreeMap::<usize, Vec<usize>>::new();
+        for (&node, &idom) in &self.idom_tree {
+            if node == idom {
+                continue;
+            } // skip root
+            children_map.entry(idom).or_default().push(node);
+        }
+
+        // DFS the parent-children map to run preorder traversal
+        let mut result = Vec::new();
+        fn dfs(node: usize, children_map: &BTreeMap<usize, Vec<usize>>, result: &mut Vec<usize>) {
+            result.push(node);
+            if let Some(children) = children_map.get(&node) {
+                for &child in children {
+                    dfs(child, children_map, result);
+                }
+            }
+        }
+        let entry = self.entry_num();
+        dfs(entry, &children_map, &mut result);
+
+        // map back to original nodes
+        result
+            .iter()
+            .map(|&n| self.postorder_num_to_node[n])
+            .collect()
     }
 }
 

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -37,6 +37,8 @@ pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";
 pub const BORROW_NAME: &str = "borrow";
 pub const BORROW_MUT_NAME: &str = "borrow_mut";
+pub const LENGTH_NAME: &str = "length";
+pub const EMPTY_NAME: &str = "empty";
 /// Functions in the std::vector module that are implemented as bytecode instructions.
 pub const VECTOR_FUNCS_WITH_BYTECODE_INSTRS: &[&str] = &[
     "empty",


### PR DESCRIPTION
## Description


This PR implements the "common subexpression elimination" (CSE) transformation. This is the second PR on the stack to introduce CSE optimizations to Move.

 Motivating Example:
 ```Move
 1. fun test(data: S, a: u64, b: u64): u64 {
 2.       if (data.x != 0) {
 3.           a / data.x
 4.       } else {
 5.           data.x + 1
 6.       }
 7.   }
 ```
 At the stackless bytecode level, `data.x` is translated into a seq of `BorrowLoc` + `BorrowField` + `ReadRef` instructions.
 *Without* CSE, all occurance of the same expression `data.x` (line 2, line 3, line 5) will be translated into the seq above,
 despite `data.x` at line 3 and line 5 share the same result of line 2 and the computations are not necessary.

 CSE aims to eliminate such repeated computations by reusing the result of previous computations.
 Specifically, in the example above, assuming the `BorrowLoc` + `BorrowField` + `ReadRef` sequence at line 2 is assigned to temp `t1`,
 then the occurrences at line 3 and line 5 can both be replaced by `t1`, eliminating the repeated computations.
 The optimized bytecode would look like:

  0: $t6 := borrow_local($t0)
  1: $t7 := borrow_field<0x8675::M::S>.x($t6)
  2: $t5 := read_ref($t7) // `data.x` at line 2 assigned to $t5
  3: $t8 := 0
  4: $t4 := !=($t5, $t8)
  5: if ($t4) goto 6 else goto 11
  6: label L0
  7: $t9 := move($t1)
  8: $t10 := copy($t5)
  9: $t3 := /($t9, $t10) // line 3 reuses $t5
  10: label L2
  11: return $t3
  12: label L1
  13: $t16 := 1
  14: $t11 := copy($t5)
  15: $t3 := +($t11, $t16) // line 5 reuses $t5
  16: goto 9

 ============================ Implementation Details ============================

 #### Step 1: Build the Control Flow Graph (CFG) and Domination Tree of a target function.

  #### Step 2: Traverse the Domination Tree in preorder, and for each basic block, for each instruction:
 - If the instruction is *PURE*, canonicalize the expression represented by the instruction into an `ExprKey` structure
   - `ExprKey` contains the operation and its arguments, represented as `ExpArg`,
   - `ExpArg` can be either a constant, a variable (temp), or another `ExprKey` to nest expressions recursively
      - Motivation to nest expression: consider the expression `ReadRef(BorrowField(BorrowLoc(x)))`, we want to
        represent it as a single one rather than three separate ones, so that we can eliminate
        the entire sequence at once upon reoccurance.
      - Conditions to nest `t1 = Op1(t0); t2 = Op2(t1);` as `Op2(Op1(t0))`:
         - The definition at `Op1` is the only definition of `t1` that can reach `Op2`
         - `t1` is only used once and exactly by `Op2`.
      - For commutative operations, the arguments are sorted to get a canonical order
 - Why pre-order traversal: ensure that all dominating blocks have been processed before the dominated ones,
   hencing not missing opportunities for replacement

  #### Step 3: Check if the `ExprKey` from Step 2 has been seen before in a dominating block.
 Given a seen-before `ExprKey` (annotated as `src_expr`) of the current expression (annotated as `dest_expr`),
 and assuming the two expressions have the following formats:
   - `src_expr`: `(src_temp1, src_temp2, ...) = src_op(src_ope1, src_ope2, ...)` defined at `src_inst`, where `src_ope1` and `src_ope2` can be nested expressions
   - `dest_expr`: `(dest_temp1, dest_temp2, ...) = dest_op(dest_ope1, dest_ope2, ...)` defined at `dest_inst`, where `dest_ope1` and `dest_ope2` can be nested expressions
 reusing the results of `src_expr` to replace `dest_expr` can incur safety issues, which we defail below with corresponding solutions:

 Safety 1: execution may reach `dest_inst` without going through `src_inst` first
 - This can lead to using incorrect values at `dest_inst`
 - Solution: check that `src_expr` dominates `dest_expr`

 Safety 2: type issues
 - `src_temps` and `dest_temps` can have different mutability when both are references (stackless bytecode does not encode mutability status)
   - This can lead to type conflict when copying `src_temp` to `dest_temp`
   - Solution: check that when `src_temps` and `dest_temps` have identical types
 - `stc_temps` can be mutably borrowed
   - This can create reference safety violations when copying `src_temps` to `dest_temps`
   - Solution: check that none of `src_temps` are mutably borrowed

 Safety 3: `src_temps` may not be copyable
 - This can lead to ability violations when copying `src_temps` to `dest_temps`
 - Solution: check that all `src_temps` are copyable

 Safety 4: `src_temps` may be re-defined before reaching `dest_expr`
 - This can lead to using incorrect values at `dest_expr`
 - Solution: check that the definitions at `src_expr` are the only definitions of `src_temps` that can reach `dest_expr`

 Safety 5: resources accessed by `src_expr` (via `BorrowGlobal` and `Exists`) may be changed before reaching `dest_expr`
 - This can lead to accessing different resource status/values at `dest_expr`
 - Solution: check that the resources accessed by `src_expr` are not changed before reaching `dest_expr`

 Safety 6: operands used in `src_expr` (i.e., `src_ope1, src_ope2, ...`) may be changed before reaching `dest_expr`
 - This means that `dest_expr` may produce different results from `src_expr`
 - Solution: check that operands used in `src_expr` are safe to reuse at `dest_expr`
   1. Operands used in `src_expr` are identical to those used in `dest_expr`
   2. None of the operands used in `src_expr` are possibly re-defined in a path between `src_expr` and `dest_expr` (without going through `src_expr` again)
   3. None of the operands used in `src_expr` are mutable references
      - In special cases (e.g., the operand is directly from function argument), our reaching definition cannot trace the memory underneath,
        and we may miss possible modifications to the memory states via the mutable reference.

 Besides safety, we also need to ensure that the replacement can bring performance gains. See comments above `gain_perf` for details

  #### Step 4: for each `src_expr` passing the conditions to replace `dest_expr` in Step 3, we check gather necessary information to perform replacement like below:

 Example:
 ```Move
 1. src_temp = pure_computation_1(t0)      // src_inst
 2. ...
 3. use(src_temp)
 4. dest_temp = pure_computation_1(t0)      // dest_inst
 5. ...
 6. use(dest_temp)
 ```
 ==>
 ```Move
 1. src_temp = pure_computation_1(t0)      // src_inst
 2. ...
 3. use(src_temp)
 4. dest_temp = copy(src_temp)      // inserted copy
 5. ...
 6. use(dest_temp)
 ```

  #### Step 5: After processing all basic blocks, we perform the recorded replacements and eliminate the marked code.

 ============================ Extensions ============================

 In principle, the algorithm above is designed to handle PURE instructions, defined as blow
 - the results only depend on the operands
 - has no side effects on `memory` (including write via references), control flow (including `abort`), or external state (global storage)
 - recomputing it multiple times yields no semantic effect.

 Yet, we found that some non-pure instructions can be safely handled under certain conditions.

 Group 1: operations that are pure if no arithmetic errors like overflows happen (`+`, `-`, `*`, `/`, `%`, etc):
 - their side effects (i.e., aborts) are safe because those, if happening, are guaranteed to happen earlier in the `src_inst`

 Group 2: operations that are pure if no type errors happen (`UnpackVariant`):
 - their side effects (i.e., aborts) are safe because those, if happening, are guaranteed to happen earlier in the `src_inst`

 Group 3: local borrow operations: `BorrowLoc`, `BorrowField`, `BorrowVariantField`
 - In principle, borrow operations are not pure as they depend on memory states.
 - Yet, our `Safety 6` guarantees that the memory underneath are not changed and, hence, their "pureness".
 - We also note that borrowing constants (e.g., `&42`) cannot be reused, as the same constant will actually reside at different memory locations.

 Group 4: `Assign`
 - It can be treated as pure when the assign kind is `Copy` or `Inferred`

 Group 5: `readref`
 - `readref` also depends on memory states
 - But similar to local borrow operations, our `Safety 6` guarantees that the memory states are not changed.

 Group 6: `Function` calls
 - A function call can be treated as pure if the callee
   - Does not modify any memory via mutable references
   - Does not access global resources

 Group 7: `BorrowGlobal` and `Exists`
 - They can be treated as pure as our `Safety 5` guarantees that the resources accessed are not modified between `src_inst` and `dst_inst`

## Stats by applying CSE on `framework` code [data from Dec 12, 2025 eval]
The evaluations are configured to run under the most restrictive configs regarding safety and bytecode reduction. The CSE implementation counts `Call Operation::Function` and `BorrowGlobal` as 4 bytecodes. 

* aptos-experimental (optimized cases: 93):
    - Total percentage increase in instructions: -0.1%, going from 128755 -> 128634, with net increase of: -121
* aptos-framework (optimized cases: 32):
    - Total percentage increase in instructions: -0.1%, going from 66487 -> 66406, with net increase of: -81
* aptos-token (optimized cases: 43):
    - Total percentage increase in instructions: -0.2%, going from 72252 -> 72129, with net increase of: -123

## TODOs
- All TODO items are marked with `TODO(#18203)`.

## How Has This Been Tested?
- Existing compiler tests and transactional tests
- New test cases will be added in next PR

#### Expected Result Changes
- Expensive recomputation is elimintated with reuse of the result from the first computation. 
- Intermediate analysis results introduced by CSE

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (Move linter)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new optimization pass, **common subexpression elimination (CSE)**, guarded by `Experiment::COMMON_SUBEXP_ELIMINATION`, and wires it into the stackless bytecode pipeline (runs before ability checks). The pass depends on live-var, reference-safety (v2/v3), reaching-def, and flush-writes analyses and clears annotations after transforming code.
> 
> - Adds `pipeline/common_subexp_elimination.rs` implementing CSE with safety and perf gating; registers reaching-def formatters
> - Integrates CSE into `stackless_bytecode_optimization_pipeline` with required analysis stages
> - Extends bytecode semantics with `AssignKind::Dup` and updates generators/analyses to honor it (file-format generator stack handling, liveness, reaching-def, dead-store elimination, reference-safety, ability processor)
> - Adds `COMMON_SUBEXP_ELIMINATION` experiment flag/constants; updates tests to reflect new dup/copy behavior and optimized code paths
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b33f3831451ab467874fdf8385b97c02a17843fa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->