### PR TITLE
x86-64-v3 no update

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -41,7 +41,10 @@ rustflags = [
 
 # Need this for RocksDB to build until its build script is fixed.
 [env]
-CXXFLAGS_x86_64_unknown_linux_gnu = "-mpclmul"
+CC_x86_64_unknown_linux_gnu = "clang"
+CXX_x86_64_unknown_linux_gnu = "clang++"
+CFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3"
+CXXFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3 -mpclmul"
 
 # 64 bit MSVC
 [target.x86_64-pc-windows-msvc]

--- a/types/src/lib.rs
+++ b/types/src/lib.rs
@@ -70,3 +70,6 @@ pub mod state_store;
 #[cfg(test)]
 mod unit_tests;
 pub mod vm;
+
+// foobar
+// 1 2 3 4 5


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configure x86_64-unknown-linux-gnu builds to use clang/clang++ with -march=x86-64-v3 (and -mpclmul for C++), replacing the previous CXXFLAGS-only setting.
> 
> - **Build (Linux x86_64-unknown-linux-gnu)**:
>   - Set `CC`/`CXX` to `clang`/`clang++`.
>   - Add `CFLAGS`/`CXXFLAGS` with `-march=x86-64-v3` (and `-mpclmul` for C++).
>   - Remove prior `CXXFLAGS_x86_64_unknown_linux_gnu = "-mpclmul"` override.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0e3e2f1b4ec948fdb5017c186ef4d09257f54968. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->