### PR TITLE
Use the new runners for Docker Rust builds and checks

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -56,7 +56,7 @@ jobs:
   # Run the crypto hasher domain separation checks
   rust-cryptohasher-domain-separation-check:
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-ubuntu22-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:non-required-tests')
     steps:
       - uses: actions/checkout@v4
@@ -65,7 +65,7 @@ jobs:
   # Run all rust lints. This is a PR required job.
   rust-lints:
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -101,7 +101,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
         github.event.pull_request.auto_merge != null
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-highperf-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       - name: Run rust doc tests
@@ -120,7 +120,7 @@ jobs:
         github.event.pull_request.auto_merge != null) ||
         contains(github.event.pull_request.body, '#e2e'
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -139,7 +139,7 @@ jobs:
         !contains(github.event.pull_request.base.ref, '-release-')
       )
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=16cpu-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -157,7 +157,7 @@ jobs:
         !contains(github.event.pull_request.base.ref, '-release-')
       )
     needs: file_change_determinator
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-highperf-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -182,7 +182,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'CICD:run-all-unit-tests') ||
         contains(github.event.pull_request.base.ref, '-release-')
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-highperf-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
       # Install Move Prover tools
@@ -205,7 +205,7 @@ jobs:
         contains(github.event.pull_request.labels.*.name, 'CICD:run-e2e-tests') ||
         github.event.pull_request.auto_merge != null
       )
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-highperf-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         if: needs.file_change_determinator.outputs.only_docs_changed != 'true'
@@ -217,7 +217,7 @@ jobs:
 
   # Run the consensus only unit tests
   rust-consensus-only-unit-test:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-highperf-ubuntu22-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4
@@ -227,7 +227,7 @@ jobs:
 
   # Run the consensus only smoke test
   rust-consensus-only-smoke-test:
-    runs-on: runs-on,cpu=64,family=c7,disk=large,image=aptos-ubuntu-x64,run-id=${{ github.run_id }}
+    runs-on: runs-on,runner=64cpu-highperf-ubuntu22-x64,run-id=${{ github.run_id }}
     if: contains(github.event.pull_request.labels.*.name, 'CICD:build-consensus-only-image')
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/workflow-run-docker-rust-build.yaml
+++ b/.github/workflows/workflow-run-docker-rust-build.yaml
@@ -87,7 +87,7 @@ permissions:
 
 jobs:
   rust-all:
-    runs-on: runs-on,cpu=64,family=c7,image=aptos-ubuntu-x64,run-id=${{ github.run_id }},spot=co,disk=large
+    runs-on: runs-on,runner=64cpu-highperf-ubuntu22-x64,run-id=${{ github.run_id }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Description

Switch Docker Rust builds to the new RunsOn highperf runner that targets the new C8 and M8 instance types.
