### PR TITLE
[qs] Make ProofOfStore and SignedBatchInfo generic over BatchInfo

### DIFF
--- a/consensus/consensus-types/src/common.rs
+++ b/consensus/consensus-types/src/common.rs
@@ -127,11 +127,11 @@ pub struct RejectedTransactionSummary {
 
 #[derive(Deserialize, Serialize, Clone, Debug, PartialEq, Eq)]
 pub struct ProofWithData {
-    pub proofs: Vec<ProofOfStore>,
+    pub proofs: Vec<ProofOfStore<BatchInfo>>,
 }
 
 impl ProofWithData {
-    pub fn new(proofs: Vec<ProofOfStore>) -> Self {
+    pub fn new(proofs: Vec<ProofOfStore<BatchInfo>>) -> Self {
         Self { proofs }
     }
 
@@ -516,9 +516,9 @@ impl Payload {
     }
 
     fn verify_with_cache(
-        proofs: &[ProofOfStore],
+        proofs: &[ProofOfStore<BatchInfo>],
         validator: &ValidatorVerifier,
-        proof_cache: &ProofCache,
+        proof_cache: &ProofCache<BatchInfo>,
     ) -> anyhow::Result<()> {
         let unverified: Vec<_> = proofs
             .iter()
@@ -571,7 +571,7 @@ impl Payload {
     pub fn verify(
         &self,
         verifier: &ValidatorVerifier,
-        proof_cache: &ProofCache,
+        proof_cache: &ProofCache<BatchInfo>,
         quorum_store_enabled: bool,
     ) -> anyhow::Result<()> {
         match (quorum_store_enabled, self) {

--- a/consensus/consensus-types/src/opt_proposal_msg.rs
+++ b/consensus/consensus-types/src/opt_proposal_msg.rs
@@ -3,7 +3,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::Author, opt_block_data::OptBlockData, proof_of_store::ProofCache, sync_info::SyncInfo,
+    common::Author,
+    opt_block_data::OptBlockData,
+    proof_of_store::{BatchInfo, ProofCache},
+    sync_info::SyncInfo,
 };
 use anyhow::{ensure, Context, Result};
 use aptos_types::validator_verifier::ValidatorVerifier;
@@ -98,7 +101,7 @@ impl OptProposalMsg {
         &self,
         sender: Author,
         validator: &ValidatorVerifier,
-        proof_cache: &ProofCache,
+        proof_cache: &ProofCache<BatchInfo>,
         quorum_store_enabled: bool,
     ) -> Result<()> {
         ensure!(

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -13,7 +13,7 @@ use std::{
 
 pub type OptBatches = BatchPointer<BatchInfo>;
 
-pub type ProofBatches = BatchPointer<ProofOfStore>;
+pub type ProofBatches = BatchPointer<ProofOfStore<BatchInfo>>;
 
 pub trait TDataInfo {
     fn num_txns(&self) -> u64;
@@ -386,7 +386,7 @@ impl OptQuorumStorePayload {
         &self.inline_batches
     }
 
-    pub fn proof_with_data(&self) -> &BatchPointer<ProofOfStore> {
+    pub fn proof_with_data(&self) -> &BatchPointer<ProofOfStore<BatchInfo>> {
         &self.proofs
     }
 

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -2,7 +2,12 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{block::Block, common::Author, proof_of_store::ProofCache, sync_info::SyncInfo};
+use crate::{
+    block::Block,
+    common::Author,
+    proof_of_store::{BatchInfo, ProofCache},
+    sync_info::SyncInfo,
+};
 use anyhow::{anyhow, ensure, format_err, Context, Result};
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::validator_verifier::ValidatorVerifier;
@@ -84,7 +89,7 @@ impl ProposalMsg {
         &self,
         sender: Author,
         validator: &ValidatorVerifier,
-        proof_cache: &ProofCache,
+        proof_cache: &ProofCache<BatchInfo>,
         quorum_store_enabled: bool,
     ) -> Result<()> {
         if let Some(proposal_author) = self.proposal.author() {

--- a/consensus/src/consensus_observer/network/observer_message.rs
+++ b/consensus/src/consensus_observer/network/observer_message.rs
@@ -379,11 +379,11 @@ impl CommitDecision {
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 pub struct PayloadWithProof {
     transactions: Vec<SignedTransaction>,
-    proofs: Vec<ProofOfStore>,
+    proofs: Vec<ProofOfStore<BatchInfo>>,
 }
 
 impl PayloadWithProof {
-    pub fn new(transactions: Vec<SignedTransaction>, proofs: Vec<ProofOfStore>) -> Self {
+    pub fn new(transactions: Vec<SignedTransaction>, proofs: Vec<ProofOfStore<BatchInfo>>) -> Self {
         Self {
             transactions,
             proofs,
@@ -439,7 +439,7 @@ impl TransactionsWithProof {
         }
     }
 
-    pub fn proofs(&self) -> Vec<ProofOfStore> {
+    pub fn proofs(&self) -> Vec<ProofOfStore<BatchInfo>> {
         match self {
             TransactionsWithProof::TransactionsWithProofAndLimits(payload) => {
                 payload.payload_with_proof.proofs.clone()
@@ -512,7 +512,7 @@ impl BlockTransactionPayload {
     /// Creates a returns a new InQuorumStore transaction payload
     pub fn new_in_quorum_store(
         transactions: Vec<SignedTransaction>,
-        proofs: Vec<ProofOfStore>,
+        proofs: Vec<ProofOfStore<BatchInfo>>,
     ) -> Self {
         let payload_with_proof = PayloadWithProof::new(transactions, proofs);
         Self::DeprecatedInQuorumStore(payload_with_proof)
@@ -521,7 +521,7 @@ impl BlockTransactionPayload {
     /// Creates a returns a new InQuorumStoreWithLimit transaction payload
     pub fn new_in_quorum_store_with_limit(
         transactions: Vec<SignedTransaction>,
-        proofs: Vec<ProofOfStore>,
+        proofs: Vec<ProofOfStore<BatchInfo>>,
         limit: Option<u64>,
     ) -> Self {
         let payload_with_proof = PayloadWithProof::new(transactions, proofs);
@@ -532,7 +532,7 @@ impl BlockTransactionPayload {
     /// Creates a returns a new QuorumStoreInlineHybrid transaction payload
     pub fn new_quorum_store_inline_hybrid(
         transactions: Vec<SignedTransaction>,
-        proofs: Vec<ProofOfStore>,
+        proofs: Vec<ProofOfStore<BatchInfo>>,
         transaction_limit: Option<u64>,
         gas_limit: Option<u64>,
         inline_batches: Vec<BatchInfo>,
@@ -557,7 +557,7 @@ impl BlockTransactionPayload {
 
     pub fn new_opt_quorum_store(
         transactions: Vec<SignedTransaction>,
-        proofs: Vec<ProofOfStore>,
+        proofs: Vec<ProofOfStore<BatchInfo>>,
         transaction_limit: Option<u64>,
         gas_limit: Option<u64>,
         batch_infos: Vec<BatchInfo>,
@@ -613,7 +613,7 @@ impl BlockTransactionPayload {
     }
 
     /// Returns the proofs of the transaction payload
-    pub fn payload_proofs(&self) -> Vec<ProofOfStore> {
+    pub fn payload_proofs(&self) -> Vec<ProofOfStore<BatchInfo>> {
         match self {
             BlockTransactionPayload::DeprecatedInQuorumStore(payload) => payload.proofs.clone(),
             BlockTransactionPayload::DeprecatedInQuorumStoreWithLimit(payload) => {
@@ -715,7 +715,7 @@ impl BlockTransactionPayload {
     }
 
     /// Verifies the payload batches against the expected batches
-    fn verify_batches(&self, expected_proofs: &[ProofOfStore]) -> Result<(), Error> {
+    fn verify_batches(&self, expected_proofs: &[ProofOfStore<BatchInfo>]) -> Result<(), Error> {
         // Get the batches in the block transaction payload
         let payload_proofs = self.payload_proofs();
         let payload_batches: Vec<&BatchInfo> =
@@ -1854,7 +1854,7 @@ mod test {
     fn create_block_payload(
         block_info: Option<BlockInfo>,
         signed_transactions: &[SignedTransaction],
-        proofs: &[ProofOfStore],
+        proofs: &[ProofOfStore<BatchInfo>],
         inline_batches: &[BatchInfo],
     ) -> BlockPayload {
         // Create the transaction payload
@@ -1878,7 +1878,7 @@ mod test {
     fn create_block_optqs_payload(
         block_info: Option<BlockInfo>,
         signed_transactions: &[SignedTransaction],
-        proofs: &[ProofOfStore],
+        proofs: &[ProofOfStore<BatchInfo>],
         opt_and_inline_batches: &[BatchInfo],
     ) -> BlockPayload {
         // Create the transaction payload
@@ -1910,7 +1910,7 @@ mod test {
     fn create_mixed_expiration_proofs(
         block_timestamp: u64,
         signed_transactions: &[SignedTransaction],
-    ) -> (Vec<ProofOfStore>, Vec<SignedTransaction>) {
+    ) -> (Vec<ProofOfStore<BatchInfo>>, Vec<SignedTransaction>) {
         let mut proofs = vec![];
         let mut non_expired_transactions = vec![];
 

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -66,7 +66,7 @@ use aptos_consensus_types::{
     block_retrieval::BlockRetrievalRequest,
     common::{Author, Round},
     epoch_retrieval::EpochRetrievalRequest,
-    proof_of_store::ProofCache,
+    proof_of_store::{BatchInfo, ProofCache},
     utils::PayloadTxnsSize,
 };
 use aptos_crypto::bls12381::PrivateKey;
@@ -172,7 +172,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     dag_config: DagConsensusConfig,
     payload_manager: Arc<dyn TPayloadManager>,
     rand_storage: Arc<dyn RandStorage<AugmentedData>>,
-    proof_cache: ProofCache,
+    proof_cache: ProofCache<BatchInfo>,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
     pending_blocks: Arc<Mutex<PendingBlocks>>,
     key_storage: PersistentSafetyStorage,

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -17,7 +17,7 @@ use aptos_consensus_types::{
     opt_proposal_msg::OptProposalMsg,
     order_vote_msg::OrderVoteMsg,
     pipeline::{commit_decision::CommitDecision, commit_vote::CommitVote},
-    proof_of_store::{ProofOfStoreMsg, SignedBatchInfoMsg},
+    proof_of_store::{BatchInfo, ProofOfStoreMsg, SignedBatchInfoMsg},
     proposal_msg::ProposalMsg,
     round_timeout::RoundTimeoutMsg,
     sync_info::SyncInfo,
@@ -71,9 +71,9 @@ pub enum ConsensusMsg {
     BatchResponse(Box<Batch>),
     /// Quorum Store: Send a signed batch digest. This is a vote for the batch and a promise that
     /// the batch of transactions was received and will be persisted until batch expiration.
-    SignedBatchInfo(Box<SignedBatchInfoMsg>),
+    SignedBatchInfo(Box<SignedBatchInfoMsg<BatchInfo>>),
     /// Quorum Store: Broadcast a certified proof of store (a digest that received 2f+1 votes).
-    ProofOfStoreMsg(Box<ProofOfStoreMsg>),
+    ProofOfStoreMsg(Box<ProofOfStoreMsg<BatchInfo>>),
     /// DAG protocol message
     DAGMessage(DAGNetworkMessage),
     /// Commit message

--- a/consensus/src/quorum_store/batch_proof_queue.rs
+++ b/consensus/src/quorum_store/batch_proof_queue.rs
@@ -37,7 +37,7 @@ struct QueueItem {
 
     /// Contains the proof associated with the batch.
     /// It is optional as the proof can be updated after the summary.
-    proof: Option<ProofOfStore>,
+    proof: Option<ProofOfStore<BatchInfo>>,
     /// The time when the proof is inserted into this item.
     proof_insertion_time: Option<Instant>,
 }
@@ -173,7 +173,7 @@ impl BatchProofQueue {
     }
 
     /// Add the ProofOfStore to proof queue.
-    pub(crate) fn insert_proof(&mut self, proof: ProofOfStore) {
+    pub(crate) fn insert_proof(&mut self, proof: ProofOfStore<BatchInfo>) {
         if proof.expiration() <= self.latest_block_timestamp {
             counters::inc_rejected_pos_count(counters::POS_EXPIRED_LABEL);
             return;
@@ -342,7 +342,7 @@ impl BatchProofQueue {
     fn log_remaining_data_after_pull(
         &self,
         excluded_batches: &HashSet<BatchInfo>,
-        pulled_proofs: &[ProofOfStore],
+        pulled_proofs: &[ProofOfStore<BatchInfo>],
     ) {
         let mut num_proofs_remaining_after_pull = 0;
         let mut num_txns_remaining_after_pull = 0;
@@ -406,7 +406,7 @@ impl BatchProofQueue {
         soft_max_txns_after_filtering: u64,
         return_non_full: bool,
         block_timestamp: Duration,
-    ) -> (Vec<ProofOfStore>, PayloadTxnsSize, u64, bool) {
+    ) -> (Vec<ProofOfStore<BatchInfo>>, PayloadTxnsSize, u64, bool) {
         let (result, all_txns, unique_txns, is_full) = self.pull_internal(
             false,
             excluded_batches,

--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -381,7 +381,7 @@ impl BatchStore {
     fn generate_signed_batch_info(
         &self,
         batch_info: BatchInfo,
-    ) -> Result<SignedBatchInfo, CryptoMaterialError> {
+    ) -> Result<SignedBatchInfo<BatchInfo>, CryptoMaterialError> {
         fail_point!("quorum_store::create_invalid_signed_batch_info", |_| {
             Ok(SignedBatchInfo::new_with_signature(
                 batch_info.clone(),
@@ -392,7 +392,7 @@ impl BatchStore {
         SignedBatchInfo::new(batch_info, &self.validator_signer)
     }
 
-    fn persist_inner(&self, persist_request: PersistedValue) -> Option<SignedBatchInfo> {
+    fn persist_inner(&self, persist_request: PersistedValue) -> Option<SignedBatchInfo<BatchInfo>> {
         match self.save(&persist_request) {
             Ok(needs_db) => {
                 let batch_info = persist_request.batch_info().clone();
@@ -483,7 +483,7 @@ impl BatchStore {
 }
 
 impl BatchWriter for BatchStore {
-    fn persist(&self, persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo> {
+    fn persist(&self, persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo<BatchInfo>> {
         let mut signed_infos = vec![];
         for persist_request in persist_requests.into_iter() {
             if let Some(signed_info) = self.persist_inner(persist_request.clone()) {
@@ -610,5 +610,5 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchReader for Batch
 }
 
 pub trait BatchWriter: Send + Sync {
-    fn persist(&self, persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo>;
+    fn persist(&self, persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo<BatchInfo>>;
 }

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -21,7 +21,7 @@ use std::{cmp::min, collections::HashSet, sync::Arc, time::Duration};
 
 #[derive(Debug)]
 pub enum ProofManagerCommand {
-    ReceiveProofs(ProofOfStoreMsg),
+    ReceiveProofs(ProofOfStoreMsg<BatchInfo>),
     ReceiveBatches(Vec<(BatchInfo, Vec<TxnSummaryWithExpiration>)>),
     CommitNotification(u64, Vec<BatchInfo>),
     Shutdown(tokio::sync::oneshot::Sender<()>),
@@ -62,7 +62,7 @@ impl ProofManager {
         }
     }
 
-    pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore>) {
+    pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore<BatchInfo>>) {
         for proof in proofs.into_iter() {
             self.batch_proof_queue.insert_proof(proof);
         }

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -30,7 +30,9 @@ use crate::{
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{BatchTransactionFilterConfig, QuorumStoreConfig};
 use aptos_consensus_types::{
-    common::Author, proof_of_store::ProofCache, request_response::GetPayloadCommand,
+    common::Author,
+    proof_of_store::{BatchInfo, ProofCache},
+    request_response::GetPayloadCommand,
 };
 use aptos_crypto::bls12381::PrivateKey;
 use aptos_logger::prelude::*;
@@ -132,7 +134,7 @@ pub struct InnerBuilder {
     aptos_db: Arc<dyn DbReader>,
     network_sender: NetworkSender,
     verifier: Arc<ValidatorVerifier>,
-    proof_cache: ProofCache,
+    proof_cache: ProofCache<BatchInfo>,
     coordinator_tx: Sender<CoordinatorCommand>,
     coordinator_rx: Option<Receiver<CoordinatorCommand>>,
     batch_generator_cmd_tx: tokio::sync::mpsc::Sender<BatchGeneratorCommand>,
@@ -168,7 +170,7 @@ impl InnerBuilder {
         aptos_db: Arc<dyn DbReader>,
         network_sender: NetworkSender,
         verifier: Arc<ValidatorVerifier>,
-        proof_cache: ProofCache,
+        proof_cache: ProofCache<BatchInfo>,
         quorum_store_storage: Arc<dyn QuorumStoreStorage>,
         broadcast_proofs: bool,
         consensus_key: Arc<PrivateKey>,

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -14,7 +14,7 @@ use crate::{
 use aptos_config::config::QuorumStoreConfig;
 use aptos_consensus_types::{
     common::{TransactionInProgress, TransactionSummary},
-    proof_of_store::SignedBatchInfo,
+    proof_of_store::{BatchInfo, SignedBatchInfo},
 };
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
 use aptos_types::{quorum_store::BatchId, transaction::SignedTransaction};
@@ -35,7 +35,7 @@ impl MockBatchWriter {
 }
 
 impl BatchWriter for MockBatchWriter {
-    fn persist(&self, _persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo> {
+    fn persist(&self, _persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo<BatchInfo>> {
         vec![]
     }
 }

--- a/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
+++ b/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
@@ -23,7 +23,7 @@ fn proof_of_store(
     batch_id: BatchId,
     gas_bucket_start: u64,
     expiration: u64,
-) -> ProofOfStore {
+) -> ProofOfStore<BatchInfo> {
     ProofOfStore::new(
         BatchInfo::new(
             author,
@@ -45,7 +45,7 @@ fn proof_of_store_with_size(
     gas_bucket_start: u64,
     expiration: u64,
     num_txns: u64,
-) -> ProofOfStore {
+) -> ProofOfStore<BatchInfo> {
     ProofOfStore::new(
         BatchInfo::new(
             author,
@@ -100,7 +100,7 @@ async fn test_proof_queue_sorting() {
     );
     let mut count_author_0 = 0;
     let mut count_author_1 = 0;
-    let mut prev: Option<&ProofOfStore> = None;
+    let mut prev: Option<&ProofOfStore<BatchInfo>> = None;
     for batch in &pulled {
         if let Some(prev) = prev {
             assert!(prev.gas_bucket_start() >= batch.gas_bucket_start());
@@ -129,7 +129,7 @@ async fn test_proof_queue_sorting() {
     );
     let mut count_author_0 = 0;
     let mut count_author_1 = 0;
-    let mut prev: Option<&ProofOfStore> = None;
+    let mut prev: Option<&ProofOfStore<BatchInfo>> = None;
     for batch in &pulled {
         if let Some(prev) = prev {
             assert!(prev.gas_bucket_start() >= batch.gas_bucket_start());

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use aptos_consensus_types::{
     common::Author,
-    proof_of_store::{ProofOfStore, SignedBatchInfo},
+    proof_of_store::{BatchInfo, ProofOfStore, SignedBatchInfo},
 };
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
@@ -56,7 +56,7 @@ impl QuorumStoreSender for MockBatchRequester {
 
     async fn send_signed_batch_info_msg(
         &self,
-        _signed_batch_infos: Vec<SignedBatchInfo>,
+        _signed_batch_infos: Vec<SignedBatchInfo<BatchInfo>>,
         _recipients: Vec<Author>,
     ) {
         unimplemented!()
@@ -66,11 +66,17 @@ impl QuorumStoreSender for MockBatchRequester {
         unimplemented!()
     }
 
-    async fn broadcast_proof_of_store_msg(&mut self, _proof_of_stores: Vec<ProofOfStore>) {
+    async fn broadcast_proof_of_store_msg(
+        &mut self,
+        _proof_of_stores: Vec<ProofOfStore<BatchInfo>>,
+    ) {
         unimplemented!()
     }
 
-    async fn send_proof_of_store_msg_to_self(&mut self, _proof_of_stores: Vec<ProofOfStore>) {
+    async fn send_proof_of_store_msg_to_self(
+        &mut self,
+        _proof_of_stores: Vec<ProofOfStore<BatchInfo>>,
+    ) {
         unimplemented!()
     }
 }

--- a/consensus/src/quorum_store/tests/proof_manager_test.rs
+++ b/consensus/src/quorum_store/tests/proof_manager_test.rs
@@ -20,7 +20,7 @@ fn create_proof_manager() -> ProofManager {
     ProofManager::new(PeerId::random(), 10, 10, batch_store, true, true, 1)
 }
 
-fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOfStore {
+fn create_proof(author: PeerId, expiration: u64, batch_sequence: u64) -> ProofOfStore<BatchInfo> {
     create_proof_with_gas(author, expiration, batch_sequence, 0)
 }
 
@@ -29,7 +29,7 @@ fn create_proof_with_gas(
     expiration: u64,
     batch_sequence: u64,
     gas_bucket_start: u64,
-) -> ProofOfStore {
+) -> ProofOfStore<BatchInfo> {
     let digest = HashValue::random();
     let batch_id = BatchId::new_for_test(batch_sequence);
     ProofOfStore::new(
@@ -72,7 +72,7 @@ async fn get_proposal(
 
 fn assert_payload_response(
     payload: Payload,
-    expected: &[ProofOfStore],
+    expected: &[ProofOfStore<BatchInfo>],
     max_txns_from_block_to_execute: Option<u64>,
     expected_block_gas_limit: Option<u64>,
 ) {
@@ -116,7 +116,7 @@ async fn get_proposal_and_assert(
     proof_manager: &mut ProofManager,
     max_txns: u64,
     filter: &[BatchInfo],
-    expected: &[ProofOfStore],
+    expected: &[ProofOfStore<BatchInfo>],
 ) {
     assert_payload_response(
         get_proposal(proof_manager, max_txns, filter).await,

--- a/consensus/src/round_manager.rs
+++ b/consensus/src/round_manager.rs
@@ -45,7 +45,7 @@ use aptos_consensus_types::{
     order_vote::OrderVote,
     order_vote_msg::OrderVoteMsg,
     pipelined_block::PipelinedBlock,
-    proof_of_store::{ProofCache, ProofOfStoreMsg, SignedBatchInfoMsg},
+    proof_of_store::{BatchInfo, ProofCache, ProofOfStoreMsg, SignedBatchInfoMsg},
     proposal_msg::ProposalMsg,
     quorum_cert::QuorumCert,
     round_timeout::{RoundTimeout, RoundTimeoutMsg, RoundTimeoutReason},
@@ -95,8 +95,8 @@ pub enum UnverifiedEvent {
     OrderVoteMsg(Box<OrderVoteMsg>),
     SyncInfo(Box<SyncInfo>),
     BatchMsg(Box<BatchMsg>),
-    SignedBatchInfo(Box<SignedBatchInfoMsg>),
-    ProofOfStoreMsg(Box<ProofOfStoreMsg>),
+    SignedBatchInfo(Box<SignedBatchInfoMsg<BatchInfo>>),
+    ProofOfStoreMsg(Box<ProofOfStoreMsg<BatchInfo>>),
     OptProposalMsg(Box<OptProposalMsg>),
 }
 
@@ -107,7 +107,7 @@ impl UnverifiedEvent {
         self,
         peer_id: PeerId,
         validator: &ValidatorVerifier,
-        proof_cache: &ProofCache,
+        proof_cache: &ProofCache<BatchInfo>,
         quorum_store_enabled: bool,
         self_message: bool,
         max_num_batches: usize,
@@ -240,8 +240,8 @@ pub enum VerifiedEvent {
     OrderVoteMsg(Box<OrderVoteMsg>),
     UnverifiedSyncInfo(Box<SyncInfo>),
     BatchMsg(Box<BatchMsg>),
-    SignedBatchInfo(Box<SignedBatchInfoMsg>),
-    ProofOfStoreMsg(Box<ProofOfStoreMsg>),
+    SignedBatchInfo(Box<SignedBatchInfoMsg<BatchInfo>>),
+    ProofOfStoreMsg(Box<ProofOfStoreMsg<BatchInfo>>),
     // local messages
     LocalTimeout(Round),
     // Shutdown the NetworkListener

--- a/consensus/src/test_utils/mock_quorum_store_sender.rs
+++ b/consensus/src/test_utils/mock_quorum_store_sender.rs
@@ -8,7 +8,9 @@ use crate::{
 };
 use aptos_consensus_types::{
     common::Author,
-    proof_of_store::{ProofOfStore, ProofOfStoreMsg, SignedBatchInfo, SignedBatchInfoMsg},
+    proof_of_store::{
+        BatchInfo, ProofOfStore, ProofOfStoreMsg, SignedBatchInfo, SignedBatchInfoMsg,
+    },
 };
 use std::time::Duration;
 use tokio::sync::mpsc::Sender;
@@ -37,7 +39,7 @@ impl QuorumStoreSender for MockQuorumStoreSender {
 
     async fn send_signed_batch_info_msg(
         &self,
-        signed_batch_infos: Vec<SignedBatchInfo>,
+        signed_batch_infos: Vec<SignedBatchInfo<BatchInfo>>,
         recipients: Vec<Author>,
     ) {
         self.tx
@@ -55,7 +57,10 @@ impl QuorumStoreSender for MockQuorumStoreSender {
         unimplemented!()
     }
 
-    async fn broadcast_proof_of_store_msg(&mut self, proof_of_stores: Vec<ProofOfStore>) {
+    async fn broadcast_proof_of_store_msg(
+        &mut self,
+        proof_of_stores: Vec<ProofOfStore<BatchInfo>>,
+    ) {
         self.tx
             .send((
                 ConsensusMsg::ProofOfStoreMsg(Box::new(ProofOfStoreMsg::new(proof_of_stores))),
@@ -65,7 +70,10 @@ impl QuorumStoreSender for MockQuorumStoreSender {
             .expect("We should be able to send the proof of store message");
     }
 
-    async fn send_proof_of_store_msg_to_self(&mut self, _proof_of_stores: Vec<ProofOfStore>) {
+    async fn send_proof_of_store_msg_to_self(
+        &mut self,
+        _proof_of_stores: Vec<ProofOfStore<BatchInfo>>,
+    ) {
         unimplemented!()
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR makes `ProofOfStore` and `SignedBatchInfo` generic over parameter `T`, where `T` is some `BatchInfo` type. It changes existing usages to `ProofOfStore<BatchInfo>` and `SignedBatchInfo<BatchInfo>`.  A new trait `TBatchInfo` is introduced and implemented for `BatchInfo`. The idea being one can use a different batch info type without duplicating code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a generic `TBatchInfo` and makes `ProofOfStore`, `SignedBatchInfo`, and related caches/messages generic, updating all call sites to `ProofOfStore<BatchInfo>` and `SignedBatchInfo<BatchInfo>`.
> 
> - **Types/Traits**:
>   - Add `TBatchInfo` trait; implement for `BatchInfo`.
>   - Make `ProofOfStore`, `SignedBatchInfo`, `ProofOfStoreMsg`, `SignedBatchInfoMsg`, and `ProofCache` generic over `TBatchInfo`.
>   - Update `TDataInfo` impls accordingly.
> - **API Changes (type updates)**:
>   - Replace usages with `ProofOfStore<BatchInfo>` and `SignedBatchInfo<BatchInfo>` across `payload`, `common::ProofWithData`, `proposal_msg`, `opt_proposal_msg`, observer, and QS components.
>   - Update aliases (e.g., `ProofBatches = BatchPointer<ProofOfStore<BatchInfo>>`).
>   - Adjust method signatures/fields (e.g., verification fns, caches, queues) to use generic types.
> - **Quorum Store & Networking**:
>   - Adapt network message enums, senders, and handlers to generic proof/signed info types.
>   - Update QS internals (batch store/proof queue/manager/coordinator/builders) to the new generics.
> - **Tests**:
>   - Migrate tests and mocks to `ProofOfStore<BatchInfo>`/`SignedBatchInfo<BatchInfo>` and updated APIs.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ec38b39d8f81c5b2e1014f1c77aa03587c41c6f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->