### PR TITLE
[localnet] Add support for using existing Docker network

### DIFF
--- a/crates/aptos/CHANGELOG.md
+++ b/crates/aptos/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to the Aptos CLI will be captured in this file. This project
 
 # Unreleased
 - When using `--bind-to 0.0.0.0`, clients created by the localnet will try to connect at 127.0.0.1, not 0.0.0.0.
+- Add `--docker-network` flag to allow specifying existing Docker network.
 
 ## [7.10.2]
 - Fix backward compatibility issue of enum-based option module

--- a/crates/aptos/src/node/local_testnet/docker.rs
+++ b/crates/aptos/src/node/local_testnet/docker.rs
@@ -111,6 +111,20 @@ pub async fn pull_docker_image(image_name: &str) -> Result<()> {
 }
 
 /// Create a network. If the network already exists, that's fine, just move on.
+/// Check if a Docker network exists.
+pub async fn network_exists(network_name: &str) -> Result<bool> {
+    let docker = get_docker().await?;
+
+    // Try to inspect the network. If it exists, this will succeed.
+    match docker.inspect_network::<&str>(network_name, None).await {
+        Ok(_) => Ok(true),
+        Err(BollardError::DockerResponseServerError {
+            status_code: 404, ..
+        }) => Ok(false),
+        Err(err) => Err(err.into()),
+    }
+}
+
 pub async fn create_network(network_name: &str) -> Result<()> {
     let docker = get_docker().await?;
 

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -4,7 +4,7 @@
 use super::{
     docker::{
         delete_container, get_docker, pull_docker_image, setup_docker_logging,
-        StopContainerShutdownStep, CONTAINER_NETWORK_NAME,
+        StopContainerShutdownStep,
     },
     health_checker::HealthChecker,
     traits::{PostHealthyStep, ServiceManager, ShutdownStep},
@@ -70,6 +70,7 @@ pub struct IndexerApiManager {
     prerequisite_health_checkers: HashSet<HealthChecker>,
     test_dir: PathBuf,
     postgres_connection_string: String,
+    docker_network: String,
 }
 
 impl IndexerApiManager {
@@ -79,6 +80,7 @@ impl IndexerApiManager {
         test_dir: PathBuf,
         postgres_connection_string: String,
     ) -> Result<Self> {
+        let (docker_network, _) = args.get_docker_network();
         Ok(Self {
             indexer_api_port: args.indexer_api_args.indexer_api_port,
             existing_hasura_url: args.indexer_api_args.existing_hasura_url.clone(),
@@ -86,6 +88,7 @@ impl IndexerApiManager {
             prerequisite_health_checkers,
             test_dir,
             postgres_connection_string,
+            docker_network: docker_network.to_string(),
         })
     }
 
@@ -188,7 +191,7 @@ impl ServiceManager for IndexerApiManager {
                 // in the Postgres pre_run steps.
                 (
                     self.postgres_connection_string,
-                    Some(CONTAINER_NETWORK_NAME.to_string()),
+                    Some(self.docker_network.clone()),
                 )
             };
 


### PR DESCRIPTION
## Description
This PR adds support for telling the localnet to use an existing Docker network. This will be helpful with the Shelby localnet, where it's simpler to pre-create the network since it will be shared by the Aptos localnet services as well as other services.

## How Has This Been Tested?
See that creating a localnet as normal still works:
```
$ cargo run -p aptos -- node run-localnet --with-indexer-api --force-restart --assume-yes
Setup is complete, you can now use the localnet!
```

See that you can specify a network in advance:
```
$ cargo run -p aptos -- node run-localnet --with-indexer-api --force-restart --assume-yes --docker-network mynetwork
Unexpected error: Docker network 'mynetwork' does not exist. Please create it first or omit --docker-network to use the default network.

$ docker network create mynetwork
a1810dd03dd1e1a31a0a405d84ac8393d76c5df25143e539643c34525bdd00f5

$ cargo run -p aptos -- node run-localnet --with-indexer-api --force-restart --assume-yes --docker-network mynetwork
Setup is complete, you can now use the localnet!
```

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [x] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds --docker-network to run-localnet to use a pre-existing Docker network, with validation and propagation to Postgres and Indexer API containers.
> 
> - **CLI (localnet)**
>   - Add `--docker-network` flag; error if used without `--with-indexer-api`.
>   - On startup, verify specified Docker network exists and log usage.
>   - Expose `get_docker_network()` to supply network name and existence flag.
> - **Docker utils**
>   - Add `network_exists(network_name)` helper to check network presence.
> - **Postgres**
>   - Accept resolved Docker network name and whether it already exists.
>   - Create network only if not pre-existing; bind container `network_mode` to selected network.
> - **Indexer API (Hasura)**
>   - Accept and use resolved Docker network for container `network_mode` when not connecting to host Postgres.
> - **Changelog**
>   - Document new `--docker-network` flag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eb77b73f3aa5b043e96a792c5744e19edd76d8c6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->