### PR TITLE
[State Sync] Bump max message size from 15MB to 20MB.

### DIFF
--- a/config/src/config/state_sync_config.rs
+++ b/config/src/config/state_sync_config.rs
@@ -18,7 +18,7 @@ const ENABLE_SIZE_AND_TIME_AWARE_CHUNKING: bool = true;
 const SERVER_MAX_MESSAGE_SIZE: usize = 10 * 1024 * 1024; // 10 MiB
 
 // The maximum message size per state sync message (for v2 data requests)
-const CLIENT_MAX_MESSAGE_SIZE_V2: usize = 15 * 1024 * 1024; // 15 MiB (used for v2 data requests)
+const CLIENT_MAX_MESSAGE_SIZE_V2: usize = 20 * 1024 * 1024; // 20 MiB (used for v2 data requests)
 const SERVER_MAX_MESSAGE_SIZE_V2: usize = 40 * 1024 * 1024; // 40 MiB (used for v2 data requests)
 
 // The maximum chunk sizes for data client requests and response


### PR DESCRIPTION
## Description
This PR bumps the max state sync message size from 15MB to 20MB. This helps to favor output syncing when running intelligent syncing mode.

## Test Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Increase v2 client max state sync message size from 15 MiB to 20 MiB.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b049dbb9371e6d01d3c40591f5bb21a46cc2ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->