### PR TITLE
Add support for configuring node txn stream worker count and channel size

### DIFF
--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -14,10 +14,18 @@ use std::{
 };
 
 // Useful indexer defaults
-const DEFAULT_PROCESSOR_TASK_COUNT: u16 = 20;
 const DEFAULT_PROCESSOR_BATCH_SIZE: u16 = 1000;
 const DEFAULT_OUTPUT_BATCH_SIZE: u16 = 100;
+const DEFAULT_TRANSACTION_CHANNEL_SIZE: usize = 35;
 pub const DEFAULT_GRPC_STREAM_PORT: u16 = 50051;
+
+pub fn get_default_processor_task_count(use_data_service_interface: bool) -> u16 {
+    if use_data_service_interface {
+        1
+    } else {
+        20
+    }
+}
 
 #[derive(Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -34,13 +42,16 @@ pub struct IndexerGrpcConfig {
     pub address: SocketAddr,
 
     /// Number of processor tasks to fan out
-    pub processor_task_count: u16,
+    pub processor_task_count: Option<u16>,
 
     /// Number of transactions each processor will process
     pub processor_batch_size: u16,
 
     /// Number of transactions returned in a single stream response
     pub output_batch_size: u16,
+
+    /// Size of the transaction channel buffer for streaming.
+    pub transaction_channel_size: usize,
 }
 
 impl Debug for IndexerGrpcConfig {
@@ -55,6 +66,7 @@ impl Debug for IndexerGrpcConfig {
             .field("processor_task_count", &self.processor_task_count)
             .field("processor_batch_size", &self.processor_batch_size)
             .field("output_batch_size", &self.output_batch_size)
+            .field("transaction_channel_size", &self.transaction_channel_size)
             .finish()
     }
 }
@@ -71,9 +83,10 @@ impl Default for IndexerGrpcConfig {
                 Ipv4Addr::new(0, 0, 0, 0),
                 DEFAULT_GRPC_STREAM_PORT,
             )),
-            processor_task_count: DEFAULT_PROCESSOR_TASK_COUNT,
+            processor_task_count: None,
             processor_batch_size: DEFAULT_PROCESSOR_BATCH_SIZE,
             output_batch_size: DEFAULT_OUTPUT_BATCH_SIZE,
+            transaction_channel_size: DEFAULT_TRANSACTION_CHANNEL_SIZE,
         }
     }
 }

--- a/config/src/config/override_node_config.rs
+++ b/config/src/config/override_node_config.rs
@@ -67,6 +67,7 @@ fn diff_override_config_yaml(
                 Ok(Some(override_config))
             }
         },
