### PR TITLE
[indexer] do not clone if not needed

### DIFF
--- a/ecosystem/indexer-grpc/indexer-grpc-table-info/src/table_info_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-table-info/src/table_info_service.rs
@@ -13,7 +13,6 @@ use aptos_indexer_grpc_fullnode::stream_coordinator::{
 };
 use aptos_indexer_grpc_utils::counters::{log_grpc_step, IndexerGrpcStep};
 use aptos_logger::{debug, error, info, sample, sample::SampleRate};
-use aptos_types::write_set::WriteSet;
 use itertools::Itertools;
 use std::{
     cmp::Ordering as CmpOrdering,
@@ -255,18 +254,22 @@ impl TableInfoService {
             .map(|txn| txn.version)
             .unwrap_or_default();
 
-        // We copy the transactions here in case we need to retry the parsing.
-        let batches: Vec<Vec<TransactionOnChainData>> = transactions
+        let transactions = Arc::new(transactions);
+        for (chunk_idx, batch_size) in transactions
             .chunks(self.parser_batch_size as usize)
-            .map(|chunk| chunk.to_vec())
-            .collect();
+            .enumerate()
+            .map(|(idx, chunk)| (idx, chunk.len()))
+        {
+            let start = chunk_idx * self.parser_batch_size as usize;
+            let end = start + batch_size;
 
-        for batch in batches {
-            let task = tokio::spawn(Self::process_transactions(
-                context.clone(),
-                indexer_async_v2.clone(),
-                batch,
-            ));
+            let transactions = transactions.clone();
+            let context = context.clone();
+            let indexer_async_v2 = indexer_async_v2.clone();
+            let task = tokio::spawn(async move {
+                Self::process_transactions(context, indexer_async_v2, &transactions[start..end])
+                    .await
+            });
             tasks.push(task);
         }
 
@@ -285,7 +288,7 @@ impl TableInfoService {
                     Self::process_transactions(
                         context.clone(),
                         indexer_async_v2.clone(),
-                        transactions,
+                        &transactions,
                     )
                     .await;
                 }
@@ -316,7 +319,7 @@ impl TableInfoService {
     async fn process_transactions(
         context: Arc<ApiContext>,
         indexer_async_v2: Arc<IndexerAsyncV2>,
-        raw_txns: Vec<TransactionOnChainData>,
+        raw_txns: &[TransactionOnChainData],
     ) -> EndVersion {
         let start_time = std::time::Instant::now();
         let start_version = raw_txns[0].version;
@@ -326,7 +329,7 @@ impl TableInfoService {
         loop {
             // NOTE: The retry is unlikely to be helpful. Put a loop here just to avoid panic and
             // allow the rest of FN functionality continue to work.
-            match Self::parse_table_info(context.clone(), &raw_txns, indexer_async_v2.clone()) {
+            match Self::parse_table_info(context.clone(), raw_txns, indexer_async_v2.clone()) {
                 Ok(_) => break,
                 Err(e) => {
                     error!(error = ?e, "Error during parse_table_info.");


### PR DESCRIPTION
## Description

No need to clone transactions and write-sets for table info parsing...

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates unnecessary cloning by processing transaction slices and write-set refs with Arc-backed batching in `table_info_service.rs`.
> 
> - **Indexer (table info parsing)**:
>   - Use `Arc<Vec<TransactionOnChainData>>` and slice ranges for parallel batches; remove intermediate cloned batch vectors.
>   - Change `process_transactions` and `parse_table_info` to accept `&[TransactionOnChainData]` instead of owned `Vec`.
>   - Build `write_sets` as references (`&txn.changes`) and pass to `index_table_info` directly; drop `WriteSet` cloning and related import.
>   - Adjust sequential retry to reuse the same `transactions` slice without cloning.
>   - Overall reduces allocations and copies during parsing and batching.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e078564ed1a35c69dd6ca09f8f391241634f7399. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->