### PR TITLE
[move value annotator] Cache FatType computation

### DIFF
--- a/third_party/move/tools/move-resource-viewer/src/fat_type.rs
+++ b/third_party/move/tools/move-resource-viewer/src/fat_type.rs
@@ -64,6 +64,7 @@ pub(crate) struct FatFunctionType {
     pub abilities: AbilitySet,
 }
 
+// INVARIANT: this type need to stay crate local. See discussion at `FatStructRef`.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialOrd, Ord, PartialEq, Eq)]
 pub(crate) enum FatType {
     Bool,

--- a/third_party/move/tools/move-resource-viewer/src/lib.rs
+++ b/third_party/move/tools/move-resource-viewer/src/lib.rs
@@ -103,6 +103,10 @@ pub struct MoveValueAnnotator<V> {
     module_viewer: V,
     /// A cache for fat type info for structs. For a generic struct, the uninstantiated
     /// FatStructType of the base definition will be stored here as well.
+    ///
+    /// Notice that this cache (and the next one) effect the computation `Limit`: no-cached
+    /// annotation may hit limits which cached ones don't. Since limits aren't precise metering,
+    /// this effect is expected and OK.
     fat_struct_def_cache: RefCell<BTreeMap<StructName, FatStructRef>>,
     /// A cache for fat type info for struct instantiations. This cache is build from
     /// substituting parameters for the uninstantiated types in `fat_struct_def_cache`.


### PR DESCRIPTION
## Description

This caches the conversion from `StructTag` to `FatStructTag` inside of the annotator. It also wraps an Rc around the `FatStructTag` to avoid cloning when taken from the cache. Computation of `FatStructTag` is supposedly the bottleneck in value annotation, because it needs to fetch transitively all struct definitions from the bytecode. However, it isn't clear yet whether the cache and annotator lifetime is long enough to have a visible effect.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces `FatStructRef` (Rc-interned) and adds caches for struct defs/instantiations in `MoveValueAnnotator`, refactoring type/struct resolution to use them.
> 
> - **move-resource-viewer**:
>   - **Interning & type model**: Introduce `FatStructRef` (Rc-backed) and switch `FatType::Struct` to `Struct(FatStructRef)`.
>   - **Caching**: Add `fat_struct_def_cache` and `fat_struct_inst_cache` in `MoveValueAnnotator` keyed by `StructName` and `(StructName, Vec<FatType>)`.
>   - **Resolution refactor**:
>     - New `StructName`, `resolve_struct_tag`, `resolve_basic_struct`, `resolve_generic_struct`, and `handle_to_struct_name`.
>     - Update signature/type-tag resolution and substitution to use caches and `FatStructRef`.
>   - **Trait/utility updates**: Derive ordering/equality on fat types; adjust cloning (`Struct` clones by ref), serialization/`TryInto` calls, and minor doc tweak for `RawMoveStruct`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc3842d2067703df2a2de30ab45d6490e79d576. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->