+        (_, serde_yaml::Value::Null) => Ok(Some(override_config)),
         (_, _) => bail!(
             "base does not match override: {:?}, {:?}",
             override_config,

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
@@ -39,7 +39,6 @@ type FullnodeResponseStream =
 // Default Values
 pub const DEFAULT_NUM_RETRIES: usize = 3;
 pub const RETRY_TIME_MILLIS: u64 = 100;
-const TRANSACTION_CHANNEL_SIZE: usize = 35;
 const DEFAULT_EMIT_SIZE: usize = 1000;
 const SERVICE_TYPE: &str = "indexer_fullnode";
 
@@ -67,6 +66,7 @@ impl FullnodeData for FullnodeDataService {
         let processor_task_count = self.service_context.processor_task_count;
         let processor_batch_size = self.service_context.processor_batch_size;
         let output_batch_size = self.service_context.output_batch_size;
+        let transaction_channel_size = self.service_context.transaction_channel_size;
         let ending_version = if let Some(count) = r.transactions_count {
             starting_version.saturating_add(count)
         } else {
@@ -77,8 +77,8 @@ impl FullnodeData for FullnodeDataService {
         let context = self.service_context.context.clone();
         let ledger_chain_id = context.chain_id().id();
 
-        // Creates a channel to send the stream to the client
-        let (tx, rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
+        // Creates a channel to send the stream to the client.
+        let (tx, rx) = mpsc::channel(transaction_channel_size);
 
         // Creates a moving average to track tps
         let mut ma = MovingAverage::new(10_000);
@@ -142,7 +142,7 @@ impl FullnodeData for FullnodeDataService {
                     Some(max_version),
                     ledger_chain_id,
                 );
-                let channel_size = TRANSACTION_CHANNEL_SIZE - tx.capacity();
+                let channel_size = transaction_channel_size - tx.capacity();
                 CHANNEL_SIZE
                     .with_label_values(&["2"])
                     .set(channel_size as i64);

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/lib.rs
@@ -17,6 +17,7 @@ pub struct ServiceContext {
     pub processor_task_count: u16,
     pub processor_batch_size: u16,
     pub output_batch_size: u16,
+    pub transaction_channel_size: usize,
 }
 
 #[cfg(test)]

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
@@ -16,7 +16,6 @@ use tonic::{Request, Response, Status};
 // Default Values
 pub const DEFAULT_NUM_RETRIES: usize = 3;
 pub const RETRY_TIME_MILLIS: u64 = 100;
-const TRANSACTION_CHANNEL_SIZE: usize = 35;
 
 type TransactionResponseStream =
     Pin<Box<dyn Stream<Item = Result<TransactionsResponse, Status>> + Send>>;
@@ -25,8 +24,9 @@ pub struct LocalnetDataService {
     pub service_context: ServiceContext,
 }
 
-/// External service on the fullnode is for testing/local development only.
-/// Performance is not optimized, e.g., single-threaded.
+/// Exposes a transaction stream on the node that matches the interface exposed by the
+/// full production data service.
+///
 /// NOTE: code is duplicated from fullnode_data_service.rs with some minor changes.
 #[tonic::async_trait]
 impl RawData for LocalnetDataService {
@@ -48,23 +48,23 @@ impl RawData for LocalnetDataService {
         } else {
             u64::MAX
         };
+        let processor_task_count = self.service_context.processor_task_count;
         let processor_batch_size = self.service_context.processor_batch_size;
         let output_batch_size = self.service_context.output_batch_size;
+        let transaction_channel_size = self.service_context.transaction_channel_size;
         let ledger_chain_id = context.chain_id().id();
         let transactions_count = r.transactions_count;
-        // Creates a channel to send the stream to the client
-        let (tx, mut rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
-        let (external_service_tx, external_service_rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
+        // Creates a channel to send the stream to the client.
+        let (tx, mut rx) = mpsc::channel(transaction_channel_size);
+        let (external_service_tx, external_service_rx) = mpsc::channel(transaction_channel_size);
 
         tokio::spawn(async move {
-            // Initialize the coordinator that tracks starting version and processes transactions
+            // Initialize the coordinator that tracks starting version and processes transactions.
             let mut coordinator = IndexerStreamCoordinator::new(
                 context,
                 starting_version,
                 ending_version,
-                // Performance is not important for raw data, and to make sure data is in order,
-                // single thread is used.
-                1,
+                processor_task_count,
                 processor_batch_size,
                 output_batch_size,
                 tx.clone(),

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
@@ -6,7 +6,7 @@ use crate::{
     ServiceContext,
 };
 use aptos_api::context::Context;
-use aptos_config::config::NodeConfig;
+use aptos_config::config::{get_default_processor_task_count, NodeConfig};
 use aptos_logger::info;
 use aptos_mempool::MempoolClientSender;
 use aptos_protos::{
@@ -51,9 +51,13 @@ pub fn bootstrap(
 
     let address = node_config.indexer_grpc.address;
     let use_data_service_interface = node_config.indexer_grpc.use_data_service_interface;
-    let processor_task_count = node_config.indexer_grpc.processor_task_count;
+    let processor_task_count = node_config
+        .indexer_grpc
+        .processor_task_count
+        .unwrap_or_else(|| get_default_processor_task_count(use_data_service_interface));
     let processor_batch_size = node_config.indexer_grpc.processor_batch_size;
     let output_batch_size = node_config.indexer_grpc.output_batch_size;
+    let transaction_channel_size = node_config.indexer_grpc.transaction_channel_size;
 
     runtime.spawn(async move {
         let context = Arc::new(Context::new(
@@ -68,6 +72,7 @@ pub fn bootstrap(
             processor_task_count,
             processor_batch_size,
             output_batch_size,
+            transaction_channel_size,
         };
         // If we are here, we know indexer grpc is enabled.
         let server = FullnodeDataService {


### PR DESCRIPTION
## Description
This PR makes it possible to configure the worker count for the data service interface on the node, and the txn channel size in general. This is useful for cases in production where we stream directly from a fullnode (e.g. for Shelby).

## How Has This Been Tested?
Just CI.

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [x] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
