### PR TITLE
[compiler] Add a simplifier rule to replace `match` with `is`

### DIFF
--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.exp
@@ -87,29 +87,8 @@ l1: move_loc l2
 
 // Function definition at index 1
 #[persistent] public fun is_inner1(l0: &Inner): bool
-    local l1: bool
-    local l2: &Inner
-    copy_loc l0
-    test_variant Inner, Inner1
-    br_false l0
     move_loc l0
-    pop
-    // @5
-    ld_true
-    st_loc l1
-    branch l1
-l0: move_loc l0
-    st_loc l2
-    // @10
-    move_loc l2
-    pop
-    ld_false
-    st_loc l1
-    branch l1
-    // @15
-    ld_u64 14566554180833181697
-    abort
-l1: move_loc l1
+    test_variant Inner, Inner1
     ret
 
 // Function definition at index 2

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/struct_variants.opt.exp
@@ -76,18 +76,8 @@ l1: ld_u64 14566554180833181697
 
 // Function definition at index 1
 #[persistent] public fun is_inner1(l0: &Inner): bool
-    copy_loc l0
-    test_variant Inner, Inner1
-    br_false l0
     move_loc l0
-    pop
-    // @5
-    ld_true
-    ret
-l0: move_loc l0
-    pop
-    ld_false
-    // @10
+    test_variant Inner, Inner1
     ret
 
 // Function definition at index 2

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/variants_match_reduces_to_is.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/variants_match_reduces_to_is.exp
@@ -12,29 +12,8 @@ enum Color
 
 // Function definition at index 0
 fun test_red(l0: &Color): bool
-    local l1: bool
-    local l2: &Color
-    copy_loc l0
-    test_variant Color, Red
-    br_false l0
     move_loc l0
-    pop
-    // @5
-    ld_true
-    st_loc l1
-    branch l1
-l0: move_loc l0
-    st_loc l2
-    // @10
-    move_loc l2
-    pop
-    ld_false
-    st_loc l1
-    branch l1
-    // @15
-    ld_u64 14566554180833181697
-    abort
-l1: move_loc l1
+    test_variant Color, Red
     ret
 
 // Function definition at index 1

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/variants_match_reduces_to_is.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/variants_match_reduces_to_is.opt.exp
@@ -12,18 +12,8 @@ enum Color
 
 // Function definition at index 0
 fun test_red(l0: &Color): bool
-    copy_loc l0
-    test_variant Color, Red
-    br_false l0
     move_loc l0
-    pop
-    // @5
-    ld_true
-    ret
-l0: move_loc l0
-    pop
-    ld_false
-    // @10
+    test_variant Color, Red
     ret
 
 // Function definition at index 1

