### PR TITLE
[vm][perf] Get rid of closure in `Container::copy_value::copy_rc_ref_vec_val`

### DIFF
--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -570,18 +570,22 @@ impl Value {
 
 impl Container {
     fn copy_value(&self, depth: u64, max_depth: Option<u64>) -> PartialVMResult<Self> {
-        let copy_rc_ref_vec_val = |r: &Rc<RefCell<Vec<Value>>>| {
-            Ok(Rc::new(RefCell::new(
-                r.borrow()
-                    .iter()
-                    .map(|v| v.copy_value(depth + 1, max_depth))
-                    .collect::<PartialVMResult<_>>()?,
-            )))
-        };
+        fn copy_rc_ref_vec_val(
+            r: &Rc<RefCell<Vec<Value>>>,
+            depth: u64,
+            max_depth: Option<u64>,
+        ) -> PartialVMResult<Rc<RefCell<Vec<Value>>>> {
+            let vals = r.borrow();
+            let mut copied_vals = Vec::with_capacity(vals.len());
+            for val in vals.iter() {
+                copied_vals.push(val.copy_value(depth + 1, max_depth)?);
+            }
+            Ok(Rc::new(RefCell::new(copied_vals)))
+        }
 
         Ok(match self {
-            Self::Vec(r) => Self::Vec(copy_rc_ref_vec_val(r)?),
-            Self::Struct(r) => Self::Struct(copy_rc_ref_vec_val(r)?),
+            Self::Vec(r) => Self::Vec(copy_rc_ref_vec_val(r, depth, max_depth)?),
+            Self::Struct(r) => Self::Struct(copy_rc_ref_vec_val(r, depth, max_depth)?),
 
             Self::VecU8(r) => Self::VecU8(Rc::new(RefCell::new(r.borrow().clone()))),
             Self::VecU16(r) => Self::VecU16(Rc::new(RefCell::new(r.borrow().clone()))),
@@ -5955,7 +5959,7 @@ fn try_get_variant_field_layouts<'a>(
     None
 }
 
-#[cfg_attr(feature = "force-inline", inline(always))]
+#[inline]
 fn check_depth(depth: u64, max_depth: Option<u64>) -> PartialVMResult<()> {
     if max_depth.is_some_and(|max_depth| depth > max_depth) {
         return Err(PartialVMError::new(StatusCode::VM_MAX_VALUE_DEPTH_REACHED));


### PR DESCRIPTION
Due to the fact that `Value::copy_value` is `#[inline(always)]` and quite large, LLVM does not inline the closure in 
```rust
r.borrow()
    .iter()
    .map(|v| v.copy_value(depth + 1, max_depth))
    .collect::<PartialVMResult<_>>()?
```
creating unnecessary invocations for every single inner value. 

Inline it manually, replacing the iterator with the loop. 

Adds 0.7% on Decibel's benchmark. 

Note: 
replacing closure with inner function is irrelevant, this way it's just easier to monitor for which specific function is it in the ASM view tool. I also personally find it cleaner, as `depth, max_depth` parameters mirror outer function ones. 


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replace iterator/closure with a manual loop for copying `Vec<Value>`/`Struct` elements in `Container::copy_value`, and change `check_depth` to `#[inline]`.
> 
> - **Move VM values (`values_impl.rs`)**:
>   - **Copy logic**: Replace iterator/closure with a helper function using a `for` loop to copy elements in `Container::copy_value` for `Vec` and `Struct`; pass `depth`/`max_depth` explicitly to the helper.
>   - **Inlining**: Change `check_depth` attribute from conditional `inline(always)` to plain `#[inline]`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6716eccdeb9e0b53c1f28d29486fb99b4abbb3a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->