### PR TITLE
Revert gas version for 1.38

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -72,7 +72,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_39;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_38;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -105,5 +105,4 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_36: u64 = 40;
     pub const RELEASE_V1_37: u64 = 41;
     pub const RELEASE_V1_38: u64 = 42;
-    pub const RELEASE_V1_39: u64 = 43;
 }


### PR DESCRIPTION
We previously bumped gas version to 1.39 on main, and later re-cut 1.38 from trunk. Therefore the gas version is now 1.39 on `aptos-release-v1.38`, and I guess we need to revert it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reverts latest gas feature version from 1.39 to 1.38 and removes the 1.39 constant.
> 
> - **Gas schedule**:
>   - Update `LATEST_GAS_FEATURE_VERSION` to `gas_feature_versions::RELEASE_V1_38` in `aptos-move/aptos-gas-schedule/src/ver.rs`.
>   - Remove `gas_feature_versions::RELEASE_V1_39` constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 539572685ee02a22f127ce2de25b46a2347e94bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->