--- a/third_party/move/move-compiler-v2/tests/simplifier/match.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier/match.exp
@@ -1,0 +1,61 @@
+// -- Model dump before first bytecode pipeline
+module 0x66::m {
+    enum E {
+        A {
+            0: u64,
+        }
+        B,
+        C {
+            0: bool,
+        }
+    }
+    private fun variant_test(e: &E): bool {
+        match (e) {
+          m::E::A{ 0: _ } => {
+            true
+          }
+          _: &E => {
+            false
+          }
+        }
+
+    }
+} // end 0x66::m
+
+// -- Sourcified model before first bytecode pipeline
+module 0x66::m {
+    enum E {
+        A {
+            0: u64,
+        }
+        B,
+        C {
+            0: bool,
+        }
+    }
+    fun variant_test(e: &E): bool {
+        match (e) {
+            E::A(_) => true,
+            _ => false,
+        }
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x66::m {
+    enum E {
+        A {
+            0: u64,
+        }
+        B,
+        C {
+            0: bool,
+        }
+    }
+    private fun variant_test(e: &E): bool {
+        test_variants m::E::A(e)
+    }
+} // end 0x66::m
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier/match.move
+++ b/third_party/move/move-compiler-v2/tests/simplifier/match.move
@@ -1,0 +1,15 @@
+module 0x66::m {
+
+    enum E {
+        A(u64),
+        B,
+        C(bool)
+    }
+
+    fun variant_test(e: &E): bool {
+        match (e) {
+            A(_) => true,
+            _ => false
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_matching.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_matching.decompiled
@@ -54,8 +54,7 @@ module 0x42::m {
         _v2 + _v3
     }
     public fun is_inner1(p0: &Inner): bool {
-        if (p0 is Inner1) return true;
-        false
+        p0 is Inner1
     }
     public fun is_some<T0>(p0: &Option<T0>): bool {
         loop {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_matching.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_matching.decompiled.baseline.exp
@@ -1,30 +1,30 @@
 processed 15 tasks
-task 0 lines 3-257:  publish [module 0x42::m {]
-task 1 lines 260-260:  run 0x42::m::t1_is_inner1
+task 0 lines 3-256:  publish [module 0x42::m {]
+task 1 lines 259-259:  run 0x42::m::t1_is_inner1
 return values: true
-task 2 lines 262-262:  run 0x42::m::t2_is_inner1
+task 2 lines 261-261:  run 0x42::m::t2_is_inner1
 return values: false
-task 3 lines 264-264:  run 0x42::m::t1_inner_value
+task 3 lines 263-263:  run 0x42::m::t1_inner_value
 return values: 7
-task 4 lines 266-266:  run 0x42::m::t1_outer_value
+task 4 lines 265-265:  run 0x42::m::t1_outer_value
 return values: 0
-task 5 lines 268-268:  run 0x42::m::t2_outer_value
+task 5 lines 267-267:  run 0x42::m::t2_outer_value
 return values: 3
-task 6 lines 270-270:  run 0x42::m::t3_outer_value
+task 6 lines 269-269:  run 0x42::m::t3_outer_value
 return values: 8
-task 7 lines 272-272:  run 0x42::m::t1_outer_value_nested
+task 7 lines 271-271:  run 0x42::m::t1_outer_value_nested
 return values: 27
-task 8 lines 274-274:  run 0x42::m::t2_outer_value_nested
+task 8 lines 273-273:  run 0x42::m::t2_outer_value_nested
 return values: 12
-task 9 lines 276-276:  run 0x42::m::t1_outer_value_with_cond
+task 9 lines 275-275:  run 0x42::m::t1_outer_value_with_cond
 return values: 1
-task 10 lines 278-278:  run 0x42::m::t1_outer_value_with_cond_ref
+task 10 lines 277-277:  run 0x42::m::t1_outer_value_with_cond_ref
 return values: true
-task 11 lines 280-280:  run 0x42::m::t1_is_some
+task 11 lines 279-279:  run 0x42::m::t1_is_some
 return values: false
-task 12 lines 282-282:  run 0x42::m::t2_is_some
+task 12 lines 281-281:  run 0x42::m::t2_is_some
 return values: true
-task 13 lines 284-284:  run 0x42::m::t1_is_some_specialized
+task 13 lines 283-283:  run 0x42::m::t1_is_some_specialized
 return values: false
-task 14 lines 286-286:  run 0x42::m::t2_is_some_specialized
+task 14 lines 285-285:  run 0x42::m::t2_is_some_specialized
 return values: true

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_scoping.decompiled
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_scoping.decompiled
@@ -25,7 +25,6 @@ module 0x42::m {
         }
     }
     public fun check_scoping(p0: &Inner): u64 {
-        if (p0 is Inner1) ();
         3
     }
     fun t1_check_scoping(): u64 {

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_scoping.decompiled.baseline.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/enum/round-trip/enum_scoping.decompiled.baseline.exp
@@ -1,4 +1,11 @@
 processed 2 tasks
-task 0 lines 3-51:  publish [module 0x42::m {]
-task 1 lines 54-54:  run 0x42::m::t1_check_scoping
+task 0 lines 3-50:  publish [module 0x42::m {]
+warning: Unused value of parameter `p0`. Consider removing the parameter, or prefixing with an underscore (e.g., `_p0`), or binding to `_`
+   ┌─ TEMPFILE:27:30
+   │
+27 │     public fun check_scoping(p0: &Inner): u64 {
+   │                              ^^
+
+
+task 1 lines 53-53:  run 0x42::m::t1_check_scoping
 return values: 3

--- a/third_party/move/move-model/src/exp_rewriter.rs
+++ b/third_party/move/move-model/src/exp_rewriter.rs
@@ -246,6 +246,9 @@ pub trait ExpRewriterFunctions {
     ) -> Option<MatchArm> {
         None
     }
+    fn rewrite_match(&mut self, id: NodeId, disc: &Exp, arms: &[MatchArm]) -> Option<Exp> {
+        None
+    }
     // Optionally rewrite a pattern, which may be in `Let`, `Lambda`, or `Assign` expression.
     //
     // Parameter`creating_scope` is `true` for `Let` and `Lambda` operations, which create a new
@@ -509,8 +512,10 @@ pub trait ExpRewriterFunctions {
                     arms_changed =
                         arms_changed || arm_changed || pat_changed || cond_changed || body_changed;
                 }
-                if id_changed || disc_changed || arms_changed {
-                    Match(*id, new_disc, new_arms).into_exp()
+                if let Some(new_exp) = self.rewrite_match(new_id, &new_disc, &new_arms) {
+                    new_exp
+                } else if id_changed || disc_changed || arms_changed {
+                    Match(new_id, new_disc, new_arms).into_exp()
                 } else {
                     exp
                 }


### PR DESCRIPTION
## Description

If looking at `match (e) { V => true, _ => false }`, we reduce this to `e is V`, which is more efficient.

## How Has This Been Tested?

Existing tests

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a simplifier rule that rewrites `match (e) { V(_) => true, _ => false }` into `e is V`, and wires a `rewrite_match` hook into the rewriter; updates tests/expectations.
> 
> - **Simplifier (env_pipeline/ast_simplifier.rs)**
>   - Add `rewrite_match` that collapses `match (e) { V(_) => true, _ => false }` to `test_variants(e, V)` (i.e., `e is V`).
>   - Import `MatchArm` to support the new rule.
> - **Rewriter API (move-model/exp_rewriter.rs)**
>   - Introduce optional `rewrite_match(id, disc, arms)` hook.
>   - Integrate hook in `Match` traversal to allow whole-expression replacement after arm rewriting.
> - **Tests**
>   - Add `simplifier/match` test demonstrating reduction to `test_variants`.
>   - Update disassembly/optimized expectations to reflect direct `test_variant`/`is` checks.
>   - Adjust transactional test baselines accordingly (including minor line shifts and an unused-parameter warning).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e4af5c4ed309525799bb8503eb37522e120aa7c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->