### PR TITLE
Migrate obsolete Runson parameter

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,4 +1,4 @@
 self-hosted-runner:
   # Labels of self-hosted runners in array of string
   labels:
-    - runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    - runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}

--- a/.github/workflows/cli-e2e-tests.yaml
+++ b/.github/workflows/cli-e2e-tests.yaml
@@ -25,7 +25,7 @@ jobs:
   # we ensure that the Aptos CLI works with all 3 prod networks, at least
   # based on the tests in the test suite.
   run-cli-tests:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/copy-images-to-dockerhub.yaml
+++ b/.github/workflows/copy-images-to-dockerhub.yaml
@@ -39,7 +39,7 @@ permissions:
 jobs:
   copy-images:
     # Run on a machine with more local storage for large docker images
-    runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=m6id,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/coverage-move-only.yaml
+++ b/.github/workflows/coverage-move-only.yaml
@@ -30,7 +30,7 @@ concurrency:
 jobs:
   rust-move-unit-coverage:
     timeout-minutes: 60
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -26,7 +26,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && github.ref_name == 'main')
     # Note the tests run slowly due to instrutmentation. It takes CI 10 hrs
     timeout-minutes: 720
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -56,7 +56,7 @@ jobs:
       contains(github.event.pull_request.labels.*.name, 'CICD:run-coverage') ||
       (github.event_name == 'workflow_dispatch' && github.ref_name == 'main')
     timeout-minutes: 720 # incremented from 240 due to execution time limit hit in cron
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/docker-build-rosetta.yaml
+++ b/.github/workflows/docker-build-rosetta.yaml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/faucet-tests-main.yaml
+++ b/.github/workflows/faucet-tests-main.yaml
@@ -49,7 +49,7 @@ jobs:
   # be compatible in production.
   run-tests-main:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: ${{ !inputs.SKIP_JOB }}

--- a/.github/workflows/faucet-tests-prod.yaml
+++ b/.github/workflows/faucet-tests-prod.yaml
@@ -37,7 +37,7 @@ jobs:
   run-tests-devnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -57,7 +57,7 @@ jobs:
   run-tests-testnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
+++ b/.github/workflows/find-packages-with-undeclared-feature-dependencies.yaml
@@ -4,7 +4,7 @@ on:
 
 jobs:
   find-packages-with-undeclared-feature-dependencies:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/rust-setup@main

--- a/.github/workflows/fuzzer-data-update.yml
+++ b/.github/workflows/fuzzer-data-update.yml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   update-fuzzer-data:
-    runs-on: runs-on,cpu=16,family=m6id,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=m6id,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/indexer-processor-testing.yaml
+++ b/.github/workflows/indexer-processor-testing.yaml
@@ -16,7 +16,7 @@ permissions:
 
 jobs:
   dispatch_event:
-    runs-on: runs-on,cpu=16,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=16,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
 
     steps:
       - name: Checkout the repository

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,7 +56,7 @@ jobs:
   # Run the crypto hasher domain separation checks
   rust-cryptohasher-domain-separation-check:
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
   # Run all rust lints. This is a PR required job.
   rust-lints:
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -101,7 +101,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
         github.event.pull_request.auto_merge != null
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - name: Run rust doc tests
@@ -120,7 +120,7 @@ jobs:
         github.event.pull_request.auto_merge != null) ||
         contains(github.event.pull_request.body, '#e2e'
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -139,7 +139,7 @@ jobs:
         !contains(github.event.pull_request.base.ref, '-release-')
       )
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -157,7 +157,7 @@ jobs:
         !contains(github.event.pull_request.base.ref, '-release-')
       )
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -182,7 +182,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests') ||
         contains(github.event.pull_request.base.ref, '-release-')
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       # Install Move Prover tools
@@ -205,7 +205,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
         github.event.pull_request.auto_merge != null
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -217,7 +217,7 @@ jobs:
 
   # Run the consensus only unit tests
   rust-consensus-only-unit-test:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4
@@ -227,7 +227,7 @@ jobs:
 
   # Run the consensus only smoke test
   rust-consensus-only-smoke-test:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/node-api-compatibility-tests.yaml
+++ b/.github/workflows/node-api-compatibility-tests.yaml
@@ -43,7 +43,7 @@ jobs:
   # if there are any changes that would affect it within the PR / commit. If
   # everything is checked in, run tests, build the SDK, and upload it to npmjs.
   node-api-compatibility-tests:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/prover-daily-test.yaml
+++ b/.github/workflows/prover-daily-test.yaml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   prover-inconsistency-test:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     timeout-minutes: ${{ github.event_name == 'pull_request' && 10 || 480}}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/run-gas-calibration.yaml
+++ b/.github/workflows/run-gas-calibration.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   run-gas-calibration:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/rust-client-tests.yaml
+++ b/.github/workflows/rust-client-tests.yaml
@@ -31,7 +31,7 @@ jobs:
   run-tests-devnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -50,7 +50,7 @@ jobs:
   run-tests-testnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
@@ -69,7 +69,7 @@ jobs:
   run-tests-mainnet:
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     needs: [permission-check]
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,cpu=64,family=c7,volume=80gb:gp3:1000mbs:4000iops,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -87,7 +87,7 @@ permissions:
 
 jobs:
   rust-all:
-    runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=large
+    runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,volume=80gb:gp3:1000mbs:4000iops
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

The new `volume` parameter is more flexible than `disk`, which was deprecated.
Basically `disk=large` -> `volume=80gb:gp3:1000mbs:4000iops`.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates self-hosted runner `runs-on` labels across CI to use `volume=80gb:gp3:1000mbs:4000iops` instead of `disk=large`.
> 
> - **CI / GitHub Actions**:
>   - Replace `disk=large` with `volume=80gb:gp3:1000mbs:4000iops` in `runs-on` labels for self-hosted runners across workflows (e.g., `lint-test`, coverage jobs, faucet tests, CLI E2E, SDK tests, docker build, rosetta build, fuzzer update, indexer processor testing) and `.github/actionlint.yaml`.
>   - Apply updates to both `c7` and `m6id` runner families, including spots with `spot=co` configurations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7234e1512fc2f0da13c614e5ccfd53357c9b860. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->