### PR TITLE
[qs] introduce BatchInfoExt and BatchSignatureAggregator  enums to support extensible BatchInfo

### DIFF
--- a/consensus/consensus-types/src/opt_proposal_msg.rs
+++ b/consensus/consensus-types/src/opt_proposal_msg.rs
@@ -3,10 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{
-    common::Author,
-    opt_block_data::OptBlockData,
-    proof_of_store::{BatchInfo, ProofCache},
-    sync_info::SyncInfo,
+    common::Author, opt_block_data::OptBlockData, proof_of_store::ProofCache, sync_info::SyncInfo,
 };
 use anyhow::{ensure, Context, Result};
 use aptos_types::validator_verifier::ValidatorVerifier;
@@ -101,7 +98,7 @@ impl OptProposalMsg {
         &self,
         sender: Author,
         validator: &ValidatorVerifier,
-        proof_cache: &ProofCache<BatchInfo>,
+        proof_cache: &ProofCache,
         quorum_store_enabled: bool,
     ) -> Result<()> {
         ensure!(

--- a/consensus/consensus-types/src/payload.rs
+++ b/consensus/consensus-types/src/payload.rs
@@ -1,7 +1,7 @@
 // Copyright (c) Aptos Foundation
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::proof_of_store::{BatchInfo, ProofOfStore};
+use crate::proof_of_store::{BatchInfo, BatchInfoExt, ProofOfStore};
 use anyhow::ensure;
 use aptos_types::{transaction::SignedTransaction, PeerId};
 use core::fmt;
@@ -290,7 +290,7 @@ pub struct OptQuorumStorePayloadV1 {
 }
 
 impl OptQuorumStorePayloadV1 {
-    pub fn get_all_batch_infos(self) -> Vec<BatchInfo> {
+    pub fn get_all_batch_infos(self) -> Vec<BatchInfoExt> {
         let Self {
             inline_batches,
             opt_batches,
@@ -303,6 +303,7 @@ impl OptQuorumStorePayloadV1 {
             .map(|batch| batch.batch_info)
             .chain(opt_batches)
             .chain(proofs.into_iter().map(|proof| proof.info().clone()))
+            .map(|info| info.into())
             .collect()
     }
 

--- a/consensus/consensus-types/src/proposal_msg.rs
+++ b/consensus/consensus-types/src/proposal_msg.rs
@@ -2,12 +2,7 @@
 // Parts of the project are originally copyright © Meta Platforms, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
-use crate::{
-    block::Block,
-    common::Author,
-    proof_of_store::{BatchInfo, ProofCache},
-    sync_info::SyncInfo,
-};
+use crate::{block::Block, common::Author, proof_of_store::ProofCache, sync_info::SyncInfo};
 use anyhow::{anyhow, ensure, format_err, Context, Result};
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::validator_verifier::ValidatorVerifier;
@@ -89,7 +84,7 @@ impl ProposalMsg {
         &self,
         sender: Author,
         validator: &ValidatorVerifier,
-        proof_cache: &ProofCache<BatchInfo>,
+        proof_cache: &ProofCache,
         quorum_store_enabled: bool,
     ) -> Result<()> {
         if let Some(proposal_author) = self.proposal.author() {

--- a/consensus/src/epoch_manager.rs
+++ b/consensus/src/epoch_manager.rs
@@ -66,7 +66,7 @@ use aptos_consensus_types::{
     block_retrieval::BlockRetrievalRequest,
     common::{Author, Round},
     epoch_retrieval::EpochRetrievalRequest,
-    proof_of_store::{BatchInfo, ProofCache},
+    proof_of_store::ProofCache,
     utils::PayloadTxnsSize,
 };
 use aptos_crypto::bls12381::PrivateKey;
@@ -172,7 +172,7 @@ pub struct EpochManager<P: OnChainConfigProvider> {
     dag_config: DagConsensusConfig,
     payload_manager: Arc<dyn TPayloadManager>,
     rand_storage: Arc<dyn RandStorage<AugmentedData>>,
-    proof_cache: ProofCache<BatchInfo>,
+    proof_cache: ProofCache,
     consensus_publisher: Option<Arc<ConsensusPublisher>>,
     pending_blocks: Arc<Mutex<PendingBlocks>>,
     key_storage: PersistentSafetyStorage,

--- a/consensus/src/payload_manager/quorum_store_payload_manager.rs
+++ b/consensus/src/payload_manager/quorum_store_payload_manager.rs
@@ -16,7 +16,7 @@ use aptos_consensus_types::{
     block::Block,
     common::{Author, Payload, ProofWithData},
     payload::{BatchPointer, TDataInfo},
-    proof_of_store::BatchInfo,
+    proof_of_store::{BatchInfo, BatchInfoExt},
 };
 use aptos_crypto::HashValue;
 use aptos_executor_types::*;
@@ -28,7 +28,7 @@ use itertools::Itertools;
 use std::{collections::HashMap, future::Future, ops::Deref, pin::Pin, sync::Arc};
 
 pub trait TQuorumStoreCommitNotifier: Send + Sync {
-    fn notify(&self, block_timestamp: u64, batches: Vec<BatchInfo>);
+    fn notify(&self, block_timestamp: u64, batches: Vec<BatchInfoExt>);
 }
 
 pub struct QuorumStoreCommitNotifier {
@@ -42,7 +42,7 @@ impl QuorumStoreCommitNotifier {
 }
 
 impl TQuorumStoreCommitNotifier for QuorumStoreCommitNotifier {
-    fn notify(&self, block_timestamp: u64, batches: Vec<BatchInfo>) {
+    fn notify(&self, block_timestamp: u64, batches: Vec<BatchInfoExt>) {
         let mut tx = self.coordinator_tx.clone();
 
         if let Err(e) = tx.try_send(CoordinatorCommand::CommitNotification(
@@ -178,24 +178,24 @@ impl TPayloadManager for QuorumStorePayloadManager {
                 Payload::InQuorumStore(proof_with_status) => proof_with_status
                     .proofs
                     .iter()
-                    .map(|proof| proof.info().clone())
+                    .map(|proof| proof.info().clone().into())
                     .collect::<Vec<_>>(),
                 Payload::InQuorumStoreWithLimit(proof_with_status) => proof_with_status
                     .proof_with_data
                     .proofs
                     .iter()
-                    .map(|proof| proof.info().clone())
+                    .map(|proof| proof.info().clone().into())
                     .collect::<Vec<_>>(),
                 Payload::QuorumStoreInlineHybrid(inline_batches, proof_with_data, _)
                 | Payload::QuorumStoreInlineHybridV2(inline_batches, proof_with_data, _) => {
                     inline_batches
                         .iter()
-                        .map(|(batch_info, _)| batch_info.clone())
+                        .map(|(batch_info, _)| batch_info.clone().into())
                         .chain(
                             proof_with_data
                                 .proofs
                                 .iter()
-                                .map(|proof| proof.info().clone()),
+                                .map(|proof| proof.info().clone().into()),
                         )
                         .collect::<Vec<_>>()
                 },

--- a/consensus/src/quorum_store/batch_coordinator.rs
+++ b/consensus/src/quorum_store/batch_coordinator.rs
@@ -93,7 +93,7 @@ impl BatchCoordinator {
                 .iter()
                 .map(|persisted_value| {
                     (
-                        persisted_value.batch_info().clone(),
+                        persisted_value.batch_info().clone().into(),
                         persisted_value.summary(),
                     )
                 })

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -14,7 +14,7 @@ use crate::{
 use aptos_config::config::QuorumStoreConfig;
 use aptos_consensus_types::{
     common::{TransactionInProgress, TransactionSummary},
-    proof_of_store::BatchInfo,
+    proof_of_store::{BatchInfoExt, TBatchInfo},
 };
 use aptos_experimental_runtimes::thread_manager::optimal_min_len;
 use aptos_logger::prelude::*;
@@ -31,7 +31,7 @@ use tokio::time::Interval;
 
 #[derive(Debug)]
 pub enum BatchGeneratorCommand {
-    CommitNotification(u64, Vec<BatchInfo>),
+    CommitNotification(u64, Vec<BatchInfoExt>),
     ProofExpiration(Vec<BatchId>),
     RemoteBatch(Batch),
     Shutdown(tokio::sync::oneshot::Sender<()>),

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -13,17 +13,17 @@ use crate::{
         utils::Timeouts,
     },
 };
-use aptos_consensus_types::{
-    payload::TDataInfo,
-    proof_of_store::{
-        BatchInfo, ProofCache, ProofOfStore, SignedBatchInfo, SignedBatchInfoError,
-        SignedBatchInfoMsg,
-    },
+use aptos_consensus_types::proof_of_store::{
+    BatchInfo, BatchInfoExt, ProofCache, ProofOfStore, SignedBatchInfo, SignedBatchInfoError,
+    SignedBatchInfoMsg, TBatchInfo,
 };
 use aptos_logger::prelude::*;
 use aptos_short_hex_str::AsShortHexStr;
 use aptos_types::{
-    ledger_info::SignatureAggregator, validator_verifier::ValidatorVerifier, PeerId,
+    aggregate_signature::AggregateSignature,
+    ledger_info::{SignatureAggregator, SignatureWithStatus},
+    validator_verifier::{ValidatorVerifier, VerifyError},
+    PeerId,
 };
 use std::{
     collections::{hash_map::Entry, HashMap},
@@ -37,13 +37,69 @@ use tokio::{
 
 #[derive(Debug)]
 pub(crate) enum ProofCoordinatorCommand {
-    AppendSignature(PeerId, SignedBatchInfoMsg<BatchInfo>),
-    CommitNotification(Vec<BatchInfo>),
+    AppendSignature(PeerId, SignedBatchInfoMsg<BatchInfoExt>),
+    CommitNotification(Vec<BatchInfoExt>),
     Shutdown(TokioOneshot::Sender<()>),
 }
 
+enum BatchSignatureAggregator {
+    BatchInfo(SignatureAggregator<BatchInfo>),
+    BatchInfoExt(SignatureAggregator<BatchInfoExt>),
+}
+
+impl BatchSignatureAggregator {
+    pub fn add_signature(&mut self, validator: PeerId, signature: &SignatureWithStatus) {
+        match self {
+            Self::BatchInfo(aggregator) => aggregator.add_signature(validator, signature),
+            Self::BatchInfoExt(aggregator) => aggregator.add_signature(validator, signature),
+        }
+    }
+
+    pub fn all_voters_count(&self) -> usize {
+        match self {
+            Self::BatchInfo(aggregator) => aggregator.all_voters().count(),
+            Self::BatchInfoExt(aggregator) => aggregator.all_voters().count(),
+        }
+    }
+
+    pub fn check_voting_power(
+        &self,
+        verifier: &ValidatorVerifier,
+        check_super_majority: bool,
+    ) -> std::result::Result<u128, VerifyError> {
+        match self {
+            Self::BatchInfo(aggregator) => {
+                aggregator.check_voting_power(verifier, check_super_majority)
+            },
+            Self::BatchInfoExt(aggregator) => {
+                aggregator.check_voting_power(verifier, check_super_majority)
+            },
+        }
+    }
+
+    pub fn aggregate_and_verify(
+        &mut self,
+        verifier: &ValidatorVerifier,
+    ) -> Result<(BatchInfoExt, AggregateSignature), VerifyError> {
+        match self {
+            Self::BatchInfo(aggregator) => {
+                let (batch_info, aggregate_sig) = aggregator.aggregate_and_verify(verifier)?;
+                Ok((batch_info.into(), aggregate_sig))
+            },
+            Self::BatchInfoExt(aggregator) => aggregator.aggregate_and_verify(verifier),
+        }
+    }
+
+    pub fn data(&self) -> BatchInfoExt {
+        match self {
+            Self::BatchInfo(aggregator) => aggregator.data().clone().into(),
+            Self::BatchInfoExt(aggregator) => aggregator.data().clone(),
+        }
+    }
+}
+
 struct IncrementalProofState {
-    signature_aggregator: SignatureAggregator<BatchInfo>,
+    signature_aggregator: BatchSignatureAggregator,
     aggregated_voting_power: u128,
     self_voted: bool,
     completed: bool,
@@ -52,9 +108,9 @@ struct IncrementalProofState {
 }
 
 impl IncrementalProofState {
-    fn new(info: BatchInfo) -> Self {
+    fn new(sig_aggregator: BatchSignatureAggregator) -> Self {
         Self {
-            signature_aggregator: SignatureAggregator::new(info),
+            signature_aggregator: sig_aggregator,
             aggregated_voting_power: 0,
             self_voted: false,
             completed: false,
@@ -62,8 +118,20 @@ impl IncrementalProofState {
         }
     }
 
+    fn new_batch_info(info: BatchInfo) -> Self {
+        Self::new(BatchSignatureAggregator::BatchInfo(
+            SignatureAggregator::new(info),
+        ))
+    }
+
+    fn new_batch_info_ext(info: BatchInfoExt) -> Self {
+        Self::new(BatchSignatureAggregator::BatchInfoExt(
+            SignatureAggregator::new(info),
+        ))
+    }
+
     pub fn voter_count(&self) -> u64 {
-        self.signature_aggregator.all_voters().count() as u64
+        self.signature_aggregator.all_voters_count() as u64
     }
 
     // Returns the aggregated voting power of all signatures include those that are invalid.
@@ -76,12 +144,12 @@ impl IncrementalProofState {
 
     fn add_signature(
         &mut self,
-        signed_batch_info: &SignedBatchInfo<BatchInfo>,
+        signed_batch_info: &SignedBatchInfo<BatchInfoExt>,
         validator_verifier: &ValidatorVerifier,
     ) -> Result<(), SignedBatchInfoError> {
-        if signed_batch_info.batch_info() != self.signature_aggregator.data() {
+        if signed_batch_info.batch_info() != &self.signature_aggregator.data() {
             return Err(SignedBatchInfoError::WrongInfo((
-                signed_batch_info.batch_id().id,
+                signed_batch_info.batch_info().batch_id().id,
                 self.signature_aggregator.data().batch_id().id,
             )));
         }
@@ -138,7 +206,7 @@ impl IncrementalProofState {
     pub fn aggregate_and_verify(
         &mut self,
         validator_verifier: &ValidatorVerifier,
-    ) -> Result<ProofOfStore<BatchInfo>, SignedBatchInfoError> {
+    ) -> Result<ProofOfStore<BatchInfoExt>, SignedBatchInfoError> {
         if self.completed {
             panic!("Cannot call take twice, unexpected issue occurred");
         }
@@ -154,7 +222,7 @@ impl IncrementalProofState {
         }
     }
 
-    pub fn batch_info(&self) -> &BatchInfo {
+    pub fn batch_info(&self) -> BatchInfoExt {
         self.signature_aggregator.data()
     }
 }
@@ -162,13 +230,13 @@ impl IncrementalProofState {
 pub(crate) struct ProofCoordinator {
     peer_id: PeerId,
     proof_timeout_ms: usize,
-    batch_info_to_proof: HashMap<BatchInfo, IncrementalProofState>,
+    batch_info_to_proof: HashMap<BatchInfoExt, IncrementalProofState>,
     // to record the batch creation time
-    batch_info_to_time: HashMap<BatchInfo, Instant>,
-    timeouts: Timeouts<BatchInfo>,
+    batch_info_to_time: HashMap<BatchInfoExt, Instant>,
+    timeouts: Timeouts<BatchInfoExt>,
     batch_reader: Arc<dyn BatchReader>,
     batch_generator_cmd_tx: tokio::sync::mpsc::Sender<BatchGeneratorCommand>,
-    proof_cache: ProofCache<BatchInfo>,
+    proof_cache: ProofCache,
     broadcast_proofs: bool,
     batch_expiry_gap_when_init_usecs: u64,
 }
@@ -180,7 +248,7 @@ impl ProofCoordinator {
         peer_id: PeerId,
         batch_reader: Arc<dyn BatchReader>,
         batch_generator_cmd_tx: tokio::sync::mpsc::Sender<BatchGeneratorCommand>,
-        proof_cache: ProofCache<BatchInfo>,
+        proof_cache: ProofCache,
         broadcast_proofs: bool,
         batch_expiry_gap_when_init_usecs: u64,
     ) -> Self {
@@ -200,7 +268,7 @@ impl ProofCoordinator {
 
     fn init_proof(
         &mut self,
-        signed_batch_info: &SignedBatchInfo<BatchInfo>,
+        signed_batch_info: &SignedBatchInfo<BatchInfoExt>,
     ) -> Result<(), SignedBatchInfoError> {
         // Check if the signed digest corresponding to our batch
         if signed_batch_info.author() != self.peer_id {
@@ -220,7 +288,7 @@ impl ProofCoordinator {
         );
         self.batch_info_to_proof.insert(
             signed_batch_info.batch_info().clone(),
-            IncrementalProofState::new(signed_batch_info.batch_info().clone()),
+            IncrementalProofState::new_batch_info(signed_batch_info.batch_info().info().clone()),
         );
         self.batch_info_to_time
             .entry(signed_batch_info.batch_info().clone())
@@ -235,9 +303,9 @@ impl ProofCoordinator {
 
     fn add_signature(
         &mut self,
-        signed_batch_info: SignedBatchInfo<BatchInfo>,
+        signed_batch_info: SignedBatchInfo<BatchInfoExt>,
         validator_verifier: &ValidatorVerifier,
-    ) -> Result<Option<ProofOfStore<BatchInfo>>, SignedBatchInfoError> {
+    ) -> Result<Option<ProofOfStore<BatchInfoExt>>, SignedBatchInfoError> {
         if !self
             .batch_info_to_proof
             .contains_key(signed_batch_info.batch_info())
@@ -347,7 +415,7 @@ impl ProofCoordinator {
                             for batch in batches {
                                 let digest = batch.digest();
                                 if let Entry::Occupied(existing_proof) = self.batch_info_to_proof.entry(batch.clone()) {
-                                    if batch == *existing_proof.get().batch_info() {
+                                    if batch == existing_proof.get().batch_info() {
                                         let incremental_proof = existing_proof.get();
                                         if incremental_proof.completed {
                                             counters::BATCH_SUCCESSFUL_CREATION.observe(1.0);
@@ -370,7 +438,7 @@ impl ProofCoordinator {
                                 error!("Empty signed batch info received from {}", signer.short_str().as_str());
                                 return;
                             };
-                            let info = signed_batch_info.info().clone();
+                            let info = signed_batch_info.batch_info().clone();
                             let approx_created_ts_usecs = signed_batch_info
                                 .expiration()
                                 .saturating_sub(self.batch_expiry_gap_when_init_usecs);
@@ -388,7 +456,8 @@ impl ProofCoordinator {
                                                 digest = digest,
                                                 batch_id = batch_id.id,
                                             );
-                                            proofs.push(proof);
+                                            let (info, sig) = proof.unpack();
+                                            proofs.push(ProofOfStore::new(info.info().clone(), sig));
                                         }
                                     },
                                     Err(e) => {

--- a/consensus/src/quorum_store/proof_manager.rs
+++ b/consensus/src/quorum_store/proof_manager.rs
@@ -9,7 +9,7 @@ use crate::{
 use aptos_consensus_types::{
     common::{Payload, PayloadFilter, ProofWithData, TxnSummaryWithExpiration},
     payload::{OptQuorumStorePayload, PayloadExecutionLimit},
-    proof_of_store::{BatchInfo, ProofOfStore, ProofOfStoreMsg},
+    proof_of_store::{BatchInfoExt, ProofOfStore, ProofOfStoreMsg},
     request_response::{GetPayloadCommand, GetPayloadResponse},
     utils::PayloadTxnsSize,
 };
@@ -21,9 +21,9 @@ use std::{cmp::min, collections::HashSet, sync::Arc, time::Duration};
 
 #[derive(Debug)]
 pub enum ProofManagerCommand {
-    ReceiveProofs(ProofOfStoreMsg<BatchInfo>),
-    ReceiveBatches(Vec<(BatchInfo, Vec<TxnSummaryWithExpiration>)>),
-    CommitNotification(u64, Vec<BatchInfo>),
+    ReceiveProofs(ProofOfStoreMsg<BatchInfoExt>),
+    ReceiveBatches(Vec<(BatchInfoExt, Vec<TxnSummaryWithExpiration>)>),
+    CommitNotification(u64, Vec<BatchInfoExt>),
     Shutdown(tokio::sync::oneshot::Sender<()>),
 }
 
@@ -62,7 +62,7 @@ impl ProofManager {
         }
     }
 
-    pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore<BatchInfo>>) {
+    pub(crate) fn receive_proofs(&mut self, proofs: Vec<ProofOfStore<BatchInfoExt>>) {
         for proof in proofs.into_iter() {
             self.batch_proof_queue.insert_proof(proof);
         }
@@ -79,7 +79,7 @@ impl ProofManager {
 
     pub(crate) fn receive_batches(
         &mut self,
-        batch_summaries: Vec<(BatchInfo, Vec<TxnSummaryWithExpiration>)>,
+        batch_summaries: Vec<(BatchInfoExt, Vec<TxnSummaryWithExpiration>)>,
     ) {
         self.batch_proof_queue.insert_batches(batch_summaries);
         self.update_remaining_txns_and_proofs();
@@ -88,7 +88,7 @@ impl ProofManager {
     pub(crate) fn handle_commit_notification(
         &mut self,
         block_timestamp: u64,
-        batches: Vec<BatchInfo>,
+        batches: Vec<BatchInfoExt>,
     ) {
         trace!(
             "QS: got clean request from execution at block timestamp {}",
@@ -184,6 +184,23 @@ impl ProofManager {
             };
         counters::NUM_INLINE_BATCHES.observe(inline_block.len() as f64);
         counters::NUM_INLINE_TXNS.observe(inline_block_size.count() as f64);
+
+        // TODO(ibalajiarun): Avoid clones
+        let inline_block: Vec<_> = inline_block
+            .into_iter()
+            .map(|(info, txns)| (info.info().clone(), txns))
+            .collect();
+        let opt_batches: Vec<_> = opt_batches
+            .into_iter()
+            .map(|info| info.info().clone())
+            .collect();
+        let proof_block: Vec<_> = proof_block
+            .into_iter()
+            .map(|proof| {
+                let (info, sig) = proof.unpack();
+                ProofOfStore::new(info.info().clone(), sig)
+            })
+            .collect();
 
         let response = if request.maybe_optqs_payload_pull_params.is_some() {
             let inline_batches = inline_block.into();

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -30,9 +30,7 @@ use crate::{
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{BatchTransactionFilterConfig, QuorumStoreConfig};
 use aptos_consensus_types::{
-    common::Author,
-    proof_of_store::{BatchInfo, ProofCache},
-    request_response::GetPayloadCommand,
+    common::Author, proof_of_store::ProofCache, request_response::GetPayloadCommand,
 };
 use aptos_crypto::bls12381::PrivateKey;
 use aptos_logger::prelude::*;
@@ -134,7 +132,7 @@ pub struct InnerBuilder {
     aptos_db: Arc<dyn DbReader>,
     network_sender: NetworkSender,
     verifier: Arc<ValidatorVerifier>,
-    proof_cache: ProofCache<BatchInfo>,
+    proof_cache: ProofCache,
     coordinator_tx: Sender<CoordinatorCommand>,
     coordinator_rx: Option<Receiver<CoordinatorCommand>>,
     batch_generator_cmd_tx: tokio::sync::mpsc::Sender<BatchGeneratorCommand>,
@@ -170,7 +168,7 @@ impl InnerBuilder {
         aptos_db: Arc<dyn DbReader>,
         network_sender: NetworkSender,
         verifier: Arc<ValidatorVerifier>,
-        proof_cache: ProofCache<BatchInfo>,
+        proof_cache: ProofCache,
         quorum_store_storage: Arc<dyn QuorumStoreStorage>,
         broadcast_proofs: bool,
         consensus_key: Arc<PrivateKey>,

--- a/consensus/src/quorum_store/quorum_store_coordinator.rs
+++ b/consensus/src/quorum_store/quorum_store_coordinator.rs
@@ -10,14 +10,14 @@ use crate::{
     round_manager::VerifiedEvent,
 };
 use aptos_channels::aptos_channel;
-use aptos_consensus_types::{common::Author, proof_of_store::BatchInfo};
+use aptos_consensus_types::{common::Author, proof_of_store::BatchInfoExt};
 use aptos_logger::prelude::*;
 use aptos_types::{account_address::AccountAddress, PeerId};
 use futures::StreamExt;
 use tokio::sync::{mpsc, oneshot};
 
 pub enum CoordinatorCommand {
-    CommitNotification(u64, Vec<BatchInfo>),
+    CommitNotification(u64, Vec<BatchInfoExt>),
     Shutdown(futures_channel::oneshot::Sender<()>),
 }
 

--- a/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
+++ b/consensus/src/quorum_store/tests/batch_proof_queue_test.rs
@@ -6,7 +6,7 @@ use crate::quorum_store::{
 };
 use aptos_consensus_types::{
     common::TxnSummaryWithExpiration,
-    proof_of_store::{BatchInfo, ProofOfStore},
+    proof_of_store::{BatchInfo, BatchInfoExt, ProofOfStore, TBatchInfo},
     utils::PayloadTxnsSize,
 };
 use aptos_crypto::HashValue;
@@ -23,7 +23,7 @@ fn proof_of_store(
     batch_id: BatchId,
     gas_bucket_start: u64,
     expiration: u64,
-) -> ProofOfStore<BatchInfo> {
+) -> ProofOfStore<BatchInfoExt> {
     ProofOfStore::new(
         BatchInfo::new(
             author,
@@ -34,7 +34,8 @@ fn proof_of_store(
             1,
             1,
             gas_bucket_start,
-        ),
+        )
+        .into(),
         AggregateSignature::empty(),
     )
 }
@@ -45,7 +46,7 @@ fn proof_of_store_with_size(
     gas_bucket_start: u64,
     expiration: u64,
     num_txns: u64,
-) -> ProofOfStore<BatchInfo> {
+) -> ProofOfStore<BatchInfoExt> {
     ProofOfStore::new(
         BatchInfo::new(
             author,
@@ -56,7 +57,8 @@ fn proof_of_store_with_size(
             num_txns,
             num_txns,
             gas_bucket_start,
-        ),
+        )
+        .into(),
         AggregateSignature::empty(),
     )
 }
@@ -100,7 +102,7 @@ async fn test_proof_queue_sorting() {
     );
     let mut count_author_0 = 0;
     let mut count_author_1 = 0;
-    let mut prev: Option<&ProofOfStore<BatchInfo>> = None;
+    let mut prev: Option<&ProofOfStore<BatchInfoExt>> = None;
     for batch in &pulled {
         if let Some(prev) = prev {
             assert!(prev.gas_bucket_start() >= batch.gas_bucket_start());
@@ -129,7 +131,7 @@ async fn test_proof_queue_sorting() {
     );
     let mut count_author_0 = 0;
     let mut count_author_1 = 0;
-    let mut prev: Option<&ProofOfStore<BatchInfo>> = None;
+    let mut prev: Option<&ProofOfStore<BatchInfoExt>> = None;
     for batch in &pulled {
         if let Some(prev) = prev {
             assert!(prev.gas_bucket_start() >= batch.gas_bucket_start());

--- a/consensus/src/quorum_store/tests/proof_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/proof_coordinator_test.rs
@@ -74,7 +74,9 @@ async fn test_proof_coordinator_basic() {
     let digest = batch.digest();
 
     for signer in &signers {
-        let signed_batch_info = SignedBatchInfo::new(batch.batch_info().clone(), signer).unwrap();
+        let signed_batch_info = SignedBatchInfo::new(batch.batch_info().clone(), signer)
+            .unwrap()
+            .into();
         assert!(proof_coordinator_tx
             .send(ProofCoordinatorCommand::AppendSignature(
                 signer.author(),
@@ -128,7 +130,8 @@ async fn test_proof_coordinator_with_unverified_signatures() {
         for (signer_index, signer) in signers.iter().enumerate() {
             if signer_index > 2 {
                 let signed_batch_info = SignedBatchInfo::new(batch.batch_info().clone(), signer)
-                    .expect("Failed to create SignedBatchInfo");
+                    .expect("Failed to create SignedBatchInfo")
+                    .into();
                 assert!(proof_coordinator_tx
                     .send(ProofCoordinatorCommand::AppendSignature(
                         signer.author(),
@@ -138,7 +141,7 @@ async fn test_proof_coordinator_with_unverified_signatures() {
                     .is_ok())
             } else {
                 let signed_batch_info =
-                    SignedBatchInfo::dummy(batch.batch_info().clone(), signer.author());
+                    SignedBatchInfo::dummy(batch.batch_info().clone().into(), signer.author());
                 assert!(proof_coordinator_tx
                     .send(ProofCoordinatorCommand::AppendSignature(
                         signer.author(),

--- a/consensus/src/quorum_store/utils.rs
+++ b/consensus/src/quorum_store/utils.rs
@@ -4,7 +4,7 @@
 use crate::monitor;
 use aptos_consensus_types::{
     common::{TransactionInProgress, TransactionSummary},
-    proof_of_store::BatchInfo,
+    proof_of_store::{BatchInfoExt, TBatchInfo},
 };
 use aptos_logger::prelude::*;
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
@@ -154,7 +154,7 @@ pub struct BatchKey {
 }
 
 impl BatchKey {
-    pub fn from_info(info: &BatchInfo) -> Self {
+    pub fn from_info(info: &BatchInfoExt) -> Self {
         Self {
             author: info.author(),
             batch_id: info.batch_id(),
@@ -169,7 +169,7 @@ pub struct BatchSortKey {
 }
 
 impl BatchSortKey {
-    pub fn from_info(info: &BatchInfo) -> Self {
+    pub fn from_info(info: &BatchInfoExt) -> Self {
         Self {
             batch_key: BatchKey::from_info(info),
             gas_bucket_start: info.gas_bucket_start(),

--- a/consensus/src/round_manager_tests/mod.rs
+++ b/consensus/src/round_manager_tests/mod.rs
@@ -43,7 +43,7 @@ use aptos_consensus_types::{
     opt_proposal_msg::OptProposalMsg,
     order_vote_msg::OrderVoteMsg,
     pipeline::commit_decision::CommitDecision,
-    proof_of_store::BatchInfo,
+    proof_of_store::{BatchInfo, BatchInfoExt},
     proposal_msg::ProposalMsg,
     round_timeout::RoundTimeoutMsg,
     utils::PayloadTxnsSize,
@@ -734,7 +734,7 @@ impl NodeSetup {
 struct MockQuorumStoreCommitNotifier;
 
 impl TQuorumStoreCommitNotifier for MockQuorumStoreCommitNotifier {
-    fn notify(&self, _block_timestamp: u64, _batches: Vec<BatchInfo>) {
+    fn notify(&self, _block_timestamp: u64, _batches: Vec<BatchInfoExt>) {
         unimplemented!()
     }
 }


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR introduces `BatchInfoExt` enum that will replace `BatchInfo`.  This should allow easy addition of new fields to `BatchInfo`. Currently, there are two variants: `V1` which is same as BatchInfo and `V2` which includes extra fields to specify `BatchKind::{Normal, Encrypted}`. `Normal` is a normal batch and `Encrypted` is a batch with encrypted transactions. 

When network message is received for `ProofOfStore<BatchInfo>`, it's converted into `ProofOfStore<BatchInfoExt>` and processed internally. Similarly, for `SignedBatchInfo`, `SignedBatchInfo<BatchInfo>` is converted into `SignedBatchInfo<BatchInfoExt>` and processed internally. 

`BatchSignatureAggregator` is an enum based signature aggregator that allows aggregating either `BatchInfo` or `BatchInfoExt` signatures. This is to support signatures sent via `SignedBatchInfo<BatchInfo>` and `SignedBatchInfo<BatchInfoExt>` separately.



