### PR TITLE
[vm] Gas charging optimizations

### DIFF
--- a/aptos-move/aptos-gas-meter/src/algebra.rs
+++ b/aptos-move/aptos-gas-meter/src/algebra.rs
@@ -107,29 +107,6 @@ where
     }
 }
 
-impl<T> StandardGasAlgebra<'_, T>
-where
-    T: BlockSynchronizationKillSwitch,
-{
-    #[inline(always)]
-    fn charge(&mut self, amount: InternalGas) -> (InternalGas, PartialVMResult<()>) {
-        match self.balance.checked_sub(amount) {
-            Some(new_balance) => {
-                self.balance = new_balance;
-                (amount, Ok(()))
-            },
-            None => {
-                let old_balance = self.balance;
-                self.balance = 0.into();
-                (
-                    old_balance,
-                    Err(PartialVMError::new(StatusCode::OUT_OF_GAS)),
-                )
-            },
-        }
-    }
-}
-
 impl<T> GasAlgebra for StandardGasAlgebra<'_, T>
 where
     T: BlockSynchronizationKillSwitch,
@@ -209,15 +186,21 @@ where
 
         let amount = abstract_amount.evaluate(self.feature_version, &self.vm_gas_params);
 
-        let (actual, res) = self.charge(amount);
-        if self.feature_version >= 12 {
-            self.execution_gas_used += actual;
-        }
-        res?;
+        match self.balance.checked_sub(amount) {
+            Some(new_balance) => {
+                self.balance = new_balance;
+                self.execution_gas_used += amount;
+            },
+            None => {
+                let old_balance = self.balance;
+                self.balance = 0.into();
+                if self.feature_version >= 12 {
+                    self.execution_gas_used += old_balance;
+                }
+                return Err(PartialVMError::new(StatusCode::OUT_OF_GAS));
+            },
+        };
 
-        if self.feature_version < 12 {
-            self.execution_gas_used += amount;
-        }
         if self.feature_version >= 7 && self.execution_gas_used > self.max_execution_gas {
             Err(PartialVMError::new(StatusCode::EXECUTION_LIMIT_REACHED))
         } else {
@@ -231,15 +214,21 @@ where
     ) -> PartialVMResult<()> {
         let amount = abstract_amount.evaluate(self.feature_version, &self.vm_gas_params);
 
-        let (actual, res) = self.charge(amount);
-        if self.feature_version >= 12 {
-            self.io_gas_used += actual;
-        }
-        res?;
+        match self.balance.checked_sub(amount) {
+            Some(new_balance) => {
+                self.balance = new_balance;
+                self.io_gas_used += amount;
+            },
+            None => {
+                let old_balance = self.balance;
+                self.balance = 0.into();
+                if self.feature_version >= 12 {
+                    self.io_gas_used += old_balance;
+                }
+                return Err(PartialVMError::new(StatusCode::OUT_OF_GAS));
+            },
+        };
 
-        if self.feature_version < 12 {
-            self.io_gas_used += amount;
-        }
         if self.feature_version >= 7 && self.io_gas_used > self.max_io_gas {
             Err(PartialVMError::new(StatusCode::IO_LIMIT_REACHED))
         } else {
@@ -284,17 +273,23 @@ where
             },
         );
 
-        let (actual, res) = self.charge(gas_consumed_internal);
-        if self.feature_version >= 12 {
-            self.storage_fee_in_internal_units += actual;
-            self.storage_fee_used += amount;
-        }
-        res?;
+        match self.balance.checked_sub(gas_consumed_internal) {
+            Some(new_balance) => {
+                self.balance = new_balance;
+                self.storage_fee_in_internal_units += gas_consumed_internal;
+                self.storage_fee_used += amount;
+            },
+            None => {
+                let old_balance = self.balance;
+                self.balance = 0.into();
+                if self.feature_version >= 12 {
+                    self.storage_fee_in_internal_units += old_balance;
+                    self.storage_fee_used += amount;
+                }
+                return Err(PartialVMError::new(StatusCode::OUT_OF_GAS));
+            },
+        };
 
-        if self.feature_version < 12 {
-            self.storage_fee_in_internal_units += gas_consumed_internal;
-            self.storage_fee_used += amount;
-        }
         if self.feature_version >= 7 && self.storage_fee_used > self.max_storage_fee {
             return Err(PartialVMError::new(StatusCode::STORAGE_LIMIT_REACHED));
         }

--- a/third_party/move/move-vm/runtime/src/frame_type_cache.rs
+++ b/third_party/move/move-vm/runtime/src/frame_type_cache.rs
@@ -70,7 +70,7 @@ pub(crate) struct FrameTypeCache {
 }
 
 macro_rules! get_or_insert {
-    ($map: expr, $idx: expr, $ty_func: tt) => {
+    ($map:expr, $idx:expr, $ty_func:tt) => {
         match $map.entry($idx) {
             std::collections::btree_map::Entry::Occupied(entry) => entry.into_mut(),
             std::collections::btree_map::Entry::Vacant(entry) => {


### PR DESCRIPTION
Non-controversial bits of https://github.com/aptos-labs/aptos-core/pull/17979

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Inline gas charging logic and introduce a `get_or_insert!` macro to streamline VM cache lookups and reduce overhead.
> 
> - **Gas Meter (`aptos-move/aptos-gas-meter/src/algebra.rs`)**:
>   - Inline balance deduction and usage accounting in `charge_execution`, `charge_io`, and `charge_storage_fee`, removing the internal `charge` helper.
>   - Adjust out-of-gas handling and counters (feature-gated updates for `>= 12`), preserving execution/IO/storage limits.
> - **Move VM (`third_party/move/move-vm/runtime/src/frame_type_cache.rs`)**:
>   - Add `get_or_insert!` macro for `BTreeMap` cache insertions.
>   - Update all `FrameTypeCache` getters to use the macro for field/variant/struct/signature caches, reducing call overhead while keeping behaviors intact.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fcb43d5e205d249610fdbdeda697949f0520dcef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->