### PR TITLE
Add support for txn filtering when streaming directly from the node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2413,6 +2413,7 @@ dependencies = [
  "aptos-secure-storage",
  "aptos-storage-interface",
  "aptos-temppath",
+ "aptos-transaction-filter 0.1.0",
  "aptos-types",
  "aptos-vm",
  "aptos-vm-validator",

--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -18,6 +18,7 @@ const DEFAULT_PROCESSOR_BATCH_SIZE: u16 = 1000;
 const DEFAULT_OUTPUT_BATCH_SIZE: u16 = 100;
 const DEFAULT_TRANSACTION_CHANNEL_SIZE: usize = 35;
 pub const DEFAULT_GRPC_STREAM_PORT: u16 = 50051;
+const DEFAULT_MAX_TRANSACTION_FILTER_SIZE_BYTES: usize = 10_000;
 
 pub fn get_default_processor_task_count(use_data_service_interface: bool) -> u16 {
     if use_data_service_interface {
@@ -52,6 +53,9 @@ pub struct IndexerGrpcConfig {
 
     /// Size of the transaction channel buffer for streaming.
     pub transaction_channel_size: usize,
+
+    /// Maximum size in bytes for transaction filters.
+    pub max_transaction_filter_size_bytes: usize,
 }
 
 impl Debug for IndexerGrpcConfig {
@@ -67,6 +71,10 @@ impl Debug for IndexerGrpcConfig {
             .field("processor_batch_size", &self.processor_batch_size)
             .field("output_batch_size", &self.output_batch_size)
             .field("transaction_channel_size", &self.transaction_channel_size)
+            .field(
+                "max_transaction_filter_size_bytes",
+                &self.max_transaction_filter_size_bytes,
+            )
             .finish()
     }
 }
@@ -87,6 +95,7 @@ impl Default for IndexerGrpcConfig {
             processor_batch_size: DEFAULT_PROCESSOR_BATCH_SIZE,
             output_batch_size: DEFAULT_OUTPUT_BATCH_SIZE,
             transaction_channel_size: DEFAULT_TRANSACTION_CHANNEL_SIZE,
+            max_transaction_filter_size_bytes: DEFAULT_MAX_TRANSACTION_FILTER_SIZE_BYTES,
         }
     }
 }

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/config.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/config.rs
@@ -9,7 +9,9 @@ use crate::{
 };
 use anyhow::Result;
 use aptos_indexer_grpc_server_framework::RunnableConfig;
-use aptos_indexer_grpc_utils::config::IndexerGrpcFileStoreConfig;
+use aptos_indexer_grpc_utils::{
+    config::IndexerGrpcFileStoreConfig, constants::DEFAULT_MAX_TRANSACTION_FILTER_SIZE_BYTES,
+};
 use aptos_protos::{
     indexer::v1::FILE_DESCRIPTOR_SET as INDEXER_V1_FILE_DESCRIPTOR_SET,
     transaction::v1::FILE_DESCRIPTOR_SET as TRANSACTION_V1_TESTING_FILE_DESCRIPTOR_SET,
@@ -35,7 +37,6 @@ const HTTP2_PING_INTERVAL_DURATION: std::time::Duration = std::time::Duration::f
 const HTTP2_PING_TIMEOUT_DURATION: std::time::Duration = std::time::Duration::from_secs(10);
 
 const DEFAULT_MAX_RESPONSE_CHANNEL_SIZE: usize = 5;
-const DEFAULT_MAX_TRANSACTION_FILTER_SIZE_BYTES: usize = 10_000;
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/historical_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service-v2/src/historical_data_service.rs
@@ -10,6 +10,7 @@ use aptos_indexer_grpc_utils::{
     constants::{get_request_metadata, IndexerGrpcRequestMetadata},
     counters::BYTES_READY_TO_TRANSFER_FROM_SERVER_AFTER_STRIPPING,
     file_store_operator_v2::file_store_reader::FileStoreReader,
+    filter_utils,
 };
 use aptos_protos::indexer::v1::{GetTransactionsRequest, ProcessedRange, TransactionsResponse};
 use aptos_transaction_filter::BooleanTransactionFilter;
@@ -80,17 +81,14 @@ impl HistoricalDataService {
                 let starting_version = request.starting_version.unwrap();
 
                 let filter = if let Some(proto_filter) = request.transaction_filter {
-                    match BooleanTransactionFilter::new_from_proto(
+                    match filter_utils::parse_transaction_filter(
                         proto_filter,
-                        Some(self.max_transaction_filter_size_bytes),
+                        self.max_transaction_filter_size_bytes,
                     ) {
                         Ok(filter) => Some(filter),
-                        Err(e) => {
-                            let err = Err(Status::invalid_argument(format!(
-                                "Invalid transaction_filter: {e:?}."
-                            )));
+                        Err(err) => {
                             info!("Client error: {err:?}.");
-                            let _ = response_sender.blocking_send(err);
+                            let _ = response_sender.blocking_send(Err(err));
                             COUNTER
                                 .with_label_values(&["historical_data_service_invalid_filter"])
                                 .inc();

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/Cargo.toml
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/Cargo.toml
@@ -41,6 +41,7 @@ aptos-moving-average = { workspace = true }
 aptos-protos = { workspace = true }
 aptos-runtimes = { workspace = true }
 aptos-storage-interface = { workspace = true }
+aptos-transaction-filter = { workspace = true }
 aptos-types = { workspace = true }
 
 move-core-types = { workspace = true }

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
@@ -106,6 +106,11 @@ impl FullnodeData for FullnodeDataService {
                 processor_batch_size,
                 output_batch_size,
                 tx.clone(),
+                // For now the request for this interface doesn't include a txn filter
+                // because it is only used for the txn stream filestore worker, which
+                // needs every transaction. Later we may add support for txn filtering
+                // to this interface too.
+                None,
                 Some(abort_handle.clone()),
             );
             // Sends init message (one time per request) to the client in the with chain id and starting version. Basically a handshake

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/lib.rs
@@ -18,6 +18,7 @@ pub struct ServiceContext {
     pub processor_batch_size: u16,
     pub output_batch_size: u16,
     pub transaction_channel_size: usize,
+    pub max_transaction_filter_size_bytes: usize,
 }
 
 #[cfg(test)]

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
@@ -58,6 +58,8 @@ pub fn bootstrap(
     let processor_batch_size = node_config.indexer_grpc.processor_batch_size;
     let output_batch_size = node_config.indexer_grpc.output_batch_size;
     let transaction_channel_size = node_config.indexer_grpc.transaction_channel_size;
+    let max_transaction_filter_size_bytes =
+        node_config.indexer_grpc.max_transaction_filter_size_bytes;
 
     runtime.spawn(async move {
         let context = Arc::new(Context::new(
@@ -73,6 +75,7 @@ pub fn bootstrap(
             processor_batch_size,
             output_batch_size,
             transaction_channel_size,
+            max_transaction_filter_size_bytes,
         };
         // If we are here, we know indexer grpc is enabled.
         let server = FullnodeDataService {

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/stream_coordinator.rs
@@ -23,6 +23,7 @@ use aptos_protos::{
     },
     util::timestamp::Timestamp,
 };
+use aptos_transaction_filter::{BooleanTransactionFilter, Filterable};
 use itertools::Itertools;
 use serde::Serialize;
 use std::{
@@ -50,6 +51,7 @@ pub struct IndexerStreamCoordinator {
     pub highest_known_version: u64,
     pub context: Arc<Context>,
     pub transactions_sender: mpsc::Sender<Result<TransactionsFromNodeResponse, tonic::Status>>,
+    pub filter: Option<BooleanTransactionFilter>,
     abort_handle: Option<Arc<AtomicBool>>,
 }
 
@@ -71,6 +73,7 @@ impl IndexerStreamCoordinator {
         processor_batch_size: u16,
         output_batch_size: u16,
         transactions_sender: mpsc::Sender<Result<TransactionsFromNodeResponse, tonic::Status>>,
+        filter: Option<BooleanTransactionFilter>,
         abort_handle: Option<Arc<AtomicBool>>,
     ) -> Self {
         Self {
@@ -82,6 +85,7 @@ impl IndexerStreamCoordinator {
             highest_known_version: 0,
             context,
             transactions_sender,
+            filter,
             abort_handle,
         }
     }
@@ -158,13 +162,24 @@ impl IndexerStreamCoordinator {
 
         let output_batch_size = self.output_batch_size;
         let ledger_chain_id = self.context.chain_id().id();
+        let filter = self.filter.clone();
         let mut tasks = vec![];
         for batch in task_batches {
             let context = self.context.clone();
+            let filter = filter.clone();
             let task = tokio::task::spawn_blocking(move || {
                 let raw_txns = batch;
                 let api_txns = Self::convert_to_api_txns(context, raw_txns);
                 let pb_txns = Self::convert_to_pb_txns(api_txns);
+                // Apply filter if present.
+                let pb_txns = if let Some(ref filter) = filter {
+                    pb_txns
+                        .into_iter()
+                        .filter(|txn| filter.matches(txn))
+                        .collect::<Vec<_>>()
+                } else {
+                    pb_txns
+                };
                 let mut responses = vec![];
                 // Wrap in stream response object and send to channel
                 for chunk in pb_txns.chunks(output_batch_size as usize) {

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/constants.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/constants.rs
@@ -17,6 +17,8 @@ pub const GRPC_REQUEST_NAME_HEADER: &str = "x-aptos-request-name";
 pub const GRPC_API_GATEWAY_API_KEY_HEADER: &str = "authorization";
 // Limit the message size to 15MB. By default the downstream can receive up to 15MB.
 pub const MESSAGE_SIZE_LIMIT: usize = 1024 * 1024 * 15;
+// Default maximum size in bytes for transaction filters.
+pub const DEFAULT_MAX_TRANSACTION_FILTER_SIZE_BYTES: usize = 10_000;
 
 // These come from API Gateway, see here:
 // https://github.com/aptos-labs/api-gateway/blob/0aae1c17fbd0f5e9b50bdb416f62b48d3d1d5e6b/src/common.rs

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/filter_utils.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/filter_utils.rs
@@ -1,0 +1,15 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+use aptos_transaction_filter::BooleanTransactionFilter;
+use tonic::Status;
+
+/// Parse and validate a transaction filter from its protobuf representation.
+/// Returns an error Status if the filter is invalid or too large.
+pub fn parse_transaction_filter(
+    proto_filter: aptos_protos::indexer::v1::BooleanTransactionFilter,
+    max_filter_size_bytes: usize,
+) -> Result<BooleanTransactionFilter, Status> {
+    BooleanTransactionFilter::new_from_proto(proto_filter, Some(max_filter_size_bytes))
+        .map_err(|e| Status::invalid_argument(format!("Invalid transaction_filter: {e:?}.")))
+}

--- a/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-utils/src/lib.rs
@@ -8,6 +8,7 @@ pub mod constants;
 pub mod counters;
 pub mod file_store_operator;
 pub mod file_store_operator_v2;
+pub mod filter_utils;
 pub mod in_memory_cache;
 pub mod status_page;
 pub mod types;

--- a/execution/executor-benchmark/src/lib.rs
+++ b/execution/executor-benchmark/src/lib.rs
@@ -165,6 +165,7 @@ fn init_indexer_wrapper(
         processor_batch_size: config.indexer_grpc.processor_batch_size,
         output_batch_size: config.indexer_grpc.output_batch_size,
         transaction_channel_size: config.indexer_grpc.transaction_channel_size,
+        max_transaction_filter_size_bytes: config.indexer_grpc.max_transaction_filter_size_bytes,
     };
 
     // Spawn table_info_service in tokio runtime


### PR DESCRIPTION
## Description
Right now we support transaction filtering, where in the request to the grpc txn stream you can specify that you only want transactions based on certain filters. This is implemented in the v2 data service, but it doesn't work if you stream txns from the fullnode directly (it has a mode where it offers the same txn stream protocol as data service, see `indexer_grpc.use_data_service_interface`). This PR adds support for txn filtering when streaming directly from the node.

We refactor the code to avoid duplication as well.

## How Has This Been Tested?
Run a localnet:
```
cargo run -p aptos -- node run-localnet --assume-yes --force-restart
```

Stream transactions like normal:
```
grpcurl -v -d '{ "starting_version": 0, "transactions_count": 10 }' -max-msg-sz 30000000 -plaintext 127.0.0.1:50051 aptos.indexer.v1.RawData/GetTransactions | grep '"type": "TRANSACTION_TYPE'
```
See that we get all the txns:
```
      "type": "TRANSACTION_TYPE_GENESIS",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_BLOCK_EPILOGUE",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_USER",
      "type": "TRANSACTION_TYPE_BLOCK_EPILOGUE",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_VALIDATOR",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_USER",
```

Stream transactions with a filter applied to only get user transactions:
```
grpcurl -v -d '{"starting_version":"0", "transactions_count":"10", "transaction_filter":{"api_filter":{"transaction_root_filter":{"transaction_type":"TRANSACTION_TYPE_USER"}}}}' -max-msg-sz 30000000 -plaintext 127.0.0.1:50051 aptos.indexer.v1.RawData/GetTransactions | grep '"type": "TRANSACTION_TYPE'
```
See that we only get the user txns:
```
      "type": "TRANSACTION_TYPE_USER",
      "type": "TRANSACTION_TYPE_USER",
```

Compare this with the existing localnet, where the txn filter does nothing:
```
aptos node run-localnet --assume-yes --force-restart
```
```
grpcurl -v -d '{"starting_version":"0", "transactions_count":"10", "transaction_filter":{"api_filter":{"transaction_root_filter":{"transaction_type":"TRANSACTION_TYPE_USER"}}}}' -max-msg-sz 30000000 -plaintext 127.0.0.1:50051 aptos.indexer.v1.RawData/GetTransactions | grep '"type": "TRANSACTION_TYPE'
```
```
      "type": "TRANSACTION_TYPE_GENESIS",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_BLOCK_EPILOGUE",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_USER",
      "type": "TRANSACTION_TYPE_BLOCK_EPILOGUE",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_VALIDATOR",
      "type": "TRANSACTION_TYPE_BLOCK_METADATA",
      "type": "TRANSACTION_TYPE_USER",
```

## Key Areas to Review
Ensure there is no regression in behavior on either the data service (v1 or v2) or the node.

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
