### PR TITLE
Enable bytecode format v9 in testnet 1.38

### DIFF
--- a/aptos-move/aptos-release-builder/data/vm-binary-format-v9.yaml
+++ b/aptos-move/aptos-release-builder/data/vm-binary-format-v9.yaml
@@ -1,0 +1,12 @@
+remote_endpoint: ~
+name: "v1.38-v-m-binary-format-v9"
+proposals:
+  - name: v_m_binary_format_v9
+    metadata:
+      title: "Proposal to enable bytecode format v9"
+      description: "See https://github.com/aptos-foundation/AIPs/blob/main/aips/aip-130.md"
+    execution_mode: MultiStep
+    update_sequence:
+      - FeatureFlag:
+          enabled:
+            - v_m_binary_format_v9


### PR DESCRIPTION
## Description
Enable bytecode format v9 on testnet v1.38.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a new release-builder proposal to enable VM bytecode format v9 for v1.38.
> 
> - **Release config**:
>   - Add `aptos-move/aptos-release-builder/data/vm-binary-format-v9.yaml` defining a MultiStep proposal to enable `v_m_binary_format_v9` via `FeatureFlag` (bytecode format v9).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd45ad43e8f3c0ef0a458eb3211dcbb62fe1cde3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->