### PR TITLE
[Storage] Enable filters for state kv

### DIFF
--- a/config/src/config/storage_config.rs
+++ b/config/src/config/storage_config.rs
@@ -112,10 +112,17 @@ pub enum RocksDBStatsLevel {
     All,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IndexType {
+    BinarySearch,
+    HashSearch,
+    TwoLevelIndexSearch,
+}
+
 /// Port selected RocksDB options for tuning underlying rocksdb instance of AptosDB.
 /// see <https://github.com/facebook/rocksdb/blob/master/include/rocksdb/options.h>
 /// for detailed explanations.
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RocksdbConfig {
     /// Maximum number of files open by RocksDB at one time
@@ -129,6 +136,10 @@ pub struct RocksdbConfig {
     pub block_cache_size: u64,
     /// Block size for Rocks DB
     pub block_size: u64,
+    /// Index type used for tables.
+    pub index_type: IndexType,
+    /// Use partitioned filters.
+    pub partition_filters: bool,
     /// Whether to cache index and filter blocks into block cache.
     pub cache_index_and_filter_blocks: bool,
     /// Whether to pin L0 filters and indexes in memory. Only makes sense if
@@ -140,6 +151,10 @@ pub struct RocksdbConfig {
     /// If not zero, dump stats to LOG every this many seconds. `None` means using RocksDB's
     /// default.
     pub stats_dump_period_sec: Option<u32>,
+    /// Enable bloom filters with given space per key.
+    pub bloom_filter_bits: Option<f64>,
+    /// If not `None`, use hybrid ribbon filter policy.
+    pub bloom_before_level: Option<i32>,
 }
 
 impl RocksdbConfig {
@@ -160,6 +175,8 @@ impl Default for RocksdbConfig {
             // Not used. Only kept for backward compatibility.
             block_cache_size: 0,
             block_size: Self::DEFAULT_BLOCK_SIZE,
+            index_type: IndexType::TwoLevelIndexSearch,
+            partition_filters: true,
             // Count index/filter blocks in block cache usage by default.
             cache_index_and_filter_blocks: true,
             // L0 index/filter blocks are usually small and used frequently.
@@ -168,11 +185,13 @@ impl Default for RocksdbConfig {
             stats_level: Some(RocksDBStatsLevel::ExceptHistogramOrTimers),
             // Use RocksDB's default if not specified.
             stats_dump_period_sec: None,
+            bloom_filter_bits: None,
+            bloom_before_level: None,
         }
     }
 }
 
-#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct RocksdbConfigs {
     // TODO(grao): Add RocksdbConfig for individual ledger DBs when necessary.
@@ -202,7 +221,11 @@ impl Default for RocksdbConfigs {
         Self {
             ledger_db_config: RocksdbConfig::default(),
             state_merkle_db_config: RocksdbConfig::default(),
-            state_kv_db_config: RocksdbConfig::default(),
+            state_kv_db_config: RocksdbConfig {
+                bloom_filter_bits: Some(10.0),
+                bloom_before_level: Some(2),
+                ..Default::default()
+            },
             index_db_config: RocksdbConfig {
                 max_open_files: 1000,
                 ..Default::default()
@@ -215,7 +238,7 @@ impl Default for RocksdbConfigs {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, PartialEq, Eq, Serialize)]
+#[derive(Clone, Debug, Deserialize, PartialEq, Serialize)]
 #[serde(default, deny_unknown_fields)]
 pub struct StorageConfig {
     pub backup_service_address: SocketAddr,

--- a/storage/aptosdb/src/db_options.rs
+++ b/storage/aptosdb/src/db_options.rs
@@ -2,10 +2,10 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::schema::*;
-use aptos_config::config::RocksdbConfig;
+use aptos_config::config::{IndexType, RocksdbConfig};
 use aptos_schemadb::{
-    BlockBasedOptions, Cache, ColumnFamilyDescriptor, ColumnFamilyName, DBCompressionType, Options,
-    SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
+    BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor, ColumnFamilyName,
+    DBCompressionType, Options, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use aptos_types::transaction::Version;
 
@@ -164,18 +164,10 @@ fn gen_cfds<F>(
 where
     F: Fn(ColumnFamilyName, &mut Options),
 {
-    let mut table_options = BlockBasedOptions::default();
-    table_options.set_cache_index_and_filter_blocks(rocksdb_config.cache_index_and_filter_blocks);
-    table_options.set_pin_l0_filter_and_index_blocks_in_cache(
-        rocksdb_config.pin_l0_filter_and_index_blocks_in_cache,
-    );
-    table_options.set_block_size(rocksdb_config.block_size as usize);
-    if let Some(cache) = block_cache {
-        table_options.set_block_cache(cache);
-    }
-
     let mut cfds = Vec::with_capacity(cfs.len());
     for cf_name in cfs {
+        let table_options = gen_table_options(rocksdb_config, block_cache, cf_name);
+
         let mut cf_opts = Options::default();
         cf_opts.set_compression_type(DBCompressionType::Lz4);
         cf_opts.set_block_based_table_factory(&table_options);
@@ -184,6 +176,50 @@ where
         cfds.push(ColumnFamilyDescriptor::new((*cf_name).to_string(), cf_opts));
     }
     cfds
+}
+
+fn gen_table_options(
+    rocksdb_config: &RocksdbConfig,
+    block_cache: Option<&Cache>,
+    cf_name: ColumnFamilyName,
+) -> BlockBasedOptions {
+    let mut table_options = BlockBasedOptions::default();
+
+    table_options.set_block_size(rocksdb_config.block_size as usize);
+
+    table_options.set_index_type(convert_index_type(rocksdb_config.index_type));
+    table_options.set_partition_filters(rocksdb_config.partition_filters);
+    table_options.set_cache_index_and_filter_blocks(rocksdb_config.cache_index_and_filter_blocks);
+    table_options.set_pin_l0_filter_and_index_blocks_in_cache(
+        rocksdb_config.pin_l0_filter_and_index_blocks_in_cache,
+    );
+
+    if let Some(cache) = block_cache {
+        table_options.set_block_cache(cache);
+    }
+
+    if let Some(bits) = rocksdb_config.bloom_filter_bits {
+        match rocksdb_config.bloom_before_level {
+            Some(level) => table_options.set_hybrid_ribbon_filter(bits, level),
+            None => table_options.set_bloom_filter(bits, /* block_based = */ false),
+        }
+    }
+
+    if cf_name == STATE_VALUE_BY_KEY_HASH_CF_NAME || cf_name == HOT_STATE_VALUE_BY_KEY_HASH_CF_NAME
+    {
+        // We do not generally perform point queries on these tables.
+        table_options.set_whole_key_filtering(false);
+    }
+
+    table_options
+}
+
+fn convert_index_type(index_type: IndexType) -> BlockBasedIndexType {
+    match index_type {
+        IndexType::BinarySearch => BlockBasedIndexType::BinarySearch,
+        IndexType::HashSearch => BlockBasedIndexType::HashSearch,
+        IndexType::TwoLevelIndexSearch => BlockBasedIndexType::TwoLevelIndexSearch,
+    }
 }
 
 fn with_state_key_extractor_processor(cf_name: ColumnFamilyName, cf_opts: &mut Options) {

--- a/storage/schemadb/src/lib.rs
+++ b/storage/schemadb/src/lib.rs
@@ -36,8 +36,8 @@ use batch::{IntoRawBatch, NativeBatch, WriteBatch};
 use iterator::{ScanDirection, SchemaIterator};
 /// Type alias to `rocksdb::ReadOptions`. See [`rocksdb doc`](https://github.com/pingcap/rust-rocksdb/blob/master/src/rocksdb_options.rs)
 pub use rocksdb::{
-    BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Env, Options, ReadOptions,
-    SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
+    BlockBasedIndexType, BlockBasedOptions, Cache, ColumnFamilyDescriptor, DBCompressionType, Env,
+    Options, ReadOptions, SliceTransform, DEFAULT_COLUMN_FAMILY_NAME,
 };
 use rocksdb::{ErrorKind, WriteOptions};
 use std::{collections::HashSet, fmt::Debug, iter::Iterator, path::Path};


### PR DESCRIPTION

We already have part of the setup. For instance, we set a prefix extractor and
we have `prefix_same_as_start` for reads. However, we don't seem to have any
filters enabled, and having them could take advantage of prefix seek and reduce
a bit access to some files. It will use some extra memory, but 10 bits per key
isn't that much.

This commit enables bloom/ribbon filters for state kv db. Also enabled
partitioned index/filters since it looks reasonable: https://github.com/facebook/rocksdb/wiki/Partitioned-Index-Filters

I pushed the change to a testnet node, manually triggered a bunch of compactions
and the stats after look reasonable. Note that this won't take effect
immediately in production, because existing files are built without filters.
Only files newly built from compactions will have filters, so it will be a
while.
