### PR TITLE
make all `[build-dependencies]` `opt-level=3` for release build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -913,7 +913,7 @@ overflow-checks = true
 
 # For [build-dependencies], cargo sets `opt-level=0` independent of the actual profile used.
 # In `aptos-cached-packages` crate, we have `aptos-framework` as a build dependency. Which in a `--release` mode,
-# results in a 335 crates more being compiled, completely unnecessary.
+# results in additional crates being compiled (335 for `opt-level=3`, 335 more for `opt-level=0`).
 # In addition to that, the same `aptos-cached-packages` build has a very compute intensive step to compile
 # the whole Aptos Framework with the Move Compiler - which with the `opt-level=0` slows down compilation a lot.
 # For the explanation, see https://github.com/rust-lang/cargo/pull/8500


### PR DESCRIPTION
For the `release` profile (and any others like `ci` and `performance`):

1. removes 335 crates from the dependency tree by allowing cargo to share dependencies between `build.rs` and runtime, 
2. makes `aptos-cached-packages` build 3.5 times faster.

By default, all `[build-dependencies]` are `opt-level=0` irrespective of the actual build profile.
See 
https://github.com/rust-lang/cargo/pull/8500

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `[profile.release.build-override] opt-level=3` so `build-dependencies` compile with `opt-level=3` in release builds, improving build performance and dependency sharing.
> 
> - **Build system**:
>   - Configure Cargo to compile `build-dependencies` with `opt-level=3` via `[profile.release.build-override]` in `Cargo.toml` (applies to profiles inheriting from `release`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 773191e888ea72e69e9b345f261ad4891d2b3990. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->