### PR TITLE
[buffer_manager] ack if commit vote round is highest committed round

### DIFF
--- a/consensus/src/pipeline/buffer_manager.rs
+++ b/consensus/src/pipeline/buffer_manager.rs
@@ -336,6 +336,10 @@ impl BufferManager {
         let block_id = vote.commit_info().id();
         let round = vote.commit_info().round();
 
+        // Don't need to store commit vote if we have already committed up to that round
+        if round <= self.highest_committed_round {
+            true
+        } else
         // Store the commit vote only if it is for one of the next 100 rounds.
         if round > self.highest_committed_round
             && self.highest_committed_round + self.max_pending_rounds_in_commit_vote_cache > round


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Fixes the log spam and CommitVote retry when the `highest_committed_round == commit_vote.round`. Don't send a nack to the sender if already committed. 