### PR TITLE
[Mempool] Reduce max_sync_lag_before_unhealthy_secs to 30s

### DIFF
--- a/config/src/config/mempool_config.rs
+++ b/config/src/config/mempool_config.rs
@@ -116,7 +116,7 @@ impl Default for MempoolConfig {
             shared_mempool_ack_timeout_ms: 2_000,
             shared_mempool_max_concurrent_inbound_syncs: 4,
             max_broadcasts_per_peer: 20,
-            max_sync_lag_before_unhealthy_secs: 300, // 5 minutes
+            max_sync_lag_before_unhealthy_secs: 30, // 30 seconds
             max_network_channel_size: 1024,
             mempool_snapshot_interval_secs: 180,
             capacity: 2_000_000,

--- a/config/src/config/peer_monitoring_config.rs
+++ b/config/src/config/peer_monitoring_config.rs
@@ -81,7 +81,7 @@ pub struct NodeMonitoringConfig {
 impl Default for NodeMonitoringConfig {
     fn default() -> Self {
         Self {
-            node_info_request_interval_ms: 20_000, // 20 seconds
+            node_info_request_interval_ms: 15_000, // 15 seconds
             node_info_request_timeout_ms: 10_000,  // 10 seconds
         }
     }


### PR DESCRIPTION
## Description
This PR reduce the `max_sync_lag_before_unhealthy_secs` from 5 minutes to 30 seconds. This means that nodes that fall behind by more than 30 seconds are deprioritized when it comes to mempool transaction forwarding. This should help reduce transaction latencies when some peers are unhealthy.

Note: we also reduced the `node_info_request_interval_ms` from 20 seconds to 15 seconds, so that this information is updated more frequently.

## Testing Plan
Existing test infrastructure.