### PR TITLE
set `debug = "line-tables-only"` for all profiles

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -911,9 +911,17 @@ move-vm-types = { path = "third_party/move/move-vm/types" }
 [profile.dev]
 debug = "line-tables-only"
 
+[profile.debugger]
+inherits = "dev"
+debug = true
+
 [profile.release]
 debug = "line-tables-only"
 overflow-checks = true
+
+[profile.profiler]
+inherits = "release"
+debug = true
 
 # For [build-dependencies], cargo sets `opt-level=0` independent of the actual profile used.
 # In `aptos-cached-packages` crate, we have `aptos-framework` as a build dependency. Which in a `--release` mode,


### PR DESCRIPTION
See
https://doc.rust-lang.org/cargo/reference/profiles.html#debug 
for the cargo reference. 

1. `debug = true` adds function / module / variable information to `debuginfo`, required for debuggers and profilers to work properly.
2. `debug = "line-tables-only"` - just adds support for the proper stacktraces. 

