### PR TITLE
aptos-experimental-layered-map: move `jemallocator` to `[dev-dependencies]`

### DIFF
--- a/experimental/storage/layered-map/Cargo.toml
+++ b/experimental/storage/layered-map/Cargo.toml
@@ -32,7 +32,7 @@ proptest = { workspace = true }
 rand = { workspace = true }
 rocksdb = { workspace = true }
 
-[target.'cfg(unix)'.dependencies]
+[target.'cfg(unix)'.dev-dependencies]
 jemallocator = { workspace = true }
 
 [lib]


### PR DESCRIPTION
Cuts `tikv-jemallocator` dependency from `e2e-move-tests` dependency tree. 