### PR TITLE
Fail on failure in VM bench

### DIFF
--- a/aptos-move/e2e-benchmark/src/main.rs
+++ b/aptos-move/e2e-benchmark/src/main.rs
@@ -9,7 +9,7 @@ use aptos_transaction_generator_lib::{
     entry_point_trait::{AutomaticArgs, EntryPointTrait, MultiSigConfig},
     publishing::publish_util::{Package, PackageHandler},
 };
-use aptos_transaction_workloads_lib::{EntryPoints, LoopType, MapType, OrderBookState};
+use aptos_transaction_workloads_lib::{EntryPoints, LoopType, MapType};
 use aptos_types::{
     account_address::AccountAddress, chain_id::ChainId, transaction::TransactionPayload,
 };
@@ -341,14 +341,15 @@ fn main() {
             repeats: 100,
             map_type: MapType::OrderedMap,
         }),
-        (LANDBLOCKING_AND_CONTINUOUS, EntryPoints::OrderBook {
-            state: OrderBookState::new(),
-            num_markets: 1,
-            overlap_ratio: 0.0, // Since we run a single txn, no matches will happen irrespectively
-            buy_frequency: 0.5,
-            max_sell_size: 1,
-            max_buy_size: 1,
-        }),
+        // TODO need to support transaction context to enable
+        // (LANDBLOCKING_AND_CONTINUOUS, EntryPoints::OrderBook {
+        //     state: OrderBookState::new(),
+        //     num_markets: 1,
+        //     overlap_ratio: 0.0, // Since we run a single txn, no matches will happen irrespectively
+        //     buy_frequency: 0.5,
+        //     max_sell_size: 1,
+        //     max_buy_size: 1,
+        // }),
     ];
 
     let mut failures = Vec::new();
@@ -403,6 +404,11 @@ fn main() {
             } else {
                 100
             },
+        );
+        assert!(
+            !measurement.had_error(),
+            "Entry point {:?} failed with an error",
+            entry_point
         );
         let elapsed_micros = measurement.elapsed_micros_f64();
         let diff = (elapsed_micros - expected_time_micros) / expected_time_micros * 100.0;


### PR DESCRIPTION
OrderBook txn is failing because VM bench doesn't have transaction context, but that is ignored in the test.

we can fix the test separately, somehow.

## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
