### PR TITLE
[vm] Use &[Type] for native type args

### DIFF
--- a/aptos-move/aptos-native-interface/src/builder.rs
+++ b/aptos-move/aptos-native-interface/src/builder.rs
@@ -81,9 +81,9 @@ impl SafeNativeBuilder {
     /// allowing the client to use [`SafeNativeContext`] instead of Move VM's [`NativeContext`].
     pub fn make_native<F>(&self, native: F) -> NativeFunction
     where
-        F: Fn(
+        F: for<'a> Fn(
                 &mut SafeNativeContext,
-                Vec<Type>,
+                &'a [Type],
                 VecDeque<Value>,
             ) -> SafeNativeResult<SmallVec<[Value; 1]>>
             + Send
@@ -95,7 +95,7 @@ impl SafeNativeBuilder {
 
         let enable_incremental_gas_charging = self.enable_incremental_gas_charging;
 
-        let closure = move |context: &mut NativeContext, ty_args, args| {
+        let closure = move |context: &mut NativeContext, ty_args: &[Type], args| {
             use SafeNativeError::*;
 
             let mut context = SafeNativeContext {
@@ -175,9 +175,9 @@ impl SafeNativeBuilder {
     ) -> impl Iterator<Item = (String, NativeFunction)> + 'a
     where
         'b: 'a,
-        F: Fn(
+        F: for<'c> Fn(
                 &mut SafeNativeContext,
-                Vec<Type>,
+                &'c [Type],
                 VecDeque<Value>,
             ) -> SafeNativeResult<SmallVec<[Value; 1]>>
             + Send

--- a/aptos-move/aptos-native-interface/src/helpers.rs
+++ b/aptos-move/aptos-native-interface/src/helpers.rs
@@ -60,26 +60,6 @@ macro_rules! safely_assert_eq {
     }};
 }
 
-/// Pops a `Type` argument off the type argument stack inside a safe native. Returns a
-/// `SafeNativeError::InvariantViolation(UNKNOWN_INVARIANT_VIOLATION_ERROR)` in case there are not
-/// enough arguments on the stack.
-///
-/// NOTE: Expects as its argument an object that has a `fn pop(&self) -> Option<_>` method (e.g., a `Vec<_>`)
-#[macro_export]
-macro_rules! safely_pop_type_arg {
-    ($ty_args:ident) => {{
-        use $crate::reexports::move_vm_types::natives::function::{PartialVMError, StatusCode};
-        match $ty_args.pop() {
-            Some(ty) => ty,
-            None => {
-                return Err($crate::SafeNativeError::InvariantViolation(
-                    PartialVMError::new(StatusCode::UNKNOWN_INVARIANT_VIOLATION_ERROR),
-                ))
-            },
-        }
-    }};
-}
-
 /// Like `pop_vec_arg` but for safe natives that return `SafeNativeResult<T>`.
 /// (Duplicates code from above, unfortunately.)
 #[macro_export]

--- a/aptos-move/aptos-native-interface/src/native.rs
+++ b/aptos-move/aptos-native-interface/src/native.rs
@@ -10,8 +10,5 @@ use std::collections::VecDeque;
 ///
 /// A raw native needs to be made into a closure that carries various configurations before
 /// it can be used in the VM.
-pub type RawSafeNative = fn(
-    &mut SafeNativeContext,
-    Vec<Type>,
-    VecDeque<Value>,
-) -> SafeNativeResult<SmallVec<[Value; 1]>>;
+pub type RawSafeNative =
+    fn(&mut SafeNativeContext, &[Type], VecDeque<Value>) -> SafeNativeResult<SmallVec<[Value; 1]>>;

--- a/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
+++ b/aptos-move/aptos-vm-profiling/src/bins/run_move.rs
@@ -37,7 +37,7 @@ enum Entrypoint {
 }
 
 fn make_native_create_signer() -> NativeFunction {
-    Arc::new(|_context, ty_args: Vec<Type>, mut args: VecDeque<Value>| {
+    Arc::new(|_context, ty_args: &[Type], mut args: VecDeque<Value>| {
         assert!(ty_args.is_empty());
         assert_eq!(args.len(), 1);
 

--- a/aptos-move/framework/move-stdlib/src/natives/cmp.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/cmp.rs
@@ -35,7 +35,7 @@ const ORDERING_GREATER_THAN_VARIANT: u16 = 2;
  **************************************************************************************************/
 fn native_compare(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(args.len() == 2);

--- a/aptos-move/framework/move-stdlib/src/natives/hash.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/hash.rs
@@ -26,7 +26,7 @@ use std::collections::VecDeque;
 #[inline]
 fn native_sha2_256(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());
@@ -51,7 +51,7 @@ fn native_sha2_256(
 #[inline]
 fn native_sha3_256(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());

--- a/aptos-move/framework/move-stdlib/src/natives/mem.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/mem.rs
@@ -28,7 +28,7 @@ pub const EFEATURE_NOT_ENABLED: u64 = 1;
  **************************************************************************************************/
 fn native_swap(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     if !context

--- a/aptos-move/framework/move-stdlib/src/natives/signer.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/signer.rs
@@ -26,7 +26,7 @@ use std::collections::VecDeque;
 #[inline]
 fn native_borrow_address(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());

--- a/aptos-move/framework/move-stdlib/src/natives/string.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/string.rs
@@ -36,7 +36,7 @@ use std::collections::VecDeque;
  **************************************************************************************************/
 fn native_check_utf8(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(args.len() == 1);
@@ -62,7 +62,7 @@ fn native_check_utf8(
  **************************************************************************************************/
 fn native_is_char_boundary(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(args.len() == 2);
@@ -88,7 +88,7 @@ fn native_is_char_boundary(
  **************************************************************************************************/
 fn native_sub_string(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(args.len() == 3);
@@ -124,7 +124,7 @@ fn native_sub_string(
  **************************************************************************************************/
 fn native_index_of(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(args.len() == 2);

--- a/aptos-move/framework/move-stdlib/src/natives/unit_test.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/unit_test.rs
@@ -29,7 +29,7 @@ fn to_le_bytes(i: u64) -> [u8; AccountAddress::LENGTH] {
 
 fn native_create_signers_for_testing(
     _context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());

--- a/aptos-move/framework/move-stdlib/src/natives/vector.rs
+++ b/aptos-move/framework/move-stdlib/src/natives/vector.rs
@@ -38,7 +38,7 @@ pub const EFEATURE_NOT_ENABLED: u64 = 2;
  **************************************************************************************************/
 fn native_move_range(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     if !context

--- a/aptos-move/framework/src/natives/account.rs
+++ b/aptos-move/framework/src/natives/account.rs
@@ -27,7 +27,7 @@ pub struct CreateAddressGasParameters {
 
 fn native_create_address(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());

--- a/aptos-move/framework/src/natives/account_abstraction.rs
+++ b/aptos-move/framework/src/natives/account_abstraction.rs
@@ -21,7 +21,7 @@ use std::collections::VecDeque;
  **************************************************************************************************/
 pub(crate) fn native_dispatch(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let (module_name, func_name) = extract_function_info(&mut arguments)?;
@@ -38,7 +38,7 @@ pub(crate) fn native_dispatch(
     Err(SafeNativeError::FunctionDispatch {
         module_name,
         func_name,
-        ty_args,
+        ty_args: ty_args.to_vec(),
         args: arguments.into_iter().collect(),
     })
 }

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator.rs
@@ -26,7 +26,7 @@ use std::collections::VecDeque;
  **************************************************************************************************/
 fn native_add(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 2);
@@ -55,7 +55,7 @@ fn native_add(
  **************************************************************************************************/
 fn native_read(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 1);
@@ -84,7 +84,7 @@ fn native_read(
 
 fn native_sub(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 2);
@@ -113,7 +113,7 @@ fn native_sub(
  **************************************************************************************************/
 fn native_destroy(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 1);

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_factory.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_factory.rs
@@ -28,7 +28,7 @@ use std::collections::VecDeque;
  **************************************************************************************************/
 fn native_new_aggregator(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 2);

--- a/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
+++ b/aptos-move/framework/src/natives/aggregator_natives/aggregator_v2.rs
@@ -137,7 +137,7 @@ fn create_aggregator_with_max_value(
 
 fn native_create_aggregator(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 1);
@@ -154,7 +154,7 @@ fn native_create_aggregator(
 
 fn native_create_unbounded_aggregator(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 0);
@@ -170,7 +170,7 @@ fn native_create_unbounded_aggregator(
  **************************************************************************************************/
 fn native_try_add(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 2);
@@ -216,7 +216,7 @@ fn native_try_add(
  **************************************************************************************************/
 fn native_try_sub(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 2);
@@ -259,7 +259,7 @@ fn native_try_sub(
 
 fn native_is_at_least_impl(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 2);
@@ -297,7 +297,7 @@ fn native_is_at_least_impl(
 
 fn native_read(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 1);
@@ -333,7 +333,7 @@ fn native_read(
 
 fn native_snapshot(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(args.len(), 1);
@@ -368,7 +368,7 @@ fn native_snapshot(
 
 fn native_create_snapshot(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(ty_args.len(), 1);
@@ -406,7 +406,7 @@ fn native_create_snapshot(
 
 fn native_copy_snapshot(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     Err(SafeNativeError::Abort {
@@ -420,7 +420,7 @@ fn native_copy_snapshot(
 
 fn native_read_snapshot(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(ty_args.len(), 1);
@@ -449,7 +449,7 @@ fn native_read_snapshot(
  **************************************************************************************************/
 fn native_string_concat(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     // Deprecated function in favor of `derive_string_concat`.
@@ -464,7 +464,7 @@ fn native_string_concat(
 
 fn native_read_derived_string(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(ty_args.len(), 0);
@@ -489,7 +489,7 @@ fn native_read_derived_string(
 
 fn native_create_derived_string(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(ty_args.len(), 0);
@@ -530,7 +530,7 @@ fn native_create_derived_string(
 
 fn native_derive_string_concat(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(ty_args.len(), 1);

--- a/aptos-move/framework/src/natives/code.rs
+++ b/aptos-move/framework/src/natives/code.rs
@@ -263,7 +263,7 @@ fn unpack_allowed_dep(v: Value) -> PartialVMResult<(AccountAddress, String)> {
  **************************************************************************************************/
 fn native_request_publish(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(matches!(args.len(), 4 | 5));

--- a/aptos-move/framework/src/natives/consensus_config.rs
+++ b/aptos-move/framework/src/natives/consensus_config.rs
@@ -12,7 +12,7 @@ use std::collections::VecDeque;
 
 pub fn validator_txn_enabled(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let config_bytes = safely_pop_arg!(args, Vec<u8>);

--- a/aptos-move/framework/src/natives/create_signer.rs
+++ b/aptos-move/framework/src/natives/create_signer.rs
@@ -19,7 +19,7 @@ use std::collections::VecDeque;
  **************************************************************************************************/
 pub(crate) fn native_create_signer(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/add.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/add.rs
@@ -22,7 +22,7 @@ use std::{
 
 pub fn add_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/div.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/div.rs
@@ -37,7 +37,7 @@ macro_rules! ark_div_internal {
 
 pub fn div_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/double.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/double.rs
@@ -19,7 +19,7 @@ use std::{collections::VecDeque, rc::Rc};
 
 pub fn double_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/inv.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/inv.rs
@@ -35,7 +35,7 @@ macro_rules! ark_inverse_internal {
 
 pub fn inv_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let structure_opt = structure_from_ty_arg!(context, &ty_args[0]);

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/mul.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/mul.rs
@@ -18,7 +18,7 @@ use std::{collections::VecDeque, ops::Mul, rc::Rc};
 
 pub fn mul_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/neg.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/neg.rs
@@ -21,7 +21,7 @@ use std::{collections::VecDeque, ops::Neg, rc::Rc};
 
 pub fn neg_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/scalar_mul.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/scalar_mul.rs
@@ -90,7 +90,7 @@ macro_rules! ark_msm_bigint_wnaf_cost {
 
 pub fn scalar_mul_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());
@@ -234,7 +234,7 @@ macro_rules! ark_msm_internal {
 
 pub fn multi_scalar_mul_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sqr.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sqr.rs
@@ -19,7 +19,7 @@ use std::{collections::VecDeque, rc::Rc};
 
 pub fn sqr_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let structure_opt = structure_from_ty_arg!(context, &ty_args[0]);

--- a/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sub.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/arithmetics/sub.rs
@@ -22,7 +22,7 @@ use std::{
 
 pub fn sub_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/casting.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/casting.rs
@@ -44,7 +44,7 @@ macro_rules! abort_unless_casting_enabled {
 
 pub fn downcast_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());
@@ -80,7 +80,7 @@ pub fn downcast_internal(
 
 pub fn upcast_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/constants.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/constants.rs
@@ -31,7 +31,7 @@ macro_rules! ark_constant_op_internal {
 
 pub fn zero_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let structure_opt = structure_from_ty_arg!(context, &ty_args[0]);
@@ -99,7 +99,7 @@ pub fn zero_internal(
 
 pub fn one_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let structure_opt = structure_from_ty_arg!(context, &ty_args[0]);
@@ -170,7 +170,7 @@ pub fn one_internal(
 
 pub fn order_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/eq.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/eq.rs
@@ -31,7 +31,7 @@ macro_rules! ark_eq_internal {
 
 pub fn eq_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/hash_to_structure.rs
@@ -80,7 +80,7 @@ macro_rules! hash_to_bls12381gx_cost {
 
 pub fn hash_to_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/new.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/new.rs
@@ -29,7 +29,7 @@ macro_rules! from_u64_internal {
 
 pub fn from_u64_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/pairing.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/pairing.rs
@@ -127,7 +127,7 @@ macro_rules! multi_pairing_internal {
 }
 pub fn multi_pairing_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(3, ty_args.len());
@@ -170,7 +170,7 @@ pub fn multi_pairing_internal(
 
 pub fn pairing_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(3, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/rand.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/rand.rs
@@ -51,7 +51,7 @@ macro_rules! ark_rand_internal {
 #[cfg(feature = "testing")]
 pub fn rand_insecure_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(1, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/algebra/serialization.rs
+++ b/aptos-move/framework/src/natives/cryptography/algebra/serialization.rs
@@ -124,7 +124,7 @@ macro_rules! serialize_element {
 
 pub fn serialize_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());
@@ -335,7 +335,7 @@ macro_rules! ark_ec_point_deserialize_internal {
 
 pub fn deserialize_internal(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(2, ty_args.len());

--- a/aptos-move/framework/src/natives/cryptography/bls12381.rs
+++ b/aptos-move/framework/src/natives/cryptography/bls12381.rs
@@ -202,11 +202,11 @@ fn signature_verify<S: traits::Signature>(
 /// failed.
 pub fn bls12381_verify_signature_helper(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
     check_pk_subgroup: bool,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 3);
 
     context.charge(BLS12381_BASE)?;
@@ -258,10 +258,10 @@ pub fn bls12381_verify_signature_helper(
  **************************************************************************************************/
 fn native_bls12381_aggregate_pubkeys(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
     // Parses a Vec<Vec<u8>> of all serialized public keys
@@ -314,10 +314,10 @@ fn native_bls12381_aggregate_pubkeys(
  **************************************************************************************************/
 pub fn native_bls12381_aggregate_signatures(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
     // Parses a Vec<Vec<u8>> of all serialized signatures
@@ -361,10 +361,10 @@ pub fn native_bls12381_aggregate_signatures(
  **************************************************************************************************/
 pub fn native_bls12381_signature_subgroup_check(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
     context.charge(BLS12381_BASE)?;
@@ -391,10 +391,10 @@ pub fn native_bls12381_signature_subgroup_check(
  **************************************************************************************************/
 fn native_bls12381_validate_pubkey(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
     context.charge(BLS12381_BASE)?;
@@ -442,10 +442,10 @@ fn native_bls12381_validate_pubkey(
 **************************************************************************************************/
 pub fn native_bls12381_verify_aggregate_signature(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 3);
 
     context.charge(BLS12381_BASE)?;
@@ -514,11 +514,11 @@ pub fn native_bls12381_verify_aggregate_signature(
  **************************************************************************************************/
 pub fn native_bls12381_verify_multisignature(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let check_pk_subgroup = false;
-    bls12381_verify_signature_helper(context, _ty_args, arguments, check_pk_subgroup)
+    bls12381_verify_signature_helper(context, ty_args, arguments, check_pk_subgroup)
 }
 
 /***************************************************************************************************
@@ -535,14 +535,14 @@ pub fn native_bls12381_verify_multisignature(
  **************************************************************************************************/
 pub fn native_bls12381_verify_normal_signature(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     // For normal (non-aggregated) signatures, PK's typically don't come with PoPs and the caller
     // might forget to check prime-order subgroup membership of the PK. Therefore, we always enforce
     // it here.
     let check_pk_subgroup = true;
-    bls12381_verify_signature_helper(context, _ty_args, arguments, check_pk_subgroup)
+    bls12381_verify_signature_helper(context, ty_args, arguments, check_pk_subgroup)
 }
 
 /***************************************************************************************************
@@ -557,10 +557,10 @@ pub fn native_bls12381_verify_normal_signature(
  **************************************************************************************************/
 fn native_bls12381_verify_proof_of_possession(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 2);
 
     context.charge(BLS12381_BASE)?;
@@ -598,20 +598,20 @@ fn native_bls12381_verify_proof_of_possession(
  **************************************************************************************************/
 pub fn native_bls12381_verify_signature_share(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     // For signature shares, the caller is REQUIRED to check the PK's PoP, and thus the PK is in the
     // prime-order subgroup.
     let check_pk_subgroup = false;
-    bls12381_verify_signature_helper(context, _ty_args, arguments, check_pk_subgroup)
+    bls12381_verify_signature_helper(context, ty_args, arguments, check_pk_subgroup)
 }
 
 #[cfg(feature = "testing")]
 pub fn native_generate_keys(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
-    mut _arguments: VecDeque<Value>,
+    _ty_args: &[Type],
+    _arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let key_pair = KeyPair::<PrivateKey, PublicKey>::generate(&mut OsRng);
     Ok(smallvec![
@@ -623,7 +623,7 @@ pub fn native_generate_keys(
 #[cfg(feature = "testing")]
 pub fn native_sign(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let msg = safely_pop_arg!(arguments, Vec<u8>);
@@ -636,7 +636,7 @@ pub fn native_sign(
 #[cfg(feature = "testing")]
 pub fn native_generate_proof_of_possession(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let sk_bytes = safely_pop_arg!(arguments, Vec<u8>);

--- a/aptos-move/framework/src/natives/cryptography/bulletproofs.rs
+++ b/aptos-move/framework/src/natives/cryptography/bulletproofs.rs
@@ -72,10 +72,10 @@ static BULLETPROOF_GENERATORS: Lazy<BulletproofGens> =
 
 fn native_verify_range_proof(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 6);
 
     let dst = safely_pop_arg!(args, Vec<u8>);
@@ -112,10 +112,10 @@ fn native_verify_range_proof(
 
 fn native_verify_batch_range_proof(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 6);
 
     let dst = safely_pop_arg!(args, Vec<u8>);
@@ -162,10 +162,10 @@ fn native_verify_batch_range_proof(
 /// This is a test-only native that charges zero gas. It is only exported in testing mode.
 fn native_test_only_prove_range(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 6);
 
     let rand_base_handle = get_point_handle(&safely_pop_arg!(args, StructRef))?;
@@ -228,10 +228,10 @@ fn native_test_only_prove_range(
 /// This is a test-only native that charges zero gas. It is only exported in testing mode.
 fn native_test_only_batch_prove_range(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(args.len() == 6);
 
     let rand_base_handle = get_point_handle(&safely_pop_arg!(args, StructRef))?;

--- a/aptos-move/framework/src/natives/cryptography/ed25519.rs
+++ b/aptos-move/framework/src/natives/cryptography/ed25519.rs
@@ -38,10 +38,10 @@ pub mod abort_codes {
  **************************************************************************************************/
 fn native_public_key_validate(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 1);
 
     let key_bytes = safely_pop_arg!(arguments, Vec<u8>);
@@ -95,7 +95,7 @@ fn native_public_key_validate(
  **************************************************************************************************/
 fn native_signature_verify_strict(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());
@@ -182,7 +182,7 @@ pub fn make_all(
 #[cfg(feature = "testing")]
 fn native_test_only_generate_keys_internal(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let key_pair = KeyPair::<Ed25519PrivateKey, Ed25519PublicKey>::generate(&mut OsRng);
@@ -195,7 +195,7 @@ fn native_test_only_generate_keys_internal(
 #[cfg(feature = "testing")]
 fn native_test_only_sign_internal(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let msg_bytes = safely_pop_arg!(args, Vec<u8>);

--- a/aptos-move/framework/src/natives/cryptography/multi_ed25519.rs
+++ b/aptos-move/framework/src/natives/cryptography/multi_ed25519.rs
@@ -29,10 +29,10 @@ use std::{collections::VecDeque, convert::TryFrom};
 /// See `public_key_validate_v2_internal` comments in `multi_ed25519.move`.
 fn native_public_key_validate_v2(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    safely_assert_eq!(_ty_args.len(), 0);
+    safely_assert_eq!(ty_args.len(), 0);
     safely_assert_eq!(arguments.len(), 1);
 
     let pks_bytes = safely_pop_arg!(arguments, Vec<u8>);
@@ -58,10 +58,10 @@ fn native_public_key_validate_v2(
 
 fn native_public_key_validate_with_gas_fix(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    safely_assert_eq!(_ty_args.len(), 0);
+    safely_assert_eq!(ty_args.len(), 0);
     safely_assert_eq!(arguments.len(), 1);
 
     let pks_bytes = safely_pop_arg!(arguments, Vec<u8>);
@@ -115,10 +115,10 @@ fn num_valid_subpks(
 
 fn native_signature_verify_strict(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    debug_assert!(_ty_args.is_empty());
+    debug_assert!(ty_args.is_empty());
     debug_assert!(arguments.len() == 3);
 
     let msg = safely_pop_arg!(arguments, Vec<u8>);
@@ -160,7 +160,7 @@ fn native_signature_verify_strict(
 #[cfg(feature = "testing")]
 fn native_generate_keys(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let n = safely_pop_arg!(arguments, u8);
@@ -187,7 +187,7 @@ fn native_generate_keys(
 #[cfg(feature = "testing")]
 fn native_sign(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let message = safely_pop_arg!(arguments, Vec<u8>);

--- a/aptos-move/framework/src/natives/cryptography/ristretto255_point.rs
+++ b/aptos-move/framework/src/natives/cryptography/ristretto255_point.rs
@@ -188,7 +188,7 @@ fn decompress_maybe_non_canonical_point_bytes(
 
 pub(crate) fn native_point_identity(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -205,10 +205,10 @@ pub(crate) fn native_point_identity(
 
 pub(crate) fn native_point_is_canonical(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    safely_assert_eq!(_ty_args.len(), 0);
+    safely_assert_eq!(ty_args.len(), 0);
     safely_assert_eq!(args.len(), 1);
 
     let bytes = safely_pop_arg!(args, Vec<u8>);
@@ -220,10 +220,10 @@ pub(crate) fn native_point_is_canonical(
 
 pub(crate) fn native_point_decompress(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
-    safely_assert_eq!(_ty_args.len(), 0);
+    safely_assert_eq!(ty_args.len(), 0);
     safely_assert_eq!(args.len(), 1);
 
     let bytes = safely_pop_arg!(args, Vec<u8>);
@@ -249,7 +249,7 @@ pub(crate) fn native_point_decompress(
 
 pub(crate) fn native_point_clone(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 0);
@@ -269,7 +269,7 @@ pub(crate) fn native_point_clone(
 
 pub(crate) fn native_point_compress(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -288,7 +288,7 @@ pub(crate) fn native_point_compress(
 
 pub(crate) fn native_point_mul(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -320,7 +320,7 @@ pub(crate) fn native_point_mul(
 
 pub(crate) fn native_point_equals(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -343,7 +343,7 @@ pub(crate) fn native_point_equals(
 
 pub(crate) fn native_point_neg(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -375,7 +375,7 @@ pub(crate) fn native_point_neg(
 
 pub(crate) fn native_point_add(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -417,7 +417,7 @@ pub(crate) fn native_point_add(
 
 pub(crate) fn native_point_sub(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -458,7 +458,7 @@ pub(crate) fn native_point_sub(
 
 pub(crate) fn native_basepoint_mul(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -481,7 +481,7 @@ pub(crate) fn native_basepoint_mul(
 #[allow(non_snake_case)]
 pub(crate) fn native_basepoint_double_mul(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -507,7 +507,7 @@ pub(crate) fn native_basepoint_double_mul(
 // NOTE: This was supposed to be more clearly named with *_sha2_512_*
 pub(crate) fn native_new_point_from_sha512(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -531,7 +531,7 @@ pub(crate) fn native_new_point_from_sha512(
 
 pub(crate) fn native_new_point_from_64_uniform_bytes(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 0);
@@ -552,7 +552,7 @@ pub(crate) fn native_new_point_from_64_uniform_bytes(
 
 pub(crate) fn native_double_scalar_mul(
     context: &mut SafeNativeContext,
-    mut _ty_args: Vec<Type>,
+    mut _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(args.len(), 4);
@@ -589,7 +589,7 @@ pub(crate) fn native_double_scalar_mul(
 /// function.
 pub(crate) fn safe_native_multi_scalar_mul_no_floating_point(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(args.len(), 2);

--- a/aptos-move/framework/src/natives/cryptography/ristretto255_scalar.rs
+++ b/aptos-move/framework/src/natives/cryptography/ristretto255_scalar.rs
@@ -27,7 +27,7 @@ use std::{
 /// This is a test-only native that charges zero gas. It is only exported in testing mode.
 pub(crate) fn native_scalar_random(
     _context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());
@@ -47,7 +47,7 @@ pub(crate) fn native_scalar_random(
 
 pub(crate) fn native_scalar_is_canonical(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -70,7 +70,7 @@ pub(crate) fn native_scalar_is_canonical(
 
 pub(crate) fn native_scalar_invert(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -87,7 +87,7 @@ pub(crate) fn native_scalar_invert(
 // NOTE: This was supposed to be more clearly named with *_sha2_512_*.
 pub(crate) fn native_scalar_from_sha512(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -108,7 +108,7 @@ pub(crate) fn native_scalar_from_sha512(
 
 pub(crate) fn native_scalar_mul(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -126,7 +126,7 @@ pub(crate) fn native_scalar_mul(
 
 pub(crate) fn native_scalar_add(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -144,7 +144,7 @@ pub(crate) fn native_scalar_add(
 
 pub(crate) fn native_scalar_sub(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -162,7 +162,7 @@ pub(crate) fn native_scalar_sub(
 
 pub(crate) fn native_scalar_neg(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -179,7 +179,7 @@ pub(crate) fn native_scalar_neg(
 
 pub(crate) fn native_scalar_from_u64(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -196,7 +196,7 @@ pub(crate) fn native_scalar_from_u64(
 
 pub(crate) fn native_scalar_from_u128(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -213,7 +213,7 @@ pub(crate) fn native_scalar_from_u128(
 
 pub(crate) fn native_scalar_reduced_from_32_bytes(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -230,7 +230,7 @@ pub(crate) fn native_scalar_reduced_from_32_bytes(
 
 pub(crate) fn native_scalar_uniform_from_64_bytes(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);

--- a/aptos-move/framework/src/natives/cryptography/secp256k1.rs
+++ b/aptos-move/framework/src/natives/cryptography/secp256k1.rs
@@ -26,7 +26,7 @@ pub mod abort_codes {
  **************************************************************************************************/
 fn native_ecdsa_recover(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());

--- a/aptos-move/framework/src/natives/debug.rs
+++ b/aptos-move/framework/src/natives/debug.rs
@@ -27,7 +27,7 @@ use std::collections::VecDeque;
 #[inline]
 fn native_print(
     _: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());
@@ -54,7 +54,7 @@ fn native_print(
 #[inline]
 fn native_stack_trace(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());
@@ -73,7 +73,7 @@ fn native_stack_trace(
 #[inline]
 fn native_old_debug_print(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     if cfg!(feature = "testing") {
@@ -91,7 +91,7 @@ fn native_old_debug_print(
 #[inline]
 fn native_old_print_stacktrace(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());

--- a/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
+++ b/aptos-move/framework/src/natives/dispatchable_fungible_asset.rs
@@ -21,7 +21,7 @@ use std::collections::VecDeque;
  **************************************************************************************************/
 pub(crate) fn native_dispatch(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     let (module_name, func_name) = extract_function_info(&mut arguments)?;
@@ -50,7 +50,7 @@ pub(crate) fn native_dispatch(
     Err(SafeNativeError::FunctionDispatch {
         module_name,
         func_name,
-        ty_args,
+        ty_args: ty_args.to_vec(),
         args: arguments.into_iter().collect(),
     })
 }

--- a/aptos-move/framework/src/natives/function_info.rs
+++ b/aptos-move/framework/src/natives/function_info.rs
@@ -72,7 +72,7 @@ pub(crate) fn extract_function_info(
  **************************************************************************************************/
 fn native_check_dispatch_type_compatibility_impl(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(arguments.len() == 2);
@@ -142,7 +142,7 @@ fn native_check_dispatch_type_compatibility_impl(
  **************************************************************************************************/
 fn native_is_identifier(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(arguments.len() == 1);
@@ -174,7 +174,7 @@ fn native_is_identifier(
  **************************************************************************************************/
 fn native_load_function_impl(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(arguments.len() == 1);

--- a/aptos-move/framework/src/natives/hash.rs
+++ b/aptos-move/framework/src/natives/hash.rs
@@ -23,7 +23,7 @@ use tiny_keccak::{Hasher as KeccakHasher, Keccak};
  **************************************************************************************************/
 fn native_sip_hash(
     context: &mut SafeNativeContext,
-    mut _ty_args: Vec<Type>,
+    mut _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());
@@ -44,7 +44,7 @@ fn native_sip_hash(
 
 fn native_keccak256(
     context: &mut SafeNativeContext,
-    mut _ty_args: Vec<Type>,
+    mut _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());
@@ -65,7 +65,7 @@ fn native_keccak256(
 
 fn native_sha2_512(
     context: &mut SafeNativeContext,
-    mut _ty_args: Vec<Type>,
+    mut _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());
@@ -85,7 +85,7 @@ fn native_sha2_512(
 
 fn native_sha3_512(
     context: &mut SafeNativeContext,
-    mut _ty_args: Vec<Type>,
+    mut _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());
@@ -111,7 +111,7 @@ pub struct Blake2B256HashGasParameters {
 
 fn native_blake2b_256(
     context: &mut SafeNativeContext,
-    mut _ty_args: Vec<Type>,
+    mut _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(_ty_args.len(), 0);
@@ -138,7 +138,7 @@ pub struct Ripemd160HashGasParameters {
 
 fn native_ripemd160(
     context: &mut SafeNativeContext,
-    mut _ty_args: Vec<Type>,
+    mut _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());

--- a/aptos-move/framework/src/natives/object.rs
+++ b/aptos-move/framework/src/natives/object.rs
@@ -65,18 +65,18 @@ pub struct ExistsAtGasParameters {
 
 fn native_exists_at(
     context: &mut SafeNativeContext,
-    mut ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     safely_assert_eq!(ty_args.len(), 1);
     safely_assert_eq!(args.len(), 1);
 
-    let type_ = ty_args.pop().unwrap();
+    let type_ = &ty_args[0];
     let address = safely_pop_arg!(args, AccountAddress);
 
     context.charge(OBJECT_EXISTS_AT_BASE)?;
 
-    let (exists, num_bytes) = context.exists_at(address, &type_).map_err(|err| {
+    let (exists, num_bytes) = context.exists_at(address, type_).map_err(|err| {
         PartialVMError::new(StatusCode::VM_EXTENSION_ERROR).with_message(format!(
             "Failed to read resource: {:?} at {}. With error: {}",
             type_, address, err
@@ -100,7 +100,7 @@ fn native_exists_at(
  **************************************************************************************************/
 fn native_create_user_derived_object_address_impl(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.is_empty());

--- a/aptos-move/framework/src/natives/permissioned_signer.rs
+++ b/aptos-move/framework/src/natives/permissioned_signer.rs
@@ -30,7 +30,7 @@ const EPERMISSION_SIGNER_DISABLED: u64 = 9;
  **************************************************************************************************/
 fn native_is_permissioned_signer_impl(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(arguments.len() == 1);
@@ -61,7 +61,7 @@ fn native_is_permissioned_signer_impl(
  **************************************************************************************************/
 fn native_permission_address(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(args.len() == 1);
@@ -94,7 +94,7 @@ fn native_permission_address(
  **************************************************************************************************/
 fn native_signer_from_permissioned(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(arguments.len() == 2);
@@ -127,7 +127,7 @@ fn native_signer_from_permissioned(
 #[inline]
 fn native_borrow_address(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());

--- a/aptos-move/framework/src/natives/randomness.rs
+++ b/aptos-move/framework/src/natives/randomness.rs
@@ -71,7 +71,7 @@ impl RandomnessContext {
 
 pub fn fetch_and_increment_txn_counter(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     if context.gas_feature_version() >= RELEASE_V1_23 {
@@ -92,7 +92,7 @@ pub fn fetch_and_increment_txn_counter(
 
 pub fn is_unbiasable(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     // Because we need to run a special transaction prologue to pre-charge maximum

--- a/aptos-move/framework/src/natives/state_storage.rs
+++ b/aptos-move/framework/src/natives/state_storage.rs
@@ -51,7 +51,7 @@ impl<'a> NativeStateStorageContext<'a> {
 /// guarantees a fresh state view then.
 fn native_get_usage(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert!(_ty_args.is_empty());

--- a/aptos-move/framework/src/natives/string_utils.rs
+++ b/aptos-move/framework/src/natives/string_utils.rs
@@ -558,7 +558,7 @@ pub(crate) fn native_format_debug(
 
 fn native_format(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.len() == 1);
@@ -592,7 +592,7 @@ fn native_format(
 
 fn native_format_list(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.len() == 1);

--- a/aptos-move/framework/src/natives/transaction_context.rs
+++ b/aptos-move/framework/src/natives/transaction_context.rs
@@ -108,7 +108,7 @@ impl NativeTransactionContext {
  **************************************************************************************************/
 fn native_get_txn_hash(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_GET_TXN_HASH_BASE)?;
@@ -127,7 +127,7 @@ fn native_get_txn_hash(
  **************************************************************************************************/
 fn native_generate_unique_address(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_GENERATE_UNIQUE_ADDRESS_BASE)?;
@@ -153,7 +153,7 @@ fn native_generate_unique_address(
  **************************************************************************************************/
 fn native_monotonically_increasing_counter_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_MONOTONICALLY_INCREASING_COUNTER_BASE)?;
@@ -208,7 +208,7 @@ fn native_monotonically_increasing_counter_internal(
  **************************************************************************************************/
 fn native_monotonically_increasing_counter_internal_for_test_only(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_MONOTONICALLY_INCREASING_COUNTER_BASE)?;
@@ -238,7 +238,7 @@ fn native_monotonically_increasing_counter_internal_for_test_only(
  **************************************************************************************************/
 fn native_get_script_hash(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_GET_SCRIPT_HASH_BASE)?;
@@ -252,7 +252,7 @@ fn native_get_script_hash(
 
 fn native_sender_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_SENDER_BASE)?;
@@ -269,7 +269,7 @@ fn native_sender_internal(
 
 fn native_secondary_signers_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_SECONDARY_SIGNERS_BASE)?;
@@ -291,7 +291,7 @@ fn native_secondary_signers_internal(
 
 fn native_gas_payer_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_FEE_PAYER_BASE)?;
@@ -308,7 +308,7 @@ fn native_gas_payer_internal(
 
 fn native_max_gas_amount_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_MAX_GAS_AMOUNT_BASE)?;
@@ -325,7 +325,7 @@ fn native_max_gas_amount_internal(
 
 fn native_gas_unit_price_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_GAS_UNIT_PRICE_BASE)?;
@@ -342,7 +342,7 @@ fn native_gas_unit_price_internal(
 
 fn native_chain_id_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_CHAIN_ID_BASE)?;
@@ -422,7 +422,7 @@ fn create_entry_function_payload(
 
 fn native_entry_function_payload_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_ENTRY_FUNCTION_PAYLOAD_BASE)?;
@@ -450,7 +450,7 @@ fn native_entry_function_payload_internal(
 
 fn native_multisig_payload_internal(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     _args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     context.charge(TRANSACTION_CONTEXT_MULTISIG_PAYLOAD_BASE)?;

--- a/aptos-move/framework/src/natives/type_info.rs
+++ b/aptos-move/framework/src/natives/type_info.rs
@@ -46,7 +46,7 @@ fn type_of_internal(struct_tag: &StructTag) -> Result<SmallVec<[Value; 1]>, std:
  **************************************************************************************************/
 fn native_type_of(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.len() == 1);
@@ -83,7 +83,7 @@ fn native_type_of(
  **************************************************************************************************/
 fn native_type_name(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(ty_args.len() == 1);
@@ -112,7 +112,7 @@ fn native_type_name(
  **************************************************************************************************/
 fn native_chain_id(
     context: &mut SafeNativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert!(_ty_args.is_empty());

--- a/aptos-move/framework/src/natives/util.rs
+++ b/aptos-move/framework/src/natives/util.rs
@@ -29,7 +29,7 @@ const EFROM_BYTES: u64 = 0x01_0001;
  **************************************************************************************************/
 fn native_from_bytes(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     debug_assert_eq!(ty_args.len(), 1);

--- a/aptos-move/framework/table-natives/src/lib.rs
+++ b/aptos-move/framework/table-natives/src/lib.rs
@@ -347,7 +347,7 @@ fn charge_load_cost(
 
 fn native_new_table_handle(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 2);
@@ -380,7 +380,7 @@ fn native_new_table_handle(
 
 fn native_add_box(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 3);
@@ -441,7 +441,7 @@ fn native_add_box(
 
 fn native_borrow_box(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 3);
@@ -501,7 +501,7 @@ fn native_borrow_box(
 
 fn native_contains_box(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 3);
@@ -555,7 +555,7 @@ fn native_contains_box(
 
 fn native_remove_box(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 3);
@@ -615,7 +615,7 @@ fn native_remove_box(
 
 fn native_destroy_empty_box(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 3);
@@ -638,7 +638,7 @@ fn native_destroy_empty_box(
 
 fn native_drop_unchecked_box(
     context: &mut SafeNativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> SafeNativeResult<SmallVec<[Value; 1]>> {
     assert_eq!(ty_args.len(), 3);

--- a/third_party/move/extensions/move-table-extension/src/lib.rs
+++ b/third_party/move/extensions/move-table-extension/src/lib.rs
@@ -355,7 +355,7 @@ pub struct NewTableHandleGasParameters {
 fn native_new_table_handle(
     gas_params: &NewTableHandleGasParameters,
     context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(ty_args.len(), 2);
@@ -404,7 +404,7 @@ fn native_add_box(
     common_gas_params: &CommonGasParameters,
     gas_params: &AddBoxGasParameters,
     context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(ty_args.len(), 3);
@@ -458,7 +458,7 @@ fn native_borrow_box(
     common_gas_params: &CommonGasParameters,
     gas_params: &BorrowBoxGasParameters,
     context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(ty_args.len(), 3);
@@ -511,7 +511,7 @@ fn native_contains_box(
     common_gas_params: &CommonGasParameters,
     gas_params: &ContainsBoxGasParameters,
     context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(ty_args.len(), 3);
@@ -563,7 +563,7 @@ fn native_remove_box(
     common_gas_params: &CommonGasParameters,
     gas_params: &RemoveGasParameters,
     context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(ty_args.len(), 3);
@@ -614,7 +614,7 @@ pub struct DestroyEmptyBoxGasParameters {
 fn native_destroy_empty_box(
     gas_params: &DestroyEmptyBoxGasParameters,
     context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(ty_args.len(), 3);
@@ -649,7 +649,7 @@ pub struct DropUncheckedBoxGasParameters {
 fn native_drop_unchecked_box(
     gas_params: &DropUncheckedBoxGasParameters,
     _context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     assert_eq!(ty_args.len(), 3);

--- a/third_party/move/move-examples/diem-framework/crates/natives/src/account.rs
+++ b/third_party/move/move-examples/diem-framework/crates/natives/src/account.rs
@@ -13,7 +13,7 @@ use std::collections::VecDeque;
 
 pub fn native_create_signer(
     _context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());
@@ -29,7 +29,7 @@ pub fn native_create_signer(
 /// remain for replaying old transactions
 pub fn native_destroy_signer(
     _context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());

--- a/third_party/move/move-examples/diem-framework/crates/natives/src/signature.rs
+++ b/third_party/move/move-examples/diem-framework/crates/natives/src/signature.rs
@@ -13,7 +13,7 @@ use std::{collections::VecDeque, convert::TryFrom};
 
 pub fn native_ed25519_publickey_validation(
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(_ty_args.is_empty());
@@ -30,7 +30,7 @@ pub fn native_ed25519_publickey_validation(
 
 pub fn native_ed25519_signature_verification(
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(_ty_args.is_empty());

--- a/third_party/move/move-stdlib/src/natives/bcs.rs
+++ b/third_party/move/move-stdlib/src/natives/bcs.rs
@@ -41,7 +41,7 @@ pub struct ToBytesGasParameters {
 fn native_to_bytes(
     gas_params: &ToBytesGasParameters,
     context: &mut NativeContext,
-    mut ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.len() == 1);
@@ -51,10 +51,10 @@ fn native_to_bytes(
 
     // pop type and value
     let ref_to_val = pop_arg!(args, Reference);
-    let arg_type = ty_args.pop().unwrap();
+    let arg_type = &ty_args[0];
 
     // get type layout
-    let layout = match context.type_to_type_layout(&arg_type) {
+    let layout = match context.type_to_type_layout(arg_type) {
         Ok(layout) => layout,
         Err(_) => {
             cost += gas_params.failure;

--- a/third_party/move/move-stdlib/src/natives/event.rs
+++ b/third_party/move/move-stdlib/src/natives/event.rs
@@ -28,7 +28,7 @@ pub struct WriteToEventStoreGasParameters {
 fn native_write_to_event_store(
     gas_params: &WriteToEventStoreGasParameters,
     _context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.len() == 1);

--- a/third_party/move/move-stdlib/src/natives/hash.rs
+++ b/third_party/move/move-stdlib/src/natives/hash.rs
@@ -31,7 +31,7 @@ pub struct Sha2_256GasParameters {
 fn native_sha2_256(
     gas_params: &Sha2_256GasParameters,
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(_ty_args.is_empty());
@@ -77,7 +77,7 @@ pub struct Sha3_256GasParameters {
 fn native_sha3_256(
     gas_params: &Sha3_256GasParameters,
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(_ty_args.is_empty());

--- a/third_party/move/move-stdlib/src/natives/signer.rs
+++ b/third_party/move/move-stdlib/src/natives/signer.rs
@@ -30,7 +30,7 @@ pub struct BorrowAddressGasParameters {
 fn native_borrow_address(
     gas_params: &BorrowAddressGasParameters,
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(_ty_args.is_empty());

--- a/third_party/move/move-stdlib/src/natives/string.rs
+++ b/third_party/move/move-stdlib/src/natives/string.rs
@@ -39,7 +39,7 @@ pub struct CheckUtf8GasParameters {
 fn native_check_utf8(
     gas_params: &CheckUtf8GasParameters,
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(args.len() == 1);
@@ -75,7 +75,7 @@ pub struct IsCharBoundaryGasParameters {
 fn native_is_char_boundary(
     gas_params: &IsCharBoundaryGasParameters,
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(args.len() == 2);
@@ -112,7 +112,7 @@ pub struct SubStringGasParameters {
 fn native_sub_string(
     gas_params: &SubStringGasParameters,
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(args.len() == 3);
@@ -160,7 +160,7 @@ pub struct IndexOfGasParameters {
 fn native_index_of(
     gas_params: &IndexOfGasParameters,
     _context: &mut NativeContext,
-    _ty_args: Vec<Type>,
+    _ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(args.len() == 2);

--- a/third_party/move/move-stdlib/src/natives/type_name.rs
+++ b/third_party/move/move-stdlib/src/natives/type_name.rs
@@ -21,7 +21,7 @@ pub struct GetGasParameters {
 fn native_get(
     gas_params: &GetGasParameters,
     context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     arguments: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert_eq!(ty_args.len(), 1);

--- a/third_party/move/move-stdlib/src/natives/unit_test.rs
+++ b/third_party/move/move-stdlib/src/natives/unit_test.rs
@@ -37,7 +37,7 @@ pub struct CreateSignersForTestingGasParameters {
 fn native_create_signers_for_testing(
     gas_params: &CreateSignersForTestingGasParameters,
     _context: &mut NativeContext,
-    ty_args: Vec<Type>,
+    ty_args: &[Type],
     mut args: VecDeque<Value>,
 ) -> PartialVMResult<NativeResult> {
     debug_assert!(ty_args.is_empty());

--- a/third_party/move/move-vm/runtime/src/interpreter.rs
+++ b/third_party/move/move-vm/runtime/src/interpreter.rs
@@ -1055,7 +1055,7 @@ where
             gas_meter,
             traversal_context,
         );
-        let result = native_function(&mut native_context, ty_args.to_vec(), args)?;
+        let result = native_function(&mut native_context, ty_args, args)?;
 
         // Note(Gas): The order by which gas is charged / error gets returned MUST NOT be modified
         //            here or otherwise it becomes an incompatible change!!!

--- a/third_party/move/move-vm/runtime/src/native_functions.rs
+++ b/third_party/move/move-vm/runtime/src/native_functions.rs
@@ -45,7 +45,7 @@ use std::{
 };
 use triomphe::Arc as TriompheArc;
 
-pub type UnboxedNativeFunction = dyn Fn(&mut NativeContext, Vec<Type>, VecDeque<Value>) -> PartialVMResult<NativeResult>
+pub type UnboxedNativeFunction = dyn for<'a> Fn(&mut NativeContext, &'a [Type], VecDeque<Value>) -> PartialVMResult<NativeResult>
     + Send
     + Sync
     + 'static;


### PR DESCRIPTION
## Description

Cherry-picking from #17932: for native functions, type arguments can be passed as slice instead of creating a vector allocation. This PR changes native signature to take `&[Type]` instead of `Vec<Type>`, and updates all natives.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches native function type-arg parameter from Vec<Type> to &[Type] across the VM, native interface, framework, stdlib, and third-party extensions, updating builders, signatures, and call sites accordingly.
> 
> - **VM/Core**:
>   - Change `NativeFunction`/`UnboxedNativeFunction` signature to accept `&[Type]` (with appropriate lifetime bounds) and update invocation to pass slices.
>   - Update `SafeNativeBuilder::{make_native,make_named_natives}` and `RawSafeNative` to use `&[Type]`.
> - **Framework & Stdlib**:
>   - Update all native functions to take `&[Type]` and adjust usages (indexing `ty_args[0]` etc.).
>   - Replace `pop()`-based type arg handling with slice access; tweak calls like `type_to_type_layout(ty)`.
>   - Adjust dispatchable natives to clone `ty_args.to_vec()` when needed.
> - **Third-party move extensions**:
>   - Update table natives and Diem example natives to `&[Type]`.
> - **Utilities/Cleanup**:
>   - Remove `safely_pop_type_arg!` macro no longer needed.
>   - Minor signature and lifetime fixes throughout to compile with slice-based API.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f6351ed05d6bf1756ac06add7343f58b2756239. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->