### PR TITLE
Revert gas version for 1.38

### DIFF
--- a/aptos-move/aptos-gas-schedule/src/ver.rs
+++ b/aptos-move/aptos-gas-schedule/src/ver.rs
@@ -72,7 +72,7 @@
 ///       global operations.
 /// - V1
 ///   - TBA
-pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_39;
+pub const LATEST_GAS_FEATURE_VERSION: u64 = gas_feature_versions::RELEASE_V1_38;
 
 pub mod gas_feature_versions {
     pub const RELEASE_V1_8: u64 = 11;
@@ -105,5 +105,4 @@ pub mod gas_feature_versions {
     pub const RELEASE_V1_36: u64 = 40;
     pub const RELEASE_V1_37: u64 = 41;
     pub const RELEASE_V1_38: u64 = 42;
-    pub const RELEASE_V1_39: u64 = 43;
 }


### PR DESCRIPTION

We previously bumped gas version to 1.39 on main, and later re-cut 1.38 from
trunk. Therefore the gas version is now 1.39 on `aptos-release-v1.38`, and I
guess we need to revert it.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/aptos-labs/aptos-core/pull/18135).
* #18139
* #18114
* #18112
* #18138
* #18137
* #18095
* #18136
* __->__ #18135