### PR TITLE
[qs] Introduce BatchV2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1003,6 +1003,7 @@ dependencies = [
  "rayon",
  "scopeguard",
  "serde",
+ "serde-name",
  "serde_bytes",
  "serde_json",
  "sha3 0.9.1",
@@ -16863,9 +16864,9 @@ dependencies = [
 
 [[package]]
 name = "serde-name"
-version = "0.1.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12c47087018ec281d1cdab673d36aea22d816b54d498264029c05d5fa1910da6"
+checksum = "3b5b14ebbcc4e4f2b3642fa99c388649da58d1dc3308c7d109f39f565d1710f0"
 dependencies = [
  "serde",
  "thiserror 1.0.69",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -785,7 +785,7 @@ serde_json = { version = "1.0.81", features = [
 ] } # Note: arbitrary_precision is required to parse u256 in JSON
 serde_repr = "0.1"
 serde_merge = "0.1.3"
-serde-name = "0.1.1"
+serde-name = "0.2.1"
 serde-generate = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 serde-reflection = { git = "https://github.com/aptos-labs/serde-reflection", rev = "73b6bbf748334b71ff6d7d09d06a29e3062ca075" }
 serde_with = "3.4.0"

--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -99,6 +99,7 @@ pub struct QuorumStoreConfig {
     pub enable_opt_quorum_store: bool,
     pub opt_qs_minimum_batch_age_usecs: u64,
     pub enable_payload_v2: bool,
+    pub enable_batch_v2: bool,
 }
 
 impl Default for QuorumStoreConfig {
@@ -140,6 +141,7 @@ impl Default for QuorumStoreConfig {
             enable_opt_quorum_store: true,
             opt_qs_minimum_batch_age_usecs: Duration::from_millis(50).as_micros() as u64,
             enable_payload_v2: false,
+            enable_batch_v2: false,
         }
     }
 }

--- a/consensus/Cargo.toml
+++ b/consensus/Cargo.toml
@@ -78,6 +78,7 @@ rand = { workspace = true }
 rayon = { workspace = true }
 scopeguard = { workspace = true }
 serde = { workspace = true }
+serde-name = { workspace = true }
 serde_bytes = { workspace = true }
 serde_json = { workspace = true }
 sha3 = { workspace = true }

--- a/consensus/consensus-types/src/proof_of_store.rs
+++ b/consensus/consensus-types/src/proof_of_store.rs
@@ -203,7 +203,68 @@ pub enum BatchInfoExt {
 }
 
 impl BatchInfoExt {
+    pub fn new_v1(
+        author: PeerId,
+        batch_id: BatchId,
+        epoch: u64,
+        expiration: u64,
+        digest: HashValue,
+        num_txns: u64,
+        num_bytes: u64,
+        gas_bucket_start: u64,
+    ) -> Self {
+        Self::V1 {
+            info: BatchInfo::new(
+                author,
+                batch_id,
+                epoch,
+                expiration,
+                digest,
+                num_txns,
+                num_bytes,
+                gas_bucket_start,
+            ),
+        }
+    }
+
+    pub fn new_v2(
+        author: PeerId,
+        batch_id: BatchId,
+        epoch: u64,
+        expiration: u64,
+        digest: HashValue,
+        num_txns: u64,
+        num_bytes: u64,
+        gas_bucket_start: u64,
+        kind: BatchKind,
+    ) -> Self {
+        Self::V2 {
+            info: BatchInfo::new(
+                author,
+                batch_id,
+                epoch,
+                expiration,
+                digest,
+                num_txns,
+                num_bytes,
+                gas_bucket_start,
+            ),
+            extra: ExtraBatchInfo { batch_kind: kind },
+        }
+    }
+
     pub fn info(&self) -> &BatchInfo {
+        match self {
+            BatchInfoExt::V1 { info } => info,
+            BatchInfoExt::V2 { info, .. } => info,
+        }
+    }
+
+    pub fn is_v2(&self) -> bool {
+        matches!(self, Self::V2 { .. })
+    }
+
+    pub fn unpack_info(self) -> BatchInfo {
         match self {
             BatchInfoExt::V1 { info } => info,
             BatchInfoExt::V2 { info, .. } => info,
@@ -435,6 +496,27 @@ impl From<SignedBatchInfo<BatchInfo>> for SignedBatchInfo<BatchInfoExt> {
             signer,
             signature,
         }
+    }
+}
+
+impl TryFrom<SignedBatchInfo<BatchInfoExt>> for SignedBatchInfo<BatchInfo> {
+    type Error = anyhow::Error;
+
+    fn try_from(signed_batch_info: SignedBatchInfo<BatchInfoExt>) -> Result<Self, Self::Error> {
+        ensure!(
+            matches!(signed_batch_info.batch_info(), &BatchInfoExt::V1 { .. }),
+            "Batch must be V1 type"
+        );
+        let SignedBatchInfo {
+            info,
+            signer,
+            signature,
+        } = signed_batch_info;
+        Ok(Self {
+            info: info.unpack_info(),
+            signer,
+            signature,
+        })
     }
 }
 

--- a/consensus/src/network_interface.rs
+++ b/consensus/src/network_interface.rs
@@ -17,7 +17,7 @@ use aptos_consensus_types::{
     opt_proposal_msg::OptProposalMsg,
     order_vote_msg::OrderVoteMsg,
     pipeline::{commit_decision::CommitDecision, commit_vote::CommitVote},
-    proof_of_store::{BatchInfo, ProofOfStoreMsg, SignedBatchInfoMsg},
+    proof_of_store::{BatchInfo, BatchInfoExt, ProofOfStoreMsg, SignedBatchInfoMsg},
     proposal_msg::ProposalMsg,
     round_timeout::RoundTimeoutMsg,
     sync_info::SyncInfo,
@@ -64,11 +64,11 @@ pub enum ConsensusMsg {
     /// it can save slow machines to quickly confirm the execution result.
     CommitDecisionMsg(Box<CommitDecision>),
     /// Quorum Store: Send a Batch of transactions.
-    BatchMsg(Box<BatchMsg>),
+    BatchMsg(Box<BatchMsg<BatchInfo>>),
     /// Quorum Store: Request the payloads of a completed batch.
     BatchRequestMsg(Box<BatchRequest>),
     /// Quorum Store: Response to the batch request.
-    BatchResponse(Box<Batch>),
+    BatchResponse(Box<Batch<BatchInfo>>),
     /// Quorum Store: Send a signed batch digest. This is a vote for the batch and a promise that
     /// the batch of transactions was received and will be persisted until batch expiration.
     SignedBatchInfo(Box<SignedBatchInfoMsg<BatchInfo>>),
@@ -91,6 +91,13 @@ pub enum ConsensusMsg {
     BlockRetrievalRequest(Box<BlockRetrievalRequest>),
     /// OptProposalMsg contains the optimistic proposal and sync info.
     OptProposalMsg(Box<OptProposalMsg>),
+    /// Quorum Store: Send a Batch of transactions.
+    BatchMsgV2(Box<BatchMsg<BatchInfoExt>>),
+    /// Quorum Store: Send a signed batch digest with BatchInfoExt. This is a vote for the batch and a promise that
+    /// the batch of transactions was received and will be persisted until batch expiration.
+    SignedBatchInfoMsgV2(Box<SignedBatchInfoMsg<BatchInfoExt>>),
+    /// Quorum Store: Broadcast a certified proof of store (a digest that received 2f+1 votes) with BatchInfoExt.
+    ProofOfStoreMsgV2(Box<ProofOfStoreMsg<BatchInfoExt>>),
 }
 
 /// Network type for consensus
@@ -121,6 +128,9 @@ impl ConsensusMsg {
             ConsensusMsg::BatchResponseV2(_) => "BatchResponseV2",
             ConsensusMsg::RoundTimeoutMsg(_) => "RoundTimeoutV2",
             ConsensusMsg::BlockRetrievalRequest(_) => "BlockRetrievalRequest",
+            ConsensusMsg::BatchMsgV2(_) => "BatchMsgV2",
+            ConsensusMsg::SignedBatchInfoMsgV2(_) => "SignedBatchInfoMsgV2",
+            ConsensusMsg::ProofOfStoreMsgV2(_) => "ProofOfStoreMsgV2",
         }
     }
 }

--- a/consensus/src/quorum_store/batch_generator.rs
+++ b/consensus/src/quorum_store/batch_generator.rs
@@ -14,7 +14,7 @@ use crate::{
 use aptos_config::config::QuorumStoreConfig;
 use aptos_consensus_types::{
     common::{TransactionInProgress, TransactionSummary},
-    proof_of_store::{BatchInfoExt, TBatchInfo},
+    proof_of_store::{BatchInfoExt, BatchKind, TBatchInfo},
 };
 use aptos_experimental_runtimes::thread_manager::optimal_min_len;
 use aptos_logger::prelude::*;
@@ -33,7 +33,7 @@ use tokio::time::Interval;
 pub enum BatchGeneratorCommand {
     CommitNotification(u64, Vec<BatchInfoExt>),
     ProofExpiration(Vec<BatchId>),
-    RemoteBatch(Batch),
+    RemoteBatch(Batch<BatchInfoExt>),
     Shutdown(tokio::sync::oneshot::Sender<()>),
 }
 
@@ -175,7 +175,7 @@ impl BatchGenerator {
         txns: Vec<SignedTransaction>,
         expiry_time: u64,
         bucket_start: u64,
-    ) -> Batch {
+    ) -> Batch<BatchInfoExt> {
         let batch_id = self.batch_id;
         self.batch_id.increment();
         self.db
@@ -187,21 +187,35 @@ impl BatchGenerator {
         counters::CREATED_BATCHES_COUNT.inc();
         counters::num_txn_per_batch(bucket_start.to_string().as_str(), txns.len());
 
-        Batch::new(
-            batch_id,
-            txns,
-            self.epoch,
-            expiry_time,
-            self.my_peer_id,
-            bucket_start,
-        )
+        if self.config.enable_batch_v2 {
+            // TODO(ibalajiarun): Specify accurate batch kind
+            let batch_kind = BatchKind::Normal;
+            Batch::new_v2(
+                batch_id,
+                txns,
+                self.epoch,
+                expiry_time,
+                self.my_peer_id,
+                bucket_start,
+                batch_kind,
+            )
+        } else {
+            Batch::new_v1(
+                batch_id,
+                txns,
+                self.epoch,
+                expiry_time,
+                self.my_peer_id,
+                bucket_start,
+            )
+        }
     }
 
     /// Push num_txns from txns into batches. If num_txns is larger than max size, then multiple
     /// batches are pushed.
     fn push_bucket_to_batches(
         &mut self,
-        batches: &mut Vec<Batch>,
+        batches: &mut Vec<Batch<BatchInfoExt>>,
         txns: &mut Vec<SignedTransaction>,
         num_txns_in_bucket: usize,
         expiry_time: u64,
@@ -242,7 +256,7 @@ impl BatchGenerator {
         &mut self,
         pulled_txns: &mut Vec<SignedTransaction>,
         expiry_time: u64,
-    ) -> Vec<Batch> {
+    ) -> Vec<Batch<BatchInfoExt>> {
         // Sort by gas, in descending order. This is a stable sort on existing mempool ordering,
         // so will not reorder accounts or their sequence numbers as long as they have the same gas.
         pulled_txns.sort_by_key(|txn| u64::MAX - txn.gas_unit_price());
@@ -325,7 +339,10 @@ impl BatchGenerator {
         self.txns_in_progress_sorted.len()
     }
 
-    pub(crate) async fn handle_scheduled_pull(&mut self, max_count: u64) -> Vec<Batch> {
+    pub(crate) async fn handle_scheduled_pull(
+        &mut self,
+        max_count: u64,
+    ) -> Vec<Batch<BatchInfoExt>> {
         counters::BATCH_PULL_EXCLUDED_TXNS.observe(self.txns_in_progress_sorted.len() as f64);
         trace!(
             "QS: excluding txs len: {:?}",
@@ -474,7 +491,14 @@ impl BatchGenerator {
                             self.batch_writer.persist(persist_requests);
                             counters::BATCH_CREATION_PERSIST_LATENCY.observe_duration(persist_start.elapsed());
 
-                            network_sender.broadcast_batch_msg(batches).await;
+                            if self.config.enable_batch_v2 {
+                                network_sender.broadcast_batch_msg_v2(batches).await;
+                            } else {
+                                let batches = batches.into_iter().map(|batch| {
+                                    batch.try_into().expect("Cannot send V2 batch with flag disabled")
+                                }).collect();
+                                network_sender.broadcast_batch_msg(batches).await;
+                            }
                         } else if tick_start.elapsed() > interval.period().checked_div(2).unwrap_or(Duration::ZERO) {
                             // If the pull takes too long, it's also accounted as a non-empty pull to avoid pulling too often.
                             last_non_empty_pull = tick_start;

--- a/consensus/src/quorum_store/batch_requester.rs
+++ b/consensus/src/quorum_store/batch_requester.rs
@@ -9,6 +9,7 @@ use crate::{
         types::{BatchRequest, BatchResponse, PersistedValue},
     },
 };
+use aptos_consensus_types::proof_of_store::BatchInfoExt;
 use aptos_crypto::HashValue;
 use aptos_executor_types::*;
 use aptos_infallible::Mutex;
@@ -102,7 +103,7 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
         digest: HashValue,
         expiration: u64,
         responders: Arc<Mutex<BTreeSet<PeerId>>>,
-        mut subscriber_rx: oneshot::Receiver<PersistedValue>,
+        mut subscriber_rx: oneshot::Receiver<PersistedValue<BatchInfoExt>>,
     ) -> ExecutorResult<Vec<SignedTransaction>> {
         let validator_verifier = self.validator_verifier.clone();
         let mut request_state = BatchRequesterState::new(responders, self.retry_limit);
@@ -148,6 +149,9 @@ impl<T: QuorumStoreSender + Sync + 'static> BatchRequester<T> {
                                     debug!("QS: batch request expired, digest:{}", digest);
                                     return Err(ExecutorError::CouldNotGetData);
                                 }
+                            }
+                            Ok(BatchResponse::BatchV2(_)) => {
+                                error!("Batch V2 response is not supported");
                             }
                             Err(e) => {
                                 counters::RECEIVED_BATCH_RESPONSE_ERROR_COUNT.inc();

--- a/consensus/src/quorum_store/batch_store.rs
+++ b/consensus/src/quorum_store/batch_store.rs
@@ -12,7 +12,7 @@ use crate::{
     },
 };
 use anyhow::bail;
-use aptos_consensus_types::proof_of_store::{BatchInfo, SignedBatchInfo};
+use aptos_consensus_types::proof_of_store::{BatchInfo, BatchInfoExt, SignedBatchInfo, TBatchInfo};
 use aptos_crypto::{CryptoMaterialError, HashValue};
 use aptos_executor_types::{ExecutorError, ExecutorResult};
 use aptos_infallible::Mutex;
@@ -113,7 +113,7 @@ impl QuotaManager {
 pub struct BatchStore {
     epoch: OnceCell<u64>,
     last_certified_time: AtomicU64,
-    db_cache: DashMap<HashValue, PersistedValue>,
+    db_cache: DashMap<HashValue, PersistedValue<BatchInfoExt>>,
     peer_quota: DashMap<PeerId, QuotaManager>,
     expirations: Mutex<TimeExpirations<HashValue>>,
     db: Arc<dyn QuorumStoreStorage>,
@@ -121,7 +121,7 @@ pub struct BatchStore {
     db_quota: usize,
     batch_quota: usize,
     validator_signer: ValidatorSigner,
-    persist_subscribers: DashMap<HashValue, Vec<oneshot::Sender<PersistedValue>>>,
+    persist_subscribers: DashMap<HashValue, Vec<oneshot::Sender<PersistedValue<BatchInfoExt>>>>,
     expiration_buffer_usecs: u64,
 }
 
@@ -155,10 +155,18 @@ impl BatchStore {
 
         if is_new_epoch {
             tokio::task::spawn_blocking(move || {
-                Self::gc_previous_epoch_batches_from_db(db_clone, epoch);
+                Self::gc_previous_epoch_batches_from_db_v1(db_clone.clone(), epoch);
+                Self::gc_previous_epoch_batches_from_db_v2(db_clone, epoch);
             });
         } else {
-            Self::populate_cache_and_gc_expired_batches(
+            Self::populate_cache_and_gc_expired_batches_v1(
+                db_clone.clone(),
+                epoch,
+                last_certified_time,
+                expiration_buffer_usecs,
+                &batch_store,
+            );
+            Self::populate_cache_and_gc_expired_batches_v2(
                 db_clone,
                 epoch,
                 last_certified_time,
@@ -170,7 +178,7 @@ impl BatchStore {
         batch_store
     }
 
-    fn gc_previous_epoch_batches_from_db(db: Arc<dyn QuorumStoreStorage>, current_epoch: u64) {
+    fn gc_previous_epoch_batches_from_db_v1(db: Arc<dyn QuorumStoreStorage>, current_epoch: u64) {
         let db_content = db.get_all_batches().expect("failed to read data from db");
         info!(
             epoch = current_epoch,
@@ -201,17 +209,98 @@ impl BatchStore {
             .expect("Deletion of expired keys should not fail");
     }
 
-    fn populate_cache_and_gc_expired_batches(
+    fn gc_previous_epoch_batches_from_db_v2(db: Arc<dyn QuorumStoreStorage>, current_epoch: u64) {
+        let db_content = db
+            .get_all_batches_v2()
+            .expect("failed to read data from db");
+        info!(
+            epoch = current_epoch,
+            "QS: Read batches from storage. Len: {}",
+            db_content.len(),
+        );
+
+        let mut expired_keys = Vec::new();
+        for (digest, value) in db_content {
+            let epoch = value.epoch();
+
+            trace!(
+                "QS: Batchreader recovery content epoch {:?}, digest {}",
+                epoch,
+                digest
+            );
+
+            if epoch < current_epoch {
+                expired_keys.push(digest);
+            }
+        }
+
+        info!(
+            "QS: Batch store bootstrap expired keys len {}",
+            expired_keys.len()
+        );
+        db.delete_batches(expired_keys)
+            .expect("Deletion of expired keys should not fail");
+    }
+
+    fn populate_cache_and_gc_expired_batches_v1(
         db: Arc<dyn QuorumStoreStorage>,
         current_epoch: u64,
         last_certified_time: u64,
         expiration_buffer_usecs: u64,
         batch_store: &BatchStore,
     ) {
-        let db_content = db.get_all_batches().expect("failed to read data from db");
+        let db_content = db
+            .get_all_batches()
+            .expect("failed to read v1 data from db");
         info!(
             epoch = current_epoch,
-            "QS: Read batches from storage. Len: {}, Last Cerified Time: {}",
+            "QS: Read v1 batches from storage. Len: {}, Last Cerified Time: {}",
+            db_content.len(),
+            last_certified_time
+        );
+
+        let mut expired_keys = Vec::new();
+        for (digest, value) in db_content {
+            let expiration = value.expiration().saturating_sub(expiration_buffer_usecs);
+
+            trace!(
+                "QS: Batchreader recovery content exp {:?}, digest {}",
+                expiration,
+                digest
+            );
+
+            if last_certified_time >= expiration {
+                expired_keys.push(digest);
+            } else {
+                batch_store
+                    .insert_to_cache(&value.into())
+                    .expect("Storage limit exceeded upon BatchReader construction");
+            }
+        }
+
+        info!(
+            "QS: Batch store bootstrap expired keys len {}",
+            expired_keys.len()
+        );
+        tokio::task::spawn_blocking(move || {
+            db.delete_batches(expired_keys)
+                .expect("Deletion of expired keys should not fail");
+        });
+    }
+
+    fn populate_cache_and_gc_expired_batches_v2(
+        db: Arc<dyn QuorumStoreStorage>,
+        current_epoch: u64,
+        last_certified_time: u64,
+        expiration_buffer_usecs: u64,
+        batch_store: &BatchStore,
+    ) {
+        let db_content = db
+            .get_all_batches_v2()
+            .expect("failed to read v1 data from db");
+        info!(
+            epoch = current_epoch,
+            "QS: Read v1 batches from storage. Len: {}, Last Cerified Time: {}",
             db_content.len(),
             last_certified_time
         );
@@ -240,7 +329,7 @@ impl BatchStore {
             expired_keys.len()
         );
         tokio::task::spawn_blocking(move || {
-            db.delete_batches(expired_keys)
+            db.delete_batches_v2(expired_keys)
                 .expect("Deletion of expired keys should not fail");
         });
     }
@@ -249,7 +338,7 @@ impl BatchStore {
         *self.epoch.get().expect("Epoch should always be set")
     }
 
-    fn free_quota(&self, value: PersistedValue) {
+    fn free_quota(&self, value: PersistedValue<BatchInfoExt>) {
         let mut quota_manager = self
             .peer_quota
             .get_mut(&value.author())
@@ -265,7 +354,10 @@ impl BatchStore {
     // Note: holds db_cache entry lock (due to DashMap), while accessing peer_quota
     // DashMap. Hence, peer_quota reference should never be held while accessing the
     // db_cache to avoid the deadlock (if needed, order is db_cache, then peer_quota).
-    pub(crate) fn insert_to_cache(&self, value: &PersistedValue) -> anyhow::Result<bool> {
+    pub(crate) fn insert_to_cache(
+        &self,
+        value: &PersistedValue<BatchInfoExt>,
+    ) -> anyhow::Result<bool> {
         let digest = *value.digest();
         let author = value.author();
         let expiration_time = value.expiration();
@@ -323,7 +415,7 @@ impl BatchStore {
         Ok(true)
     }
 
-    pub(crate) fn save(&self, value: &PersistedValue) -> anyhow::Result<bool> {
+    pub(crate) fn save(&self, value: &PersistedValue<BatchInfoExt>) -> anyhow::Result<bool> {
         let last_certified_time = self.last_certified_time();
         if value.expiration() > last_certified_time {
             fail_point!("quorum_store::save", |_| {
@@ -378,10 +470,10 @@ impl BatchStore {
         ret
     }
 
-    fn generate_signed_batch_info(
+    fn generate_signed_batch_info<T: TBatchInfo>(
         &self,
-        batch_info: BatchInfo,
-    ) -> Result<SignedBatchInfo<BatchInfo>, CryptoMaterialError> {
+        batch_info: T,
+    ) -> Result<SignedBatchInfo<T>, CryptoMaterialError> {
         fail_point!("quorum_store::create_invalid_signed_batch_info", |_| {
             Ok(SignedBatchInfo::new_with_signature(
                 batch_info.clone(),
@@ -392,20 +484,41 @@ impl BatchStore {
         SignedBatchInfo::new(batch_info, &self.validator_signer)
     }
 
-    fn persist_inner(&self, persist_request: PersistedValue) -> Option<SignedBatchInfo<BatchInfo>> {
+    fn persist_inner(
+        &self,
+        batch_info: BatchInfoExt,
+        persist_request: PersistedValue<BatchInfoExt>,
+    ) -> Option<SignedBatchInfo<BatchInfoExt>> {
+        assert!(
+            &batch_info == persist_request.batch_info(),
+            "Provided batch info doesn't match persist request batch info"
+        );
         match self.save(&persist_request) {
             Ok(needs_db) => {
-                let batch_info = persist_request.batch_info().clone();
                 trace!("QS: sign digest {}", persist_request.digest());
                 if needs_db {
-                    #[allow(clippy::unwrap_in_result)]
-                    self.db
-                        .save_batch(persist_request)
-                        .expect("Could not write to DB");
+                    if !batch_info.is_v2() {
+                        let persist_request =
+                            persist_request.try_into().expect("Must be a V1 batch");
+                        #[allow(clippy::unwrap_in_result)]
+                        self.db
+                            .save_batch(persist_request)
+                            .expect("Could not write to DB");
+                    } else {
+                        #[allow(clippy::unwrap_in_result)]
+                        self.db
+                            .save_batch_v2(persist_request)
+                            .expect("Could not write to DB")
+                    }
                 }
-                self.generate_signed_batch_info(batch_info).ok()
+                if !batch_info.is_v2() {
+                    self.generate_signed_batch_info(batch_info.info().clone())
+                        .ok()
+                        .map(|inner| inner.into())
+                } else {
+                    self.generate_signed_batch_info(batch_info).ok()
+                }
             },
-
             Err(e) => {
                 debug!("QS: failed to store to cache {:?}", e);
                 None
@@ -428,25 +541,39 @@ impl BatchStore {
         self.last_certified_time.load(Ordering::Relaxed)
     }
 
-    fn get_batch_from_db(&self, digest: &HashValue) -> ExecutorResult<PersistedValue> {
+    fn get_batch_from_db(
+        &self,
+        digest: &HashValue,
+        is_v2: bool,
+    ) -> ExecutorResult<PersistedValue<BatchInfoExt>> {
         counters::GET_BATCH_FROM_DB_COUNT.inc();
 
-        match self.db.get_batch(digest) {
-            Ok(Some(value)) => Ok(value),
-            Ok(None) | Err(_) => {
-                warn!("Could not get batch from db");
-                Err(ExecutorError::CouldNotGetData)
-            },
+        if is_v2 {
+            match self.db.get_batch_v2(digest) {
+                Ok(Some(value)) => Ok(value),
+                Ok(None) | Err(_) => {
+                    warn!("Could not get batch from db");
+                    Err(ExecutorError::CouldNotGetData)
+                },
+            }
+        } else {
+            match self.db.get_batch(digest) {
+                Ok(Some(value)) => Ok(value.into()),
+                Ok(None) | Err(_) => {
+                    warn!("Could not get batch from db");
+                    Err(ExecutorError::CouldNotGetData)
+                },
+            }
         }
     }
 
     pub(crate) fn get_batch_from_local(
         &self,
         digest: &HashValue,
-    ) -> ExecutorResult<PersistedValue> {
+    ) -> ExecutorResult<PersistedValue<BatchInfoExt>> {
         if let Some(value) = self.db_cache.get(digest) {
             if value.payload_storage_mode() == StorageMode::PersistedOnly {
-                self.get_batch_from_db(digest)
+                self.get_batch_from_db(digest, value.batch_info().is_v2())
             } else {
                 // Available in memory.
                 Ok(value.clone())
@@ -460,7 +587,7 @@ impl BatchStore {
     /// This can be useful in cases where there are multiple flows to add a batch (like
     /// direct from author batch / batch requester fetch) to the batch store and either
     /// flow needs to subscribe to the other.
-    fn subscribe(&self, digest: HashValue) -> oneshot::Receiver<PersistedValue> {
+    fn subscribe(&self, digest: HashValue) -> oneshot::Receiver<PersistedValue<BatchInfoExt>> {
         let (tx, rx) = oneshot::channel();
         self.persist_subscribers.entry(digest).or_default().push(tx);
 
@@ -473,7 +600,7 @@ impl BatchStore {
         rx
     }
 
-    fn notify_subscribers(&self, value: PersistedValue) {
+    fn notify_subscribers(&self, value: PersistedValue<BatchInfoExt>) {
         if let Some((_, subscribers)) = self.persist_subscribers.remove(value.digest()) {
             for subscriber in subscribers {
                 subscriber.send(value.clone()).ok();
@@ -483,10 +610,14 @@ impl BatchStore {
 }
 
 impl BatchWriter for BatchStore {
-    fn persist(&self, persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo<BatchInfo>> {
+    fn persist(
+        &self,
+        persist_requests: Vec<PersistedValue<BatchInfoExt>>,
+    ) -> Vec<SignedBatchInfo<BatchInfoExt>> {
         let mut signed_infos = vec![];
         for persist_request in persist_requests.into_iter() {
-            if let Some(signed_info) = self.persist_inner(persist_request.clone()) {
+            let batch_info = persist_request.batch_info().clone();
+            if let Some(signed_info) = self.persist_inner(batch_info, persist_request.clone()) {
                 self.notify_subscribers(persist_request);
                 signed_infos.push(signed_info);
             }
@@ -554,6 +685,7 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchReaderImpl<T> {
                     defer!({
                         inflight_requests_clone.lock().remove(&batch_digest);
                     });
+                    // TODO(ibalajiarun): Support V2 batch
                     if let Ok(mut value) = batch_store.get_batch_from_local(&batch_digest) {
                         Ok(value.take_payload().expect("Must have payload"))
                     } else {
@@ -568,8 +700,10 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchReaderImpl<T> {
                                 subscriber_rx,
                             )
                             .await?;
-                        batch_store
-                            .persist(vec![PersistedValue::new(batch_info, Some(payload.clone()))]);
+                        batch_store.persist(vec![PersistedValue::new(
+                            batch_info.into(),
+                            Some(payload.clone()),
+                        )]);
                         Ok(payload)
                     }
                 }
@@ -610,5 +744,8 @@ impl<T: QuorumStoreSender + Clone + Send + Sync + 'static> BatchReader for Batch
 }
 
 pub trait BatchWriter: Send + Sync {
-    fn persist(&self, persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo<BatchInfo>>;
+    fn persist(
+        &self,
+        persist_requests: Vec<PersistedValue<BatchInfoExt>>,
+    ) -> Vec<SignedBatchInfo<BatchInfoExt>>;
 }

--- a/consensus/src/quorum_store/proof_coordinator.rs
+++ b/consensus/src/quorum_store/proof_coordinator.rs
@@ -286,10 +286,19 @@ impl ProofCoordinator {
             signed_batch_info.batch_info().clone(),
             self.proof_timeout_ms,
         );
-        self.batch_info_to_proof.insert(
-            signed_batch_info.batch_info().clone(),
-            IncrementalProofState::new_batch_info(signed_batch_info.batch_info().info().clone()),
-        );
+        if signed_batch_info.batch_info().is_v2() {
+            self.batch_info_to_proof.insert(
+                signed_batch_info.batch_info().clone(),
+                IncrementalProofState::new_batch_info_ext(signed_batch_info.batch_info().clone()),
+            );
+        } else {
+            self.batch_info_to_proof.insert(
+                signed_batch_info.batch_info().clone(),
+                IncrementalProofState::new_batch_info(
+                    signed_batch_info.batch_info().info().clone(),
+                ),
+            );
+        }
         self.batch_info_to_time
             .entry(signed_batch_info.batch_info().clone())
             .or_insert(Instant::now());
@@ -442,24 +451,23 @@ impl ProofCoordinator {
                             let approx_created_ts_usecs = signed_batch_info
                                 .expiration()
                                 .saturating_sub(self.batch_expiry_gap_when_init_usecs);
+                            let self_peer_id = self.peer_id;
+                            let enable_broadcast_proofs = self.broadcast_proofs;
 
-                            let mut proofs = vec![];
-                            for signed_batch_info in signed_batch_infos.into_iter() {
+                            let mut proofs_iter = signed_batch_infos.into_iter().filter_map(|signed_batch_info| {
                                 let peer_id = signed_batch_info.signer();
                                 let digest = *signed_batch_info.digest();
                                 let batch_id = signed_batch_info.batch_id();
                                 match self.add_signature(signed_batch_info, &validator_verifier) {
-                                    Ok(result) => {
-                                        if let Some(proof) = result {
-                                            debug!(
-                                                LogSchema::new(LogEvent::ProofOfStoreReady),
-                                                digest = digest,
-                                                batch_id = batch_id.id,
-                                            );
-                                            let (info, sig) = proof.unpack();
-                                            proofs.push(ProofOfStore::new(info.info().clone(), sig));
-                                        }
+                                    Ok(Some(proof)) => {
+                                        debug!(
+                                            LogSchema::new(LogEvent::ProofOfStoreReady),
+                                            digest = digest,
+                                            batch_id = batch_id.id,
+                                        );
+                                        Some(proof)
                                     },
+                                    Ok(None) => None,
                                     Err(e) => {
                                         // Can happen if we already garbage collected, the commit notification is late, or the peer is misbehaving.
                                         if peer_id == self.peer_id {
@@ -467,19 +475,30 @@ impl ProofCoordinator {
                                         } else {
                                             debug!("QS: could not add signature from peer {}, digest = {}, batch_id = {}, err = {:?}", peer_id, digest, batch_id, e);
                                         }
+                                        None
                                     },
+                                }
+                            }).peekable();
+                            if proofs_iter.peek().is_some() {
+                                observe_batch(approx_created_ts_usecs, self_peer_id, BatchStage::POS_FORMED);
+                                if enable_broadcast_proofs {
+                                    if proofs_iter.peek().is_some_and(|p| p.info().is_v2()) {
+                                        let proofs: Vec<_> = proofs_iter.collect();
+                                        network_sender.broadcast_proof_of_store_msg_v2(proofs).await;
+                                    } else {
+                                        let proofs: Vec<_> = proofs_iter.map(|proof| {
+                                            let (info, sig) = proof.unpack();
+                                            ProofOfStore::new(info.info().clone(), sig)
+                                        }).collect();
+                                        network_sender.broadcast_proof_of_store_msg(proofs).await;
+                                    }
+                                } else {
+                                    let proofs: Vec<_> = proofs_iter.collect();
+                                    network_sender.send_proof_of_store_msg_to_self(proofs).await;
                                 }
                             }
                             if let Some(value) = self.batch_info_to_proof.get_mut(&info) {
                                 value.observe_voting_pct(approx_created_ts_usecs, &validator_verifier);
-                            }
-                            if !proofs.is_empty() {
-                                observe_batch(approx_created_ts_usecs, self.peer_id, BatchStage::POS_FORMED);
-                                if self.broadcast_proofs {
-                                    network_sender.broadcast_proof_of_store_msg(proofs).await;
-                                } else {
-                                    network_sender.send_proof_of_store_msg_to_self(proofs).await;
-                                }
                             }
                         },
                     }

--- a/consensus/src/quorum_store/quorum_store_builder.rs
+++ b/consensus/src/quorum_store/quorum_store_builder.rs
@@ -30,7 +30,9 @@ use crate::{
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};
 use aptos_config::config::{BatchTransactionFilterConfig, QuorumStoreConfig};
 use aptos_consensus_types::{
-    common::Author, proof_of_store::ProofCache, request_response::GetPayloadCommand,
+    common::Author,
+    proof_of_store::{BatchInfo, BatchInfoExt, ProofCache},
+    request_response::GetPayloadCommand,
 };
 use aptos_crypto::bls12381::PrivateKey;
 use aptos_logger::prelude::*;
@@ -406,7 +408,10 @@ impl InnerBuilder {
                 let response = if let Ok(value) =
                     batch_store.get_batch_from_local(&rpc_request.req.digest())
                 {
-                    let batch: Batch = value.try_into().unwrap();
+                    let batch: Batch<BatchInfoExt> = value.try_into().unwrap();
+                    let batch: Batch<BatchInfo> = batch
+                        .try_into()
+                        .expect("Batch retieval requests must be for V1 batch");
                     BatchResponse::Batch(batch)
                 } else {
                     match aptos_db_clone.get_latest_ledger_info() {

--- a/consensus/src/quorum_store/schema.rs
+++ b/consensus/src/quorum_store/schema.rs
@@ -3,6 +3,7 @@
 
 use crate::quorum_store::types::PersistedValue;
 use anyhow::Result;
+use aptos_consensus_types::proof_of_store::{BatchInfo, BatchInfoExt};
 use aptos_crypto::HashValue;
 use aptos_schemadb::{
     schema::{KeyCodec, Schema, ValueCodec},
@@ -12,13 +13,14 @@ use aptos_types::quorum_store::BatchId;
 
 pub(crate) const BATCH_CF_NAME: ColumnFamilyName = "batch";
 pub(crate) const BATCH_ID_CF_NAME: ColumnFamilyName = "batch_ID";
+pub(crate) const BATCH_V2_CF_NAME: ColumnFamilyName = "batch_v2";
 
 #[derive(Debug)]
 pub(crate) struct BatchSchema;
 
 impl Schema for BatchSchema {
     type Key = HashValue;
-    type Value = PersistedValue;
+    type Value = PersistedValue<BatchInfo>;
 
     const COLUMN_FAMILY_NAME: aptos_schemadb::ColumnFamilyName = BATCH_CF_NAME;
 }
@@ -33,7 +35,37 @@ impl KeyCodec<BatchSchema> for HashValue {
     }
 }
 
-impl ValueCodec<BatchSchema> for PersistedValue {
+impl ValueCodec<BatchSchema> for PersistedValue<BatchInfo> {
+    fn encode_value(&self) -> Result<Vec<u8>> {
+        Ok(bcs::to_bytes(&self)?)
+    }
+
+    fn decode_value(data: &[u8]) -> Result<Self> {
+        Ok(bcs::from_bytes(data)?)
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct BatchV2Schema;
+
+impl Schema for BatchV2Schema {
+    type Key = HashValue;
+    type Value = PersistedValue<BatchInfoExt>;
+
+    const COLUMN_FAMILY_NAME: aptos_schemadb::ColumnFamilyName = BATCH_V2_CF_NAME;
+}
+
+impl KeyCodec<BatchV2Schema> for HashValue {
+    fn encode_key(&self) -> Result<Vec<u8>> {
+        Ok(self.to_vec())
+    }
+
+    fn decode_key(data: &[u8]) -> Result<Self> {
+        Ok(HashValue::from_slice(data)?)
+    }
+}
+
+impl ValueCodec<BatchV2Schema> for PersistedValue<BatchInfoExt> {
     fn encode_value(&self) -> Result<Vec<u8>> {
         Ok(bcs::to_bytes(&self)?)
     }

--- a/consensus/src/quorum_store/tests/batch_coordinator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_coordinator_test.rs
@@ -51,7 +51,7 @@ async fn test_handle_batches_msg_filter_disabled() {
     // Create a single batch with some transactions
     let transactions = create_signed_transactions(10);
     let account_address = AccountAddress::random();
-    let batch = Batch::new(
+    let batch = Batch::new_v1(
         BatchId::new_for_test(100),
         transactions.clone(),
         1,
@@ -101,7 +101,7 @@ async fn test_handle_batches_msg_filter_enabled() {
 
     // Create a single batch
     let account_address = AccountAddress::random();
-    let batch = Batch::new(
+    let batch = Batch::new_v1(
         BatchId::new_for_test(109),
         transactions.clone(),
         1,

--- a/consensus/src/quorum_store/tests/batch_generator_test.rs
+++ b/consensus/src/quorum_store/tests/batch_generator_test.rs
@@ -14,7 +14,7 @@ use crate::{
 use aptos_config::config::QuorumStoreConfig;
 use aptos_consensus_types::{
     common::{TransactionInProgress, TransactionSummary},
-    proof_of_store::{BatchInfo, SignedBatchInfo},
+    proof_of_store::{BatchInfoExt, SignedBatchInfo, TBatchInfo},
 };
 use aptos_mempool::{QuorumStoreRequest, QuorumStoreResponse};
 use aptos_types::{quorum_store::BatchId, transaction::SignedTransaction};
@@ -35,7 +35,10 @@ impl MockBatchWriter {
 }
 
 impl BatchWriter for MockBatchWriter {
-    fn persist(&self, _persist_requests: Vec<PersistedValue>) -> Vec<SignedBatchInfo<BatchInfo>> {
+    fn persist(
+        &self,
+        _persist_requests: Vec<PersistedValue<BatchInfoExt>>,
+    ) -> Vec<SignedBatchInfo<BatchInfoExt>> {
         vec![]
     }
 }

--- a/consensus/src/quorum_store/tests/batch_requester_test.rs
+++ b/consensus/src/quorum_store/tests/batch_requester_test.rs
@@ -11,7 +11,7 @@ use crate::{
 };
 use aptos_consensus_types::{
     common::Author,
-    proof_of_store::{BatchInfo, ProofOfStore, SignedBatchInfo},
+    proof_of_store::{BatchInfo, BatchInfoExt, ProofOfStore, SignedBatchInfo},
 };
 use aptos_crypto::HashValue;
 use aptos_infallible::Mutex;
@@ -62,7 +62,19 @@ impl QuorumStoreSender for MockBatchRequester {
         unimplemented!()
     }
 
-    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch>) {
+    async fn send_signed_batch_info_msg_v2(
+        &self,
+        _signed_batch_infos: Vec<SignedBatchInfo<BatchInfoExt>>,
+        _recipients: Vec<Author>,
+    ) {
+        unimplemented!()
+    }
+
+    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch<BatchInfo>>) {
+        unimplemented!()
+    }
+
+    async fn broadcast_batch_msg_v2(&mut self, _batches: Vec<Batch<BatchInfoExt>>) {
         unimplemented!()
     }
 
@@ -73,9 +85,16 @@ impl QuorumStoreSender for MockBatchRequester {
         unimplemented!()
     }
 
+    async fn broadcast_proof_of_store_msg_v2(
+        &mut self,
+        _proof_of_stores: Vec<ProofOfStore<BatchInfoExt>>,
+    ) {
+        unimplemented!()
+    }
+
     async fn send_proof_of_store_msg_to_self(
         &mut self,
-        _proof_of_stores: Vec<ProofOfStore<BatchInfo>>,
+        _proof_of_stores: Vec<ProofOfStore<BatchInfoExt>>,
     ) {
         unimplemented!()
     }

--- a/consensus/src/quorum_store/tests/batch_store_test.rs
+++ b/consensus/src/quorum_store/tests/batch_store_test.rs
@@ -6,7 +6,7 @@ use crate::quorum_store::{
     quorum_store_db::QuorumStoreDB,
     types::{PersistedValue, StorageMode},
 };
-use aptos_consensus_types::proof_of_store::BatchInfo;
+use aptos_consensus_types::proof_of_store::{BatchInfo, BatchInfoExt};
 use aptos_crypto::HashValue;
 use aptos_temppath::TempPath;
 use aptos_types::{
@@ -46,7 +46,7 @@ fn request_for_test(
     round: u64,
     num_bytes: u64,
     maybe_payload: Option<Vec<SignedTransaction>>,
-) -> PersistedValue {
+) -> PersistedValue<BatchInfoExt> {
     PersistedValue::new(
         BatchInfo::new(
             *TEST_REQUEST_ACCOUNT, // make sure all request come from the same account
@@ -60,6 +60,7 @@ fn request_for_test(
         ),
         maybe_payload,
     )
+    .into()
 }
 
 #[tokio::test]
@@ -96,7 +97,7 @@ async fn test_extend_expiration_vs_save() {
     let batch_store_clone2 = batch_store.clone();
 
     let digests: Vec<HashValue> = (0..num_experiments).map(|_| HashValue::random()).collect();
-    let later_exp_values: Vec<PersistedValue> = (0..num_experiments)
+    let later_exp_values: Vec<PersistedValue<BatchInfoExt>> = (0..num_experiments)
         .map(|i| {
             // Pre-insert some of them.
             if i % 2 == 0 {

--- a/consensus/src/quorum_store/tests/quorum_store_db_test.rs
+++ b/consensus/src/quorum_store/tests/quorum_store_db_test.rs
@@ -8,6 +8,7 @@ use crate::{
     },
     test_utils::create_vec_signed_transactions,
 };
+use aptos_consensus_types::proof_of_store::BatchInfo;
 use aptos_temppath::TempPath;
 use aptos_types::{account_address::AccountAddress, quorum_store::BatchId};
 use claims::assert_ok;
@@ -19,7 +20,7 @@ fn test_db_for_data() {
 
     let source = AccountAddress::random();
     let signed_txns = create_vec_signed_transactions(100);
-    let persist_request_1: PersistedValue =
+    let persist_request_1: PersistedValue<BatchInfo> =
         Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source, 0).into();
     let clone_1 = persist_request_1.clone();
     assert!(db.save_batch(clone_1).is_ok());
@@ -32,13 +33,13 @@ fn test_db_for_data() {
     );
 
     let signed_txns = create_vec_signed_transactions(200);
-    let persist_request_2: PersistedValue =
+    let persist_request_2: PersistedValue<BatchInfo> =
         Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source, 0).into();
     let clone_2 = persist_request_2.clone();
     assert_ok!(db.save_batch(clone_2));
 
     let signed_txns = create_vec_signed_transactions(300);
-    let persist_request_3: PersistedValue =
+    let persist_request_3: PersistedValue<BatchInfo> =
         Batch::new(BatchId::new_for_test(1), signed_txns, 1, 20, source, 0).into();
     let clone_3 = persist_request_3.clone();
     assert_ok!(db.save_batch(clone_3));

--- a/consensus/src/quorum_store/types.rs
+++ b/consensus/src/quorum_store/types.rs
@@ -4,7 +4,7 @@
 use anyhow::ensure;
 use aptos_consensus_types::{
     common::{BatchPayload, TxnSummaryWithExpiration},
-    proof_of_store::BatchInfo,
+    proof_of_store::{BatchInfo, BatchInfoExt, BatchKind, TBatchInfo},
 };
 use aptos_crypto::{hash::CryptoHash, HashValue};
 use aptos_types::{
@@ -12,14 +12,15 @@ use aptos_types::{
     validator_verifier::ValidatorVerifier, PeerId,
 };
 use serde::{Deserialize, Serialize};
+use serde_name::{DeserializeNameAdapter, SerializeNameAdapter};
 use std::{
     fmt::{Display, Formatter},
     ops::Deref,
 };
 
 #[derive(Clone, Eq, Deserialize, Serialize, PartialEq, Debug)]
-pub struct PersistedValue {
-    info: BatchInfo,
+pub struct PersistedValue<T> {
+    info: T,
     maybe_payload: Option<Vec<SignedTransaction>>,
 }
 
@@ -29,8 +30,8 @@ pub(crate) enum StorageMode {
     MemoryAndPersisted,
 }
 
-impl PersistedValue {
-    pub(crate) fn new(info: BatchInfo, maybe_payload: Option<Vec<SignedTransaction>>) -> Self {
+impl<T: TBatchInfo> PersistedValue<T> {
+    pub(crate) fn new(info: T, maybe_payload: Option<Vec<SignedTransaction>>) -> Self {
         Self {
             info,
             maybe_payload,
@@ -53,7 +54,7 @@ impl PersistedValue {
         self.maybe_payload = None;
     }
 
-    pub fn batch_info(&self) -> &BatchInfo {
+    pub fn batch_info(&self) -> &T {
         &self.info
     }
 
@@ -78,23 +79,23 @@ impl PersistedValue {
         vec![]
     }
 
-    pub fn unpack(self) -> (BatchInfo, Option<Vec<SignedTransaction>>) {
+    pub fn unpack(self) -> (T, Option<Vec<SignedTransaction>>) {
         (self.info, self.maybe_payload)
     }
 }
 
-impl Deref for PersistedValue {
-    type Target = BatchInfo;
+impl<T: TBatchInfo> Deref for PersistedValue<T> {
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &self.info
     }
 }
 
-impl TryFrom<PersistedValue> for Batch {
+impl<T: TBatchInfo> TryFrom<PersistedValue<T>> for Batch<T> {
     type Error = anyhow::Error;
 
-    fn try_from(value: PersistedValue) -> Result<Self, Self::Error> {
+    fn try_from(value: PersistedValue<T>) -> Result<Self, Self::Error> {
         let author = value.author();
         Ok(Batch {
             batch_info: value.info,
@@ -105,6 +106,23 @@ impl TryFrom<PersistedValue> for Batch {
                     .ok_or_else(|| anyhow::anyhow!("Payload not exist"))?,
             ),
         })
+    }
+}
+
+impl From<PersistedValue<BatchInfo>> for PersistedValue<BatchInfoExt> {
+    fn from(value: PersistedValue<BatchInfo>) -> Self {
+        let (batch_info, payload) = value.unpack();
+        PersistedValue::new(batch_info.into(), payload)
+    }
+}
+
+impl TryFrom<PersistedValue<BatchInfoExt>> for PersistedValue<BatchInfo> {
+    type Error = anyhow::Error;
+
+    fn try_from(value: PersistedValue<BatchInfoExt>) -> Result<Self, Self::Error> {
+        let (batch_info, payload) = value.unpack();
+        ensure!(!batch_info.is_v2(), "Expected Batch Info V1");
+        Ok(PersistedValue::new(batch_info.unpack_info(), payload))
     }
 }
 
@@ -125,12 +143,43 @@ mod tests {
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct Batch {
-    batch_info: BatchInfo,
+#[serde(remote = "Batch")]
+pub struct Batch<T: TBatchInfo> {
+    batch_info: T,
     payload: BatchPayload,
 }
 
-impl Batch {
+impl<'de, T> Deserialize<'de> for Batch<T>
+where
+    T: Deserialize<'de> + TBatchInfo,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::de::Deserializer<'de>,
+    {
+        Batch::deserialize(DeserializeNameAdapter::new(
+            deserializer,
+            std::any::type_name::<Self>(),
+        ))
+    }
+}
+
+impl<T> Serialize for Batch<T>
+where
+    T: Serialize + TBatchInfo,
+{
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::ser::Serializer,
+    {
+        Batch::serialize(
+            self,
+            SerializeNameAdapter::new(serializer, std::any::type_name::<Self>()),
+        )
+    }
+}
+
+impl Batch<BatchInfo> {
     pub fn new(
         batch_id: BatchId,
         payload: Vec<SignedTransaction>,
@@ -150,6 +199,60 @@ impl Batch {
             payload.num_bytes() as u64,
             gas_bucket_start,
         );
+        Self::new_generic(batch_info, payload)
+    }
+}
+
+impl Batch<BatchInfoExt> {
+    pub fn new_v2(
+        batch_id: BatchId,
+        payload: Vec<SignedTransaction>,
+        epoch: u64,
+        expiration: u64,
+        batch_author: PeerId,
+        gas_bucket_start: u64,
+        batch_kind: BatchKind,
+    ) -> Self {
+        let payload = BatchPayload::new(batch_author, payload);
+        let batch_info = BatchInfoExt::new_v2(
+            batch_author,
+            batch_id,
+            epoch,
+            expiration,
+            payload.hash(),
+            payload.num_txns() as u64,
+            payload.num_bytes() as u64,
+            gas_bucket_start,
+            batch_kind,
+        );
+        Self::new_generic(batch_info, payload)
+    }
+
+    pub fn new_v1(
+        batch_id: BatchId,
+        payload: Vec<SignedTransaction>,
+        epoch: u64,
+        expiration: u64,
+        batch_author: PeerId,
+        gas_bucket_start: u64,
+    ) -> Self {
+        let payload = BatchPayload::new(batch_author, payload);
+        let batch_info = BatchInfoExt::new_v1(
+            batch_author,
+            batch_id,
+            epoch,
+            expiration,
+            payload.hash(),
+            payload.num_txns() as u64,
+            payload.num_bytes() as u64,
+            gas_bucket_start,
+        );
+        Self::new_generic(batch_info, payload)
+    }
+}
+
+impl<T: TBatchInfo> Batch<T> {
+    pub fn new_generic(batch_info: T, payload: BatchPayload) -> Self {
         Self {
             batch_info,
             payload,
@@ -204,16 +307,48 @@ impl Batch {
         self.payload.txns()
     }
 
-    pub fn batch_info(&self) -> &BatchInfo {
+    pub fn batch_info(&self) -> &T {
         &self.batch_info
     }
 }
 
-impl Deref for Batch {
-    type Target = BatchInfo;
+impl<T: TBatchInfo> Deref for Batch<T> {
+    type Target = T;
 
     fn deref(&self) -> &Self::Target {
         &self.batch_info
+    }
+}
+
+impl From<Batch<BatchInfo>> for Batch<BatchInfoExt> {
+    fn from(batch: Batch<BatchInfo>) -> Self {
+        let Batch {
+            batch_info,
+            payload,
+        } = batch;
+        Self {
+            batch_info: batch_info.into(),
+            payload,
+        }
+    }
+}
+
+impl TryFrom<Batch<BatchInfoExt>> for Batch<BatchInfo> {
+    type Error = anyhow::Error;
+
+    fn try_from(batch: Batch<BatchInfoExt>) -> Result<Self, Self::Error> {
+        ensure!(
+            matches!(batch.batch_info(), &BatchInfoExt::V1 { .. }),
+            "Batch must be V1 type"
+        );
+        let Batch {
+            batch_info,
+            payload,
+        } = batch;
+        Ok(Self {
+            batch_info: batch_info.unpack_info(),
+            payload,
+        })
     }
 }
 
@@ -268,8 +403,8 @@ impl BatchRequest {
     }
 }
 
-impl From<Batch> for PersistedValue {
-    fn from(value: Batch) -> Self {
+impl<T: TBatchInfo> From<Batch<T>> for PersistedValue<T> {
+    fn from(value: Batch<T>) -> Self {
         let Batch {
             batch_info,
             payload,
@@ -280,17 +415,18 @@ impl From<Batch> for PersistedValue {
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub enum BatchResponse {
-    Batch(Batch),
+    Batch(Batch<BatchInfo>),
     NotFound(LedgerInfoWithSignatures),
+    BatchV2(Batch<BatchInfoExt>),
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
-pub struct BatchMsg {
-    batches: Vec<Batch>,
+pub struct BatchMsg<T: TBatchInfo> {
+    batches: Vec<Batch<T>>,
 }
 
-impl BatchMsg {
-    pub fn new(batches: Vec<Batch>) -> Self {
+impl<T: TBatchInfo> BatchMsg<T> {
+    pub fn new(batches: Vec<Batch<T>>) -> Self {
         Self { batches }
     }
 
@@ -342,7 +478,15 @@ impl BatchMsg {
         self.batches.first().map(|batch| batch.author())
     }
 
-    pub fn take(self) -> Vec<Batch> {
+    pub fn take(self) -> Vec<Batch<T>> {
         self.batches
+    }
+}
+
+impl From<BatchMsg<BatchInfo>> for BatchMsg<BatchInfoExt> {
+    fn from(msg: BatchMsg<BatchInfo>) -> Self {
+        Self {
+            batches: msg.batches.into_iter().map(|b| b.into()).collect(),
+        }
     }
 }

--- a/consensus/src/test_utils/mock_quorum_store_sender.rs
+++ b/consensus/src/test_utils/mock_quorum_store_sender.rs
@@ -9,7 +9,7 @@ use crate::{
 use aptos_consensus_types::{
     common::Author,
     proof_of_store::{
-        BatchInfo, ProofOfStore, ProofOfStoreMsg, SignedBatchInfo, SignedBatchInfoMsg,
+        BatchInfo, BatchInfoExt, ProofOfStore, ProofOfStoreMsg, SignedBatchInfo, SignedBatchInfoMsg,
     },
 };
 use std::time::Duration;
@@ -53,7 +53,27 @@ impl QuorumStoreSender for MockQuorumStoreSender {
             .expect("could not send");
     }
 
-    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch>) {
+    async fn send_signed_batch_info_msg_v2(
+        &self,
+        signed_batch_infos: Vec<SignedBatchInfo<BatchInfoExt>>,
+        recipients: Vec<Author>,
+    ) {
+        self.tx
+            .send((
+                ConsensusMsg::SignedBatchInfoMsgV2(Box::new(SignedBatchInfoMsg::new(
+                    signed_batch_infos,
+                ))),
+                recipients,
+            ))
+            .await
+            .expect("could not send");
+    }
+
+    async fn broadcast_batch_msg(&mut self, _batches: Vec<Batch<BatchInfo>>) {
+        unimplemented!()
+    }
+
+    async fn broadcast_batch_msg_v2(&mut self, _batches: Vec<Batch<BatchInfoExt>>) {
         unimplemented!()
     }
 
@@ -72,8 +92,21 @@ impl QuorumStoreSender for MockQuorumStoreSender {
 
     async fn send_proof_of_store_msg_to_self(
         &mut self,
-        _proof_of_stores: Vec<ProofOfStore<BatchInfo>>,
+        _proof_of_stores: Vec<ProofOfStore<BatchInfoExt>>,
     ) {
         unimplemented!()
+    }
+
+    async fn broadcast_proof_of_store_msg_v2(
+        &mut self,
+        proof_of_stores: Vec<ProofOfStore<BatchInfoExt>>,
+    ) {
+        self.tx
+            .send((
+                ConsensusMsg::ProofOfStoreMsgV2(Box::new(ProofOfStoreMsg::new(proof_of_stores))),
+                vec![],
+            ))
+            .await
+            .expect("We should be able to send the proof of store message");
     }
 }

--- a/consensus/src/util/db_tool.rs
+++ b/consensus/src/util/db_tool.rs
@@ -11,7 +11,7 @@ use crate::{
     },
 };
 use anyhow::{bail, Result};
-use aptos_consensus_types::{block::Block, common::Payload};
+use aptos_consensus_types::{block::Block, common::Payload, proof_of_store::BatchInfo};
 use aptos_crypto::HashValue;
 use aptos_types::transaction::{SignedTransaction, Transaction};
 use clap::Parser;
@@ -63,7 +63,7 @@ impl Command {
 
 fn extract_txns_from_quorum_store(
     digests: impl Iterator<Item = HashValue>,
-    all_batches: &HashMap<HashValue, PersistedValue>,
+    all_batches: &HashMap<HashValue, PersistedValue<BatchInfo>>,
 ) -> anyhow::Result<Vec<&SignedTransaction>> {
     let mut block_txns = Vec::new();
     for digest in digests {
@@ -82,7 +82,7 @@ fn extract_txns_from_quorum_store(
 
 pub fn extract_txns_from_block<'a>(
     block: &'a Block,
-    all_batches: &'a HashMap<HashValue, PersistedValue>,
+    all_batches: &'a HashMap<HashValue, PersistedValue<BatchInfo>>,
 ) -> anyhow::Result<Vec<&'a SignedTransaction>> {
     match block.payload().as_ref() {
         Some(payload) => match payload {

--- a/testsuite/generate-format/src/consensus.rs
+++ b/testsuite/generate-format/src/consensus.rs
@@ -116,8 +116,10 @@ pub fn get_registry() -> Result<Registry> {
     tracer.trace_type::<PersistedStateValueMetadata>(&samples)?;
 
     tracer.trace_type::<StateKey>(&samples)?;
-    tracer.trace_type::<aptos_consensus::quorum_store::types::BatchResponse>(&samples)?;
+    tracer.trace_type::<aptos_consensus_types::proof_of_store::BatchInfoExt>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::round_timeout::RoundTimeoutReason>(&samples)?;
+    tracer.trace_type::<aptos_consensus_types::proof_of_store::BatchKind>(&samples)?;
+    tracer.trace_type::<aptos_consensus::quorum_store::types::BatchResponse>(&samples)?;
     tracer.trace_type::<aptos_consensus::network_interface::ConsensusMsg>(&samples)?;
     tracer.trace_type::<aptos_consensus::network_interface::CommitMessage>(&samples)?;
     tracer.trace_type::<aptos_consensus_types::block_data::BlockType>(&samples)?;

--- a/testsuite/generate-format/tests/staged/consensus.yaml
+++ b/testsuite/generate-format/tests/staged/consensus.yaml
@@ -136,12 +136,6 @@ AssertionSignature:
         STRUCT:
           - signature:
               TYPENAME: Secp256r1EcdsaSignature
-Batch:
-  STRUCT:
-    - batch_info:
-        TYPENAME: BatchInfo
-    - payload:
-        TYPENAME: BatchPayload
 BatchId:
   STRUCT:
     - id: U64
@@ -159,11 +153,31 @@ BatchInfo:
     - num_txns: U64
     - num_bytes: U64
     - gas_bucket_start: U64
+BatchInfoExt:
+  ENUM:
+    0:
+      V1:
+        STRUCT:
+          - info:
+              TYPENAME: BatchInfo
+    1:
+      V2:
+        STRUCT:
+          - info:
+              TYPENAME: BatchInfo
+          - extra:
+              TYPENAME: ExtraBatchInfo
+BatchKind:
+  ENUM:
+    0:
+      Normal: UNIT
+    1:
+      Encrypted: UNIT
 BatchMsg:
   STRUCT:
     - batches:
         SEQ:
-          TYPENAME: Batch
+          TYPENAME: "aptos_consensus::quorum_store::types::Batch<aptos_consensus_types::proof_of_store::BatchInfo>"
 BatchPayload:
   STRUCT:
     - author:
@@ -188,11 +202,15 @@ BatchResponse:
     0:
       Batch:
         NEWTYPE:
-          TYPENAME: Batch
+          TYPENAME: "aptos_consensus::quorum_store::types::Batch<aptos_consensus_types::proof_of_store::BatchInfo>"
     1:
       NotFound:
         NEWTYPE:
           TYPENAME: LedgerInfoWithSignatures
+    2:
+      BatchV2:
+        NEWTYPE:
+          TYPENAME: "aptos_consensus::quorum_store::types::Batch<aptos_consensus_types::proof_of_store::BatchInfoExt>"
 BitVec:
   STRUCT:
     - inner: BYTES
@@ -447,7 +465,7 @@ ConsensusMsg:
     11:
       BatchResponse:
         NEWTYPE:
-          TYPENAME: Batch
+          TYPENAME: "aptos_consensus::quorum_store::types::Batch<aptos_consensus_types::proof_of_store::BatchInfo>"
     12:
       SignedBatchInfo:
         NEWTYPE:
@@ -488,6 +506,18 @@ ConsensusMsg:
       OptProposalMsg:
         NEWTYPE:
           TYPENAME: OptProposalMsg
+    22:
+      BatchMsgV2:
+        NEWTYPE:
+          TYPENAME: BatchMsg
+    23:
+      SignedBatchInfoMsgV2:
+        NEWTYPE:
+          TYPENAME: SignedBatchInfoMsg
+    24:
+      ProofOfStoreMsgV2:
+        NEWTYPE:
+          TYPENAME: ProofOfStoreMsg
 ContractEvent:
   ENUM:
     0:
@@ -628,6 +658,10 @@ EventKey:
     - creation_number: U64
     - account_address:
         TYPENAME: AccountAddress
+ExtraBatchInfo:
+  STRUCT:
+    - batch_kind:
+        TYPENAME: BatchKind
 FederatedKeylessPublicKey:
   STRUCT:
     - jwk_addr:
@@ -1522,3 +1556,15 @@ ZeroKnowledgeSig:
     - training_wheels_signature:
         OPTION:
           TYPENAME: EphemeralSignature
+"aptos_consensus::quorum_store::types::Batch<aptos_consensus_types::proof_of_store::BatchInfo>":
+  STRUCT:
+    - batch_info:
+        TYPENAME: BatchInfo
+    - payload:
+        TYPENAME: BatchPayload
+"aptos_consensus::quorum_store::types::Batch<aptos_consensus_types::proof_of_store::BatchInfoExt>":
+  STRUCT:
+    - batch_info:
+        TYPENAME: BatchInfoExt
+    - payload:
+        TYPENAME: BatchPayload

--- a/types/src/transaction/mod.rs
+++ b/types/src/transaction/mod.rs
@@ -1301,6 +1301,10 @@ impl SignedTransaction {
     pub fn replay_protector(&self) -> ReplayProtector {
         self.raw_txn.replay_protector()
     }
+
+    pub fn is_encrypted_txn(&self) -> bool {
+        self.payload().is_encrypted_variant()
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]


### PR DESCRIPTION
## Description
<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

This PR introduces support for BatchV2 in QuorumStore, enabling batches to carry additional metadata (such as batch kind) while maintaining full backward compatibility with BatchV1. The implementation uses `BatchInfoExt` as a unified type that can represent both V1 and V2 batches, and adds new network message types to handle V2 batches. Sending BatchV2 is configured via a local Quorum Store Config flag. 

BatchMsg and related QS messages are used to handle BatchInfo or BatchInfoExt::V1 batches normally. BatchMsgV2 and other V2 messages verify that BatchInfoExt::V2 is used. This is to simplify handling of different message types on the receiver.