### PR TITLE
[nocommit] x86-64-v3

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -41,7 +41,10 @@ rustflags = [
 
 # Need this for RocksDB to build until its build script is fixed.
 [env]
-CXXFLAGS_x86_64_unknown_linux_gnu = "-mpclmul"
+CC_x86_64_unknown_linux_gnu = "clang"
+CXX_x86_64_unknown_linux_gnu = "clang++"
+CFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3"
+CXXFLAGS_x86_64_unknown_linux_gnu = "-march=x86-64-v3 -mpclmul"
 
 # 64 bit MSVC
 [target.x86_64-pc-windows-msvc]


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Configure Linux builds to use clang/clang++ and set C/C++ flags to target x86-64-v3, updating CXXFLAGS to include -march and mpclmul.
> 
> - **Build config (Linux `x86_64-unknown-linux-gnu`)**:
>   - Set `CC_x86_64_unknown_linux_gnu="clang"` and `CXX_x86_64_unknown_linux_gnu="clang++"` in `.cargo/config.toml`.
>   - Add `CFLAGS_x86_64_unknown_linux_gnu="-march=x86-64-v3"`.
>   - Update `CXXFLAGS_x86_64_unknown_linux_gnu` to `-march=x86-64-v3 -mpclmul` (was `-mpclmul`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 24cc939a0d6d7725a3edb3ce5f54b52bea13119f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->