### PR TITLE
pepper service should skip constant-time scalarMul check in dev mode...

### DIFF
--- a/keyless/pepper/service/src/main.rs
+++ b/keyless/pepper/service/src/main.rs
@@ -171,8 +171,8 @@ async fn main() {
     // Fetch the VUF public and private keypair (this will load the private key into memory)
     info!("Fetching the VUF public and private keypair for the pepper service...");
     let vuf_keypair = Arc::new(vuf_keypair::get_pepper_service_vuf_keypair(
-        args.vuf_private_key_hex,
-        args.vuf_private_key_seed_hex,
+        args.vuf_private_key_hex.clone(),
+        args.vuf_private_key_seed_hex.clone(),
     ));
     info!(
         "Retrieved the VUF public key: {:?}",
@@ -181,11 +181,7 @@ async fn main() {
 
     // Verify the critical service invariants
     info!("Verifying critical service invariants...");
-    verify_critical_service_invariants(
-        &args,
-        vuf_keypair.clone(),
-        deployment_information.clone(),
-    );
+    verify_critical_service_invariants(&args, vuf_keypair.clone(), deployment_information.clone());
 
     // Collect the account recovery managers
     info!("Collecting the account recovery managers...");
@@ -399,7 +395,9 @@ fn verify_critical_service_invariants(
 ) {
     // Verify constant-time scalar multiplication if in production.
     if args.local_development_mode {
-        info!("Constant-time scalar multiplication verification skipped in local development mode.");
+        info!(
+            "Constant-time scalar multiplication verification skipped in local development mode."
+        );
     } else {
         info!("Verifying constant-time scalar multiplication...");
         verify_constant_time_scalar_multiplication();


### PR DESCRIPTION
## Description

So it can run on some CI maches.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Skip constant-time scalar-multiplication verification when running in local development mode and refactor invariant checks to take Args, adjusting callers accordingly.
> 
> - **Service (pepper)**:
>   - **Invariant verification**:
>     - `verify_critical_service_invariants` now takes `&Args` and conditionally skips constant-time scalar multiplication when `local_development_mode` is true.
>     - Uses `args.expected_vuf_pubkey_on_startup` and `args.expected_derived_pepper_on_startup` via `.as_ref()`; updated call sites accordingly.
>   - **Keypair init**:
>     - Pass cloned `args.vuf_private_key_hex` and `args.vuf_private_key_seed_hex` into `vuf_keypair::get_pepper_service_vuf_keypair`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f94c5efcf7a50c927142feb030d393945bd5ec3e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->