### PR TITLE
[vm][perf] Inline `TypeBuilder::check`

### DIFF
--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -1191,25 +1191,35 @@ impl TypeBuilder {
         self.subst_impl(ty, ty_args, &mut count, 1, check)
     }
 
-    #[cfg_attr(feature = "force-inline", inline(always))]
+    #[inline]
     fn check(&self, count: &mut u64, depth: u64) -> PartialVMResult<()> {
         if *count >= self.max_ty_size {
-            return Err(
-                PartialVMError::new(StatusCode::TOO_MANY_TYPE_NODES).with_message(format!(
-                    "Type size is larger than maximum {}",
-                    self.max_ty_size
-                )),
-            );
+            return self.too_many_nodes_error();
         }
         if depth > self.max_ty_depth {
-            return Err(
-                PartialVMError::new(StatusCode::VM_MAX_TYPE_DEPTH_REACHED).with_message(format!(
-                    "Type depth is larger than maximum {}",
-                    self.max_ty_depth
-                )),
-            );
+            return self.too_large_depth_error();
         }
         Ok(())
+    }
+
+    #[cold]
+    fn too_many_nodes_error(&self) -> PartialVMResult<()> {
+        Err(
+            PartialVMError::new(StatusCode::TOO_MANY_TYPE_NODES).with_message(format!(
+                "Type size is larger than maximum {}",
+                self.max_ty_size
+            )),
+        )
+    }
+
+    #[cold]
+    fn too_large_depth_error(&self) -> PartialVMResult<()> {
+        Err(
+            PartialVMError::new(StatusCode::VM_MAX_TYPE_DEPTH_REACHED).with_message(format!(
+                "Type depth is larger than maximum {}",
+                self.max_ty_depth
+            )),
+        )
     }
 
     fn create_constant_ty_impl(


### PR DESCRIPTION
Reduces `TypeBuilder::check` size to under 40 lines of code, and inline. 

Adds 0.5% perf for Decibel's benchmark. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Inline `TypeBuilder::check` and move error construction into cold helper methods to shrink the hot path.
> 
> - **VM Types (`runtime_types.rs`)**:
>   - **`TypeBuilder::check`**: Marked `#[inline]` and refactored to delegate errors to new cold helpers.
>     - Added `#[cold]` helpers: `too_many_nodes_error()` and `too_large_depth_error()` returning the corresponding `PartialVMError`.
>     - Replaced inlined error construction with calls to these helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36cc78ccaf4ac56d474a46d4915866503e6e185f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->