### PR TITLE
iterator -> loop for `collect::<PartialVMResult>`

### DIFF
--- a/third_party/move/move-vm/runtime/src/frame.rs
+++ b/third_party/move/move-vm/runtime/src/frame.rs
@@ -437,8 +437,10 @@ impl Frame {
         let fields = struct_ty.fields(variant)?;
         let mut generic_fields = Vec::with_capacity(fields.len());
         for (_, inst_ty) in fields {
-            generic_fields.push(self.ty_builder
-                .create_ty_with_subst(inst_ty, &instantiation_tys)?);
+            generic_fields.push(
+                self.ty_builder
+                    .create_ty_with_subst(inst_ty, &instantiation_tys)?,
+            );
         }
         Ok(generic_fields)
     }

--- a/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
+++ b/third_party/move/move-vm/runtime/src/storage/ty_layout_converter.rs
@@ -339,16 +339,15 @@ where
         let mut contains_delayed_fields = false;
         let mut layouts = Vec::with_capacity(tys.len());
         for ty in tys {
-            let (layout, ty_contains_delayed_fields) = self
-                .type_to_type_layout_impl::<ANNOTATED>(
-                    gas_meter,
-                    traversal_context,
-                    modules,
-                    ty,
-                    count,
-                    depth,
-                    check_option_type,
-                )?;
+            let (layout, ty_contains_delayed_fields) = self.type_to_type_layout_impl::<ANNOTATED>(
+                gas_meter,
+                traversal_context,
+                modules,
+                ty,
+                count,
+                depth,
+                check_option_type,
+            )?;
             contains_delayed_fields |= ty_contains_delayed_fields;
             layouts.push(layout);
         }

--- a/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
+++ b/third_party/move/move-vm/types/src/loaded_data/runtime_types.rs
@@ -1134,7 +1134,8 @@ impl TypeBuilder {
         let mut subst_ty_args = Vec::with_capacity(ty_params.len());
         for ty in ty_params {
             // Note that depth is 2 because we accounted for the parent struct type.
-            let ty_arg = self.subst_impl(ty, ty_args, &mut count, 2, check)
+            let ty_arg = self
+                .subst_impl(ty, ty_args, &mut count, 2, check)
                 .map_err(|e| {
                     e.append_message_with_separator(
                         '.',


### PR DESCRIPTION
Adds 2% TPS on Decibel. 

Looks like rustc+LLVM cannot optimize `.map().collect::<Result>` into an optimal code - unpacking it as a loop reduces CPU instructions 2x.  

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors multiple type instantiation and layout conversion paths to use preallocated for-loops instead of map().collect::<PartialVMResult<_>>() for better performance, with minor inlining tweaks.
> 
> - **Runtime (frame.rs)**
>   - Replace `map().collect::<PartialVMResult<_>>()` with preallocated `for` loops in:
>     - `make_new_frame` local type instantiation for generics
>     - `instantiate_ty`
>     - `instantiate_generic_fields`
>     - `instantiate_generic_function`
> - **Storage (ty_layout_converter.rs)**
>   - Use explicit loops with preallocation in:
>     - `types_to_type_layouts`
>     - `apply_subst_for_field_tys`
> - **Types (runtime_types.rs)**
>   - Loop-based construction instead of `map().collect()` for:
>     - Ability aggregation of `StructInstantiation` type args in `Type::abilities`
>     - `TypeBuilder::create_struct_instantiation_ty` param substitution
>     - `TypeBuilder::apply_subst` for `StructInstantiation` and `Function` args/results
>   - Add `#[inline]` to `subst_impl` and `clone_impl`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0ddc199104ff6247c1dfa04d18bcf7f02de77bfa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->