### PR TITLE
Rust 1.90

### DIFF
--- a/aptos-move/block-executor/src/unit_tests/mod.rs
+++ b/aptos-move/block-executor/src/unit_tests/mod.rs
@@ -605,7 +605,7 @@ where
 
 fn random_value(delete_value: bool) -> ValueType {
     ValueType::from_value(
-        (0..32).map(|_| (random::<u8>())).collect::<Vec<u8>>(),
+        (0..32).map(|_| random::<u8>()).collect::<Vec<u8>>(),
         !delete_value,
     )
 }

--- a/aptos-move/e2e-move-tests/src/aptos_governance.rs
+++ b/aptos-move/e2e-move-tests/src/aptos_governance.rs
@@ -5,27 +5,9 @@ use crate::harness::MoveHarness;
 use aptos_cached_packages::aptos_stdlib;
 use aptos_language_e2e_tests::account::Account;
 use aptos_types::{
-    account_address::AccountAddress, move_utils::MemberId, state_store::table::TableHandle,
-    transaction::TransactionStatus,
+    account_address::AccountAddress, move_utils::MemberId, transaction::TransactionStatus,
 };
-use serde::{Deserialize, Serialize};
 use std::str::FromStr;
-
-#[derive(Deserialize, Serialize)]
-struct PartialVotingProposals {
-    pub proposals: TableHandle,
-}
-
-#[derive(Deserialize, Serialize)]
-struct RecordKey {
-    pub stake_pool: AccountAddress,
-    pub proposal_id: u64,
-}
-
-#[derive(Deserialize, Serialize)]
-struct VotingRecordsV2 {
-    pub votes: TableHandle,
-}
 
 pub fn create_proposal_v2(
     harness: &mut MoveHarness,

--- a/aptos-move/e2e-move-tests/src/tests/error_map.rs
+++ b/aptos-move/e2e-move-tests/src/tests/error_map.rs
@@ -10,13 +10,6 @@ use aptos_types::{
     transaction::{ExecutionStatus, TransactionStatus},
 };
 use move_core_types::value::MoveValue;
-use serde::{Deserialize, Serialize};
-
-/// Mimics `0xcafe::test::ModuleData`
-#[derive(Serialize, Deserialize)]
-struct ModuleData {
-    state: Vec<u8>,
-}
 
 #[test]
 fn error_map() {

--- a/aptos-move/e2e-move-tests/src/tests/max_loop_depth.rs
+++ b/aptos-move/e2e-move-tests/src/tests/max_loop_depth.rs
@@ -3,13 +3,6 @@
 
 use crate::{assert_success, assert_vm_status, tests::common, MoveHarness};
 use aptos_types::{account_address::AccountAddress, vm_status::StatusCode};
-use serde::{Deserialize, Serialize};
-
-/// Mimics `0xcafe::test::ModuleData`
-#[derive(Serialize, Deserialize)]
-struct ModuleData {
-    state: Vec<u8>,
-}
 
 #[test]
 fn module_loop_depth_at_limit() {

--- a/aptos-move/e2e-move-tests/src/tests/per_category_gas_limits.rs
+++ b/aptos-move/e2e-move-tests/src/tests/per_category_gas_limits.rs
@@ -13,13 +13,7 @@ use aptos_types::{
     vm_status::StatusCode,
 };
 use move_core_types::gas_algebra::{InternalGas, NumBytes};
-use serde::{Deserialize, Serialize};
-
-/// Mimics `0xcafe::test::ModuleData`
-#[derive(Serialize, Deserialize)]
-struct ModuleData {
-    state: Vec<u8>,
-}
+use serde::Serialize;
 
 #[test]
 fn execution_limit_reached() {

--- a/crates/aptos-dkg/src/pvss/chunky/chunks.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/chunks.rs
@@ -7,7 +7,7 @@ use ark_ff::{BigInteger, PrimeField};
 #[allow(dead_code)]
 pub(crate) fn scalar_to_le_chunks<F: PrimeField>(num_bits: u8, scalar: &F) -> Vec<F> {
     assert!(
-        num_bits % 8 == 0 && num_bits > 0 && num_bits <= 64,
+        num_bits.is_multiple_of(8) && num_bits > 0 && num_bits <= 64,
         "Invalid chunk size"
     );
 
@@ -33,7 +33,7 @@ pub(crate) fn scalar_to_le_chunks<F: PrimeField>(num_bits: u8, scalar: &F) -> Ve
 #[allow(dead_code)]
 pub(crate) fn le_chunks_to_scalar<F: PrimeField>(num_bits: u8, chunks: &[F]) -> F {
     assert!(
-        num_bits % 8 == 0 && num_bits > 0 && num_bits <= 64, // TODO: so make num_bits a u8?
+        num_bits.is_multiple_of(8) && num_bits > 0 && num_bits <= 64, // TODO: so make num_bits a u8?
         "Invalid chunk size"
     );
 

--- a/crates/aptos-dkg/src/pvss/chunky/mod.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/mod.rs
@@ -4,7 +4,9 @@
 mod chunked_elgamal;
 mod chunks;
 mod hkzg_chunked_elgamal;
+#[allow(dead_code)] // TODO: remove.
 mod input_secret;
+#[allow(dead_code)] // TODO: remove.
 mod keys;
 mod public_parameters;
 //mod transcript;

--- a/crates/aptos-logger/src/kv.rs
+++ b/crates/aptos-logger/src/kv.rs
@@ -36,9 +36,9 @@ impl Key {
 /// The value part of a logging key value pair e.g. `info!(key = value)`
 #[derive(Clone, Copy)]
 pub enum Value<'v> {
-    Debug(&'v (dyn fmt::Debug)),
-    Display(&'v (dyn fmt::Display)),
-    Serde(&'v (dyn erased_serde::Serialize)),
+    Debug(&'v dyn fmt::Debug),
+    Display(&'v dyn fmt::Display),
+    Serde(&'v dyn erased_serde::Serialize),
 }
 
 impl fmt::Debug for Value<'_> {

--- a/crates/aptos-openapi/src/helpers.rs
+++ b/crates/aptos-openapi/src/helpers.rs
@@ -171,12 +171,14 @@ macro_rules! impl_poem_parameter {
     };
 }
 
+#[cfg(test)]
 mod test {
     #[allow(unused_imports)]
     use poem_openapi::types::ParseFromParameter;
     use serde::{Deserialize, Serialize};
     use std::str::FromStr;
 
+    #[allow(dead_code)]
     #[derive(Debug, Deserialize, Serialize)]
     struct This {
         value: String,

--- a/crates/aptos-rest-client/src/lib.rs
+++ b/crates/aptos-rest-client/src/lib.rs
@@ -22,11 +22,10 @@ pub use aptos_api_types::{
     self, IndexResponseBcs, MoveModuleBytecode, PendingTransaction, Transaction,
 };
 use aptos_api_types::{
-    deserialize_from_string,
     mime_types::{BCS, BCS_SIGNED_TRANSACTION, BCS_VIEW_FUNCTION, JSON},
-    AptosError, AptosErrorCode, BcsBlock, Block, GasEstimation, HexEncodedBytes, IndexResponse,
-    MoveModuleId, TransactionData, TransactionOnChainData, TransactionsBatchSubmissionResult,
-    UserTransaction, VersionedEvent, ViewFunction, ViewRequest,
+    AptosError, AptosErrorCode, BcsBlock, Block, GasEstimation, IndexResponse, MoveModuleId,
+    TransactionData, TransactionOnChainData, TransactionsBatchSubmissionResult, UserTransaction,
+    VersionedEvent, ViewFunction, ViewRequest,
 };
 use aptos_crypto::HashValue;
 use aptos_logger::{debug, info, sample, sample::SampleRate};
@@ -1430,23 +1429,6 @@ impl Client {
         start: Option<u64>,
         limit: Option<u16>,
     ) -> Result<Response<Vec<VersionedNewBlockEvent>>> {
-        #[derive(Clone, Debug, Serialize, Deserialize)]
-        pub struct NewBlockEventResponse {
-            hash: String,
-            #[serde(deserialize_with = "deserialize_from_string")]
-            epoch: u64,
-            #[serde(deserialize_with = "deserialize_from_string")]
-            round: u64,
-            #[serde(deserialize_with = "deserialize_from_string")]
-            height: u64,
-            #[serde(deserialize_with = "deserialize_from_prefixed_hex_string")]
-            previous_block_votes_bitvec: HexEncodedBytes,
-            proposer: String,
-            failed_proposer_indices: Vec<String>,
-            #[serde(deserialize_with = "deserialize_from_string")]
-            time_microseconds: u64,
-        }
-
         let response = self
             .get_account_events_bcs(
                 CORE_CODE_ADDRESS,

--- a/crates/aptos-speculative-state-helper/src/tests/proptests.rs
+++ b/crates/aptos-speculative-state-helper/src/tests/proptests.rs
@@ -134,7 +134,7 @@ fn test_counter(counter_ops: Vec<(usize, usize)>, test_total: bool) {
 
     let idx_gen = AtomicUsize::new(0);
     let clear_barriers: Vec<CachePadded<RwLock<usize>>> = (0..num_counters)
-        .map(|_| (CachePadded::new(RwLock::new(0))))
+        .map(|_| CachePadded::new(RwLock::new(0)))
         .collect();
     rayon::scope(|s| {
         for _ in 0..num_workers {
@@ -202,7 +202,7 @@ fn test_events(counter_ops: Vec<(usize, usize)>) {
     let idx_gen = AtomicUsize::new(0);
     let worker_done_cnt = AtomicUsize::new(0);
     let clear_barriers: Vec<CachePadded<RwLock<usize>>> = (0..num_counters)
-        .map(|_| (CachePadded::new(RwLock::new(0))))
+        .map(|_| CachePadded::new(RwLock::new(0)))
         .collect();
     // This is the number of events we expect to be dispatched at the end.
     let recorded_final_event_cnt = AtomicUsize::new(0);

--- a/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-cache-worker/src/worker.rs
@@ -418,7 +418,7 @@ async fn process_streaming_response(
                     let result = join_all(tasks_to_run).await;
                     if result
                         .iter()
-                        .any(|r| (r.is_err() || r.as_ref().unwrap().is_err()))
+                        .any(|r| r.is_err() || r.as_ref().unwrap().is_err())
                     {
                         error!(
                             start_version = start_version,

--- a/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-data-service/src/service.rs
@@ -181,7 +181,7 @@ impl RawData for RawDataServerWrapper {
             SERVICE_TYPE,
             IndexerGrpcStep::DataServiceNewRequestReceived,
             Some(current_version as i64),
-            transactions_count.map(|v| (v as i64 + current_version as i64 - 1)),
+            transactions_count.map(|v| v as i64 + current_version as i64 - 1),
             None,
             None,
             None,

--- a/execution/executor-service/src/lib.rs
+++ b/execution/executor-service/src/lib.rs
@@ -11,6 +11,7 @@ use aptos_types::{
 };
 use serde::{Deserialize, Serialize};
 
+#[allow(dead_code)] // TODO: remove.
 mod error;
 pub mod local_executor_helper;
 mod metrics;

--- a/mempool/src/shared_mempool/types.rs
+++ b/mempool/src/shared_mempool/types.rs
@@ -286,24 +286,6 @@ impl PeerSyncState {
     }
 }
 
-/// Identifier for a broadcasted batch of txns.
-/// For BatchId(`start_id`, `end_id`), (`start_id`, `end_id`) is the range of timeline IDs read from
-/// the core mempool timeline index that produced the txns in this batch.
-#[derive(Clone, Copy, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
-struct BatchId(pub u64, pub u64);
-
-impl PartialOrd for BatchId {
-    fn partial_cmp(&self, other: &BatchId) -> Option<std::cmp::Ordering> {
-        Some(self.cmp(other))
-    }
-}
-
-impl Ord for BatchId {
-    fn cmp(&self, other: &BatchId) -> std::cmp::Ordering {
-        (other.0, other.1).cmp(&(self.0, self.1))
-    }
-}
-
 #[derive(Clone, Debug, Deserialize, Eq, Hash, PartialEq, Serialize)]
 pub struct MultiBucketTimelineIndexIds {
     pub id_per_bucket: Vec<TimelineId>,

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-channel = "1.89.0"
+channel = "1.90.0"
 
 # Note: we don't specify cargofmt in our toolchain because we rely on
 # the nightly version of cargofmt and verify formatting in CI/CD.

--- a/secure/net/src/network_controller/mod.rs
+++ b/secure/net/src/network_controller/mod.rs
@@ -13,6 +13,7 @@ use std::{
 };
 use tokio::{runtime::Runtime, sync::oneshot};
 
+#[allow(dead_code)] // TODO: remove.
 mod error;
 mod inbound_handler;
 pub(crate) mod metrics;

--- a/state-sync/inter-component/event-notifications/src/tests.rs
+++ b/state-sync/inter-component/event-notifications/src/tests.rs
@@ -18,14 +18,12 @@ use aptos_types::{
     contract_event::ContractEvent,
     event::EventKey,
     on_chain_config,
-    on_chain_config::OnChainConfig,
     transaction::{Transaction, Version, WriteSetPayload},
 };
 use aptos_vm::aptos_vm::AptosVMBlockExecutor;
 use claims::{assert_lt, assert_matches, assert_ok};
 use futures::{FutureExt, StreamExt};
 use move_core_types::language_storage::TypeTag;
-use serde::{Deserialize, Serialize};
 use std::{convert::TryInto, str::FromStr, sync::Arc};
 
 #[test]
@@ -415,17 +413,6 @@ fn test_event_v2_subscription_by_tag() {
     // Listener 2 should receive 1 event.
     verify_event_notification_received(vec![&mut listener_2], version, vec![event_1]);
     verify_no_event_notifications(vec![&mut listener_2]);
-}
-
-/// Defines a new on-chain config for test purposes.
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, PartialOrd, Ord, Serialize)]
-pub struct TestOnChainConfig {
-    pub some_value: u64,
-}
-
-impl OnChainConfig for TestOnChainConfig {
-    const MODULE_IDENTIFIER: &'static str = "test_on_chain_config";
-    const TYPE_IDENTIFIER: &'static str = "TestOnChainConfig";
 }
 
 // Counts the number of event notifications received by the listener. Also ensures that

--- a/testsuite/forge/src/interface/prometheus_metrics.rs
+++ b/testsuite/forge/src/interface/prometheus_metrics.rs
@@ -161,7 +161,7 @@ impl LatencyBreakdown {
 }
 
 pub async fn fetch_latency_breakdown(
-    swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+    swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     start_time: u64,
     end_time: u64,
 ) -> anyhow::Result<LatencyBreakdown> {

--- a/testsuite/testcases/src/modifiers.rs
+++ b/testsuite/testcases/src/modifiers.rs
@@ -13,7 +13,7 @@ use rand::Rng;
 use std::sync::Arc;
 
 async fn add_execution_delay(
-    swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+    swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     config: &ExecutionDelayConfig,
 ) -> anyhow::Result<()> {
     let validators = { swarm.read().await.get_validator_clients_with_names() };
@@ -52,7 +52,7 @@ async fn add_execution_delay(
 }
 
 async fn remove_execution_delay(
-    swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+    swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
 ) -> anyhow::Result<()> {
     let validators = { swarm.read().await.get_validator_clients_with_names() };
 
@@ -229,7 +229,7 @@ impl CpuChaosTest {
     /// not the fullnodes).
     async fn create_cpu_chaos(
         &self,
-        swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+        swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     ) -> SwarmCpuStress {
         let all_validators = swarm
             .read()

--- a/testsuite/testcases/src/multi_region_network_test.rs
+++ b/testsuite/testcases/src/multi_region_network_test.rs
@@ -281,7 +281,7 @@ impl MultiRegionNetworkEmulationTest {
     /// the fullnodes).
     async fn create_netem_chaos(
         &self,
-        swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+        swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     ) -> SwarmNetEm {
         let (all_validators, all_vfns) = {
             let swarm = swarm.read().await;

--- a/testsuite/testcases/src/public_fullnode_performance.rs
+++ b/testsuite/testcases/src/public_fullnode_performance.rs
@@ -59,7 +59,7 @@ impl PFNPerformance {
     /// to all validators, VFNs and PFNs in the swarm.
     async fn create_cpu_chaos(
         &self,
-        swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+        swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     ) -> SwarmCpuStress {
         // Gather and shuffle all peers IDs (so that we get random CPU chaos)
         let shuffled_peer_ids = self.gather_and_shuffle_peer_ids(swarm).await;
@@ -72,7 +72,7 @@ impl PFNPerformance {
     /// is added to all validators, VFNs and PFNs in the swarm.
     async fn create_network_emulation_chaos(
         &self,
-        swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+        swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     ) -> SwarmNetEm {
         // Gather and shuffle all peers IDs (so that we get random network emulation)
         let shuffled_peer_ids = self
@@ -86,7 +86,7 @@ impl PFNPerformance {
     /// Gathers and shuffles all peer IDs in the swarm
     async fn gather_and_shuffle_peer_ids(
         &self,
-        swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+        swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     ) -> Vec<AccountAddress> {
         // Identify the validators and fullnodes in the swarm
         let (validator_peer_ids, fullnode_peer_ids) = {
@@ -110,7 +110,7 @@ impl PFNPerformance {
     /// Gathers and shuffles all peer IDs in the swarm, colocating VFNs with their validator
     async fn gather_and_shuffle_peer_ids_with_colocation(
         &self,
-        swarm: Arc<tokio::sync::RwLock<Box<(dyn Swarm)>>>,
+        swarm: Arc<tokio::sync::RwLock<Box<dyn Swarm>>>,
     ) -> Vec<Vec<AccountAddress>> {
         // Identify the validators and fullnodes in the swarm
         let (validator_peer_ids, fullnode_peer_ids) = {

--- a/third_party/move/move-core/types/src/gas_algebra.rs
+++ b/third_party/move/move-core/types/src/gas_algebra.rs
@@ -270,7 +270,7 @@ fn apply_ratio_round_up(val: u64, nominator: u64, denominator: u64) -> u64 {
     let n = val as u128 * nominator as u128;
     let d = denominator as u128;
 
-    let res = n / d + if n % d == 0 { 0 } else { 1 };
+    let res = n / d + if n.is_multiple_of(d) { 0 } else { 1 };
     if res > u64::MAX as u128 {
         u64::MAX
     } else {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Upgrade toolchain to Rust 1.90.0 and make widespread minor refactors/lint fixes (trait object refs, type signatures, unused code removals, small logic cleanups) across crates and tests.
> 
> - **Toolchain**:
>   - Update `rust-toolchain.toml` to `channel = "1.90.0"`.
> - **Core libs and utils**:
>   - `aptos-logger`: simplify trait object refs in `Value` (`&dyn`), no behavior change.
>   - `move-core gas_algebra`: use `is_multiple_of` in rounding logic.
>   - `aptos-dkg chunky`: validate chunk size using `is_multiple_of(8)`.
> - **REST Client** (`crates/aptos-rest-client`):
>   - Clean imports; remove unused local struct in `get_new_block_events_bcs`; simplify deserialization paths.
> - **Indexer (gRPC)**:
>   - Cache worker/data service: minor logic simplifications (e.g., `any(...)` condition, mapping arithmetic) and tracing param tweaks.
> - **OpenAPI helpers**:
>   - Gate tests with `#[cfg(test)]`; add minor `allow(dead_code)` in test struct.
> - **Execution/Networking**:
>   - Add `#[allow(dead_code)]` on internal modules in executor service and network controller.
> - **Mempool**:
>   - Remove unused `BatchId` type; no functional changes to message id handling.
> - **Tests and harnesses**:
>   - Remove unused serde structs/imports; adjust signatures to `Box<dyn Swarm>`; small iterator/closure cleanups; minor randomness/map/parens tweaks.
> - **Misc**:
>   - Minor style fixes (e.g., remove redundant parens, iterator usage) across various modules and tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 15498143f91a45dcf34f71a7a5707180318e38df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->