### PR TITLE
[compiler] add visibility modifier to structs/enums: step 2

### DIFF
--- a/aptos-move/e2e-move-tests/src/tests/mod.rs
+++ b/aptos-move/e2e-move-tests/src/tests/mod.rs
@@ -52,6 +52,7 @@ mod object_code_deployment;
 mod offer_rotation_capability;
 mod offer_signer_capability;
 mod per_category_gas_limits;
+mod public_structs_enums_upgrade;
 mod randomness_test_and_abort;
 mod remote_state;
 mod resource_groups;

--- a/aptos-move/e2e-move-tests/src/tests/public_structs_enums_upgrade.rs
+++ b/aptos-move/e2e-move-tests/src/tests/public_structs_enums_upgrade.rs
@@ -1,0 +1,226 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Tests for upgrade compatibility of public/package structs/enums
+
+use crate::{assert_success, assert_vm_status, MoveHarness};
+use aptos_framework::BuildOptions;
+use aptos_language_e2e_tests::account::Account;
+use aptos_package_builder::PackageBuilder;
+use aptos_types::{account_address::AccountAddress, transaction::TransactionStatus};
+use move_core_types::vm_status::StatusCode;
+
+#[test]
+fn public_enum_upgrade() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x815").unwrap());
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m {
+            enum Data {
+               V1{x: u64}
+            }
+        }
+    "#,
+    );
+    assert_success!(result);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m {
+            public enum Data {
+               V1{x: u64},
+            }
+        }
+    "#,
+    );
+    assert_success!(result);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m {
+            public enum Data {
+               V1{x: u64},
+               V2{x: u64, y: u8},
+            }
+        }
+    "#,
+    );
+    assert_success!(result);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m {
+            enum Data {
+               V1{x: u64},
+               V2{x: u64, y: u8},
+            }
+        }
+    "#,
+    );
+    assert_vm_status!(result, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m {
+            package enum Data {
+               V1{x: u64},
+               V2{x: u64, y: u8},
+            }
+        }
+    "#,
+    );
+    assert_vm_status!(result, StatusCode::BACKWARD_INCOMPATIBLE_MODULE_UPDATE);
+}
+
+#[test]
+fn friend_enum_struct_upgrade() {
+    let mut h = MoveHarness::new();
+    let acc = h.new_account_at(AccountAddress::from_hex_literal("0x815").unwrap());
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m {
+            friend 0x815::m2;
+            enum Data {
+               V1{x: u64}
+            }
+        }
+        module 0x815::m2 {
+        }
+    "#,
+    );
+    assert_success!(result);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m2 {
+            use 0x815::m::Data;
+            fun get_data(): Data {
+                Data::V2{x: 1, y: 2}
+            }
+        }
+        module 0x815::m {
+            friend 0x815::m2;
+            friend enum Data {
+               V1{x: u64},
+               V2{x: u64, y: u8},
+            }
+        }
+    "#,
+    );
+    assert_success!(result);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m2 {
+        }
+        module 0x815::m {
+            enum Data {
+               V1{x: u64},
+               V2{x: u64, y: u8},
+            }
+        }
+    "#,
+    );
+    assert_success!(result);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+        module 0x815::m2 {
+            use 0x815::m::Data;
+            use 0x815::m::S;
+            fun get_data(): Data {
+                Data::V1{x: 1}
+            }
+            fun pack_struct(): S {
+                S { x: 22 }
+            }
+        }
+        module 0x815::m {
+            package enum Data {
+               V1{x: u64},
+               V2{x: u64, y: u8},
+            }
+
+            package struct S {
+                x: u64,
+            }
+        }
+    "#,
+    );
+    assert_success!(result);
+
+    let result = publish(
+        &mut h,
+        &acc,
+        r#"
+            module 0x815::m2 {
+                use 0x815::m::Data;
+                use 0x815::m::S;
+                use 0x815::m::Predicate;
+                use 0x815::m::Holder;
+                fun get_data(): Data {
+                    Data::V1{x: 1}
+                }
+                public fun pack_struct(): S {
+                S { x: 22 }
+                }
+
+                public fun apply_pred(p: Predicate<u64>, val: u64): bool {
+                    p(&val)
+                }
+
+                public fun apply_holder(h: Holder<u64>, val: u64): bool {
+                    let Holder(p) = h;
+                    p(&val)
+                }
+            }
+            module 0x815::m {
+                public enum Data {
+                   V1{x: u64},
+                   V2{x: u64, y: u8},
+                }
+
+                public struct S {
+                    x: u64,
+                }
+
+                package struct Predicate<T>(|&T| bool) has copy, drop;
+
+                package struct Holder<T>(Predicate<T>) has copy, drop;
+            }
+        "#,
+    );
+    assert_success!(result);
+}
+
+fn publish(h: &mut MoveHarness, account: &Account, source: &str) -> TransactionStatus {
+    let mut builder = PackageBuilder::new("Package");
+    builder.add_source("m.move", source);
+    let path = builder.write_to_temp().unwrap();
+    h.publish_package_with_options(
+        account,
+        path.path(),
+        BuildOptions::move_2().set_latest_language(),
+    )
+}

--- a/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
+++ b/third_party/move/move-compiler-v2/src/file_format_generator/function_generator.rs
@@ -20,9 +20,12 @@ use move_core_types::{ability, function::ClosureMask};
 use move_model::{
     ast::{ExpData, Spec, SpecBlockTarget, TempIndex},
     exp_rewriter::{ExpRewriter, ExpRewriterFunctions, RewriteTarget},
-    model::{FunId, FunctionEnv, Loc, NodeId, Parameter, QualifiedId, StructId, TypeParameter},
+    model::{
+        FunId, FunctionEnv, Loc, NodeId, Parameter, QualifiedId, StructEnv, StructId, TypeParameter,
+    },
     symbol::Symbol,
-    ty::{PrimitiveType, Type},
+    ty::{PrimitiveType, ReferenceKind, Type},
+    well_known,
 };
 use move_stackless_bytecode::{
     function_target::FunctionTarget,
@@ -33,7 +36,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 pub struct FunctionGenerator<'a> {
     /// The underlying module generator.
-    r#gen: &'a mut ModuleGenerator,
+    genr: &'a mut ModuleGenerator,
     /// The set of temporaries which need to be pinned to locals because references are taken for
     /// them, or they are used in specs.
     pinned: BTreeSet<TempIndex>,
@@ -104,40 +107,37 @@ struct LabelInfo {
 impl<'a> FunctionGenerator<'a> {
     /// Runs the function generator for the given function.
     pub fn run<'b>(
-        r#gen: &'a mut ModuleGenerator,
+        genr: &'a mut ModuleGenerator,
         ctx: &'b ModuleContext,
         fun_env: FunctionEnv<'b>,
         acquires_list: &BTreeSet<StructId>,
     ) {
         let loc = fun_env.get_id_loc();
-        let function = r#gen.function_index(ctx, &loc, &fun_env);
+        let function = genr.function_index(ctx, &loc, &fun_env);
         let visibility = fun_env.visibility();
-        let fun_count = r#gen.module.function_defs.len();
+        let fun_count = genr.module.function_defs.len();
         let def_idx = FunctionDefinitionIndex::new(ctx.checked_bound(
             &loc,
             fun_count,
             MAX_FUNCTION_DEF_COUNT,
             "defined function",
         ));
-        r#gen
-            .source_map
+        genr.source_map
             .add_top_level_function_mapping(def_idx, ctx.env.to_ir_loc(&loc), fun_env.is_native())
             .expect(SOURCE_MAP_OK);
         for TypeParameter(name, _, loc) in fun_env.get_type_parameters() {
-            r#gen
-                .source_map
+            genr.source_map
                 .add_function_type_parameter_mapping(def_idx, ctx.source_name(name, loc))
                 .expect(SOURCE_MAP_OK)
         }
         for Parameter(name, _, loc) in fun_env.get_parameters() {
-            r#gen
-                .source_map
+            genr.source_map
                 .add_parameter_mapping(def_idx, ctx.source_name(name, loc))
                 .expect(SOURCE_MAP_OK)
         }
-        let (r#gen, code) = if !fun_env.is_native() {
+        let (genr, code) = if !fun_env.is_native() {
             let mut fun_gen = Self {
-                r#gen,
+                genr,
                 pinned: Default::default(),
                 temps: Default::default(),
                 stack: vec![],
@@ -162,7 +162,7 @@ impl<'a> FunctionGenerator<'a> {
                 let transformed_code_chunk = peephole_optimizer::optimize(&code.code);
                 // Fix the source map for the optimized code.
                 fun_gen
-                    .r#gen
+                    .genr
                     .source_map
                     .remap_code_map(def_idx, &transformed_code_chunk.original_offsets)
                     .expect(SOURCE_MAP_OK);
@@ -174,15 +174,15 @@ impl<'a> FunctionGenerator<'a> {
             if !fun_gen.spec_blocks.is_empty() {
                 fun_env.get_mut_spec().on_impl = fun_gen.spec_blocks;
             }
-            (fun_gen.r#gen, Some(code))
+            (fun_gen.genr, Some(code))
         } else {
-            (r#gen, None)
+            (genr, None)
         };
         let acquires_global_resources = acquires_list
             .iter()
             .map(|id| {
                 let struct_env = fun_env.module_env.get_struct(*id);
-                r#gen.struct_def_index(ctx, &struct_env.get_loc(), &struct_env)
+                genr.struct_def_index(ctx, &struct_env.get_loc(), &struct_env)
             })
             .collect();
         let def = FF::FunctionDefinition {
@@ -193,7 +193,452 @@ impl<'a> FunctionGenerator<'a> {
             code,
         };
 
-        r#gen.module.function_defs.push(def)
+        genr.module.function_defs.push(def)
+    }
+
+    /// Common builder for generating function definitions for struct APIs
+    fn gen_struct_api_common<'b, F>(
+        genr: &'a mut ModuleGenerator,
+        ctx: &'b ModuleContext,
+        struct_env: &'b StructEnv<'b>,
+        visibility: FF::Visibility,
+        base_loc: &'b Loc,
+        type_parameters: &[Type],
+        function_indices: BTreeMap<Option<Symbol>, FF::FunctionHandleIndex>,
+        mut mk_body: F,
+    ) where
+        F: FnMut(
+            &mut ModuleGenerator,
+            &ModuleContext,
+            &StructEnv<'_>,
+            Option<Symbol>,
+            FunctionDefinitionIndex,
+            &Loc,
+            &[Type],
+        ) -> FF::CodeUnit,
+    {
+        assert!(visibility.is_public_or_friend());
+
+        for (variant, function_index) in function_indices {
+            let def_idx = FunctionDefinitionIndex::new(ctx.checked_bound(
+                base_loc,
+                genr.module.function_defs.len(),
+                MAX_FUNCTION_DEF_COUNT,
+                "defined function",
+            ));
+
+            let loc = if let Some(variant_id) = variant {
+                struct_env.get_variant_loc(variant_id)
+            } else {
+                base_loc
+            };
+
+            genr.source_map
+                .add_top_level_function_mapping(def_idx, ctx.env.to_ir_loc(loc), false)
+                .expect(SOURCE_MAP_OK);
+
+            for TypeParameter(name, _, tp_loc) in struct_env.get_type_parameters() {
+                genr.source_map
+                    .add_function_type_parameter_mapping(
+                        def_idx,
+                        ctx.source_name(name, tp_loc.clone()),
+                    )
+                    .expect(SOURCE_MAP_OK);
+            }
+
+            // Let the caller build the actual body.
+            let code = mk_body(
+                genr,
+                ctx,
+                struct_env,
+                variant,
+                def_idx,
+                loc,
+                type_parameters,
+            );
+
+            let def = FF::FunctionDefinition {
+                function: function_index,
+                visibility,
+                is_entry: false,
+                acquires_global_resources: vec![],
+                code: Some(code),
+            };
+
+            genr.module.function_defs.push(def);
+        }
+    }
+
+    /// Generates test variant APIs for all variants of an enum
+    pub fn gen_struct_test_variant_api<'b>(
+        genr: &'a mut ModuleGenerator,
+        ctx: &'b ModuleContext,
+        struct_env: &'b StructEnv<'b>,
+    ) {
+        if !struct_env.has_variants() {
+            return;
+        }
+
+        let visibility = struct_env.get_visibility();
+        assert!(visibility.is_public_or_friend());
+
+        let type_parameters = TypeParameter::vec_to_formals(struct_env.get_type_parameters());
+        let struct_ty = Type::Struct(
+            struct_env.module_env.get_id(),
+            struct_env.get_id(),
+            type_parameters.clone(),
+        );
+        let ref_struct_ty = Type::Reference(ReferenceKind::Immutable, Box::new(struct_ty));
+        let loc = struct_env.get_loc();
+
+        let raw_function_indices = genr.struct_api_test_variant_index(ctx, &loc, struct_env);
+        let function_indices = raw_function_indices
+            .into_iter()
+            .map(|(variant, fh_idx)| (Some(variant), fh_idx))
+            .collect();
+
+        Self::gen_struct_api_common(
+            genr,
+            ctx,
+            struct_env,
+            visibility,
+            &loc,
+            &type_parameters,
+            function_indices,
+            |genr, ctx, struct_env, variant_opt, def_idx, variant_loc, type_parameters| {
+                let variant = variant_opt.expect("test_variant API only generated for variants");
+
+                let input_param_name = struct_env
+                    .env()
+                    .symbol_pool()
+                    .make(well_known::PARAM_NAME_FOR_STRUCT_API);
+                genr.source_map
+                    .add_parameter_mapping(
+                        def_idx,
+                        ctx.source_name(input_param_name, variant_loc.clone()),
+                    )
+                    .expect(SOURCE_MAP_OK);
+
+                // Function body:
+                // MoveLoc(0)
+                // TestVariant/TestVariantGeneric
+                // Ret
+                let locals = genr.signature(ctx, &loc, vec![ref_struct_ty.clone()]);
+
+                let mut code = vec![FF::Bytecode::MoveLoc(0 as FF::LocalIndex)];
+
+                let test_variant_bc = if type_parameters.is_empty() {
+                    let idx = genr.struct_variant_index(ctx, &loc, struct_env, variant);
+                    FF::Bytecode::TestVariant(idx)
+                } else {
+                    let idx = genr.struct_variant_inst_index(
+                        ctx,
+                        &loc,
+                        struct_env,
+                        variant,
+                        type_parameters.to_vec(),
+                    );
+                    FF::Bytecode::TestVariantGeneric(idx)
+                };
+
+                code.push(test_variant_bc);
+                code.push(FF::Bytecode::Ret);
+
+                FF::CodeUnit { locals, code }
+            },
+        );
+    }
+
+    /// Generates pack APIs
+    pub fn gen_struct_pack_api<'b>(
+        genr: &'a mut ModuleGenerator,
+        ctx: &'b ModuleContext,
+        struct_env: &'b StructEnv<'b>,
+    ) {
+        let visibility = struct_env.get_visibility();
+        let type_parameters = TypeParameter::vec_to_formals(struct_env.get_type_parameters());
+        let loc = struct_env.get_loc();
+        let function_indices = genr.struct_api_pack_index(ctx, &loc, struct_env);
+
+        Self::gen_struct_api_common(
+            genr,
+            ctx,
+            struct_env,
+            visibility,
+            &loc,
+            type_parameters.as_slice(),
+            function_indices,
+            |genr, ctx, struct_env, variant, def_idx, loc, type_parameters| {
+                // Function body:
+                // MoveLoc(0)
+                // MoveLoc(1)
+                // ...
+                // MoveLoc(parameter_count - 1)
+                // Pack/PackGeneric/PackVariant/PackVariantGeneric
+                // Ret
+                let mut tys = vec![];
+                let mut code = vec![];
+
+                for (i, field) in struct_env.get_fields_optional_variant(variant).enumerate() {
+                    let field_symbol = struct_env.env().symbol_pool().make(&format!(
+                        "_{}",
+                        field.get_name().display(struct_env.env().symbol_pool())
+                    ));
+                    genr.source_map
+                        .add_parameter_mapping(def_idx, ctx.source_name(field_symbol, loc.clone()))
+                        .expect(SOURCE_MAP_OK);
+
+                    // number of fields will not exceed 255, so we can safely cast it
+                    code.push(FF::Bytecode::MoveLoc(i as FF::LocalIndex));
+                    tys.push(field.get_type());
+                }
+
+                let locals = genr.signature(ctx, loc, tys);
+
+                let pack_bc = match (type_parameters.is_empty(), variant) {
+                    (true, Some(variant_id)) => {
+                        let idx = genr.struct_variant_index(ctx, loc, struct_env, variant_id);
+                        FF::Bytecode::PackVariant(idx)
+                    },
+                    (true, None) => {
+                        let idx = genr.struct_def_index(ctx, loc, struct_env);
+                        FF::Bytecode::Pack(idx)
+                    },
+                    (false, Some(variant_id)) => {
+                        let idx = genr.struct_variant_inst_index(
+                            ctx,
+                            loc,
+                            struct_env,
+                            variant_id,
+                            type_parameters.to_vec(),
+                        );
+                        FF::Bytecode::PackVariantGeneric(idx)
+                    },
+                    (false, None) => {
+                        let idx = genr.struct_def_instantiation_index(
+                            ctx,
+                            loc,
+                            struct_env,
+                            type_parameters.to_vec(),
+                        );
+                        FF::Bytecode::PackGeneric(idx)
+                    },
+                };
+
+                code.push(pack_bc);
+                code.push(FF::Bytecode::Ret);
+
+                FF::CodeUnit { locals, code }
+            },
+        );
+    }
+
+    /// Generates unpack api
+    pub fn gen_struct_unpack_api<'b>(
+        genr: &'a mut ModuleGenerator,
+        ctx: &'b ModuleContext,
+        struct_env: &'b StructEnv<'b>,
+    ) {
+        let visibility = struct_env.get_visibility();
+        let type_parameters = TypeParameter::vec_to_formals(struct_env.get_type_parameters());
+        let loc = struct_env.get_loc();
+        let function_indices = genr.struct_api_unpack_index(ctx, &loc, struct_env);
+
+        let struct_ty = Type::Struct(
+            struct_env.module_env.get_id(),
+            struct_env.get_id(),
+            type_parameters.clone(),
+        );
+
+        Self::gen_struct_api_common(
+            genr,
+            ctx,
+            struct_env,
+            visibility,
+            &loc,
+            &type_parameters,
+            function_indices,
+            |genr, ctx, struct_env, variant, def_idx, loc, type_parameters| {
+                let input_param_name = struct_env
+                    .env()
+                    .symbol_pool()
+                    .make(well_known::PARAM_NAME_FOR_STRUCT_API);
+
+                genr.source_map
+                    .add_parameter_mapping(def_idx, ctx.source_name(input_param_name, loc.clone()))
+                    .expect(SOURCE_MAP_OK);
+
+                // Function body:
+                // MoveLoc(0)
+                // Unpack/UnpackGeneric/UnpackVariant/UnpackVariantGeneric
+                // Ret
+                let locals = genr.signature(ctx, loc, vec![struct_ty.clone()]);
+                let mut code = vec![FF::Bytecode::MoveLoc(0 as FF::LocalIndex)];
+
+                let unpack_bc = match (type_parameters.is_empty(), variant) {
+                    (true, Some(variant_id)) => {
+                        let idx = genr.struct_variant_index(ctx, loc, struct_env, variant_id);
+                        FF::Bytecode::UnpackVariant(idx)
+                    },
+                    (true, None) => {
+                        let idx = genr.struct_def_index(ctx, loc, struct_env);
+                        FF::Bytecode::Unpack(idx)
+                    },
+                    (false, Some(variant_id)) => {
+                        let idx = genr.struct_variant_inst_index(
+                            ctx,
+                            loc,
+                            struct_env,
+                            variant_id,
+                            type_parameters.to_vec(),
+                        );
+                        FF::Bytecode::UnpackVariantGeneric(idx)
+                    },
+                    (false, None) => {
+                        let idx = genr.struct_def_instantiation_index(
+                            ctx,
+                            loc,
+                            struct_env,
+                            type_parameters.to_vec(),
+                        );
+                        FF::Bytecode::UnpackGeneric(idx)
+                    },
+                };
+
+                code.push(unpack_bc);
+                code.push(FF::Bytecode::Ret);
+
+                FF::CodeUnit { locals, code }
+            },
+        );
+    }
+
+    /// Generates borrow field api
+    pub fn gen_struct_borrow_field_api<'b>(
+        genr: &'a mut ModuleGenerator,
+        ctx: &'b ModuleContext,
+        struct_env: &'b StructEnv<'b>,
+        is_imm: bool,
+    ) {
+        let visibility = struct_env.get_visibility();
+        assert!(visibility.is_public_or_friend());
+        if struct_env.is_empty_struct() {
+            return;
+        }
+        let type_parameters = TypeParameter::vec_to_formals(struct_env.get_type_parameters());
+        let loc = struct_env.get_loc();
+        let function_indices = genr.struct_api_borrow_index(ctx, &loc, struct_env, is_imm);
+        let struct_ty = Type::Struct(
+            struct_env.module_env.get_id(),
+            struct_env.get_id(),
+            type_parameters.clone(),
+        );
+        let ref_struct_ty = Type::Reference(
+            if is_imm {
+                ReferenceKind::Immutable
+            } else {
+                ReferenceKind::Mutable
+            },
+            Box::new(struct_ty),
+        );
+        for ((variant_opt, offset, _), function_index) in function_indices {
+            let def_idx = FunctionDefinitionIndex::new(ctx.checked_bound(
+                &loc,
+                genr.module.function_defs.len(),
+                MAX_FUNCTION_DEF_COUNT,
+                "defined function",
+            ));
+            genr.source_map
+                .add_top_level_function_mapping(def_idx, ctx.env.to_ir_loc(&loc), false)
+                .expect(SOURCE_MAP_OK);
+            for TypeParameter(name, _, loc) in struct_env.get_type_parameters() {
+                genr.source_map
+                    .add_function_type_parameter_mapping(
+                        def_idx,
+                        ctx.source_name(name, loc.clone()),
+                    )
+                    .expect(SOURCE_MAP_OK)
+            }
+            let input_param_name = struct_env
+                .env()
+                .symbol_pool()
+                .make(well_known::PARAM_NAME_FOR_STRUCT_API);
+            genr.source_map
+                .add_parameter_mapping(def_idx, ctx.source_name(input_param_name, loc.clone()))
+                .expect(SOURCE_MAP_OK);
+
+            // Function body:
+            // MoveLoc(0)
+            // ImmBorrowField/MutBorrowField/ImmBorrowFieldGeneric/MutBorrowFieldGeneric/
+            // ImmBorrowVariantField/MutBorrowVariantField/ImmBorrowVariantFieldGeneric/MutBorrowVariantFieldGeneric
+            // Ret
+            let locals = genr.signature(ctx, &loc, vec![ref_struct_ty.clone()]);
+            let mut code = vec![];
+            code.push(FF::Bytecode::MoveLoc(0 as FF::LocalIndex));
+            let field_env = &struct_env.get_field_by_offset_optional_variant(
+                variant_opt.clone().map(|variants| variants[0]),
+                offset,
+            );
+            let borrow_field_bc = match (type_parameters.is_empty(), variant_opt, is_imm) {
+                (true, Some(variants), true) => {
+                    let idx = genr.variant_field_index(ctx, &loc, &variants, field_env);
+                    FF::Bytecode::ImmBorrowVariantField(idx)
+                },
+                (true, Some(variants), false) => {
+                    let idx = genr.variant_field_index(ctx, &loc, &variants, field_env);
+                    FF::Bytecode::MutBorrowVariantField(idx)
+                },
+                (true, None, true) => {
+                    let idx = genr.field_index(ctx, &loc, field_env);
+                    FF::Bytecode::ImmBorrowField(idx)
+                },
+                (true, None, false) => {
+                    let idx = genr.field_index(ctx, &loc, field_env);
+                    FF::Bytecode::MutBorrowField(idx)
+                },
+                (false, Some(variants), true) => {
+                    let idx = genr.variant_field_inst_index(
+                        ctx,
+                        &loc,
+                        &variants,
+                        field_env,
+                        type_parameters.to_vec(),
+                    );
+                    FF::Bytecode::ImmBorrowVariantFieldGeneric(idx)
+                },
+                (false, Some(variants), false) => {
+                    let idx = genr.variant_field_inst_index(
+                        ctx,
+                        &loc,
+                        &variants,
+                        field_env,
+                        type_parameters.to_vec(),
+                    );
+                    FF::Bytecode::MutBorrowVariantFieldGeneric(idx)
+                },
+                (false, None, true) => {
+                    let idx = genr.field_inst_index(ctx, &loc, field_env, type_parameters.to_vec());
+                    FF::Bytecode::ImmBorrowFieldGeneric(idx)
+                },
+                (false, None, false) => {
+                    let idx = genr.field_inst_index(ctx, &loc, field_env, type_parameters.to_vec());
+                    FF::Bytecode::MutBorrowFieldGeneric(idx)
+                },
+            };
+            code.push(borrow_field_bc);
+            code.push(FF::Bytecode::Ret);
+            let code = FF::CodeUnit { locals, code };
+
+            let def = FF::FunctionDefinition {
+                function: function_index,
+                visibility,
+                is_entry: false,
+                acquires_global_resources: vec![],
+                code: Some(code),
+            };
+
+            genr.module.function_defs.push(def);
+        }
     }
 
     /// Generates code for a function.
@@ -253,7 +698,7 @@ impl<'a> FunctionGenerator<'a> {
         }
 
         // Deliver result
-        let locals = self.r#gen.signature(
+        let locals = self.genr.signature(
             &ctx.module,
             &ctx.loc,
             self.locals[ctx.fun.get_parameter_count()..].to_vec(),
@@ -267,7 +712,7 @@ impl<'a> FunctionGenerator<'a> {
     /// Generate file-format bytecode from a stackless bytecode and an optional next bytecode
     /// for peephole optimizations.
     fn gen_bytecode(&mut self, ctx: &BytecodeContext, bc: &Bytecode, next_bc: Option<&Bytecode>) {
-        self.r#gen
+        self.genr
             .source_map
             .add_code_mapping(
                 ctx.fun_ctx.def_idx,
@@ -420,62 +865,170 @@ impl<'a> FunctionGenerator<'a> {
                 self.gen_invoke(ctx, dest, source);
             },
             Operation::Pack(mid, sid, inst) => {
-                self.gen_struct_oper(
-                    ctx,
-                    dest,
-                    mid.qualified(*sid),
-                    inst,
-                    source,
-                    FF::Bytecode::Pack,
-                    FF::Bytecode::PackGeneric,
-                );
+                let struct_env = &fun_ctx.module.env.get_struct(mid.qualified(*sid));
+                let fun_mid = ctx.fun_ctx.fun.func_env.module_env.get_id();
+                if mid != &fun_mid {
+                    if !struct_env
+                        .env()
+                        .language_version()
+                        .language_version_for_public_struct()
+                    {
+                        fun_ctx.internal_error(format!(
+                            "cross module struct access is not supported by language version {}",
+                            struct_env.env().language_version()
+                        ));
+                        return;
+                    }
+                    self.gen_pack_unpack_api_call::<true>(
+                        ctx, dest, source, fun_ctx, &None, inst, struct_env,
+                    );
+                } else {
+                    self.gen_struct_oper(
+                        ctx,
+                        dest,
+                        mid.qualified(*sid),
+                        inst,
+                        source,
+                        FF::Bytecode::Pack,
+                        FF::Bytecode::PackGeneric,
+                    );
+                }
             },
             Operation::PackVariant(mid, sid, variant, inst) => {
-                self.gen_struct_variant_oper(
-                    ctx,
-                    dest,
-                    mid.qualified(*sid),
-                    *variant,
-                    inst,
-                    source,
-                    FF::Bytecode::PackVariant,
-                    FF::Bytecode::PackVariantGeneric,
-                );
+                let struct_env = &fun_ctx.module.env.get_struct(mid.qualified(*sid));
+                let fun_mid = ctx.fun_ctx.fun.func_env.module_env.get_id();
+                if mid != &fun_mid {
+                    if !struct_env
+                        .env()
+                        .language_version()
+                        .language_version_for_public_struct()
+                    {
+                        fun_ctx.internal_error(format!(
+                            "cross module struct access is not supported by language version {}",
+                            struct_env.env().language_version()
+                        ));
+                        return;
+                    }
+                    self.gen_pack_unpack_api_call::<true>(
+                        ctx,
+                        dest,
+                        source,
+                        fun_ctx,
+                        &Some(*variant),
+                        inst,
+                        struct_env,
+                    );
+                } else {
+                    self.gen_struct_variant_oper(
+                        ctx,
+                        dest,
+                        mid.qualified(*sid),
+                        *variant,
+                        inst,
+                        source,
+                        FF::Bytecode::PackVariant,
+                        FF::Bytecode::PackVariantGeneric,
+                    );
+                }
             },
             Operation::Unpack(mid, sid, inst) => {
-                self.gen_struct_oper(
-                    ctx,
-                    dest,
-                    mid.qualified(*sid),
-                    inst,
-                    source,
-                    FF::Bytecode::Unpack,
-                    FF::Bytecode::UnpackGeneric,
-                );
+                let struct_env = &fun_ctx.module.env.get_struct(mid.qualified(*sid));
+                let fun_mid = ctx.fun_ctx.fun.func_env.module_env.get_id();
+                if mid != &fun_mid {
+                    if !struct_env
+                        .env()
+                        .language_version()
+                        .language_version_for_public_struct()
+                    {
+                        fun_ctx.internal_error(format!(
+                            "cross module struct access is not supported by language version {}",
+                            struct_env.env().language_version()
+                        ));
+                        return;
+                    }
+                    self.gen_pack_unpack_api_call::<false>(
+                        ctx, dest, source, fun_ctx, &None, inst, struct_env,
+                    );
+                } else {
+                    self.gen_struct_oper(
+                        ctx,
+                        dest,
+                        mid.qualified(*sid),
+                        inst,
+                        source,
+                        FF::Bytecode::Unpack,
+                        FF::Bytecode::UnpackGeneric,
+                    );
+                }
             },
             Operation::UnpackVariant(mid, sid, variant, inst) => {
-                self.gen_struct_variant_oper(
-                    ctx,
-                    dest,
-                    mid.qualified(*sid),
-                    *variant,
-                    inst,
-                    source,
-                    FF::Bytecode::UnpackVariant,
-                    FF::Bytecode::UnpackVariantGeneric,
-                );
+                let struct_env = &fun_ctx.module.env.get_struct(mid.qualified(*sid));
+                let fun_mid = ctx.fun_ctx.fun.func_env.module_env.get_id();
+                if mid != &fun_mid {
+                    if !struct_env
+                        .env()
+                        .language_version()
+                        .language_version_for_public_struct()
+                    {
+                        fun_ctx.internal_error(format!(
+                            "cross module struct access is not supported by language version {}",
+                            struct_env.env().language_version()
+                        ));
+                        return;
+                    }
+                    self.gen_pack_unpack_api_call::<false>(
+                        ctx,
+                        dest,
+                        source,
+                        fun_ctx,
+                        &Some(*variant),
+                        inst,
+                        struct_env,
+                    );
+                } else {
+                    self.gen_struct_variant_oper(
+                        ctx,
+                        dest,
+                        mid.qualified(*sid),
+                        *variant,
+                        inst,
+                        source,
+                        FF::Bytecode::UnpackVariant,
+                        FF::Bytecode::UnpackVariantGeneric,
+                    );
+                }
             },
             Operation::TestVariant(mid, sid, variant, inst) => {
-                self.gen_struct_variant_oper(
-                    ctx,
-                    dest,
-                    mid.qualified(*sid),
-                    *variant,
-                    inst,
-                    source,
-                    FF::Bytecode::TestVariant,
-                    FF::Bytecode::TestVariantGeneric,
-                );
+                let struct_env = &fun_ctx.module.env.get_struct(mid.qualified(*sid));
+                let fun_mid = ctx.fun_ctx.fun.func_env.module_env.get_id();
+                let is_mut_src = fun_ctx.fun.get_local_type(source[0]).is_mutable_reference();
+                if mid != &fun_mid {
+                    if !struct_env
+                        .env()
+                        .language_version()
+                        .language_version_for_public_struct()
+                    {
+                        fun_ctx.internal_error(format!(
+                            "cross module struct access is not supported by language version {}",
+                            struct_env.env().language_version()
+                        ));
+                        return;
+                    }
+                    self.gen_test_variant_api_call(
+                        ctx, dest, source, fun_ctx, variant, inst, struct_env, is_mut_src,
+                    );
+                } else {
+                    self.gen_struct_variant_oper(
+                        ctx,
+                        dest,
+                        mid.qualified(*sid),
+                        *variant,
+                        inst,
+                        source,
+                        FF::Bytecode::TestVariant,
+                        FF::Bytecode::TestVariantGeneric,
+                    );
+                }
             },
             Operation::MoveTo(mid, sid, inst) => {
                 self.gen_struct_oper(
@@ -520,26 +1073,71 @@ impl<'a> FunctionGenerator<'a> {
                 self.abstract_push_result(ctx, dest)
             },
             Operation::BorrowField(mid, sid, inst, offset) => {
-                self.gen_borrow_field(
-                    ctx,
-                    dest,
-                    mid.qualified(*sid),
-                    inst.clone(),
-                    None,
-                    *offset,
-                    source,
-                );
+                let struct_env = &fun_ctx.module.env.get_struct(mid.qualified(*sid));
+                let fun_mid = ctx.fun_ctx.fun.func_env.module_env.get_id();
+                if mid != &fun_mid {
+                    if !struct_env
+                        .env()
+                        .language_version()
+                        .language_version_for_public_struct()
+                    {
+                        fun_ctx.internal_error(format!(
+                            "cross module struct access is not supported by language version {}",
+                            struct_env.env().language_version()
+                        ));
+                        return;
+                    }
+                    self.gen_borrow_field_api_call(
+                        ctx, dest, source, fun_ctx, &None, inst, offset, struct_env,
+                    );
+                } else {
+                    self.gen_borrow_field(
+                        ctx,
+                        dest,
+                        mid.qualified(*sid),
+                        inst.clone(),
+                        None,
+                        *offset,
+                        source,
+                    );
+                }
             },
             Operation::BorrowVariantField(mid, sid, variants, inst, offset) => {
-                self.gen_borrow_field(
-                    ctx,
-                    dest,
-                    mid.qualified(*sid),
-                    inst.clone(),
-                    Some(variants),
-                    *offset,
-                    source,
-                );
+                let struct_env = &fun_ctx.module.env.get_struct(mid.qualified(*sid));
+                let fun_mid = ctx.fun_ctx.fun.func_env.module_env.get_id();
+                if mid != &fun_mid {
+                    if !struct_env
+                        .env()
+                        .language_version()
+                        .language_version_for_public_struct()
+                    {
+                        fun_ctx.internal_error(format!(
+                            "cross module struct access is not supported by language version {}",
+                            struct_env.env().language_version()
+                        ));
+                        return;
+                    }
+                    self.gen_borrow_field_api_call(
+                        ctx,
+                        dest,
+                        source,
+                        fun_ctx,
+                        &Some(variants.clone()),
+                        inst,
+                        offset,
+                        struct_env,
+                    );
+                } else {
+                    self.gen_borrow_field(
+                        ctx,
+                        dest,
+                        mid.qualified(*sid),
+                        inst.clone(),
+                        Some(variants),
+                        *offset,
+                        source,
+                    );
+                }
             },
             Operation::BorrowGlobal(mid, sid, inst) => {
                 let is_mut = fun_ctx.fun.get_local_type(dest[0]).is_mutable_reference();
@@ -569,7 +1167,7 @@ impl<'a> FunctionGenerator<'a> {
                     Type::new_prim(PrimitiveType::Bool)
                 };
                 let sign = self
-                    .r#gen
+                    .genr
                     .signature(&fun_ctx.module, &fun_ctx.loc, vec![elem_type]);
                 self.gen_builtin(
                     ctx,
@@ -653,6 +1251,330 @@ impl<'a> FunctionGenerator<'a> {
         }
     }
 
+    /// Generate code for calling the borrow field api.
+    fn gen_borrow_field_api_call(
+        &mut self,
+        ctx: &BytecodeContext<'_>,
+        dest: &[usize],
+        source: &[usize],
+        fun_ctx: &FunctionContext<'_>,
+        variants: &Option<Vec<Symbol>>,
+        inst: &[Type],
+        offset: &usize,
+        struct_env: &StructEnv<'_>,
+    ) {
+        let is_mut_dest = fun_ctx.fun.get_local_type(dest[0]).is_mutable_reference();
+        let is_mut_src = fun_ctx.fun.get_local_type(source[0]).is_mutable_reference();
+        let vec = self.genr.struct_api_borrow_index(
+            &ctx.fun_ctx.module,
+            &fun_ctx.loc,
+            struct_env,
+            !is_mut_dest,
+        );
+        // generate code for calling borrow field API
+        // for struct, we can directly call the API when the offset matches;
+        // for enum, there are two cases:
+        // when variants in the borrow instruction are exact match with the variants in the API, we can directly call the API;
+        // when variants in the borrow instruction are a subset of the variants in the API,
+        // we need to generate code for calling the test variant API for each variant in the instruction;
+        // when variants in the borrow instruction are intersect with the variants in the API, we need to generate an error;
+        let mut found = false;
+        for ((cur_variants_opt, cur_offset, _), borrow_field_handle_index) in &vec {
+            if offset == cur_offset {
+                // handle borrow from a struct
+                if cur_variants_opt.is_none() {
+                    assert!(variants.is_none());
+                    self.abstract_push_args(ctx, source, None);
+                    // need to freeze mutable ref if the target is an immutable reference
+                    if is_mut_src && !is_mut_dest {
+                        self.emit(FF::Bytecode::FreezeRef);
+                    }
+                    if inst.is_empty() {
+                        self.emit(FF::Bytecode::Call(*borrow_field_handle_index));
+                    } else {
+                        let function_instantiation_index =
+                            self.genr.function_instantiation_index_from_handle_index(
+                                *borrow_field_handle_index,
+                                &ctx.fun_ctx.module,
+                                &fun_ctx.loc,
+                                inst.to_vec(),
+                            );
+                        self.emit(FF::Bytecode::CallGeneric(function_instantiation_index));
+                    }
+                    self.abstract_pop_n(ctx, source.len());
+                    self.abstract_push_result(ctx, dest);
+                    found = true;
+                    break;
+                } else if let Some(cur_variants) = cur_variants_opt {
+                    // handle borrow from an enum
+                    assert!(variants.is_some());
+                    let cur_variants_set = cur_variants.iter().collect::<BTreeSet<_>>();
+                    let variants_set = variants.as_ref().unwrap().iter().collect::<BTreeSet<_>>();
+                    // case 1: exact match
+                    if cur_variants_set == variants_set {
+                        self.abstract_push_args(ctx, source, None);
+                        // need to freeze mutable ref if the target is an immutable reference
+                        if is_mut_src && !is_mut_dest {
+                            self.emit(FF::Bytecode::FreezeRef);
+                        }
+                        if inst.is_empty() {
+                            self.emit(FF::Bytecode::Call(*borrow_field_handle_index));
+                        } else {
+                            let function_instantiation_index =
+                                self.genr.function_instantiation_index_from_handle_index(
+                                    *borrow_field_handle_index,
+                                    &ctx.fun_ctx.module,
+                                    &fun_ctx.loc,
+                                    inst.to_vec(),
+                                );
+                            self.emit(FF::Bytecode::CallGeneric(function_instantiation_index));
+                        }
+                        self.abstract_pop_n(ctx, source.len());
+                        self.abstract_push_result(ctx, dest);
+                        found = true;
+                        break;
+                    } else if variants_set.is_subset(&cur_variants_set) {
+                        // case 2: variants in the borrow field are a subset of the variants in the api
+                        let intersected_variants = variants_set
+                            .intersection(&cur_variants_set)
+                            .collect::<Vec<_>>();
+                        let test_variant_api_map = self.genr.struct_api_test_variant_index(
+                            &ctx.fun_ctx.module,
+                            &fun_ctx.loc,
+                            struct_env,
+                        );
+                        // before calling the test variant function, we need to flush the stack
+                        self.abstract_flush_stack_before(ctx, 0);
+                        let mut local_to_freeze = None;
+                        if is_mut_src {
+                            self.abstract_push_args(ctx, source, Some(&AssignKind::Copy));
+                            self.emit(FF::Bytecode::FreezeRef);
+                            let (temp, _) = self.stack.pop().unwrap();
+                            let ty = fun_ctx.temp_type(temp).skip_reference();
+                            let new_local = self.new_local(fun_ctx, ty.wrap_in_reference(false));
+                            self.emit(FF::Bytecode::StLoc(new_local));
+                            local_to_freeze = Some(new_local);
+                        }
+                        // the base code offset to compute the target offset for each test variant
+                        let code_offset_for_test_variant = self.code.len();
+                        let variants_size = intersected_variants.len();
+                        // TODO(#18319): optimize code generation here.
+                        // offset count for each test variant:
+                        // if the source is a mutable reference:
+                        //    copy source
+                        //    freeze ref
+                        //    stloc new_local
+                        // code_offset_for_test_variant is the length of code here.
+                        // 1. copy source / copy new_local
+                        // 2. test variant
+                        // 3. btrue L2
+                        // 4. copy source / copy new_local
+                        // 5. test variant
+                        // 6. btrue L2
+                        let offset_count_for_each_variant = 3;
+                        // if the source is a mutable reference:
+                        //     move new_local
+                        //     pop
+                        // 7. move source to stack
+                        // 8. pop
+                        // 9. ld 64
+                        // 10. abort
+                        // L2: if the source is a mutable reference:
+                        //     move new_local
+                        //     pop
+                        // ...
+                        let offset_count_for_abort = if is_mut_src { 6 } else { 4 };
+                        for variant in intersected_variants {
+                            if let Some(test_variant_handle_index) =
+                                test_variant_api_map.get(variant)
+                            {
+                                // self.abstract_push_args(ctx, source, Some(&AssignKind::Copy));
+                                // for test variant, we need to freeze mutable ref if the source is a mutable reference
+                                if let Some(local) = local_to_freeze {
+                                    self.emit(FF::Bytecode::CopyLoc(local));
+                                } else {
+                                    self.abstract_push_args(ctx, source, Some(&AssignKind::Copy));
+                                }
+                                if inst.is_empty() {
+                                    self.emit(FF::Bytecode::Call(*test_variant_handle_index));
+                                } else {
+                                    let function_instantiation_index =
+                                        self.genr.function_instantiation_index_from_handle_index(
+                                            *test_variant_handle_index,
+                                            &ctx.fun_ctx.module,
+                                            &fun_ctx.loc,
+                                            inst.to_vec(),
+                                        );
+                                    self.emit(FF::Bytecode::CallGeneric(
+                                        function_instantiation_index,
+                                    ));
+                                }
+                                if local_to_freeze.is_none() {
+                                    self.abstract_pop_n(ctx, source.len());
+                                }
+
+                                // Block when the test variant fails.
+                                self.code.push(FF::Bytecode::BrTrue(
+                                    (code_offset_for_test_variant
+                                        + variants_size * offset_count_for_each_variant
+                                        + offset_count_for_abort)
+                                        as FF::CodeOffset,
+                                ));
+                            } else {
+                                fun_ctx.internal_error(format!(
+                                    "cannot perform test variant {} of {} at offset {}",
+                                    variant.display(struct_env.env().symbol_pool()),
+                                    struct_env.get_full_name_with_address(),
+                                    offset
+                                ));
+                            }
+                        }
+                        if let Some(local) = local_to_freeze {
+                            self.emit(FF::Bytecode::MoveLoc(local));
+                            self.emit(FF::Bytecode::Pop);
+                        }
+                        // when all the test variants fail, we need to abort the function
+                        let local = self.temp_to_local(ctx.fun_ctx, Some(ctx.attr_id), source[0]);
+                        self.code.push(FF::Bytecode::MoveLoc(local));
+                        self.code.push(FF::Bytecode::Pop);
+                        self.code
+                            .push(FF::Bytecode::LdU64(well_known::INCOMPLETE_MATCH_ABORT_CODE));
+                        self.code.push(FF::Bytecode::Abort);
+                        if let Some(local) = local_to_freeze {
+                            self.emit(FF::Bytecode::MoveLoc(local));
+                            self.emit(FF::Bytecode::Pop);
+                        }
+                        // call borrow field api
+                        self.abstract_push_args(ctx, source, None);
+                        // need to freeze mutable ref if the target is an immutable reference
+                        if is_mut_src && !is_mut_dest {
+                            self.emit(FF::Bytecode::FreezeRef);
+                        }
+                        if inst.is_empty() {
+                            self.emit(FF::Bytecode::Call(*borrow_field_handle_index));
+                        } else {
+                            let function_instantiation_index =
+                                self.genr.function_instantiation_index_from_handle_index(
+                                    *borrow_field_handle_index,
+                                    &ctx.fun_ctx.module,
+                                    &fun_ctx.loc,
+                                    inst.to_vec(),
+                                );
+                            self.emit(FF::Bytecode::CallGeneric(function_instantiation_index));
+                        }
+                        self.abstract_pop_n(ctx, source.len());
+                        self.abstract_push_result(ctx, dest);
+                        found = true;
+                        break;
+                    } else if !variants_set
+                        .intersection(&cur_variants_set)
+                        .collect::<Vec<_>>()
+                        .is_empty()
+                    {
+                        // handle the case e.x where x appears in multiple variants at the same offset but have different or may be instantiated with different types.
+                        struct_env.env().error(&fun_ctx.fun.get_bytecode_loc(ctx.attr_id), &format!("cannot perform borrow operation for field `{}` for struct `{}` since it has or may be instantiated with different types in variants",
+                        struct_env.get_field_by_offset_optional_variant(Some(cur_variants[0]), *offset).get_name().display(struct_env.env().symbol_pool()),
+                        struct_env.get_full_name_with_address()));
+                        found = true;
+                        break;
+                    }
+                }
+            }
+        }
+        if !found {
+            fun_ctx.internal_error(format!(
+                "cannot generate borrow field for {} at offset {}",
+                struct_env.get_full_name_with_address(),
+                offset
+            ));
+        }
+    }
+
+    /// Generates call to test variant api.
+    fn gen_test_variant_api_call(
+        &mut self,
+        ctx: &BytecodeContext<'_>,
+        dest: &[usize],
+        source: &[usize],
+        fun_ctx: &FunctionContext<'_>,
+        variant: &Symbol,
+        inst: &[Type],
+        struct_env: &StructEnv<'_>,
+        is_mut_src: bool,
+    ) {
+        let test_variant_api_map =
+            self.genr
+                .struct_api_test_variant_index(&ctx.fun_ctx.module, &fun_ctx.loc, struct_env);
+        if let Some(handle_index) = test_variant_api_map.get(variant) {
+            self.abstract_push_args(ctx, source, None);
+            // need to freeze mutable ref
+            if is_mut_src {
+                self.emit(FF::Bytecode::FreezeRef);
+            }
+            if inst.is_empty() {
+                self.emit(FF::Bytecode::Call(*handle_index));
+            } else {
+                let function_instantiation_index =
+                    self.genr.function_instantiation_index_from_handle_index(
+                        *handle_index,
+                        &ctx.fun_ctx.module,
+                        &fun_ctx.loc,
+                        inst.to_vec(),
+                    );
+                self.emit(FF::Bytecode::CallGeneric(function_instantiation_index));
+            }
+            self.abstract_pop_n(ctx, source.len());
+            self.abstract_push_result(ctx, dest);
+        } else {
+            fun_ctx.internal_error(format!(
+                "variant {} not found in test variant api map",
+                variant.display(struct_env.env().symbol_pool())
+            ));
+        }
+    }
+
+    /// Generates call to pack/unpack API.
+    fn gen_pack_unpack_api_call<const IS_PACK: bool>(
+        &mut self,
+        ctx: &BytecodeContext<'_>,
+        dest: &[usize],
+        source: &[usize],
+        fun_ctx: &FunctionContext<'_>,
+        variant_opt: &Option<Symbol>,
+        inst: &[Type],
+        struct_env: &StructEnv<'_>,
+    ) {
+        let api_map = if IS_PACK {
+            self.genr
+                .struct_api_pack_index(&ctx.fun_ctx.module, &fun_ctx.loc, struct_env)
+        } else {
+            self.genr
+                .struct_api_unpack_index(&ctx.fun_ctx.module, &fun_ctx.loc, struct_env)
+        };
+        if let Some(handle_index) = api_map.get(variant_opt) {
+            self.abstract_push_args(ctx, source, None);
+            if inst.is_empty() {
+                self.emit(FF::Bytecode::Call(*handle_index));
+            } else {
+                let function_instantiation_index =
+                    self.genr.function_instantiation_index_from_handle_index(
+                        *handle_index,
+                        &ctx.fun_ctx.module,
+                        &fun_ctx.loc,
+                        inst.to_vec(),
+                    );
+                self.emit(FF::Bytecode::CallGeneric(function_instantiation_index));
+            }
+            self.abstract_pop_n(ctx, source.len());
+            self.abstract_push_result(ctx, dest);
+        } else {
+            fun_ctx.internal_error(format!(
+                "not found in {} api map",
+                if IS_PACK { "pack" } else { "unpack" }
+            ));
+        }
+    }
+
     /// Generates code for a function call.
     fn gen_call(
         &mut self,
@@ -668,20 +1590,20 @@ impl<'a> FunctionGenerator<'a> {
             &ctx.fun_ctx.loc,
             id,
             Some(
-                self.r#gen
+                self.genr
                     .signature(&ctx.fun_ctx.module, &ctx.fun_ctx.loc, inst.to_vec()),
             ),
         ) {
             self.emit(opcode)
         } else if inst.is_empty() {
-            let idx = self.r#gen.function_index(
+            let idx = self.genr.function_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,
                 &fun_ctx.module.env.get_function(id),
             );
             self.emit(FF::Bytecode::Call(idx))
         } else {
-            let idx = self.r#gen.function_instantiation_index(
+            let idx = self.genr.function_instantiation_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,
                 &fun_ctx.module.env.get_function(id),
@@ -706,14 +1628,14 @@ impl<'a> FunctionGenerator<'a> {
         let fun_ctx = ctx.fun_ctx;
         self.abstract_push_args(ctx, source, None);
         if inst.is_empty() {
-            let idx = self.r#gen.function_index(
+            let idx = self.genr.function_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,
                 &fun_ctx.module.env.get_function(id),
             );
             self.emit(FF::Bytecode::PackClosure(idx, mask))
         } else {
-            let idx = self.r#gen.function_instantiation_index(
+            let idx = self.genr.function_instantiation_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,
                 &fun_ctx.module.env.get_function(id),
@@ -732,7 +1654,7 @@ impl<'a> FunctionGenerator<'a> {
             .fun
             .get_local_type(*source.last().expect("invoke has function argument last"));
         let sign_idx = self
-            .r#gen
+            .genr
             .signature(&ctx.fun_ctx.module, &ctx.fun_ctx.loc, vec![
                 clos_type.clone()
             ]);
@@ -760,11 +1682,11 @@ impl<'a> FunctionGenerator<'a> {
         let struct_env = &fun_ctx.module.env.get_struct(id);
         if inst.is_empty() {
             let idx = self
-                .r#gen
+                .genr
                 .struct_def_index(&fun_ctx.module, &fun_ctx.loc, struct_env);
             self.emit(mk_simple(idx))
         } else {
-            let idx = self.r#gen.struct_def_instantiation_index(
+            let idx = self.genr.struct_def_instantiation_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,
                 struct_env,
@@ -792,11 +1714,11 @@ impl<'a> FunctionGenerator<'a> {
         let struct_env = &fun_ctx.module.env.get_struct(id);
         if inst.is_empty() {
             let idx =
-                self.r#gen
+                self.genr
                     .struct_variant_index(&fun_ctx.module, &fun_ctx.loc, struct_env, variant);
             self.emit(mk_simple(idx))
         } else {
-            let idx = self.r#gen.struct_variant_inst_index(
+            let idx = self.genr.struct_variant_inst_index(
                 &fun_ctx.module,
                 &fun_ctx.loc,
                 struct_env,
@@ -830,7 +1752,7 @@ impl<'a> FunctionGenerator<'a> {
             let field_env =
                 &struct_env.get_field_by_offset_optional_variant(Some(variants[0]), offset);
             if inst.is_empty() {
-                let idx = self.r#gen.variant_field_index(
+                let idx = self.genr.variant_field_index(
                     &fun_ctx.module,
                     &fun_ctx.loc,
                     variants,
@@ -842,7 +1764,7 @@ impl<'a> FunctionGenerator<'a> {
                     self.emit(FF::Bytecode::ImmBorrowVariantField(idx))
                 }
             } else {
-                let idx = self.r#gen.variant_field_inst_index(
+                let idx = self.genr.variant_field_inst_index(
                     &fun_ctx.module,
                     &fun_ctx.loc,
                     variants,
@@ -859,7 +1781,7 @@ impl<'a> FunctionGenerator<'a> {
             let field_env = &struct_env.get_field_by_offset_optional_variant(None, offset);
             if inst.is_empty() {
                 let idx = self
-                    .r#gen
+                    .genr
                     .field_index(&fun_ctx.module, &fun_ctx.loc, field_env);
                 if is_mut {
                     self.emit(FF::Bytecode::MutBorrowField(idx))
@@ -868,7 +1790,7 @@ impl<'a> FunctionGenerator<'a> {
                 }
             } else {
                 let idx =
-                    self.r#gen
+                    self.genr
                         .field_inst_index(&fun_ctx.module, &fun_ctx.loc, field_env, inst);
                 if is_mut {
                     self.emit(FF::Bytecode::MutBorrowFieldGeneric(idx))
@@ -932,7 +1854,7 @@ impl<'a> FunctionGenerator<'a> {
                 self.gen_vector_load_push(ctx, vec, dest_type);
             },
             _ => {
-                let cons = self.r#gen.constant_index(
+                let cons = self.genr.constant_index(
                     &ctx.fun_ctx.module,
                     &ctx.fun_ctx.loc,
                     cons,
@@ -955,7 +1877,7 @@ impl<'a> FunctionGenerator<'a> {
             self.gen_load_push(ctx, cons, &elem_type);
         }
         let sign = self
-            .r#gen
+            .genr
             .signature(&fun_ctx.module, &fun_ctx.loc, vec![elem_type]);
         self.emit(FF::Bytecode::VecPack(sign, vec.len() as u64));
     }
@@ -1271,7 +2193,7 @@ impl<'a> FunctionGenerator<'a> {
                 };
                 // Only add to the source map if it wasn't a parameter.
                 let name = ctx.fun.get_local_name(temp);
-                self.r#gen
+                self.genr
                     .source_map
                     .add_local_mapping(ctx.def_idx, ctx.module.source_name(name, loc))
                     .expect(SOURCE_MAP_OK);

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16222_fv_wrapper_unpack.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16222_fv_wrapper_unpack.exp
@@ -223,19 +223,112 @@ public fun n::test_friend() {
 }
 
 
-Diagnostics:
-bug: compiler internal error: struct not defined
-   ┌─ tests/bytecode-generator/bug_16222_fv_wrapper_unpack.move:20:16
-   │
-20 │     public fun test() {
-   │                ^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+friend 0xc0ffee::n
+struct Lazy has drop
+  _0: || has drop
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/bytecode-generator/bug_16222_fv_wrapper_unpack.move:25:16
-   │
-25 │     public fun test_friend() {
-   │                ^^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 0
+friend fun pack$Lazy(l0: || has drop): Lazy
+    local l1: || has drop
+    move_loc l0
+    pack Lazy
+    ret
+
+// Function definition at index 1
+friend fun unpack$Lazy(l0: Lazy): || has drop
+    local l1: Lazy
+    move_loc l0
+    unpack Lazy
+    ret
+
+// Function definition at index 2
+friend fun borrow$Lazy$0(l0: &Lazy): &|| has drop
+    local l1: &Lazy
+    move_loc l0
+    borrow_field Lazy, _0
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$Lazy$0(l0: &mut Lazy): &mut || has drop
+    local l1: &mut Lazy
+    move_loc l0
+    mut_borrow_field Lazy, _0
+    ret
+
+// Function definition at index 4
+#[persistent] public fun make_lazy(): Lazy
+    pack_closure __lambda__1__make_lazy, 0
+    pack Lazy
+    ret
+
+// Function definition at index 5
+fun __lambda__1__make_lazy()
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n
+struct Lazy has drop
+  _0: || has drop
+
+// Function definition at index 0
+friend fun pack$Lazy(l0: || has drop): Lazy
+    local l1: || has drop
+    move_loc l0
+    pack Lazy
+    ret
+
+// Function definition at index 1
+friend fun unpack$Lazy(l0: Lazy): || has drop
+    local l1: Lazy
+    move_loc l0
+    unpack Lazy
+    ret
+
+// Function definition at index 2
+friend fun borrow$Lazy$0(l0: &Lazy): &|| has drop
+    local l1: &Lazy
+    move_loc l0
+    borrow_field Lazy, _0
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$Lazy$0(l0: &mut Lazy): &mut || has drop
+    local l1: &mut Lazy
+    move_loc l0
+    mut_borrow_field Lazy, _0
+    ret
+
+// Function definition at index 4
+#[persistent] public fun make_lazy(): Lazy
+    pack_closure __lambda__1__make_lazy, 0
+    pack Lazy
+    ret
+
+// Function definition at index 5
+fun __lambda__1__make_lazy()
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n
+use 0xc0ffee::m
+use 0xc0ffee::m_friend
+// Function definition at index 0
+#[persistent] public fun test()
+    call m::make_lazy
+    call m::unpack$Lazy
+    call_closure <|| has drop>
+    ret
+
+// Function definition at index 1
+#[persistent] public fun test_friend()
+    call m_friend::make_lazy
+    call m_friend::unpack$Lazy
+    call_closure <|| has drop>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16543_fv_wrapper_pack.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/bug_16543_fv_wrapper_pack.exp
@@ -143,19 +143,98 @@ fun n::__lambda__1__test_friend() {
 }
 
 
-Diagnostics:
-bug: compiler internal error: struct not defined
-   ┌─ tests/bytecode-generator/bug_16543_fv_wrapper_pack.move:13:16
-   │
-13 │     public fun test(): 0xc0ffee::m::Lazy {
-   │                ^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+friend 0xc0ffee::n
+struct Lazy has drop
+  _0: || has drop
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/bytecode-generator/bug_16543_fv_wrapper_pack.move:17:16
-   │
-17 │     public fun test_friend(): 0xc0ffee::m_friend::Lazy {
-   │                ^^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 0
+friend fun pack$Lazy(l0: || has drop): Lazy
+    local l1: || has drop
+    move_loc l0
+    pack Lazy
+    ret
+
+// Function definition at index 1
+friend fun unpack$Lazy(l0: Lazy): || has drop
+    local l1: Lazy
+    move_loc l0
+    unpack Lazy
+    ret
+
+// Function definition at index 2
+friend fun borrow$Lazy$0(l0: &Lazy): &|| has drop
+    local l1: &Lazy
+    move_loc l0
+    borrow_field Lazy, _0
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$Lazy$0(l0: &mut Lazy): &mut || has drop
+    local l1: &mut Lazy
+    move_loc l0
+    mut_borrow_field Lazy, _0
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n
+struct Lazy has drop
+  _0: || has drop
+
+// Function definition at index 0
+friend fun pack$Lazy(l0: || has drop): Lazy
+    local l1: || has drop
+    move_loc l0
+    pack Lazy
+    ret
+
+// Function definition at index 1
+friend fun unpack$Lazy(l0: Lazy): || has drop
+    local l1: Lazy
+    move_loc l0
+    unpack Lazy
+    ret
+
+// Function definition at index 2
+friend fun borrow$Lazy$0(l0: &Lazy): &|| has drop
+    local l1: &Lazy
+    move_loc l0
+    borrow_field Lazy, _0
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$Lazy$0(l0: &mut Lazy): &mut || has drop
+    local l1: &mut Lazy
+    move_loc l0
+    mut_borrow_field Lazy, _0
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n
+use 0xc0ffee::m
+use 0xc0ffee::m_friend
+// Function definition at index 0
+#[persistent] public fun test(): m::Lazy
+    pack_closure __lambda__1__test, 0
+    call m::pack$Lazy
+    ret
+
+// Function definition at index 1
+#[persistent] public fun test_friend(): m_friend::Lazy
+    pack_closure __lambda__1__test_friend, 0
+    call m_friend::pack$Lazy
+    ret
+
+// Function definition at index 2
+fun __lambda__1__test()
+    ret
+
+// Function definition at index 3
+fun __lambda__1__test_friend()
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_borrow_field_err.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_borrow_field_err.exp
@@ -446,19 +446,233 @@ fun n::test_no_err() {
 }
 
 
-Diagnostics:
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_borrow_field_err.move:16:9
-   │
-16 │     fun test_1() {
-   │         ^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+enum Wrapper has drop
+  V1
+    _0: u64
+    _1: u64
+  V2
+    _0: u64
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_borrow_field_err.move:41:9
+// Function definition at index 0
+public fun test_variant$Wrapper$V1(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V1
+    ret
+
+// Function definition at index 1
+public fun test_variant$Wrapper$V2(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V2
+    ret
+
+// Function definition at index 2
+public fun pack$Wrapper$V1(l0: u64, l1: u64): Wrapper
+    local l2: u64
+    local l3: u64
+    move_loc l0
+    move_loc l1
+    pack_variant Wrapper, V1
+    ret
+
+// Function definition at index 3
+public fun pack$Wrapper$V2(l0: u64): Wrapper
+    local l1: u64
+    move_loc l0
+    pack_variant Wrapper, V2
+    ret
+
+// Function definition at index 4
+public fun unpack$Wrapper$V1(l0: Wrapper): (u64, u64)
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V1
+    ret
+
+// Function definition at index 5
+public fun unpack$Wrapper$V2(l0: Wrapper): u64
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V2
+    ret
+
+// Function definition at index 6
+public fun borrow$Wrapper$0$0(l0: &Wrapper): &u64
+    local l1: &Wrapper
+    move_loc l0
+    borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 7
+public fun borrow$Wrapper$1$1(l0: &Wrapper): &u64
+    local l1: &Wrapper
+    move_loc l0
+    borrow_variant_field Wrapper, V1::_1
+    ret
+
+// Function definition at index 8
+public fun borrow_mut$Wrapper$0$0(l0: &mut Wrapper): &mut u64
+    local l1: &mut Wrapper
+    move_loc l0
+    mut_borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 9
+public fun borrow_mut$Wrapper$1$1(l0: &mut Wrapper): &mut u64
+    local l1: &mut Wrapper
+    move_loc l0
+    mut_borrow_variant_field Wrapper, V1::_1
+    ret
+
+// Function definition at index 10
+#[persistent] public fun make(l0: u64): Wrapper
+    copy_loc l0
+    move_loc l0
+    ld_u64 1
+    add
+    pack_variant Wrapper, V1
+    // @5
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n
+use 0xc0ffee::m
+// Function definition at index 0
+fun foo(l0: &mut u64, l1: &mut u64)
+    move_loc l0
+    pop
+    move_loc l1
+    pop
+    ret
+
+// Function definition at index 1
+fun test_1()
+    local l0: m::Wrapper
+    local l1: &mut u64
+    local l2: &mut u64
+    ld_u64 22
+    call m::make
+    st_loc l0
+    mut_borrow_loc l0
+    call m::borrow_mut$Wrapper$0$0
+    // @5
+    mut_borrow_loc l0
+    call m::borrow_mut$Wrapper$1$1
+    call foo
+    ret
+
+// Function definition at index 2
+fun test_2()
+    local l0: m::Wrapper
+    local l1: u64
+    local l2: &mut u64
+    local l3: &mut u64
+    ld_u64 22
+    call m::make
+    st_loc l0
+    mut_borrow_loc l0
+    call m::borrow_mut$Wrapper$0$0
+    // @5
+    mut_borrow_loc l0
+    call m::borrow_mut$Wrapper$1$1
+    st_loc l2
+    st_loc l3
+    ld_u64 23
+    // @10
+    move_loc l3
+    write_ref
+    ld_u64 24
+    move_loc l2
+    write_ref
+    // @15
+    ret
+
+// Function definition at index 3
+fun test_match()
+    local l0: m::Wrapper
+    local l1: &mut m::Wrapper
+    local l2: &m::Wrapper
+    local l3: &mut u64
+    local l4: &mut u64
+    ld_u64 22
+    call m::make
+    st_loc l0
+    mut_borrow_loc l0
+    st_loc l1
+    // @5
+    copy_loc l1
+    freeze_ref
+    call m::test_variant$Wrapper$V2
+    br_false l0
+    move_loc l1
+    // @10
+    pop
+    ret
+l0: copy_loc l1
+    freeze_ref
+    call m::test_variant$Wrapper$V1
+    // @15
+    br_false l1
+    copy_loc l1
+    freeze_ref
+    st_loc l2
+    copy_loc l2
+    // @20
+    call m::test_variant$Wrapper$V1
+    br_true l2
+    move_loc l2
+    pop
+    move_loc l1
+    // @25
+    pop
+    ld_u64 14566554180833181697
+    abort
+l2: move_loc l2
+    pop
+    // @30
+    copy_loc l1
+    call m::borrow_mut$Wrapper$0$0
+    move_loc l1
+    call m::borrow_mut$Wrapper$1$1
+    call foo
+    // @35
+    ret
+l1: move_loc l1
+    pop
+    ld_u64 14566554180833181697
+    abort
+
+// Function definition at index 4
+fun test_no_err()
+    local l0: m::Wrapper
+    ld_u64 22
+    call m::make
+    st_loc l0
+    ld_u64 23
+    mut_borrow_loc l0
+    // @5
+    call m::borrow_mut$Wrapper$0$0
+    write_ref
+    ld_u64 24
+    mut_borrow_loc l0
+    call m::borrow_mut$Wrapper$1$1
+    // @10
+    write_ref
+    ret
+
+
+============ bytecode verification failed ========
+
+Diagnostics:
+bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`:
+Error message: none
+   ┌─ tests/checking-lang-v2.4/cross_module_borrow_field_err.move:20:19
    │
-41 │     fun test_match() {
-   │         ^^^^^^^^^^
+20 │         let x_1 = &mut x.1;
+   │                   ^^^^^^^^
    │
    = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_borrow_field_err.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_borrow_field_err.move
@@ -1,3 +1,4 @@
+// TODO: #18199
 module 0xc0ffee::m {
     public enum Wrapper has drop {
         V1(u64, u64),

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_package_access_success.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_package_access_success.exp
@@ -1,5 +1,8 @@
 // -- Model dump before first bytecode pipeline
 module 0xc0ffee::m {
+    struct Empty {
+        dummy_field: bool,
+    }
     struct S {
         x: u64,
     }
@@ -140,6 +143,8 @@ module 0xc0ffee::m {
     friend 0xc0ffee::n7;
     friend 0xc0ffee::n8;
     friend 0xc0ffee::n9;
+    struct Empty {
+    }
     struct S {
         x: u64,
     }
@@ -399,6 +404,9 @@ fun n_friend::test_pack_friend_struct(): 0xc0ffee::m_friend::T {
 
 // -- Model dump before second bytecode pipeline
 module 0xc0ffee::m {
+    struct Empty {
+        dummy_field: bool,
+    }
     struct S {
         x: u64,
     }
@@ -676,83 +684,351 @@ fun n_friend::test_pack_friend_struct(): 0xc0ffee::m_friend::T {
 }
 
 
-Diagnostics:
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:35:9
-   │
-35 │     fun test() {
-   │         ^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+friend 0xc0ffee::n
+friend 0xc0ffee::n2
+friend 0xc0ffee::n3
+friend 0xc0ffee::n4
+friend 0xc0ffee::n5
+friend 0xc0ffee::n6
+friend 0xc0ffee::n7
+friend 0xc0ffee::n8
+friend 0xc0ffee::n9
+struct Empty
+  dummy_field: bool
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:44:9
-   │
-44 │     fun test_pack() {
-   │         ^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+struct S
+  x: u64
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:52:9
-   │
-52 │     fun test_unpack(w: Wrapper) {
-   │         ^^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+struct S2
+  x: u64
+  s: S
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:60:9
-   │
-60 │     fun test_select_variant(w: Wrapper): u64 {
-   │         ^^^^^^^^^^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+enum Wrapper has drop
+  V1
+    _0: u64
+  V2
+    _0: u64
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:68:9
-   │
-68 │     fun test_test_variant(w: Wrapper): bool {
-   │         ^^^^^^^^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 0
+friend fun pack$Empty(l0: bool): Empty
+    local l1: bool
+    move_loc l0
+    pack Empty
+    ret
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:76:9
-   │
-76 │     fun test_match(w: Wrapper): bool {
-   │         ^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 1
+friend fun unpack$Empty(l0: Empty): bool
+    local l1: Empty
+    move_loc l0
+    unpack Empty
+    ret
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:87:9
-   │
-87 │     fun test_pack_struct(): S {
-   │         ^^^^^^^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 2
+friend fun pack$S(l0: u64): S
+    local l1: u64
+    move_loc l0
+    pack S
+    ret
 
-bug: compiler internal error: struct not defined
-   ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:95:9
-   │
-95 │     fun test_pack_friend_struct(): T {
-   │         ^^^^^^^^^^^^^^^^^^^^^^^
-   │
-   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 3
+friend fun unpack$S(l0: S): u64
+    local l1: S
+    move_loc l0
+    unpack S
+    ret
 
-bug: compiler internal error: struct not defined
-    ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:107:9
-    │
-107 │     fun test_pack_struct(): S {
-    │         ^^^^^^^^^^^^^^^^
-    │
-    = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 4
+friend fun borrow$S$0(l0: &S): &u64
+    local l1: &S
+    move_loc l0
+    borrow_field S, x
+    ret
 
-bug: compiler internal error: struct not defined
-    ┌─ tests/checking-lang-v2.4/cross_module_package_access_success.move:120:9
-    │
-120 │     fun test_pack_unpack_struct_in_lambda() {
-    │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    │
-    = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+// Function definition at index 5
+friend fun borrow_mut$S$0(l0: &mut S): &mut u64
+    local l1: &mut S
+    move_loc l0
+    mut_borrow_field S, x
+    ret
+
+// Function definition at index 6
+friend fun pack$S2(l0: u64, l1: S): S2
+    local l2: u64
+    local l3: S
+    move_loc l0
+    move_loc l1
+    pack S2
+    ret
+
+// Function definition at index 7
+friend fun unpack$S2(l0: S2): (u64, S)
+    local l1: S2
+    move_loc l0
+    unpack S2
+    ret
+
+// Function definition at index 8
+friend fun borrow$S2$0(l0: &S2): &u64
+    local l1: &S2
+    move_loc l0
+    borrow_field S2, x
+    ret
+
+// Function definition at index 9
+friend fun borrow$S2$1(l0: &S2): &S
+    local l1: &S2
+    move_loc l0
+    borrow_field S2, s
+    ret
+
+// Function definition at index 10
+friend fun borrow_mut$S2$0(l0: &mut S2): &mut u64
+    local l1: &mut S2
+    move_loc l0
+    mut_borrow_field S2, x
+    ret
+
+// Function definition at index 11
+friend fun borrow_mut$S2$1(l0: &mut S2): &mut S
+    local l1: &mut S2
+    move_loc l0
+    mut_borrow_field S2, s
+    ret
+
+// Function definition at index 12
+friend fun test_variant$Wrapper$V1(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V1
+    ret
+
+// Function definition at index 13
+friend fun test_variant$Wrapper$V2(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V2
+    ret
+
+// Function definition at index 14
+friend fun pack$Wrapper$V1(l0: u64): Wrapper
+    local l1: u64
+    move_loc l0
+    pack_variant Wrapper, V1
+    ret
+
+// Function definition at index 15
+friend fun pack$Wrapper$V2(l0: u64): Wrapper
+    local l1: u64
+    move_loc l0
+    pack_variant Wrapper, V2
+    ret
+
+// Function definition at index 16
+friend fun unpack$Wrapper$V1(l0: Wrapper): u64
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V1
+    ret
+
+// Function definition at index 17
+friend fun unpack$Wrapper$V2(l0: Wrapper): u64
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V2
+    ret
+
+// Function definition at index 18
+friend fun borrow$Wrapper$0$0(l0: &Wrapper): &u64
+    local l1: &Wrapper
+    move_loc l0
+    borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 19
+friend fun borrow_mut$Wrapper$0$0(l0: &mut Wrapper): &mut u64
+    local l1: &mut Wrapper
+    move_loc l0
+    mut_borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 20
+#[persistent] public fun make(l0: u64): Wrapper
+    move_loc l0
+    pack_variant Wrapper, V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n_friend
+struct T
+  x: u64
+
+// Function definition at index 0
+friend fun pack$T(l0: u64): T
+    local l1: u64
+    move_loc l0
+    pack T
+    ret
+
+// Function definition at index 1
+friend fun unpack$T(l0: T): u64
+    local l1: T
+    move_loc l0
+    unpack T
+    ret
+
+// Function definition at index 2
+friend fun borrow$T$0(l0: &T): &u64
+    local l1: &T
+    move_loc l0
+    borrow_field T, x
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$T$0(l0: &mut T): &mut u64
+    local l1: &mut T
+    move_loc l0
+    mut_borrow_field T, x
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n
+use 0xc0ffee::m
+// Function definition at index 0
+fun test()
+    local l0: m::Wrapper
+    ld_u64 22
+    call m::make
+    st_loc l0
+    borrow_loc l0
+    call m::borrow$Wrapper$0$0
+    // @5
+    read_ref
+    ld_u64 22
+    eq
+    br_false l0
+    ret
+    // @10
+l0: ld_u64 1
+    abort
+
+// Bytecode version v9
+module 0xc0ffee::n2
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack()
+    ld_u64 22
+    call m::pack$Wrapper$V1
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n3
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_unpack(l0: m::Wrapper)
+    move_loc l0
+    call m::unpack$Wrapper$V1
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n4
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_select_variant(l0: m::Wrapper): u64
+    borrow_loc l0
+    call m::borrow$Wrapper$0$0
+    read_ref
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n5
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_test_variant(l0: m::Wrapper): bool
+    borrow_loc l0
+    call m::test_variant$Wrapper$V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n6
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_match(l0: m::Wrapper): bool
+    local l1: &m::Wrapper
+    borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$Wrapper$V1
+    br_false l0
+    // @5
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$Wrapper$V1
+    pop
+    // @10
+    ld_true
+    ret
+l0: move_loc l1
+    call m::test_variant$Wrapper$V2
+    br_false l1
+    // @15
+    move_loc l0
+    call m::unpack$Wrapper$V2
+    pop
+    ld_false
+    ret
+    // @20
+l1: ld_u64 14566554180833181697
+    abort
+
+// Bytecode version v9
+module 0xc0ffee::n7
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_struct(): m::S
+    ld_u64 22
+    call m::pack$S
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n8
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_struct(): m::S
+    ld_u64 22
+    call m::pack$S
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n9
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_unpack_struct_in_lambda()
+    ld_u64 22
+    ld_u64 33
+    call m::pack$S
+    call m::pack$S2
+    call m::unpack$S2
+    // @5
+    call m::unpack$S
+    pop
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n_friend
+use 0xc0ffee::m_friend
+// Function definition at index 0
+fun test_pack_friend_struct(): m_friend::T
+    ld_u64 22
+    call m_friend::pack$T
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_package_access_success.move
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.4/cross_module_package_access_success.move
@@ -18,6 +18,8 @@ module 0xc0ffee::m {
         s: S,
     }
 
+    public(package) struct Empty {}
+
 }
 
 module 0xc0ffee::m_friend {

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_enums.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_enums.exp
@@ -1,0 +1,224 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+friend 0xc0ffee::n
+friend 0xc0ffee::n2
+friend 0xc0ffee::n3
+friend 0xc0ffee::n4
+friend 0xc0ffee::n5
+friend 0xc0ffee::n6
+friend 0xc0ffee::n7
+enum Wrapper has drop
+  V1
+    _0: u64
+  V2
+    _0: u64
+
+// Function definition at index 0
+friend fun test_variant$Wrapper$V1(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V1
+    ret
+
+// Function definition at index 1
+friend fun test_variant$Wrapper$V2(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V2
+    ret
+
+// Function definition at index 2
+friend fun pack$Wrapper$V1(l0: u64): Wrapper
+    local l1: u64
+    move_loc l0
+    pack_variant Wrapper, V1
+    ret
+
+// Function definition at index 3
+friend fun pack$Wrapper$V2(l0: u64): Wrapper
+    local l1: u64
+    move_loc l0
+    pack_variant Wrapper, V2
+    ret
+
+// Function definition at index 4
+friend fun unpack$Wrapper$V1(l0: Wrapper): u64
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V1
+    ret
+
+// Function definition at index 5
+friend fun unpack$Wrapper$V2(l0: Wrapper): u64
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V2
+    ret
+
+// Function definition at index 6
+friend fun borrow$Wrapper$0$0(l0: &Wrapper): &u64
+    local l1: &Wrapper
+    move_loc l0
+    borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 7
+friend fun borrow_mut$Wrapper$0$0(l0: &mut Wrapper): &mut u64
+    local l1: &mut Wrapper
+    move_loc l0
+    mut_borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 8
+#[persistent] public fun make(l0: u64): Wrapper
+    move_loc l0
+    pack_variant Wrapper, V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n
+use 0xc0ffee::m
+// Function definition at index 0
+fun test()
+    local l0: m::Wrapper
+    ld_u64 22
+    call m::make
+    st_loc l0
+    borrow_loc l0
+    call m::borrow$Wrapper$0$0
+    // @5
+    read_ref
+    ld_u64 22
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 1
+    abort
+l1: ret
+
+// Bytecode version v9
+module 0xc0ffee::n2
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack()
+    ld_u64 22
+    call m::pack$Wrapper$V1
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n3
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_unpack(l0: m::Wrapper)
+    move_loc l0
+    call m::unpack$Wrapper$V1
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n4
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_select_variant(l0: m::Wrapper): u64
+    borrow_loc l0
+    call m::borrow$Wrapper$0$0
+    read_ref
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n5
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_test_variant(l0: m::Wrapper): bool
+    borrow_loc l0
+    call m::test_variant$Wrapper$V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n6
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_test_variant_immutable_borrow(l0: &m::Wrapper): bool
+    move_loc l0
+    call m::test_variant$Wrapper$V1
+    ret
+
+// Function definition at index 1
+fun test_test_variant_mut_borrow(l0: &mut m::Wrapper): bool
+    move_loc l0
+    freeze_ref
+    call m::test_variant$Wrapper$V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n7
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_match(l0: m::Wrapper): bool
+    local l1: &m::Wrapper
+    local l2: bool
+    borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$Wrapper$V1
+    br_false l0
+    // @5
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$Wrapper$V1
+    ld_true
+    // @10
+    st_loc l2
+    pop
+    branch l1
+l0: move_loc l1
+    call m::test_variant$Wrapper$V2
+    // @15
+    br_false l2
+    move_loc l0
+    call m::unpack$Wrapper$V2
+    ld_false
+    st_loc l2
+    // @20
+    pop
+    branch l1
+l2: ld_u64 14566554180833181697
+    abort
+l1: move_loc l2
+    // @25
+    ret
+
+// Function definition at index 1
+fun test_match_mut_borrow(l0: &mut m::Wrapper): bool
+    local l1: bool
+    copy_loc l0
+    freeze_ref
+    call m::test_variant$Wrapper$V1
+    br_false l0
+    move_loc l0
+    // @5
+    pop
+    ld_true
+    st_loc l1
+    branch l1
+l0: move_loc l0
+    // @10
+    freeze_ref
+    call m::test_variant$Wrapper$V2
+    br_false l2
+    ld_false
+    st_loc l1
+    // @15
+    branch l1
+l2: ld_u64 14566554180833181697
+    abort
+l1: move_loc l1
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_enums.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_enums.move
@@ -1,0 +1,85 @@
+module 0xc0ffee::m {
+
+    package enum Wrapper has drop {
+        V1(u64), // same type at the same offset
+        V2(u64),
+    }
+
+    public fun make(x: u64): Wrapper {
+        Wrapper::V1(x)
+    }
+
+}
+
+module 0xc0ffee::n {
+    use 0xc0ffee::m;
+
+    fun test() {
+        let x = m::make(22);
+        assert!(x.0 == 22, 1);
+    }
+}
+
+module 0xc0ffee::n2 {
+    use 0xc0ffee::m::Wrapper;
+
+    fun test_pack() {
+        let _x = Wrapper::V1(22);
+    }
+}
+
+module 0xc0ffee::n3 {
+    use 0xc0ffee::m::Wrapper;
+
+    fun test_unpack(w: Wrapper) {
+        let V1(_x) = w;
+    }
+}
+
+module 0xc0ffee::n4 {
+    use 0xc0ffee::m::Wrapper;
+
+    fun test_select_variant(w: Wrapper): u64 {
+        w.0
+    }
+}
+
+module 0xc0ffee::n5 {
+    use 0xc0ffee::m::Wrapper;
+
+    fun test_test_variant(w: Wrapper): bool {
+        w is V1
+    }
+}
+
+module 0xc0ffee::n6 {
+    use 0xc0ffee::m::Wrapper;
+
+    fun test_test_variant_mut_borrow(w: &mut Wrapper): bool {
+        w is V1
+    }
+
+    fun test_test_variant_immutable_borrow(w: &Wrapper): bool {
+        w is V1
+    }
+
+}
+
+module 0xc0ffee::n7 {
+    use 0xc0ffee::m::Wrapper;
+
+    fun test_match(w: Wrapper): bool {
+        match (w) {
+            V1(_) => true,
+            V2(_) => false,
+        }
+    }
+
+    fun test_match_mut_borrow(w: &mut Wrapper): bool {
+        match (w) {
+            V1(_) => true,
+            V2(_) => false,
+        }
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_enums.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_enums.opt.exp
@@ -1,0 +1,212 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+friend 0xc0ffee::n
+friend 0xc0ffee::n2
+friend 0xc0ffee::n3
+friend 0xc0ffee::n4
+friend 0xc0ffee::n5
+friend 0xc0ffee::n6
+friend 0xc0ffee::n7
+enum Wrapper has drop
+  V1
+    _0: u64
+  V2
+    _0: u64
+
+// Function definition at index 0
+friend fun test_variant$Wrapper$V1(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V1
+    ret
+
+// Function definition at index 1
+friend fun test_variant$Wrapper$V2(l0: &Wrapper): bool
+    local l1: &Wrapper
+    move_loc l0
+    test_variant Wrapper, V2
+    ret
+
+// Function definition at index 2
+friend fun pack$Wrapper$V1(l0: u64): Wrapper
+    local l1: u64
+    move_loc l0
+    pack_variant Wrapper, V1
+    ret
+
+// Function definition at index 3
+friend fun pack$Wrapper$V2(l0: u64): Wrapper
+    local l1: u64
+    move_loc l0
+    pack_variant Wrapper, V2
+    ret
+
+// Function definition at index 4
+friend fun unpack$Wrapper$V1(l0: Wrapper): u64
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V1
+    ret
+
+// Function definition at index 5
+friend fun unpack$Wrapper$V2(l0: Wrapper): u64
+    local l1: Wrapper
+    move_loc l0
+    unpack_variant Wrapper, V2
+    ret
+
+// Function definition at index 6
+friend fun borrow$Wrapper$0$0(l0: &Wrapper): &u64
+    local l1: &Wrapper
+    move_loc l0
+    borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 7
+friend fun borrow_mut$Wrapper$0$0(l0: &mut Wrapper): &mut u64
+    local l1: &mut Wrapper
+    move_loc l0
+    mut_borrow_variant_field Wrapper, V1::_0, V2::_0
+    ret
+
+// Function definition at index 8
+#[persistent] public fun make(l0: u64): Wrapper
+    move_loc l0
+    pack_variant Wrapper, V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n
+use 0xc0ffee::m
+// Function definition at index 0
+fun test()
+    local l0: m::Wrapper
+    ld_u64 22
+    call m::make
+    st_loc l0
+    borrow_loc l0
+    call m::borrow$Wrapper$0$0
+    // @5
+    read_ref
+    ld_u64 22
+    eq
+    br_false l0
+    ret
+    // @10
+l0: ld_u64 1
+    abort
+
+// Bytecode version v9
+module 0xc0ffee::n2
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack()
+    ld_u64 22
+    call m::pack$Wrapper$V1
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n3
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_unpack(l0: m::Wrapper)
+    move_loc l0
+    call m::unpack$Wrapper$V1
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n4
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_select_variant(l0: m::Wrapper): u64
+    borrow_loc l0
+    call m::borrow$Wrapper$0$0
+    read_ref
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n5
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_test_variant(l0: m::Wrapper): bool
+    borrow_loc l0
+    call m::test_variant$Wrapper$V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n6
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_test_variant_immutable_borrow(l0: &m::Wrapper): bool
+    move_loc l0
+    call m::test_variant$Wrapper$V1
+    ret
+
+// Function definition at index 1
+fun test_test_variant_mut_borrow(l0: &mut m::Wrapper): bool
+    move_loc l0
+    freeze_ref
+    call m::test_variant$Wrapper$V1
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n7
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_match(l0: m::Wrapper): bool
+    local l1: &m::Wrapper
+    borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$Wrapper$V1
+    br_false l0
+    // @5
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$Wrapper$V1
+    pop
+    // @10
+    ld_true
+    ret
+l0: move_loc l1
+    call m::test_variant$Wrapper$V2
+    br_false l1
+    // @15
+    move_loc l0
+    call m::unpack$Wrapper$V2
+    pop
+    ld_false
+    ret
+    // @20
+l1: ld_u64 14566554180833181697
+    abort
+
+// Function definition at index 1
+fun test_match_mut_borrow(l0: &mut m::Wrapper): bool
+    copy_loc l0
+    freeze_ref
+    call m::test_variant$Wrapper$V1
+    br_false l0
+    move_loc l0
+    // @5
+    pop
+    ld_true
+    ret
+l0: move_loc l0
+    freeze_ref
+    // @10
+    call m::test_variant$Wrapper$V2
+    br_false l1
+    ld_false
+    ret
+l1: ld_u64 14566554180833181697
+    // @15
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_structs.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_structs.exp
@@ -1,0 +1,180 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+friend 0xc0ffee::n9
+struct Empty
+  dummy_field: bool
+
+struct S
+  x: u64
+
+struct S2
+  x: u64
+  s: S
+
+// Function definition at index 0
+friend fun pack$Empty(l0: bool): Empty
+    local l1: bool
+    move_loc l0
+    pack Empty
+    ret
+
+// Function definition at index 1
+friend fun unpack$Empty(l0: Empty): bool
+    local l1: Empty
+    move_loc l0
+    unpack Empty
+    ret
+
+// Function definition at index 2
+public fun pack$S(l0: u64): S
+    local l1: u64
+    move_loc l0
+    pack S
+    ret
+
+// Function definition at index 3
+public fun unpack$S(l0: S): u64
+    local l1: S
+    move_loc l0
+    unpack S
+    ret
+
+// Function definition at index 4
+public fun borrow$S$0(l0: &S): &u64
+    local l1: &S
+    move_loc l0
+    borrow_field S, x
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$S$0(l0: &mut S): &mut u64
+    local l1: &mut S
+    move_loc l0
+    mut_borrow_field S, x
+    ret
+
+// Function definition at index 6
+friend fun pack$S2(l0: u64, l1: S): S2
+    local l2: u64
+    local l3: S
+    move_loc l0
+    move_loc l1
+    pack S2
+    ret
+
+// Function definition at index 7
+friend fun unpack$S2(l0: S2): (u64, S)
+    local l1: S2
+    move_loc l0
+    unpack S2
+    ret
+
+// Function definition at index 8
+friend fun borrow$S2$0(l0: &S2): &u64
+    local l1: &S2
+    move_loc l0
+    borrow_field S2, x
+    ret
+
+// Function definition at index 9
+friend fun borrow$S2$1(l0: &S2): &S
+    local l1: &S2
+    move_loc l0
+    borrow_field S2, s
+    ret
+
+// Function definition at index 10
+friend fun borrow_mut$S2$0(l0: &mut S2): &mut u64
+    local l1: &mut S2
+    move_loc l0
+    mut_borrow_field S2, x
+    ret
+
+// Function definition at index 11
+friend fun borrow_mut$S2$1(l0: &mut S2): &mut S
+    local l1: &mut S2
+    move_loc l0
+    mut_borrow_field S2, s
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n_friend
+struct T
+  x: u64
+
+// Function definition at index 0
+friend fun pack$T(l0: u64): T
+    local l1: u64
+    move_loc l0
+    pack T
+    ret
+
+// Function definition at index 1
+friend fun unpack$T(l0: T): u64
+    local l1: T
+    move_loc l0
+    unpack T
+    ret
+
+// Function definition at index 2
+friend fun borrow$T$0(l0: &T): &u64
+    local l1: &T
+    move_loc l0
+    borrow_field T, x
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$T$0(l0: &mut T): &mut u64
+    local l1: &mut T
+    move_loc l0
+    mut_borrow_field T, x
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n7
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_struct(): m::S
+    ld_u64 22
+    call m::pack$S
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n8
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_struct(): m::S
+    ld_u64 22
+    call m::pack$S
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n9
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_unpack_struct_in_lambda()
+    ld_u64 22
+    ld_u64 33
+    call m::pack$S
+    call m::pack$S2
+    call m::unpack$S2
+    // @5
+    call m::unpack$S
+    pop
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n_friend
+use 0xc0ffee::m_friend
+// Function definition at index 0
+fun test_pack_friend_struct(): m_friend::T
+    ld_u64 22
+    call m_friend::pack$T
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_structs.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_structs.move
@@ -1,0 +1,64 @@
+module 0xc0ffee::m {
+
+    public struct S {
+        x: u64,
+    }
+
+    package struct S2 {
+        x: u64,
+        s: S,
+    }
+
+    public(package) struct Empty {}
+
+}
+
+module 0xc0ffee::m_friend {
+    friend 0xc0ffee::n_friend;
+
+    friend struct T {
+        x: u64,
+    }
+
+}
+
+module 0xc0ffee::n7 {
+    use 0xc0ffee::m::S;
+
+    fun test_pack_struct(): S {
+        S { x: 22 }
+    }
+}
+
+module 0xc0ffee::n_friend {
+    use 0xc0ffee::m_friend::T;
+
+    fun test_pack_friend_struct(): T {
+        T { x: 22 }
+    }
+}
+
+module 0xc0ffee::n8 {
+    use 0xc0ffee::m::S;
+
+    inline fun test_pack_struct_inline(): S {
+        S { x: 22 }
+    }
+
+    fun test_pack_struct(): S {
+        test_pack_struct_inline()
+    }
+}
+
+module 0xc0ffee::n9 {
+    use 0xc0ffee::m::S;
+    use 0xc0ffee::m::S2;
+
+    inline fun test_inline(x: ||) {
+        x()
+    }
+
+    fun test_pack_unpack_struct_in_lambda() {
+        test_inline(|| {let x = S2 { x: 22, s: S { x: 33 } }; let S2 { x: _x, s: S { x: _y } } = x;} )
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_structs.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/basic_structs.opt.exp
@@ -1,0 +1,180 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+friend 0xc0ffee::n9
+struct Empty
+  dummy_field: bool
+
+struct S
+  x: u64
+
+struct S2
+  x: u64
+  s: S
+
+// Function definition at index 0
+friend fun pack$Empty(l0: bool): Empty
+    local l1: bool
+    move_loc l0
+    pack Empty
+    ret
+
+// Function definition at index 1
+friend fun unpack$Empty(l0: Empty): bool
+    local l1: Empty
+    move_loc l0
+    unpack Empty
+    ret
+
+// Function definition at index 2
+public fun pack$S(l0: u64): S
+    local l1: u64
+    move_loc l0
+    pack S
+    ret
+
+// Function definition at index 3
+public fun unpack$S(l0: S): u64
+    local l1: S
+    move_loc l0
+    unpack S
+    ret
+
+// Function definition at index 4
+public fun borrow$S$0(l0: &S): &u64
+    local l1: &S
+    move_loc l0
+    borrow_field S, x
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$S$0(l0: &mut S): &mut u64
+    local l1: &mut S
+    move_loc l0
+    mut_borrow_field S, x
+    ret
+
+// Function definition at index 6
+friend fun pack$S2(l0: u64, l1: S): S2
+    local l2: u64
+    local l3: S
+    move_loc l0
+    move_loc l1
+    pack S2
+    ret
+
+// Function definition at index 7
+friend fun unpack$S2(l0: S2): (u64, S)
+    local l1: S2
+    move_loc l0
+    unpack S2
+    ret
+
+// Function definition at index 8
+friend fun borrow$S2$0(l0: &S2): &u64
+    local l1: &S2
+    move_loc l0
+    borrow_field S2, x
+    ret
+
+// Function definition at index 9
+friend fun borrow$S2$1(l0: &S2): &S
+    local l1: &S2
+    move_loc l0
+    borrow_field S2, s
+    ret
+
+// Function definition at index 10
+friend fun borrow_mut$S2$0(l0: &mut S2): &mut u64
+    local l1: &mut S2
+    move_loc l0
+    mut_borrow_field S2, x
+    ret
+
+// Function definition at index 11
+friend fun borrow_mut$S2$1(l0: &mut S2): &mut S
+    local l1: &mut S2
+    move_loc l0
+    mut_borrow_field S2, s
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n_friend
+struct T
+  x: u64
+
+// Function definition at index 0
+friend fun pack$T(l0: u64): T
+    local l1: u64
+    move_loc l0
+    pack T
+    ret
+
+// Function definition at index 1
+friend fun unpack$T(l0: T): u64
+    local l1: T
+    move_loc l0
+    unpack T
+    ret
+
+// Function definition at index 2
+friend fun borrow$T$0(l0: &T): &u64
+    local l1: &T
+    move_loc l0
+    borrow_field T, x
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$T$0(l0: &mut T): &mut u64
+    local l1: &mut T
+    move_loc l0
+    mut_borrow_field T, x
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n7
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_struct(): m::S
+    ld_u64 22
+    call m::pack$S
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n8
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_struct(): m::S
+    ld_u64 22
+    call m::pack$S
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n9
+use 0xc0ffee::m
+// Function definition at index 0
+fun test_pack_unpack_struct_in_lambda()
+    ld_u64 22
+    ld_u64 33
+    call m::pack$S
+    call m::pack$S2
+    call m::unpack$S2
+    // @5
+    call m::unpack$S
+    pop
+    pop
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n_friend
+use 0xc0ffee::m_friend
+// Function definition at index 0
+fun test_pack_friend_struct(): m_friend::T
+    ld_u64 22
+    call m_friend::pack$T
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.exp
@@ -1,0 +1,410 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m
+friend 0x42::m2
+enum Data has drop
+  V1
+    x: u64
+  V2
+    x: u64
+    y: bool
+  V3
+
+enum Data2<T0, T1> has drop
+  V1
+    x: T0
+  V2
+    y: u64
+    x: T1
+  V3
+
+// Function definition at index 0
+friend fun test_variant$Data$V1(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V1
+    ret
+
+// Function definition at index 1
+friend fun test_variant$Data$V2(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V2
+    ret
+
+// Function definition at index 2
+friend fun test_variant$Data$V3(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V3
+    ret
+
+// Function definition at index 3
+friend fun pack$Data$V1(l0: u64): Data
+    local l1: u64
+    move_loc l0
+    pack_variant Data, V1
+    ret
+
+// Function definition at index 4
+friend fun pack$Data$V2(l0: u64, l1: bool): Data
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack_variant Data, V2
+    ret
+
+// Function definition at index 5
+friend fun pack$Data$V3(): Data
+    pack_variant Data, V3
+    ret
+
+// Function definition at index 6
+friend fun unpack$Data$V1(l0: Data): u64
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V1
+    ret
+
+// Function definition at index 7
+friend fun unpack$Data$V2(l0: Data): (u64, bool)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V2
+    ret
+
+// Function definition at index 8
+friend fun unpack$Data$V3(l0: Data)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V3
+    ret
+
+// Function definition at index 9
+friend fun borrow$Data$0$0(l0: &Data): &u64
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 10
+friend fun borrow$Data$1$1(l0: &Data): &bool
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 11
+friend fun borrow_mut$Data$0$0(l0: &mut Data): &mut u64
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 12
+friend fun borrow_mut$Data$1$1(l0: &mut Data): &mut bool
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 13
+friend fun test_variant$Data2$V1<T0, T1>(l0: &Data2<T0, T1>): bool
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    test_variant Data2<T0, T1>, V1
+    ret
+
+// Function definition at index 14
+friend fun test_variant$Data2$V2<T0, T1>(l0: &Data2<T0, T1>): bool
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    test_variant Data2<T0, T1>, V2
+    ret
+
+// Function definition at index 15
+friend fun test_variant$Data2$V3<T0, T1>(l0: &Data2<T0, T1>): bool
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    test_variant Data2<T0, T1>, V3
+    ret
+
+// Function definition at index 16
+friend fun pack$Data2$V1<T0, T1>(l0: T0): Data2<T0, T1>
+    local l1: T0
+    move_loc l0
+    pack_variant Data2<T0, T1>, V1
+    ret
+
+// Function definition at index 17
+friend fun pack$Data2$V2<T0, T1>(l0: u64, l1: T1): Data2<T0, T1>
+    local l2: u64
+    local l3: T1
+    move_loc l0
+    move_loc l1
+    pack_variant Data2<T0, T1>, V2
+    ret
+
+// Function definition at index 18
+friend fun pack$Data2$V3<T0, T1>(): Data2<T0, T1>
+    pack_variant Data2<T0, T1>, V3
+    ret
+
+// Function definition at index 19
+friend fun unpack$Data2$V1<T0, T1>(l0: Data2<T0, T1>): T0
+    local l1: Data2<T0, T1>
+    move_loc l0
+    unpack_variant Data2<T0, T1>, V1
+    ret
+
+// Function definition at index 20
+friend fun unpack$Data2$V2<T0, T1>(l0: Data2<T0, T1>): (u64, T1)
+    local l1: Data2<T0, T1>
+    move_loc l0
+    unpack_variant Data2<T0, T1>, V2
+    ret
+
+// Function definition at index 21
+friend fun unpack$Data2$V3<T0, T1>(l0: Data2<T0, T1>)
+    local l1: Data2<T0, T1>
+    move_loc l0
+    unpack_variant Data2<T0, T1>, V3
+    ret
+
+// Function definition at index 22
+friend fun borrow$Data2$0$1<T0, T1>(l0: &Data2<T0, T1>): &u64
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    borrow_variant_field Data2<T0, T1>, V2::y
+    ret
+
+// Function definition at index 23
+friend fun borrow$Data2$0$0<T0, T1>(l0: &Data2<T0, T1>): &T0
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    borrow_variant_field Data2<T0, T1>, V1::x
+    ret
+
+// Function definition at index 24
+friend fun borrow$Data2$1$2<T0, T1>(l0: &Data2<T0, T1>): &T1
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    borrow_variant_field Data2<T0, T1>, V2::x
+    ret
+
+// Function definition at index 25
+friend fun borrow_mut$Data2$0$1<T0, T1>(l0: &mut Data2<T0, T1>): &mut u64
+    local l1: &mut Data2<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Data2<T0, T1>, V2::y
+    ret
+
+// Function definition at index 26
+friend fun borrow_mut$Data2$0$0<T0, T1>(l0: &mut Data2<T0, T1>): &mut T0
+    local l1: &mut Data2<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Data2<T0, T1>, V1::x
+    ret
+
+// Function definition at index 27
+friend fun borrow_mut$Data2$1$2<T0, T1>(l0: &mut Data2<T0, T1>): &mut T1
+    local l1: &mut Data2<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Data2<T0, T1>, V2::x
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m
+// Function definition at index 0
+fun test_data2_mut_borrow()
+    local l0: m::Data2<u64, u64>
+    local l1: &mut m::Data2<u64, u64>
+    local l2: bool
+    local l3: u64
+    local l4: &mut u64
+    ld_u64 43
+    ld_u64 44
+    call m::pack$Data2$V2<u64, u64>
+    st_loc l0
+    ld_u64 45
+    // @5
+    mut_borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    freeze_ref
+    call m::test_variant$Data2$V2<u64, u64>
+    // @10
+    st_loc l2
+    st_loc l3
+    move_loc l2
+    br_true l0
+    branch l1
+    // @15
+l0: move_loc l1
+    call m::borrow_mut$Data2$1$2<u64, u64>
+    st_loc l4
+    branch l2
+l1: move_loc l1
+    // @20
+    call m::borrow_mut$Data2$0$0<u64, u64>
+    st_loc l4
+l2: move_loc l3
+    move_loc l4
+    write_ref
+    // @25
+    ret
+
+// Function definition at index 1
+fun test_v1()
+    local l0: m::Data
+    local l1: &m::Data
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    call m::borrow$Data$0$0
+    // @5
+    read_ref
+    ld_u64 43
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 1
+    abort
+l1: borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    // @15
+    call m::test_variant$Data$V1
+    br_true l2
+    move_loc l1
+    pop
+    ld_u64 14566554180833181697
+    // @20
+    abort
+l2: move_loc l1
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 43
+    // @25
+    eq
+    br_false l3
+    branch l4
+l3: ld_u64 2
+    abort
+    // @30
+l4: mut_borrow_loc l0
+    freeze_ref
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 43
+    // @35
+    eq
+    br_false l5
+    branch l6
+l5: ld_u64 3
+    abort
+    // @40
+l6: ret
+
+// Function definition at index 2
+fun test_v1_mut_borrow()
+    local l0: m::Data
+    local l1: u64
+    local l2: &mut u64
+    local l3: u64
+    local l4: &mut m::Data
+    local l5: &mut u64
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    mut_borrow_loc l0
+    call m::borrow_mut$Data$0$0
+    // @5
+    ld_u64 44
+    st_loc l1
+    st_loc l2
+    move_loc l1
+    move_loc l2
+    // @10
+    write_ref
+    borrow_loc l0
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 44
+    // @15
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 1
+    abort
+    // @20
+l1: mut_borrow_loc l0
+    ld_u64 45
+    st_loc l3
+    st_loc l4
+    move_loc l4
+    // @25
+    call m::borrow_mut$Data$0$0
+    st_loc l5
+    move_loc l3
+    move_loc l5
+    write_ref
+    // @30
+    borrow_loc l0
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 45
+    eq
+    // @35
+    br_false l2
+    branch l3
+l2: ld_u64 3
+    abort
+l3: ret
+
+// Function definition at index 3
+fun test_v2_mut_borrow()
+    local l0: m::Data
+    local l1: &mut m::Data
+    ld_u64 43
+    ld_true
+    call m::pack$Data$V2
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    st_loc l1
+    copy_loc l1
+    freeze_ref
+    call m::borrow$Data$0$0
+    read_ref
+    // @10
+    ld_u64 43
+    eq
+    br_false l0
+    branch l1
+l0: move_loc l1
+    // @15
+    pop
+    ld_u64 1
+    abort
+l1: move_loc l1
+    freeze_ref
+    // @20
+    call m::borrow$Data$1$1
+    read_ref
+    ld_true
+    eq
+    br_false l2
+    // @25
+    branch l3
+l2: ld_u64 2
+    abort
+l3: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.move
@@ -1,0 +1,59 @@
+module 0x42::m {
+
+  friend 0x42::m2;
+
+  friend enum Data has drop {
+    V1{x: u64},
+    V2{x: u64, y: bool}
+    V3
+  }
+
+  friend enum Data2<T1, T2> has drop {
+    V1{x: T1},
+    V2{y: u64, x: T2}
+    V3
+  }
+
+}
+
+module 0x42::m2 {
+
+  use 0x42::m::Data;
+  use 0x42::m::Data2;
+
+  fun test_v1() {
+    let d = Data::V1{x: 43};
+    assert!(d.x == 43, 1);
+    let Data::V1{x} = &d;
+    assert!(*x == 43, 2);
+    let data_x = &mut d;
+    let ref_x = &data_x.x;
+    assert!(*ref_x == 43, 3);
+  }
+
+  fun test_v1_mut_borrow() {
+    let d = Data::V1{x: 43};
+    let r = &mut d.x;
+    *r = 44;
+    assert!(d.x == 44, 1);
+    let r2 = &mut d;
+    r2.x = 45;
+    assert!(d.x == 45, 3);
+  }
+
+  fun test_v2_mut_borrow() {
+    let d = Data::V2{x: 43, y: true};
+    let mut_ref_d = &mut d;
+    let ref_x = &mut_ref_d.x;
+    assert!(*ref_x == 43, 1);
+    let ref_y = &mut_ref_d.y;
+    assert!(*ref_y == true, 2);
+  }
+
+  fun test_data2_mut_borrow() {
+    let d = Data2::V2<u64, u64>{y: 43, x: 44};
+    d.x = 45;
+  }
+
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_field_api.opt.exp
@@ -1,0 +1,388 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m
+friend 0x42::m2
+enum Data has drop
+  V1
+    x: u64
+  V2
+    x: u64
+    y: bool
+  V3
+
+enum Data2<T0, T1> has drop
+  V1
+    x: T0
+  V2
+    y: u64
+    x: T1
+  V3
+
+// Function definition at index 0
+friend fun test_variant$Data$V1(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V1
+    ret
+
+// Function definition at index 1
+friend fun test_variant$Data$V2(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V2
+    ret
+
+// Function definition at index 2
+friend fun test_variant$Data$V3(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V3
+    ret
+
+// Function definition at index 3
+friend fun pack$Data$V1(l0: u64): Data
+    local l1: u64
+    move_loc l0
+    pack_variant Data, V1
+    ret
+
+// Function definition at index 4
+friend fun pack$Data$V2(l0: u64, l1: bool): Data
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack_variant Data, V2
+    ret
+
+// Function definition at index 5
+friend fun pack$Data$V3(): Data
+    pack_variant Data, V3
+    ret
+
+// Function definition at index 6
+friend fun unpack$Data$V1(l0: Data): u64
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V1
+    ret
+
+// Function definition at index 7
+friend fun unpack$Data$V2(l0: Data): (u64, bool)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V2
+    ret
+
+// Function definition at index 8
+friend fun unpack$Data$V3(l0: Data)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V3
+    ret
+
+// Function definition at index 9
+friend fun borrow$Data$0$0(l0: &Data): &u64
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 10
+friend fun borrow$Data$1$1(l0: &Data): &bool
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 11
+friend fun borrow_mut$Data$0$0(l0: &mut Data): &mut u64
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 12
+friend fun borrow_mut$Data$1$1(l0: &mut Data): &mut bool
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 13
+friend fun test_variant$Data2$V1<T0, T1>(l0: &Data2<T0, T1>): bool
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    test_variant Data2<T0, T1>, V1
+    ret
+
+// Function definition at index 14
+friend fun test_variant$Data2$V2<T0, T1>(l0: &Data2<T0, T1>): bool
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    test_variant Data2<T0, T1>, V2
+    ret
+
+// Function definition at index 15
+friend fun test_variant$Data2$V3<T0, T1>(l0: &Data2<T0, T1>): bool
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    test_variant Data2<T0, T1>, V3
+    ret
+
+// Function definition at index 16
+friend fun pack$Data2$V1<T0, T1>(l0: T0): Data2<T0, T1>
+    local l1: T0
+    move_loc l0
+    pack_variant Data2<T0, T1>, V1
+    ret
+
+// Function definition at index 17
+friend fun pack$Data2$V2<T0, T1>(l0: u64, l1: T1): Data2<T0, T1>
+    local l2: u64
+    local l3: T1
+    move_loc l0
+    move_loc l1
+    pack_variant Data2<T0, T1>, V2
+    ret
+
+// Function definition at index 18
+friend fun pack$Data2$V3<T0, T1>(): Data2<T0, T1>
+    pack_variant Data2<T0, T1>, V3
+    ret
+
+// Function definition at index 19
+friend fun unpack$Data2$V1<T0, T1>(l0: Data2<T0, T1>): T0
+    local l1: Data2<T0, T1>
+    move_loc l0
+    unpack_variant Data2<T0, T1>, V1
+    ret
+
+// Function definition at index 20
+friend fun unpack$Data2$V2<T0, T1>(l0: Data2<T0, T1>): (u64, T1)
+    local l1: Data2<T0, T1>
+    move_loc l0
+    unpack_variant Data2<T0, T1>, V2
+    ret
+
+// Function definition at index 21
+friend fun unpack$Data2$V3<T0, T1>(l0: Data2<T0, T1>)
+    local l1: Data2<T0, T1>
+    move_loc l0
+    unpack_variant Data2<T0, T1>, V3
+    ret
+
+// Function definition at index 22
+friend fun borrow$Data2$0$1<T0, T1>(l0: &Data2<T0, T1>): &u64
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    borrow_variant_field Data2<T0, T1>, V2::y
+    ret
+
+// Function definition at index 23
+friend fun borrow$Data2$0$0<T0, T1>(l0: &Data2<T0, T1>): &T0
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    borrow_variant_field Data2<T0, T1>, V1::x
+    ret
+
+// Function definition at index 24
+friend fun borrow$Data2$1$2<T0, T1>(l0: &Data2<T0, T1>): &T1
+    local l1: &Data2<T0, T1>
+    move_loc l0
+    borrow_variant_field Data2<T0, T1>, V2::x
+    ret
+
+// Function definition at index 25
+friend fun borrow_mut$Data2$0$1<T0, T1>(l0: &mut Data2<T0, T1>): &mut u64
+    local l1: &mut Data2<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Data2<T0, T1>, V2::y
+    ret
+
+// Function definition at index 26
+friend fun borrow_mut$Data2$0$0<T0, T1>(l0: &mut Data2<T0, T1>): &mut T0
+    local l1: &mut Data2<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Data2<T0, T1>, V1::x
+    ret
+
+// Function definition at index 27
+friend fun borrow_mut$Data2$1$2<T0, T1>(l0: &mut Data2<T0, T1>): &mut T1
+    local l1: &mut Data2<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Data2<T0, T1>, V2::x
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m
+// Function definition at index 0
+fun test_data2_mut_borrow()
+    local l0: m::Data2<u64, u64>
+    local l1: u64
+    local l2: &mut m::Data2<u64, u64>
+    local l3: &mut u64
+    ld_u64 43
+    ld_u64 44
+    call m::pack$Data2$V2<u64, u64>
+    st_loc l0
+    ld_u64 45
+    // @5
+    st_loc l1
+    mut_borrow_loc l0
+    st_loc l2
+    copy_loc l2
+    freeze_ref
+    // @10
+    call m::test_variant$Data2$V2<u64, u64>
+    br_true l0
+    move_loc l2
+    call m::borrow_mut$Data2$0$0<u64, u64>
+    st_loc l3
+    // @15
+l1: move_loc l1
+    move_loc l3
+    write_ref
+    ret
+l0: move_loc l2
+    // @20
+    call m::borrow_mut$Data2$1$2<u64, u64>
+    st_loc l3
+    branch l1
+
+// Function definition at index 1
+fun test_v1()
+    local l0: m::Data
+    local l1: &m::Data
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    call m::borrow$Data$0$0
+    // @5
+    read_ref
+    ld_u64 43
+    eq
+    br_false l0
+    borrow_loc l0
+    // @10
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$Data$V1
+    br_true l1
+    move_loc l1
+    // @15
+    pop
+    ld_u64 14566554180833181697
+    abort
+l1: move_loc l1
+    call m::borrow$Data$0$0
+    // @20
+    read_ref
+    ld_u64 43
+    eq
+    br_false l2
+    mut_borrow_loc l0
+    // @25
+    freeze_ref
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 43
+    eq
+    // @30
+    br_false l3
+    ret
+l3: ld_u64 3
+    abort
+l2: ld_u64 2
+    // @35
+    abort
+l0: ld_u64 1
+    abort
+
+// Function definition at index 2
+fun test_v1_mut_borrow()
+    local l0: m::Data
+    local l1: u64
+    local l2: &mut u64
+    local l3: &mut m::Data
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    mut_borrow_loc l0
+    call m::borrow_mut$Data$0$0
+    // @5
+    st_loc l2
+    ld_u64 44
+    move_loc l2
+    write_ref
+    borrow_loc l0
+    // @10
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 44
+    eq
+    br_false l0
+    // @15
+    mut_borrow_loc l0
+    st_loc l3
+    ld_u64 45
+    move_loc l3
+    call m::borrow_mut$Data$0$0
+    // @20
+    write_ref
+    borrow_loc l0
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 45
+    // @25
+    eq
+    br_false l1
+    ret
+l1: ld_u64 3
+    abort
+    // @30
+l0: ld_u64 1
+    abort
+
+// Function definition at index 3
+fun test_v2_mut_borrow()
+    local l0: m::Data
+    local l1: &mut m::Data
+    ld_u64 43
+    ld_true
+    call m::pack$Data$V2
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    st_loc l1
+    copy_loc l1
+    freeze_ref
+    call m::borrow$Data$0$0
+    read_ref
+    // @10
+    ld_u64 43
+    eq
+    br_false l0
+    move_loc l1
+    freeze_ref
+    // @15
+    call m::borrow$Data$1$1
+    read_ref
+    ld_true
+    eq
+    br_false l1
+    // @20
+    ret
+l1: ld_u64 2
+    abort
+l0: move_loc l1
+    pop
+    // @25
+    ld_u64 1
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_offset.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_offset.exp
@@ -1,0 +1,292 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+enum E has copy + drop
+  V1
+    o1: u8
+  V2
+    o1: u8
+    o3: u16
+  V3
+    o2: u8
+  V4
+    o2: u8
+
+// Function definition at index 0
+public fun test_variant$E$V1(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V1
+    ret
+
+// Function definition at index 1
+public fun test_variant$E$V2(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V2
+    ret
+
+// Function definition at index 2
+public fun test_variant$E$V3(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V3
+    ret
+
+// Function definition at index 3
+public fun test_variant$E$V4(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V4
+    ret
+
+// Function definition at index 4
+public fun pack$E$V1(l0: u8): E
+    local l1: u8
+    move_loc l0
+    pack_variant E, V1
+    ret
+
+// Function definition at index 5
+public fun pack$E$V2(l0: u8, l1: u16): E
+    local l2: u8
+    local l3: u16
+    move_loc l0
+    move_loc l1
+    pack_variant E, V2
+    ret
+
+// Function definition at index 6
+public fun pack$E$V3(l0: u8): E
+    local l1: u8
+    move_loc l0
+    pack_variant E, V3
+    ret
+
+// Function definition at index 7
+public fun pack$E$V4(l0: u8): E
+    local l1: u8
+    move_loc l0
+    pack_variant E, V4
+    ret
+
+// Function definition at index 8
+public fun unpack$E$V1(l0: E): u8
+    local l1: E
+    move_loc l0
+    unpack_variant E, V1
+    ret
+
+// Function definition at index 9
+public fun unpack$E$V2(l0: E): (u8, u16)
+    local l1: E
+    move_loc l0
+    unpack_variant E, V2
+    ret
+
+// Function definition at index 10
+public fun unpack$E$V3(l0: E): u8
+    local l1: E
+    move_loc l0
+    unpack_variant E, V3
+    ret
+
+// Function definition at index 11
+public fun unpack$E$V4(l0: E): u8
+    local l1: E
+    move_loc l0
+    unpack_variant E, V4
+    ret
+
+// Function definition at index 12
+public fun borrow$E$0$0(l0: &E): &u8
+    local l1: &E
+    move_loc l0
+    borrow_variant_field E, V1::o1, V2::o1, V3::o2, V4::o2
+    ret
+
+// Function definition at index 13
+public fun borrow$E$1$1(l0: &E): &u16
+    local l1: &E
+    move_loc l0
+    borrow_variant_field E, V2::o3
+    ret
+
+// Function definition at index 14
+public fun borrow_mut$E$0$0(l0: &mut E): &mut u8
+    local l1: &mut E
+    move_loc l0
+    mut_borrow_variant_field E, V1::o1, V2::o1, V3::o2, V4::o2
+    ret
+
+// Function definition at index 15
+public fun borrow_mut$E$1$1(l0: &mut E): &mut u16
+    local l1: &mut E
+    move_loc l0
+    mut_borrow_variant_field E, V2::o3
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n6
+use 0xc0ffee::m
+// Function definition at index 0
+fun mut_borrow(l0: &mut m::E): (&mut u8, u16)
+    local l1: u16
+    local l2: &m::E
+    copy_loc l0
+    freeze_ref
+    call m::borrow$E$1$1
+    read_ref
+    st_loc l1
+    // @5
+    copy_loc l0
+    freeze_ref
+    st_loc l2
+    copy_loc l2
+    call m::test_variant$E$V1
+    // @10
+    br_true l0
+    copy_loc l2
+    call m::test_variant$E$V2
+    br_true l0
+    move_loc l2
+    // @15
+    pop
+    move_loc l0
+    pop
+    ld_u64 14566554180833181697
+    abort
+    // @20
+l0: move_loc l2
+    pop
+    move_loc l0
+    call m::borrow_mut$E$0$0
+    move_loc l1
+    // @25
+    ret
+
+// Function definition at index 1
+fun test_match(l0: m::E): bool
+    local l1: &m::E
+    local l2: bool
+    borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$E$V1
+    br_false l0
+    // @5
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$E$V1
+    ld_true
+    // @10
+    st_loc l2
+    pop
+    branch l1
+l0: copy_loc l1
+    call m::test_variant$E$V2
+    // @15
+    br_false l2
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$E$V2
+    // @20
+    ld_false
+    st_loc l2
+    pop
+    pop
+    branch l1
+    // @25
+l2: copy_loc l1
+    call m::test_variant$E$V3
+    br_false l3
+    move_loc l1
+    pop
+    // @30
+    move_loc l0
+    call m::unpack$E$V3
+    ld_false
+    st_loc l2
+    pop
+    // @35
+    branch l1
+l3: move_loc l1
+    call m::test_variant$E$V4
+    br_false l4
+    move_loc l0
+    // @40
+    call m::unpack$E$V4
+    ld_false
+    st_loc l2
+    pop
+    branch l1
+    // @45
+l4: ld_u64 14566554180833181697
+    abort
+l1: move_loc l2
+    ret
+
+// Function definition at index 2
+fun test_mut_borrow()
+    local l0: m::E
+    local l1: u8
+    local l2: &mut u8
+    local l3: &m::E
+    ld_u8 0
+    ld_u16 0
+    call m::pack$E$V2
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    call mut_borrow
+    ld_u8 1
+    st_loc l1
+    pop
+    st_loc l2
+    // @10
+    move_loc l1
+    move_loc l2
+    write_ref
+    borrow_loc l0
+    st_loc l3
+    // @15
+    copy_loc l3
+    call m::test_variant$E$V1
+    br_true l0
+    copy_loc l3
+    call m::test_variant$E$V2
+    // @20
+    br_true l0
+    move_loc l3
+    pop
+    ld_u64 14566554180833181697
+    abort
+    // @25
+l0: move_loc l3
+    call m::borrow$E$0$0
+    read_ref
+    ld_u8 1
+    eq
+    // @30
+    br_false l1
+    branch l2
+l1: ld_u64 1
+    abort
+l2: borrow_loc l0
+    // @35
+    call m::borrow$E$1$1
+    read_ref
+    ld_u16 0
+    eq
+    br_false l3
+    // @40
+    branch l4
+l3: ld_u64 2
+    abort
+l4: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_offset.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_offset.move
@@ -1,0 +1,54 @@
+module 0xc0ffee::m {
+
+    public enum E has copy, drop {
+        V1 {
+            o1: u8
+        },
+        V2 {
+            o1: u8, o3: u16
+        },
+        V3 {
+            o2: u8
+        },
+        V4 {
+            o2: u8
+        }
+    }
+
+}
+
+module 0xc0ffee::n6 {
+    use 0xc0ffee::m::E;
+
+    fun test_match(w: E): bool {
+        match (w) {
+            V1 {
+                o1: _
+            } => true,
+            V2 {
+                o1: _, o3: _
+            } => false,
+            V3 {
+                o2: _
+            } => false,
+            V4 {
+                o2: _
+            } => false,
+        }
+    }
+
+    fun mut_borrow(w: &mut E): (&mut u8, u16) {
+        let y = w.o3;
+        (&mut w.o1, y)
+    }
+
+    fun test_mut_borrow() {
+        let x = E::V2 { o1: 0, o3: 0 };
+        let (a, _) = mut_borrow(&mut x);
+        *a = 1;
+        assert!(x.o1 == 1, 1);
+        assert!(x.o3 == 0, 2);
+    }
+
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_offset.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_offset.opt.exp
@@ -1,0 +1,280 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+enum E has copy + drop
+  V1
+    o1: u8
+  V2
+    o1: u8
+    o3: u16
+  V3
+    o2: u8
+  V4
+    o2: u8
+
+// Function definition at index 0
+public fun test_variant$E$V1(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V1
+    ret
+
+// Function definition at index 1
+public fun test_variant$E$V2(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V2
+    ret
+
+// Function definition at index 2
+public fun test_variant$E$V3(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V3
+    ret
+
+// Function definition at index 3
+public fun test_variant$E$V4(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, V4
+    ret
+
+// Function definition at index 4
+public fun pack$E$V1(l0: u8): E
+    local l1: u8
+    move_loc l0
+    pack_variant E, V1
+    ret
+
+// Function definition at index 5
+public fun pack$E$V2(l0: u8, l1: u16): E
+    local l2: u8
+    local l3: u16
+    move_loc l0
+    move_loc l1
+    pack_variant E, V2
+    ret
+
+// Function definition at index 6
+public fun pack$E$V3(l0: u8): E
+    local l1: u8
+    move_loc l0
+    pack_variant E, V3
+    ret
+
+// Function definition at index 7
+public fun pack$E$V4(l0: u8): E
+    local l1: u8
+    move_loc l0
+    pack_variant E, V4
+    ret
+
+// Function definition at index 8
+public fun unpack$E$V1(l0: E): u8
+    local l1: E
+    move_loc l0
+    unpack_variant E, V1
+    ret
+
+// Function definition at index 9
+public fun unpack$E$V2(l0: E): (u8, u16)
+    local l1: E
+    move_loc l0
+    unpack_variant E, V2
+    ret
+
+// Function definition at index 10
+public fun unpack$E$V3(l0: E): u8
+    local l1: E
+    move_loc l0
+    unpack_variant E, V3
+    ret
+
+// Function definition at index 11
+public fun unpack$E$V4(l0: E): u8
+    local l1: E
+    move_loc l0
+    unpack_variant E, V4
+    ret
+
+// Function definition at index 12
+public fun borrow$E$0$0(l0: &E): &u8
+    local l1: &E
+    move_loc l0
+    borrow_variant_field E, V1::o1, V2::o1, V3::o2, V4::o2
+    ret
+
+// Function definition at index 13
+public fun borrow$E$1$1(l0: &E): &u16
+    local l1: &E
+    move_loc l0
+    borrow_variant_field E, V2::o3
+    ret
+
+// Function definition at index 14
+public fun borrow_mut$E$0$0(l0: &mut E): &mut u8
+    local l1: &mut E
+    move_loc l0
+    mut_borrow_variant_field E, V1::o1, V2::o1, V3::o2, V4::o2
+    ret
+
+// Function definition at index 15
+public fun borrow_mut$E$1$1(l0: &mut E): &mut u16
+    local l1: &mut E
+    move_loc l0
+    mut_borrow_variant_field E, V2::o3
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n6
+use 0xc0ffee::m
+// Function definition at index 0
+fun mut_borrow(l0: &mut m::E): (&mut u8, u16)
+    local l1: u16
+    local l2: &m::E
+    local l3: &mut u8
+    copy_loc l0
+    freeze_ref
+    call m::borrow$E$1$1
+    read_ref
+    st_loc l1
+    // @5
+    copy_loc l0
+    freeze_ref
+    st_loc l2
+    copy_loc l2
+    call m::test_variant$E$V1
+    // @10
+    br_true l0
+    copy_loc l2
+    call m::test_variant$E$V2
+    br_true l0
+    move_loc l2
+    // @15
+    pop
+    move_loc l0
+    pop
+    ld_u64 14566554180833181697
+    abort
+    // @20
+l0: move_loc l2
+    pop
+    move_loc l0
+    call m::borrow_mut$E$0$0
+    move_loc l1
+    // @25
+    ret
+
+// Function definition at index 1
+fun test_match(l0: m::E): bool
+    local l1: &m::E
+    borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$E$V1
+    br_false l0
+    // @5
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$E$V1
+    pop
+    // @10
+    ld_true
+    ret
+l0: copy_loc l1
+    call m::test_variant$E$V2
+    br_false l1
+    // @15
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$E$V2
+    pop
+    // @20
+    pop
+    ld_false
+    ret
+l1: copy_loc l1
+    call m::test_variant$E$V3
+    // @25
+    br_false l2
+    move_loc l1
+    pop
+    move_loc l0
+    call m::unpack$E$V3
+    // @30
+    pop
+    ld_false
+    ret
+l2: move_loc l1
+    call m::test_variant$E$V4
+    // @35
+    br_false l3
+    move_loc l0
+    call m::unpack$E$V4
+    pop
+    ld_false
+    // @40
+    ret
+l3: ld_u64 14566554180833181697
+    abort
+
+// Function definition at index 2
+fun test_mut_borrow()
+    local l0: m::E
+    local l1: u8
+    local l2: &mut u8
+    local l3: &m::E
+    ld_u8 0
+    ld_u16 0
+    call m::pack$E$V2
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    call mut_borrow
+    pop
+    st_loc l2
+    ld_u8 1
+    move_loc l2
+    // @10
+    write_ref
+    borrow_loc l0
+    st_loc l3
+    copy_loc l3
+    call m::test_variant$E$V1
+    // @15
+    br_true l0
+    copy_loc l3
+    call m::test_variant$E$V2
+    br_true l0
+    move_loc l3
+    // @20
+    pop
+    ld_u64 14566554180833181697
+    abort
+l0: move_loc l3
+    call m::borrow$E$0$0
+    // @25
+    read_ref
+    ld_u8 1
+    eq
+    br_false l1
+    borrow_loc l0
+    // @30
+    call m::borrow$E$1$1
+    read_ref
+    ld_u16 0
+    eq
+    br_false l2
+    // @35
+    ret
+l2: ld_u64 2
+    abort
+l1: ld_u64 1
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.exp
@@ -1,0 +1,112 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+enum Result<T0: copy + drop, T1: copy + drop> has copy + drop
+  Ok
+    _0: T0
+  Err
+    _0: T1
+
+// Function definition at index 0
+public fun test_variant$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 1
+public fun test_variant$Result$Err<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 2
+public fun pack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: T0): Result<T0, T1>
+    local l1: T0
+    move_loc l0
+    pack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 3
+public fun pack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: T1): Result<T0, T1>
+    local l1: T1
+    move_loc l0
+    pack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 4
+public fun unpack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T0
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 5
+public fun unpack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T1
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 6
+public fun borrow$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T0
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 7
+public fun borrow$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T1
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Function definition at index 8
+public fun borrow_mut$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T0
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 9
+public fun borrow_mut$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T1
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun test_pack_unpack_abort()
+    local l0: m1::Result<u64, u64>
+    ld_u64 42
+    call m1::pack$Result$Ok<u64, u64>
+    st_loc l0
+    copy_loc l0
+    ld_u64 42
+    // @5
+    call m1::pack$Result$Ok<u64, u64>
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 1
+    // @10
+    abort
+l1: move_loc l0
+    call m1::unpack$Result$Err<u64, u64>
+    ld_u64 42
+    eq
+    // @15
+    br_false l2
+    branch l3
+l2: ld_u64 2
+    abort
+l3: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.move
@@ -1,0 +1,22 @@
+module 0x42::m1 {
+
+    public enum Result<T: copy + drop, E: copy +drop> has copy, drop {
+        Ok(T),
+        Err(E)
+    }
+
+}
+
+//# publish
+module 0x42::m2 {
+
+    use 0x42::m1::Result;
+
+    public fun test_pack_unpack_abort() {
+        let result = Result::Ok<u64, u64>(42);
+        assert!(result == Result::Ok(42), 1);
+        let Result::Err(err) = result;
+        assert!(err == 42, 2);
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_abort.opt.exp
@@ -1,0 +1,110 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+enum Result<T0: copy + drop, T1: copy + drop> has copy + drop
+  Ok
+    _0: T0
+  Err
+    _0: T1
+
+// Function definition at index 0
+public fun test_variant$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 1
+public fun test_variant$Result$Err<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 2
+public fun pack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: T0): Result<T0, T1>
+    local l1: T0
+    move_loc l0
+    pack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 3
+public fun pack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: T1): Result<T0, T1>
+    local l1: T1
+    move_loc l0
+    pack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 4
+public fun unpack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T0
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 5
+public fun unpack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T1
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 6
+public fun borrow$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T0
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 7
+public fun borrow$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T1
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Function definition at index 8
+public fun borrow_mut$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T0
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 9
+public fun borrow_mut$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T1
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun test_pack_unpack_abort()
+    local l0: m1::Result<u64, u64>
+    ld_u64 42
+    call m1::pack$Result$Ok<u64, u64>
+    st_loc l0
+    copy_loc l0
+    ld_u64 42
+    // @5
+    call m1::pack$Result$Ok<u64, u64>
+    eq
+    br_false l0
+    move_loc l0
+    call m1::unpack$Result$Err<u64, u64>
+    // @10
+    ld_u64 42
+    eq
+    br_false l1
+    ret
+l1: ld_u64 2
+    // @15
+    abort
+l0: ld_u64 1
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.exp
@@ -1,0 +1,398 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+enum E has drop
+  A
+    x: u64
+  B
+    x: u64
+
+enum Inner
+  Inner1
+    x: u64
+  Inner2
+    x: u64
+    y: u64
+
+enum Result<T0: copy + drop, T1: copy + drop> has copy + drop
+  Ok
+    _0: T0
+  Err
+    _0: T1
+
+// Function definition at index 0
+public fun test_variant$E$A(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, A
+    ret
+
+// Function definition at index 1
+public fun test_variant$E$B(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, B
+    ret
+
+// Function definition at index 2
+public fun pack$E$A(l0: u64): E
+    local l1: u64
+    move_loc l0
+    pack_variant E, A
+    ret
+
+// Function definition at index 3
+public fun pack$E$B(l0: u64): E
+    local l1: u64
+    move_loc l0
+    pack_variant E, B
+    ret
+
+// Function definition at index 4
+public fun unpack$E$A(l0: E): u64
+    local l1: E
+    move_loc l0
+    unpack_variant E, A
+    ret
+
+// Function definition at index 5
+public fun unpack$E$B(l0: E): u64
+    local l1: E
+    move_loc l0
+    unpack_variant E, B
+    ret
+
+// Function definition at index 6
+public fun borrow$E$0$0(l0: &E): &u64
+    local l1: &E
+    move_loc l0
+    borrow_variant_field E, A::x, B::x
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$E$0$0(l0: &mut E): &mut u64
+    local l1: &mut E
+    move_loc l0
+    mut_borrow_variant_field E, A::x, B::x
+    ret
+
+// Function definition at index 8
+public fun test_variant$Inner$Inner1(l0: &Inner): bool
+    local l1: &Inner
+    move_loc l0
+    test_variant Inner, Inner1
+    ret
+
+// Function definition at index 9
+public fun test_variant$Inner$Inner2(l0: &Inner): bool
+    local l1: &Inner
+    move_loc l0
+    test_variant Inner, Inner2
+    ret
+
+// Function definition at index 10
+public fun pack$Inner$Inner1(l0: u64): Inner
+    local l1: u64
+    move_loc l0
+    pack_variant Inner, Inner1
+    ret
+
+// Function definition at index 11
+public fun pack$Inner$Inner2(l0: u64, l1: u64): Inner
+    local l2: u64
+    local l3: u64
+    move_loc l0
+    move_loc l1
+    pack_variant Inner, Inner2
+    ret
+
+// Function definition at index 12
+public fun unpack$Inner$Inner1(l0: Inner): u64
+    local l1: Inner
+    move_loc l0
+    unpack_variant Inner, Inner1
+    ret
+
+// Function definition at index 13
+public fun unpack$Inner$Inner2(l0: Inner): (u64, u64)
+    local l1: Inner
+    move_loc l0
+    unpack_variant Inner, Inner2
+    ret
+
+// Function definition at index 14
+public fun borrow$Inner$0$0(l0: &Inner): &u64
+    local l1: &Inner
+    move_loc l0
+    borrow_variant_field Inner, Inner1::x, Inner2::x
+    ret
+
+// Function definition at index 15
+public fun borrow$Inner$1$1(l0: &Inner): &u64
+    local l1: &Inner
+    move_loc l0
+    borrow_variant_field Inner, Inner2::y
+    ret
+
+// Function definition at index 16
+public fun borrow_mut$Inner$0$0(l0: &mut Inner): &mut u64
+    local l1: &mut Inner
+    move_loc l0
+    mut_borrow_variant_field Inner, Inner1::x, Inner2::x
+    ret
+
+// Function definition at index 17
+public fun borrow_mut$Inner$1$1(l0: &mut Inner): &mut u64
+    local l1: &mut Inner
+    move_loc l0
+    mut_borrow_variant_field Inner, Inner2::y
+    ret
+
+// Function definition at index 18
+public fun test_variant$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 19
+public fun test_variant$Result$Err<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 20
+public fun pack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: T0): Result<T0, T1>
+    local l1: T0
+    move_loc l0
+    pack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 21
+public fun pack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: T1): Result<T0, T1>
+    local l1: T1
+    move_loc l0
+    pack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 22
+public fun unpack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T0
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 23
+public fun unpack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T1
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 24
+public fun borrow$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T0
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 25
+public fun borrow$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T1
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Function definition at index 26
+public fun borrow_mut$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T0
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 27
+public fun borrow_mut$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T1
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun test_pack_unpack_result_err()
+    ld_u8 7
+    call m1::pack$Result$Err<u64, u8>
+    call m1::unpack$Result$Err<u64, u8>
+    ld_u8 7
+    eq
+    // @5
+    br_false l0
+    branch l1
+l0: ld_u64 3
+    abort
+l1: ret
+
+// Function definition at index 1
+#[persistent] public fun test_pack_unpack_result_ok()
+    local l0: m1::Result<u64, u64>
+    ld_u64 42
+    call m1::pack$Result$Ok<u64, u64>
+    st_loc l0
+    copy_loc l0
+    ld_u64 42
+    // @5
+    call m1::pack$Result$Ok<u64, u64>
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 1
+    // @10
+    abort
+l1: move_loc l0
+    call m1::unpack$Result$Ok<u64, u64>
+    ld_u64 42
+    eq
+    // @15
+    br_false l2
+    branch l3
+l2: ld_u64 2
+    abort
+l3: ret
+
+// Function definition at index 2
+#[persistent] public fun test_unpack_enum_e()
+    local l0: m1::E
+    local l1: m1::E
+    ld_u64 100
+    call m1::pack$E$A
+    ld_u64 200
+    call m1::pack$E$B
+    st_loc l0
+    // @5
+    st_loc l1
+    move_loc l1
+    call m1::unpack$E$A
+    ld_u64 100
+    eq
+    // @10
+    br_false l0
+    branch l1
+l0: ld_u64 4
+    abort
+l1: move_loc l0
+    // @15
+    call m1::unpack$E$B
+    ld_u64 200
+    eq
+    br_false l2
+    branch l3
+    // @20
+l2: ld_u64 5
+    abort
+l3: ret
+
+// Function definition at index 3
+#[persistent] public fun test_unpack_inner()
+    local l0: m1::Inner
+    local l1: m1::Inner
+    local l2: &m1::Inner
+    local l3: u64
+    local l4: u64
+    local l5: u64
+    local l6: &m1::Inner
+    local l7: u64
+    local l8: u64
+    local l9: u64
+    ld_u64 10
+    call m1::pack$Inner$Inner1
+    st_loc l0
+    ld_u64 20
+    ld_u64 30
+    // @5
+    call m1::pack$Inner$Inner2
+    st_loc l1
+    borrow_loc l0
+    st_loc l2
+    copy_loc l2
+    // @10
+    call m1::test_variant$Inner$Inner1
+    br_false l0
+    move_loc l2
+    pop
+    move_loc l0
+    // @15
+    call m1::unpack$Inner$Inner1
+    st_loc l3
+    branch l1
+l0: move_loc l2
+    call m1::test_variant$Inner$Inner2
+    // @20
+    br_false l2
+    move_loc l0
+    call m1::unpack$Inner$Inner2
+    st_loc l4
+    st_loc l5
+    // @25
+    move_loc l5
+    move_loc l4
+    add
+    st_loc l3
+    branch l1
+    // @30
+l2: ld_u64 14566554180833181697
+    abort
+l1: borrow_loc l1
+    st_loc l6
+    copy_loc l6
+    // @35
+    call m1::test_variant$Inner$Inner1
+    br_false l3
+    move_loc l6
+    pop
+    move_loc l1
+    // @40
+    call m1::unpack$Inner$Inner1
+    st_loc l7
+    branch l4
+l3: move_loc l6
+    call m1::test_variant$Inner$Inner2
+    // @45
+    br_false l5
+    move_loc l1
+    call m1::unpack$Inner$Inner2
+    st_loc l8
+    st_loc l9
+    // @50
+    move_loc l9
+    move_loc l8
+    add
+    st_loc l7
+    branch l4
+    // @55
+l5: ld_u64 14566554180833181697
+    abort
+l4: move_loc l3
+    ld_u64 10
+    eq
+    // @60
+    br_false l6
+    branch l7
+l6: ld_u64 6
+    abort
+l7: move_loc l7
+    // @65
+    ld_u64 50
+    eq
+    br_false l8
+    branch l9
+l8: ld_u64 7
+    // @70
+    abort
+l9: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.move
@@ -1,0 +1,70 @@
+module 0x42::m1 {
+
+
+    public enum Result<T: copy + drop, E: copy +drop> has copy, drop {
+        Ok(T),
+        Err(E)
+    }
+
+
+    public enum E has drop {
+        A {x: u64},
+        B {x: u64}
+    }
+
+    public enum Inner {
+        Inner1{ x: u64 }
+        Inner2{ x: u64, y: u64 }
+    }
+
+
+}
+
+module 0x42::m2 {
+
+    use 0x42::m1::Result;
+    use 0x42::m1::E;
+    use 0x42::m1::Inner;
+
+    public fun test_pack_unpack_result_ok() {
+        let result = Result::Ok<u64, u64>(42);
+        assert!(result == Result::Ok(42), 1);
+        let Result::Ok(ok) = result;
+        assert!(ok == 42, 2);
+    }
+
+    public fun test_pack_unpack_result_err() {
+        let result: Result<u64, u8> = Result::Err(7);
+        let Result::Err(err) = result;
+        assert!(err == 7, 3);
+    }
+
+    public fun test_unpack_enum_e() {
+        let a = E::A { x: 100 };
+        let b = E::B { x: 200 };
+
+        let E::A { x } = a;
+        assert!(x == 100, 4);
+
+        let E::B { x: y } = b;
+        assert!(y == 200, 5);
+    }
+
+    public fun test_unpack_inner() {
+        let v1 = Inner::Inner1 { x: 10 };
+        let v2 = Inner::Inner2 { x: 20, y: 30 };
+
+        let val1 = match (v1) {
+            Inner::Inner1 { x } => x,
+            Inner::Inner2 { x, y } => x + y
+        };
+        let val2 = match (v2) {
+            Inner::Inner1 { x } => x,
+            Inner::Inner2 { x, y } => x + y
+        };
+        assert!(val1 == 10, 6);
+        assert!(val2 == 50, 7);
+    }
+
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_pack_unpack_api.opt.exp
@@ -1,0 +1,372 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+enum E has drop
+  A
+    x: u64
+  B
+    x: u64
+
+enum Inner
+  Inner1
+    x: u64
+  Inner2
+    x: u64
+    y: u64
+
+enum Result<T0: copy + drop, T1: copy + drop> has copy + drop
+  Ok
+    _0: T0
+  Err
+    _0: T1
+
+// Function definition at index 0
+public fun test_variant$E$A(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, A
+    ret
+
+// Function definition at index 1
+public fun test_variant$E$B(l0: &E): bool
+    local l1: &E
+    move_loc l0
+    test_variant E, B
+    ret
+
+// Function definition at index 2
+public fun pack$E$A(l0: u64): E
+    local l1: u64
+    move_loc l0
+    pack_variant E, A
+    ret
+
+// Function definition at index 3
+public fun pack$E$B(l0: u64): E
+    local l1: u64
+    move_loc l0
+    pack_variant E, B
+    ret
+
+// Function definition at index 4
+public fun unpack$E$A(l0: E): u64
+    local l1: E
+    move_loc l0
+    unpack_variant E, A
+    ret
+
+// Function definition at index 5
+public fun unpack$E$B(l0: E): u64
+    local l1: E
+    move_loc l0
+    unpack_variant E, B
+    ret
+
+// Function definition at index 6
+public fun borrow$E$0$0(l0: &E): &u64
+    local l1: &E
+    move_loc l0
+    borrow_variant_field E, A::x, B::x
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$E$0$0(l0: &mut E): &mut u64
+    local l1: &mut E
+    move_loc l0
+    mut_borrow_variant_field E, A::x, B::x
+    ret
+
+// Function definition at index 8
+public fun test_variant$Inner$Inner1(l0: &Inner): bool
+    local l1: &Inner
+    move_loc l0
+    test_variant Inner, Inner1
+    ret
+
+// Function definition at index 9
+public fun test_variant$Inner$Inner2(l0: &Inner): bool
+    local l1: &Inner
+    move_loc l0
+    test_variant Inner, Inner2
+    ret
+
+// Function definition at index 10
+public fun pack$Inner$Inner1(l0: u64): Inner
+    local l1: u64
+    move_loc l0
+    pack_variant Inner, Inner1
+    ret
+
+// Function definition at index 11
+public fun pack$Inner$Inner2(l0: u64, l1: u64): Inner
+    local l2: u64
+    local l3: u64
+    move_loc l0
+    move_loc l1
+    pack_variant Inner, Inner2
+    ret
+
+// Function definition at index 12
+public fun unpack$Inner$Inner1(l0: Inner): u64
+    local l1: Inner
+    move_loc l0
+    unpack_variant Inner, Inner1
+    ret
+
+// Function definition at index 13
+public fun unpack$Inner$Inner2(l0: Inner): (u64, u64)
+    local l1: Inner
+    move_loc l0
+    unpack_variant Inner, Inner2
+    ret
+
+// Function definition at index 14
+public fun borrow$Inner$0$0(l0: &Inner): &u64
+    local l1: &Inner
+    move_loc l0
+    borrow_variant_field Inner, Inner1::x, Inner2::x
+    ret
+
+// Function definition at index 15
+public fun borrow$Inner$1$1(l0: &Inner): &u64
+    local l1: &Inner
+    move_loc l0
+    borrow_variant_field Inner, Inner2::y
+    ret
+
+// Function definition at index 16
+public fun borrow_mut$Inner$0$0(l0: &mut Inner): &mut u64
+    local l1: &mut Inner
+    move_loc l0
+    mut_borrow_variant_field Inner, Inner1::x, Inner2::x
+    ret
+
+// Function definition at index 17
+public fun borrow_mut$Inner$1$1(l0: &mut Inner): &mut u64
+    local l1: &mut Inner
+    move_loc l0
+    mut_borrow_variant_field Inner, Inner2::y
+    ret
+
+// Function definition at index 18
+public fun test_variant$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 19
+public fun test_variant$Result$Err<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): bool
+    local l1: &Result<T0, T1>
+    move_loc l0
+    test_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 20
+public fun pack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: T0): Result<T0, T1>
+    local l1: T0
+    move_loc l0
+    pack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 21
+public fun pack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: T1): Result<T0, T1>
+    local l1: T1
+    move_loc l0
+    pack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 22
+public fun unpack$Result$Ok<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T0
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Ok
+    ret
+
+// Function definition at index 23
+public fun unpack$Result$Err<T0: copy + drop, T1: copy + drop>(l0: Result<T0, T1>): T1
+    local l1: Result<T0, T1>
+    move_loc l0
+    unpack_variant Result<T0, T1>, Err
+    ret
+
+// Function definition at index 24
+public fun borrow$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T0
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 25
+public fun borrow$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &Result<T0, T1>): &T1
+    local l1: &Result<T0, T1>
+    move_loc l0
+    borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Function definition at index 26
+public fun borrow_mut$Result$0$0<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T0
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Ok::_0
+    ret
+
+// Function definition at index 27
+public fun borrow_mut$Result$0$1<T0: copy + drop, T1: copy + drop>(l0: &mut Result<T0, T1>): &mut T1
+    local l1: &mut Result<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Result<T0, T1>, Err::_0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun test_pack_unpack_result_err()
+    ld_u8 7
+    call m1::pack$Result$Err<u64, u8>
+    call m1::unpack$Result$Err<u64, u8>
+    ld_u8 7
+    eq
+    // @5
+    br_false l0
+    ret
+l0: ld_u64 3
+    abort
+
+// Function definition at index 1
+#[persistent] public fun test_pack_unpack_result_ok()
+    local l0: m1::Result<u64, u64>
+    ld_u64 42
+    call m1::pack$Result$Ok<u64, u64>
+    st_loc l0
+    copy_loc l0
+    ld_u64 42
+    // @5
+    call m1::pack$Result$Ok<u64, u64>
+    eq
+    br_false l0
+    move_loc l0
+    call m1::unpack$Result$Ok<u64, u64>
+    // @10
+    ld_u64 42
+    eq
+    br_false l1
+    ret
+l1: ld_u64 2
+    // @15
+    abort
+l0: ld_u64 1
+    abort
+
+// Function definition at index 2
+#[persistent] public fun test_unpack_enum_e()
+    local l0: m1::E
+    ld_u64 100
+    call m1::pack$E$A
+    ld_u64 200
+    call m1::pack$E$B
+    st_loc l0
+    // @5
+    call m1::unpack$E$A
+    ld_u64 100
+    eq
+    br_false l0
+    move_loc l0
+    // @10
+    call m1::unpack$E$B
+    ld_u64 200
+    eq
+    br_false l1
+    ret
+    // @15
+l1: ld_u64 5
+    abort
+l0: ld_u64 4
+    abort
+
+// Function definition at index 3
+#[persistent] public fun test_unpack_inner()
+    local l0: m1::Inner
+    local l1: m1::Inner
+    local l2: &m1::Inner
+    local l3: u64
+    local l4: &m1::Inner
+    local l5: u64
+    local l6: u64
+    local l7: u64
+    ld_u64 10
+    call m1::pack$Inner$Inner1
+    st_loc l0
+    ld_u64 20
+    ld_u64 30
+    // @5
+    call m1::pack$Inner$Inner2
+    st_loc l1
+    borrow_loc l0
+    st_loc l2
+    copy_loc l2
+    // @10
+    call m1::test_variant$Inner$Inner1
+    br_false l0
+    move_loc l2
+    pop
+    move_loc l0
+    // @15
+    call m1::unpack$Inner$Inner1
+    st_loc l3
+l7: borrow_loc l1
+    st_loc l4
+    copy_loc l4
+    // @20
+    call m1::test_variant$Inner$Inner1
+    br_false l1
+    move_loc l4
+    pop
+    move_loc l1
+    // @25
+    call m1::unpack$Inner$Inner1
+    st_loc l5
+l5: move_loc l3
+    ld_u64 10
+    eq
+    // @30
+    br_false l2
+    move_loc l5
+    ld_u64 50
+    eq
+    br_false l3
+    // @35
+    ret
+l3: ld_u64 7
+    abort
+l2: ld_u64 6
+    abort
+    // @40
+l1: move_loc l4
+    call m1::test_variant$Inner$Inner2
+    br_false l4
+    move_loc l1
+    call m1::unpack$Inner$Inner2
+    // @45
+    add
+    st_loc l5
+    branch l5
+l4: ld_u64 14566554180833181697
+    abort
+    // @50
+l0: move_loc l2
+    call m1::test_variant$Inner$Inner2
+    br_false l6
+    move_loc l0
+    call m1::unpack$Inner$Inner2
+    // @55
+    add
+    st_loc l3
+    branch l7
+l6: ld_u64 14566554180833181697
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_variant.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_variant.exp
@@ -1,0 +1,687 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m
+friend 0x42::m2
+enum Data has drop
+  V1
+    x: u64
+  V2
+    x: u64
+    y: bool
+  V3
+
+enum Data2 has drop
+  V1
+    x: u64
+  V2
+    y: u64
+    x: u64
+  V3
+
+enum Data3 has drop
+  V1
+    d1: Data
+  V2
+    d1: Data
+    d2: Data2
+  V3
+    d1: Data
+    d2: Data2
+    d3: V<u64>
+  V4
+    d1: Data
+    d2: Data2
+    d3: V<u64>
+    d4: vector<u64>
+
+struct V<T0> has drop
+  x: vector<T0>
+
+// Function definition at index 0
+friend fun test_variant$Data$V1(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V1
+    ret
+
+// Function definition at index 1
+friend fun test_variant$Data$V2(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V2
+    ret
+
+// Function definition at index 2
+friend fun test_variant$Data$V3(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V3
+    ret
+
+// Function definition at index 3
+friend fun pack$Data$V1(l0: u64): Data
+    local l1: u64
+    move_loc l0
+    pack_variant Data, V1
+    ret
+
+// Function definition at index 4
+friend fun pack$Data$V2(l0: u64, l1: bool): Data
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack_variant Data, V2
+    ret
+
+// Function definition at index 5
+friend fun pack$Data$V3(): Data
+    pack_variant Data, V3
+    ret
+
+// Function definition at index 6
+friend fun unpack$Data$V1(l0: Data): u64
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V1
+    ret
+
+// Function definition at index 7
+friend fun unpack$Data$V2(l0: Data): (u64, bool)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V2
+    ret
+
+// Function definition at index 8
+friend fun unpack$Data$V3(l0: Data)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V3
+    ret
+
+// Function definition at index 9
+friend fun borrow$Data$0$0(l0: &Data): &u64
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 10
+friend fun borrow$Data$1$1(l0: &Data): &bool
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 11
+friend fun borrow_mut$Data$0$0(l0: &mut Data): &mut u64
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 12
+friend fun borrow_mut$Data$1$1(l0: &mut Data): &mut bool
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 13
+friend fun test_variant$Data2$V1(l0: &Data2): bool
+    local l1: &Data2
+    move_loc l0
+    test_variant Data2, V1
+    ret
+
+// Function definition at index 14
+friend fun test_variant$Data2$V2(l0: &Data2): bool
+    local l1: &Data2
+    move_loc l0
+    test_variant Data2, V2
+    ret
+
+// Function definition at index 15
+friend fun test_variant$Data2$V3(l0: &Data2): bool
+    local l1: &Data2
+    move_loc l0
+    test_variant Data2, V3
+    ret
+
+// Function definition at index 16
+friend fun pack$Data2$V1(l0: u64): Data2
+    local l1: u64
+    move_loc l0
+    pack_variant Data2, V1
+    ret
+
+// Function definition at index 17
+friend fun pack$Data2$V2(l0: u64, l1: u64): Data2
+    local l2: u64
+    local l3: u64
+    move_loc l0
+    move_loc l1
+    pack_variant Data2, V2
+    ret
+
+// Function definition at index 18
+friend fun pack$Data2$V3(): Data2
+    pack_variant Data2, V3
+    ret
+
+// Function definition at index 19
+friend fun unpack$Data2$V1(l0: Data2): u64
+    local l1: Data2
+    move_loc l0
+    unpack_variant Data2, V1
+    ret
+
+// Function definition at index 20
+friend fun unpack$Data2$V2(l0: Data2): (u64, u64)
+    local l1: Data2
+    move_loc l0
+    unpack_variant Data2, V2
+    ret
+
+// Function definition at index 21
+friend fun unpack$Data2$V3(l0: Data2)
+    local l1: Data2
+    move_loc l0
+    unpack_variant Data2, V3
+    ret
+
+// Function definition at index 22
+friend fun borrow$Data2$0$0(l0: &Data2): &u64
+    local l1: &Data2
+    move_loc l0
+    borrow_variant_field Data2, V1::x, V2::y
+    ret
+
+// Function definition at index 23
+friend fun borrow$Data2$1$1(l0: &Data2): &u64
+    local l1: &Data2
+    move_loc l0
+    borrow_variant_field Data2, V2::x
+    ret
+
+// Function definition at index 24
+friend fun borrow_mut$Data2$0$0(l0: &mut Data2): &mut u64
+    local l1: &mut Data2
+    move_loc l0
+    mut_borrow_variant_field Data2, V1::x, V2::y
+    ret
+
+// Function definition at index 25
+friend fun borrow_mut$Data2$1$1(l0: &mut Data2): &mut u64
+    local l1: &mut Data2
+    move_loc l0
+    mut_borrow_variant_field Data2, V2::x
+    ret
+
+// Function definition at index 26
+friend fun test_variant$Data3$V1(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V1
+    ret
+
+// Function definition at index 27
+friend fun test_variant$Data3$V2(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V2
+    ret
+
+// Function definition at index 28
+friend fun test_variant$Data3$V3(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V3
+    ret
+
+// Function definition at index 29
+friend fun test_variant$Data3$V4(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V4
+    ret
+
+// Function definition at index 30
+friend fun pack$Data3$V1(l0: Data): Data3
+    local l1: Data
+    move_loc l0
+    pack_variant Data3, V1
+    ret
+
+// Function definition at index 31
+friend fun pack$Data3$V2(l0: Data, l1: Data2): Data3
+    local l2: Data
+    local l3: Data2
+    move_loc l0
+    move_loc l1
+    pack_variant Data3, V2
+    ret
+
+// Function definition at index 32
+friend fun pack$Data3$V3(l0: Data, l1: Data2, l2: V<u64>): Data3
+    local l3: Data
+    local l4: Data2
+    local l5: V<u64>
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    pack_variant Data3, V3
+    ret
+
+// Function definition at index 33
+friend fun pack$Data3$V4(l0: Data, l1: Data2, l2: V<u64>, l3: vector<u64>): Data3
+    local l4: Data
+    local l5: Data2
+    local l6: V<u64>
+    local l7: vector<u64>
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    move_loc l3
+    pack_variant Data3, V4
+    // @5
+    ret
+
+// Function definition at index 34
+friend fun unpack$Data3$V1(l0: Data3): Data
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V1
+    ret
+
+// Function definition at index 35
+friend fun unpack$Data3$V2(l0: Data3): (Data, Data2)
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V2
+    ret
+
+// Function definition at index 36
+friend fun unpack$Data3$V3(l0: Data3): (Data, Data2, V<u64>)
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V3
+    ret
+
+// Function definition at index 37
+friend fun unpack$Data3$V4(l0: Data3): (Data, Data2, V<u64>, vector<u64>)
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V4
+    ret
+
+// Function definition at index 38
+friend fun borrow$Data3$0$0(l0: &Data3): &Data
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V1::d1, V2::d1, V3::d1, V4::d1
+    ret
+
+// Function definition at index 39
+friend fun borrow$Data3$1$1(l0: &Data3): &Data2
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V2::d2, V3::d2, V4::d2
+    ret
+
+// Function definition at index 40
+friend fun borrow$Data3$2$2(l0: &Data3): &V<u64>
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V3::d3, V4::d3
+    ret
+
+// Function definition at index 41
+friend fun borrow$Data3$3$3(l0: &Data3): &vector<u64>
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V4::d4
+    ret
+
+// Function definition at index 42
+friend fun borrow_mut$Data3$0$0(l0: &mut Data3): &mut Data
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V1::d1, V2::d1, V3::d1, V4::d1
+    ret
+
+// Function definition at index 43
+friend fun borrow_mut$Data3$1$1(l0: &mut Data3): &mut Data2
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V2::d2, V3::d2, V4::d2
+    ret
+
+// Function definition at index 44
+friend fun borrow_mut$Data3$2$2(l0: &mut Data3): &mut V<u64>
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V3::d3, V4::d3
+    ret
+
+// Function definition at index 45
+friend fun borrow_mut$Data3$3$3(l0: &mut Data3): &mut vector<u64>
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V4::d4
+    ret
+
+// Function definition at index 46
+friend fun pack$V<T0>(l0: vector<T0>): V<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack V<T0>
+    ret
+
+// Function definition at index 47
+friend fun unpack$V<T0>(l0: V<T0>): vector<T0>
+    local l1: V<T0>
+    move_loc l0
+    unpack V<T0>
+    ret
+
+// Function definition at index 48
+friend fun borrow$V$0<T0>(l0: &V<T0>): &vector<T0>
+    local l1: &V<T0>
+    move_loc l0
+    borrow_field V<T0>, x
+    ret
+
+// Function definition at index 49
+friend fun borrow_mut$V$0<T0>(l0: &mut V<T0>): &mut vector<T0>
+    local l1: &mut V<T0>
+    move_loc l0
+    mut_borrow_field V<T0>, x
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m
+// Function definition at index 0
+fun test_v1(): bool
+    local l0: m::Data
+    local l1: &m::Data
+    local l2: bool
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    call m::test_variant$Data$V1
+    // @5
+    br_false l0
+    borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$Data$V1
+    // @10
+    st_loc l2
+    copy_loc l2
+    br_false l1
+    move_loc l1
+    pop
+    // @15
+    branch l2
+l1: move_loc l1
+    call m::test_variant$Data$V3
+    st_loc l2
+    copy_loc l2
+    // @20
+    br_false l2
+    branch l2
+l2: branch l3
+l0: ld_false
+    st_loc l2
+    // @25
+l3: move_loc l2
+    ret
+
+// Function definition at index 1
+#[persistent] public fun test_v1_mut_borrow()
+    local l0: m::Data
+    local l1: u64
+    local l2: &mut u64
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    mut_borrow_loc l0
+    call m::borrow_mut$Data$0$0
+    // @5
+    ld_u64 44
+    st_loc l1
+    st_loc l2
+    move_loc l1
+    move_loc l2
+    // @10
+    write_ref
+    borrow_loc l0
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 44
+    // @15
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 1
+    abort
+    // @20
+l1: ret
+
+// Function definition at index 2
+fun test_v1v3(): bool
+    local l0: m::Data
+    local l1: &m::Data
+    local l2: bool
+    local l3: m::Data
+    local l4: &m::Data
+    local l5: bool
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    st_loc l1
+    // @5
+    copy_loc l1
+    call m::test_variant$Data$V1
+    st_loc l2
+    copy_loc l2
+    br_false l0
+    // @10
+    move_loc l1
+    pop
+    branch l1
+l0: move_loc l1
+    call m::test_variant$Data$V3
+    // @15
+    st_loc l2
+    copy_loc l2
+    br_false l1
+    branch l1
+l1: call m::pack$Data$V3
+    // @20
+    st_loc l3
+    move_loc l2
+    br_false l2
+    borrow_loc l3
+    st_loc l4
+    // @25
+    copy_loc l4
+    call m::test_variant$Data$V1
+    st_loc l5
+    copy_loc l5
+    br_false l3
+    // @30
+    move_loc l4
+    pop
+    branch l4
+l3: move_loc l4
+    call m::test_variant$Data$V3
+    // @35
+    st_loc l5
+    copy_loc l5
+    br_false l4
+    branch l4
+l4: branch l5
+    // @40
+l2: ld_false
+    st_loc l5
+l5: move_loc l5
+    ret
+
+// Function definition at index 3
+fun test_v1v3_ref(): bool
+    local l0: m::Data
+    local l1: &m::Data
+    local l2: bool
+    local l3: m::Data
+    local l4: &mut m::Data
+    local l5: bool
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    st_loc l1
+    // @5
+    copy_loc l1
+    call m::test_variant$Data$V1
+    st_loc l2
+    copy_loc l2
+    br_false l0
+    // @10
+    move_loc l1
+    pop
+    branch l1
+l0: move_loc l1
+    call m::test_variant$Data$V3
+    // @15
+    st_loc l2
+    copy_loc l2
+    br_false l1
+    branch l1
+l1: call m::pack$Data$V3
+    // @20
+    st_loc l3
+    move_loc l2
+    br_false l2
+    mut_borrow_loc l3
+    st_loc l4
+    // @25
+    copy_loc l4
+    freeze_ref
+    call m::test_variant$Data$V1
+    st_loc l5
+    copy_loc l5
+    // @30
+    br_false l3
+    move_loc l4
+    pop
+    branch l4
+l3: move_loc l4
+    // @35
+    freeze_ref
+    call m::test_variant$Data$V3
+    st_loc l5
+    copy_loc l5
+    br_false l4
+    // @40
+    branch l4
+l4: branch l5
+l2: ld_false
+    st_loc l5
+l5: move_loc l5
+    // @45
+    ret
+
+// Function definition at index 4
+#[persistent] public fun test_v2_mut_borrow_2()
+    local l0: m::Data2
+    local l1: &mut m::Data2
+    local l2: &mut u64
+    local l3: &m::Data2
+    local l4: &m::Data2
+    local l5: &u64
+    ld_u64 43
+    ld_u64 44
+    call m::pack$Data2$V2
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    st_loc l1
+    copy_loc l1
+    freeze_ref
+    call m::test_variant$Data2$V2
+    br_true l0
+    // @10
+    branch l1
+l0: move_loc l1
+    call m::borrow_mut$Data2$1$1
+    st_loc l2
+    branch l2
+    // @15
+l1: copy_loc l1
+    freeze_ref
+    st_loc l3
+    copy_loc l3
+    call m::test_variant$Data2$V1
+    // @20
+    br_true l3
+    move_loc l3
+    pop
+    move_loc l1
+    pop
+    // @25
+    ld_u64 14566554180833181697
+    abort
+l3: move_loc l3
+    pop
+    move_loc l1
+    // @30
+    call m::borrow_mut$Data2$0$0
+    st_loc l2
+l2: ld_u64 45
+    move_loc l2
+    write_ref
+    // @35
+    borrow_loc l0
+    st_loc l4
+    copy_loc l4
+    call m::test_variant$Data2$V2
+    br_true l4
+    // @40
+    branch l5
+l4: move_loc l4
+    call m::borrow$Data2$1$1
+    st_loc l5
+    branch l6
+    // @45
+l5: copy_loc l4
+    call m::test_variant$Data2$V1
+    br_true l7
+    move_loc l4
+    pop
+    // @50
+    ld_u64 14566554180833181697
+    abort
+l7: move_loc l4
+    call m::borrow$Data2$0$0
+    st_loc l5
+    // @55
+l6: move_loc l5
+    read_ref
+    ld_u64 45
+    eq
+    br_false l8
+    // @60
+    branch l9
+l8: ld_u64 1
+    abort
+l9: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_variant.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_variant.move
@@ -1,0 +1,69 @@
+module 0x42::m {
+
+  friend 0x42::m2;
+
+  friend enum Data has drop {
+    V1{x: u64},
+    V2{x: u64, y: bool}
+    V3
+  }
+
+  friend enum Data2 has drop {
+    V1{x: u64},
+    V2{y: u64, x: u64}
+    V3
+  }
+
+  friend struct V<T> has drop {
+    x: vector<T>
+  }
+
+  friend enum Data3 has drop {
+    V1{d1: Data},
+    V2{d1: Data, d2: Data2},
+    V3{d1: Data, d2: Data2, d3: V<u64>}
+    V4{d1: Data, d2: Data2, d3: V<u64>, d4: vector<u64>}
+  }
+
+}
+
+module 0x42::m2 {
+
+  use 0x42::m::Data;
+  use 0x42::m::Data2;
+
+  fun test_v1(): bool {
+    let d = Data::V1{x: 43};
+    (d is V1) && (&d is V1|V3)
+  }
+
+  fun test_v1v3(): bool {
+    let d = Data::V1{x: 43};
+    let t = (d is V1|V3);
+    let d = Data::V3{};
+    t && (d is V1|V3)
+  }
+
+  fun test_v1v3_ref(): bool {
+    let d = Data::V1{x: 43};
+    let t = (&d is V1|V3);
+    let d = Data::V3{};
+    t && (&mut d is V1|V3)
+  }
+
+  public fun test_v1_mut_borrow() {
+    let d = Data::V1{x: 43};
+    let r = &mut d.x;
+    *r = 44;
+    assert!(d.x == 44, 1);
+  }
+
+  public fun test_v2_mut_borrow_2() {
+    let d = Data2::V2{y: 43, x: 44};
+    let r = &mut d.x;
+    *r = 45;
+    assert!(d.x == 45, 1);
+  }
+
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_variant.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/enum_variant.opt.exp
@@ -1,0 +1,673 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m
+friend 0x42::m2
+enum Data has drop
+  V1
+    x: u64
+  V2
+    x: u64
+    y: bool
+  V3
+
+enum Data2 has drop
+  V1
+    x: u64
+  V2
+    y: u64
+    x: u64
+  V3
+
+enum Data3 has drop
+  V1
+    d1: Data
+  V2
+    d1: Data
+    d2: Data2
+  V3
+    d1: Data
+    d2: Data2
+    d3: V<u64>
+  V4
+    d1: Data
+    d2: Data2
+    d3: V<u64>
+    d4: vector<u64>
+
+struct V<T0> has drop
+  x: vector<T0>
+
+// Function definition at index 0
+friend fun test_variant$Data$V1(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V1
+    ret
+
+// Function definition at index 1
+friend fun test_variant$Data$V2(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V2
+    ret
+
+// Function definition at index 2
+friend fun test_variant$Data$V3(l0: &Data): bool
+    local l1: &Data
+    move_loc l0
+    test_variant Data, V3
+    ret
+
+// Function definition at index 3
+friend fun pack$Data$V1(l0: u64): Data
+    local l1: u64
+    move_loc l0
+    pack_variant Data, V1
+    ret
+
+// Function definition at index 4
+friend fun pack$Data$V2(l0: u64, l1: bool): Data
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack_variant Data, V2
+    ret
+
+// Function definition at index 5
+friend fun pack$Data$V3(): Data
+    pack_variant Data, V3
+    ret
+
+// Function definition at index 6
+friend fun unpack$Data$V1(l0: Data): u64
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V1
+    ret
+
+// Function definition at index 7
+friend fun unpack$Data$V2(l0: Data): (u64, bool)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V2
+    ret
+
+// Function definition at index 8
+friend fun unpack$Data$V3(l0: Data)
+    local l1: Data
+    move_loc l0
+    unpack_variant Data, V3
+    ret
+
+// Function definition at index 9
+friend fun borrow$Data$0$0(l0: &Data): &u64
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 10
+friend fun borrow$Data$1$1(l0: &Data): &bool
+    local l1: &Data
+    move_loc l0
+    borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 11
+friend fun borrow_mut$Data$0$0(l0: &mut Data): &mut u64
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V1::x, V2::x
+    ret
+
+// Function definition at index 12
+friend fun borrow_mut$Data$1$1(l0: &mut Data): &mut bool
+    local l1: &mut Data
+    move_loc l0
+    mut_borrow_variant_field Data, V2::y
+    ret
+
+// Function definition at index 13
+friend fun test_variant$Data2$V1(l0: &Data2): bool
+    local l1: &Data2
+    move_loc l0
+    test_variant Data2, V1
+    ret
+
+// Function definition at index 14
+friend fun test_variant$Data2$V2(l0: &Data2): bool
+    local l1: &Data2
+    move_loc l0
+    test_variant Data2, V2
+    ret
+
+// Function definition at index 15
+friend fun test_variant$Data2$V3(l0: &Data2): bool
+    local l1: &Data2
+    move_loc l0
+    test_variant Data2, V3
+    ret
+
+// Function definition at index 16
+friend fun pack$Data2$V1(l0: u64): Data2
+    local l1: u64
+    move_loc l0
+    pack_variant Data2, V1
+    ret
+
+// Function definition at index 17
+friend fun pack$Data2$V2(l0: u64, l1: u64): Data2
+    local l2: u64
+    local l3: u64
+    move_loc l0
+    move_loc l1
+    pack_variant Data2, V2
+    ret
+
+// Function definition at index 18
+friend fun pack$Data2$V3(): Data2
+    pack_variant Data2, V3
+    ret
+
+// Function definition at index 19
+friend fun unpack$Data2$V1(l0: Data2): u64
+    local l1: Data2
+    move_loc l0
+    unpack_variant Data2, V1
+    ret
+
+// Function definition at index 20
+friend fun unpack$Data2$V2(l0: Data2): (u64, u64)
+    local l1: Data2
+    move_loc l0
+    unpack_variant Data2, V2
+    ret
+
+// Function definition at index 21
+friend fun unpack$Data2$V3(l0: Data2)
+    local l1: Data2
+    move_loc l0
+    unpack_variant Data2, V3
+    ret
+
+// Function definition at index 22
+friend fun borrow$Data2$0$0(l0: &Data2): &u64
+    local l1: &Data2
+    move_loc l0
+    borrow_variant_field Data2, V1::x, V2::y
+    ret
+
+// Function definition at index 23
+friend fun borrow$Data2$1$1(l0: &Data2): &u64
+    local l1: &Data2
+    move_loc l0
+    borrow_variant_field Data2, V2::x
+    ret
+
+// Function definition at index 24
+friend fun borrow_mut$Data2$0$0(l0: &mut Data2): &mut u64
+    local l1: &mut Data2
+    move_loc l0
+    mut_borrow_variant_field Data2, V1::x, V2::y
+    ret
+
+// Function definition at index 25
+friend fun borrow_mut$Data2$1$1(l0: &mut Data2): &mut u64
+    local l1: &mut Data2
+    move_loc l0
+    mut_borrow_variant_field Data2, V2::x
+    ret
+
+// Function definition at index 26
+friend fun test_variant$Data3$V1(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V1
+    ret
+
+// Function definition at index 27
+friend fun test_variant$Data3$V2(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V2
+    ret
+
+// Function definition at index 28
+friend fun test_variant$Data3$V3(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V3
+    ret
+
+// Function definition at index 29
+friend fun test_variant$Data3$V4(l0: &Data3): bool
+    local l1: &Data3
+    move_loc l0
+    test_variant Data3, V4
+    ret
+
+// Function definition at index 30
+friend fun pack$Data3$V1(l0: Data): Data3
+    local l1: Data
+    move_loc l0
+    pack_variant Data3, V1
+    ret
+
+// Function definition at index 31
+friend fun pack$Data3$V2(l0: Data, l1: Data2): Data3
+    local l2: Data
+    local l3: Data2
+    move_loc l0
+    move_loc l1
+    pack_variant Data3, V2
+    ret
+
+// Function definition at index 32
+friend fun pack$Data3$V3(l0: Data, l1: Data2, l2: V<u64>): Data3
+    local l3: Data
+    local l4: Data2
+    local l5: V<u64>
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    pack_variant Data3, V3
+    ret
+
+// Function definition at index 33
+friend fun pack$Data3$V4(l0: Data, l1: Data2, l2: V<u64>, l3: vector<u64>): Data3
+    local l4: Data
+    local l5: Data2
+    local l6: V<u64>
+    local l7: vector<u64>
+    move_loc l0
+    move_loc l1
+    move_loc l2
+    move_loc l3
+    pack_variant Data3, V4
+    // @5
+    ret
+
+// Function definition at index 34
+friend fun unpack$Data3$V1(l0: Data3): Data
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V1
+    ret
+
+// Function definition at index 35
+friend fun unpack$Data3$V2(l0: Data3): (Data, Data2)
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V2
+    ret
+
+// Function definition at index 36
+friend fun unpack$Data3$V3(l0: Data3): (Data, Data2, V<u64>)
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V3
+    ret
+
+// Function definition at index 37
+friend fun unpack$Data3$V4(l0: Data3): (Data, Data2, V<u64>, vector<u64>)
+    local l1: Data3
+    move_loc l0
+    unpack_variant Data3, V4
+    ret
+
+// Function definition at index 38
+friend fun borrow$Data3$0$0(l0: &Data3): &Data
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V1::d1, V2::d1, V3::d1, V4::d1
+    ret
+
+// Function definition at index 39
+friend fun borrow$Data3$1$1(l0: &Data3): &Data2
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V2::d2, V3::d2, V4::d2
+    ret
+
+// Function definition at index 40
+friend fun borrow$Data3$2$2(l0: &Data3): &V<u64>
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V3::d3, V4::d3
+    ret
+
+// Function definition at index 41
+friend fun borrow$Data3$3$3(l0: &Data3): &vector<u64>
+    local l1: &Data3
+    move_loc l0
+    borrow_variant_field Data3, V4::d4
+    ret
+
+// Function definition at index 42
+friend fun borrow_mut$Data3$0$0(l0: &mut Data3): &mut Data
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V1::d1, V2::d1, V3::d1, V4::d1
+    ret
+
+// Function definition at index 43
+friend fun borrow_mut$Data3$1$1(l0: &mut Data3): &mut Data2
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V2::d2, V3::d2, V4::d2
+    ret
+
+// Function definition at index 44
+friend fun borrow_mut$Data3$2$2(l0: &mut Data3): &mut V<u64>
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V3::d3, V4::d3
+    ret
+
+// Function definition at index 45
+friend fun borrow_mut$Data3$3$3(l0: &mut Data3): &mut vector<u64>
+    local l1: &mut Data3
+    move_loc l0
+    mut_borrow_variant_field Data3, V4::d4
+    ret
+
+// Function definition at index 46
+friend fun pack$V<T0>(l0: vector<T0>): V<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack V<T0>
+    ret
+
+// Function definition at index 47
+friend fun unpack$V<T0>(l0: V<T0>): vector<T0>
+    local l1: V<T0>
+    move_loc l0
+    unpack V<T0>
+    ret
+
+// Function definition at index 48
+friend fun borrow$V$0<T0>(l0: &V<T0>): &vector<T0>
+    local l1: &V<T0>
+    move_loc l0
+    borrow_field V<T0>, x
+    ret
+
+// Function definition at index 49
+friend fun borrow_mut$V$0<T0>(l0: &mut V<T0>): &mut vector<T0>
+    local l1: &mut V<T0>
+    move_loc l0
+    mut_borrow_field V<T0>, x
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m
+// Function definition at index 0
+fun test_v1(): bool
+    local l0: m::Data
+    local l1: &m::Data
+    local l2: bool
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    call m::test_variant$Data$V1
+    // @5
+    br_false l0
+    borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call m::test_variant$Data$V1
+    // @10
+    st_loc l2
+    copy_loc l2
+    br_false l1
+    move_loc l1
+    pop
+    // @15
+l3: move_loc l2
+    ret
+l1: move_loc l1
+    call m::test_variant$Data$V3
+    st_loc l2
+    // @20
+    copy_loc l2
+    br_true l2
+    branch l3
+l2: move_loc l2
+    ret
+    // @25
+l0: ld_false
+    ret
+
+// Function definition at index 1
+#[persistent] public fun test_v1_mut_borrow()
+    local l0: m::Data
+    local l1: u64
+    local l2: &mut u64
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    mut_borrow_loc l0
+    call m::borrow_mut$Data$0$0
+    // @5
+    st_loc l2
+    ld_u64 44
+    move_loc l2
+    write_ref
+    borrow_loc l0
+    // @10
+    call m::borrow$Data$0$0
+    read_ref
+    ld_u64 44
+    eq
+    br_false l0
+    // @15
+    ret
+l0: ld_u64 1
+    abort
+
+// Function definition at index 2
+fun test_v1v3(): bool
+    local l0: m::Data
+    local l1: &m::Data
+    local l2: bool
+    local l3: m::Data
+    local l4: &m::Data
+    local l5: bool
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    st_loc l1
+    // @5
+    copy_loc l1
+    call m::test_variant$Data$V1
+    st_loc l2
+    copy_loc l2
+    br_false l0
+    // @10
+    move_loc l1
+    pop
+l5: call m::pack$Data$V3
+    st_loc l3
+    move_loc l2
+    // @15
+    br_false l1
+    borrow_loc l3
+    st_loc l4
+    copy_loc l4
+    call m::test_variant$Data$V1
+    // @20
+    st_loc l5
+    copy_loc l5
+    br_false l2
+    move_loc l4
+    pop
+    // @25
+l4: move_loc l5
+    ret
+l2: move_loc l4
+    call m::test_variant$Data$V3
+    st_loc l5
+    // @30
+    copy_loc l5
+    br_true l3
+    branch l4
+l3: move_loc l5
+    ret
+    // @35
+l1: ld_false
+    ret
+l0: move_loc l1
+    call m::test_variant$Data$V3
+    st_loc l2
+    // @40
+    branch l5
+
+// Function definition at index 3
+fun test_v1v3_ref(): bool
+    local l0: m::Data
+    local l1: &m::Data
+    local l2: bool
+    local l3: m::Data
+    local l4: &mut m::Data
+    local l5: bool
+    ld_u64 43
+    call m::pack$Data$V1
+    st_loc l0
+    borrow_loc l0
+    st_loc l1
+    // @5
+    copy_loc l1
+    call m::test_variant$Data$V1
+    st_loc l2
+    copy_loc l2
+    br_false l0
+    // @10
+    move_loc l1
+    pop
+l5: call m::pack$Data$V3
+    st_loc l3
+    move_loc l2
+    // @15
+    br_false l1
+    mut_borrow_loc l3
+    st_loc l4
+    copy_loc l4
+    freeze_ref
+    // @20
+    call m::test_variant$Data$V1
+    st_loc l5
+    copy_loc l5
+    br_false l2
+    move_loc l4
+    // @25
+    pop
+l4: move_loc l5
+    ret
+l2: move_loc l4
+    freeze_ref
+    // @30
+    call m::test_variant$Data$V3
+    st_loc l5
+    copy_loc l5
+    br_true l3
+    branch l4
+    // @35
+l3: move_loc l5
+    ret
+l1: ld_false
+    ret
+l0: move_loc l1
+    // @40
+    call m::test_variant$Data$V3
+    st_loc l2
+    branch l5
+
+// Function definition at index 4
+#[persistent] public fun test_v2_mut_borrow_2()
+    local l0: m::Data2
+    local l1: &mut m::Data2
+    local l2: &m::Data2
+    local l3: &mut u64
+    local l4: &m::Data2
+    local l5: &u64
+    ld_u64 43
+    ld_u64 44
+    call m::pack$Data2$V2
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    st_loc l1
+    copy_loc l1
+    freeze_ref
+    call m::test_variant$Data2$V2
+    br_true l0
+    // @10
+    copy_loc l1
+    freeze_ref
+    st_loc l2
+    copy_loc l2
+    call m::test_variant$Data2$V1
+    // @15
+    br_true l1
+    move_loc l2
+    pop
+    move_loc l1
+    pop
+    // @20
+    ld_u64 14566554180833181697
+    abort
+l1: move_loc l2
+    pop
+    move_loc l1
+    // @25
+    call m::borrow_mut$Data2$0$0
+    st_loc l3
+l6: ld_u64 45
+    move_loc l3
+    write_ref
+    // @30
+    borrow_loc l0
+    st_loc l4
+    copy_loc l4
+    call m::test_variant$Data2$V2
+    br_true l2
+    // @35
+    copy_loc l4
+    call m::test_variant$Data2$V1
+    br_true l3
+    move_loc l4
+    pop
+    // @40
+    ld_u64 14566554180833181697
+    abort
+l3: move_loc l4
+    call m::borrow$Data2$0$0
+    st_loc l5
+    // @45
+l5: move_loc l5
+    read_ref
+    ld_u64 45
+    eq
+    br_false l4
+    // @50
+    ret
+l4: ld_u64 1
+    abort
+l2: move_loc l4
+    call m::borrow$Data2$1$1
+    // @55
+    st_loc l5
+    branch l5
+l0: move_loc l1
+    call m::borrow_mut$Data2$1$1
+    st_loc l3
+    // @60
+    branch l6
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_enum_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_enum_api.exp
@@ -1,0 +1,527 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x66::fv_enum_basic
+enum Action has drop
+  Noop
+  Call
+    _0: |u64|u64 has drop
+
+enum FunVec<T0> has drop
+  V1
+    v1: vector<|&mut T0|T0 has copy + drop + store>
+  V2
+    v0: u64
+    v1: vector<|&mut T0|T0 has copy + drop + store>
+
+enum Mapper<T0, T1> has drop
+  Id
+    _0: |T0|T1 has copy + drop + store
+  Twice
+    _0: Version<T0, T1>
+
+enum Version<T0, T1> has copy + drop + store
+  V1
+    v1: |T0|T1 has copy + drop + store
+
+// Function definition at index 0
+public fun test_variant$Action$Noop(l0: &Action): bool
+    local l1: &Action
+    move_loc l0
+    test_variant Action, Noop
+    ret
+
+// Function definition at index 1
+public fun test_variant$Action$Call(l0: &Action): bool
+    local l1: &Action
+    move_loc l0
+    test_variant Action, Call
+    ret
+
+// Function definition at index 2
+public fun pack$Action$Noop(): Action
+    pack_variant Action, Noop
+    ret
+
+// Function definition at index 3
+public fun pack$Action$Call(l0: |u64|u64 has drop): Action
+    local l1: |u64|u64 has drop
+    move_loc l0
+    pack_variant Action, Call
+    ret
+
+// Function definition at index 4
+public fun unpack$Action$Noop(l0: Action)
+    local l1: Action
+    move_loc l0
+    unpack_variant Action, Noop
+    ret
+
+// Function definition at index 5
+public fun unpack$Action$Call(l0: Action): |u64|u64 has drop
+    local l1: Action
+    move_loc l0
+    unpack_variant Action, Call
+    ret
+
+// Function definition at index 6
+public fun borrow$Action$0$0(l0: &Action): &|u64|u64 has drop
+    local l1: &Action
+    move_loc l0
+    borrow_variant_field Action, Call::_0
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$Action$0$0(l0: &mut Action): &mut |u64|u64 has drop
+    local l1: &mut Action
+    move_loc l0
+    mut_borrow_variant_field Action, Call::_0
+    ret
+
+// Function definition at index 8
+public fun test_variant$FunVec$V1<T0>(l0: &FunVec<T0>): bool
+    local l1: &FunVec<T0>
+    move_loc l0
+    test_variant FunVec<T0>, V1
+    ret
+
+// Function definition at index 9
+public fun test_variant$FunVec$V2<T0>(l0: &FunVec<T0>): bool
+    local l1: &FunVec<T0>
+    move_loc l0
+    test_variant FunVec<T0>, V2
+    ret
+
+// Function definition at index 10
+public fun pack$FunVec$V1<T0>(l0: vector<|&mut T0|T0 has copy + drop + store>): FunVec<T0>
+    local l1: vector<|&mut T0|T0 has copy + drop + store>
+    move_loc l0
+    pack_variant FunVec<T0>, V1
+    ret
+
+// Function definition at index 11
+public fun pack$FunVec$V2<T0>(l0: u64, l1: vector<|&mut T0|T0 has copy + drop + store>): FunVec<T0>
+    local l2: u64
+    local l3: vector<|&mut T0|T0 has copy + drop + store>
+    move_loc l0
+    move_loc l1
+    pack_variant FunVec<T0>, V2
+    ret
+
+// Function definition at index 12
+public fun unpack$FunVec$V1<T0>(l0: FunVec<T0>): vector<|&mut T0|T0 has copy + drop + store>
+    local l1: FunVec<T0>
+    move_loc l0
+    unpack_variant FunVec<T0>, V1
+    ret
+
+// Function definition at index 13
+public fun unpack$FunVec$V2<T0>(l0: FunVec<T0>): (u64, vector<|&mut T0|T0 has copy + drop + store>)
+    local l1: FunVec<T0>
+    move_loc l0
+    unpack_variant FunVec<T0>, V2
+    ret
+
+// Function definition at index 14
+public fun borrow$FunVec$0$1<T0>(l0: &FunVec<T0>): &u64
+    local l1: &FunVec<T0>
+    move_loc l0
+    borrow_variant_field FunVec<T0>, V2::v0
+    ret
+
+// Function definition at index 15
+public fun borrow$FunVec$0$0<T0>(l0: &FunVec<T0>): &vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &FunVec<T0>
+    move_loc l0
+    borrow_variant_field FunVec<T0>, V1::v1
+    ret
+
+// Function definition at index 16
+public fun borrow$FunVec$1$2<T0>(l0: &FunVec<T0>): &vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &FunVec<T0>
+    move_loc l0
+    borrow_variant_field FunVec<T0>, V2::v1
+    ret
+
+// Function definition at index 17
+public fun borrow_mut$FunVec$0$1<T0>(l0: &mut FunVec<T0>): &mut u64
+    local l1: &mut FunVec<T0>
+    move_loc l0
+    mut_borrow_variant_field FunVec<T0>, V2::v0
+    ret
+
+// Function definition at index 18
+public fun borrow_mut$FunVec$0$0<T0>(l0: &mut FunVec<T0>): &mut vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &mut FunVec<T0>
+    move_loc l0
+    mut_borrow_variant_field FunVec<T0>, V1::v1
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$FunVec$1$2<T0>(l0: &mut FunVec<T0>): &mut vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &mut FunVec<T0>
+    move_loc l0
+    mut_borrow_variant_field FunVec<T0>, V2::v1
+    ret
+
+// Function definition at index 20
+public fun test_variant$Mapper$Id<T0, T1>(l0: &Mapper<T0, T1>): bool
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    test_variant Mapper<T0, T1>, Id
+    ret
+
+// Function definition at index 21
+public fun test_variant$Mapper$Twice<T0, T1>(l0: &Mapper<T0, T1>): bool
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    test_variant Mapper<T0, T1>, Twice
+    ret
+
+// Function definition at index 22
+public fun pack$Mapper$Id<T0, T1>(l0: |T0|T1 has copy + drop + store): Mapper<T0, T1>
+    local l1: |T0|T1 has copy + drop + store
+    move_loc l0
+    pack_variant Mapper<T0, T1>, Id
+    ret
+
+// Function definition at index 23
+public fun pack$Mapper$Twice<T0, T1>(l0: Version<T0, T1>): Mapper<T0, T1>
+    local l1: Version<T0, T1>
+    move_loc l0
+    pack_variant Mapper<T0, T1>, Twice
+    ret
+
+// Function definition at index 24
+public fun unpack$Mapper$Id<T0, T1>(l0: Mapper<T0, T1>): |T0|T1 has copy + drop + store
+    local l1: Mapper<T0, T1>
+    move_loc l0
+    unpack_variant Mapper<T0, T1>, Id
+    ret
+
+// Function definition at index 25
+public fun unpack$Mapper$Twice<T0, T1>(l0: Mapper<T0, T1>): Version<T0, T1>
+    local l1: Mapper<T0, T1>
+    move_loc l0
+    unpack_variant Mapper<T0, T1>, Twice
+    ret
+
+// Function definition at index 26
+public fun borrow$Mapper$0$1<T0, T1>(l0: &Mapper<T0, T1>): &Version<T0, T1>
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    borrow_variant_field Mapper<T0, T1>, Twice::_0
+    ret
+
+// Function definition at index 27
+public fun borrow$Mapper$0$0<T0, T1>(l0: &Mapper<T0, T1>): &|T0|T1 has copy + drop + store
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    borrow_variant_field Mapper<T0, T1>, Id::_0
+    ret
+
+// Function definition at index 28
+public fun borrow_mut$Mapper$0$1<T0, T1>(l0: &mut Mapper<T0, T1>): &mut Version<T0, T1>
+    local l1: &mut Mapper<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Mapper<T0, T1>, Twice::_0
+    ret
+
+// Function definition at index 29
+public fun borrow_mut$Mapper$0$0<T0, T1>(l0: &mut Mapper<T0, T1>): &mut |T0|T1 has copy + drop + store
+    local l1: &mut Mapper<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Mapper<T0, T1>, Id::_0
+    ret
+
+// Function definition at index 30
+public fun test_variant$Version$V1<T0, T1>(l0: &Version<T0, T1>): bool
+    local l1: &Version<T0, T1>
+    move_loc l0
+    test_variant Version<T0, T1>, V1
+    ret
+
+// Function definition at index 31
+public fun pack$Version$V1<T0, T1>(l0: |T0|T1 has copy + drop + store): Version<T0, T1>
+    local l1: |T0|T1 has copy + drop + store
+    move_loc l0
+    pack_variant Version<T0, T1>, V1
+    ret
+
+// Function definition at index 32
+public fun unpack$Version$V1<T0, T1>(l0: Version<T0, T1>): |T0|T1 has copy + drop + store
+    local l1: Version<T0, T1>
+    move_loc l0
+    unpack_variant Version<T0, T1>, V1
+    ret
+
+// Function definition at index 33
+public fun borrow$Version$0$0<T0, T1>(l0: &Version<T0, T1>): &|T0|T1 has copy + drop + store
+    local l1: &Version<T0, T1>
+    move_loc l0
+    borrow_variant_field Version<T0, T1>, V1::v1
+    ret
+
+// Function definition at index 34
+public fun borrow_mut$Version$0$0<T0, T1>(l0: &mut Version<T0, T1>): &mut |T0|T1 has copy + drop + store
+    local l1: &mut Version<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Version<T0, T1>, V1::v1
+    ret
+
+// Bytecode version v9
+module 0x66::fv_enum_basic_public
+use 0x66::fv_enum_basic
+// Function definition at index 0
+#[persistent] fun add_k_persistent(l0: u64, l1: u64): u64
+    move_loc l0
+    move_loc l1
+    add
+    ret
+
+// Function definition at index 1
+#[persistent] fun add_k_persistent_ref(l0: &mut u64, l1: u64): u64
+    copy_loc l0
+    read_ref
+    ld_u64 1
+    add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    read_ref
+    move_loc l1
+    add
+    // @10
+    ret
+
+// Function definition at index 2
+fun call_square(l0: u64)
+    local l1: fv_enum_basic::Action
+    local l2: |u64|u64 has drop
+    local l3: u64
+    pack_closure square, 0
+    call fv_enum_basic::pack$Action$Call
+    st_loc l1
+    borrow_loc l1
+    call fv_enum_basic::test_variant$Action$Call
+    // @5
+    br_false l0
+    move_loc l1
+    call fv_enum_basic::unpack$Action$Call
+    st_loc l2
+    move_loc l0
+    // @10
+    move_loc l2
+    call_closure <|u64|u64 has drop>
+    st_loc l3
+    branch l1
+l0: move_loc l1
+    // @15
+    ld_u64 0
+    st_loc l3
+    pop
+    branch l1
+    ld_u64 14566554180833181697
+    // @20
+    abort
+l1: move_loc l3
+    ld_u64 49
+    eq
+    br_false l2
+    // @25
+    branch l3
+l2: ld_u64 14566554180833181696
+    abort
+l3: ret
+
+// Function definition at index 3
+fun square(l0: u64): u64
+    copy_loc l0
+    move_loc l0
+    mul
+    ret
+
+// Function definition at index 4
+fun test_enum_in_another_enum()
+    local l0: fv_enum_basic::Mapper<u64, u64>
+    local l1: &mut fv_enum_basic::Mapper<u64, u64>
+    local l2: u64
+    local l3: &mut fv_enum_basic::Version<u64, u64>
+    local l4: |u64|u64 has copy + drop + store
+    local l5: u64
+    local l6: u64
+    local l7: &mut |u64|u64 has copy + drop + store
+    local l8: |u64|u64 has copy + drop + store
+    ld_u64 3
+    pack_closure add_k_persistent, 10
+    call fv_enum_basic::pack$Version$V1<u64, u64>
+    call fv_enum_basic::pack$Mapper$Twice<u64, u64>
+    st_loc l0
+    // @5
+    mut_borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    freeze_ref
+    call fv_enum_basic::test_variant$Mapper$Twice<u64, u64>
+    // @10
+    br_false l0
+    move_loc l1
+    call fv_enum_basic::borrow_mut$Mapper$0$1<u64, u64>
+    ld_u64 10
+    st_loc l2
+    // @15
+    st_loc l3
+    copy_loc l3
+    freeze_ref
+    call fv_enum_basic::borrow$Version$0$0<u64, u64>
+    read_ref
+    // @20
+    st_loc l4
+    move_loc l2
+    move_loc l4
+    call_closure <|u64|u64 has copy + drop + store>
+    move_loc l3
+    // @25
+    freeze_ref
+    call fv_enum_basic::borrow$Version$0$0<u64, u64>
+    read_ref
+    call_closure <|u64|u64 has copy + drop + store>
+    st_loc l5
+    // @30
+    branch l1
+l0: copy_loc l1
+    freeze_ref
+    call fv_enum_basic::test_variant$Mapper$Id<u64, u64>
+    br_false l2
+    // @35
+    move_loc l1
+    call fv_enum_basic::borrow_mut$Mapper$0$0<u64, u64>
+    ld_u64 10
+    st_loc l6
+    st_loc l7
+    // @40
+    move_loc l7
+    read_ref
+    st_loc l8
+    move_loc l6
+    move_loc l8
+    // @45
+    call_closure <|u64|u64 has copy + drop + store>
+    st_loc l5
+    branch l1
+l2: move_loc l1
+    pop
+    // @50
+    ld_u64 14566554180833181697
+    abort
+l1: move_loc l5
+    ld_u64 16
+    eq
+    // @55
+    br_false l3
+    branch l4
+l3: ld_u64 99
+    abort
+l4: ret
+
+// Function definition at index 5
+fun test_fun_vec()
+    local l0: |&mut u64|u64 has copy + drop + store
+    local l1: fv_enum_basic::FunVec<u64>
+    local l2: &fv_enum_basic::FunVec<u64>
+    local l3: vector<|&mut u64|u64 has copy + drop + store>
+    local l4: u64
+    local l5: &mut u64
+    local l6: |&mut u64|u64 has copy + drop + store
+    local l7: bool
+    local l8: u64
+    local l9: bool
+    ld_u64 3
+    pack_closure add_k_persistent_ref, 10
+    st_loc l0
+    copy_loc l0
+    move_loc l0
+    // @5
+    vec_pack <|&mut u64|u64 has copy + drop + store>, 2
+    call fv_enum_basic::pack$FunVec$V1<u64>
+    st_loc l1
+    borrow_loc l1
+    st_loc l2
+    // @10
+    copy_loc l2
+    call fv_enum_basic::test_variant$FunVec$V1<u64>
+    br_false l0
+    move_loc l2
+    pop
+    // @15
+    move_loc l1
+    call fv_enum_basic::unpack$FunVec$V1<u64>
+    st_loc l3
+    mut_borrow_loc l3
+    vec_pop_back <|&mut u64|u64 has copy + drop + store>
+    // @20
+    ld_u64 3
+    st_loc l4
+    mut_borrow_loc l4
+    st_loc l5
+    st_loc l6
+    // @25
+    move_loc l5
+    copy_loc l6
+    call_closure <|&mut u64|u64 has copy + drop + store>
+    move_loc l4
+    ld_u64 4
+    // @30
+    eq
+    st_loc l7
+    st_loc l8
+    move_loc l7
+    br_false l1
+    // @35
+    branch l2
+l1: ld_u64 0
+    abort
+l2: move_loc l8
+    ld_u64 7
+    // @40
+    eq
+    br_false l3
+    branch l4
+l3: ld_u64 1
+    abort
+    // @45
+l4: mut_borrow_loc l3
+    move_loc l6
+    vec_push_back <|&mut u64|u64 has copy + drop + store>
+    ld_u64 10
+    move_loc l3
+    // @50
+    call fv_enum_basic::pack$FunVec$V2<u64>
+    pop
+    branch l5
+l0: move_loc l2
+    call fv_enum_basic::test_variant$FunVec$V2<u64>
+    // @55
+    br_false l6
+    move_loc l1
+    call fv_enum_basic::unpack$FunVec$V2<u64>
+    vec_unpack <|&mut u64|u64 has copy + drop + store>, 0
+    ld_false
+    // @60
+    st_loc l9
+    pop
+    move_loc l9
+    br_false l7
+    branch l8
+    // @65
+l7: ld_u64 2
+    abort
+l8: branch l5
+l6: ld_u64 14566554180833181697
+    abort
+    // @70
+l5: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_enum_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_enum_api.move
@@ -1,0 +1,80 @@
+module 0x66::fv_enum_basic {
+    public enum Action has drop {
+        Noop,
+        Call(|u64|u64),
+    }
+
+    public enum Mapper<T, R> has drop {
+        Id(|T|R has copy + drop + store),
+        Twice(Version<T, R>),
+    }
+
+    public enum Version<T, R> has copy,store, drop {
+        V1 { v1: |T|R has copy + drop + store },
+    }
+
+    public enum FunVec<T> has drop {
+        V1 { v1: vector<|&mut T|T has copy + drop + store> },
+        V2 { v0: u64, v1: vector<|&mut T|T has copy + drop + store> },
+    }
+
+}
+
+module 0x66::fv_enum_basic_public {
+    use 0x66::fv_enum_basic::Action;
+    use 0x66::fv_enum_basic::Mapper;
+    use 0x66::fv_enum_basic::Version;
+    use 0x66::fv_enum_basic::FunVec;
+
+    fun square(x: u64): u64 { x * x }
+
+    fun call_square(x: u64) {
+        let act = Action::Call(square);
+        let v = match (act) {
+            Action::Call(f) => f(x),
+            _ => 0
+        };
+        assert!(v == 49);
+    }
+
+    #[persistent]
+    fun add_k_persistent(x: u64, k: u64): u64 { x + k }
+
+    fun test_enum_in_another_enum() {
+        let k = 3;
+        let add_k: |u64|u64 has copy + drop + store = |x: u64| add_k_persistent(x, k);
+        let v1 = Version::V1 { v1: add_k };
+        let v2 = Mapper::Twice(v1);
+        let v = match (&mut v2) {
+            Mapper::Twice(v1) => (v1.v1)((v1.v1)(10)),
+            Mapper::Id(f)    => (*f)(10),
+        };
+        assert!(v == 16, 99);
+    }
+
+    #[persistent]
+    fun add_k_persistent_ref(x: &mut u64, k: u64): u64 { *x = *x + 1; *x + k }
+
+    fun test_fun_vec() {
+        use std::vector;
+        let k = 3;
+        let add_k: |&mut u64|u64 has copy + store + drop = |x: &mut u64| add_k_persistent_ref(x, k);
+        let v1 = FunVec::V1 { v1: vector[add_k, add_k] };
+        match (v1) {
+            FunVec::V1 { v1 } => {
+                let add = vector::pop_back(&mut v1);
+                let v = 3;
+                let x = add(&mut v);
+                assert!(v == 4, 0);
+                assert!(x == 7, 1);
+                vector::push_back(&mut v1, add);
+                let _m = FunVec::V2 { v0: 10, v1 };
+            }
+            FunVec::V2 { v0: _, v1 } => {
+                vector::destroy_empty(v1);
+                assert!(false, 2);
+            }
+        };
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_enum_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_enum_api.opt.exp
@@ -1,0 +1,489 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x66::fv_enum_basic
+enum Action has drop
+  Noop
+  Call
+    _0: |u64|u64 has drop
+
+enum FunVec<T0> has drop
+  V1
+    v1: vector<|&mut T0|T0 has copy + drop + store>
+  V2
+    v0: u64
+    v1: vector<|&mut T0|T0 has copy + drop + store>
+
+enum Mapper<T0, T1> has drop
+  Id
+    _0: |T0|T1 has copy + drop + store
+  Twice
+    _0: Version<T0, T1>
+
+enum Version<T0, T1> has copy + drop + store
+  V1
+    v1: |T0|T1 has copy + drop + store
+
+// Function definition at index 0
+public fun test_variant$Action$Noop(l0: &Action): bool
+    local l1: &Action
+    move_loc l0
+    test_variant Action, Noop
+    ret
+
+// Function definition at index 1
+public fun test_variant$Action$Call(l0: &Action): bool
+    local l1: &Action
+    move_loc l0
+    test_variant Action, Call
+    ret
+
+// Function definition at index 2
+public fun pack$Action$Noop(): Action
+    pack_variant Action, Noop
+    ret
+
+// Function definition at index 3
+public fun pack$Action$Call(l0: |u64|u64 has drop): Action
+    local l1: |u64|u64 has drop
+    move_loc l0
+    pack_variant Action, Call
+    ret
+
+// Function definition at index 4
+public fun unpack$Action$Noop(l0: Action)
+    local l1: Action
+    move_loc l0
+    unpack_variant Action, Noop
+    ret
+
+// Function definition at index 5
+public fun unpack$Action$Call(l0: Action): |u64|u64 has drop
+    local l1: Action
+    move_loc l0
+    unpack_variant Action, Call
+    ret
+
+// Function definition at index 6
+public fun borrow$Action$0$0(l0: &Action): &|u64|u64 has drop
+    local l1: &Action
+    move_loc l0
+    borrow_variant_field Action, Call::_0
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$Action$0$0(l0: &mut Action): &mut |u64|u64 has drop
+    local l1: &mut Action
+    move_loc l0
+    mut_borrow_variant_field Action, Call::_0
+    ret
+
+// Function definition at index 8
+public fun test_variant$FunVec$V1<T0>(l0: &FunVec<T0>): bool
+    local l1: &FunVec<T0>
+    move_loc l0
+    test_variant FunVec<T0>, V1
+    ret
+
+// Function definition at index 9
+public fun test_variant$FunVec$V2<T0>(l0: &FunVec<T0>): bool
+    local l1: &FunVec<T0>
+    move_loc l0
+    test_variant FunVec<T0>, V2
+    ret
+
+// Function definition at index 10
+public fun pack$FunVec$V1<T0>(l0: vector<|&mut T0|T0 has copy + drop + store>): FunVec<T0>
+    local l1: vector<|&mut T0|T0 has copy + drop + store>
+    move_loc l0
+    pack_variant FunVec<T0>, V1
+    ret
+
+// Function definition at index 11
+public fun pack$FunVec$V2<T0>(l0: u64, l1: vector<|&mut T0|T0 has copy + drop + store>): FunVec<T0>
+    local l2: u64
+    local l3: vector<|&mut T0|T0 has copy + drop + store>
+    move_loc l0
+    move_loc l1
+    pack_variant FunVec<T0>, V2
+    ret
+
+// Function definition at index 12
+public fun unpack$FunVec$V1<T0>(l0: FunVec<T0>): vector<|&mut T0|T0 has copy + drop + store>
+    local l1: FunVec<T0>
+    move_loc l0
+    unpack_variant FunVec<T0>, V1
+    ret
+
+// Function definition at index 13
+public fun unpack$FunVec$V2<T0>(l0: FunVec<T0>): (u64, vector<|&mut T0|T0 has copy + drop + store>)
+    local l1: FunVec<T0>
+    move_loc l0
+    unpack_variant FunVec<T0>, V2
+    ret
+
+// Function definition at index 14
+public fun borrow$FunVec$0$1<T0>(l0: &FunVec<T0>): &u64
+    local l1: &FunVec<T0>
+    move_loc l0
+    borrow_variant_field FunVec<T0>, V2::v0
+    ret
+
+// Function definition at index 15
+public fun borrow$FunVec$0$0<T0>(l0: &FunVec<T0>): &vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &FunVec<T0>
+    move_loc l0
+    borrow_variant_field FunVec<T0>, V1::v1
+    ret
+
+// Function definition at index 16
+public fun borrow$FunVec$1$2<T0>(l0: &FunVec<T0>): &vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &FunVec<T0>
+    move_loc l0
+    borrow_variant_field FunVec<T0>, V2::v1
+    ret
+
+// Function definition at index 17
+public fun borrow_mut$FunVec$0$1<T0>(l0: &mut FunVec<T0>): &mut u64
+    local l1: &mut FunVec<T0>
+    move_loc l0
+    mut_borrow_variant_field FunVec<T0>, V2::v0
+    ret
+
+// Function definition at index 18
+public fun borrow_mut$FunVec$0$0<T0>(l0: &mut FunVec<T0>): &mut vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &mut FunVec<T0>
+    move_loc l0
+    mut_borrow_variant_field FunVec<T0>, V1::v1
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$FunVec$1$2<T0>(l0: &mut FunVec<T0>): &mut vector<|&mut T0|T0 has copy + drop + store>
+    local l1: &mut FunVec<T0>
+    move_loc l0
+    mut_borrow_variant_field FunVec<T0>, V2::v1
+    ret
+
+// Function definition at index 20
+public fun test_variant$Mapper$Id<T0, T1>(l0: &Mapper<T0, T1>): bool
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    test_variant Mapper<T0, T1>, Id
+    ret
+
+// Function definition at index 21
+public fun test_variant$Mapper$Twice<T0, T1>(l0: &Mapper<T0, T1>): bool
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    test_variant Mapper<T0, T1>, Twice
+    ret
+
+// Function definition at index 22
+public fun pack$Mapper$Id<T0, T1>(l0: |T0|T1 has copy + drop + store): Mapper<T0, T1>
+    local l1: |T0|T1 has copy + drop + store
+    move_loc l0
+    pack_variant Mapper<T0, T1>, Id
+    ret
+
+// Function definition at index 23
+public fun pack$Mapper$Twice<T0, T1>(l0: Version<T0, T1>): Mapper<T0, T1>
+    local l1: Version<T0, T1>
+    move_loc l0
+    pack_variant Mapper<T0, T1>, Twice
+    ret
+
+// Function definition at index 24
+public fun unpack$Mapper$Id<T0, T1>(l0: Mapper<T0, T1>): |T0|T1 has copy + drop + store
+    local l1: Mapper<T0, T1>
+    move_loc l0
+    unpack_variant Mapper<T0, T1>, Id
+    ret
+
+// Function definition at index 25
+public fun unpack$Mapper$Twice<T0, T1>(l0: Mapper<T0, T1>): Version<T0, T1>
+    local l1: Mapper<T0, T1>
+    move_loc l0
+    unpack_variant Mapper<T0, T1>, Twice
+    ret
+
+// Function definition at index 26
+public fun borrow$Mapper$0$1<T0, T1>(l0: &Mapper<T0, T1>): &Version<T0, T1>
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    borrow_variant_field Mapper<T0, T1>, Twice::_0
+    ret
+
+// Function definition at index 27
+public fun borrow$Mapper$0$0<T0, T1>(l0: &Mapper<T0, T1>): &|T0|T1 has copy + drop + store
+    local l1: &Mapper<T0, T1>
+    move_loc l0
+    borrow_variant_field Mapper<T0, T1>, Id::_0
+    ret
+
+// Function definition at index 28
+public fun borrow_mut$Mapper$0$1<T0, T1>(l0: &mut Mapper<T0, T1>): &mut Version<T0, T1>
+    local l1: &mut Mapper<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Mapper<T0, T1>, Twice::_0
+    ret
+
+// Function definition at index 29
+public fun borrow_mut$Mapper$0$0<T0, T1>(l0: &mut Mapper<T0, T1>): &mut |T0|T1 has copy + drop + store
+    local l1: &mut Mapper<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Mapper<T0, T1>, Id::_0
+    ret
+
+// Function definition at index 30
+public fun test_variant$Version$V1<T0, T1>(l0: &Version<T0, T1>): bool
+    local l1: &Version<T0, T1>
+    move_loc l0
+    test_variant Version<T0, T1>, V1
+    ret
+
+// Function definition at index 31
+public fun pack$Version$V1<T0, T1>(l0: |T0|T1 has copy + drop + store): Version<T0, T1>
+    local l1: |T0|T1 has copy + drop + store
+    move_loc l0
+    pack_variant Version<T0, T1>, V1
+    ret
+
+// Function definition at index 32
+public fun unpack$Version$V1<T0, T1>(l0: Version<T0, T1>): |T0|T1 has copy + drop + store
+    local l1: Version<T0, T1>
+    move_loc l0
+    unpack_variant Version<T0, T1>, V1
+    ret
+
+// Function definition at index 33
+public fun borrow$Version$0$0<T0, T1>(l0: &Version<T0, T1>): &|T0|T1 has copy + drop + store
+    local l1: &Version<T0, T1>
+    move_loc l0
+    borrow_variant_field Version<T0, T1>, V1::v1
+    ret
+
+// Function definition at index 34
+public fun borrow_mut$Version$0$0<T0, T1>(l0: &mut Version<T0, T1>): &mut |T0|T1 has copy + drop + store
+    local l1: &mut Version<T0, T1>
+    move_loc l0
+    mut_borrow_variant_field Version<T0, T1>, V1::v1
+    ret
+
+// Bytecode version v9
+module 0x66::fv_enum_basic_public
+use 0x66::fv_enum_basic
+// Function definition at index 0
+#[persistent] fun add_k_persistent(l0: u64, l1: u64): u64
+    move_loc l0
+    move_loc l1
+    add
+    ret
+
+// Function definition at index 1
+#[persistent] fun add_k_persistent_ref(l0: &mut u64, l1: u64): u64
+    copy_loc l0
+    read_ref
+    ld_u64 1
+    add
+    copy_loc l0
+    // @5
+    write_ref
+    move_loc l0
+    read_ref
+    move_loc l1
+    add
+    // @10
+    ret
+
+// Function definition at index 2
+fun call_square(l0: u64)
+    local l1: fv_enum_basic::Action
+    local l2: |u64|u64 has drop
+    local l3: u64
+    pack_closure square, 0
+    call fv_enum_basic::pack$Action$Call
+    st_loc l1
+    borrow_loc l1
+    call fv_enum_basic::test_variant$Action$Call
+    // @5
+    br_false l0
+    move_loc l1
+    call fv_enum_basic::unpack$Action$Call
+    st_loc l2
+    move_loc l0
+    // @10
+    move_loc l2
+    call_closure <|u64|u64 has drop>
+    st_loc l3
+l2: move_loc l3
+    ld_u64 49
+    // @15
+    eq
+    br_false l1
+    ret
+l1: ld_u64 14566554180833181696
+    abort
+    // @20
+l0: ld_u64 0
+    st_loc l3
+    branch l2
+
+// Function definition at index 3
+fun square(l0: u64): u64
+    copy_loc l0
+    move_loc l0
+    mul
+    ret
+
+// Function definition at index 4
+fun test_enum_in_another_enum()
+    local l0: fv_enum_basic::Mapper<u64, u64>
+    local l1: &mut fv_enum_basic::Mapper<u64, u64>
+    local l2: &mut fv_enum_basic::Version<u64, u64>
+    local l3: u64
+    local l4: &mut |u64|u64 has copy + drop + store
+    ld_u64 3
+    pack_closure add_k_persistent, 10
+    call fv_enum_basic::pack$Version$V1<u64, u64>
+    call fv_enum_basic::pack$Mapper$Twice<u64, u64>
+    st_loc l0
+    // @5
+    mut_borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    freeze_ref
+    call fv_enum_basic::test_variant$Mapper$Twice<u64, u64>
+    // @10
+    br_false l0
+    move_loc l1
+    call fv_enum_basic::borrow_mut$Mapper$0$1<u64, u64>
+    st_loc l2
+    ld_u64 10
+    // @15
+    copy_loc l2
+    freeze_ref
+    call fv_enum_basic::borrow$Version$0$0<u64, u64>
+    read_ref
+    call_closure <|u64|u64 has copy + drop + store>
+    // @20
+    move_loc l2
+    freeze_ref
+    call fv_enum_basic::borrow$Version$0$0<u64, u64>
+    read_ref
+    call_closure <|u64|u64 has copy + drop + store>
+    // @25
+    st_loc l3
+l3: move_loc l3
+    ld_u64 16
+    eq
+    br_false l1
+    // @30
+    ret
+l1: ld_u64 99
+    abort
+l0: copy_loc l1
+    freeze_ref
+    // @35
+    call fv_enum_basic::test_variant$Mapper$Id<u64, u64>
+    br_false l2
+    move_loc l1
+    call fv_enum_basic::borrow_mut$Mapper$0$0<u64, u64>
+    st_loc l4
+    // @40
+    ld_u64 10
+    move_loc l4
+    read_ref
+    call_closure <|u64|u64 has copy + drop + store>
+    st_loc l3
+    // @45
+    branch l3
+l2: move_loc l1
+    pop
+    ld_u64 14566554180833181697
+    abort
+
+// Function definition at index 5
+fun test_fun_vec()
+    local l0: |&mut u64|u64 has copy + drop + store
+    local l1: fv_enum_basic::FunVec<u64>
+    local l2: &fv_enum_basic::FunVec<u64>
+    local l3: vector<|&mut u64|u64 has copy + drop + store>
+    local l4: u64
+    local l5: u64
+    local l6: bool
+    ld_u64 3
+    pack_closure add_k_persistent_ref, 10
+    st_loc l0
+    copy_loc l0
+    move_loc l0
+    // @5
+    vec_pack <|&mut u64|u64 has copy + drop + store>, 2
+    call fv_enum_basic::pack$FunVec$V1<u64>
+    st_loc l1
+    borrow_loc l1
+    st_loc l2
+    // @10
+    copy_loc l2
+    call fv_enum_basic::test_variant$FunVec$V1<u64>
+    br_false l0
+    move_loc l2
+    pop
+    // @15
+    move_loc l1
+    call fv_enum_basic::unpack$FunVec$V1<u64>
+    st_loc l3
+    mut_borrow_loc l3
+    vec_pop_back <|&mut u64|u64 has copy + drop + store>
+    // @20
+    st_loc l0
+    ld_u64 3
+    st_loc l4
+    mut_borrow_loc l4
+    copy_loc l0
+    // @25
+    call_closure <|&mut u64|u64 has copy + drop + store>
+    st_loc l5
+    move_loc l4
+    ld_u64 4
+    eq
+    // @30
+    br_false l1
+    move_loc l5
+    ld_u64 7
+    eq
+    br_false l2
+    // @35
+    mut_borrow_loc l3
+    move_loc l0
+    vec_push_back <|&mut u64|u64 has copy + drop + store>
+    ld_u64 10
+    move_loc l3
+    // @40
+    call fv_enum_basic::pack$FunVec$V2<u64>
+    pop
+    ret
+l2: ld_u64 1
+    abort
+    // @45
+l1: ld_u64 0
+    abort
+l0: move_loc l2
+    call fv_enum_basic::test_variant$FunVec$V2<u64>
+    br_false l3
+    // @50
+    move_loc l1
+    call fv_enum_basic::unpack$FunVec$V2<u64>
+    vec_unpack <|&mut u64|u64 has copy + drop + store>, 0
+    pop
+    ld_false
+    // @55
+    br_false l4
+    ret
+l4: ld_u64 2
+    abort
+l3: ld_u64 14566554180833181697
+    // @60
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_struct_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_struct_api.exp
@@ -1,0 +1,267 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct Holder<T0> has copy + drop
+  _0: Predicate<T0>
+
+struct Predicate<T0> has copy + drop
+  _0: |&T0|bool has copy + drop
+
+// Function definition at index 0
+public fun pack$Holder<T0>(l0: Predicate<T0>): Holder<T0>
+    local l1: Predicate<T0>
+    move_loc l0
+    pack Holder<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$Holder<T0>(l0: Holder<T0>): Predicate<T0>
+    local l1: Holder<T0>
+    move_loc l0
+    unpack Holder<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$Holder$0<T0>(l0: &Holder<T0>): &Predicate<T0>
+    local l1: &Holder<T0>
+    move_loc l0
+    borrow_field Holder<T0>, _0
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$Holder$0<T0>(l0: &mut Holder<T0>): &mut Predicate<T0>
+    local l1: &mut Holder<T0>
+    move_loc l0
+    mut_borrow_field Holder<T0>, _0
+    ret
+
+// Function definition at index 4
+public fun pack$Predicate<T0>(l0: |&T0|bool has copy + drop): Predicate<T0>
+    local l1: |&T0|bool has copy + drop
+    move_loc l0
+    pack Predicate<T0>
+    ret
+
+// Function definition at index 5
+public fun unpack$Predicate<T0>(l0: Predicate<T0>): |&T0|bool has copy + drop
+    local l1: Predicate<T0>
+    move_loc l0
+    unpack Predicate<T0>
+    ret
+
+// Function definition at index 6
+public fun borrow$Predicate$0<T0>(l0: &Predicate<T0>): &|&T0|bool has copy + drop
+    local l1: &Predicate<T0>
+    move_loc l0
+    borrow_field Predicate<T0>, _0
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$Predicate$0<T0>(l0: &mut Predicate<T0>): &mut |&T0|bool has copy + drop
+    local l1: &mut Predicate<T0>
+    move_loc l0
+    mut_borrow_field Predicate<T0>, _0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+fun apply_holder(l0: m1::Holder<u64>, l1: u64): bool
+    local l2: &u64
+    local l3: m1::Predicate<u64>
+    local l4: |&u64|bool has copy + drop
+    move_loc l0
+    call m1::unpack$Holder<u64>
+    borrow_loc l1
+    st_loc l2
+    st_loc l3
+    // @5
+    move_loc l3
+    call m1::unpack$Predicate<u64>
+    st_loc l4
+    move_loc l2
+    move_loc l4
+    // @10
+    call_closure <|&u64|bool has copy + drop>
+    ret
+
+// Function definition at index 1
+fun apply_pred(l0: m1::Predicate<u64>, l1: u64): bool
+    borrow_loc l1
+    move_loc l0
+    call m1::unpack$Predicate<u64>
+    call_closure <|&u64|bool has copy + drop>
+    ret
+
+// Function definition at index 2
+fun try_direct_assignment_and_call()
+    local l0: u64
+    local l1: &u64
+    local l2: m1::Predicate<u64>
+    local l3: |&u64|bool has copy + drop
+    local l4: u64
+    pack_closure __lambda__1__try_direct_assignment_and_call, 0
+    call m1::pack$Predicate<u64>
+    ld_u64 99
+    st_loc l0
+    borrow_loc l0
+    // @5
+    st_loc l1
+    st_loc l2
+    copy_loc l2
+    call m1::unpack$Predicate<u64>
+    st_loc l3
+    // @10
+    move_loc l1
+    move_loc l3
+    call_closure <|&u64|bool has copy + drop>
+    br_false l0
+    branch l1
+    // @15
+l0: ld_u64 1
+    abort
+l1: ld_u64 101
+    st_loc l4
+    borrow_loc l4
+    // @20
+    move_loc l2
+    call m1::unpack$Predicate<u64>
+    call_closure <|&u64|bool has copy + drop>
+    not
+    br_false l2
+    // @25
+    branch l3
+l2: ld_u64 2
+    abort
+l3: ret
+
+// Function definition at index 3
+fun try_nested_wrapper()
+    local l0: m1::Holder<u64>
+    pack_closure __lambda__1__try_nested_wrapper, 0
+    call m1::pack$Predicate<u64>
+    call m1::pack$Holder<u64>
+    st_loc l0
+    copy_loc l0
+    // @5
+    ld_u64 42
+    call apply_holder
+    br_false l0
+    branch l1
+l0: ld_u64 7
+    // @10
+    abort
+l1: move_loc l0
+    ld_u64 99
+    call apply_holder
+    not
+    // @15
+    br_false l2
+    branch l3
+l2: ld_u64 8
+    abort
+l3: ret
+
+// Function definition at index 4
+fun try_pass_to_apply()
+    local l0: m1::Predicate<u64>
+    pack_closure __lambda__1__try_pass_to_apply, 0
+    call m1::pack$Predicate<u64>
+    st_loc l0
+    copy_loc l0
+    ld_u64 4
+    // @5
+    call apply_pred
+    br_false l0
+    branch l1
+l0: ld_u64 5
+    abort
+    // @10
+l1: move_loc l0
+    ld_u64 5
+    call apply_pred
+    not
+    br_false l2
+    // @15
+    branch l3
+l2: ld_u64 6
+    abort
+l3: ret
+
+// Function definition at index 5
+fun try_unpack_wrapper()
+    local l0: u64
+    local l1: &u64
+    local l2: |&u64|bool has copy + drop
+    local l3: u64
+    pack_closure __lambda__1__try_unpack_wrapper, 0
+    call m1::pack$Predicate<u64>
+    call m1::unpack$Predicate<u64>
+    ld_u64 1
+    st_loc l0
+    // @5
+    borrow_loc l0
+    st_loc l1
+    st_loc l2
+    move_loc l1
+    copy_loc l2
+    // @10
+    call_closure <|&u64|bool has copy + drop>
+    br_false l0
+    branch l1
+l0: ld_u64 9
+    abort
+    // @15
+l1: ld_u64 0
+    st_loc l3
+    borrow_loc l3
+    move_loc l2
+    call_closure <|&u64|bool has copy + drop>
+    // @20
+    not
+    br_false l2
+    branch l3
+l2: ld_u64 10
+    abort
+    // @25
+l3: ret
+
+// Function definition at index 6
+fun __lambda__1__try_direct_assignment_and_call(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 100
+    lt
+    ret
+
+// Function definition at index 7
+fun __lambda__1__try_nested_wrapper(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 42
+    eq
+    ret
+
+// Function definition at index 8
+fun __lambda__1__try_pass_to_apply(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 2
+    mod
+    ld_u64 0
+    // @5
+    eq
+    ret
+
+// Function definition at index 9
+fun __lambda__1__try_unpack_wrapper(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 0
+    neq
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_struct_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_struct_api.move
@@ -1,0 +1,45 @@
+module 0x42::m1 {
+    public struct Predicate<T>(|&T| bool) has copy, drop;
+
+    public struct Holder<T>(Predicate<T>) has copy, drop;
+
+}
+
+module 0x42::m2 {
+    use 0x42::m1::Predicate;
+    use 0x42::m1::Holder;
+
+    fun apply_pred(p: Predicate<u64>, val: u64): bool {
+        p(&val)
+    }
+
+    fun apply_holder(h: Holder<u64>, val: u64): bool {
+        let Holder(p) = h;
+        p(&val)
+    }
+
+    fun try_direct_assignment_and_call() {
+        let p: Predicate<u64> = |x| *x < 100;
+        assert!(p(&99), 1);
+        assert!(!p(&101), 2);
+    }
+
+    fun try_pass_to_apply() {
+        let p: Predicate<u64> = |x| *x % 2 == 0;
+        assert!(apply_pred(p, 4), 5);
+        assert!(!apply_pred(p, 5), 6);
+    }
+
+    fun try_nested_wrapper() {
+        let h = Holder(|x| *x == 42);
+        assert!(apply_holder(h, 42), 7);
+        assert!(!apply_holder(h, 99), 8);
+    }
+
+    fun try_unpack_wrapper() {
+        let p: Predicate<u64> = |x| *x != 0;
+        let Predicate(f) = p;
+        assert!(f(&1), 9);
+        assert!(!f(&0), 10);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_struct_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/fv_struct_api.opt.exp
@@ -1,0 +1,237 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct Holder<T0> has copy + drop
+  _0: Predicate<T0>
+
+struct Predicate<T0> has copy + drop
+  _0: |&T0|bool has copy + drop
+
+// Function definition at index 0
+public fun pack$Holder<T0>(l0: Predicate<T0>): Holder<T0>
+    local l1: Predicate<T0>
+    move_loc l0
+    pack Holder<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$Holder<T0>(l0: Holder<T0>): Predicate<T0>
+    local l1: Holder<T0>
+    move_loc l0
+    unpack Holder<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$Holder$0<T0>(l0: &Holder<T0>): &Predicate<T0>
+    local l1: &Holder<T0>
+    move_loc l0
+    borrow_field Holder<T0>, _0
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$Holder$0<T0>(l0: &mut Holder<T0>): &mut Predicate<T0>
+    local l1: &mut Holder<T0>
+    move_loc l0
+    mut_borrow_field Holder<T0>, _0
+    ret
+
+// Function definition at index 4
+public fun pack$Predicate<T0>(l0: |&T0|bool has copy + drop): Predicate<T0>
+    local l1: |&T0|bool has copy + drop
+    move_loc l0
+    pack Predicate<T0>
+    ret
+
+// Function definition at index 5
+public fun unpack$Predicate<T0>(l0: Predicate<T0>): |&T0|bool has copy + drop
+    local l1: Predicate<T0>
+    move_loc l0
+    unpack Predicate<T0>
+    ret
+
+// Function definition at index 6
+public fun borrow$Predicate$0<T0>(l0: &Predicate<T0>): &|&T0|bool has copy + drop
+    local l1: &Predicate<T0>
+    move_loc l0
+    borrow_field Predicate<T0>, _0
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$Predicate$0<T0>(l0: &mut Predicate<T0>): &mut |&T0|bool has copy + drop
+    local l1: &mut Predicate<T0>
+    move_loc l0
+    mut_borrow_field Predicate<T0>, _0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+fun apply_holder(l0: m1::Holder<u64>, l1: u64): bool
+    local l2: m1::Predicate<u64>
+    move_loc l0
+    call m1::unpack$Holder<u64>
+    st_loc l2
+    borrow_loc l1
+    move_loc l2
+    // @5
+    call m1::unpack$Predicate<u64>
+    call_closure <|&u64|bool has copy + drop>
+    ret
+
+// Function definition at index 1
+fun apply_pred(l0: m1::Predicate<u64>, l1: u64): bool
+    borrow_loc l1
+    move_loc l0
+    call m1::unpack$Predicate<u64>
+    call_closure <|&u64|bool has copy + drop>
+    ret
+
+// Function definition at index 2
+fun try_direct_assignment_and_call()
+    local l0: m1::Predicate<u64>
+    local l1: u64
+    local l2: u64
+    pack_closure __lambda__1__try_direct_assignment_and_call, 0
+    call m1::pack$Predicate<u64>
+    st_loc l0
+    ld_u64 99
+    st_loc l1
+    // @5
+    borrow_loc l1
+    copy_loc l0
+    call m1::unpack$Predicate<u64>
+    call_closure <|&u64|bool has copy + drop>
+    br_false l0
+    // @10
+    ld_u64 101
+    st_loc l2
+    borrow_loc l2
+    move_loc l0
+    call m1::unpack$Predicate<u64>
+    // @15
+    call_closure <|&u64|bool has copy + drop>
+    br_true l1
+    ret
+l1: ld_u64 2
+    abort
+    // @20
+l0: ld_u64 1
+    abort
+
+// Function definition at index 3
+fun try_nested_wrapper()
+    local l0: m1::Holder<u64>
+    pack_closure __lambda__1__try_nested_wrapper, 0
+    call m1::pack$Predicate<u64>
+    call m1::pack$Holder<u64>
+    st_loc l0
+    copy_loc l0
+    // @5
+    ld_u64 42
+    call apply_holder
+    br_false l0
+    move_loc l0
+    ld_u64 99
+    // @10
+    call apply_holder
+    br_true l1
+    ret
+l1: ld_u64 8
+    abort
+    // @15
+l0: ld_u64 7
+    abort
+
+// Function definition at index 4
+fun try_pass_to_apply()
+    local l0: m1::Predicate<u64>
+    pack_closure __lambda__1__try_pass_to_apply, 0
+    call m1::pack$Predicate<u64>
+    st_loc l0
+    copy_loc l0
+    ld_u64 4
+    // @5
+    call apply_pred
+    br_false l0
+    move_loc l0
+    ld_u64 5
+    call apply_pred
+    // @10
+    br_true l1
+    ret
+l1: ld_u64 6
+    abort
+l0: ld_u64 5
+    // @15
+    abort
+
+// Function definition at index 5
+fun try_unpack_wrapper()
+    local l0: |&u64|bool has copy + drop
+    local l1: u64
+    local l2: u64
+    pack_closure __lambda__1__try_unpack_wrapper, 0
+    call m1::pack$Predicate<u64>
+    call m1::unpack$Predicate<u64>
+    st_loc l0
+    ld_u64 1
+    // @5
+    st_loc l1
+    borrow_loc l1
+    copy_loc l0
+    call_closure <|&u64|bool has copy + drop>
+    br_false l0
+    // @10
+    ld_u64 0
+    st_loc l2
+    borrow_loc l2
+    move_loc l0
+    call_closure <|&u64|bool has copy + drop>
+    // @15
+    br_true l1
+    ret
+l1: ld_u64 10
+    abort
+l0: ld_u64 9
+    // @20
+    abort
+
+// Function definition at index 6
+fun __lambda__1__try_direct_assignment_and_call(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 100
+    lt
+    ret
+
+// Function definition at index 7
+fun __lambda__1__try_nested_wrapper(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 42
+    eq
+    ret
+
+// Function definition at index 8
+fun __lambda__1__try_pass_to_apply(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 2
+    mod
+    ld_u64 0
+    // @5
+    eq
+    ret
+
+// Function definition at index 9
+fun __lambda__1__try_unpack_wrapper(l0: &u64): bool
+    move_loc l0
+    read_ref
+    ld_u64 0
+    neq
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_field_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_field_api.exp
@@ -1,0 +1,469 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct NestedPair<T0: drop> has drop
+  _0: Pair
+  _1: Wrapper<T0>
+
+struct Pair has copy + drop
+  _0: u64
+  _1: bool
+
+struct VecWrap<T0: drop> has drop
+  _0: vector<T0>
+
+struct Wrapper<T0: drop> has drop
+  _0: T0
+
+// Function definition at index 0
+public fun pack$NestedPair<T0: drop>(l0: Pair, l1: Wrapper<T0>): NestedPair<T0>
+    local l2: Pair
+    local l3: Wrapper<T0>
+    move_loc l0
+    move_loc l1
+    pack NestedPair<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$NestedPair<T0: drop>(l0: NestedPair<T0>): (Pair, Wrapper<T0>)
+    local l1: NestedPair<T0>
+    move_loc l0
+    unpack NestedPair<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$NestedPair$0<T0: drop>(l0: &NestedPair<T0>): &Pair
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 3
+public fun borrow$NestedPair$1<T0: drop>(l0: &NestedPair<T0>): &Wrapper<T0>
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 4
+public fun borrow_mut$NestedPair$0<T0: drop>(l0: &mut NestedPair<T0>): &mut Pair
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$NestedPair$1<T0: drop>(l0: &mut NestedPair<T0>): &mut Wrapper<T0>
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 6
+public fun pack$Pair(l0: u64, l1: bool): Pair
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack Pair
+    ret
+
+// Function definition at index 7
+public fun unpack$Pair(l0: Pair): (u64, bool)
+    local l1: Pair
+    move_loc l0
+    unpack Pair
+    ret
+
+// Function definition at index 8
+public fun borrow$Pair$0(l0: &Pair): &u64
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _0
+    ret
+
+// Function definition at index 9
+public fun borrow$Pair$1(l0: &Pair): &bool
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _1
+    ret
+
+// Function definition at index 10
+public fun borrow_mut$Pair$0(l0: &mut Pair): &mut u64
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _0
+    ret
+
+// Function definition at index 11
+public fun borrow_mut$Pair$1(l0: &mut Pair): &mut bool
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _1
+    ret
+
+// Function definition at index 12
+public fun pack$VecWrap<T0: drop>(l0: vector<T0>): VecWrap<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack VecWrap<T0>
+    ret
+
+// Function definition at index 13
+public fun unpack$VecWrap<T0: drop>(l0: VecWrap<T0>): vector<T0>
+    local l1: VecWrap<T0>
+    move_loc l0
+    unpack VecWrap<T0>
+    ret
+
+// Function definition at index 14
+public fun borrow$VecWrap$0<T0: drop>(l0: &VecWrap<T0>): &vector<T0>
+    local l1: &VecWrap<T0>
+    move_loc l0
+    borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 15
+public fun borrow_mut$VecWrap$0<T0: drop>(l0: &mut VecWrap<T0>): &mut vector<T0>
+    local l1: &mut VecWrap<T0>
+    move_loc l0
+    mut_borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 16
+public fun pack$Wrapper<T0: drop>(l0: T0): Wrapper<T0>
+    local l1: T0
+    move_loc l0
+    pack Wrapper<T0>
+    ret
+
+// Function definition at index 17
+public fun unpack$Wrapper<T0: drop>(l0: Wrapper<T0>): T0
+    local l1: Wrapper<T0>
+    move_loc l0
+    unpack Wrapper<T0>
+    ret
+
+// Function definition at index 18
+public fun borrow$Wrapper$0<T0: drop>(l0: &Wrapper<T0>): &T0
+    local l1: &Wrapper<T0>
+    move_loc l0
+    borrow_field Wrapper<T0>, _0
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$Wrapper$0<T0: drop>(l0: &mut Wrapper<T0>): &mut T0
+    local l1: &mut Wrapper<T0>
+    move_loc l0
+    mut_borrow_field Wrapper<T0>, _0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun test_borrow_nested_pair_fields()
+    local l0: m1::Wrapper<u64>
+    local l1: m1::Pair
+    local l2: m1::NestedPair<u64>
+    local l3: &bool
+    local l4: &u64
+    ld_u64 1
+    ld_false
+    call m1::pack$Pair
+    ld_u64 99
+    call m1::pack$Wrapper<u64>
+    // @5
+    st_loc l0
+    st_loc l1
+    move_loc l1
+    move_loc l0
+    call m1::pack$NestedPair<u64>
+    // @10
+    st_loc l2
+    borrow_loc l2
+    call m1::borrow$NestedPair$0<u64>
+    call m1::borrow$Pair$0
+    borrow_loc l2
+    // @15
+    call m1::borrow$NestedPair$0<u64>
+    call m1::borrow$Pair$1
+    st_loc l3
+    borrow_loc l2
+    call m1::borrow$NestedPair$1<u64>
+    // @20
+    call m1::borrow$Wrapper$0<u64>
+    st_loc l4
+    read_ref
+    ld_u64 1
+    eq
+    // @25
+    br_false l0
+    branch l1
+l0: move_loc l3
+    pop
+    move_loc l4
+    // @30
+    pop
+    ld_u64 3
+    abort
+l1: move_loc l3
+    read_ref
+    // @35
+    not
+    br_false l2
+    branch l3
+l2: move_loc l4
+    pop
+    // @40
+    ld_u64 4
+    abort
+l3: move_loc l4
+    read_ref
+    ld_u64 99
+    // @45
+    eq
+    br_false l4
+    branch l5
+l4: ld_u64 5
+    abort
+    // @50
+l5: ret
+
+// Function definition at index 1
+#[persistent] public fun test_borrow_pair_fields()
+    local l0: m1::Pair
+    local l1: &bool
+    ld_u64 42
+    ld_true
+    call m1::pack$Pair
+    st_loc l0
+    borrow_loc l0
+    // @5
+    call m1::borrow$Pair$0
+    borrow_loc l0
+    call m1::borrow$Pair$1
+    st_loc l1
+    read_ref
+    // @10
+    ld_u64 42
+    eq
+    br_false l0
+    branch l1
+l0: move_loc l1
+    // @15
+    pop
+    ld_u64 0
+    abort
+l1: move_loc l1
+    read_ref
+    // @20
+    br_false l2
+    branch l3
+l2: ld_u64 1
+    abort
+l3: ret
+
+// Function definition at index 2
+#[persistent] public fun test_borrow_vecwrap_element()
+    local l0: m1::VecWrap<u64>
+    local l1: &u64
+    ld_const<vector<u64>> [10, 20, 30]
+    call m1::pack$VecWrap<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$VecWrap$0<u64>
+    // @5
+    ld_u64 0
+    vec_borrow <u64>
+    borrow_loc l0
+    call m1::borrow$VecWrap$0<u64>
+    ld_u64 1
+    // @10
+    vec_borrow <u64>
+    st_loc l1
+    read_ref
+    ld_u64 10
+    eq
+    // @15
+    br_false l0
+    branch l1
+l0: move_loc l1
+    pop
+    ld_u64 6
+    // @20
+    abort
+l1: move_loc l1
+    read_ref
+    ld_u64 20
+    eq
+    // @25
+    br_false l2
+    branch l3
+l2: ld_u64 7
+    abort
+l3: ret
+
+// Function definition at index 3
+#[persistent] public fun test_borrow_wrapper_field()
+    local l0: m1::Wrapper<u64>
+    ld_u64 100
+    call m1::pack$Wrapper<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$Wrapper$0<u64>
+    // @5
+    read_ref
+    ld_u64 100
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 2
+    abort
+l1: ret
+
+// Function definition at index 4
+#[persistent] public fun test_mut_borrow_nestedpair()
+    local l0: m1::Wrapper<u64>
+    local l1: m1::Pair
+    local l2: m1::NestedPair<u64>
+    local l3: &mut m1::NestedPair<u64>
+    local l4: u64
+    local l5: &mut u64
+    local l6: u64
+    local l7: &mut u64
+    ld_u64 0
+    ld_true
+    call m1::pack$Pair
+    ld_u64 77
+    call m1::pack$Wrapper<u64>
+    // @5
+    st_loc l0
+    st_loc l1
+    move_loc l1
+    move_loc l0
+    call m1::pack$NestedPair<u64>
+    // @10
+    st_loc l2
+    mut_borrow_loc l2
+    st_loc l3
+    copy_loc l3
+    call m1::borrow_mut$NestedPair$0<u64>
+    // @15
+    call m1::borrow_mut$Pair$0
+    ld_u64 123
+    st_loc l4
+    st_loc l5
+    move_loc l4
+    // @20
+    move_loc l5
+    write_ref
+    move_loc l3
+    call m1::borrow_mut$NestedPair$1<u64>
+    call m1::borrow_mut$Wrapper$0<u64>
+    // @25
+    ld_u64 456
+    st_loc l6
+    st_loc l7
+    move_loc l6
+    move_loc l7
+    // @30
+    write_ref
+    borrow_loc l2
+    call m1::borrow$NestedPair$0<u64>
+    call m1::borrow$Pair$0
+    read_ref
+    // @35
+    ld_u64 123
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 10
+    // @40
+    abort
+l1: borrow_loc l2
+    call m1::borrow$NestedPair$1<u64>
+    call m1::borrow$Wrapper$0<u64>
+    read_ref
+    // @45
+    ld_u64 456
+    eq
+    br_false l2
+    branch l3
+l2: ld_u64 11
+    // @50
+    abort
+l3: ret
+
+// Function definition at index 5
+#[persistent] public fun test_mut_borrow_pair()
+    local l0: m1::Pair
+    local l1: u64
+    local l2: &mut u64
+    ld_u64 7
+    ld_false
+    call m1::pack$Pair
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    call m1::borrow_mut$Pair$0
+    ld_u64 8
+    st_loc l1
+    st_loc l2
+    move_loc l1
+    // @10
+    move_loc l2
+    write_ref
+    borrow_loc l0
+    call m1::borrow$Pair$0
+    read_ref
+    // @15
+    ld_u64 8
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 8
+    // @20
+    abort
+l1: ret
+
+// Function definition at index 6
+#[persistent] public fun test_mut_borrow_vecwrap_element()
+    local l0: m1::VecWrap<u64>
+    local l1: u64
+    local l2: &mut u64
+    ld_const<vector<u64>> [1, 2, 3]
+    call m1::pack$VecWrap<u64>
+    st_loc l0
+    mut_borrow_loc l0
+    call m1::borrow_mut$VecWrap$0<u64>
+    // @5
+    ld_u64 1
+    vec_mut_borrow <u64>
+    ld_u64 10
+    st_loc l1
+    st_loc l2
+    // @10
+    move_loc l1
+    move_loc l2
+    write_ref
+    borrow_loc l0
+    call m1::borrow$VecWrap$0<u64>
+    // @15
+    ld_u64 1
+    vec_borrow <u64>
+    read_ref
+    ld_u64 10
+    eq
+    // @20
+    br_false l0
+    branch l1
+l0: ld_u64 9
+    abort
+l1: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_field_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_field_api.move
@@ -1,0 +1,79 @@
+module 0x42::m1 {
+    public struct Pair(u64, bool) has copy, drop;
+
+    public struct Wrapper<T: drop>(T) has drop;
+
+    public struct NestedPair<T: drop>(Pair, Wrapper<T>) has drop;
+
+    public struct VecWrap<T: drop>(vector<T>) has drop;
+}
+
+//# publish
+module 0x42::m2 {
+    use 0x42::m1::{Pair, Wrapper, NestedPair, VecWrap};
+
+    public fun test_borrow_pair_fields() {
+        let p = Pair(42, true);
+        let x = &p.0;
+        let y = &p.1;
+        assert!(*x == 42, 0);
+        assert!(*y, 1);
+    }
+
+    public fun test_borrow_wrapper_field() {
+        let w = Wrapper<u64>(100);
+        let inner = &w.0;
+        assert!(*inner == 100, 2);
+    }
+
+    public fun test_borrow_nested_pair_fields() {
+        let p = Pair(1, false);
+        let w = Wrapper<u64>(99);
+        let np = NestedPair<u64>(p, w);
+
+        let inner_pair_0 = &np.0.0;
+        let inner_pair_1 = &np.0.1;
+        let wrapped_val = &np.1.0;
+
+        assert!(*inner_pair_0 == 1, 3);
+        assert!(!*inner_pair_1, 4);
+        assert!(*wrapped_val == 99, 5);
+    }
+
+    public fun test_borrow_vecwrap_element() {
+        let v = VecWrap<u64>(vector[10, 20, 30]);
+        let first = &v.0[0];
+        let second = &v.0[1];
+        assert!(*first == 10, 6);
+        assert!(*second == 20, 7);
+    }
+
+    public fun test_mut_borrow_pair() {
+        let p = Pair(7, false);
+        let r = &mut p;
+        let r0 = &mut r.0;
+        *r0 = 8;
+        assert!(p.0 == 8, 8);
+    }
+
+    public fun test_mut_borrow_vecwrap_element() {
+        let v = VecWrap<u64>(vector[1, 2, 3]);
+        let r = &mut v;
+        let el = &mut r.0[1];
+        *el = 10;
+        assert!(v.0[1] == 10, 9);
+    }
+
+    public fun test_mut_borrow_nestedpair() {
+        let p = Pair(0, true);
+        let w = Wrapper<u64>(77);
+        let np = NestedPair<u64>(p, w);
+        let r = &mut np;
+        let b1 = &mut r.0.0;
+        *b1 = 123;
+        let b2 = &mut r.1.0;
+        *b2 = 456;
+        assert!(np.0.0 == 123, 10);
+        assert!(np.1.0 == 456, 11);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_field_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_field_api.opt.exp
@@ -1,0 +1,433 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct NestedPair<T0: drop> has drop
+  _0: Pair
+  _1: Wrapper<T0>
+
+struct Pair has copy + drop
+  _0: u64
+  _1: bool
+
+struct VecWrap<T0: drop> has drop
+  _0: vector<T0>
+
+struct Wrapper<T0: drop> has drop
+  _0: T0
+
+// Function definition at index 0
+public fun pack$NestedPair<T0: drop>(l0: Pair, l1: Wrapper<T0>): NestedPair<T0>
+    local l2: Pair
+    local l3: Wrapper<T0>
+    move_loc l0
+    move_loc l1
+    pack NestedPair<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$NestedPair<T0: drop>(l0: NestedPair<T0>): (Pair, Wrapper<T0>)
+    local l1: NestedPair<T0>
+    move_loc l0
+    unpack NestedPair<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$NestedPair$0<T0: drop>(l0: &NestedPair<T0>): &Pair
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 3
+public fun borrow$NestedPair$1<T0: drop>(l0: &NestedPair<T0>): &Wrapper<T0>
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 4
+public fun borrow_mut$NestedPair$0<T0: drop>(l0: &mut NestedPair<T0>): &mut Pair
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$NestedPair$1<T0: drop>(l0: &mut NestedPair<T0>): &mut Wrapper<T0>
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 6
+public fun pack$Pair(l0: u64, l1: bool): Pair
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack Pair
+    ret
+
+// Function definition at index 7
+public fun unpack$Pair(l0: Pair): (u64, bool)
+    local l1: Pair
+    move_loc l0
+    unpack Pair
+    ret
+
+// Function definition at index 8
+public fun borrow$Pair$0(l0: &Pair): &u64
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _0
+    ret
+
+// Function definition at index 9
+public fun borrow$Pair$1(l0: &Pair): &bool
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _1
+    ret
+
+// Function definition at index 10
+public fun borrow_mut$Pair$0(l0: &mut Pair): &mut u64
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _0
+    ret
+
+// Function definition at index 11
+public fun borrow_mut$Pair$1(l0: &mut Pair): &mut bool
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _1
+    ret
+
+// Function definition at index 12
+public fun pack$VecWrap<T0: drop>(l0: vector<T0>): VecWrap<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack VecWrap<T0>
+    ret
+
+// Function definition at index 13
+public fun unpack$VecWrap<T0: drop>(l0: VecWrap<T0>): vector<T0>
+    local l1: VecWrap<T0>
+    move_loc l0
+    unpack VecWrap<T0>
+    ret
+
+// Function definition at index 14
+public fun borrow$VecWrap$0<T0: drop>(l0: &VecWrap<T0>): &vector<T0>
+    local l1: &VecWrap<T0>
+    move_loc l0
+    borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 15
+public fun borrow_mut$VecWrap$0<T0: drop>(l0: &mut VecWrap<T0>): &mut vector<T0>
+    local l1: &mut VecWrap<T0>
+    move_loc l0
+    mut_borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 16
+public fun pack$Wrapper<T0: drop>(l0: T0): Wrapper<T0>
+    local l1: T0
+    move_loc l0
+    pack Wrapper<T0>
+    ret
+
+// Function definition at index 17
+public fun unpack$Wrapper<T0: drop>(l0: Wrapper<T0>): T0
+    local l1: Wrapper<T0>
+    move_loc l0
+    unpack Wrapper<T0>
+    ret
+
+// Function definition at index 18
+public fun borrow$Wrapper$0<T0: drop>(l0: &Wrapper<T0>): &T0
+    local l1: &Wrapper<T0>
+    move_loc l0
+    borrow_field Wrapper<T0>, _0
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$Wrapper$0<T0: drop>(l0: &mut Wrapper<T0>): &mut T0
+    local l1: &mut Wrapper<T0>
+    move_loc l0
+    mut_borrow_field Wrapper<T0>, _0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun test_borrow_nested_pair_fields()
+    local l0: m1::Wrapper<u64>
+    local l1: m1::Pair
+    local l2: m1::NestedPair<u64>
+    local l3: &bool
+    local l4: &u64
+    ld_u64 1
+    ld_false
+    call m1::pack$Pair
+    ld_u64 99
+    call m1::pack$Wrapper<u64>
+    // @5
+    call m1::pack$NestedPair<u64>
+    st_loc l2
+    borrow_loc l2
+    call m1::borrow$NestedPair$0<u64>
+    call m1::borrow$Pair$0
+    // @10
+    borrow_loc l2
+    call m1::borrow$NestedPair$0<u64>
+    call m1::borrow$Pair$1
+    st_loc l3
+    borrow_loc l2
+    // @15
+    call m1::borrow$NestedPair$1<u64>
+    call m1::borrow$Wrapper$0<u64>
+    st_loc l4
+    read_ref
+    ld_u64 1
+    // @20
+    eq
+    br_false l0
+    move_loc l3
+    read_ref
+    br_true l1
+    // @25
+    move_loc l4
+    read_ref
+    ld_u64 99
+    eq
+    br_false l2
+    // @30
+    ret
+l2: ld_u64 5
+    abort
+l1: move_loc l4
+    pop
+    // @35
+    ld_u64 4
+    abort
+l0: move_loc l3
+    pop
+    move_loc l4
+    // @40
+    pop
+    ld_u64 3
+    abort
+
+// Function definition at index 1
+#[persistent] public fun test_borrow_pair_fields()
+    local l0: m1::Pair
+    local l1: &bool
+    ld_u64 42
+    ld_true
+    call m1::pack$Pair
+    st_loc l0
+    borrow_loc l0
+    // @5
+    call m1::borrow$Pair$0
+    borrow_loc l0
+    call m1::borrow$Pair$1
+    st_loc l1
+    read_ref
+    // @10
+    ld_u64 42
+    eq
+    br_false l0
+    move_loc l1
+    read_ref
+    // @15
+    br_false l1
+    ret
+l1: ld_u64 1
+    abort
+l0: move_loc l1
+    // @20
+    pop
+    ld_u64 0
+    abort
+
+// Function definition at index 2
+#[persistent] public fun test_borrow_vecwrap_element()
+    local l0: m1::VecWrap<u64>
+    local l1: &u64
+    ld_const<vector<u64>> [10, 20, 30]
+    call m1::pack$VecWrap<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$VecWrap$0<u64>
+    // @5
+    ld_u64 0
+    vec_borrow <u64>
+    borrow_loc l0
+    call m1::borrow$VecWrap$0<u64>
+    ld_u64 1
+    // @10
+    vec_borrow <u64>
+    st_loc l1
+    read_ref
+    ld_u64 10
+    eq
+    // @15
+    br_false l0
+    move_loc l1
+    read_ref
+    ld_u64 20
+    eq
+    // @20
+    br_false l1
+    ret
+l1: ld_u64 7
+    abort
+l0: move_loc l1
+    // @25
+    pop
+    ld_u64 6
+    abort
+
+// Function definition at index 3
+#[persistent] public fun test_borrow_wrapper_field()
+    local l0: m1::Wrapper<u64>
+    ld_u64 100
+    call m1::pack$Wrapper<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$Wrapper$0<u64>
+    // @5
+    read_ref
+    ld_u64 100
+    eq
+    br_false l0
+    ret
+    // @10
+l0: ld_u64 2
+    abort
+
+// Function definition at index 4
+#[persistent] public fun test_mut_borrow_nestedpair()
+    local l0: m1::Wrapper<u64>
+    local l1: m1::Pair
+    local l2: m1::NestedPair<u64>
+    local l3: &mut m1::NestedPair<u64>
+    local l4: u64
+    local l5: &mut u64
+    ld_u64 0
+    ld_true
+    call m1::pack$Pair
+    ld_u64 77
+    call m1::pack$Wrapper<u64>
+    // @5
+    call m1::pack$NestedPair<u64>
+    st_loc l2
+    mut_borrow_loc l2
+    st_loc l3
+    copy_loc l3
+    // @10
+    call m1::borrow_mut$NestedPair$0<u64>
+    call m1::borrow_mut$Pair$0
+    st_loc l5
+    ld_u64 123
+    move_loc l5
+    // @15
+    write_ref
+    move_loc l3
+    call m1::borrow_mut$NestedPair$1<u64>
+    call m1::borrow_mut$Wrapper$0<u64>
+    st_loc l5
+    // @20
+    ld_u64 456
+    move_loc l5
+    write_ref
+    borrow_loc l2
+    call m1::borrow$NestedPair$0<u64>
+    // @25
+    call m1::borrow$Pair$0
+    read_ref
+    ld_u64 123
+    eq
+    br_false l0
+    // @30
+    borrow_loc l2
+    call m1::borrow$NestedPair$1<u64>
+    call m1::borrow$Wrapper$0<u64>
+    read_ref
+    ld_u64 456
+    // @35
+    eq
+    br_false l1
+    ret
+l1: ld_u64 11
+    abort
+    // @40
+l0: ld_u64 10
+    abort
+
+// Function definition at index 5
+#[persistent] public fun test_mut_borrow_pair()
+    local l0: m1::Pair
+    local l1: u64
+    local l2: &mut u64
+    ld_u64 7
+    ld_false
+    call m1::pack$Pair
+    st_loc l0
+    mut_borrow_loc l0
+    // @5
+    call m1::borrow_mut$Pair$0
+    st_loc l2
+    ld_u64 8
+    move_loc l2
+    write_ref
+    // @10
+    borrow_loc l0
+    call m1::borrow$Pair$0
+    read_ref
+    ld_u64 8
+    eq
+    // @15
+    br_false l0
+    ret
+l0: ld_u64 8
+    abort
+
+// Function definition at index 6
+#[persistent] public fun test_mut_borrow_vecwrap_element()
+    local l0: m1::VecWrap<u64>
+    local l1: u64
+    local l2: &mut u64
+    ld_const<vector<u64>> [1, 2, 3]
+    call m1::pack$VecWrap<u64>
+    st_loc l0
+    mut_borrow_loc l0
+    call m1::borrow_mut$VecWrap$0<u64>
+    // @5
+    ld_u64 1
+    vec_mut_borrow <u64>
+    st_loc l2
+    ld_u64 10
+    move_loc l2
+    // @10
+    write_ref
+    borrow_loc l0
+    call m1::borrow$VecWrap$0<u64>
+    ld_u64 1
+    vec_borrow <u64>
+    // @15
+    read_ref
+    ld_u64 10
+    eq
+    br_false l0
+    ret
+    // @20
+l0: ld_u64 9
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_pack_unpack_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_pack_unpack_api.exp
@@ -1,0 +1,376 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct NestedPair<T0: drop> has drop
+  _0: Pair
+  _1: Wrapper<T0>
+
+struct Pair has copy + drop
+  _0: u64
+  _1: bool
+
+struct VecWrap<T0: drop> has drop
+  _0: vector<T0>
+
+struct Wrapper<T0: drop> has drop
+  _0: T0
+
+// Function definition at index 0
+public fun pack$NestedPair<T0: drop>(l0: Pair, l1: Wrapper<T0>): NestedPair<T0>
+    local l2: Pair
+    local l3: Wrapper<T0>
+    move_loc l0
+    move_loc l1
+    pack NestedPair<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$NestedPair<T0: drop>(l0: NestedPair<T0>): (Pair, Wrapper<T0>)
+    local l1: NestedPair<T0>
+    move_loc l0
+    unpack NestedPair<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$NestedPair$0<T0: drop>(l0: &NestedPair<T0>): &Pair
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 3
+public fun borrow$NestedPair$1<T0: drop>(l0: &NestedPair<T0>): &Wrapper<T0>
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 4
+public fun borrow_mut$NestedPair$0<T0: drop>(l0: &mut NestedPair<T0>): &mut Pair
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$NestedPair$1<T0: drop>(l0: &mut NestedPair<T0>): &mut Wrapper<T0>
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 6
+public fun pack$Pair(l0: u64, l1: bool): Pair
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack Pair
+    ret
+
+// Function definition at index 7
+public fun unpack$Pair(l0: Pair): (u64, bool)
+    local l1: Pair
+    move_loc l0
+    unpack Pair
+    ret
+
+// Function definition at index 8
+public fun borrow$Pair$0(l0: &Pair): &u64
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _0
+    ret
+
+// Function definition at index 9
+public fun borrow$Pair$1(l0: &Pair): &bool
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _1
+    ret
+
+// Function definition at index 10
+public fun borrow_mut$Pair$0(l0: &mut Pair): &mut u64
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _0
+    ret
+
+// Function definition at index 11
+public fun borrow_mut$Pair$1(l0: &mut Pair): &mut bool
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _1
+    ret
+
+// Function definition at index 12
+public fun pack$VecWrap<T0: drop>(l0: vector<T0>): VecWrap<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack VecWrap<T0>
+    ret
+
+// Function definition at index 13
+public fun unpack$VecWrap<T0: drop>(l0: VecWrap<T0>): vector<T0>
+    local l1: VecWrap<T0>
+    move_loc l0
+    unpack VecWrap<T0>
+    ret
+
+// Function definition at index 14
+public fun borrow$VecWrap$0<T0: drop>(l0: &VecWrap<T0>): &vector<T0>
+    local l1: &VecWrap<T0>
+    move_loc l0
+    borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 15
+public fun borrow_mut$VecWrap$0<T0: drop>(l0: &mut VecWrap<T0>): &mut vector<T0>
+    local l1: &mut VecWrap<T0>
+    move_loc l0
+    mut_borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 16
+public fun pack$Wrapper<T0: drop>(l0: T0): Wrapper<T0>
+    local l1: T0
+    move_loc l0
+    pack Wrapper<T0>
+    ret
+
+// Function definition at index 17
+public fun unpack$Wrapper<T0: drop>(l0: Wrapper<T0>): T0
+    local l1: Wrapper<T0>
+    move_loc l0
+    unpack Wrapper<T0>
+    ret
+
+// Function definition at index 18
+public fun borrow$Wrapper$0<T0: drop>(l0: &Wrapper<T0>): &T0
+    local l1: &Wrapper<T0>
+    move_loc l0
+    borrow_field Wrapper<T0>, _0
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$Wrapper$0<T0: drop>(l0: &mut Wrapper<T0>): &mut T0
+    local l1: &mut Wrapper<T0>
+    move_loc l0
+    mut_borrow_field Wrapper<T0>, _0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun try_nested_pair_unpack()
+    local l0: m1::Wrapper<vector<u64>>
+    local l1: m1::Pair
+    local l2: m1::Wrapper<vector<u64>>
+    local l3: m1::Pair
+    local l4: vector<u64>
+    local l5: bool
+    local l6: u64
+    ld_u64 5
+    ld_false
+    call m1::pack$Pair
+    ld_const<vector<u64>> [42, 43]
+    call m1::pack$Wrapper<vector<u64>>
+    // @5
+    st_loc l0
+    st_loc l1
+    move_loc l1
+    move_loc l0
+    call m1::pack$NestedPair<vector<u64>>
+    // @10
+    call m1::unpack$NestedPair<vector<u64>>
+    st_loc l2
+    st_loc l3
+    move_loc l3
+    call m1::unpack$Pair
+    // @15
+    move_loc l2
+    call m1::unpack$Wrapper<vector<u64>>
+    st_loc l4
+    st_loc l5
+    st_loc l6
+    // @20
+    move_loc l6
+    ld_u64 5
+    eq
+    br_false l0
+    branch l1
+    // @25
+l0: ld_u64 4
+    abort
+l1: move_loc l5
+    ld_false
+    eq
+    // @30
+    br_false l2
+    branch l3
+l2: ld_u64 5
+    abort
+l3: borrow_loc l4
+    // @35
+    ld_u64 1
+    vec_borrow <u64>
+    read_ref
+    ld_u64 43
+    eq
+    // @40
+    br_false l4
+    branch l5
+l4: ld_u64 6
+    abort
+l5: ret
+
+// Function definition at index 1
+#[persistent] public fun try_pack_unpack_pair()
+    local l0: bool
+    local l1: u64
+    ld_u64 1
+    ld_true
+    call m1::pack$Pair
+    call m1::unpack$Pair
+    st_loc l0
+    // @5
+    st_loc l1
+    move_loc l1
+    ld_u64 1
+    eq
+    br_false l0
+    // @10
+    branch l1
+l0: ld_u64 1
+    abort
+l1: move_loc l0
+    ld_true
+    // @15
+    eq
+    br_false l2
+    branch l3
+l2: ld_u64 2
+    abort
+    // @20
+l3: ret
+
+// Function definition at index 2
+#[persistent] public fun try_pack_unpack_wrapper()
+    ld_u64 100
+    call m1::pack$Wrapper<u64>
+    call m1::unpack$Wrapper<u64>
+    ld_u64 100
+    eq
+    // @5
+    br_false l0
+    branch l1
+l0: ld_u64 3
+    abort
+l1: ret
+
+// Function definition at index 3
+#[persistent] public fun try_pass_as_arg()
+    ld_u64 88
+    ld_true
+    call m1::pack$Pair
+    call use_as_param
+    ret
+
+// Function definition at index 4
+#[persistent] public fun try_return_positional(): m1::Pair
+    ld_u64 77
+    ld_false
+    call m1::pack$Pair
+    ret
+
+// Function definition at index 5
+#[persistent] public fun try_unpack_from_return()
+    local l0: bool
+    local l1: u64
+    call try_return_positional
+    call m1::unpack$Pair
+    st_loc l0
+    st_loc l1
+    move_loc l1
+    // @5
+    ld_u64 77
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 9
+    // @10
+    abort
+l1: move_loc l0
+    ld_false
+    eq
+    br_false l2
+    // @15
+    branch l3
+l2: ld_u64 10
+    abort
+l3: ret
+
+// Function definition at index 6
+#[persistent] public fun try_vecwrap_unpack()
+    local l0: vector<u64>
+    ld_const<vector<u64>> [10, 20, 30]
+    call m1::pack$VecWrap<u64>
+    call m1::unpack$VecWrap<u64>
+    st_loc l0
+    borrow_loc l0
+    // @5
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    ld_u64 10
+    eq
+    // @10
+    br_false l0
+    branch l1
+l0: ld_u64 7
+    abort
+l1: borrow_loc l0
+    // @15
+    ld_u64 2
+    vec_borrow <u64>
+    read_ref
+    ld_u64 30
+    eq
+    // @20
+    br_false l2
+    branch l3
+l2: ld_u64 8
+    abort
+l3: ret
+
+// Function definition at index 7
+#[persistent] public fun use_as_param(l0: m1::Pair)
+    local l1: bool
+    local l2: u64
+    move_loc l0
+    call m1::unpack$Pair
+    st_loc l1
+    st_loc l2
+    move_loc l2
+    // @5
+    ld_u64 88
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 11
+    // @10
+    abort
+l1: move_loc l1
+    ld_true
+    eq
+    br_false l2
+    // @15
+    branch l3
+l2: ld_u64 12
+    abort
+l3: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_pack_unpack_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_pack_unpack_api.move
@@ -1,0 +1,67 @@
+module 0x42::m1 {
+    public struct Pair(u64, bool) has copy, drop;
+
+    public struct Wrapper<T: drop>(T) has drop;
+
+    public struct NestedPair<T: drop>(Pair, Wrapper<T>) has drop;
+
+    public struct VecWrap<T: drop>(vector<T>) has drop;
+}
+
+module 0x42::m2 {
+    use 0x42::m1::Pair;
+    use 0x42::m1::Wrapper;
+    use 0x42::m1::NestedPair;
+    use 0x42::m1::VecWrap;
+
+    public fun try_pack_unpack_pair() {
+        let p = Pair(1, true);
+        let Pair(x, y) = p;
+        assert!(x == 1, 1);
+        assert!(y == true, 2);
+    }
+
+    public fun try_pack_unpack_wrapper() {
+        let w = Wrapper(100);
+        let Wrapper(x) = w;
+        assert!(x == 100, 3);
+    }
+
+    public fun try_nested_pair_unpack() {
+        let p = Pair(5, false);
+        let w = Wrapper(vector[42, 43]);
+        let n = NestedPair(p, w);
+        let NestedPair(Pair(a, b), Wrapper(v)) = n;
+        assert!(a == 5, 4);
+        assert!(b == false, 5);
+        assert!(v[1] == 43, 6);
+    }
+
+    public fun try_vecwrap_unpack() {
+        let vw = VecWrap(vector[10, 20, 30]);
+        let VecWrap(v) = vw;
+        assert!(v[0] == 10, 7);
+        assert!(v[2] == 30, 8);
+    }
+
+    public fun try_return_positional(): Pair {
+        Pair(77, false)
+    }
+
+    public fun try_unpack_from_return() {
+        let Pair(x, y) = try_return_positional();
+        assert!(x == 77, 9);
+        assert!(y == false, 10);
+    }
+
+    public fun use_as_param(p: Pair) {
+        let Pair(a, b) = p;
+        assert!(a == 88, 11);
+        assert!(b == true, 12);
+    }
+
+    public fun try_pass_as_arg() {
+        let p = Pair(88, true);
+        use_as_param(p);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_pack_unpack_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/positional_pack_unpack_api.opt.exp
@@ -1,0 +1,339 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct NestedPair<T0: drop> has drop
+  _0: Pair
+  _1: Wrapper<T0>
+
+struct Pair has copy + drop
+  _0: u64
+  _1: bool
+
+struct VecWrap<T0: drop> has drop
+  _0: vector<T0>
+
+struct Wrapper<T0: drop> has drop
+  _0: T0
+
+// Function definition at index 0
+public fun pack$NestedPair<T0: drop>(l0: Pair, l1: Wrapper<T0>): NestedPair<T0>
+    local l2: Pair
+    local l3: Wrapper<T0>
+    move_loc l0
+    move_loc l1
+    pack NestedPair<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$NestedPair<T0: drop>(l0: NestedPair<T0>): (Pair, Wrapper<T0>)
+    local l1: NestedPair<T0>
+    move_loc l0
+    unpack NestedPair<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$NestedPair$0<T0: drop>(l0: &NestedPair<T0>): &Pair
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 3
+public fun borrow$NestedPair$1<T0: drop>(l0: &NestedPair<T0>): &Wrapper<T0>
+    local l1: &NestedPair<T0>
+    move_loc l0
+    borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 4
+public fun borrow_mut$NestedPair$0<T0: drop>(l0: &mut NestedPair<T0>): &mut Pair
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _0
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$NestedPair$1<T0: drop>(l0: &mut NestedPair<T0>): &mut Wrapper<T0>
+    local l1: &mut NestedPair<T0>
+    move_loc l0
+    mut_borrow_field NestedPair<T0>, _1
+    ret
+
+// Function definition at index 6
+public fun pack$Pair(l0: u64, l1: bool): Pair
+    local l2: u64
+    local l3: bool
+    move_loc l0
+    move_loc l1
+    pack Pair
+    ret
+
+// Function definition at index 7
+public fun unpack$Pair(l0: Pair): (u64, bool)
+    local l1: Pair
+    move_loc l0
+    unpack Pair
+    ret
+
+// Function definition at index 8
+public fun borrow$Pair$0(l0: &Pair): &u64
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _0
+    ret
+
+// Function definition at index 9
+public fun borrow$Pair$1(l0: &Pair): &bool
+    local l1: &Pair
+    move_loc l0
+    borrow_field Pair, _1
+    ret
+
+// Function definition at index 10
+public fun borrow_mut$Pair$0(l0: &mut Pair): &mut u64
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _0
+    ret
+
+// Function definition at index 11
+public fun borrow_mut$Pair$1(l0: &mut Pair): &mut bool
+    local l1: &mut Pair
+    move_loc l0
+    mut_borrow_field Pair, _1
+    ret
+
+// Function definition at index 12
+public fun pack$VecWrap<T0: drop>(l0: vector<T0>): VecWrap<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack VecWrap<T0>
+    ret
+
+// Function definition at index 13
+public fun unpack$VecWrap<T0: drop>(l0: VecWrap<T0>): vector<T0>
+    local l1: VecWrap<T0>
+    move_loc l0
+    unpack VecWrap<T0>
+    ret
+
+// Function definition at index 14
+public fun borrow$VecWrap$0<T0: drop>(l0: &VecWrap<T0>): &vector<T0>
+    local l1: &VecWrap<T0>
+    move_loc l0
+    borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 15
+public fun borrow_mut$VecWrap$0<T0: drop>(l0: &mut VecWrap<T0>): &mut vector<T0>
+    local l1: &mut VecWrap<T0>
+    move_loc l0
+    mut_borrow_field VecWrap<T0>, _0
+    ret
+
+// Function definition at index 16
+public fun pack$Wrapper<T0: drop>(l0: T0): Wrapper<T0>
+    local l1: T0
+    move_loc l0
+    pack Wrapper<T0>
+    ret
+
+// Function definition at index 17
+public fun unpack$Wrapper<T0: drop>(l0: Wrapper<T0>): T0
+    local l1: Wrapper<T0>
+    move_loc l0
+    unpack Wrapper<T0>
+    ret
+
+// Function definition at index 18
+public fun borrow$Wrapper$0<T0: drop>(l0: &Wrapper<T0>): &T0
+    local l1: &Wrapper<T0>
+    move_loc l0
+    borrow_field Wrapper<T0>, _0
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$Wrapper$0<T0: drop>(l0: &mut Wrapper<T0>): &mut T0
+    local l1: &mut Wrapper<T0>
+    move_loc l0
+    mut_borrow_field Wrapper<T0>, _0
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun try_nested_pair_unpack()
+    local l0: m1::Wrapper<vector<u64>>
+    local l1: m1::Pair
+    local l2: bool
+    local l3: vector<u64>
+    ld_u64 5
+    ld_false
+    call m1::pack$Pair
+    ld_const<vector<u64>> [42, 43]
+    call m1::pack$Wrapper<vector<u64>>
+    // @5
+    call m1::pack$NestedPair<vector<u64>>
+    call m1::unpack$NestedPair<vector<u64>>
+    st_loc l0
+    call m1::unpack$Pair
+    st_loc l2
+    // @10
+    move_loc l0
+    call m1::unpack$Wrapper<vector<u64>>
+    st_loc l3
+    ld_u64 5
+    eq
+    // @15
+    br_false l0
+    move_loc l2
+    ld_false
+    eq
+    br_false l1
+    // @20
+    borrow_loc l3
+    ld_u64 1
+    vec_borrow <u64>
+    read_ref
+    ld_u64 43
+    // @25
+    eq
+    br_false l2
+    ret
+l2: ld_u64 6
+    abort
+    // @30
+l1: ld_u64 5
+    abort
+l0: ld_u64 4
+    abort
+
+// Function definition at index 1
+#[persistent] public fun try_pack_unpack_pair()
+    local l0: bool
+    ld_u64 1
+    ld_true
+    call m1::pack$Pair
+    call m1::unpack$Pair
+    st_loc l0
+    // @5
+    ld_u64 1
+    eq
+    br_false l0
+    move_loc l0
+    ld_true
+    // @10
+    eq
+    br_false l1
+    ret
+l1: ld_u64 2
+    abort
+    // @15
+l0: ld_u64 1
+    abort
+
+// Function definition at index 2
+#[persistent] public fun try_pack_unpack_wrapper()
+    ld_u64 100
+    call m1::pack$Wrapper<u64>
+    call m1::unpack$Wrapper<u64>
+    ld_u64 100
+    eq
+    // @5
+    br_false l0
+    ret
+l0: ld_u64 3
+    abort
+
+// Function definition at index 3
+#[persistent] public fun try_pass_as_arg()
+    ld_u64 88
+    ld_true
+    call m1::pack$Pair
+    call use_as_param
+    ret
+
+// Function definition at index 4
+#[persistent] public fun try_return_positional(): m1::Pair
+    ld_u64 77
+    ld_false
+    call m1::pack$Pair
+    ret
+
+// Function definition at index 5
+#[persistent] public fun try_unpack_from_return()
+    local l0: bool
+    call try_return_positional
+    call m1::unpack$Pair
+    st_loc l0
+    ld_u64 77
+    eq
+    // @5
+    br_false l0
+    move_loc l0
+    ld_false
+    eq
+    br_false l1
+    // @10
+    ret
+l1: ld_u64 10
+    abort
+l0: ld_u64 9
+    abort
+
+// Function definition at index 6
+#[persistent] public fun try_vecwrap_unpack()
+    local l0: vector<u64>
+    ld_const<vector<u64>> [10, 20, 30]
+    call m1::pack$VecWrap<u64>
+    call m1::unpack$VecWrap<u64>
+    st_loc l0
+    borrow_loc l0
+    // @5
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    ld_u64 10
+    eq
+    // @10
+    br_false l0
+    borrow_loc l0
+    ld_u64 2
+    vec_borrow <u64>
+    read_ref
+    // @15
+    ld_u64 30
+    eq
+    br_false l1
+    ret
+l1: ld_u64 8
+    // @20
+    abort
+l0: ld_u64 7
+    abort
+
+// Function definition at index 7
+#[persistent] public fun use_as_param(l0: m1::Pair)
+    local l1: bool
+    move_loc l0
+    call m1::unpack$Pair
+    st_loc l1
+    ld_u64 88
+    eq
+    // @5
+    br_false l0
+    move_loc l1
+    ld_true
+    eq
+    br_false l1
+    // @10
+    ret
+l1: ld_u64 12
+    abort
+l0: ld_u64 11
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.exp
@@ -1,0 +1,426 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct T<T0: drop + store> has copy + drop + store
+  h: T0
+
+struct S<T0: drop + store> has drop
+  f: u64
+  g: T<T0>
+
+// Function definition at index 0
+public fun pack$T<T0: drop + store>(l0: T0): T<T0>
+    local l1: T0
+    move_loc l0
+    pack T<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$T<T0: drop + store>(l0: T<T0>): T0
+    local l1: T<T0>
+    move_loc l0
+    unpack T<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$T$0<T0: drop + store>(l0: &T<T0>): &T0
+    local l1: &T<T0>
+    move_loc l0
+    borrow_field T<T0>, h
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$T$0<T0: drop + store>(l0: &mut T<T0>): &mut T0
+    local l1: &mut T<T0>
+    move_loc l0
+    mut_borrow_field T<T0>, h
+    ret
+
+// Function definition at index 4
+public fun pack$S<T0: drop + store>(l0: u64, l1: T<T0>): S<T0>
+    local l2: u64
+    local l3: T<T0>
+    move_loc l0
+    move_loc l1
+    pack S<T0>
+    ret
+
+// Function definition at index 5
+public fun unpack$S<T0: drop + store>(l0: S<T0>): (u64, T<T0>)
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 6
+public fun borrow$S$0<T0: drop + store>(l0: &S<T0>): &u64
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 7
+public fun borrow$S$1<T0: drop + store>(l0: &S<T0>): &T<T0>
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, g
+    ret
+
+// Function definition at index 8
+public fun borrow_mut$S$0<T0: drop + store>(l0: &mut S<T0>): &mut u64
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Function definition at index 9
+public fun borrow_mut$S$1<T0: drop + store>(l0: &mut S<T0>): &mut T<T0>
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, g
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun try_immut_and_mut_diff_fields()
+    local l0: u64
+    local l1: m1::T<u64>
+    local l2: m1::S<u64>
+    local l3: &mut u64
+    ld_u64 30
+    call m1::pack$T<u64>
+    ld_u64 40
+    st_loc l0
+    st_loc l1
+    // @5
+    move_loc l0
+    move_loc l1
+    call m1::pack$S<u64>
+    st_loc l2
+    borrow_loc l2
+    // @10
+    call m1::borrow$S$0<u64>
+    read_ref
+    ld_u64 40
+    eq
+    br_false l0
+    // @15
+    branch l1
+l0: ld_u64 9
+    abort
+l1: mut_borrow_loc l2
+    call m1::borrow_mut$S$1<u64>
+    // @20
+    call m1::borrow_mut$T$0<u64>
+    st_loc l3
+    copy_loc l3
+    read_ref
+    ld_u64 1
+    // @25
+    add
+    copy_loc l3
+    write_ref
+    move_loc l3
+    read_ref
+    // @30
+    ld_u64 31
+    eq
+    br_false l2
+    branch l3
+l2: ld_u64 10
+    // @35
+    abort
+l3: ret
+
+// Function definition at index 1
+#[persistent] public fun try_immut_borrow_fields()
+    local l0: u64
+    local l1: m1::T<u64>
+    local l2: m1::S<u64>
+    local l3: &u64
+    ld_u64 100
+    call m1::pack$T<u64>
+    ld_u64 200
+    st_loc l0
+    st_loc l1
+    // @5
+    move_loc l0
+    move_loc l1
+    call m1::pack$S<u64>
+    st_loc l2
+    borrow_loc l2
+    // @10
+    call m1::borrow$S$0<u64>
+    borrow_loc l2
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    st_loc l3
+    // @15
+    read_ref
+    ld_u64 200
+    eq
+    br_false l0
+    branch l1
+    // @20
+l0: move_loc l3
+    pop
+    ld_u64 3
+    abort
+l1: move_loc l3
+    // @25
+    read_ref
+    ld_u64 100
+    eq
+    br_false l2
+    branch l3
+    // @30
+l2: ld_u64 4
+    abort
+l3: ret
+
+// Function definition at index 2
+#[persistent] public fun try_immut_from_mut()
+    local l0: u64
+    local l1: m1::T<u64>
+    local l2: m1::S<u64>
+    ld_u64 5
+    call m1::pack$T<u64>
+    ld_u64 6
+    st_loc l0
+    st_loc l1
+    // @5
+    move_loc l0
+    move_loc l1
+    call m1::pack$S<u64>
+    st_loc l2
+    mut_borrow_loc l2
+    // @10
+    freeze_ref
+    call m1::borrow$S$0<u64>
+    read_ref
+    ld_u64 6
+    eq
+    // @15
+    br_false l0
+    branch l1
+l0: ld_u64 5
+    abort
+l1: ret
+
+// Function definition at index 3
+#[persistent] public fun try_mut_borrow_seq()
+    local l0: u64
+    local l1: m1::T<u64>
+    local l2: m1::S<u64>
+    local l3: &mut u64
+    local l4: &mut u64
+    ld_u64 1
+    call m1::pack$T<u64>
+    ld_u64 2
+    st_loc l0
+    st_loc l1
+    // @5
+    move_loc l0
+    move_loc l1
+    call m1::pack$S<u64>
+    st_loc l2
+    mut_borrow_loc l2
+    // @10
+    call m1::borrow_mut$S$0<u64>
+    st_loc l3
+    copy_loc l3
+    read_ref
+    ld_u64 10
+    // @15
+    add
+    move_loc l3
+    write_ref
+    mut_borrow_loc l2
+    call m1::borrow_mut$S$1<u64>
+    // @20
+    call m1::borrow_mut$T$0<u64>
+    st_loc l4
+    copy_loc l4
+    read_ref
+    ld_u64 20
+    // @25
+    add
+    move_loc l4
+    write_ref
+    borrow_loc l2
+    call m1::borrow$S$0<u64>
+    // @30
+    read_ref
+    ld_u64 12
+    eq
+    br_false l0
+    branch l1
+    // @35
+l0: ld_u64 7
+    abort
+l1: borrow_loc l2
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    // @40
+    read_ref
+    ld_u64 21
+    eq
+    br_false l2
+    branch l3
+    // @45
+l2: ld_u64 8
+    abort
+l3: ret
+
+// Function definition at index 4
+#[persistent] public fun try_reborrow_same_field_seq()
+    local l0: u64
+    local l1: m1::T<u64>
+    local l2: m1::S<u64>
+    local l3: u64
+    local l4: &mut u64
+    local l5: &mut u64
+    ld_u64 9
+    call m1::pack$T<u64>
+    ld_u64 8
+    st_loc l0
+    st_loc l1
+    // @5
+    move_loc l0
+    move_loc l1
+    call m1::pack$S<u64>
+    st_loc l2
+    mut_borrow_loc l2
+    // @10
+    call m1::borrow_mut$S$0<u64>
+    ld_u64 88
+    st_loc l3
+    st_loc l4
+    move_loc l3
+    // @15
+    move_loc l4
+    write_ref
+    mut_borrow_loc l2
+    call m1::borrow_mut$S$0<u64>
+    st_loc l5
+    // @20
+    copy_loc l5
+    read_ref
+    ld_u64 1
+    add
+    move_loc l5
+    // @25
+    write_ref
+    borrow_loc l2
+    call m1::borrow$S$0<u64>
+    read_ref
+    ld_u64 89
+    // @30
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 11
+    abort
+    // @35
+l1: ret
+
+// Function definition at index 5
+#[persistent] public fun try_unpack_ref()
+    local l0: u64
+    local l1: m1::T<u64>
+    local l2: m1::S<u64>
+    local l3: &m1::S<u64>
+    local l4: &m1::T<u64>
+    local l5: &m1::S<u64>
+    local l6: &m1::T<u64>
+    ld_u64 9
+    call m1::pack$T<u64>
+    ld_u64 8
+    st_loc l0
+    st_loc l1
+    // @5
+    move_loc l0
+    move_loc l1
+    call m1::pack$S<u64>
+    st_loc l2
+    borrow_loc l2
+    // @10
+    st_loc l3
+    copy_loc l3
+    call m1::borrow$S$0<u64>
+    move_loc l3
+    call m1::borrow$S$1<u64>
+    // @15
+    st_loc l4
+    read_ref
+    ld_u64 8
+    eq
+    br_false l0
+    // @20
+    branch l1
+l0: move_loc l4
+    pop
+    ld_u64 11
+    abort
+    // @25
+l1: move_loc l4
+    call m1::borrow$T$0<u64>
+    read_ref
+    ld_u64 9
+    eq
+    // @30
+    br_false l2
+    branch l3
+l2: ld_u64 12
+    abort
+l3: borrow_loc l2
+    // @35
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    read_ref
+    ld_u64 9
+    eq
+    // @40
+    br_false l4
+    branch l5
+l4: ld_u64 14
+    abort
+l5: borrow_loc l2
+    // @45
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    read_ref
+    ld_u64 9
+    eq
+    // @50
+    br_false l6
+    branch l7
+l6: ld_u64 15
+    abort
+l7: borrow_loc l2
+    // @55
+    st_loc l5
+    copy_loc l5
+    call m1::borrow$S$0<u64>
+    move_loc l5
+    call m1::borrow$S$1<u64>
+    // @60
+    st_loc l6
+    move_loc l6
+    pop
+    read_ref
+    ld_u64 8
+    // @65
+    eq
+    br_false l8
+    branch l9
+l8: ld_u64 15
+    abort
+    // @70
+l9: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.move
@@ -1,0 +1,78 @@
+module 0x42::m1 {
+
+    public struct S<G: store + drop> has drop {
+        f: u64,
+        g: T<G>
+    }
+
+    public struct T<G: store + drop> has store, copy, drop {
+        h: G
+    }
+}
+
+module 0x42::m2 {
+
+    use 0x42::m1::{S, T};
+
+    public fun try_immut_borrow_fields() {
+        let t = T { h: 100 };
+        let s = S { f: 200, g: t };
+        let f = &s.f;
+        let h = &s.g.h;
+        assert!(*f == 200, 3);
+        assert!(*h == 100, 4);
+    }
+
+    public fun try_immut_from_mut() {
+        let t = T { h: 5 };
+        let s = S { f: 6, g: t };
+        let r = &mut s;
+        let f = &r.f;
+        assert!(*f == 6, 5);
+    }
+
+    public fun try_mut_borrow_seq() {
+        let t = T { h: 1 };
+        let s = S { f: 2, g: t };
+        let f = &mut s.f;
+        *f = *f + 10;
+        let h = &mut s.g.h;
+        *h = *h + 20;
+        assert!(s.f == 12, 7);
+        assert!(s.g.h == 21, 8);
+    }
+
+    public fun try_immut_and_mut_diff_fields() {
+        let t = T { h: 30 };
+        let s = S { f: 40, g: t };
+        let f = &s.f;
+        assert!(*f == 40, 9);
+        let h = &mut s.g.h;
+        *h = *h + 1;
+        assert!(*h == 31, 10);
+    }
+
+    public fun try_reborrow_same_field_seq() {
+        let t = T { h: 9 };
+        let s = S { f: 8, g: t };
+        let f = &mut s.f;
+        *f = 88;
+        let f2 = &mut s.f;
+        *f2 = *f2 + 1;
+        assert!(s.f == 89, 11);
+    }
+
+    public fun try_unpack_ref() {
+        let t = T { h: 9 };
+        let s = S { f: 8, g: t };
+        let S { f, g } = &s;
+        assert!(*f == 8, 11);
+        assert!(g.h == 9, 12);
+        let S { f: _, g } = &s;
+        assert!(g.h == 9, 14);
+        let S { f: _, g: T { h } } = &s;
+        assert!(*h == 9, 15);
+        let S { f, g: T { h: _ } } = &s;
+        assert!(*f == 8, 15);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_borrow_field_api.opt.exp
@@ -1,0 +1,382 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct T<T0: drop + store> has copy + drop + store
+  h: T0
+
+struct S<T0: drop + store> has drop
+  f: u64
+  g: T<T0>
+
+// Function definition at index 0
+public fun pack$T<T0: drop + store>(l0: T0): T<T0>
+    local l1: T0
+    move_loc l0
+    pack T<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$T<T0: drop + store>(l0: T<T0>): T0
+    local l1: T<T0>
+    move_loc l0
+    unpack T<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$T$0<T0: drop + store>(l0: &T<T0>): &T0
+    local l1: &T<T0>
+    move_loc l0
+    borrow_field T<T0>, h
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$T$0<T0: drop + store>(l0: &mut T<T0>): &mut T0
+    local l1: &mut T<T0>
+    move_loc l0
+    mut_borrow_field T<T0>, h
+    ret
+
+// Function definition at index 4
+public fun pack$S<T0: drop + store>(l0: u64, l1: T<T0>): S<T0>
+    local l2: u64
+    local l3: T<T0>
+    move_loc l0
+    move_loc l1
+    pack S<T0>
+    ret
+
+// Function definition at index 5
+public fun unpack$S<T0: drop + store>(l0: S<T0>): (u64, T<T0>)
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 6
+public fun borrow$S$0<T0: drop + store>(l0: &S<T0>): &u64
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 7
+public fun borrow$S$1<T0: drop + store>(l0: &S<T0>): &T<T0>
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, g
+    ret
+
+// Function definition at index 8
+public fun borrow_mut$S$0<T0: drop + store>(l0: &mut S<T0>): &mut u64
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Function definition at index 9
+public fun borrow_mut$S$1<T0: drop + store>(l0: &mut S<T0>): &mut T<T0>
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, g
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+// Function definition at index 0
+#[persistent] public fun try_immut_and_mut_diff_fields()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    local l2: &mut u64
+    ld_u64 30
+    call m1::pack$T<u64>
+    st_loc l0
+    ld_u64 40
+    move_loc l0
+    // @5
+    call m1::pack$S<u64>
+    st_loc l1
+    borrow_loc l1
+    call m1::borrow$S$0<u64>
+    read_ref
+    // @10
+    ld_u64 40
+    eq
+    br_false l0
+    mut_borrow_loc l1
+    call m1::borrow_mut$S$1<u64>
+    // @15
+    call m1::borrow_mut$T$0<u64>
+    st_loc l2
+    copy_loc l2
+    read_ref
+    ld_u64 1
+    // @20
+    add
+    copy_loc l2
+    write_ref
+    move_loc l2
+    read_ref
+    // @25
+    ld_u64 31
+    eq
+    br_false l1
+    ret
+l1: ld_u64 10
+    // @30
+    abort
+l0: ld_u64 9
+    abort
+
+// Function definition at index 1
+#[persistent] public fun try_immut_borrow_fields()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    local l2: &u64
+    ld_u64 100
+    call m1::pack$T<u64>
+    st_loc l0
+    ld_u64 200
+    move_loc l0
+    // @5
+    call m1::pack$S<u64>
+    st_loc l1
+    borrow_loc l1
+    call m1::borrow$S$0<u64>
+    borrow_loc l1
+    // @10
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    st_loc l2
+    read_ref
+    ld_u64 200
+    // @15
+    eq
+    br_false l0
+    move_loc l2
+    read_ref
+    ld_u64 100
+    // @20
+    eq
+    br_false l1
+    ret
+l1: ld_u64 4
+    abort
+    // @25
+l0: move_loc l2
+    pop
+    ld_u64 3
+    abort
+
+// Function definition at index 2
+#[persistent] public fun try_immut_from_mut()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    ld_u64 5
+    call m1::pack$T<u64>
+    st_loc l0
+    ld_u64 6
+    move_loc l0
+    // @5
+    call m1::pack$S<u64>
+    st_loc l1
+    mut_borrow_loc l1
+    freeze_ref
+    call m1::borrow$S$0<u64>
+    // @10
+    read_ref
+    ld_u64 6
+    eq
+    br_false l0
+    ret
+    // @15
+l0: ld_u64 5
+    abort
+
+// Function definition at index 3
+#[persistent] public fun try_mut_borrow_seq()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    local l2: &mut u64
+    ld_u64 1
+    call m1::pack$T<u64>
+    st_loc l0
+    ld_u64 2
+    move_loc l0
+    // @5
+    call m1::pack$S<u64>
+    st_loc l1
+    mut_borrow_loc l1
+    call m1::borrow_mut$S$0<u64>
+    st_loc l2
+    // @10
+    copy_loc l2
+    read_ref
+    ld_u64 10
+    add
+    move_loc l2
+    // @15
+    write_ref
+    mut_borrow_loc l1
+    call m1::borrow_mut$S$1<u64>
+    call m1::borrow_mut$T$0<u64>
+    st_loc l2
+    // @20
+    copy_loc l2
+    read_ref
+    ld_u64 20
+    add
+    move_loc l2
+    // @25
+    write_ref
+    borrow_loc l1
+    call m1::borrow$S$0<u64>
+    read_ref
+    ld_u64 12
+    // @30
+    eq
+    br_false l0
+    borrow_loc l1
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    // @35
+    read_ref
+    ld_u64 21
+    eq
+    br_false l1
+    ret
+    // @40
+l1: ld_u64 8
+    abort
+l0: ld_u64 7
+    abort
+
+// Function definition at index 4
+#[persistent] public fun try_reborrow_same_field_seq()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    local l2: u64
+    local l3: &mut u64
+    ld_u64 9
+    call m1::pack$T<u64>
+    st_loc l0
+    ld_u64 8
+    move_loc l0
+    // @5
+    call m1::pack$S<u64>
+    st_loc l1
+    mut_borrow_loc l1
+    call m1::borrow_mut$S$0<u64>
+    st_loc l3
+    // @10
+    ld_u64 88
+    move_loc l3
+    write_ref
+    mut_borrow_loc l1
+    call m1::borrow_mut$S$0<u64>
+    // @15
+    st_loc l3
+    copy_loc l3
+    read_ref
+    ld_u64 1
+    add
+    // @20
+    move_loc l3
+    write_ref
+    borrow_loc l1
+    call m1::borrow$S$0<u64>
+    read_ref
+    // @25
+    ld_u64 89
+    eq
+    br_false l0
+    ret
+l0: ld_u64 11
+    // @30
+    abort
+
+// Function definition at index 5
+#[persistent] public fun try_unpack_ref()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    local l2: &m1::S<u64>
+    local l3: &m1::T<u64>
+    local l4: &m1::T<u64>
+    ld_u64 9
+    call m1::pack$T<u64>
+    st_loc l0
+    ld_u64 8
+    move_loc l0
+    // @5
+    call m1::pack$S<u64>
+    st_loc l1
+    borrow_loc l1
+    st_loc l2
+    copy_loc l2
+    // @10
+    call m1::borrow$S$0<u64>
+    move_loc l2
+    call m1::borrow$S$1<u64>
+    st_loc l3
+    read_ref
+    // @15
+    ld_u64 8
+    eq
+    br_false l0
+    move_loc l3
+    call m1::borrow$T$0<u64>
+    // @20
+    read_ref
+    ld_u64 9
+    eq
+    br_false l1
+    borrow_loc l1
+    // @25
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    read_ref
+    ld_u64 9
+    eq
+    // @30
+    br_false l2
+    borrow_loc l1
+    call m1::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    read_ref
+    // @35
+    ld_u64 9
+    eq
+    br_false l3
+    borrow_loc l1
+    st_loc l2
+    // @40
+    copy_loc l2
+    call m1::borrow$S$0<u64>
+    move_loc l2
+    call m1::borrow$S$1<u64>
+    pop
+    // @45
+    read_ref
+    ld_u64 8
+    eq
+    br_false l4
+    ret
+    // @50
+l4: ld_u64 15
+    abort
+l3: ld_u64 15
+    abort
+l2: ld_u64 14
+    // @55
+    abort
+l1: ld_u64 12
+    abort
+l0: move_loc l3
+    pop
+    // @60
+    ld_u64 11
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_mutate_vector.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_mutate_vector.exp
@@ -1,0 +1,65 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m
+struct Scalar has copy + drop + store
+  data: vector<u8>
+
+// Function definition at index 0
+public fun pack$Scalar(l0: vector<u8>): Scalar
+    local l1: vector<u8>
+    move_loc l0
+    pack Scalar
+    ret
+
+// Function definition at index 1
+public fun unpack$Scalar(l0: Scalar): vector<u8>
+    local l1: Scalar
+    move_loc l0
+    unpack Scalar
+    ret
+
+// Function definition at index 2
+public fun borrow$Scalar$0(l0: &Scalar): &vector<u8>
+    local l1: &Scalar
+    move_loc l0
+    borrow_field Scalar, data
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$Scalar$0(l0: &mut Scalar): &mut vector<u8>
+    local l1: &mut Scalar
+    move_loc l0
+    mut_borrow_field Scalar, data
+    ret
+
+// Bytecode version v9
+module 0x42::test_m
+use 0x42::m
+// Function definition at index 0
+#[persistent] public fun new_scalar_from_u8(l0: u8): m::Scalar
+    local l1: m::Scalar
+    local l2: &mut u8
+    call scalar_zero
+    st_loc l1
+    mut_borrow_loc l1
+    call m::borrow_mut$Scalar$0
+    ld_u64 0
+    // @5
+    vec_mut_borrow <u8>
+    st_loc l2
+    move_loc l0
+    move_loc l2
+    write_ref
+    // @10
+    move_loc l1
+    ret
+
+// Function definition at index 1
+#[persistent] public fun scalar_zero(): m::Scalar
+    ld_const<vector<u8>> [0]
+    call m::pack$Scalar
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_mutate_vector.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_mutate_vector.move
@@ -1,0 +1,30 @@
+//# publish
+module 0x42::m {
+
+    public struct Scalar has copy, store, drop {
+        data: vector<u8>
+    }
+
+}
+
+//# publish
+module 0x42::test_m {
+    use std::vector;
+    use 0x42::m::Scalar;
+
+    /// Creates a Scalar from an u8.
+    public fun new_scalar_from_u8(byte: u8): Scalar {
+        let s = scalar_zero();
+        let byte_zero = vector::borrow_mut(&mut s.data, 0);
+        *byte_zero = byte;
+        s
+    }
+
+    /// Returns 0 as a Scalar.
+    public fun scalar_zero(): Scalar {
+        Scalar {
+            data: x"00"
+        }
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_mutate_vector.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_mutate_vector.opt.exp
@@ -1,0 +1,65 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m
+struct Scalar has copy + drop + store
+  data: vector<u8>
+
+// Function definition at index 0
+public fun pack$Scalar(l0: vector<u8>): Scalar
+    local l1: vector<u8>
+    move_loc l0
+    pack Scalar
+    ret
+
+// Function definition at index 1
+public fun unpack$Scalar(l0: Scalar): vector<u8>
+    local l1: Scalar
+    move_loc l0
+    unpack Scalar
+    ret
+
+// Function definition at index 2
+public fun borrow$Scalar$0(l0: &Scalar): &vector<u8>
+    local l1: &Scalar
+    move_loc l0
+    borrow_field Scalar, data
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$Scalar$0(l0: &mut Scalar): &mut vector<u8>
+    local l1: &mut Scalar
+    move_loc l0
+    mut_borrow_field Scalar, data
+    ret
+
+// Bytecode version v9
+module 0x42::test_m
+use 0x42::m
+// Function definition at index 0
+#[persistent] public fun new_scalar_from_u8(l0: u8): m::Scalar
+    local l1: m::Scalar
+    local l2: &mut u8
+    call scalar_zero
+    st_loc l1
+    mut_borrow_loc l1
+    call m::borrow_mut$Scalar$0
+    ld_u64 0
+    // @5
+    vec_mut_borrow <u8>
+    st_loc l2
+    move_loc l0
+    move_loc l2
+    write_ref
+    // @10
+    move_loc l1
+    ret
+
+// Function definition at index 1
+#[persistent] public fun scalar_zero(): m::Scalar
+    ld_const<vector<u8>> [0]
+    call m::pack$Scalar
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_nested_mutate.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_nested_mutate.exp
@@ -1,0 +1,129 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+struct T has copy + drop
+  y: u64
+
+struct S has copy + drop
+  x: T
+
+// Function definition at index 0
+public fun pack$T(l0: u64): T
+    local l1: u64
+    move_loc l0
+    pack T
+    ret
+
+// Function definition at index 1
+public fun unpack$T(l0: T): u64
+    local l1: T
+    move_loc l0
+    unpack T
+    ret
+
+// Function definition at index 2
+public fun borrow$T$0(l0: &T): &u64
+    local l1: &T
+    move_loc l0
+    borrow_field T, y
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$T$0(l0: &mut T): &mut u64
+    local l1: &mut T
+    move_loc l0
+    mut_borrow_field T, y
+    ret
+
+// Function definition at index 4
+public fun pack$S(l0: T): S
+    local l1: T
+    move_loc l0
+    pack S
+    ret
+
+// Function definition at index 5
+public fun unpack$S(l0: S): T
+    local l1: S
+    move_loc l0
+    unpack S
+    ret
+
+// Function definition at index 6
+public fun borrow$S$0(l0: &S): &T
+    local l1: &S
+    move_loc l0
+    borrow_field S, x
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$S$0(l0: &mut S): &mut T
+    local l1: &mut S
+    move_loc l0
+    mut_borrow_field S, x
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::test_m
+use 0xc0ffee::m
+// Function definition at index 0
+fun foo(l0: m::S, l1: m::S): m::S
+    local l2: u64
+    ld_u64 1
+    borrow_loc l1
+    call m::borrow$S$0
+    call m::borrow$T$0
+    read_ref
+    // @5
+    mut_borrow_loc l0
+    call m::borrow_mut$S$0
+    call m::borrow_mut$T$0
+    write_ref
+    borrow_loc l0
+    // @10
+    call m::borrow$S$0
+    call m::borrow$T$0
+    read_ref
+    st_loc l2
+    mut_borrow_loc l2
+    // @15
+    write_ref
+    move_loc l0
+    ret
+
+// Function definition at index 1
+#[persistent] public fun test()
+    local l0: m::S
+    local l1: m::S
+    local l2: m::S
+    ld_u64 42
+    call m::pack$T
+    call m::pack$S
+    ld_u64 43
+    call m::pack$T
+    // @5
+    call m::pack$S
+    st_loc l0
+    st_loc l1
+    move_loc l1
+    move_loc l0
+    // @10
+    call foo
+    st_loc l2
+    borrow_loc l2
+    call m::borrow$S$0
+    call m::borrow$T$0
+    // @15
+    read_ref
+    ld_u64 43
+    eq
+    br_false l0
+    branch l1
+    // @20
+l0: ld_u64 0
+    abort
+l1: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_nested_mutate.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_nested_mutate.move
@@ -1,0 +1,30 @@
+//# publish
+module 0xc0ffee::m {
+    public struct S has copy, drop {
+        x: T,
+    }
+
+    public struct T has copy, drop {
+        y: u64,
+    }
+}
+
+//# publish
+module 0xc0ffee::test_m {
+    use 0xc0ffee::m::S;
+    use 0xc0ffee::m::T;
+
+    fun foo(s: S, p: S): S {
+        *&mut {s.x.y = p.x.y; s.x.y} = 1;
+        s
+    }
+
+    public fun test() {
+        let s = S { x: T { y: 42 } };
+        let p = S { x: T { y: 43 } };
+        let result = foo(s, p);
+        assert!(result.x.y == 43, 0);
+    }
+}
+
+//# run 0xc0ffee::test_m::test

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_nested_mutate.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_nested_mutate.opt.exp
@@ -1,0 +1,123 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+struct T has copy + drop
+  y: u64
+
+struct S has copy + drop
+  x: T
+
+// Function definition at index 0
+public fun pack$T(l0: u64): T
+    local l1: u64
+    move_loc l0
+    pack T
+    ret
+
+// Function definition at index 1
+public fun unpack$T(l0: T): u64
+    local l1: T
+    move_loc l0
+    unpack T
+    ret
+
+// Function definition at index 2
+public fun borrow$T$0(l0: &T): &u64
+    local l1: &T
+    move_loc l0
+    borrow_field T, y
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$T$0(l0: &mut T): &mut u64
+    local l1: &mut T
+    move_loc l0
+    mut_borrow_field T, y
+    ret
+
+// Function definition at index 4
+public fun pack$S(l0: T): S
+    local l1: T
+    move_loc l0
+    pack S
+    ret
+
+// Function definition at index 5
+public fun unpack$S(l0: S): T
+    local l1: S
+    move_loc l0
+    unpack S
+    ret
+
+// Function definition at index 6
+public fun borrow$S$0(l0: &S): &T
+    local l1: &S
+    move_loc l0
+    borrow_field S, x
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$S$0(l0: &mut S): &mut T
+    local l1: &mut S
+    move_loc l0
+    mut_borrow_field S, x
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::test_m
+use 0xc0ffee::m
+// Function definition at index 0
+fun foo(l0: m::S, l1: m::S): m::S
+    local l2: u64
+    ld_u64 1
+    borrow_loc l1
+    call m::borrow$S$0
+    call m::borrow$T$0
+    read_ref
+    // @5
+    mut_borrow_loc l0
+    call m::borrow_mut$S$0
+    call m::borrow_mut$T$0
+    write_ref
+    borrow_loc l0
+    // @10
+    call m::borrow$S$0
+    call m::borrow$T$0
+    read_ref
+    st_loc l2
+    mut_borrow_loc l2
+    // @15
+    write_ref
+    move_loc l0
+    ret
+
+// Function definition at index 1
+#[persistent] public fun test()
+    local l0: m::S
+    local l1: m::S
+    local l2: m::S
+    ld_u64 42
+    call m::pack$T
+    call m::pack$S
+    ld_u64 43
+    call m::pack$T
+    // @5
+    call m::pack$S
+    call foo
+    st_loc l2
+    borrow_loc l2
+    call m::borrow$S$0
+    // @10
+    call m::borrow$T$0
+    read_ref
+    ld_u64 43
+    eq
+    br_false l0
+    // @15
+    ret
+l0: ld_u64 0
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_pack_unpack_api.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_pack_unpack_api.exp
@@ -1,0 +1,576 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct T<T0: drop + store> has copy + drop + store
+  h: T0
+
+struct Inner<T0: drop + store> has drop
+  t: T0
+
+struct Nested<T0: copy + drop + store> has copy + drop + store
+  inner: T<V<T0>>
+
+struct NoFields has drop
+  dummy_field: bool
+
+struct P<phantom T0> has drop
+  p: u64
+
+struct S<T0: drop + store> has drop
+  f: u64
+  g: T<T0>
+
+struct V<T0: drop + store> has copy + drop + store
+  items: vector<T0>
+
+// Function definition at index 0
+public fun pack$T<T0: drop + store>(l0: T0): T<T0>
+    local l1: T0
+    move_loc l0
+    pack T<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$T<T0: drop + store>(l0: T<T0>): T0
+    local l1: T<T0>
+    move_loc l0
+    unpack T<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$T$0<T0: drop + store>(l0: &T<T0>): &T0
+    local l1: &T<T0>
+    move_loc l0
+    borrow_field T<T0>, h
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$T$0<T0: drop + store>(l0: &mut T<T0>): &mut T0
+    local l1: &mut T<T0>
+    move_loc l0
+    mut_borrow_field T<T0>, h
+    ret
+
+// Function definition at index 4
+public fun pack$Nested<T0: copy + drop + store>(l0: T<V<T0>>): Nested<T0>
+    local l1: T<V<T0>>
+    move_loc l0
+    pack Nested<T0>
+    ret
+
+// Function definition at index 5
+public fun unpack$Nested<T0: copy + drop + store>(l0: Nested<T0>): T<V<T0>>
+    local l1: Nested<T0>
+    move_loc l0
+    unpack Nested<T0>
+    ret
+
+// Function definition at index 6
+public fun borrow$Nested$0<T0: copy + drop + store>(l0: &Nested<T0>): &T<V<T0>>
+    local l1: &Nested<T0>
+    move_loc l0
+    borrow_field Nested<T0>, inner
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$Nested$0<T0: copy + drop + store>(l0: &mut Nested<T0>): &mut T<V<T0>>
+    local l1: &mut Nested<T0>
+    move_loc l0
+    mut_borrow_field Nested<T0>, inner
+    ret
+
+// Function definition at index 8
+public fun pack$NoFields(l0: bool): NoFields
+    local l1: bool
+    move_loc l0
+    pack NoFields
+    ret
+
+// Function definition at index 9
+public fun unpack$NoFields(l0: NoFields): bool
+    local l1: NoFields
+    move_loc l0
+    unpack NoFields
+    ret
+
+// Function definition at index 10
+public fun pack$P<T0>(l0: u64): P<T0>
+    local l1: u64
+    move_loc l0
+    pack P<T0>
+    ret
+
+// Function definition at index 11
+public fun unpack$P<T0>(l0: P<T0>): u64
+    local l1: P<T0>
+    move_loc l0
+    unpack P<T0>
+    ret
+
+// Function definition at index 12
+public fun borrow$P$0<T0>(l0: &P<T0>): &u64
+    local l1: &P<T0>
+    move_loc l0
+    borrow_field P<T0>, p
+    ret
+
+// Function definition at index 13
+public fun borrow_mut$P$0<T0>(l0: &mut P<T0>): &mut u64
+    local l1: &mut P<T0>
+    move_loc l0
+    mut_borrow_field P<T0>, p
+    ret
+
+// Function definition at index 14
+public fun pack$S<T0: drop + store>(l0: u64, l1: T<T0>): S<T0>
+    local l2: u64
+    local l3: T<T0>
+    move_loc l0
+    move_loc l1
+    pack S<T0>
+    ret
+
+// Function definition at index 15
+public fun unpack$S<T0: drop + store>(l0: S<T0>): (u64, T<T0>)
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 16
+public fun borrow$S$0<T0: drop + store>(l0: &S<T0>): &u64
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 17
+public fun borrow$S$1<T0: drop + store>(l0: &S<T0>): &T<T0>
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, g
+    ret
+
+// Function definition at index 18
+public fun borrow_mut$S$0<T0: drop + store>(l0: &mut S<T0>): &mut u64
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$S$1<T0: drop + store>(l0: &mut S<T0>): &mut T<T0>
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, g
+    ret
+
+// Function definition at index 20
+public fun pack$V<T0: drop + store>(l0: vector<T0>): V<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack V<T0>
+    ret
+
+// Function definition at index 21
+public fun unpack$V<T0: drop + store>(l0: V<T0>): vector<T0>
+    local l1: V<T0>
+    move_loc l0
+    unpack V<T0>
+    ret
+
+// Function definition at index 22
+public fun borrow$V$0<T0: drop + store>(l0: &V<T0>): &vector<T0>
+    local l1: &V<T0>
+    move_loc l0
+    borrow_field V<T0>, items
+    ret
+
+// Function definition at index 23
+public fun borrow_mut$V$0<T0: drop + store>(l0: &mut V<T0>): &mut vector<T0>
+    local l1: &mut V<T0>
+    move_loc l0
+    mut_borrow_field V<T0>, items
+    ret
+
+// Bytecode version v9
+module 0x42::m3
+use 0x42::m1
+struct S<T0: drop + store> has drop
+  f: u64
+  g: m1::T<T0>
+
+// Function definition at index 0
+public fun pack$S<T0: drop + store>(l0: u64, l1: m1::T<T0>): S<T0>
+    local l2: u64
+    local l3: m1::T<T0>
+    move_loc l0
+    move_loc l1
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$S<T0: drop + store>(l0: S<T0>): (u64, m1::T<T0>)
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$S$0<T0: drop + store>(l0: &S<T0>): &u64
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+public fun borrow$S$1<T0: drop + store>(l0: &S<T0>): &m1::T<T0>
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, g
+    ret
+
+// Function definition at index 4
+public fun borrow_mut$S$0<T0: drop + store>(l0: &mut S<T0>): &mut u64
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$S$1<T0: drop + store>(l0: &mut S<T0>): &mut m1::T<T0>
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, g
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+use 0x42::m3
+// Function definition at index 0
+#[persistent] public fun return_struct(): m1::S<u64>
+    ld_u64 77
+    ld_u64 88
+    call m1::pack$T<u64>
+    call m1::pack$S<u64>
+    ret
+
+// Function definition at index 1
+#[persistent] public fun take_struct(l0: m1::S<vector<u8>>)
+    borrow_loc l0
+    call m1::borrow$S$1<vector<u8>>
+    call m1::borrow$T$0<vector<u8>>
+    ld_u64 0
+    vec_borrow <u8>
+    // @5
+    read_ref
+    ld_u8 255
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 12
+    abort
+l1: ret
+
+// Function definition at index 2
+#[persistent] public fun try_nested_pack()
+    local l0: m1::Nested<u64>
+    ld_const<vector<u64>> [1, 2, 3]
+    call m1::pack$V<u64>
+    call m1::pack$T<m1::V<u64>>
+    call m1::pack$Nested<u64>
+    st_loc l0
+    // @5
+    borrow_loc l0
+    call m1::borrow$Nested$0<u64>
+    call m1::borrow$T$0<m1::V<u64>>
+    call m1::borrow$V$0<u64>
+    ld_u64 2
+    // @10
+    vec_borrow <u64>
+    read_ref
+    ld_u64 3
+    eq
+    br_false l0
+    // @15
+    branch l1
+l0: ld_u64 7
+    abort
+l1: ret
+
+// Function definition at index 3
+#[persistent] public fun try_pack()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    ld_u64 42
+    call m1::pack$T<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$T$0<u64>
+    // @5
+    read_ref
+    ld_u64 42
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 1
+    abort
+l1: ld_u64 43
+    move_loc l0
+    call m1::pack$S<u64>
+    // @15
+    st_loc l1
+    borrow_loc l1
+    call m1::borrow$S$0<u64>
+    read_ref
+    ld_u64 43
+    // @20
+    eq
+    br_false l2
+    branch l3
+l2: ld_u64 2
+    abort
+    // @25
+l3: ret
+
+// Function definition at index 4
+#[persistent] public fun try_pack_S3()
+    local l0: m1::T<u64>
+    local l1: m3::S<u64>
+    ld_u64 42
+    call m1::pack$T<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$T$0<u64>
+    // @5
+    read_ref
+    ld_u64 42
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 1
+    abort
+l1: ld_u64 43
+    move_loc l0
+    call m3::pack$S<u64>
+    // @15
+    st_loc l1
+    borrow_loc l1
+    call m3::borrow$S$0<u64>
+    read_ref
+    ld_u64 43
+    // @20
+    eq
+    br_false l2
+    branch l3
+l2: ld_u64 13
+    abort
+    // @25
+l3: borrow_loc l1
+    call m3::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    read_ref
+    ld_u64 42
+    // @30
+    eq
+    br_false l4
+    branch l5
+l4: ld_u64 14
+    abort
+    // @35
+l5: ret
+
+// Function definition at index 5
+#[persistent] public fun try_pack_unpack_no_fields()
+    ld_false
+    call m1::pack$NoFields
+    call m1::unpack$NoFields
+    pop
+    ret
+
+// Function definition at index 6
+#[persistent] public fun try_pack_unpack_phantom()
+    local l0: m1::P<m1::Inner<u64>>
+    ld_u64 42
+    call m1::pack$P<m1::Inner<u64>>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$P$0<m1::Inner<u64>>
+    // @5
+    read_ref
+    ld_u64 42
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 1
+    abort
+l1: move_loc l0
+    call m1::unpack$P<m1::Inner<u64>>
+    ld_u64 42
+    // @15
+    eq
+    br_false l2
+    branch l3
+l2: ld_u64 4
+    abort
+    // @20
+l3: ret
+
+// Function definition at index 7
+#[persistent] public fun try_pack_vector()
+    local l0: m1::T<vector<u64>>
+    ld_const<vector<u64>> [42]
+    call m1::pack$T<vector<u64>>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$T$0<vector<u64>>
+    // @5
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    ld_u64 42
+    eq
+    // @10
+    br_false l0
+    branch l1
+l0: ld_u64 3
+    abort
+l1: ret
+
+// Function definition at index 8
+#[persistent] public fun try_pass_struct_as_arg()
+    ld_u64 1
+    ld_const<vector<u8>> [255]
+    call m1::pack$T<vector<u8>>
+    call m1::pack$S<vector<u8>>
+    call take_struct
+    // @5
+    ret
+
+// Function definition at index 9
+#[persistent] public fun try_return_struct()
+    local l0: u64
+    local l1: u64
+    call return_struct
+    call m1::unpack$S<u64>
+    call m1::unpack$T<u64>
+    st_loc l0
+    st_loc l1
+    // @5
+    move_loc l1
+    ld_u64 77
+    eq
+    br_false l0
+    branch l1
+    // @10
+l0: ld_u64 10
+    abort
+l1: move_loc l0
+    ld_u64 88
+    eq
+    // @15
+    br_false l2
+    branch l3
+l2: ld_u64 11
+    abort
+l3: ret
+
+// Function definition at index 10
+#[persistent] public fun try_unpack()
+    local l0: u64
+    local l1: u64
+    ld_u64 43
+    ld_u64 42
+    call m1::pack$T<u64>
+    call m1::pack$S<u64>
+    call m1::unpack$S<u64>
+    // @5
+    call m1::unpack$T<u64>
+    st_loc l0
+    st_loc l1
+    move_loc l1
+    ld_u64 43
+    // @10
+    eq
+    br_false l0
+    branch l1
+l0: ld_u64 4
+    abort
+    // @15
+l1: move_loc l0
+    ld_u64 42
+    eq
+    br_false l2
+    branch l3
+    // @20
+l2: ld_u64 5
+    abort
+l3: ret
+
+// Function definition at index 11
+#[persistent] public fun try_unpack_nested()
+    local l0: vector<u64>
+    ld_const<vector<u64>> [10, 20]
+    call m1::pack$V<u64>
+    call m1::pack$T<m1::V<u64>>
+    call m1::pack$Nested<u64>
+    call m1::unpack$Nested<u64>
+    // @5
+    call m1::unpack$T<m1::V<u64>>
+    call m1::unpack$V<u64>
+    st_loc l0
+    borrow_loc l0
+    ld_u64 0
+    // @10
+    vec_borrow <u64>
+    read_ref
+    ld_u64 10
+    eq
+    br_false l0
+    // @15
+    branch l1
+l0: ld_u64 8
+    abort
+l1: borrow_loc l0
+    ld_u64 1
+    // @20
+    vec_borrow <u64>
+    read_ref
+    ld_u64 20
+    eq
+    br_false l2
+    // @25
+    branch l3
+l2: ld_u64 9
+    abort
+l3: ret
+
+// Function definition at index 12
+#[persistent] public fun try_unpack_with_let_ignore()
+    local l0: u64
+    ld_u64 100
+    ld_u64 7
+    call m1::pack$T<u64>
+    call m1::pack$S<u64>
+    call m1::unpack$S<u64>
+    // @5
+    pop
+    st_loc l0
+    move_loc l0
+    ld_u64 100
+    eq
+    // @10
+    br_false l0
+    branch l1
+l0: ld_u64 6
+    abort
+l1: ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_pack_unpack_api.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_pack_unpack_api.move
@@ -1,0 +1,126 @@
+module 0x42::m1 {
+
+    public struct S<G: store + drop> has drop {
+        f: u64,
+        g: T<G>
+    }
+
+    public struct T<G: store + drop> has store, copy, drop {
+        h: G
+    }
+
+    public struct V<G: store + drop> has store, copy, drop {
+        items: vector<G>
+    }
+
+    public struct Nested<G: store + copy +drop> has store, copy, drop {
+        inner: T<V<G>>
+    }
+
+    public struct P<phantom T> has drop {
+        p: u64
+    }
+
+    struct Inner<T: store + drop> has drop {
+        t: T
+    }
+
+    public struct NoFields has drop {}
+
+}
+
+module 0x42::m3 {
+    use 0x42::m1::T;
+
+    public struct S<G: store + drop> has drop {
+        f: u64,
+        g: T<G>
+    }
+
+}
+
+module 0x42::m2 {
+
+    use 0x42::m1::{S, T, V, Nested, P, Inner, NoFields};
+    use 0x42::m3::S as S3;
+
+    public fun try_pack_unpack_no_fields() {
+        let no_fields = NoFields {};
+        let NoFields {} = no_fields;
+    }
+
+    public fun try_pack_unpack_phantom() {
+        let p = P<Inner<u64>> { p: 42 };
+        assert!(p.p == 42, 1);
+        let P { p } = p;
+        assert!(p == 42, 4);
+    }
+
+    public fun try_pack() {
+        let t = T { h: 42 };
+        assert!(t.h == 42, 1);
+        let s = S { f: 43, g: t };
+        assert!(s.f == 43, 2);
+    }
+
+    public fun try_pack_vector() {
+        let t = T { h: vector[42] };
+        assert!(t.h[0] == 42, 3);
+    }
+
+    public fun try_unpack() {
+        let s = S { f: 43, g: T { h: 42 } };
+        let S { f, g: T { h } } = s;
+        assert!(f == 43, 4);
+        assert!(h == 42, 5);
+    }
+
+    public fun try_unpack_with_let_ignore() {
+        let s = S { f: 100, g: T { h: 7 } };
+        let S { f, g: _ } = s;
+        assert!(f == 100, 6);
+    }
+
+    public fun try_nested_pack() {
+        let v = V { items: vector[1, 2, 3] };
+        let nested = Nested { inner: T { h: v } };
+        assert!(nested.inner.h.items[2] == 3, 7);
+    }
+
+    public fun try_unpack_nested() {
+        let s = Nested {
+            inner: T { h: V { items: vector[10, 20] } }
+        };
+        let Nested { inner: T { h: V { items } } } = s;
+        assert!(items[0] == 10, 8);
+        assert!(items[1] == 20, 9);
+    }
+
+    public fun return_struct(): S<u64> {
+        S { f: 77, g: T { h: 88 } }
+    }
+
+    public fun try_return_struct() {
+        let s = return_struct();
+        let S { f, g: T { h } } = s;
+        assert!(f == 77, 10);
+        assert!(h == 88, 11);
+    }
+
+    public fun take_struct(s: S<vector<u8>>) {
+        assert!(s.g.h[0] == 255, 12);
+    }
+
+    public fun try_pass_struct_as_arg() {
+        let s = S { f: 1, g: T { h: vector[255] } };
+        take_struct(s);
+    }
+
+    public fun try_pack_S3() {
+        let t = T { h: 42 };
+        assert!(t.h == 42, 1);
+        let s = S3 { f: 43, g: t };
+        assert!(s.f == 43, 13);
+        assert!(s.g.h == 42, 14);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_pack_unpack_api.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_pack_unpack_api.opt.exp
@@ -1,0 +1,546 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::m1
+struct T<T0: drop + store> has copy + drop + store
+  h: T0
+
+struct Inner<T0: drop + store> has drop
+  t: T0
+
+struct Nested<T0: copy + drop + store> has copy + drop + store
+  inner: T<V<T0>>
+
+struct NoFields has drop
+  dummy_field: bool
+
+struct P<phantom T0> has drop
+  p: u64
+
+struct S<T0: drop + store> has drop
+  f: u64
+  g: T<T0>
+
+struct V<T0: drop + store> has copy + drop + store
+  items: vector<T0>
+
+// Function definition at index 0
+public fun pack$T<T0: drop + store>(l0: T0): T<T0>
+    local l1: T0
+    move_loc l0
+    pack T<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$T<T0: drop + store>(l0: T<T0>): T0
+    local l1: T<T0>
+    move_loc l0
+    unpack T<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$T$0<T0: drop + store>(l0: &T<T0>): &T0
+    local l1: &T<T0>
+    move_loc l0
+    borrow_field T<T0>, h
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$T$0<T0: drop + store>(l0: &mut T<T0>): &mut T0
+    local l1: &mut T<T0>
+    move_loc l0
+    mut_borrow_field T<T0>, h
+    ret
+
+// Function definition at index 4
+public fun pack$Nested<T0: copy + drop + store>(l0: T<V<T0>>): Nested<T0>
+    local l1: T<V<T0>>
+    move_loc l0
+    pack Nested<T0>
+    ret
+
+// Function definition at index 5
+public fun unpack$Nested<T0: copy + drop + store>(l0: Nested<T0>): T<V<T0>>
+    local l1: Nested<T0>
+    move_loc l0
+    unpack Nested<T0>
+    ret
+
+// Function definition at index 6
+public fun borrow$Nested$0<T0: copy + drop + store>(l0: &Nested<T0>): &T<V<T0>>
+    local l1: &Nested<T0>
+    move_loc l0
+    borrow_field Nested<T0>, inner
+    ret
+
+// Function definition at index 7
+public fun borrow_mut$Nested$0<T0: copy + drop + store>(l0: &mut Nested<T0>): &mut T<V<T0>>
+    local l1: &mut Nested<T0>
+    move_loc l0
+    mut_borrow_field Nested<T0>, inner
+    ret
+
+// Function definition at index 8
+public fun pack$NoFields(l0: bool): NoFields
+    local l1: bool
+    move_loc l0
+    pack NoFields
+    ret
+
+// Function definition at index 9
+public fun unpack$NoFields(l0: NoFields): bool
+    local l1: NoFields
+    move_loc l0
+    unpack NoFields
+    ret
+
+// Function definition at index 10
+public fun pack$P<T0>(l0: u64): P<T0>
+    local l1: u64
+    move_loc l0
+    pack P<T0>
+    ret
+
+// Function definition at index 11
+public fun unpack$P<T0>(l0: P<T0>): u64
+    local l1: P<T0>
+    move_loc l0
+    unpack P<T0>
+    ret
+
+// Function definition at index 12
+public fun borrow$P$0<T0>(l0: &P<T0>): &u64
+    local l1: &P<T0>
+    move_loc l0
+    borrow_field P<T0>, p
+    ret
+
+// Function definition at index 13
+public fun borrow_mut$P$0<T0>(l0: &mut P<T0>): &mut u64
+    local l1: &mut P<T0>
+    move_loc l0
+    mut_borrow_field P<T0>, p
+    ret
+
+// Function definition at index 14
+public fun pack$S<T0: drop + store>(l0: u64, l1: T<T0>): S<T0>
+    local l2: u64
+    local l3: T<T0>
+    move_loc l0
+    move_loc l1
+    pack S<T0>
+    ret
+
+// Function definition at index 15
+public fun unpack$S<T0: drop + store>(l0: S<T0>): (u64, T<T0>)
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 16
+public fun borrow$S$0<T0: drop + store>(l0: &S<T0>): &u64
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 17
+public fun borrow$S$1<T0: drop + store>(l0: &S<T0>): &T<T0>
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, g
+    ret
+
+// Function definition at index 18
+public fun borrow_mut$S$0<T0: drop + store>(l0: &mut S<T0>): &mut u64
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Function definition at index 19
+public fun borrow_mut$S$1<T0: drop + store>(l0: &mut S<T0>): &mut T<T0>
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, g
+    ret
+
+// Function definition at index 20
+public fun pack$V<T0: drop + store>(l0: vector<T0>): V<T0>
+    local l1: vector<T0>
+    move_loc l0
+    pack V<T0>
+    ret
+
+// Function definition at index 21
+public fun unpack$V<T0: drop + store>(l0: V<T0>): vector<T0>
+    local l1: V<T0>
+    move_loc l0
+    unpack V<T0>
+    ret
+
+// Function definition at index 22
+public fun borrow$V$0<T0: drop + store>(l0: &V<T0>): &vector<T0>
+    local l1: &V<T0>
+    move_loc l0
+    borrow_field V<T0>, items
+    ret
+
+// Function definition at index 23
+public fun borrow_mut$V$0<T0: drop + store>(l0: &mut V<T0>): &mut vector<T0>
+    local l1: &mut V<T0>
+    move_loc l0
+    mut_borrow_field V<T0>, items
+    ret
+
+// Bytecode version v9
+module 0x42::m3
+use 0x42::m1
+struct S<T0: drop + store> has drop
+  f: u64
+  g: m1::T<T0>
+
+// Function definition at index 0
+public fun pack$S<T0: drop + store>(l0: u64, l1: m1::T<T0>): S<T0>
+    local l2: u64
+    local l3: m1::T<T0>
+    move_loc l0
+    move_loc l1
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$S<T0: drop + store>(l0: S<T0>): (u64, m1::T<T0>)
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$S$0<T0: drop + store>(l0: &S<T0>): &u64
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+public fun borrow$S$1<T0: drop + store>(l0: &S<T0>): &m1::T<T0>
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, g
+    ret
+
+// Function definition at index 4
+public fun borrow_mut$S$0<T0: drop + store>(l0: &mut S<T0>): &mut u64
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Function definition at index 5
+public fun borrow_mut$S$1<T0: drop + store>(l0: &mut S<T0>): &mut m1::T<T0>
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, g
+    ret
+
+// Bytecode version v9
+module 0x42::m2
+use 0x42::m1
+use 0x42::m3
+// Function definition at index 0
+#[persistent] public fun return_struct(): m1::S<u64>
+    ld_u64 77
+    ld_u64 88
+    call m1::pack$T<u64>
+    call m1::pack$S<u64>
+    ret
+
+// Function definition at index 1
+#[persistent] public fun take_struct(l0: m1::S<vector<u8>>)
+    borrow_loc l0
+    call m1::borrow$S$1<vector<u8>>
+    call m1::borrow$T$0<vector<u8>>
+    ld_u64 0
+    vec_borrow <u8>
+    // @5
+    read_ref
+    ld_u8 255
+    eq
+    br_false l0
+    ret
+    // @10
+l0: ld_u64 12
+    abort
+
+// Function definition at index 2
+#[persistent] public fun try_nested_pack()
+    local l0: m1::Nested<u64>
+    ld_const<vector<u64>> [1, 2, 3]
+    call m1::pack$V<u64>
+    call m1::pack$T<m1::V<u64>>
+    call m1::pack$Nested<u64>
+    st_loc l0
+    // @5
+    borrow_loc l0
+    call m1::borrow$Nested$0<u64>
+    call m1::borrow$T$0<m1::V<u64>>
+    call m1::borrow$V$0<u64>
+    ld_u64 2
+    // @10
+    vec_borrow <u64>
+    read_ref
+    ld_u64 3
+    eq
+    br_false l0
+    // @15
+    ret
+l0: ld_u64 7
+    abort
+
+// Function definition at index 3
+#[persistent] public fun try_pack()
+    local l0: m1::T<u64>
+    local l1: m1::S<u64>
+    ld_u64 42
+    call m1::pack$T<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$T$0<u64>
+    // @5
+    read_ref
+    ld_u64 42
+    eq
+    br_false l0
+    ld_u64 43
+    // @10
+    move_loc l0
+    call m1::pack$S<u64>
+    st_loc l1
+    borrow_loc l1
+    call m1::borrow$S$0<u64>
+    // @15
+    read_ref
+    ld_u64 43
+    eq
+    br_false l1
+    ret
+    // @20
+l1: ld_u64 2
+    abort
+l0: ld_u64 1
+    abort
+
+// Function definition at index 4
+#[persistent] public fun try_pack_S3()
+    local l0: m1::T<u64>
+    local l1: m3::S<u64>
+    ld_u64 42
+    call m1::pack$T<u64>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$T$0<u64>
+    // @5
+    read_ref
+    ld_u64 42
+    eq
+    br_false l0
+    ld_u64 43
+    // @10
+    move_loc l0
+    call m3::pack$S<u64>
+    st_loc l1
+    borrow_loc l1
+    call m3::borrow$S$0<u64>
+    // @15
+    read_ref
+    ld_u64 43
+    eq
+    br_false l1
+    borrow_loc l1
+    // @20
+    call m3::borrow$S$1<u64>
+    call m1::borrow$T$0<u64>
+    read_ref
+    ld_u64 42
+    eq
+    // @25
+    br_false l2
+    ret
+l2: ld_u64 14
+    abort
+l1: ld_u64 13
+    // @30
+    abort
+l0: ld_u64 1
+    abort
+
+// Function definition at index 5
+#[persistent] public fun try_pack_unpack_no_fields()
+    ld_false
+    call m1::pack$NoFields
+    call m1::unpack$NoFields
+    pop
+    ret
+
+// Function definition at index 6
+#[persistent] public fun try_pack_unpack_phantom()
+    local l0: m1::P<m1::Inner<u64>>
+    ld_u64 42
+    call m1::pack$P<m1::Inner<u64>>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$P$0<m1::Inner<u64>>
+    // @5
+    read_ref
+    ld_u64 42
+    eq
+    br_false l0
+    move_loc l0
+    // @10
+    call m1::unpack$P<m1::Inner<u64>>
+    ld_u64 42
+    eq
+    br_false l1
+    ret
+    // @15
+l1: ld_u64 4
+    abort
+l0: ld_u64 1
+    abort
+
+// Function definition at index 7
+#[persistent] public fun try_pack_vector()
+    local l0: m1::T<vector<u64>>
+    ld_const<vector<u64>> [42]
+    call m1::pack$T<vector<u64>>
+    st_loc l0
+    borrow_loc l0
+    call m1::borrow$T$0<vector<u64>>
+    // @5
+    ld_u64 0
+    vec_borrow <u64>
+    read_ref
+    ld_u64 42
+    eq
+    // @10
+    br_false l0
+    ret
+l0: ld_u64 3
+    abort
+
+// Function definition at index 8
+#[persistent] public fun try_pass_struct_as_arg()
+    ld_u64 1
+    ld_const<vector<u8>> [255]
+    call m1::pack$T<vector<u8>>
+    call m1::pack$S<vector<u8>>
+    call take_struct
+    // @5
+    ret
+
+// Function definition at index 9
+#[persistent] public fun try_return_struct()
+    local l0: u64
+    call return_struct
+    call m1::unpack$S<u64>
+    call m1::unpack$T<u64>
+    st_loc l0
+    ld_u64 77
+    // @5
+    eq
+    br_false l0
+    move_loc l0
+    ld_u64 88
+    eq
+    // @10
+    br_false l1
+    ret
+l1: ld_u64 11
+    abort
+l0: ld_u64 10
+    // @15
+    abort
+
+// Function definition at index 10
+#[persistent] public fun try_unpack()
+    local l0: u64
+    ld_u64 43
+    ld_u64 42
+    call m1::pack$T<u64>
+    call m1::pack$S<u64>
+    call m1::unpack$S<u64>
+    // @5
+    call m1::unpack$T<u64>
+    st_loc l0
+    ld_u64 43
+    eq
+    br_false l0
+    // @10
+    move_loc l0
+    ld_u64 42
+    eq
+    br_false l1
+    ret
+    // @15
+l1: ld_u64 5
+    abort
+l0: ld_u64 4
+    abort
+
+// Function definition at index 11
+#[persistent] public fun try_unpack_nested()
+    local l0: vector<u64>
+    ld_const<vector<u64>> [10, 20]
+    call m1::pack$V<u64>
+    call m1::pack$T<m1::V<u64>>
+    call m1::pack$Nested<u64>
+    call m1::unpack$Nested<u64>
+    // @5
+    call m1::unpack$T<m1::V<u64>>
+    call m1::unpack$V<u64>
+    st_loc l0
+    borrow_loc l0
+    ld_u64 0
+    // @10
+    vec_borrow <u64>
+    read_ref
+    ld_u64 10
+    eq
+    br_false l0
+    // @15
+    borrow_loc l0
+    ld_u64 1
+    vec_borrow <u64>
+    read_ref
+    ld_u64 20
+    // @20
+    eq
+    br_false l1
+    ret
+l1: ld_u64 9
+    abort
+    // @25
+l0: ld_u64 8
+    abort
+
+// Function definition at index 12
+#[persistent] public fun try_unpack_with_let_ignore()
+    ld_u64 100
+    ld_u64 7
+    call m1::pack$T<u64>
+    call m1::pack$S<u64>
+    call m1::unpack$S<u64>
+    // @5
+    pop
+    ld_u64 100
+    eq
+    br_false l0
+    ret
+    // @10
+l0: ld_u64 6
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_phantoms.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_phantoms.exp
@@ -1,0 +1,50 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::phantoms
+struct T
+  dummy_field: bool
+
+struct S<phantom T0> has drop
+  addr: address
+
+// Function definition at index 0
+public fun pack$S<T0>(l0: address): S<T0>
+    local l1: address
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$S<T0>(l0: S<T0>): address
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$S$0<T0>(l0: &S<T0>): &address
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, addr
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$S$0<T0>(l0: &mut S<T0>): &mut address
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, addr
+    ret
+
+// Bytecode version v9
+module 0x42::phantoms2
+use 0x42::phantoms
+// Function definition at index 0
+fun test_phantoms()
+    ld_const<address> 18
+    call phantoms::pack$S<phantoms::T>
+    pop
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_phantoms.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_phantoms.move
@@ -1,0 +1,20 @@
+module 0x42::phantoms {
+
+    public struct S<phantom T> has drop {
+        addr: address,
+    }
+
+    struct T {}
+
+
+}
+
+module 0x42::phantoms2 {
+    use 0x42::phantoms::S;
+    use 0x42::phantoms::T;
+
+    fun test_phantoms() {
+       let _s = S<T>{ addr: @0x12 };
+        // _s is dropped
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_phantoms.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/struct_phantoms.opt.exp
@@ -1,0 +1,50 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::phantoms
+struct T
+  dummy_field: bool
+
+struct S<phantom T0> has drop
+  addr: address
+
+// Function definition at index 0
+public fun pack$S<T0>(l0: address): S<T0>
+    local l1: address
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+public fun unpack$S<T0>(l0: S<T0>): address
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+public fun borrow$S$0<T0>(l0: &S<T0>): &address
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, addr
+    ret
+
+// Function definition at index 3
+public fun borrow_mut$S$0<T0>(l0: &mut S<T0>): &mut address
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, addr
+    ret
+
+// Bytecode version v9
+module 0x42::phantoms2
+use 0x42::phantoms
+// Function definition at index 0
+fun test_phantoms()
+    ld_const<address> 18
+    call phantoms::pack$S<phantoms::T>
+    pop
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_same_name.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_same_name.exp
@@ -1,0 +1,124 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n_friend
+struct S<T0: copy>
+  f: T0
+
+// Function definition at index 0
+friend fun pack$S<T0: copy>(l0: T0): S<T0>
+    local l1: T0
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+friend fun unpack$S<T0: copy>(l0: S<T0>): T0
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+friend fun borrow$S$0<T0: copy>(l0: &S<T0>): &T0
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$S$0<T0: copy>(l0: &mut S<T0>): &mut T0
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::m_friend_2
+friend 0xc0ffee::n_friend
+struct S<T0: copy>
+  f: T0
+
+// Function definition at index 0
+friend fun pack$S<T0: copy>(l0: T0): S<T0>
+    local l1: T0
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+friend fun unpack$S<T0: copy>(l0: S<T0>): T0
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+friend fun borrow$S$0<T0: copy>(l0: &S<T0>): &T0
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$S$0<T0: copy>(l0: &mut S<T0>): &mut T0
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n_friend
+use 0xc0ffee::m_friend
+use 0xc0ffee::m_friend_2
+// Function definition at index 0
+fun test_borrow_friend_struct(l0: &m_friend::S<u64>): &u64
+    move_loc l0
+    call m_friend::borrow$S$0<u64>
+    ret
+
+// Function definition at index 1
+fun test_borrow_friend_struct_2(l0: &m_friend_2::S<u64>): &u64
+    move_loc l0
+    call m_friend_2::borrow$S$0<u64>
+    ret
+
+// Function definition at index 2
+fun test_mut_borrow_friend_struct(l0: &mut m_friend::S<u64>): &mut u64
+    move_loc l0
+    call m_friend::borrow_mut$S$0<u64>
+    ret
+
+// Function definition at index 3
+fun test_mut_borrow_friend_struct_2(l0: &mut m_friend_2::S<u64>): &mut u64
+    move_loc l0
+    call m_friend_2::borrow_mut$S$0<u64>
+    ret
+
+// Function definition at index 4
+fun test_pack_friend_struct(): m_friend::S<u64>
+    ld_u64 22
+    call m_friend::pack$S<u64>
+    ret
+
+// Function definition at index 5
+fun test_pack_friend_struct_2(): m_friend_2::S<u64>
+    ld_u64 22
+    call m_friend_2::pack$S<u64>
+    ret
+
+// Function definition at index 6
+fun test_unpack_friend_struct(l0: m_friend::S<u64>): u64
+    move_loc l0
+    call m_friend::unpack$S<u64>
+    ret
+
+// Function definition at index 7
+fun test_unpack_friend_struct_2(l0: m_friend_2::S<u64>): u64
+    move_loc l0
+    call m_friend_2::unpack$S<u64>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_same_name.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_same_name.move
@@ -1,0 +1,55 @@
+module 0xc0ffee::m_friend {
+    friend 0xc0ffee::n_friend;
+
+    friend struct S<T: copy> {
+        f: T,
+    }
+
+}
+
+module 0xc0ffee::m_friend_2 {
+
+    package struct S<T: copy> {
+        f: T,
+    }
+
+}
+
+module 0xc0ffee::n_friend {
+    use 0xc0ffee::m_friend::S;
+    use 0xc0ffee::m_friend_2::S as S2;
+
+    fun test_pack_friend_struct(): S<u64> {
+        S { f: 22 }
+    }
+
+    fun test_unpack_friend_struct(s: S<u64>): u64 {
+        let S { f } = s;
+        f
+    }
+
+    fun test_borrow_friend_struct(s: &S<u64>): &u64 {
+        &s.f
+    }
+
+    fun test_mut_borrow_friend_struct(s: &mut S<u64>): &mut u64 {
+        &mut s.f
+    }
+
+    fun test_pack_friend_struct_2(): S2<u64> {
+        S2 { f: 22 }
+    }
+
+    fun test_unpack_friend_struct_2(s: S2<u64>): u64 {
+        let S2 { f } = s;
+        f
+    }
+
+    fun test_borrow_friend_struct_2(s: &S2<u64>): &u64 {
+        &s.f
+    }
+
+    fun test_mut_borrow_friend_struct_2(s: &mut S2<u64>): &mut u64 {
+        &mut s.f
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_same_name.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_same_name.opt.exp
@@ -1,0 +1,124 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n_friend
+struct S<T0: copy>
+  f: T0
+
+// Function definition at index 0
+friend fun pack$S<T0: copy>(l0: T0): S<T0>
+    local l1: T0
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+friend fun unpack$S<T0: copy>(l0: S<T0>): T0
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+friend fun borrow$S$0<T0: copy>(l0: &S<T0>): &T0
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$S$0<T0: copy>(l0: &mut S<T0>): &mut T0
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::m_friend_2
+friend 0xc0ffee::n_friend
+struct S<T0: copy>
+  f: T0
+
+// Function definition at index 0
+friend fun pack$S<T0: copy>(l0: T0): S<T0>
+    local l1: T0
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+friend fun unpack$S<T0: copy>(l0: S<T0>): T0
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+friend fun borrow$S$0<T0: copy>(l0: &S<T0>): &T0
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$S$0<T0: copy>(l0: &mut S<T0>): &mut T0
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n_friend
+use 0xc0ffee::m_friend
+use 0xc0ffee::m_friend_2
+// Function definition at index 0
+fun test_borrow_friend_struct(l0: &m_friend::S<u64>): &u64
+    move_loc l0
+    call m_friend::borrow$S$0<u64>
+    ret
+
+// Function definition at index 1
+fun test_borrow_friend_struct_2(l0: &m_friend_2::S<u64>): &u64
+    move_loc l0
+    call m_friend_2::borrow$S$0<u64>
+    ret
+
+// Function definition at index 2
+fun test_mut_borrow_friend_struct(l0: &mut m_friend::S<u64>): &mut u64
+    move_loc l0
+    call m_friend::borrow_mut$S$0<u64>
+    ret
+
+// Function definition at index 3
+fun test_mut_borrow_friend_struct_2(l0: &mut m_friend_2::S<u64>): &mut u64
+    move_loc l0
+    call m_friend_2::borrow_mut$S$0<u64>
+    ret
+
+// Function definition at index 4
+fun test_pack_friend_struct(): m_friend::S<u64>
+    ld_u64 22
+    call m_friend::pack$S<u64>
+    ret
+
+// Function definition at index 5
+fun test_pack_friend_struct_2(): m_friend_2::S<u64>
+    ld_u64 22
+    call m_friend_2::pack$S<u64>
+    ret
+
+// Function definition at index 6
+fun test_unpack_friend_struct(l0: m_friend::S<u64>): u64
+    move_loc l0
+    call m_friend::unpack$S<u64>
+    ret
+
+// Function definition at index 7
+fun test_unpack_friend_struct_2(l0: m_friend_2::S<u64>): u64
+    move_loc l0
+    call m_friend_2::unpack$S<u64>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_with_ability.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_with_ability.exp
@@ -1,0 +1,65 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n_friend
+struct S<T0: copy>
+  f: T0
+
+// Function definition at index 0
+friend fun pack$S<T0: copy>(l0: T0): S<T0>
+    local l1: T0
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+friend fun unpack$S<T0: copy>(l0: S<T0>): T0
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+friend fun borrow$S$0<T0: copy>(l0: &S<T0>): &T0
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$S$0<T0: copy>(l0: &mut S<T0>): &mut T0
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n_friend
+use 0xc0ffee::m_friend
+// Function definition at index 0
+fun test_borrow_friend_struct(l0: &m_friend::S<u64>): &u64
+    move_loc l0
+    call m_friend::borrow$S$0<u64>
+    ret
+
+// Function definition at index 1
+fun test_mut_borrow_friend_struct(l0: &mut m_friend::S<u64>): &mut u64
+    move_loc l0
+    call m_friend::borrow_mut$S$0<u64>
+    ret
+
+// Function definition at index 2
+fun test_pack_friend_struct(): m_friend::S<u64>
+    ld_u64 22
+    call m_friend::pack$S<u64>
+    ret
+
+// Function definition at index 3
+fun test_unpack_friend_struct(l0: m_friend::S<u64>): u64
+    move_loc l0
+    call m_friend::unpack$S<u64>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_with_ability.move
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_with_ability.move
@@ -1,0 +1,30 @@
+module 0xc0ffee::m_friend {
+    friend 0xc0ffee::n_friend;
+
+    friend struct S<T: copy> {
+        f: T,
+    }
+
+}
+
+module 0xc0ffee::n_friend {
+    use 0xc0ffee::m_friend::S;
+
+    fun test_pack_friend_struct(): S<u64> {
+        S { f: 22 }
+    }
+
+    fun test_unpack_friend_struct(s: S<u64>): u64 {
+        let S { f } = s;
+        f
+    }
+
+    fun test_borrow_friend_struct(s: &S<u64>): &u64 {
+        &s.f
+    }
+
+    fun test_mut_borrow_friend_struct(s: &mut S<u64>): &mut u64 {
+        &mut s.f
+    }
+
+}

--- a/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_with_ability.opt.exp
+++ b/third_party/move/move-compiler-v2/tests/file-format-generator/structs_visibility/structs_with_ability.opt.exp
@@ -1,0 +1,65 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m_friend
+friend 0xc0ffee::n_friend
+struct S<T0: copy>
+  f: T0
+
+// Function definition at index 0
+friend fun pack$S<T0: copy>(l0: T0): S<T0>
+    local l1: T0
+    move_loc l0
+    pack S<T0>
+    ret
+
+// Function definition at index 1
+friend fun unpack$S<T0: copy>(l0: S<T0>): T0
+    local l1: S<T0>
+    move_loc l0
+    unpack S<T0>
+    ret
+
+// Function definition at index 2
+friend fun borrow$S$0<T0: copy>(l0: &S<T0>): &T0
+    local l1: &S<T0>
+    move_loc l0
+    borrow_field S<T0>, f
+    ret
+
+// Function definition at index 3
+friend fun borrow_mut$S$0<T0: copy>(l0: &mut S<T0>): &mut T0
+    local l1: &mut S<T0>
+    move_loc l0
+    mut_borrow_field S<T0>, f
+    ret
+
+// Bytecode version v9
+module 0xc0ffee::n_friend
+use 0xc0ffee::m_friend
+// Function definition at index 0
+fun test_borrow_friend_struct(l0: &m_friend::S<u64>): &u64
+    move_loc l0
+    call m_friend::borrow$S$0<u64>
+    ret
+
+// Function definition at index 1
+fun test_mut_borrow_friend_struct(l0: &mut m_friend::S<u64>): &mut u64
+    move_loc l0
+    call m_friend::borrow_mut$S$0<u64>
+    ret
+
+// Function definition at index 2
+fun test_pack_friend_struct(): m_friend::S<u64>
+    ld_u64 22
+    call m_friend::pack$S<u64>
+    ret
+
+// Function definition at index 3
+fun test_unpack_friend_struct(l0: m_friend::S<u64>): u64
+    move_loc l0
+    call m_friend::unpack$S<u64>
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_field.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_field.exp
@@ -1,0 +1,84 @@
+processed 9 tasks
+task 0 lines 2-19:  publish [module 0x42::test {]
+task 1 lines 21-131:  publish [module 0x42::test_assign_field {]
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`:
+Error message: none
+   ┌─ TEMPFILE1:62:13
+   │
+62 │             E::V1(x, y) => {
+   │             ^^^^^^^^^^^
+   │
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+
+task 2 lines 133-133:  run --verbose -- 0x42::test_assign_field::test_simple
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test_assign_field doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}
+task 3 lines 135-135:  run --verbose -- 0x42::test_assign_field::test_simple_ref
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test_assign_field doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}
+task 4 lines 137-137:  run --verbose -- 0x42::test_assign_field::test_assign0
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test_assign_field doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}
+task 5 lines 139-139:  run --verbose -- 0x42::test_assign_field::test_assign1
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test_assign_field doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}
+task 6 lines 141-141:  run --verbose -- 0x42::test_assign_field::test_assign_chained
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test_assign_field doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}
+task 7 lines 143-143:  run --verbose -- 0x42::test_assign_field::test_assign_enum_1
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test_assign_field doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}
+task 8 lines 145-145:  run --verbose -- 0x42::test_assign_field::test_assign_enum_2
+Error: Function execution failed with VMError: {
+    message: Linker Error: Module 0000000000000000000000000000000000000000000000000000000000000042::test_assign_field doesn't exist,
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+    exec_state: None,
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_field.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_field.move
@@ -1,0 +1,145 @@
+// TODO: #18199
+//# publish
+module 0x42::test {
+    public struct S0 has copy, drop {
+        x: u8,
+    }
+
+    public struct S1(u64, bool) has drop;
+
+    public struct S2(S0, u8) has copy, drop;
+
+    public struct S3(S2, S0, S2) has drop;
+
+    public enum E has drop {
+        V1(u8, bool),
+        V2(S3),
+    }
+
+}
+
+//# publish
+module 0x42::test_assign_field {
+    use 0x42::test::S0;
+    use 0x42::test::S1;
+    use 0x42::test::S2;
+    use 0x42::test::S3;
+    use 0x42::test::E;
+
+    fun simple(x: S1): S1 {
+        x.0 = 42;
+        x.1 = true;
+        x
+    }
+
+    fun simple_ref(x: &mut S1) {
+        x.0 = 42;
+        x.1 = true;
+    }
+
+    fun assign0(a: u64, b: bool): S1 {
+        let x = S1(a, b);
+        while (x.1) {
+            x = S1(x.0 - 1, x.0 >= 2);
+        };
+        x
+    }
+
+    fun assign1(x: S1): u64 {
+        let count = 0;
+        while (x.1) {
+            let y = if (x.0 > 0) { x.0 - 1 } else { 0 };
+            x = S1(y, y >=1);
+            count = count + 1;
+        };
+        count
+    }
+
+    fun assign_chained(x: S3): S3 {
+        x.0.0.x + x.1.x + x.2.0.x;
+        x.0.0.x = 0;
+        x.1.x = 1;
+        x.2.0.x = 2;
+        x
+    }
+
+    fun assign_enum(x: &mut E) {
+        match (x) {
+            E::V1(x, y) => {
+                *x = 42;
+                *y = true;
+            },
+            E::V2(x) => {
+                x.0.0.x = 0;
+                x.1.x = 1;
+                x.2.0.x = 2;
+            }
+        }
+    }
+
+    fun test_simple(): S1 {
+        let x = S1(0, false);
+        let y = simple(x);
+        y
+    }
+
+    fun test_simple_ref(): S1 {
+        let x = S1(0, false);
+        simple_ref(&mut x);
+        x
+    }
+
+    fun test_assign0(): S1 {
+        assign0(4, true)
+    }
+
+    fun test_assign1(): u64 {
+        let x = S1(4, true);
+        assign1(x)
+    }
+
+    fun test_assign_chained(): S3 {
+        let x0 = S0 { x: 42 };
+        let x1 = S2(x0, 42);
+        let x2 = S3(x1, x0, x1);
+        x2 = assign_chained(x2);
+        x2
+    }
+
+    fun test_assign_enum_1(): bool {
+        let x0 = S0 { x: 43 };
+        let x1 = S2(x0, 42);
+        let x2 = S3(x1, x0, x1);
+        let x3 = E::V2(x2);
+        assign_enum(&mut x3);
+        let y0 = S0 { x: 0 };
+        let y1 = S0 { x: 1 };
+        let y2 = S0 { x: 2 };
+        let y3 = S2(y0, 42);
+        let y4 = S2(y2, 42);
+        let y5 = S3(y3, y1, y4);
+        let y6 = E::V2(y5);
+        x3 == y6
+    }
+
+    fun test_assign_enum_2(): bool {
+        let x = E::V1(0, false);
+        assign_enum(&mut x);
+        let y = E::V1(42, true);
+        x == y
+    }
+}
+
+//# run --verbose -- 0x42::test_assign_field::test_simple
+
+//# run --verbose -- 0x42::test_assign_field::test_simple_ref
+
+//# run --verbose -- 0x42::test_assign_field::test_assign0
+
+//# run --verbose -- 0x42::test_assign_field::test_assign1
+
+//# run --verbose -- 0x42::test_assign_field::test_assign_chained
+
+//# run --verbose -- 0x42::test_assign_field::test_assign_enum_1
+
+//# run --verbose -- 0x42::test_assign_field::test_assign_enum_2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_unpack_references.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_unpack_references.exp
@@ -1,0 +1,30 @@
+processed 4 tasks
+task 0 lines 2-8:  publish [module 0x42::m {]
+task 1 lines 10-35:  publish [module 0x42::m2 {]
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`:
+Error message: none
+   ┌─ TEMPFILE1:24:9
+   │
+24 │         R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
+   │         ^^^^^^^^^^^^^^^^^^^^^
+   │
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+
+task 2 lines 37-37:  run 0x42::m2::t1
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 3 lines 39-39:  run 0x42::m2::t2
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_unpack_references.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_assign_unpack_references.move
@@ -1,0 +1,39 @@
+// TODO: #18199
+//# publish
+module 0x42::m {
+    public struct S has drop{ f: u64 }
+    public struct R has drop{ s1: S, s2: S }
+
+
+}
+
+//# publish
+module 0x42::m2 {
+    use 0x42::m::R;
+    use 0x42::m::S;
+
+    fun t1() {
+        let f;
+        let s2;
+        R { s1: S { f }, s2 } = &R { s1: S{f: 0}, s2: S{f: 1} };
+        assert!(*f == 0, 0);
+        assert!(s2.f == 1, 1);
+    }
+
+    fun t2() {
+        let f;
+        let s2;
+        R { s1: S { f }, s2 } = &mut R { s1: S{f: 0}, s2: S{f: 1} }; f; s2;
+        assert!(*f == 0, 0);
+        assert!(s2.f == 1, 1);
+        f = &mut 5;
+        s2 = &mut S { f: 0 };
+        assert!(*f == 5, 0);
+        assert!(s2.f == 0, 1);
+    }
+
+}
+
+//# run 0x42::m2::t1
+
+//# run 0x42::m2::t2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_closures_in_enums.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_closures_in_enums.exp
@@ -1,0 +1,7 @@
+processed 6 tasks
+task 0 lines 1-8:  publish [module 0xc0ffee::m {]
+task 1 lines 10-115:  publish [module 0xc0ffee::m_closures_in_enums {]
+task 2 lines 117-117:  run 0xc0ffee::m_closures_in_enums::test_1
+task 3 lines 119-119:  run 0xc0ffee::m_closures_in_enums::test_2
+task 4 lines 121-121:  run 0xc0ffee::m_closures_in_enums::test_3
+task 5 lines 123-123:  run 0xc0ffee::m_closures_in_enums::test_4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_closures_in_enums.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_closures_in_enums.move
@@ -1,0 +1,123 @@
+//# publish
+module 0xc0ffee::m {
+    public enum Function has copy, drop {
+        NoParam(||u64),
+        OneParam(|u64|u64),
+        TwoParam(|u64, u64|u64),
+    }
+}
+
+//# publish
+module 0xc0ffee::m_closures_in_enums {
+    use 0xc0ffee::m::Function;
+
+    fun runner_1(f: Function): u64 {
+        match (f) {
+            Function::NoParam(func) => func(),
+            Function::OneParam(func) => func(0),
+            Function::TwoParam(func) => func(0, 0),
+        }
+    }
+
+    public fun test_1() {
+        let f1 = Function::NoParam(|| 0);
+        assert!(runner_1(f1) == 0);
+
+        let f2 = Function::OneParam(|x| x);
+        assert!(runner_1(f2) == 0);
+
+        let f3 = Function::TwoParam(|x, y| x + y);
+        assert!(runner_1(f3) == 0);
+
+        let x = 1;
+        let f4 = Function::NoParam(|| x);
+        assert!(runner_1(f4) == 1);
+
+        let x = 1;
+        let f5 = Function::OneParam(|y| x + y);
+        assert!(runner_1(f5) == 1);
+    }
+
+    fun runner_2(f: Function): u64 {
+        let to_call = match (f) {
+            Function::NoParam(func) => func,
+            Function::OneParam(func) => || func(0),
+            Function::TwoParam(func) => || func(0, 0),
+        };
+        to_call()
+    }
+
+    public fun test_2() {
+        let f1 = Function::NoParam(|| 0);
+        assert!(runner_2(f1) == 0);
+
+        let f2 = Function::OneParam(|x| x);
+        assert!(runner_2(f2) == 0);
+
+        let f3 = Function::TwoParam(|x, y| x + y);
+        assert!(runner_2(f3) == 0);
+
+        let x = 1;
+        let f4 = Function::NoParam(|| x);
+        assert!(runner_2(f4) == 1);
+
+        let x = 1;
+        let f5 = Function::OneParam(|y| x + y);
+        assert!(runner_2(f5) == 1);
+    }
+
+    fun get_func(f: &Function): &||u64 has copy {
+        match (f) {
+            Function::NoParam(func) => func,
+            _ => abort 42
+        }
+    }
+
+    fun runner_3(f: &Function): u64 {
+        (*get_func(f))()
+    }
+
+    fun test_3() {
+        let f1 = Function::NoParam(|| 0);
+        assert!(runner_3(&f1) == 0);
+    }
+
+    fun get_func_recursive(f: Function): ||u64 {
+        match (f) {
+            Function::NoParam(func) => func,
+            Function::OneParam(func) => get_func_recursive(Function::NoParam(||func(0))),
+            Function::TwoParam(func) => get_func_recursive(Function::OneParam(|x|func(0, x))),
+        }
+    }
+
+    fun runner_4(f: Function): u64 {
+        get_func_recursive(f)()
+    }
+
+    public fun test_4() {
+        let f1 = Function::NoParam(|| 0);
+        assert!(runner_4(f1) == 0);
+
+        let f2 = Function::OneParam(|x| x);
+        assert!(runner_4(f2) == 0);
+
+        let f3 = Function::TwoParam(|x, y| x + y);
+        assert!(runner_4(f3) == 0);
+
+        let x = 1;
+        let f4 = Function::NoParam(|| x);
+        assert!(runner_4(f4) == 1);
+
+        let x = 1;
+        let f5 = Function::OneParam(|y| x + y);
+        assert!(runner_4(f5) == 1);
+    }
+}
+
+//# run 0xc0ffee::m_closures_in_enums::test_1
+
+//# run 0xc0ffee::m_closures_in_enums::test_2
+
+//# run 0xc0ffee::m_closures_in_enums::test_3
+
+//# run 0xc0ffee::m_closures_in_enums::test_4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_exhaustive_check.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_exhaustive_check.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-18:  publish [module 0x42::test {]
+task 1 lines 20-31:  publish [module 0x42::test_bug_14296 {]

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_exhaustive_check.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_exhaustive_check.move
@@ -1,0 +1,31 @@
+//# publish
+module 0x42::test {
+    public struct S0 has drop {}
+
+    public struct S1<A, B> has drop {
+        x: A,
+        y: B
+    }
+
+    public enum E has drop {
+        V1{ x: u8, y: S1<u8, bool>},
+        V2 {
+            x: u8,
+            y: S0
+        }
+    }
+
+}
+
+//# publish
+module 0x42::test_bug_14296 {
+    use 0x42::test::E;
+    use 0x42::test::S1;
+
+    fun extract_last_u8(y: &E): u8 {
+        match (y) {
+            E::V1{ x: _, y: S1 { x, y: _}} => *x,
+            E::V2 { y: _, x: _ } => 1,
+        }
+    }
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_field_select_different_offsets.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_field_select_different_offsets.exp
@@ -1,0 +1,27 @@
+processed 8 tasks
+task 0 lines 1-10:  publish [module 0x42::m {]
+task 1 lines 12-46:  publish [module 0x42::test_m {]
+task 2 lines 48-48:  run 0x42::test_m::test_get_x_v1
+return values: 43
+task 3 lines 50-50:  run 0x42::test_m::test_get_x_v2
+return values: 43
+task 4 lines 52-52:  run 0x42::test_m::test_get_x_v3
+return values: 43
+task 5 lines 54-54:  run 0x42::test_m::test_get_y_v1
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(9), 1)],
+}
+task 6 lines 56-56:  run 0x42::test_m::test_get_y_v2
+return values: true
+task 7 lines 58-58:  run 0x42::test_m::test_get_y_v3
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(9), 1)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_field_select_different_offsets.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_field_select_different_offsets.move
@@ -1,0 +1,58 @@
+//# publish
+module 0x42::m {
+
+  public enum Data has drop {
+    V1{x: u64},
+    V2{y: bool, x: u64}
+    V3{z: u8, x: u64}
+  }
+
+}
+
+//# publish
+module 0x42::test_m {
+  use 0x42::m::Data;
+
+  fun test_get_x_v1(): u64 {
+    let d = Data::V1{x: 43};
+    d.x
+  }
+
+  fun test_get_x_v2(): u64 {
+    let d = Data::V2{x: 43, y: false};
+    d.x
+  }
+
+  fun test_get_x_v3(): u64 {
+    let d = Data::V3{z: 1, x: 43};
+    d.x
+  }
+
+  fun test_get_y_v1(): bool {
+    let d = Data::V1{x: 43};
+    d.y
+  }
+
+  fun test_get_y_v2(): bool {
+    let d = Data::V2{x: 43, y: true};
+    d.y
+  }
+
+  fun test_get_y_v3(): bool {
+    let d = Data::V3{x: 43, z: 1};
+    d.y
+  }
+
+}
+
+//# run 0x42::test_m::test_get_x_v1
+
+//# run 0x42::test_m::test_get_x_v2
+
+//# run 0x42::test_m::test_get_x_v3
+
+//# run 0x42::test_m::test_get_y_v1
+
+//# run 0x42::test_m::test_get_y_v2
+
+//# run 0x42::test_m::test_get_y_v3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_matching.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_matching.exp
@@ -1,0 +1,31 @@
+processed 16 tasks
+task 0 lines 1-30:  publish [module 0x42::m {]
+task 1 lines 32-184:  publish [module 0x42::test_m {]
+task 2 lines 186-186:  run 0x42::test_m::t1_is_inner1
+return values: true
+task 3 lines 188-188:  run 0x42::test_m::t2_is_inner1
+return values: false
+task 4 lines 190-190:  run 0x42::test_m::t1_inner_value
+return values: 7
+task 5 lines 192-192:  run 0x42::test_m::t1_outer_value
+return values: 0
+task 6 lines 194-194:  run 0x42::test_m::t2_outer_value
+return values: 3
+task 7 lines 196-196:  run 0x42::test_m::t3_outer_value
+return values: 8
+task 8 lines 198-198:  run 0x42::test_m::t1_outer_value_nested
+return values: 27
+task 9 lines 200-200:  run 0x42::test_m::t2_outer_value_nested
+return values: 12
+task 10 lines 202-202:  run 0x42::test_m::t1_outer_value_with_cond
+return values: 1
+task 11 lines 204-204:  run 0x42::test_m::t1_outer_value_with_cond_ref
+return values: true
+task 12 lines 206-206:  run 0x42::test_m::t1_is_some
+return values: false
+task 13 lines 208-208:  run 0x42::test_m::t2_is_some
+return values: true
+task 14 lines 210-210:  run 0x42::test_m::t1_is_some_specialized
+return values: false
+task 15 lines 212-212:  run 0x42::test_m::t2_is_some_specialized
+return values: true

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_matching.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_enum_matching.move
@@ -1,0 +1,212 @@
+//# publish
+module 0x42::m {
+
+    public enum Inner has drop {
+        Inner1{ x: u64 }
+        Inner2{ x: u64, y: u64 }
+    }
+
+    public struct Box has drop {
+        x: u64
+    }
+
+    public enum Outer has drop {
+        None,
+        One{i: Inner},
+        Two{i: Inner, b: Box},
+    }
+
+    /// Matching with abilities and generics
+    public enum Option<A> has drop {
+        None,
+        Some{value: A}
+    }
+
+    // Common fields
+    public enum CommonFields {
+        Foo{x: u64, y: u64},
+        Bar{z: u64, x: u64}
+    }
+}
+
+//# publish
+module 0x42::test_m {
+    use 0x42::m::Inner;
+    use 0x42::m::Box;
+    use 0x42::m::Outer;
+    use 0x42::m::Option;
+    use 0x42::m::CommonFields;
+
+    /// Simple matching
+    public fun inner_value(i: Inner): u64 {
+        match (i) {
+            Inner1{x} => x,
+            Inner2{x, y} => x + y
+        }
+    }
+
+    /// Matching with wildcard and reference
+    public fun is_inner1(i: &Inner): bool {
+        match (i) {
+            Inner1{x: _} => true,
+            _ => false
+        }
+    }
+
+    /// Matching which delegates ownership
+    public fun outer_value(o: Outer): u64 {
+        match (o) {
+            None => 0,
+            // `i` is moved and consumed by `inner_value`
+            One{i} => inner_value(i),
+            Two{i, b} => inner_value(i) + b.x
+        }
+    }
+
+    /// Nested matching with delegation
+    public fun outer_value_nested(o: Outer): u64 {
+        match (o) {
+            None => 0,
+            // Nested match will require multiple probing steps
+            One{i: Inner::Inner1{x}} => x,
+            One{i} => inner_value(i),
+            Two{i, b} => inner_value(i) + b.x
+        }
+    }
+
+    /// Matching with condition
+    public fun outer_value_with_cond(o: Outer): u64 {
+        match (o) {
+            None => 0,
+            // Match with condition requires probing and conversion from 'Deref(Borrow(x))` to `x`.
+            One{i} if is_inner1(&i) => inner_value(i) % 2,
+            One{i} => inner_value(i),
+            Two{i, b} => inner_value(i) + b.x
+        }
+    }
+
+    /// Matching with condition with references and wildcard
+    public fun outer_value_with_cond_ref(o: &Outer): bool {
+        match (o) {
+            None => false,
+            One{i} if is_inner1(i) => true,
+            One{i} => is_inner1(i),
+            Two{i, b: _} => is_inner1(i)
+        }
+    }
+
+
+    public fun is_some<A>(x: &Option<A>): bool {
+        match (x) {
+            None => false,
+            Some{value: _} => true
+        }
+    }
+
+    public fun is_some_specialized(x: &Option<Option<u64>>): bool {
+        match (x) {
+            None => false,
+            Some{value: Option::None} => false,
+            Some{value: Option::Some{value: _}} => true,
+        }
+    }
+
+    public fun is_some_dropped<A:drop>(x: Option<A>): bool {
+        match (x) {
+            None => false,
+            _ => true
+        }
+    }
+
+
+    fun select_common_fields(s: CommonFields): u64 {
+        s.x + (match (s) { Foo{x: _, y} => y, Bar{z, x: _} => z })
+    }
+
+    // -------------------
+    // Test entry points
+
+    fun t1_is_inner1(): bool {
+        is_inner1(&Inner::Inner1{x: 2})
+    }
+
+    fun t2_is_inner1(): bool {
+        is_inner1(&Inner::Inner2{x: 2, y: 3})
+    }
+
+    fun t1_inner_value(): u64 {
+        inner_value(Inner::Inner2{x: 2, y: 5})
+    }
+
+    fun t1_outer_value(): u64 {
+        outer_value(Outer::None{})
+    }
+
+    fun t2_outer_value(): u64 {
+        outer_value(Outer::One{i: Inner::Inner2{x: 1, y: 2}})
+    }
+
+    fun t3_outer_value(): u64 {
+        outer_value(Outer::Two{i: Inner::Inner1{x: 1}, b: Box{x: 7}})
+    }
+
+    fun t1_outer_value_nested(): u64 {
+        outer_value_nested(Outer::One{i: Inner::Inner1{x: 27}})
+    }
+
+    fun t2_outer_value_nested(): u64 {
+        outer_value_nested(Outer::Two{i: Inner::Inner1{x: 5}, b: Box{x: 7}})
+    }
+
+    fun t1_outer_value_with_cond(): u64 {
+        outer_value_with_cond(Outer::One{i: Inner::Inner1{x: 43}})
+    }
+
+    fun t1_outer_value_with_cond_ref(): bool {
+        outer_value_with_cond_ref(&Outer::One{i: Inner::Inner1{x: 43}})
+    }
+
+    fun t1_is_some(): bool {
+        is_some(&Option::None<u64>{})
+    }
+
+    fun t2_is_some(): bool {
+        is_some(&Option::Some{value: 3})
+    }
+
+    fun t1_is_some_specialized(): bool {
+        is_some_specialized(&Option::Some{value: Option::None{}})
+    }
+
+    fun t2_is_some_specialized(): bool {
+        is_some_specialized(&Option::Some{value: Option::Some{value: 1}})
+    }
+}
+
+//# run 0x42::test_m::t1_is_inner1
+
+//# run 0x42::test_m::t2_is_inner1
+
+//# run 0x42::test_m::t1_inner_value
+
+//# run 0x42::test_m::t1_outer_value
+
+//# run 0x42::test_m::t2_outer_value
+
+//# run 0x42::test_m::t3_outer_value
+
+//# run 0x42::test_m::t1_outer_value_nested
+
+//# run 0x42::test_m::t2_outer_value_nested
+
+//# run 0x42::test_m::t1_outer_value_with_cond
+
+//# run 0x42::test_m::t1_outer_value_with_cond_ref
+
+//# run 0x42::test_m::t1_is_some
+
+//# run 0x42::test_m::t2_is_some
+
+//# run 0x42::test_m::t1_is_some_specialized
+
+//# run 0x42::test_m::t2_is_some_specialized

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_field_access_closure.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_field_access_closure.exp
@@ -1,0 +1,9 @@
+processed 5 tasks
+task 0 lines 1-15:  publish [module 0xc0ffee::m {]
+task 1 lines 17-39:  publish [module 0xc0ffee::m2 {]
+task 2 lines 41-41:  run 0xc0ffee::m2::test1
+return values: 42
+task 3 lines 43-43:  run 0xc0ffee::m2::test2
+return values: 87
+task 4 lines 45-45:  run 0xc0ffee::m2::test3
+return values: 42

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_field_access_closure.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_field_access_closure.move
@@ -1,0 +1,45 @@
+//# publish
+module 0xc0ffee::m {
+    public struct Func1 {
+        bar: ||u64
+     } has copy, drop;
+
+
+    public enum Func2 {
+        V1 { bar: |u64|u64 },
+        V2 { bar: |u64|u64, x: u64 },
+     } has copy, drop;
+
+    public struct Func3(||u64) has copy, drop;
+
+}
+
+//# publish
+module 0xc0ffee::m2 {
+    use 0xc0ffee::m::Func1;
+    use 0xc0ffee::m::Func2;
+    use 0xc0ffee::m::Func3;
+
+    fun test1(): u64 {
+        let f = Func1{ bar: || 42};
+        (f.bar)()
+    }
+
+
+    fun test2(): u64 {
+        let f1 = Func2::V1{ bar: |x| x};
+        let f2 = Func2::V2{ bar: |x| x + 1, x: 44};
+        (f1.bar)(42) + (f2.bar)(f2.x)
+    }
+
+    fun test3(): u64 {
+        let f = Func3(|| 42);
+        (f.0)()
+    }
+}
+
+//# run 0xc0ffee::m2::test1
+
+//# run 0xc0ffee::m2::test2
+
+//# run 0xc0ffee::m2::test3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_freeze_mut_ref.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_freeze_mut_ref.exp
@@ -1,0 +1,7 @@
+processed 6 tasks
+task 0 lines 1-6:  publish [module 0x42::freeze_mut_ref {]
+task 1 lines 8-59:  publish [module 0x42::test_freeze_mut_ref {]
+task 2 lines 61-61:  run 0x42::test_freeze_mut_ref::test_1
+task 3 lines 63-63:  run 0x42::test_freeze_mut_ref::test_2
+task 4 lines 65-65:  run 0x42::test_freeze_mut_ref::test_6
+task 5 lines 67-67:  run 0x42::test_freeze_mut_ref::test_7

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_freeze_mut_ref.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_freeze_mut_ref.move
@@ -1,0 +1,67 @@
+//# publish
+module 0x42::freeze_mut_ref {
+
+    public struct G has drop { f: u64 }
+
+}
+
+//# publish
+module 0x42::test_freeze_mut_ref {
+    use 0x42::freeze_mut_ref::G;
+
+    fun t1(s: &mut G): &G {
+        s
+    }
+
+    public fun t5(s: &mut G): (u64, u64, u64) {
+        let x = 0;
+        let f = { x = x + 1; &mut ({x = x + 1; s}).f };
+        let y = &mut 2;
+        let z: &u64;
+
+        *({*f = 0; z = y; f}) = 2;
+        (*z, *f, x)
+    }
+
+
+    fun test_1() {
+        let x: &u64 = &mut 0;
+        assert!(*x == 0, 0);
+        let g = G {f: 3};
+        let y = t1(&mut g);
+        assert!(y.f == 3, 1);
+    }
+
+    fun test_2() {
+        let para_g = G { f: 50 };
+        let (z, f, x) = t5(&mut para_g);
+        assert!(z == 2, 0);
+        assert!(f == 2, 1);
+        assert!(x == 2, 2);
+    }
+
+
+    fun test_6() {
+        let s1 = G {f: 2};
+        let s2 = G {f: 3};
+        let x;
+        x = if (true) &s1 else &mut s2;
+        assert!(x.f == 2, 0);
+    }
+
+    fun test_7() {
+        let s1 = G {f: 2};
+        let s2 = G {f: 3};
+        let x: &G = if (true) &s1 else &mut s2;
+        assert!(x.f == 2, 0);
+    }
+
+}
+
+//# run 0x42::test_freeze_mut_ref::test_1
+
+//# run 0x42::test_freeze_mut_ref::test_2
+
+//# run 0x42::test_freeze_mut_ref::test_6
+
+//# run 0x42::test_freeze_mut_ref::test_7

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_fv_enum.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_fv_enum.exp
@@ -1,0 +1,6 @@
+processed 5 tasks
+task 0 lines 1-22:  publish [module 0x66::fv_enum_basic {]
+task 1 lines 24-82:  publish [module 0x66::fv_enum_basic_public {]
+task 2 lines 84-84:  run 0x66::fv_enum_basic_public::call_square --args 7
+task 3 lines 86-86:  run 0x66::fv_enum_basic_public::test_enum_in_another_enum
+task 4 lines 88-88:  run 0x66::fv_enum_basic_public::test_fun_vec

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_fv_enum.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_fv_enum.move
@@ -1,0 +1,88 @@
+//# publish
+module 0x66::fv_enum_basic {
+    public enum Action has drop {
+        Noop,
+        Call(|u64|u64),
+    }
+
+    public enum Mapper<T, R> has drop {
+        Id(|T|R has copy + drop + store),
+        Twice(Version<T, R>),
+    }
+
+    public enum Version<T, R> has copy,store, drop {
+        V1 { v1: |T|R has copy + drop + store },
+    }
+
+    public enum FunVec<T> has drop {
+        V1 { v1: vector<|&mut T|T has copy + drop + store> },
+        V2 { v0: u64, v1: vector<|&mut T|T has copy + drop + store> },
+    }
+
+}
+
+//# publish
+module 0x66::fv_enum_basic_public {
+    use 0x66::fv_enum_basic::Action;
+    use 0x66::fv_enum_basic::Mapper;
+    use 0x66::fv_enum_basic::Version;
+    use 0x66::fv_enum_basic::FunVec;
+
+    fun square(x: u64): u64 { x * x }
+
+    fun call_square(x: u64) {
+        let act = Action::Call(square);
+        let v = match (act) {
+            Action::Call(f) => f(x),
+            _ => 0
+        };
+        assert!(v == 49);
+    }
+
+    #[persistent]
+    fun add_k_persistent(x: u64, k: u64): u64 { x + k }
+
+    fun test_enum_in_another_enum() {
+        let k = 3;
+        let add_k: |u64|u64 has copy + drop + store = |x: u64| add_k_persistent(x, k);
+        let v1 = Version::V1 { v1: add_k };
+        let v2 = Mapper::Twice(v1);
+        let v = match (&mut v2) {
+            Mapper::Twice(v1) => (v1.v1)((v1.v1)(10)),
+            Mapper::Id(f)    => (*f)(10),
+        };
+        assert!(v == 16, 99);
+    }
+
+    #[persistent]
+    fun add_k_persistent_ref(x: &mut u64, k: u64): u64 { *x = *x + 1; *x + k }
+
+    fun test_fun_vec() {
+        use std::vector;
+        let k = 3;
+        let add_k: |&mut u64|u64 has copy + store + drop = |x: &mut u64| add_k_persistent_ref(x, k);
+        let v1 = FunVec::V1 { v1: vector[add_k, add_k] };
+        match (v1) {
+            FunVec::V1 { v1 } => {
+                let add = vector::pop_back(&mut v1);
+                let v = 3;
+                let x = add(&mut v);
+                assert!(v == 4, 0);
+                assert!(x == 7, 1);
+                vector::push_back(&mut v1, add);
+                let _m = FunVec::V2 { v0: 10, v1 };
+            }
+            FunVec::V2 { v0: _, v1 } => {
+                vector::destroy_empty(v1);
+                assert!(false, 2);
+            }
+        };
+    }
+
+}
+
+//# run 0x66::fv_enum_basic_public::call_square --args 7
+
+//# run 0x66::fv_enum_basic_public::test_enum_in_another_enum
+
+//# run 0x66::fv_enum_basic_public::test_fun_vec

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_mutate_vector.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_mutate_vector.exp
@@ -1,0 +1,3 @@
+processed 2 tasks
+task 0 lines 1-8:  publish [module 0x42::m {]
+task 1 lines 10-30:  publish [module 0x42::test_m {]

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_mutate_vector.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_mutate_vector.move
@@ -1,0 +1,30 @@
+//# publish
+module 0x42::m {
+
+    public struct Scalar has copy, store, drop {
+        data: vector<u8>
+    }
+
+}
+
+//# publish
+module 0x42::test_m {
+    use std::vector;
+    use 0x42::m::Scalar;
+
+    /// Creates a Scalar from an u8.
+    public fun new_scalar_from_u8(byte: u8): Scalar {
+        let s = scalar_zero();
+        let byte_zero = vector::borrow_mut(&mut s.data, 0);
+        *byte_zero = byte;
+        s
+    }
+
+    /// Returns 0 as a Scalar.
+    public fun scalar_zero(): Scalar {
+        Scalar {
+            data: x"00"
+        }
+    }
+
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested.exp
@@ -1,0 +1,11 @@
+processed 6 tasks
+task 0 lines 1-17:  publish [module 0x42::test {]
+task 1 lines 19-58:  publish [module 0x42::test_nested {]
+task 2 lines 60-60:  run --verbose -- 0x42::test_nested::test1
+return values: 42
+task 3 lines 62-62:  run --verbose -- 0x42::test_nested::test2
+return values: 42
+task 4 lines 64-64:  run --verbose -- 0x42::test_nested::test3
+return values: 43
+task 5 lines 66-66:  run --verbose -- 0x42::test_nested::test4
+return values: 43

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested.move
@@ -1,0 +1,66 @@
+//# publish
+module 0x42::test {
+    public struct S0<A, B>(A, B) has drop;
+
+    public struct S1<A, B> has drop {
+        x: A,
+        y: B
+    }
+
+    public enum E has drop {
+        V1(u8, S1<u8, bool>),
+        V2 {
+            x: u8,
+            y: S0<u8, bool>
+        }
+    }
+}
+
+//# publish
+module 0x42::test_nested {
+    use 0x42::test::E;
+    use 0x42::test::S0;
+    use 0x42::test::S1;
+
+    fun extract_first_u8(x: &E): u8 {
+        match (x) {
+            E::V1(a, ..) => *a,
+            E::V2 { x, .. } => *x,
+        }
+    }
+
+    fun extract_last_u8(x: &E): u8 {
+        match (x) {
+            E::V1(.., S1 { x, ..}) => *x,
+            E::V2 { y: S0(x, ..), .. } => *x,
+        }
+    }
+
+    fun test1(): u8 {
+        let x = E::V1(42, S1 { x: 43, y: true });
+        extract_first_u8(&x)
+    }
+
+    fun test2(): u8 {
+        let x = E::V2 { x: 42, y: S0(43, true) };
+        extract_first_u8(&x)
+    }
+
+    fun test3(): u8 {
+        let x = E::V1(42, S1 { x: 43, y: true });
+        extract_last_u8(&x)
+    }
+
+    fun test4(): u8 {
+        let x = E::V2 { x: 42, y: S0(43, true) };
+        extract_last_u8(&x)
+    }
+}
+
+//# run --verbose -- 0x42::test_nested::test1
+
+//# run --verbose -- 0x42::test_nested::test2
+
+//# run --verbose -- 0x42::test_nested::test3
+
+//# run --verbose -- 0x42::test_nested::test4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested_mutate.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested_mutate.exp
@@ -1,0 +1,4 @@
+processed 3 tasks
+task 0 lines 1-10:  publish [module 0xc0ffee::m {]
+task 1 lines 12-28:  publish [module 0xc0ffee::test_m {]
+task 2 lines 30-30:  run 0xc0ffee::test_m::test

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested_mutate.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_nested_mutate.move
@@ -1,0 +1,30 @@
+//# publish
+module 0xc0ffee::m {
+    public struct S has copy, drop {
+        x: T,
+    }
+
+    public struct T has copy, drop {
+        y: u64,
+    }
+}
+
+//# publish
+module 0xc0ffee::test_m {
+    use 0xc0ffee::m::S;
+    use 0xc0ffee::m::T;
+
+    fun foo(s: S, p: S): S {
+        *&mut {s.x.y = p.x.y; s.x.y} = 1;
+        s
+    }
+
+    public fun test() {
+        let s = S { x: T { y: 42 } };
+        let p = S { x: T { y: 43 } };
+        let result = foo(s, p);
+        assert!(result.x.y == 43, 0);
+    }
+}
+
+//# run 0xc0ffee::test_m::test

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_pack_unpack_ref.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_pack_unpack_ref.exp
@@ -1,0 +1,22 @@
+processed 3 tasks
+task 0 lines 2-14:  publish [module 0x42::pack_unpack_ref {]
+task 1 lines 16-39:  publish [module 0x42::test_pack_unpack_ref {]
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`:
+Error message: none
+   ┌─ TEMPFILE1:23:13
+   │
+23 │         let G{ x1, x2, s  } = &mut g;
+   │             ^^^^^^^^^^^^^^^
+   │
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+
+task 2 lines 41-41:  run  0x42::test_pack_unpack_ref::unpack_ref_G
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_pack_unpack_ref.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_pack_unpack_ref.move
@@ -1,0 +1,41 @@
+// TODO: #18199
+//# publish
+module 0x42::pack_unpack_ref {
+    public struct S has drop {
+        f: u64,
+        g: u64
+    }
+
+    public struct G has drop {
+        x1: u64,
+        x2: u64,
+        s: S,
+    }
+}
+
+//# publish
+module 0x42::test_pack_unpack_ref {
+    use 0x42::pack_unpack_ref::S;
+    use 0x42::pack_unpack_ref::G;
+
+    fun unpack_ref_G() {
+        let s = S {f: 0, g: 1};
+        let g = G {x1: 2, x2: 3, s};
+        let G{ x1, x2, s  } = &mut g;
+        let S {f, g} = s;
+        assert!(*f == 0, 0);
+        assert!(*g == 1, 1);
+        assert!(*x1 == 2, 2);
+        assert!(*x2 == 3, 3);
+        *x1 = *x1 + 1;
+        *x2 = *x2 + 1;
+        *f = *f + 1;
+        *g = *g + 1;
+        assert!(*f == 1, 0);
+        assert!(*g == 2, 1);
+        assert!(*x1 == 3, 2);
+        assert!(*x2 == 4, 3);
+    }
+}
+
+//# run  0x42::test_pack_unpack_ref::unpack_ref_G

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_phantoms.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_phantoms.exp
@@ -1,0 +1,4 @@
+processed 3 tasks
+task 0 lines 1-13:  publish [module 0x42::phantoms {]
+task 1 lines 15-24:  publish [module 0x42::phantoms2 {]
+task 2 lines 27-27:  run 0x42::phantoms2::test_phantoms

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_phantoms.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_phantoms.move
@@ -1,0 +1,27 @@
+//# publish
+module 0x42::phantoms {
+
+
+    /// A struct with a phantom parameter. Even if the parameter is not dropable, the struct should still be.
+    public struct S<phantom T> has drop {
+        addr: address,
+    }
+
+    struct T {} // no abilities
+
+
+}
+
+//# publish
+module 0x42::phantoms2 {
+    use 0x42::phantoms::S;
+    use 0x42::phantoms::T;
+
+    fun test_phantoms() {
+       let _s = S<T>{ addr: @0x12 };
+        // _s is dropped
+    }
+}
+
+
+//# run 0x42::phantoms2::test_phantoms

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_projection.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_projection.exp
@@ -1,0 +1,15 @@
+processed 8 tasks
+task 0 lines 1-9:  publish [module 0x42::test {]
+task 1 lines 11-76:  publish [module 0x42::test_projection {]
+task 2 lines 78-78:  run --verbose -- 0x42::test_projection::test_proj_0
+return values: 42
+task 3 lines 80-80:  run --verbose -- 0x42::test_projection::test_proj_0_ref
+return values: 42
+task 4 lines 82-82:  run --verbose -- 0x42::test_projection::test_proj_2
+return values: true
+task 5 lines 84-84:  run --verbose -- 0x42::test_projection::test_proj_2_ref
+return values: true
+task 6 lines 86-86:  run --verbose -- 0x42::test_projection::test_get_x
+return values: 42
+task 7 lines 88-88:  run --verbose -- 0x42::test_projection::test_get_x_ref
+return values: 42

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_projection.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_projection.move
@@ -1,0 +1,88 @@
+//# publish
+module 0x42::test {
+	public struct S<A, B, C>(A, B, C) has drop;
+
+	public struct T<A, B> has drop {
+		x: A,
+		y: B
+	}
+}
+
+//# publish
+module 0x42::test_projection {
+	use 0x42::test::S;
+	use 0x42::test::T;
+
+
+	fun proj_0<A, B: drop, C: drop>(s: S<A, B, C>): A {
+		let S(x, ..) = s;
+		x
+	}
+
+	fun proj_0_ref<A, B, C>(x: &S<A, B, C>): &A {
+		let S(x, ..) = x;
+		x
+	}
+
+	fun proj_2<A: drop, B: drop, C>(x: S<A, B, C>): C {
+		let S(.., z) = x;
+		z
+	}
+
+	fun proj_2_ref<A, B, C>(x: &S<A, B, C>): &C {
+		let S(.., z) = x;
+		z
+	}
+
+	fun get_x<A, B: drop>(s: T<A, B>): A {
+		let T { x, .. } = s;
+		x
+	}
+
+	fun get_x_ref<A, B>(s: &T<A, B>): &A {
+		let T { x, .. } = s;
+		x
+	}
+
+	fun test_proj_0(): u8 {
+		let x = S(42, @0x1, true);
+		proj_0(x)
+	}
+
+	fun test_proj_0_ref(): u8 {
+		let x = S(42, @0x1, true);
+		*proj_0_ref(&x)
+	}
+
+	fun test_proj_2(): bool {
+		let x = S(42, @0x1, true);
+		proj_2(x)
+	}
+
+	fun test_proj_2_ref(): bool {
+		let x = S(42, @0x1, true);
+		*proj_2_ref(&x)
+	}
+
+	fun test_get_x(): u8 {
+		let x = T{ x: 42, y: true };
+		get_x(x)
+	}
+
+	fun test_get_x_ref(): u8 {
+		let x = T{ x: 42, y: true };
+		*get_x_ref(&x)
+	}
+}
+
+//# run --verbose -- 0x42::test_projection::test_proj_0
+
+//# run --verbose -- 0x42::test_projection::test_proj_0_ref
+
+//# run --verbose -- 0x42::test_projection::test_proj_2
+
+//# run --verbose -- 0x42::test_projection::test_proj_2_ref
+
+//# run --verbose -- 0x42::test_projection::test_get_x
+
+//# run --verbose -- 0x42::test_projection::test_get_x_ref

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_struct_assign_swap.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_struct_assign_swap.exp
@@ -1,0 +1,11 @@
+processed 6 tasks
+task 0 lines 1-7:  publish [module 0xc0ffee::m {]
+task 1 lines 9-45:  publish [module 0xc0ffee::test_m {]
+task 2 lines 47-47:  run 0xc0ffee::test_m::test1
+return values: 2, 1
+task 3 lines 49-49:  run 0xc0ffee::test_m::swap2
+return values: 55, 44
+task 4 lines 51-51:  run 0xc0ffee::test_m::test3
+return values: 2, 1
+task 5 lines 53-53:  run 0xc0ffee::test_m::test4
+return values: 2, 1

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_struct_assign_swap.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/public_struct_assign_swap.move
@@ -1,0 +1,53 @@
+//# publish
+module 0xc0ffee::m {
+    public struct S {
+        f: u32,
+        g: u32,
+    }
+}
+
+//# publish
+module 0xc0ffee::test_m {
+    use 0xc0ffee::m::S;
+    fun swap1(x: u32, y: u32): (u32, u32) {
+        let S { f: x, g: y } = S { f: y, g: x };
+        (x, y)
+    }
+
+    fun swap2(): (u32, u32) {
+        let x = 44;
+        let y = 55;
+        let S { f: _x, g: _y } = S { f: y, g: x };
+        (_x, _y)
+    }
+
+    fun swap3(x: u32, y: u32): (u32, u32) {
+        let S { f: y, g: x } = S { f: x, g: y };
+        (x, y)
+    }
+
+    fun swap4(f: u32, g: u32): (u32, u32) {
+        let S { f: g, g: f } = S { f: f, g: g };
+        (f, g)
+    }
+
+    fun test1(): (u32, u32) {
+        swap1(1, 2)
+    }
+
+    fun test3(): (u32, u32) {
+        swap3(1, 2)
+    }
+
+    fun test4(): (u32, u32) {
+        swap4(1, 2)
+    }
+}
+
+//# run 0xc0ffee::test_m::test1
+
+//# run 0xc0ffee::test_m::swap2
+
+//# run 0xc0ffee::test_m::test3
+
+//# run 0xc0ffee::test_m::test4

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_field_api.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_field_api.exp
@@ -1,0 +1,66 @@
+processed 9 tasks
+task 0 lines 1-4:  publish [module 0x42::m2 {]
+task 1 lines 6-35:  publish [module 0x42::m {]
+task 2 lines 37-93:  publish [module 0x42::m2 {]
+Error: compilation errors:
+ warning: This assignment/binding to the left-hand-side variable `ref_x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_ref_x`), or renaming to `_`
+   ┌─ TEMPFILE2:76:17
+   │
+76 │     let ref_x = &mut_ref_d.x;
+   │                 ^^^^^^^^^^^^
+
+error: cannot perform borrow operation for field `x` for struct `0x42::m::Data4` since it has or may be instantiated with different types in variants
+   ┌─ TEMPFILE2:81:17
+   │
+81 │     let ref_x = &mut_ref_d.x;
+   │                 ^^^^^^^^^^^^
+
+
+task 3 lines 95-95:  run 0x42::m2::test_v1
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 4 lines 97-97:  run 0x42::m2::test_v1_mut_borrow
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 5 lines 99-99:  run 0x42::m2::test_v2_mut_borrow
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 6 lines 101-101:  run 0x42::m2::test_data2_mut_borrow
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 7 lines 103-103:  run 0x42::m2::test_data3_mut_borrow
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 8 lines 105-105:  run 0x42::m2::test_data4_mut_borrow
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_field_api.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_field_api.move
@@ -1,0 +1,105 @@
+//# publish
+module 0x42::m2 {
+
+}
+
+//# publish
+module 0x42::m {
+
+  friend 0x42::m2;
+
+  friend enum Data has drop {
+    V1{x: u64},
+    V2{x: u64, y: bool}
+    V3
+  }
+
+  friend enum Data2<T1, T2> has drop {
+    V1{x: T1},
+    V2{y: u64, x: T2}
+    V3
+  }
+
+  friend enum Data3<T1, T2> has drop {
+    V1{x: T1},
+    V2{y: u64, x: T2}
+    V3{x: T1}
+  }
+
+  friend enum Data4<T1, T2> has drop {
+    V1{x: T1},
+    V2{x: T2, y: u64}
+    V3
+  }
+
+}
+
+//# publish
+module 0x42::m2 {
+
+  use 0x42::m::Data;
+  use 0x42::m::Data2;
+  use 0x42::m::Data3;
+  use 0x42::m::Data4;
+
+  fun test_v1() {
+    let d = Data::V1{x: 43};
+    assert!(d.x == 43, 1);
+    let Data::V1{x} = &d;
+    assert!(*x == 43, 2);
+    let data_x = &mut d;
+    let ref_x = &data_x.x;
+    assert!(*ref_x == 43, 3);
+  }
+
+  fun test_v1_mut_borrow() {
+    let d = Data::V1{x: 43};
+    let r = &mut d.x;
+    *r = 44;
+    assert!(d.x == 44, 1);
+    let r2 = &mut d;
+    r2.x = 45;
+    assert!(d.x == 45, 3);
+  }
+
+  fun test_v2_mut_borrow() {
+    let d = Data::V2{x: 43, y: true};
+    let mut_ref_d = &mut d;
+    let ref_x = &mut_ref_d.x;
+    assert!(*ref_x == 43, 1);
+    let ref_y = &mut_ref_d.y;
+    assert!(*ref_y == true, 2);
+  }
+
+  fun test_data2_mut_borrow() {
+    let d = Data2::V2<u64, u64>{y: 43, x: 44};
+    d.x = 45;
+  }
+
+  fun test_data3_mut_borrow() {
+    let d = Data3::V3<u64, u64>{x: 44};
+    let mut_ref_d = &mut d;
+    let ref_x = &mut_ref_d.x;
+  }
+
+  fun test_data4_mut_borrow() {
+    let d = Data4::V2<u64, u64>{x: 44, y: 43};
+    let mut_ref_d = &mut d;
+    let ref_x = &mut_ref_d.x;
+    assert!(*ref_x == 44, 1);
+  }
+
+
+}
+
+//# run 0x42::m2::test_v1
+
+//# run 0x42::m2::test_v1_mut_borrow
+
+//# run 0x42::m2::test_v2_mut_borrow
+
+//# run 0x42::m2::test_data2_mut_borrow
+
+//# run 0x42::m2::test_data3_mut_borrow
+
+//# run 0x42::m2::test_data4_mut_borrow

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_abort.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_abort.exp
@@ -1,0 +1,11 @@
+processed 3 tasks
+task 0 lines 1-11:  publish [module 0x42::m1 {]
+task 1 lines 13-25:  publish [module 0x42::m2 {]
+task 2 lines 27-27:  run 0x42::m2::test_pack_unpack_abort
+Error: Function execution failed with VMError: {
+    major_status: STRUCT_VARIANT_MISMATCH,
+    sub_status: None,
+    location: 0x42::m1,
+    indices: [],
+    offsets: [(FunctionDefinitionIndex(5), 1)],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_abort.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_abort.move
@@ -1,0 +1,27 @@
+//# publish
+module 0x42::m1 {
+
+
+    public enum Result<T: copy + drop, E: copy +drop> has copy, drop {
+        Ok(T),
+        Err(E)
+    }
+
+
+}
+
+//# publish
+module 0x42::m2 {
+
+    use 0x42::m1::Result;
+
+    public fun test_pack_unpack_abort() {
+        let result = Result::Ok<u64, u64>(42);
+        assert!(result == Result::Ok(42), 1);
+        let Result::Err(err) = result;
+        assert!(err == 42, 2);
+    }
+
+}
+
+//# run 0x42::m2::test_pack_unpack_abort

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_api.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_api.exp
@@ -1,0 +1,7 @@
+processed 6 tasks
+task 0 lines 1-22:  publish [module 0x42::m1 {]
+task 1 lines 24-72:  publish [module 0x42::m2 {]
+task 2 lines 74-74:  run 0x42::m2::test_pack_unpack_result_ok
+task 3 lines 76-76:  run 0x42::m2::test_pack_unpack_result_err
+task 4 lines 78-78:  run 0x42::m2::test_unpack_enum_e
+task 5 lines 80-80:  run 0x42::m2::test_unpack_inner

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_api.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_pack_unpack_api.move
@@ -1,0 +1,80 @@
+//# publish
+module 0x42::m1 {
+
+
+    public enum Result<T: copy + drop, E: copy +drop> has copy, drop {
+        Ok(T),
+        Err(E)
+    }
+
+
+    public enum E has drop {
+        A {x: u64},
+        B {x: u64}
+    }
+
+    public enum Inner {
+        Inner1{ x: u64 }
+        Inner2{ x: u64, y: u64 }
+    }
+
+
+}
+
+//# publish
+module 0x42::m2 {
+
+    use 0x42::m1::Result;
+    use 0x42::m1::E;
+    use 0x42::m1::Inner;
+
+    public fun test_pack_unpack_result_ok() {
+        let result = Result::Ok<u64, u64>(42);
+        assert!(result == Result::Ok(42), 1);
+        let Result::Ok(ok) = result;
+        assert!(ok == 42, 2);
+    }
+
+    public fun test_pack_unpack_result_err() {
+        let result: Result<u64, u8> = Result::Err(7);
+        let Result::Err(err) = result;
+        assert!(err == 7, 3);
+    }
+
+    public fun test_unpack_enum_e() {
+        let a = E::A { x: 100 };
+        let b = E::B { x: 200 };
+
+        let E::A { x } = a;
+        assert!(x == 100, 4);
+
+        let E::B { x: y } = b;
+        assert!(y == 200, 5);
+    }
+
+    public fun test_unpack_inner() {
+        let v1 = Inner::Inner1 { x: 10 };
+        let v2 = Inner::Inner2 { x: 20, y: 30 };
+
+        let val1 = match (v1) {
+            Inner::Inner1 { x } => x,
+            Inner::Inner2 { x, y } => x + y
+        };
+        let val2 = match (v2) {
+            Inner::Inner1 { x } => x,
+            Inner::Inner2 { x, y } => x + y
+        };
+        assert!(val1 == 10, 6);
+        assert!(val2 == 50, 7);
+    }
+
+
+}
+
+//# run 0x42::m2::test_pack_unpack_result_ok
+
+//# run 0x42::m2::test_pack_unpack_result_err
+
+//# run 0x42::m2::test_unpack_enum_e
+
+//# run 0x42::m2::test_unpack_inner

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_variant_test.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_variant_test.exp
@@ -1,0 +1,63 @@
+processed 9 tasks
+task 0 lines 2-5:  publish [module 0x42::m2 {]
+task 1 lines 7-24:  publish [module 0x42::m {]
+task 2 lines 26-77:  publish [module 0x42::m2 {]
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`:
+Error message: none
+   ┌─ TEMPFILE2:61:7
+   │
+61 │       Data2::V2{y, x} if (*y == 43) => {
+   │       ^^^^^^^^^^^^^^^
+   │
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+
+task 3 lines 79-79:  run 0x42::m2::test_v1
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 4 lines 81-81:  run 0x42::m2::test_v1v3
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 5 lines 83-83:  run 0x42::m2::test_v1v3_ref
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 6 lines 85-85:  run 0x42::m2::test_v1_mut_borrow
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 7 lines 87-87:  run 0x42::m2::test_v2_mut_borrow_2
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 8 lines 89-89:  run 0x42::m2::test_match_mut_borrow
+Error: Function execution failed with VMError: {
+    major_status: FUNCTION_RESOLUTION_FAILURE,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_variant_test.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_enum_variant_test.move
@@ -1,0 +1,89 @@
+// TODO: #18199
+//# publish
+module 0x42::m2 {
+
+}
+
+//# publish
+module 0x42::m {
+
+  friend 0x42::m2;
+
+  friend enum Data has drop {
+    V1{x: u64},
+    V2{x: u64, y: bool}
+    V3
+  }
+
+  friend enum Data2 has drop {
+    V1{x: u64},
+    V2{y: u64, x: u64}
+    V3
+  }
+
+}
+
+//# publish
+module 0x42::m2 {
+
+  use 0x42::m::Data;
+  use 0x42::m::Data2;
+
+  fun test_v1(): bool {
+    let d = Data::V1{x: 43};
+    (d is V1) && (&d is V1|V3)
+  }
+
+  fun test_v1v3(): bool {
+    let d = Data::V1{x: 43};
+    let t = (d is V1|V3);
+    let d = Data::V3{};
+    t && (d is V1|V3)
+  }
+
+  fun test_v1v3_ref(): bool {
+    let d = Data::V1{x: 43};
+    let t = (&d is V1|V3);
+    let d = Data::V3{};
+    t && (&mut d is V1|V3)
+  }
+
+  public fun test_v1_mut_borrow() {
+    let d = Data::V1{x: 43};
+    let r = &mut d.x;
+    *r = 44;
+    assert!(d.x == 44, 1);
+  }
+
+  public fun test_v2_mut_borrow_2() {
+    let d = Data2::V2{y: 43, x: 44};
+    let r = &mut d.x;
+    *r = 45;
+    assert!(d.x == 45, 1);
+  }
+
+  public fun test_match_mut_borrow() {
+    let d = Data2::V2{y: 43, x: 44};
+    match (&mut d) {
+      Data2::V2{y, x} if (*y == 43) => {
+        *x = 45;
+        assert!(d.x == 45, 1);
+      },
+      _ => {}
+    }
+  }
+
+
+}
+
+//# run 0x42::m2::test_v1
+
+//# run 0x42::m2::test_v1v3
+
+//# run 0x42::m2::test_v1v3_ref
+
+//# run 0x42::m2::test_v1_mut_borrow
+
+//# run 0x42::m2::test_v2_mut_borrow_2
+
+//# run 0x42::m2::test_match_mut_borrow

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_fv_struct_api.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_fv_struct_api.exp
@@ -1,0 +1,7 @@
+processed 6 tasks
+task 0 lines 1-7:  publish [module 0x42::m1 {]
+task 1 lines 9-47:  publish [module 0x42::m2 {]
+task 2 lines 49-49:  run 0x42::m2::try_direct_assignment_and_call
+task 3 lines 51-51:  run 0x42::m2::try_pass_to_apply
+task 4 lines 53-53:  run 0x42::m2::try_nested_wrapper
+task 5 lines 55-55:  run 0x42::m2::try_unpack_wrapper

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_fv_struct_api.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_fv_struct_api.move
@@ -1,0 +1,55 @@
+//# publish
+module 0x42::m1 {
+    public struct Predicate<T>(|&T| bool) has copy, drop;
+
+    public struct Holder<T>(Predicate<T>) has copy, drop;
+
+}
+
+//# publish
+module 0x42::m2 {
+    use 0x42::m1::Predicate;
+    use 0x42::m1::Holder;
+
+    fun apply_pred(p: Predicate<u64>, val: u64): bool {
+        p(&val)
+    }
+
+    fun apply_holder(h: Holder<u64>, val: u64): bool {
+        let Holder(p) = h;
+        p(&val)
+    }
+
+    fun try_direct_assignment_and_call() {
+        let p: Predicate<u64> = |x| *x < 100;
+        assert!(p(&99), 1);
+        assert!(!p(&101), 2);
+    }
+
+    fun try_pass_to_apply() {
+        let p: Predicate<u64> = |x| *x % 2 == 0;
+        assert!(apply_pred(p, 4), 5);
+        assert!(!apply_pred(p, 5), 6);
+    }
+
+    fun try_nested_wrapper() {
+        let h = Holder(|x| *x == 42);
+        assert!(apply_holder(h, 42), 7);
+        assert!(!apply_holder(h, 99), 8);
+    }
+
+    fun try_unpack_wrapper() {
+        let p: Predicate<u64> = |x| *x != 0;
+        let Predicate(f) = p;
+        assert!(f(&1), 9);
+        assert!(!f(&0), 10);
+    }
+}
+
+//# run 0x42::m2::try_direct_assignment_and_call
+
+//# run 0x42::m2::try_pass_to_apply
+
+//# run 0x42::m2::try_nested_wrapper
+
+//# run 0x42::m2::try_unpack_wrapper

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_field_api.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_field_api.exp
@@ -1,0 +1,78 @@
+processed 10 tasks
+task 0 lines 2-11:  publish [module 0x42::m1 {]
+task 1 lines 13-94:  publish [module 0x42::m2 {]
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`:
+Error message: none
+   ┌─ TEMPFILE1:76:13
+   │
+76 │         let NestedPair(p, w) = &mut np;
+   │             ^^^^^^^^^^^^^^^^
+   │
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+
+task 2 lines 97-97:  run 0x42::m2::test_borrow_pair_fields
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 3 lines 99-99:  run 0x42::m2::test_borrow_wrapper_field
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 4 lines 101-101:  run 0x42::m2::test_borrow_nested_pair_fields
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 5 lines 103-103:  run 0x42::m2::test_borrow_vecwrap_element
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 6 lines 105-105:  run 0x42::m2::test_mut_borrow_pair
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 7 lines 107-107:  run 0x42::m2::test_mut_borrow_vecwrap_element
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 8 lines 109-109:  run 0x42::m2::test_mut_borrow_nestedpair
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 9 lines 111-111:  run 0x42::m2::test_mut_borrow_nestedpair_2
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_field_api.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_field_api.move
@@ -1,0 +1,111 @@
+// TODO: #18199
+//# publish
+module 0x42::m1 {
+    public struct Pair(u64, bool) has copy, drop;
+
+    public struct Wrapper<T: drop>(T) has drop;
+
+    public struct NestedPair<T: drop>(Pair, Wrapper<T>) has drop;
+
+    public struct VecWrap<T: drop>(vector<T>) has drop;
+}
+
+//# publish
+module 0x42::m2 {
+    use 0x42::m1::{Pair, Wrapper, NestedPair, VecWrap};
+
+    public fun test_borrow_pair_fields() {
+        let p = Pair(42, true);
+        let x = &p.0;
+        let y = &p.1;
+        assert!(*x == 42, 0);
+        assert!(*y, 1);
+    }
+
+    public fun test_borrow_wrapper_field() {
+        let w = Wrapper<u64>(100);
+        let inner = &w.0;
+        assert!(*inner == 100, 2);
+    }
+
+    public fun test_borrow_nested_pair_fields() {
+        let p = Pair(1, false);
+        let w = Wrapper<u64>(99);
+        let np = NestedPair<u64>(p, w);
+
+        let inner_pair_0 = &np.0.0;
+        let inner_pair_1 = &np.0.1;
+        let wrapped_val = &np.1.0;
+
+        assert!(*inner_pair_0 == 1, 3);
+        assert!(!*inner_pair_1, 4);
+        assert!(*wrapped_val == 99, 5);
+    }
+
+    public fun test_borrow_vecwrap_element() {
+        let v = VecWrap<u64>(vector[10, 20, 30]);
+        let first = &v.0[0];
+        let second = &v.0[1];
+        assert!(*first == 10, 6);
+        assert!(*second == 20, 7);
+    }
+
+    public fun test_mut_borrow_pair() {
+        let p = Pair(7, false);
+        let r = &mut p;
+        let r0 = &mut r.0;
+        *r0 = 8;
+        assert!(p.0 == 8, 8);
+    }
+
+    public fun test_mut_borrow_vecwrap_element() {
+        let v = VecWrap<u64>(vector[1, 2, 3]);
+        let r = &mut v;
+        let el = &mut r.0[1];
+        *el = 10;
+        assert!(v.0[1] == 10, 9);
+    }
+
+    public fun test_mut_borrow_nestedpair() {
+        let p = Pair(0, true);
+        let w = Wrapper<u64>(77);
+        let np = NestedPair<u64>(p, w);
+        let r = &mut np;
+        let b1 = &mut r.0.0;
+        *b1 = 123;
+        let b2 = &mut r.1.0;
+        *b2 = 456;
+        assert!(np.0.0 == 123, 10);
+        assert!(np.1.0 == 456, 11);
+    }
+
+    public fun test_mut_borrow_nestedpair_2() {
+        let p = Pair(0, true);
+        let w = Wrapper<u64>(77);
+        let np = NestedPair<u64>(p, w);
+        let NestedPair(p, w) = &mut np;
+        let Pair(b1, _) = p;
+        let Wrapper(b2) = w;
+        *b1 = 123;
+        *b2 = 456;
+        assert!(np.0.0 == 123, 10);
+        assert!(np.1.0 == 456, 11);
+    }
+}
+
+
+//# run 0x42::m2::test_borrow_pair_fields
+
+//# run 0x42::m2::test_borrow_wrapper_field
+
+//# run 0x42::m2::test_borrow_nested_pair_fields
+
+//# run 0x42::m2::test_borrow_vecwrap_element
+
+//# run 0x42::m2::test_mut_borrow_pair
+
+//# run 0x42::m2::test_mut_borrow_vecwrap_element
+
+//# run 0x42::m2::test_mut_borrow_nestedpair
+
+//# run 0x42::m2::test_mut_borrow_nestedpair_2

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_pack_unpack_api.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_pack_unpack_api.exp
@@ -1,0 +1,9 @@
+processed 8 tasks
+task 0 lines 1-10:  publish [module 0x42::m1 {]
+task 1 lines 12-69:  publish [module 0x42::m2 {]
+task 2 lines 71-71:  run 0x42::m2::try_pack_unpack_pair
+task 3 lines 73-73:  run 0x42::m2::try_pack_unpack_wrapper
+task 4 lines 75-75:  run 0x42::m2::try_nested_pair_unpack
+task 5 lines 77-77:  run 0x42::m2::try_vecwrap_unpack
+task 6 lines 79-79:  run 0x42::m2::try_unpack_from_return
+task 7 lines 81-81:  run 0x42::m2::try_pass_as_arg

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_pack_unpack_api.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_positional_pack_unpack_api.move
@@ -1,0 +1,81 @@
+//# publish
+module 0x42::m1 {
+    public struct Pair(u64, bool) has copy, drop;
+
+    public struct Wrapper<T: drop>(T) has drop;
+
+    public struct NestedPair<T: drop>(Pair, Wrapper<T>) has drop;
+
+    public struct VecWrap<T: drop>(vector<T>) has drop;
+}
+
+//# publish
+module 0x42::m2 {
+    use 0x42::m1::Pair;
+    use 0x42::m1::Wrapper;
+    use 0x42::m1::NestedPair;
+    use 0x42::m1::VecWrap;
+
+    public fun try_pack_unpack_pair() {
+        let p = Pair(1, true);
+        let Pair(x, y) = p;
+        assert!(x == 1, 1);
+        assert!(y == true, 2);
+    }
+
+    public fun try_pack_unpack_wrapper() {
+        let w = Wrapper(100);
+        let Wrapper(x) = w;
+        assert!(x == 100, 3);
+    }
+
+    public fun try_nested_pair_unpack() {
+        let p = Pair(5, false);
+        let w = Wrapper(vector[42, 43]);
+        let n = NestedPair(p, w);
+        let NestedPair(Pair(a, b), Wrapper(v)) = n;
+        assert!(a == 5, 4);
+        assert!(b == false, 5);
+        assert!(v[1] == 43, 6);
+    }
+
+    public fun try_vecwrap_unpack() {
+        let vw = VecWrap(vector[10, 20, 30]);
+        let VecWrap(v) = vw;
+        assert!(v[0] == 10, 7);
+        assert!(v[2] == 30, 8);
+    }
+
+    public fun try_return_positional(): Pair {
+        Pair(77, false)
+    }
+
+    public fun try_unpack_from_return() {
+        let Pair(x, y) = try_return_positional();
+        assert!(x == 77, 9);
+        assert!(y == false, 10);
+    }
+
+    public fun use_as_param(p: Pair) {
+        let Pair(a, b) = p;
+        assert!(a == 88, 11);
+        assert!(b == true, 12);
+    }
+
+    public fun try_pass_as_arg() {
+        let p = Pair(88, true);
+        use_as_param(p);
+    }
+}
+
+//# run 0x42::m2::try_pack_unpack_pair
+
+//# run 0x42::m2::try_pack_unpack_wrapper
+
+//# run 0x42::m2::try_nested_pair_unpack
+
+//# run 0x42::m2::try_vecwrap_unpack
+
+//# run 0x42::m2::try_unpack_from_return
+
+//# run 0x42::m2::try_pass_as_arg

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_borrow_field_api.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_borrow_field_api.exp
@@ -1,0 +1,62 @@
+processed 8 tasks
+task 0 lines 2-13:  publish [module 0x42::m1 {]
+task 1 lines 15-100:  publish [module 0x42::m2 {]
+Error: compilation errors:
+ bug: bytecode verification failed with unexpected status code `CALL_BORROWED_MUTABLE_REFERENCE_ERROR`:
+Error message: none
+   ┌─ TEMPFILE1:64:13
+   │
+64 │         let S { f, g } = &mut s;
+   │             ^^^^^^^^^^
+   │
+   = please consider reporting this issue (see https://aptos.dev/en/build/smart-contracts/compiler_v2#reporting-an-issue)
+
+
+task 2 lines 102-102:  run 0x42::m2::try_immut_borrow_fields
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 3 lines 104-104:  run 0x42::m2::try_immut_from_mut
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 4 lines 106-106:  run 0x42::m2::try_mut_borrow_seq
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 5 lines 108-108:  run 0x42::m2::try_immut_and_mut_diff_fields
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 6 lines 110-110:  run 0x42::m2::try_reborrow_same_field_seq
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}
+task 7 lines 112-112:  run 0x42::m2::try_unpack_mut_ref
+Error: Function execution failed with VMError: {
+    major_status: LINKER_ERROR,
+    sub_status: None,
+    location: undefined,
+    indices: [],
+    offsets: [],
+}

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_borrow_field_api.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_borrow_field_api.move
@@ -1,0 +1,112 @@
+// TODO: #18199
+//# publish
+module 0x42::m1 {
+
+    public struct S<G: store + drop> has drop {
+        f: u64,
+        g: T<G>
+    }
+
+    public struct T<G: store + drop> has store, copy, drop {
+        h: G
+    }
+}
+
+//# publish
+module 0x42::m2 {
+
+    use 0x42::m1::{S, T};
+
+    public fun try_immut_borrow_fields() {
+        let t = T { h: 100 };
+        let s = S { f: 200, g: t };
+        let f = &s.f;
+        let h = &s.g.h;
+        assert!(*f == 200, 3);
+        assert!(*h == 100, 4);
+    }
+
+    public fun try_immut_from_mut() {
+        let t = T { h: 5 };
+        let s = S { f: 6, g: t };
+        let r = &mut s;
+        let f = &r.f;
+        assert!(*f == 6, 5);
+    }
+
+    public fun try_mut_borrow_seq() {
+        let t = T { h: 1 };
+        let s = S { f: 2, g: t };
+        let f = &mut s.f;
+        *f = *f + 10;
+        let h = &mut s.g.h;
+        *h = *h + 20;
+        assert!(s.f == 12, 7);
+        assert!(s.g.h == 21, 8);
+    }
+
+    public fun try_immut_and_mut_diff_fields() {
+        let t = T { h: 30 };
+        let s = S { f: 40, g: t };
+        let f = &s.f;
+        assert!(*f == 40, 9);
+        let h = &mut s.g.h;
+        *h = *h + 1;
+        assert!(*h == 31, 10);
+    }
+
+    public fun try_reborrow_same_field_seq() {
+        let t = T { h: 9 };
+        let s = S { f: 8, g: t };
+        let f = &mut s.f;
+        *f = 88;
+        let f2 = &mut s.f;
+        *f2 = *f2 + 1;
+        assert!(s.f == 89, 11);
+    }
+
+    public fun try_unpack_mut_ref() {
+        let t = T { h: 9 };
+        let s = S { f: 8, g: t };
+        let S { f, g } = &mut s;
+        *f = 88;
+        g.h = 99;
+        assert!(s.f == 88, 11);
+        assert!(s.g.h == 99, 12);
+        let S { f: _, g } = &mut s;
+        g.h = 100;
+        assert!(g.h == 100, 14);
+        let S { f: _, g: T { h } } = &mut s;
+        *h = 101;
+        assert!(s.g.h == 101, 15);
+        let S { f, g: T { h: _ } } = &mut s;
+        *f = 101;
+        assert!(s.f == 101, 15);
+    }
+
+    public fun try_unpack_ref() {
+        let t = T { h: 9 };
+        let s = S { f: 8, g: t };
+        let S { f, g } = &s;
+        assert!(*f == 8, 11);
+        assert!(g.h == 9, 12);
+        let S { f: _, g } = &s;
+        assert!(g.h == 9, 14);
+        let S { f: _, g: T { h } } = &s;
+        assert!(*h == 9, 15);
+        let S { f, g: T { h: _ } } = &s;
+        assert!(*f == 8, 15);
+    }
+}
+
+//# run 0x42::m2::try_immut_borrow_fields
+
+//# run 0x42::m2::try_immut_from_mut
+
+//# run 0x42::m2::try_mut_borrow_seq
+
+//# run 0x42::m2::try_immut_and_mut_diff_fields
+
+//# run 0x42::m2::try_reborrow_same_field_seq
+
+//# run 0x42::m2::try_unpack_mut_ref

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_pack_unpack_api.exp
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_pack_unpack_api.exp
@@ -1,0 +1,14 @@
+processed 13 tasks
+task 0 lines 1-31:  publish [module 0x42::m1 {]
+task 1 lines 33-42:  publish [module 0x42::m3 {]
+task 2 lines 44-129:  publish [module 0x42::m2 {]
+task 3 lines 131-131:  run 0x42::m2::try_pack
+task 4 lines 133-133:  run 0x42::m2::try_pack_vector
+task 5 lines 135-135:  run 0x42::m2::try_unpack
+task 6 lines 137-137:  run 0x42::m2::try_unpack_with_let_ignore
+task 7 lines 139-139:  run 0x42::m2::try_nested_pack
+task 8 lines 141-141:  run 0x42::m2::try_unpack_nested
+task 9 lines 143-143:  run 0x42::m2::try_return_struct
+task 10 lines 145-145:  run 0x42::m2::try_pass_struct_as_arg
+task 11 lines 147-147:  run 0x42::m2::try_pack_unpack_phantom
+task 12 lines 149-149:  run 0x42::m2::try_pack_S3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_pack_unpack_api.move
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/no-v1-comparison/structs_visibility/test_struct_pack_unpack_api.move
@@ -1,0 +1,149 @@
+//# publish
+module 0x42::m1 {
+
+    public struct S<G: store + drop> has drop {
+        f: u64,
+        g: T<G>
+    }
+
+    public struct T<G: store + drop> has store, copy, drop {
+        h: G
+    }
+
+    public struct V<G: store + drop> has store, copy, drop {
+        items: vector<G>
+    }
+
+    public struct Nested<G: store + copy +drop> has store, copy, drop {
+        inner: T<V<G>>
+    }
+
+    public struct P<phantom T> has drop {
+        p: u64
+    }
+
+    struct Inner<T: store + drop> has drop {
+        t: T
+    }
+
+    public struct NoFields has drop {}
+
+}
+
+//# publish
+module 0x42::m3 {
+    use 0x42::m1::T;
+
+    public struct S<G: store + drop> has drop {
+        f: u64,
+        g: T<G>
+    }
+
+}
+
+//# publish
+module 0x42::m2 {
+
+    use 0x42::m1::{S, T, V, Nested, P, Inner, NoFields};
+    use 0x42::m3::S as S3;
+
+    public fun try_pack_unpack_no_fields() {
+        let no_fields = NoFields {};
+        let NoFields {} = no_fields;
+    }
+
+    public fun try_pack_unpack_phantom() {
+        let p = P<Inner<u64>> { p: 42 };
+        assert!(p.p == 42, 1);
+        let P { p } = p;
+        assert!(p == 42, 4);
+    }
+
+    public fun try_pack() {
+        let t = T { h: 42 };
+        assert!(t.h == 42, 1);
+        let s = S { f: 43, g: t };
+        assert!(s.f == 43, 2);
+    }
+
+    public fun try_pack_vector() {
+        let t = T { h: vector[42] };
+        assert!(t.h[0] == 42, 3);
+    }
+
+    public fun try_unpack() {
+        let s = S { f: 43, g: T { h: 42 } };
+        let S { f, g: T { h } } = s;
+        assert!(f == 43, 4);
+        assert!(h == 42, 5);
+    }
+
+    public fun try_unpack_with_let_ignore() {
+        let s = S { f: 100, g: T { h: 7 } };
+        let S { f, g: _ } = s;
+        assert!(f == 100, 6);
+    }
+
+    public fun try_nested_pack() {
+        let v = V { items: vector[1, 2, 3] };
+        let nested = Nested { inner: T { h: v } };
+        assert!(nested.inner.h.items[2] == 3, 7);
+    }
+
+    public fun try_unpack_nested() {
+        let s = Nested {
+            inner: T { h: V { items: vector[10, 20] } }
+        };
+        let Nested { inner: T { h: V { items } } } = s;
+        assert!(items[0] == 10, 8);
+        assert!(items[1] == 20, 9);
+    }
+
+    public fun return_struct(): S<u64> {
+        S { f: 77, g: T { h: 88 } }
+    }
+
+    public fun try_return_struct() {
+        let s = return_struct();
+        let S { f, g: T { h } } = s;
+        assert!(f == 77, 10);
+        assert!(h == 88, 11);
+    }
+
+    public fun take_struct(s: S<vector<u8>>) {
+        assert!(s.g.h[0] == 255, 12);
+    }
+
+    public fun try_pass_struct_as_arg() {
+        let s = S { f: 1, g: T { h: vector[255] } };
+        take_struct(s);
+    }
+
+    public fun try_pack_S3() {
+        let t = T { h: 42 };
+        assert!(t.h == 42, 1);
+        let s = S3 { f: 43, g: t };
+        assert!(s.f == 43, 13);
+        assert!(s.g.h == 42, 14);
+    }
+}
+
+//# run 0x42::m2::try_pack
+
+//# run 0x42::m2::try_pack_vector
+
+//# run 0x42::m2::try_unpack
+
+//# run 0x42::m2::try_unpack_with_let_ignore
+
+//# run 0x42::m2::try_nested_pack
+
+//# run 0x42::m2::try_unpack_nested
+
+//# run 0x42::m2::try_return_struct
+
+//# run 0x42::m2::try_pass_struct_as_arg
+
+//# run 0x42::m2::try_pack_unpack_phantom
+
+//# run 0x42::m2::try_pack_S3

--- a/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
+++ b/third_party/move/move-compiler-v2/transactional-tests/tests/tests.rs
@@ -40,6 +40,7 @@ const COMMON_EXCLUSIONS: &[&str] = &[
     "/no-access-check/",
     "/no-recursive-type-check/",
     "/testing-constant/",
+    "/structs_visibility/",
 ];
 
 /// Note that any config which has different output for a test directory
@@ -101,7 +102,7 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::OPTIMIZE, true)],
         language_version: LanguageVersion::V1,
         include: &["/operator_eval/"],
-        exclude: &[],
+        exclude: &["/structs_visibility/"],
         cross_compile: false,
     },
     TestConfig {
@@ -110,7 +111,7 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::OPTIMIZE, true)],
         language_version: LanguageVersion::latest(),
         include: &["/operator_eval/"],
-        exclude: &[],
+        exclude: &["/structs_visibility/"],
         cross_compile: true,
     },
     TestConfig {
@@ -119,7 +120,7 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::RECURSIVE_TYPE_CHECK, false)],
         language_version: LanguageVersion::latest(),
         include: &["/no-recursive-check/"],
-        exclude: &[],
+        exclude: &["/structs_visibility/"],
         cross_compile: false,
     },
     TestConfig {
@@ -128,7 +129,7 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::ACCESS_CHECK, false)],
         language_version: LanguageVersion::latest(),
         include: &["/no-access-check/"],
-        exclude: &[],
+        exclude: &["/structs_visibility/"],
         cross_compile: false,
     },
     TestConfig {
@@ -137,6 +138,15 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::RECURSIVE_TYPE_CHECK, false)],
         language_version: LanguageVersion::latest(),
         include: &["/no-recursive-type-check/"],
+        exclude: &["/structs_visibility/"],
+        cross_compile: false,
+    },
+    TestConfig {
+        name: "public-struct",
+        runner: |p| run(p, get_config_by_name("public-struct")),
+        experiments: &[],
+        language_version: LanguageVersion::latest(),
+        include: &["/structs_visibility/"],
         exclude: &[],
         cross_compile: false,
     },
@@ -146,7 +156,7 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::COMPILE_FOR_TESTING, true)],
         language_version: LanguageVersion::latest(),
         include: &["/testing-constant/"],
-        exclude: &[],
+        exclude: &["/structs_visibility/"],
         cross_compile: false,
     },
     TestConfig {
@@ -155,7 +165,7 @@ const TEST_CONFIGS: &[TestConfig] = &[
         experiments: &[(Experiment::COMPILE_FOR_TESTING, false)],
         language_version: LanguageVersion::latest(),
         include: &["/testing-constant/"],
-        exclude: &[],
+        exclude: &["/structs_visibility/"],
         cross_compile: false,
     },
 ];
@@ -181,6 +191,7 @@ const SEPARATE_BASELINE: &[&str] = &[
     "no-v1-comparison/assert_one.move",
     "no-v1-comparison/closures/reentrancy",
     "no-v1-comparison/closures/reentrancy",
+    "no-v1-comparison/structs_visibility/migrated_tests/public_enum_field_select.move",
     "control_flow/for_loop_non_terminating.move",
     "control_flow/for_loop_nested_break.move",
     "evaluation_order/lazy_assert.move",

--- a/third_party/move/move-model/src/builder/module_builder.rs
+++ b/third_party/move/move-model/src/builder/module_builder.rs
@@ -3617,6 +3617,7 @@ impl ModuleBuilder<'_, '_> {
                 is_native: entry.is_native,
                 visibility: entry.visibility,
                 has_package_visibility: self.package_structs.contains(&entry.struct_id),
+                is_empty_struct: entry.is_empty_struct,
             };
             struct_data.insert(StructId::new(name.symbol), data);
             if entry.visibility != Visibility::Private

--- a/third_party/move/move-model/src/ty.rs
+++ b/third_party/move/move-model/src/ty.rs
@@ -1343,6 +1343,11 @@ impl Type {
         }
     }
 
+    /// Wrap the type in a reference
+    pub fn wrap_in_reference(&self, is_mut: bool) -> Type {
+        Type::Reference(ReferenceKind::from_is_mut(is_mut), Box::new(self.clone()))
+    }
+
     /// If this is a reference, return its kind.
     pub fn try_reference_kind(&self) -> Option<ReferenceKind> {
         if let Type::Reference(k, _) = self {

--- a/third_party/move/move-model/src/well_known.rs
+++ b/third_party/move/move-model/src/well_known.rs
@@ -25,6 +25,13 @@ pub fn is_verify_only_attribute_name(s: &str) -> bool {
     s == "verify_only"
 }
 
+// For public struct/enum APIs
+pub const PUBLIC_STRUCT_DELIMITER: &str = "$";
+pub const PACK: &str = "pack";
+pub const UNPACK: &str = "unpack";
+pub const TEST_VARIANT: &str = "test_variant";
+pub const PARAM_NAME_FOR_STRUCT_API: &str = "_s";
+
 pub const VECTOR_MODULE: &str = "vector";
 pub const VECTOR_BORROW_MUT: &str = "vector::borrow_mut";
 pub const EVENT_EMIT_EVENT: &str = "event::emit_event";


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR adds the code generation of public APIs for structs and enums to file format generator.

For structs and enums the following apis are generated:

- `pack$struct[$variant](_field_name: _field_type, ...): struct_type`
-  `unpack$struct[$variant](_s: struct_type): (field_type, ...)`
-  `borrow[_mut]$struct$offset$ty_idx(_s: &[mut] struct_type): &[mut] ty` where `ty_idx` is a unique id for each (offset, ty) pair based on the order when traversing variants.

For enums, test variant api is generated:

- `test_variant$enum$variant(_s: &enum_type): bool`

For a struct with `n` fields, the number of generated functions is 2 + 2 * n;
For an enum with `m` variants and each variant has `n` fields and all fields have separated borrow field functions, the number of generated functions is 3*m + 2 * m * n.

Note that attributes will be added in sub sequent PRs.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

New unit tests, transactional tests and e2e move test cases are added. Note that some cases are generating bytecode verification error due to limitation of current borrow semantics for functions. This will be resolved in subsequent PRs. 

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce compiler support to auto-generate public pack/unpack/borrow/test-variant APIs for structs/enums and route cross-module operations through these APIs, with extensive tests and config updates.
> 
> - **Move Compiler v2**:
>   - **Function generation**: Add generic builders for struct/enum APIs (`pack`, `unpack`, `borrow`/`borrow_mut`, `test_variant`) and invoke them for non-private types.
>   - **Cross-module routing**: Replace direct struct ops with calls to generated APIs (including type-instantiated variants); add helpers to build function instantiations from handles.
>   - **Indices/handles**: Construct function handles for all struct/enum APIs (including per-variant and per-field cases), cache indices, and track variant/field mappings.
>   - **Misc compiler model**: Track empty structs, expose struct names, wrap types in references, add well-known constants for API naming; compute used/called functions for auto-generated APIs.
> - **Tests**:
>   - Add comprehensive file-format and transactional tests for public struct/enum visibility and APIs (pack/unpack, field borrows, variant tests, closures, matching, projections, phantoms); some marked with TODOs for borrow verifier limits.
>   - **E2E**: New Rust tests `public_structs_enums_upgrade` and module registration.
>   - **Test runner**: Introduce `public-struct` config; adjust includes/excludes to isolate `structs_visibility` suite.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b63f7009dae8d7db52ff7f45078402e1ada1e43f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->