### PR TITLE
[replay-verify] Use performance images

### DIFF
--- a/.github/workflows/workflow-run-replay-verify-on-archive.yaml
+++ b/.github/workflows/workflow-run-replay-verify-on-archive.yaml
@@ -56,6 +56,7 @@ jobs:
     with:
       GIT_SHA: ${{ inputs.IMAGE_TAG || github.event.pull_request.head.sha || github.sha }}
       TARGET_CACHE_ID: ${{ github.event.number && format('pr-{0}', github.event.number) || github.ref_name }}
+      PROFILE: performance
       DRY_RUN: ${{ inputs.DRY_RUN }}
 
   run-replay-verify:
@@ -70,7 +71,7 @@ jobs:
           # get the last 10 commits to find images that have been built
           # we can optionally use the IMAGE_TAG to find the exact commit to checkout
           fetch-depth: 10
-      
+
       - uses: aptos-labs/aptos-core/.github/actions/docker-setup@main
         id: docker-setup
         with:
@@ -106,7 +107,7 @@ jobs:
       - name: "Setup GCloud project"
         shell: bash
         run: gcloud config set project aptos-devinfra-0
-      
+
       - uses: ./.github/actions/python-setup
         with:
           pyproject_directory: testsuite/replay-verify
@@ -128,6 +129,7 @@ jobs:
           if [ -n "${{ inputs.IMAGE_TAG }}" ]; then  
             CMD="$CMD --image_tag ${{ inputs.IMAGE_TAG }}"  
           fi
+          CMD="$CMD --image_profile performance"
 
           eval $CMD
         timeout-minutes: 420 # 7 hours

--- a/docker/builder/build-tools.sh
+++ b/docker/builder/build-tools.sh
@@ -3,7 +3,11 @@
 # SPDX-License-Identifier: Apache-2.0
 set -e
 
-PROFILE=cli
+# We usually just need to build with `cli` profile, but building `aptos-debugger`
+# with `performance` profile helps speed up replay-verify.
+if [[ "${PROFILE}" != "performance" ]]; then
+  PROFILE=cli
+fi
 
 echo "Building tools and services docker images"
 echo "PROFILE: $PROFILE"

--- a/testsuite/replay-verify/main.py
+++ b/testsuite/replay-verify/main.py
@@ -718,12 +718,13 @@ def parse_args() -> argparse.Namespace:
         "--namespace", required=False, type=str, default="replay-verify"
     )
     parser.add_argument("--image_tag", required=False, type=str)
+    parser.add_argument("--image_profile", required=False, type=str, default="performance")
     parser.add_argument("--cleanup", required=False, action="store_true", default=False)
     args = parser.parse_args()
     return args
 
 
-def get_image(image_tag: str | None = None) -> str:
+def get_image(profile: str, image_tag: str | None = None) -> str:
     shell = forge.LocalShell()
     git = forge.Git(shell)
     image_name = "tools"
@@ -737,7 +738,8 @@ def get_image(image_tag: str | None = None) -> str:
         if image_tag is None
         else image_tag
     )
-    full_image = f"{forge.GAR_REPO_NAME}/{image_name}:{default_latest_image}"
+    tag_prefix = "" if profile == "release" else f"{profile}_"
+    full_image = f"{forge.GAR_REPO_NAME}/{image_name}:{tag_prefix}{default_latest_image}"
     return full_image
 
 
@@ -758,7 +760,7 @@ if __name__ == "__main__":
     args = parse_args()
     get_kubectl_credentials("aptos-devinfra-0", "us-central1", "devinfra-usce1-0")
     (start, end, skip_ranges) = read_skip_ranges(args.network)
-    image = get_image(args.image_tag) if args.image_tag is not None else get_image()
+    image = get_image(profile=args.image_profile, image_tag=args.image_tag)
     run_id = f"{datetime.datetime.now().strftime('%Y%m%d-%H%M%S')}-{image[-5:]}"
     network = Network.from_string(args.network)
     config = ReplayConfig(network)


### PR DESCRIPTION

I noticed that the binary we use to run replay-verify (`aptos-debugger`) is
currently built with `cli` profile. This means that the build optimizes more for
binary size instead of performance.

This change switches the default profile to `performance` and we get quite a bit
of speedup (2h -> 1h27m):
https://github.com/aptos-labs/aptos-core/actions/runs/19448179748/job/55647615373

Not sure if we want to leave an option to allow users to specify a
non-performance image, but the github workflows are kind of annoying to modify
lol.
