### PR TITLE
[move compiler] address nits

### DIFF
--- a/third_party/move/move-bytecode-verifier/src/reference_safety/abstract_state.rs
+++ b/third_party/move/move-bytecode-verifier/src/reference_safety/abstract_state.rs
@@ -466,6 +466,16 @@ impl AbstractState {
         mut_: bool,
     ) -> PartialVMResult<AbstractValue> {
         let vec_id = safe_unwrap!(vector.ref_id());
+
+        // For immutable borrow, check that the vector is readable
+        if !mut_ && !self.is_readable(vec_id, None) {
+            return Err(self.error(
+                StatusCode::VEC_BORROW_ELEMENT_EXISTS_MUTABLE_BORROW_ERROR,
+                offset,
+            ));
+        }
+
+        // For mutable borrow, check that the vector is writable
         if mut_ && !self.is_writable(vec_id) {
             return Err(self.error(
                 StatusCode::VEC_BORROW_ELEMENT_EXISTS_MUTABLE_BORROW_ERROR,


### PR DESCRIPTION
## Description
This PR address some nits in the bytecode verifier.

## How Has This Been Tested?
- Existing test cases

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add readability (immutable) and writability (mutable) checks to `vector_element_borrow`, returning proper errors when violated.
> 
> - **Bytecode Verifier (reference safety)**:
>   - Update `vector_element_borrow` in `third_party/move/move-bytecode-verifier/src/reference_safety/abstract_state.rs`:
>     - For immutable borrows, require `is_readable` on the vector; error with `VEC_BORROW_ELEMENT_EXISTS_MUTABLE_BORROW_ERROR` if not.
>     - For mutable borrows, require `is_writable` on the vector; same error on failure.
>     - Maintain borrow creation via `add_borrow` and release the original vector ref.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0286d067ff59d441dfad4c061bdf665bb5744e85. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->