### PR TITLE
Update release.yaml for testnet framework release

### DIFF
--- a/aptos-move/aptos-release-builder/data/release.yaml
+++ b/aptos-move/aptos-release-builder/data/release.yaml
@@ -1,20 +1,20 @@
 ---
-remote_endpoint: https://fullnode.mainnet.aptoslabs.com
+remote_endpoint: https://fullnode.testnet.aptoslabs.com
 # replace with below for actual release, compat test needs concrete URL above:
 # remote_endpoint: ~
-name: "vX.YY.Z"
+name: "v1.38.1"
 proposals:
   - name: proposal_1_upgrade_framework
     metadata:
-      title: "Multi-step proposal to upgrade mainnet framework, version vX.YY.Z"
-      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-vX.YY.Z"
+      title: "Multi-step proposal to upgrade testnet framework, version v1.38.1"
+      description: "This includes changes in https://github.com/aptos-labs/aptos-core/releases/tag/aptos-node-v1.38.1"
     execution_mode: MultiStep
     update_sequence:
       - Gas:
-          new: current
+          # new: current
           # replace with below for actual release, above "current" is needed for compat tests:
-          # old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.WW.Z.json
-          # new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/vX.YY.Z.json
+          old: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.37.0.json
+          new: https://raw.githubusercontent.com/aptos-labs/aptos-networks/main/gas/v1.38.1.json
       - Framework:
           bytecode_version: 8
           git_hash: ~


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Update `release.yaml` for testnet v1.38.1, switching endpoint to testnet and pointing gas schedules from v1.37.0 to v1.38.1 with updated metadata.
> 
> - **Release config (`aptos-move/aptos-release-builder/data/release.yaml`)**:
>   - Switch `remote_endpoint` to `https://fullnode.testnet.aptoslabs.com`.
>   - Set version `name` to `"v1.38.1"`.
>   - Update proposal metadata to testnet and version `v1.38.1` (title/description link).
>   - Gas update:
>     - Comment out `new: current` and use explicit URLs.
>     - `old`: `gas/v1.37.0.json` → `new`: `gas/v1.38.1.json`.
>   - Keep `Framework` settings unchanged (`bytecode_version: 8`, `git_hash: ~`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69c659defe078dbbf8754bdbfd2d74c1a26daf2a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->