### PR TITLE
Add EPILOGUE_ECANT_PAY_GAS_DEPOSIT constant

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/transaction_validation.move
+++ b/aptos-move/framework/aptos-framework/sources/transaction_validation.move
@@ -71,6 +71,7 @@ module aptos_framework::transaction_validation {
     const PROLOGUE_PERMISSIONED_GAS_LIMIT_INSUFFICIENT: u64 = 1011;
     const PROLOGUE_ENONCE_ALREADY_USED: u64 = 1012;
     const PROLOGUE_ETRANSACTION_EXPIRATION_TOO_FAR_IN_FUTURE: u64 = 1013;
+    const EPILOGUE_ECANT_PAY_GAS_DEPOSIT: u64 = 1014;
 
     /// Permission management
     ///
@@ -609,12 +610,12 @@ module aptos_framework::transaction_validation {
             if (features::operations_default_to_fa_apt_store_enabled()) {
                 assert!(
                     aptos_account::is_fungible_balance_at_least(gas_payer, transaction_fee_amount),
-                    error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    error::out_of_range(EPILOGUE_ECANT_PAY_GAS_DEPOSIT),
                 );
             } else {
                 assert!(
                     coin::is_balance_at_least<AptosCoin>(gas_payer, transaction_fee_amount),
-                    error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    error::out_of_range(EPILOGUE_ECANT_PAY_GAS_DEPOSIT),
                 );
             };
 
@@ -829,12 +830,12 @@ module aptos_framework::transaction_validation {
             if (features::operations_default_to_fa_apt_store_enabled()) {
                 assert!(
                     aptos_account::is_fungible_balance_at_least(gas_payer_address, transaction_fee_amount),
-                    error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    error::out_of_range(EPILOGUE_ECANT_PAY_GAS_DEPOSIT),
                 );
             } else {
                 assert!(
                     coin::is_balance_at_least<AptosCoin>(gas_payer_address, transaction_fee_amount),
-                    error::out_of_range(PROLOGUE_ECANT_PAY_GAS_DEPOSIT),
+                    error::out_of_range(EPILOGUE_ECANT_PAY_GAS_DEPOSIT),
                 );
             };
 


### PR DESCRIPTION
wrong error code in epilogue


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `EPILOGUE_ECANT_PAY_GAS_DEPOSIT (1014)` and switches epilogue gas payment assertions to use it.
> 
> - **Aptos Move (`aptos-framework/sources/transaction_validation.move`)**:
>   - **Constant**: Add `EPILOGUE_ECANT_PAY_GAS_DEPOSIT: 1014`.
>   - **Epilogue checks**: Replace `PROLOGUE_ECANT_PAY_GAS_DEPOSIT` with `EPILOGUE_ECANT_PAY_GAS_DEPOSIT` in balance assertions within `epilogue_gas_payer_extended` and `unified_epilogue_v2` for both `aptos_account::is_fungible_balance_at_least` and `coin::is_balance_at_least<AptosCoin>`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8599f75e17c04ac83d154d4b4889ac845052d32d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->