### PR TITLE
[move compiler] [CSE Step 1] add reaching-def analysis

### DIFF
--- a/third_party/move/move-compiler-v2/src/experiments.rs
+++ b/third_party/move/move-compiler-v2/src/experiments.rs
@@ -239,6 +239,11 @@ pub static EXPERIMENTS: Lazy<BTreeMap<String, Experiment>> = Lazy::new(|| {
             default: Given(false),
         },
         Experiment {
+            name: Experiment::REACHING_DEF_ANALYSIS.to_string(),
+            description: "Whether to run reaching definition analysis.".to_string(),
+            default: Given(false),
+        },
+        Experiment {
             name: Experiment::FLUSH_WRITES_OPTIMIZATION.to_string(),
             description: "Whether to run flush writes processor and optimization".to_string(),
             default: Inherited(Experiment::OPTIMIZE.to_string()),
@@ -343,6 +348,7 @@ impl Experiment {
     pub const OPTIMIZE_WAITING_FOR_COMPARE_TESTS: &'static str =
         "optimize-waiting-for-compare-tests";
     pub const PEEPHOLE_OPTIMIZATION: &'static str = "peephole-optimization";
+    pub const REACHING_DEF_ANALYSIS: &'static str = "reaching-def-analysis";
     pub const RECURSIVE_TYPE_CHECK: &'static str = "recursive-type-check";
     pub const REFERENCE_SAFETY: &'static str = "reference-safety";
     pub const REFERENCE_SAFETY_V3: &'static str = "reference-safety-v3";

--- a/third_party/move/move-compiler-v2/src/lib.rs
+++ b/third_party/move/move-compiler-v2/src/lib.rs
@@ -31,6 +31,7 @@ use crate::{
         flush_writes_processor::FlushWritesProcessor,
         lint_processor::LintProcessor,
         livevar_analysis_processor::LiveVarAnalysisProcessor,
+        reaching_def_analysis_processor::ReachingDefProcessor,
         reference_safety::{reference_safety_processor_v2, reference_safety_processor_v3},
         split_critical_edges_processor::SplitCriticalEdgesProcessor,
         uninitialized_use_checker::UninitializedUseChecker,
@@ -531,6 +532,11 @@ pub fn stackless_bytecode_check_pipeline(options: &Options) -> FunctionTargetPip
         pipeline.add_processor(Box::new(
             reference_safety_processor_v2::ReferenceSafetyProcessor {},
         ));
+    }
+
+    // Reaching definition analysis (depends on livevar and lifetime annotations)
+    if options.experiment_on(Experiment::REACHING_DEF_ANALYSIS) {
+        pipeline.add_processor(Box::new(ReachingDefProcessor {}));
     }
 
     if options.experiment_on(Experiment::ABILITY_CHECK) {

--- a/third_party/move/move-compiler-v2/src/pipeline/mod.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/mod.rs
@@ -5,6 +5,7 @@
 use crate::pipeline::{
     exit_state_analysis::ExitStateAnalysisProcessor, flush_writes_processor::FlushWritesProcessor,
     livevar_analysis_processor::LiveVarAnalysisProcessor,
+    reaching_def_analysis_processor::ReachingDefProcessor,
     uninitialized_use_checker::UninitializedUseChecker,
     unreachable_code_analysis::UnreachableCodeProcessor, variable_coalescing::VariableCoalescing,
 };
@@ -17,6 +18,7 @@ pub mod exit_state_analysis;
 pub mod flush_writes_processor;
 pub mod lint_processor;
 pub mod livevar_analysis_processor;
+pub mod reaching_def_analysis_processor;
 pub mod reference_safety;
 pub mod split_critical_edges_processor;
 pub mod uninitialized_use_checker;
@@ -32,6 +34,7 @@ pub fn register_formatters(target: &FunctionTarget) {
     ExitStateAnalysisProcessor::register_formatters(target);
     FlushWritesProcessor::register_formatters(target);
     LiveVarAnalysisProcessor::register_formatters(target);
+    ReachingDefProcessor::register_formatters(target);
     reference_safety::register_formatters(target);
     UninitializedUseChecker::register_formatters(target);
     UnreachableCodeProcessor::register_formatters(target);

--- a/third_party/move/move-compiler-v2/src/pipeline/reaching_def_analysis_processor.rs
+++ b/third_party/move/move-compiler-v2/src/pipeline/reaching_def_analysis_processor.rs
@@ -1,0 +1,547 @@
+// Copyright © Aptos Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+//! Reaching Definition Analysis (RDA) pass for Move stackless bytecode.
+//!
+//! # Prerequisites
+//!
+//! - `LiveVarAnnotation` (from livevar analysis)
+//! - `LifetimeAnnotation` (from reference safety analysis)
+//!
+//! # Overview
+//!
+//! This analysis computes reaching definition information for temporaries and global
+//! resources within a function. For each bytecode at a given `code_offset`, it provides
+//! a mapping from each local temporary or global resource to the set of code offsets
+//! where they may be defined and can reach `code_offset`:
+//!
+//! ```text
+//! ReachingDefState(code_offset) := Map<Object, Set<CodeOffset>>
+//! Object := Local(TempIndex) | Global(QualifiedId<StructId>)
+//! ```
+//!
+//! The analysis is a may-analysis (over-approximating). A result like
+//! `ReachingDefState(offset_1) := {obj1 -> {offset_2, offset_3}}` means that `obj1`
+//! is possibly defined at `offset_2` and `offset_3`, and those definitions may reach `offset_1`.
+//!
+//! # Temporaries
+//!
+//! Definitions of temporaries are created at:
+//! - `Assign` and `Load` instructions
+//! - `Call` instructions (for destination operands)
+//!
+//! Definitions are killed when the temporary is re-defined or moved.
+//!
+//! Definitions via dereferences are handled conservatively:
+//! - `WriteRef`: all temporaries potentially pointed to by the reference are killed and re-defined
+//! - Mutable reference passed to callees: all temporaries it may point to are killed and re-defined
+//! - Mutable reference passed to invoked closures: all temporaries it may point to are killed and re-defined
+//!
+//! # Global Resources
+//!
+//! Definitions of global resources are killed and re-defined at:
+//! - `MoveFrom`
+//! - `MoveTo`
+//! - Mutation via mutable reference dereference (handled conservatively, same as temporaries)
+//!
+//! Callees and invoked closures are handled conservatively:
+//! - On `Call`: the callee and its transitively used functions are analyzed to collect accessed resources
+//! - On `Invoke`: all resources in the current module are assumed to be potentially modified,
+//!   since the closure target is unknown at compile time (it could come from function parameters,
+//!   global storage, or other indirect sources)
+//!
+//! **Note**: Only global resources declared in the same module as the target function are considered.
+
+use crate::{
+    bytecode_generator::generate_bytecode,
+    pipeline::{
+        livevar_analysis_processor::LiveVarAnnotation,
+        reference_safety::{LifetimeAnnotation, Object},
+    },
+};
+use itertools::Itertools;
+use move_binary_format::file_format::CodeOffset;
+use move_model::{
+    model::{FunId, FunctionEnv, QualifiedId},
+    ty::{ReferenceKind, Type},
+};
+use move_stackless_bytecode::{
+    dataflow_analysis::{DataflowAnalysis, TransferFunctions},
+    dataflow_domains::{AbstractDomain, JoinResult},
+    function_target::{FunctionData, FunctionTarget},
+    function_target_pipeline::{FunctionTargetProcessor, FunctionTargetsHolder},
+    stackless_bytecode::{AbortAction, AssignKind, Bytecode, Operation},
+    stackless_control_flow_graph::StacklessControlFlowGraph,
+};
+use std::{
+    cell::RefCell,
+    collections::{BTreeMap, BTreeSet},
+};
+
+type DefMap = BTreeMap<Object, BTreeSet<CodeOffset>>;
+
+/// The reaching definition state at a particular code offset.
+///
+/// Maps each object (local temporary or global resource) to the set of code offsets
+/// where that object may have been defined and those definitions can reach this point.
+///
+/// This is a may-analysis: the result over-approximates the actual reaching definitions.
+#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Default)]
+pub struct ReachingDefState {
+    pub map: DefMap,
+}
+
+/// The annotation for reaching definitions produced by `ReachingDefProcessor`.
+///
+/// For each code position, maps it to the `ReachingDefState` representing which
+/// definitions may reach that position.
+///
+/// # Limitations
+///
+/// **Global resources**: Only global resources declared in the same module as the
+/// analyzed function are tracked. Global resources declared in other modules are
+/// not included in the analysis.
+///
+/// # Example
+///
+/// For code like:
+/// ```move
+/// let x = 1;      // offset 0: defines x
+/// let y = 2;      // offset 1: defines y
+/// if (cond) {
+///     x = 3;      // offset 3: defines x
+/// }
+/// use(x);         // offset 5: x has reaching defs from {0, 3}
+/// ```
+///
+/// At offset 5, `get_info_at(5).map[Local(x)]` would be `{0, 3}`.
+#[derive(Clone, Default)]
+pub struct ReachingDefAnnotation(BTreeMap<CodeOffset, ReachingDefState>);
+
+impl ReachingDefAnnotation {
+    /// Returns the reaching definition information at the given code offset.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no information exists for the given offset (indicates the
+    /// analysis was not run or the offset is invalid).
+    pub fn get_info_at(&self, code_offset: CodeOffset) -> &ReachingDefState {
+        self.0.get(&code_offset).expect("reaching def info")
+    }
+}
+
+/// A processor that computes reaching definition analysis for Move stackless bytecode.
+///
+/// This processor analyzes which definitions of variables and global resources may
+/// reach each program point. It produces a `ReachingDefAnnotation` that can be
+/// queried by subsequent pipeline stages.
+///
+/// # Prerequisites
+///
+/// This processor requires the following annotations to be present:
+/// - `LiveVarAnnotation` from `LiveVarAnalysisProcessor`
+/// - `LifetimeAnnotation` from reference safety analysis
+///
+/// If these annotations are missing, the processor returns the function data unchanged.
+///
+/// # See Also
+///
+/// - `ReachingDefAnnotation` for the output format and limitations
+/// - `ReachingDefState` for the per-offset state
+pub struct ReachingDefProcessor {}
+
+impl FunctionTargetProcessor for ReachingDefProcessor {
+    fn process(
+        &self,
+        _targets: &mut FunctionTargetsHolder,
+        func_env: &FunctionEnv,
+        mut data: FunctionData,
+        _scc_opt: Option<&[FunctionEnv]>,
+    ) -> FunctionData {
+        if func_env.is_native() {
+            return data;
+        }
+
+        let target = FunctionTarget::new(func_env, &data);
+        // Reaching definition analysis requires lifetime and livevar annotations
+        let Some(ref_annotation) = target.get_annotations().get::<LifetimeAnnotation>() else {
+            return data;
+        };
+        let Some(livevar_annotation) = target.get_annotations().get::<LiveVarAnnotation>() else {
+            return data;
+        };
+        // Collect all resource structs (structs with `key` ability) in the module
+        let module_env = target.module_env();
+        let all_module_resources: BTreeSet<Object> = module_env
+            .get_structs()
+            .filter(|s| s.has_memory()) // has_memory() checks for `key` ability
+            .map(|s| Object::Global(module_env.get_id().qualified(s.get_id())))
+            .collect();
+
+        // init and run the analyzer
+        let analyzer = ReachingDefAnalysis {
+            target,
+            livevar_annotation,
+            ref_annotation,
+            transitive_global_access: RefCell::new(BTreeMap::new()),
+            direct_global_access: RefCell::new(BTreeMap::new()),
+            all_module_resources,
+        };
+        let cfg = StacklessControlFlowGraph::new_forward(&data.code);
+        let block_state_map = analyzer.analyze_function(
+            ReachingDefState {
+                map: BTreeMap::new(),
+            },
+            &data.code,
+            &cfg,
+        );
+        let per_bytecode_state = analyzer.state_per_instruction_with_default(
+            block_state_map,
+            &data.code,
+            &cfg,
+            |before, _| before.clone(),
+        );
+
+        let annotations = ReachingDefAnnotation(per_bytecode_state);
+        data.annotations.set(annotations, true);
+        data
+    }
+
+    fn name(&self) -> String {
+        "ReachingDefProcessor".to_string()
+    }
+}
+
+impl ReachingDefProcessor {
+    /// Registers annotation formatter at the given function target. This is for debugging and
+    /// testing.
+    pub fn register_formatters(target: &FunctionTarget) {
+        target.register_annotation_formatter(Box::new(format_reaching_def_annotation))
+    }
+}
+
+struct ReachingDefAnalysis<'env> {
+    target: FunctionTarget<'env>,
+    livevar_annotation: &'env LiveVarAnnotation,
+    ref_annotation: &'env LifetimeAnnotation,
+    /// Cache: function ID -> global resources accessed by the function and its transitive callees.
+    transitive_global_access: RefCell<BTreeMap<QualifiedId<FunId>, BTreeSet<Object>>>,
+    /// Cache: function ID -> global resources directly accessed by the function (not including callees).
+    direct_global_access: RefCell<BTreeMap<QualifiedId<FunId>, BTreeSet<Object>>>,
+    /// All resource structs (structs with `key` ability) in the current module.
+    /// Computed once at initialization and used for conservative analysis.
+    all_module_resources: BTreeSet<Object>,
+}
+
+impl ReachingDefAnalysis<'_> {
+    /// Gets global resources accessed by the given function and its transitive callees.
+    /// Results are cached to avoid recomputation.
+    fn get_transitive_global_access(&self, qualified_fid: QualifiedId<FunId>) -> BTreeSet<Object> {
+        if let Some(cached) = self.transitive_global_access.borrow().get(&qualified_fid) {
+            return cached.clone();
+        }
+
+        let global_env = self.target.global_env();
+        let module_env = global_env.get_module(qualified_fid.module_id);
+        let func_env = module_env.get_function(qualified_fid.id);
+
+        let mut transitive_used_funcs = func_env.get_transitive_closure_of_used_functions();
+        transitive_used_funcs.insert(qualified_fid);
+
+        let target_mid = self.target.module_env().get_id();
+        let mut global_resources = BTreeSet::new();
+
+        for child_fid in transitive_used_funcs.iter() {
+            // Skip functions from external modules because they cannot access
+            // global resources declared in the current module:
+            // - External modules cannot directly access this module's resources
+            // - If they called back into this module, it would create a cyclic dependency
+            if child_fid.module_id != target_mid {
+                continue;
+            }
+            global_resources.extend(self.get_direct_global_access(*child_fid));
+        }
+
+        self.transitive_global_access
+            .borrow_mut()
+            .insert(qualified_fid, global_resources.clone());
+        global_resources
+    }
+
+    /// Gets the global resources directly accessed by a single function (not including callees).
+    /// Results are cached to avoid re-analyzing the same function's bytecode.
+    fn get_direct_global_access(&self, qualified_fid: QualifiedId<FunId>) -> BTreeSet<Object> {
+        if let Some(cached) = self.direct_global_access.borrow().get(&qualified_fid) {
+            return cached.clone();
+        }
+
+        let global_env = self.target.global_env();
+        let func_env = global_env.get_function(qualified_fid);
+
+        // Native functions do not access global resources
+        // Inline functions are expanded at call sites
+        if func_env.is_native() || func_env.is_inline() {
+            return BTreeSet::new();
+        }
+
+        let func_data = generate_bytecode(global_env, qualified_fid);
+        let mut resources = BTreeSet::new();
+
+        for bytecode in func_data.code.iter() {
+            match bytecode {
+                Bytecode::Call(
+                    _,
+                    _,
+                    Operation::MoveTo(mid, sid, _) | Operation::MoveFrom(mid, sid, _),
+                    _,
+                    _,
+                ) => {
+                    resources.insert(Object::Global(mid.qualified(*sid)));
+                },
+                // Mutable borrow gives the function the capability to modify the global.
+                // Since we don't analyze the code for actual WriteRef usage,
+                // we conservatively assume any mutable borrow may modify the resource.
+                Bytecode::Call(_, dests, Operation::BorrowGlobal(mid, sid, _), _, _)
+                    if !dests.is_empty()
+                        && func_data.local_types[dests[0]].is_mutable_reference() =>
+                {
+                    resources.insert(Object::Global(mid.qualified(*sid)));
+                },
+                // If the function invokes a closure, conservatively assume all module
+                // resources could be modified (closure target is unknown).
+                Bytecode::Call(_, _, Operation::Invoke, _, _) => {
+                    resources.extend(self.all_module_resources.clone());
+                },
+                _ => {},
+            }
+        }
+
+        self.direct_global_access
+            .borrow_mut()
+            .insert(qualified_fid, resources.clone());
+        resources
+    }
+}
+
+impl TransferFunctions for ReachingDefAnalysis<'_> {
+    type State = ReachingDefState;
+
+    const BACKWARD: bool = false;
+
+    fn execute(&self, state: &mut ReachingDefState, instr: &Bytecode, offset: CodeOffset) {
+        use Bytecode::*;
+        use Operation::*;
+
+        match instr {
+            Assign(_, dest, src, kind) => {
+                // Move semantics invalidate the source, essentially killing it
+                match kind {
+                    AssignKind::Copy => {
+                        state.kill(Object::Local(*dest));
+                        state.def(Object::Local(*dest), offset);
+                    },
+                    AssignKind::Move => {
+                        state.kill(Object::Local(*dest));
+                        state.def(Object::Local(*dest), offset);
+                        state.kill(Object::Local(*src));
+                    },
+                    AssignKind::Inferred => {
+                        state.kill(Object::Local(*dest));
+                        state.def(Object::Local(*dest), offset);
+
+                        let lifetime = self.ref_annotation.get_info_at(offset);
+                        let live_info = self.livevar_annotation.get_info_at(offset);
+                        // If the source temp is not used after this instruction and is not borrowed,
+                        // it will be moved, and we need to consider it killed.
+                        if !live_info.is_temp_used_after(src, instr) && !lifetime.is_borrowed(*src)
+                        {
+                            state.kill(Object::Local(*src));
+                        }
+                    },
+                    AssignKind::Store => {
+                        state.kill(Object::Local(*dest));
+                        state.def(Object::Local(*dest), offset);
+                    },
+                }
+            },
+            Load(_, dest, ..) => {
+                state.kill(Object::Local(*dest));
+                state.def(Object::Local(*dest), offset);
+            },
+            Call(_, dests, oper, srcs, on_abort) => {
+                // generic kills
+                for dest in dests {
+                    state.kill(Object::Local(*dest));
+                    state.def(Object::Local(*dest), offset);
+                }
+                if let Some(AbortAction(_, dest)) = on_abort {
+                    state.kill(Object::Local(*dest));
+                    state.def(Object::Local(*dest), offset);
+                }
+                // op-specific actions
+                match oper {
+                    Drop => {
+                        state.kill(Object::Local(srcs[0]));
+                    },
+                    WriteRef => {
+                        let ref_info = self.ref_annotation.get_info_at(offset);
+                        for obj in ref_info.referenced_objects_before(srcs[0]) {
+                            state.kill(obj);
+                            state.def(obj, offset);
+                        }
+                    },
+                    // MoveFrom removes the resource from global storage.
+                    // This is a redefinition point: the resource state changes from
+                    // "exists with value" to "does not exist".
+                    MoveFrom(mid, sid, _) => {
+                        let obj = Object::Global(mid.qualified(*sid));
+                        state.kill(obj);
+                        state.def(obj, offset);
+                    },
+                    // MoveTo stores a new value to global storage.
+                    // This is a redefinition point: the resource state changes to
+                    // "exists with new value".
+                    MoveTo(mid, sid, _) => {
+                        let obj = Object::Global(mid.qualified(*sid));
+                        state.kill(obj);
+                        state.def(obj, offset);
+                    },
+                    // If a mut ref is passed to a callee, we consider all the objects it points to is redefined
+                    // Also collect all the global resources transitively accessed by the callee
+                    Function(mid, fid, _) => {
+                        for src in srcs.iter() {
+                            if self.target.get_local_type(*src).is_mutable_reference() {
+                                for obj in self
+                                    .ref_annotation
+                                    .get_info_at(offset)
+                                    .referenced_objects_before(*src)
+                                {
+                                    state.kill(obj);
+                                    state.def(obj, offset);
+                                }
+                            }
+                        }
+                        for obj in self.get_transitive_global_access(mid.qualified(*fid)) {
+                            state.kill(obj);
+                            state.def(obj, offset);
+                        }
+                    },
+                    // Handle closure invocation conservatively:
+                    // 1. Mutable refs passed as arguments: redefine all objects they may point to
+                    // 2. Global resources: we conservatively assume the invoked closure could
+                    //    modify ANY resource in the current module. This is necessary because
+                    //    the closure's target function is generally unknown at compile time -
+                    //    it could come from function parameters, global storage, or other
+                    //    indirect sources. Without full alias/pointer analysis, we cannot
+                    //    determine which specific function will be invoked.
+                    Invoke => {
+                        let fun_type = self
+                            .target
+                            .get_local_type(*srcs.last().expect("closure expected"));
+                        if let Type::Fun(args_ty, _, _) = fun_type {
+                            let ref_info = self.ref_annotation.get_info_at(offset);
+                            match args_ty.as_ref() {
+                                // A single arg closure
+                                Type::Reference(ReferenceKind::Mutable, _) => {
+                                    assert!(srcs.len() == 2, "one argument expected for invoke");
+                                    for obj in ref_info.referenced_objects_before(srcs[0]) {
+                                        state.kill(obj);
+                                        state.def(obj, offset);
+                                    }
+                                },
+                                Type::Tuple(x) => {
+                                    assert!(
+                                        srcs.len() == x.len() + 1,
+                                        "{} arguments expected for invoke",
+                                        x.len()
+                                    );
+                                    for (i, ty) in x.iter().enumerate() {
+                                        if ty.is_mutable_reference() {
+                                            for obj in ref_info.referenced_objects_before(srcs[i]) {
+                                                state.kill(obj);
+                                                state.def(obj, offset);
+                                            }
+                                        }
+                                    }
+                                },
+                                _ => {},
+                            }
+                        }
+                        // Conservatively assume any module resource could be modified
+                        for obj in self.all_module_resources.clone() {
+                            state.kill(obj);
+                            state.def(obj, offset);
+                        }
+                    },
+                    _ => (),
+                }
+            },
+            _ => {},
+        }
+    }
+}
+
+impl DataflowAnalysis for ReachingDefAnalysis<'_> {}
+
+impl AbstractDomain for ReachingDefState {
+    fn join(&mut self, other: &Self) -> JoinResult {
+        let mut result = JoinResult::Unchanged;
+        // why we merge them:
+        // - we want to collect a sound set of may-reach definitions
+        for (idx, other_defs) in &other.map {
+            let defs = self.map.entry(*idx).or_default();
+            for d in other_defs {
+                if defs.insert(*d) {
+                    result = JoinResult::Changed;
+                }
+            }
+        }
+        result
+    }
+}
+
+impl ReachingDefState {
+    fn def(&mut self, dest: Object, loc: CodeOffset) {
+        // ensure that the previous def is killed
+        assert!(!self.map.contains_key(&dest));
+
+        // update the new defs
+        self.map.entry(dest).or_default().insert(loc);
+    }
+
+    fn kill(&mut self, dest: Object) {
+        self.map.remove(&dest);
+    }
+}
+
+// =================================================================================================
+// Formatting
+
+/// Format a reaching definition annotation.
+pub fn format_reaching_def_annotation(
+    target: &FunctionTarget<'_>,
+    code_offset: CodeOffset,
+) -> Option<String> {
+    if let Some(ReachingDefAnnotation(map)) =
+        target.get_annotations().get::<ReachingDefAnnotation>()
+    {
+        if let Some(map_at) = map.get(&code_offset) {
+            let res = map_at
+                .map
+                .iter()
+                .map(|(idx, defs)| {
+                    format!(
+                        "`{}` @ {{{}}}",
+                        match idx {
+                            Object::Local(t) => format!("t{}", t),
+                            Object::Global(sid) => format!("Struct {:?}", sid),
+                        },
+                        defs.iter().map(|def| format!("{}", def)).join(", ")
+                    )
+                })
+                .join(", ");
+            return Some(format!("reaching instruction #{}: {}", code_offset, res));
+        }
+    }
+    None
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/abort_assert.exp
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/abort_assert.exp
@@ -1,0 +1,947 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun abort_assert::abort_after_assign(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+  0: $t1 := 1
+  1: $t3 := infer($t1)
+  2: $t4 := 1
+  3: $t2 := +($t3, $t4)
+  4: abort($t2)
+  5: $t0 := infer($t1)
+  6: return $t0
+}
+
+
+[variant baseline]
+fun abort_assert::assign_before_abort($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: if ($t0) goto 1 else goto 7
+  1: label L0
+  2: $t3 := 1
+  3: $t2 := infer($t3)
+  4: $t4 := 0
+  5: abort($t4)
+  6: goto 10
+  7: label L1
+  8: $t5 := 2
+  9: $t2 := infer($t5)
+ 10: label L2
+ 11: $t1 := infer($t2)
+ 12: return $t1
+}
+
+
+[variant baseline]
+fun abort_assert::both_may_abort($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+  0: if ($t0) goto 1 else goto 15
+  1: label L0
+  2: $t5 := infer($t1)
+  3: $t6 := 0
+  4: $t4 := >($t5, $t6)
+  5: if ($t4) goto 6 else goto 8
+  6: label L3
+  7: goto 11
+  8: label L4
+  9: $t7 := 100
+ 10: abort($t7)
+ 11: label L5
+ 12: $t8 := 1
+ 13: $t3 := infer($t8)
+ 14: goto 28
+ 15: label L1
+ 16: $t10 := infer($t1)
+ 17: $t11 := 10
+ 18: $t9 := >($t10, $t11)
+ 19: if ($t9) goto 20 else goto 22
+ 20: label L6
+ 21: goto 25
+ 22: label L7
+ 23: $t12 := 101
+ 24: abort($t12)
+ 25: label L8
+ 26: $t13 := 2
+ 27: $t3 := infer($t13)
+ 28: label L2
+ 29: $t2 := infer($t3)
+ 30: return $t2
+}
+
+
+[variant baseline]
+fun abort_assert::conditional_abort($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 1
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 0
+  4: abort($t3)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t1 := infer($t2)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun abort_assert::multiple_asserts($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+  0: $t3 := 1
+  1: $t5 := infer($t0)
+  2: $t6 := 0
+  3: $t4 := >($t5, $t6)
+  4: if ($t4) goto 5 else goto 7
+  5: label L0
+  6: goto 10
+  7: label L1
+  8: $t7 := 100
+  9: abort($t7)
+ 10: label L2
+ 11: $t8 := 2
+ 12: $t10 := infer($t1)
+ 13: $t11 := 0
+ 14: $t9 := >($t10, $t11)
+ 15: if ($t9) goto 16 else goto 18
+ 16: label L3
+ 17: goto 21
+ 18: label L4
+ 19: $t12 := 101
+ 20: abort($t12)
+ 21: label L5
+ 22: $t13 := infer($t3)
+ 23: $t2 := +($t13, $t8)
+ 24: return $t2
+}
+
+
+[variant baseline]
+fun abort_assert::nested_abort($t0: bool, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := 0
+  1: if ($t0) goto 2 else goto 15
+  2: label L0
+  3: if ($t1) goto 4 else goto 10
+  4: label L3
+  5: $t4 := 1
+  6: $t3 := infer($t4)
+  7: $t5 := 0
+  8: abort($t5)
+  9: goto 13
+ 10: label L4
+ 11: $t6 := 2
+ 12: $t3 := infer($t6)
+ 13: label L5
+ 14: goto 18
+ 15: label L1
+ 16: $t7 := 3
+ 17: $t3 := infer($t7)
+ 18: label L2
+ 19: $t2 := infer($t3)
+ 20: return $t2
+}
+
+
+[variant baseline]
+fun abort_assert::simple_abort(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+  0: $t1 := 1
+  1: $t2 := 0
+  2: abort($t2)
+  3: $t0 := infer($t1)
+  4: return $t0
+}
+
+
+[variant baseline]
+fun abort_assert::with_assert($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+  0: $t2 := 1
+  1: $t4 := infer($t0)
+  2: $t5 := 0
+  3: $t3 := >($t4, $t5)
+  4: if ($t3) goto 5 else goto 7
+  5: label L0
+  6: goto 10
+  7: label L1
+  8: $t6 := 100
+  9: abort($t6)
+ 10: label L2
+ 11: $t1 := infer($t2)
+ 12: return $t1
+}
+
+
+Diagnostics:
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+  ┌─ tests/reaching-def/abort_assert.move:5:17
+  │
+5 │         let x = 1;
+  │                 ^
+
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+   ┌─ tests/reaching-def/abort_assert.move:23:13
+   │
+23 │             x = 1;
+   │             ^^^^^
+
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+   ┌─ tests/reaching-def/abort_assert.move:49:17
+   │
+49 │         let x = 0;
+   │                 ^
+
+warning: This assignment/binding to the left-hand-side variable `x` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_x`), or renaming to `_`
+   ┌─ tests/reaching-def/abort_assert.move:52:17
+   │
+52 │                 x = 1;
+   │                 ^^^^^
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun abort_assert::abort_after_assign(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := 1
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: $t3 := infer($t1)
+     # live vars: $t3
+     # reaching instruction #2: `t3` @ {1}
+     # refs: []
+     #
+  2: $t4 := 1
+     # live vars: $t3, $t4
+     # reaching instruction #3: `t3` @ {1}, `t4` @ {2}
+     # refs: []
+     #
+  3: $t2 := +($t3, $t4)
+     # live vars: $t2
+     # reaching instruction #4: `t2` @ {3}, `t3` @ {1}, `t4` @ {2}
+     # refs: []
+     #
+  4: abort($t2)
+     # live vars: $t1
+     # reaching instruction #5:
+  5: $t0 := infer($t1)
+     # live vars: $t0
+     # reaching instruction #6:
+  6: return $t0
+}
+
+
+[variant baseline]
+fun abort_assert::assign_before_abort($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: if ($t0) goto 1 else goto 7
+     # live vars:
+     # reaching instruction #1:
+     # refs: []
+     #
+  1: label L0
+     # live vars:
+     # reaching instruction #2:
+     # refs: []
+     #
+  2: $t3 := 1
+     # live vars: $t3
+     # reaching instruction #3: `t3` @ {2}
+     # refs: []
+     #
+  3: $t2 := infer($t3)
+     # live vars:
+     # reaching instruction #4: `t2` @ {3}
+     # refs: []
+     #
+  4: $t4 := 0
+     # live vars: $t4
+     # reaching instruction #5: `t2` @ {3}, `t4` @ {4}
+     # refs: []
+     #
+  5: abort($t4)
+     # live vars: $t2
+     # reaching instruction #6:
+  6: goto 10
+     # live vars:
+     # reaching instruction #7:
+     # refs: []
+     #
+  7: label L1
+     # live vars:
+     # reaching instruction #8:
+     # refs: []
+     #
+  8: $t5 := 2
+     # live vars: $t5
+     # reaching instruction #9: `t5` @ {8}
+     # refs: []
+     #
+  9: $t2 := infer($t5)
+     # live vars: $t2
+     # reaching instruction #10: `t2` @ {9}
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t2
+     # reaching instruction #11: `t2` @ {9}
+     # refs: []
+     #
+ 11: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #12: `t1` @ {11}
+     # refs: []
+     #
+ 12: return $t1
+}
+
+
+[variant baseline]
+fun abort_assert::both_may_abort($t0: bool, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: if ($t0) goto 1 else goto 15
+     # live vars: $t1
+     # reaching instruction #1:
+     # refs: []
+     #
+  1: label L0
+     # live vars: $t1
+     # reaching instruction #2:
+     # refs: []
+     #
+  2: $t5 := infer($t1)
+     # live vars: $t5
+     # reaching instruction #3: `t5` @ {2}
+     # refs: []
+     #
+  3: $t6 := 0
+     # live vars: $t5, $t6
+     # reaching instruction #4: `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+  4: $t4 := >($t5, $t6)
+     # live vars: $t4
+     # reaching instruction #5: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+  5: if ($t4) goto 6 else goto 8
+     # live vars:
+     # reaching instruction #6: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+  6: label L3
+     # live vars:
+     # reaching instruction #7: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+  7: goto 11
+     # live vars:
+     # reaching instruction #8: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+  8: label L4
+     # live vars:
+     # reaching instruction #9: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+  9: $t7 := 100
+     # live vars: $t7
+     # reaching instruction #10: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}, `t7` @ {9}
+     # refs: []
+     #
+ 10: abort($t7)
+     # live vars:
+     # reaching instruction #11: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+ 11: label L5
+     # live vars:
+     # reaching instruction #12: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+ 12: $t8 := 1
+     # live vars: $t8
+     # reaching instruction #13: `t4` @ {4}, `t5` @ {2}, `t6` @ {3}, `t8` @ {12}
+     # refs: []
+     #
+ 13: $t3 := infer($t8)
+     # live vars: $t3
+     # reaching instruction #14: `t3` @ {13}, `t4` @ {4}, `t5` @ {2}, `t6` @ {3}
+     # refs: []
+     #
+ 14: goto 28
+     # live vars: $t1
+     # reaching instruction #15:
+     # refs: []
+     #
+ 15: label L1
+     # live vars: $t1
+     # reaching instruction #16:
+     # refs: []
+     #
+ 16: $t10 := infer($t1)
+     # live vars: $t10
+     # reaching instruction #17: `t10` @ {16}
+     # refs: []
+     #
+ 17: $t11 := 10
+     # live vars: $t10, $t11
+     # reaching instruction #18: `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 18: $t9 := >($t10, $t11)
+     # live vars: $t9
+     # reaching instruction #19: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 19: if ($t9) goto 20 else goto 22
+     # live vars:
+     # reaching instruction #20: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 20: label L6
+     # live vars:
+     # reaching instruction #21: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 21: goto 25
+     # live vars:
+     # reaching instruction #22: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 22: label L7
+     # live vars:
+     # reaching instruction #23: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 23: $t12 := 101
+     # live vars: $t12
+     # reaching instruction #24: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}, `t12` @ {23}
+     # refs: []
+     #
+ 24: abort($t12)
+     # live vars:
+     # reaching instruction #25: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 25: label L8
+     # live vars:
+     # reaching instruction #26: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 26: $t13 := 2
+     # live vars: $t13
+     # reaching instruction #27: `t9` @ {18}, `t10` @ {16}, `t11` @ {17}, `t13` @ {26}
+     # refs: []
+     #
+ 27: $t3 := infer($t13)
+     # live vars: $t3
+     # reaching instruction #28: `t3` @ {13, 27}, `t4` @ {4}, `t5` @ {2}, `t6` @ {3}, `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 28: label L2
+     # live vars: $t3
+     # reaching instruction #29: `t3` @ {13, 27}, `t4` @ {4}, `t5` @ {2}, `t6` @ {3}, `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 29: $t2 := infer($t3)
+     # live vars: $t2
+     # reaching instruction #30: `t2` @ {29}, `t4` @ {4}, `t5` @ {2}, `t6` @ {3}, `t9` @ {18}, `t10` @ {16}, `t11` @ {17}
+     # refs: []
+     #
+ 30: return $t2
+}
+
+
+[variant baseline]
+fun abort_assert::conditional_abort($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: if ($t0) goto 2 else goto 6
+     # live vars: $t2
+     # reaching instruction #2: `t2` @ {0}
+     # refs: []
+     #
+  2: label L0
+     # live vars:
+     # reaching instruction #3: `t2` @ {0}
+     # refs: []
+     #
+  3: $t3 := 0
+     # live vars: $t3
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {3}
+     # refs: []
+     #
+  4: abort($t3)
+     # live vars: $t2
+     # reaching instruction #5:
+  5: goto 7
+     # live vars: $t2
+     # reaching instruction #6: `t2` @ {0}
+     # refs: []
+     #
+  6: label L1
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {0}
+     # refs: []
+     #
+  7: label L2
+     # live vars: $t2
+     # reaching instruction #8: `t2` @ {0}
+     # refs: []
+     #
+  8: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #9: `t1` @ {8}
+     # refs: []
+     #
+  9: return $t1
+}
+
+
+[variant baseline]
+fun abort_assert::multiple_asserts($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: bool
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 1
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: $t5 := infer($t0)
+     # live vars: $t1, $t3, $t5
+     # reaching instruction #2: `t3` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  2: $t6 := 0
+     # live vars: $t1, $t3, $t5, $t6
+     # reaching instruction #3: `t3` @ {0}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+  3: $t4 := >($t5, $t6)
+     # live vars: $t1, $t3, $t4
+     # reaching instruction #4: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+  4: if ($t4) goto 5 else goto 7
+     # live vars: $t1, $t3
+     # reaching instruction #5: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t1, $t3
+     # reaching instruction #6: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+  6: goto 10
+     # live vars: $t1, $t3
+     # reaching instruction #7: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+  7: label L1
+     # live vars:
+     # reaching instruction #8: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+  8: $t7 := 100
+     # live vars: $t7
+     # reaching instruction #9: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t7` @ {8}
+     # refs: []
+     #
+  9: abort($t7)
+     # live vars: $t1, $t3
+     # reaching instruction #10: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1, $t3
+     # reaching instruction #11: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}
+     # refs: []
+     #
+ 11: $t8 := 2
+     # live vars: $t1, $t3, $t8
+     # reaching instruction #12: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}
+     # refs: []
+     #
+ 12: $t10 := infer($t1)
+     # live vars: $t3, $t8, $t10
+     # reaching instruction #13: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t10` @ {12}
+     # refs: []
+     #
+ 13: $t11 := 0
+     # live vars: $t3, $t8, $t10, $t11
+     # reaching instruction #14: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 14: $t9 := >($t10, $t11)
+     # live vars: $t3, $t8, $t9
+     # reaching instruction #15: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 15: if ($t9) goto 16 else goto 18
+     # live vars: $t3, $t8
+     # reaching instruction #16: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 16: label L3
+     # live vars: $t3, $t8
+     # reaching instruction #17: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 17: goto 21
+     # live vars: $t3, $t8
+     # reaching instruction #18: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 18: label L4
+     # live vars:
+     # reaching instruction #19: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 19: $t12 := 101
+     # live vars: $t12
+     # reaching instruction #20: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}, `t12` @ {19}
+     # refs: []
+     #
+ 20: abort($t12)
+     # live vars: $t3, $t8
+     # reaching instruction #21: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 21: label L5
+     # live vars: $t3, $t8
+     # reaching instruction #22: `t3` @ {0}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 22: $t13 := infer($t3)
+     # live vars: $t8, $t13
+     # reaching instruction #23: `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}, `t13` @ {22}
+     # refs: []
+     #
+ 23: $t2 := +($t13, $t8)
+     # live vars: $t2
+     # reaching instruction #24: `t2` @ {23}, `t4` @ {3}, `t5` @ {1}, `t6` @ {2}, `t8` @ {11}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}, `t13` @ {22}
+     # refs: []
+     #
+ 24: return $t2
+}
+
+
+[variant baseline]
+fun abort_assert::nested_abort($t0: bool, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 0
+     # live vars: $t0, $t1
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: if ($t0) goto 2 else goto 15
+     # live vars: $t1
+     # reaching instruction #2: `t3` @ {0}
+     # refs: []
+     #
+  2: label L0
+     # live vars: $t1
+     # reaching instruction #3: `t3` @ {0}
+     # refs: []
+     #
+  3: if ($t1) goto 4 else goto 10
+     # live vars:
+     # reaching instruction #4: `t3` @ {0}
+     # refs: []
+     #
+  4: label L3
+     # live vars:
+     # reaching instruction #5: `t3` @ {0}
+     # refs: []
+     #
+  5: $t4 := 1
+     # live vars: $t4
+     # reaching instruction #6: `t3` @ {0}, `t4` @ {5}
+     # refs: []
+     #
+  6: $t3 := infer($t4)
+     # live vars:
+     # reaching instruction #7: `t3` @ {6}
+     # refs: []
+     #
+  7: $t5 := 0
+     # live vars: $t5
+     # reaching instruction #8: `t3` @ {6}, `t5` @ {7}
+     # refs: []
+     #
+  8: abort($t5)
+     # live vars: $t3
+     # reaching instruction #9:
+  9: goto 13
+     # live vars:
+     # reaching instruction #10: `t3` @ {0}
+     # refs: []
+     #
+ 10: label L4
+     # live vars:
+     # reaching instruction #11: `t3` @ {0}
+     # refs: []
+     #
+ 11: $t6 := 2
+     # live vars: $t6
+     # reaching instruction #12: `t3` @ {0}, `t6` @ {11}
+     # refs: []
+     #
+ 12: $t3 := infer($t6)
+     # live vars: $t3
+     # reaching instruction #13: `t3` @ {12}
+     # refs: []
+     #
+ 13: label L5
+     # live vars: $t3
+     # reaching instruction #14: `t3` @ {12}
+     # refs: []
+     #
+ 14: goto 18
+     # live vars: $t1
+     # reaching instruction #15: `t3` @ {0}
+     # refs: []
+     #
+ 15: label L1
+     # live vars:
+     # reaching instruction #16: `t3` @ {0}
+     # refs: []
+     #
+ 16: $t7 := 3
+     # live vars: $t7
+     # reaching instruction #17: `t3` @ {0}, `t7` @ {16}
+     # refs: []
+     #
+ 17: $t3 := infer($t7)
+     # live vars: $t3
+     # reaching instruction #18: `t3` @ {12, 17}
+     # refs: []
+     #
+ 18: label L2
+     # live vars: $t3
+     # reaching instruction #19: `t3` @ {12, 17}
+     # refs: []
+     #
+ 19: $t2 := infer($t3)
+     # live vars: $t2
+     # reaching instruction #20: `t2` @ {19}
+     # refs: []
+     #
+ 20: return $t2
+}
+
+
+[variant baseline]
+fun abort_assert::simple_abort(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := 1
+     # live vars:
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: $t2 := 0
+     # live vars: $t2
+     # reaching instruction #2: `t1` @ {0}, `t2` @ {1}
+     # refs: []
+     #
+  2: abort($t2)
+     # live vars: $t1
+     # reaching instruction #3:
+  3: $t0 := infer($t1)
+     # live vars: $t0
+     # reaching instruction #4:
+  4: return $t0
+}
+
+
+[variant baseline]
+fun abort_assert::with_assert($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t4 := infer($t0)
+     # live vars: $t2, $t4
+     # reaching instruction #2: `t2` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: $t5 := 0
+     # live vars: $t2, $t4, $t5
+     # reaching instruction #3: `t2` @ {0}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  3: $t3 := >($t4, $t5)
+     # live vars: $t2, $t3
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 7
+     # live vars: $t2
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t2
+     # reaching instruction #6: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  6: goto 10
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  7: label L1
+     # live vars:
+     # reaching instruction #8: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  8: $t6 := 100
+     # live vars: $t6
+     # reaching instruction #9: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}, `t6` @ {8}
+     # refs: []
+     #
+  9: abort($t6)
+     # live vars: $t2
+     # reaching instruction #10: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t2
+     # reaching instruction #11: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+ 11: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #12: `t1` @ {11}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+ 12: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/abort_assert.move
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/abort_assert.move
@@ -1,0 +1,83 @@
+module 0x42::abort_assert {
+
+    // Test simple abort - code after abort is unreachable
+    fun simple_abort(): u64 {
+        let x = 1;
+        abort 0;
+        x  // unreachable, but x still has def from above
+    }
+
+    // Test conditional abort
+    fun conditional_abort(cond: bool): u64 {
+        let x = 1;
+        if (cond) {
+            abort 0;
+        };
+        x  // x has def from init (abort path doesn't reach here)
+    }
+
+    // Test assignment before abort in branch
+    fun assign_before_abort(cond: bool): u64 {
+        let x;
+        if (cond) {
+            x = 1;
+            abort 0;
+        } else {
+            x = 2;
+        };
+        x  // x only has def from else branch (true branch aborts)
+    }
+
+    // Test assert (which may abort)
+    fun with_assert(n: u64): u64 {
+        let x = 1;
+        assert!(n > 0, 100);
+        x  // x has def from init (assert may or may not abort)
+    }
+
+    // Test multiple asserts
+    fun multiple_asserts(a: u64, b: u64): u64 {
+        let x = 1;
+        assert!(a > 0, 100);
+        let y = 2;
+        assert!(b > 0, 101);
+        x + y
+    }
+
+    // Test abort in nested conditional
+    fun nested_abort(a: bool, b: bool): u64 {
+        let x = 0;
+        if (a) {
+            if (b) {
+                x = 1;
+                abort 0;
+            } else {
+                x = 2;
+            };
+        } else {
+            x = 3;
+        };
+        x  // x has defs from: else-inner (2) and else-outer (3)
+    }
+
+    // Test abort after assignment in same block
+    fun abort_after_assign(): u64 {
+        let x = 1;
+        let y = x + 1;
+        abort y;
+        x  // unreachable
+    }
+
+    // Test conditional with both branches potentially aborting
+    fun both_may_abort(cond: bool, n: u64): u64 {
+        let x;
+        if (cond) {
+            assert!(n > 0, 100);
+            x = 1;
+        } else {
+            assert!(n > 10, 101);
+            x = 2;
+        };
+        x  // x has defs from both branches (asserts don't guarantee abort)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/basic.exp
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/basic.exp
@@ -1,0 +1,445 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun basic::conditional_tuple($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+  0: if ($t0) goto 1 else goto 6
+  1: label L0
+  2: $t4 := 1
+  3: $t5 := 2
+  4: ($t2, $t3) := basic::return_pair($t4, $t5)
+  5: goto 10
+  6: label L1
+  7: $t6 := 10
+  8: $t7 := 20
+  9: ($t2, $t3) := basic::return_pair($t6, $t7)
+ 10: label L2
+ 11: $t8 := infer($t2)
+ 12: $t1 := +($t8, $t3)
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun basic::move_test(): u64 {
+     var $t0: u64
+     var $t1: 0x42::basic::R
+     var $t2: u64
+     var $t3: 0x42::basic::R
+     var $t4: &0x42::basic::R
+     var $t5: &u64
+  0: $t2 := 42
+  1: $t1 := pack 0x42::basic::R($t2)
+  2: $t3 := infer($t1)
+  3: $t4 := borrow_local($t3)
+  4: $t5 := borrow_field<0x42::basic::R>.value($t4)
+  5: $t0 := read_ref($t5)
+  6: return $t0
+}
+
+
+[variant baseline]
+fun basic::reassign($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := 1
+  1: if ($t0) goto 2 else goto 6
+  2: label L0
+  3: $t3 := 2
+  4: $t2 := infer($t3)
+  5: goto 7
+  6: label L1
+  7: label L2
+  8: $t1 := infer($t2)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun basic::return_pair($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t4 := infer($t0)
+  1: $t5 := 1
+  2: $t2 := +($t4, $t5)
+  3: $t6 := infer($t1)
+  4: $t7 := 1
+  5: $t3 := +($t6, $t7)
+  6: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun basic::simple_assign($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t4 := infer($t0)
+  1: $t3 := +($t4, $t1)
+  2: $t6 := infer($t3)
+  3: $t7 := 2
+  4: $t5 := *($t6, $t7)
+  5: $t2 := infer($t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun basic::tuple_destructure(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t3 := 1
+  1: $t4 := 2
+  2: ($t1, $t2) := basic::return_pair($t3, $t4)
+  3: $t5 := infer($t1)
+  4: $t0 := +($t5, $t2)
+  5: return $t0
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun basic::conditional_tuple($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: if ($t0) goto 1 else goto 6
+     # live vars:
+     # reaching instruction #1:
+     # refs: []
+     #
+  1: label L0
+     # live vars:
+     # reaching instruction #2:
+     # refs: []
+     #
+  2: $t4 := 1
+     # live vars: $t4
+     # reaching instruction #3: `t4` @ {2}
+     # refs: []
+     #
+  3: $t5 := 2
+     # live vars: $t4, $t5
+     # reaching instruction #4: `t4` @ {2}, `t5` @ {3}
+     # refs: []
+     #
+  4: ($t2, $t3) := basic::return_pair($t4, $t5)
+     # live vars: $t2, $t3
+     # reaching instruction #5: `t2` @ {4}, `t3` @ {4}, `t4` @ {2}, `t5` @ {3}
+     # refs: []
+     #
+  5: goto 10
+     # live vars:
+     # reaching instruction #6:
+     # refs: []
+     #
+  6: label L1
+     # live vars:
+     # reaching instruction #7:
+     # refs: []
+     #
+  7: $t6 := 10
+     # live vars: $t6
+     # reaching instruction #8: `t6` @ {7}
+     # refs: []
+     #
+  8: $t7 := 20
+     # live vars: $t6, $t7
+     # reaching instruction #9: `t6` @ {7}, `t7` @ {8}
+     # refs: []
+     #
+  9: ($t2, $t3) := basic::return_pair($t6, $t7)
+     # live vars: $t2, $t3
+     # reaching instruction #10: `t2` @ {4, 9}, `t3` @ {4, 9}, `t4` @ {2}, `t5` @ {3}, `t6` @ {7}, `t7` @ {8}
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t2, $t3
+     # reaching instruction #11: `t2` @ {4, 9}, `t3` @ {4, 9}, `t4` @ {2}, `t5` @ {3}, `t6` @ {7}, `t7` @ {8}
+     # refs: []
+     #
+ 11: $t8 := infer($t2)
+     # live vars: $t3, $t8
+     # reaching instruction #12: `t3` @ {4, 9}, `t4` @ {2}, `t5` @ {3}, `t6` @ {7}, `t7` @ {8}, `t8` @ {11}
+     # refs: []
+     #
+ 12: $t1 := +($t8, $t3)
+     # live vars: $t1
+     # reaching instruction #13: `t1` @ {12}, `t3` @ {4, 9}, `t4` @ {2}, `t5` @ {3}, `t6` @ {7}, `t7` @ {8}, `t8` @ {11}
+     # refs: []
+     #
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun basic::move_test(): u64 {
+     var $t0: u64
+     var $t1: 0x42::basic::R
+     var $t2: u64
+     var $t3: 0x42::basic::R
+     var $t4: &0x42::basic::R
+     var $t5: &u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 42
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t1 := pack 0x42::basic::R($t2)
+     # live vars: $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}
+     # refs: []
+     #
+  2: $t3 := infer($t1)
+     # live vars: $t3
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {2}
+     # refs: []
+     #
+  3: $t4 := borrow_local($t3)
+     # live vars: $t4
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {2}, `t4` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `r2`] at line 25
+     #
+  4: $t5 := borrow_field<0x42::basic::R>.value($t4)
+     # live vars: $t5
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {2}, `t4` @ {3}, `t5` @ {4}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `r2`, field `value`] at line 25
+     #
+  5: $t0 := read_ref($t5)
+     # live vars: $t0
+     # reaching instruction #6: `t0` @ {5}, `t2` @ {0}, `t3` @ {2}, `t4` @ {3}, `t5` @ {4}
+     # refs: []
+     #
+  6: return $t0
+}
+
+
+[variant baseline]
+fun basic::reassign($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: if ($t0) goto 2 else goto 6
+     # live vars: $t2
+     # reaching instruction #2: `t2` @ {0}
+     # refs: []
+     #
+  2: label L0
+     # live vars:
+     # reaching instruction #3: `t2` @ {0}
+     # refs: []
+     #
+  3: $t3 := 2
+     # live vars: $t3
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {3}
+     # refs: []
+     #
+  4: $t2 := infer($t3)
+     # live vars: $t2
+     # reaching instruction #5: `t2` @ {4}
+     # refs: []
+     #
+  5: goto 7
+     # live vars: $t2
+     # reaching instruction #6: `t2` @ {0}
+     # refs: []
+     #
+  6: label L1
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {0, 4}
+     # refs: []
+     #
+  7: label L2
+     # live vars: $t2
+     # reaching instruction #8: `t2` @ {0, 4}
+     # refs: []
+     #
+  8: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #9: `t1` @ {8}
+     # refs: []
+     #
+  9: return $t1
+}
+
+
+[variant baseline]
+fun basic::return_pair($t0: u64, $t1: u64): (u64, u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # live vars: $t1, $t4
+     # reaching instruction #1: `t4` @ {0}
+     # refs: []
+     #
+  1: $t5 := 1
+     # live vars: $t1, $t4, $t5
+     # reaching instruction #2: `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  2: $t2 := +($t4, $t5)
+     # live vars: $t1, $t2
+     # reaching instruction #3: `t2` @ {2}, `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  3: $t6 := infer($t1)
+     # live vars: $t2, $t6
+     # reaching instruction #4: `t2` @ {2}, `t4` @ {0}, `t5` @ {1}, `t6` @ {3}
+     # refs: []
+     #
+  4: $t7 := 1
+     # live vars: $t2, $t6, $t7
+     # reaching instruction #5: `t2` @ {2}, `t4` @ {0}, `t5` @ {1}, `t6` @ {3}, `t7` @ {4}
+     # refs: []
+     #
+  5: $t3 := +($t6, $t7)
+     # live vars: $t2, $t3
+     # reaching instruction #6: `t2` @ {2}, `t3` @ {5}, `t4` @ {0}, `t5` @ {1}, `t6` @ {3}, `t7` @ {4}
+     # refs: []
+     #
+  6: return ($t2, $t3)
+}
+
+
+[variant baseline]
+fun basic::simple_assign($t0: u64, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # live vars: $t1, $t4
+     # reaching instruction #1: `t4` @ {0}
+     # refs: []
+     #
+  1: $t3 := +($t4, $t1)
+     # live vars: $t3
+     # reaching instruction #2: `t3` @ {1}, `t4` @ {0}
+     # refs: []
+     #
+  2: $t6 := infer($t3)
+     # live vars: $t6
+     # reaching instruction #3: `t4` @ {0}, `t6` @ {2}
+     # refs: []
+     #
+  3: $t7 := 2
+     # live vars: $t6, $t7
+     # reaching instruction #4: `t4` @ {0}, `t6` @ {2}, `t7` @ {3}
+     # refs: []
+     #
+  4: $t5 := *($t6, $t7)
+     # live vars: $t5
+     # reaching instruction #5: `t4` @ {0}, `t5` @ {4}, `t6` @ {2}, `t7` @ {3}
+     # refs: []
+     #
+  5: $t2 := infer($t5)
+     # live vars: $t2
+     # reaching instruction #6: `t2` @ {5}, `t4` @ {0}, `t6` @ {2}, `t7` @ {3}
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun basic::tuple_destructure(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 1
+     # live vars: $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: $t4 := 2
+     # live vars: $t3, $t4
+     # reaching instruction #2: `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: ($t1, $t2) := basic::return_pair($t3, $t4)
+     # live vars: $t1, $t2
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  3: $t5 := infer($t1)
+     # live vars: $t2, $t5
+     # reaching instruction #4: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {3}
+     # refs: []
+     #
+  4: $t0 := +($t5, $t2)
+     # live vars: $t0
+     # reaching instruction #5: `t0` @ {4}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {3}
+     # refs: []
+     #
+  5: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/basic.move
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/basic.move
@@ -1,0 +1,48 @@
+module 0x42::basic {
+
+    // Test basic assignment reaching definitions
+    fun simple_assign(a: u64, b: u64): u64 {
+        let x = a + b;
+        let y = x * 2;
+        y
+    }
+
+    // Test with reassignment - x has two definitions
+    fun reassign(cond: bool): u64 {
+        let x = 1;
+        if (cond) {
+            x = 2;
+        };
+        x  // x should have reaching defs from both assignments
+    }
+
+    // Test move semantics
+    struct R has drop { value: u64 }
+
+    fun move_test(): u64 {
+        let r = R { value: 42 };
+        let r2 = r;  // r is moved here
+        r2.value
+    }
+
+    // Test multiple return values - exercises iterating over multiple dests in Call
+    fun return_pair(a: u64, b: u64): (u64, u64) {
+        (a + 1, b + 1)
+    }
+
+    fun tuple_destructure(): u64 {
+        let (x, y) = return_pair(1, 2);
+        x + y  // both x and y have reaching defs from the call
+    }
+
+    // Test conditional with multiple return values
+    fun conditional_tuple(cond: bool): u64 {
+        let (a, b);
+        if (cond) {
+            (a, b) = return_pair(1, 2);
+        } else {
+            (a, b) = return_pair(10, 20);
+        };
+        a + b  // a and b each have defs from both branches
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/control_flow.exp
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/control_flow.exp
@@ -1,0 +1,711 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun control_flow::if_else_chain($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+  0: $t4 := infer($t0)
+  1: $t5 := 0
+  2: $t3 := ==($t4, $t5)
+  3: if ($t3) goto 4 else goto 8
+  4: label L0
+  5: $t6 := 10
+  6: $t2 := infer($t6)
+  7: goto 31
+  8: label L1
+  9: $t8 := infer($t0)
+ 10: $t9 := 1
+ 11: $t7 := ==($t8, $t9)
+ 12: if ($t7) goto 13 else goto 17
+ 13: label L3
+ 14: $t10 := 20
+ 15: $t2 := infer($t10)
+ 16: goto 30
+ 17: label L4
+ 18: $t12 := infer($t0)
+ 19: $t13 := 2
+ 20: $t11 := ==($t12, $t13)
+ 21: if ($t11) goto 22 else goto 26
+ 22: label L6
+ 23: $t14 := 30
+ 24: $t2 := infer($t14)
+ 25: goto 29
+ 26: label L7
+ 27: $t15 := 40
+ 28: $t2 := infer($t15)
+ 29: label L8
+ 30: label L5
+ 31: label L2
+ 32: $t1 := infer($t2)
+ 33: return $t1
+}
+
+
+[variant baseline]
+fun control_flow::multi_var_branches($t0: bool, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+  0: $t3 := 0
+  1: $t4 := 0
+  2: $t5 := 0
+  3: if ($t0) goto 4 else goto 15
+  4: label L0
+  5: $t6 := 1
+  6: $t3 := infer($t6)
+  7: if ($t1) goto 8 else goto 12
+  8: label L3
+  9: $t7 := 1
+ 10: $t4 := infer($t7)
+ 11: goto 13
+ 12: label L4
+ 13: label L5
+ 14: goto 18
+ 15: label L1
+ 16: $t8 := 1
+ 17: $t5 := infer($t8)
+ 18: label L2
+ 19: $t10 := infer($t3)
+ 20: $t9 := +($t10, $t4)
+ 21: $t2 := +($t9, $t5)
+ 22: return $t2
+}
+
+
+[variant baseline]
+fun control_flow::nested_if($t0: bool, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: if ($t0) goto 1 else goto 12
+  1: label L0
+  2: if ($t1) goto 3 else goto 7
+  3: label L3
+  4: $t4 := 1
+  5: $t3 := infer($t4)
+  6: goto 10
+  7: label L4
+  8: $t5 := 2
+  9: $t3 := infer($t5)
+ 10: label L5
+ 11: goto 22
+ 12: label L1
+ 13: if ($t1) goto 14 else goto 18
+ 14: label L6
+ 15: $t6 := 3
+ 16: $t3 := infer($t6)
+ 17: goto 21
+ 18: label L7
+ 19: $t7 := 4
+ 20: $t3 := infer($t7)
+ 21: label L8
+ 22: label L2
+ 23: $t2 := infer($t3)
+ 24: return $t2
+}
+
+
+[variant baseline]
+fun control_flow::partial_assign($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t2 := 0
+  1: $t3 := 0
+  2: if ($t0) goto 3 else goto 9
+  3: label L0
+  4: $t4 := 1
+  5: $t2 := infer($t4)
+  6: $t5 := 1
+  7: $t3 := infer($t5)
+  8: goto 12
+  9: label L1
+ 10: $t6 := 2
+ 11: $t3 := infer($t6)
+ 12: label L2
+ 13: $t7 := infer($t2)
+ 14: $t1 := +($t7, $t3)
+ 15: return $t1
+}
+
+
+Diagnostics:
+warning: This assignment/binding to the left-hand-side variable `y` is unused. Consider removing this assignment/binding, or prefixing the left-hand-side variable with an underscore (e.g., `_y`), or renaming to `_`
+   ┌─ tests/reaching-def/control_flow.move:40:17
+   │
+40 │         let y = 0;
+   │                 ^
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun control_flow::if_else_chain($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: bool
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t4 := infer($t0)
+     # live vars: $t0, $t4
+     # reaching instruction #1: `t4` @ {0}
+     # refs: []
+     #
+  1: $t5 := 0
+     # live vars: $t0, $t4, $t5
+     # reaching instruction #2: `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  2: $t3 := ==($t4, $t5)
+     # live vars: $t0, $t3
+     # reaching instruction #3: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  3: if ($t3) goto 4 else goto 8
+     # live vars: $t0
+     # reaching instruction #4: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  4: label L0
+     # live vars:
+     # reaching instruction #5: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  5: $t6 := 10
+     # live vars: $t6
+     # reaching instruction #6: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t6` @ {5}
+     # refs: []
+     #
+  6: $t2 := infer($t6)
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {6}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  7: goto 31
+     # live vars: $t0
+     # reaching instruction #8: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  8: label L1
+     # live vars: $t0
+     # reaching instruction #9: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}
+     # refs: []
+     #
+  9: $t8 := infer($t0)
+     # live vars: $t0, $t8
+     # reaching instruction #10: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t8` @ {9}
+     # refs: []
+     #
+ 10: $t9 := 1
+     # live vars: $t0, $t8, $t9
+     # reaching instruction #11: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t8` @ {9}, `t9` @ {10}
+     # refs: []
+     #
+ 11: $t7 := ==($t8, $t9)
+     # live vars: $t0, $t7
+     # reaching instruction #12: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}
+     # refs: []
+     #
+ 12: if ($t7) goto 13 else goto 17
+     # live vars: $t0
+     # reaching instruction #13: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}
+     # refs: []
+     #
+ 13: label L3
+     # live vars:
+     # reaching instruction #14: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}
+     # refs: []
+     #
+ 14: $t10 := 20
+     # live vars: $t10
+     # reaching instruction #15: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t10` @ {14}
+     # refs: []
+     #
+ 15: $t2 := infer($t10)
+     # live vars: $t2
+     # reaching instruction #16: `t2` @ {15}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}
+     # refs: []
+     #
+ 16: goto 30
+     # live vars: $t0
+     # reaching instruction #17: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}
+     # refs: []
+     #
+ 17: label L4
+     # live vars: $t0
+     # reaching instruction #18: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}
+     # refs: []
+     #
+ 18: $t12 := infer($t0)
+     # live vars: $t12
+     # reaching instruction #19: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t12` @ {18}
+     # refs: []
+     #
+ 19: $t13 := 2
+     # live vars: $t12, $t13
+     # reaching instruction #20: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 20: $t11 := ==($t12, $t13)
+     # live vars: $t11
+     # reaching instruction #21: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 21: if ($t11) goto 22 else goto 26
+     # live vars:
+     # reaching instruction #22: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 22: label L6
+     # live vars:
+     # reaching instruction #23: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 23: $t14 := 30
+     # live vars: $t14
+     # reaching instruction #24: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}, `t14` @ {23}
+     # refs: []
+     #
+ 24: $t2 := infer($t14)
+     # live vars: $t2
+     # reaching instruction #25: `t2` @ {24}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 25: goto 29
+     # live vars:
+     # reaching instruction #26: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 26: label L7
+     # live vars:
+     # reaching instruction #27: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 27: $t15 := 40
+     # live vars: $t15
+     # reaching instruction #28: `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}, `t15` @ {27}
+     # refs: []
+     #
+ 28: $t2 := infer($t15)
+     # live vars: $t2
+     # reaching instruction #29: `t2` @ {24, 28}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 29: label L8
+     # live vars: $t2
+     # reaching instruction #30: `t2` @ {15, 24, 28}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 30: label L5
+     # live vars: $t2
+     # reaching instruction #31: `t2` @ {6, 15, 24, 28}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 31: label L2
+     # live vars: $t2
+     # reaching instruction #32: `t2` @ {6, 15, 24, 28}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 32: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #33: `t1` @ {32}, `t3` @ {2}, `t4` @ {0}, `t5` @ {1}, `t7` @ {11}, `t8` @ {9}, `t9` @ {10}, `t11` @ {20}, `t12` @ {18}, `t13` @ {19}
+     # refs: []
+     #
+ 33: return $t1
+}
+
+
+[variant baseline]
+fun control_flow::multi_var_branches($t0: bool, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 0
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: $t4 := 0
+     # live vars: $t0, $t1, $t3, $t4
+     # reaching instruction #2: `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: $t5 := 0
+     # live vars: $t0, $t1, $t3, $t4, $t5
+     # reaching instruction #3: `t3` @ {0}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  3: if ($t0) goto 4 else goto 15
+     # live vars: $t1, $t3, $t4, $t5
+     # reaching instruction #4: `t3` @ {0}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  4: label L0
+     # live vars: $t1, $t4, $t5
+     # reaching instruction #5: `t3` @ {0}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  5: $t6 := 1
+     # live vars: $t1, $t4, $t5, $t6
+     # reaching instruction #6: `t3` @ {0}, `t4` @ {1}, `t5` @ {2}, `t6` @ {5}
+     # refs: []
+     #
+  6: $t3 := infer($t6)
+     # live vars: $t1, $t3, $t4, $t5
+     # reaching instruction #7: `t3` @ {6}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  7: if ($t1) goto 8 else goto 12
+     # live vars: $t3, $t4, $t5
+     # reaching instruction #8: `t3` @ {6}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  8: label L3
+     # live vars: $t3, $t5
+     # reaching instruction #9: `t3` @ {6}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  9: $t7 := 1
+     # live vars: $t3, $t5, $t7
+     # reaching instruction #10: `t3` @ {6}, `t4` @ {1}, `t5` @ {2}, `t7` @ {9}
+     # refs: []
+     #
+ 10: $t4 := infer($t7)
+     # live vars: $t3, $t4, $t5
+     # reaching instruction #11: `t3` @ {6}, `t4` @ {10}, `t5` @ {2}
+     # refs: []
+     #
+ 11: goto 13
+     # live vars: $t3, $t4, $t5
+     # reaching instruction #12: `t3` @ {6}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+ 12: label L4
+     # live vars: $t3, $t4, $t5
+     # reaching instruction #13: `t3` @ {6}, `t4` @ {1, 10}, `t5` @ {2}
+     # refs: []
+     #
+ 13: label L5
+     # live vars: $t3, $t4, $t5
+     # reaching instruction #14: `t3` @ {6}, `t4` @ {1, 10}, `t5` @ {2}
+     # refs: []
+     #
+ 14: goto 18
+     # live vars: $t1, $t3, $t4, $t5
+     # reaching instruction #15: `t3` @ {0}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+ 15: label L1
+     # live vars: $t3, $t4
+     # reaching instruction #16: `t3` @ {0}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+ 16: $t8 := 1
+     # live vars: $t3, $t4, $t8
+     # reaching instruction #17: `t3` @ {0}, `t4` @ {1}, `t5` @ {2}, `t8` @ {16}
+     # refs: []
+     #
+ 17: $t5 := infer($t8)
+     # live vars: $t3, $t4, $t5
+     # reaching instruction #18: `t3` @ {0, 6}, `t4` @ {1, 10}, `t5` @ {2, 17}
+     # refs: []
+     #
+ 18: label L2
+     # live vars: $t3, $t4, $t5
+     # reaching instruction #19: `t3` @ {0, 6}, `t4` @ {1, 10}, `t5` @ {2, 17}
+     # refs: []
+     #
+ 19: $t10 := infer($t3)
+     # live vars: $t4, $t5, $t10
+     # reaching instruction #20: `t4` @ {1, 10}, `t5` @ {2, 17}, `t10` @ {19}
+     # refs: []
+     #
+ 20: $t9 := +($t10, $t4)
+     # live vars: $t5, $t9
+     # reaching instruction #21: `t4` @ {1, 10}, `t5` @ {2, 17}, `t9` @ {20}, `t10` @ {19}
+     # refs: []
+     #
+ 21: $t2 := +($t9, $t5)
+     # live vars: $t2
+     # reaching instruction #22: `t2` @ {21}, `t4` @ {1, 10}, `t5` @ {2, 17}, `t9` @ {20}, `t10` @ {19}
+     # refs: []
+     #
+ 22: return $t2
+}
+
+
+[variant baseline]
+fun control_flow::nested_if($t0: bool, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: if ($t0) goto 1 else goto 12
+     # live vars: $t1
+     # reaching instruction #1:
+     # refs: []
+     #
+  1: label L0
+     # live vars: $t1
+     # reaching instruction #2:
+     # refs: []
+     #
+  2: if ($t1) goto 3 else goto 7
+     # live vars:
+     # reaching instruction #3:
+     # refs: []
+     #
+  3: label L3
+     # live vars:
+     # reaching instruction #4:
+     # refs: []
+     #
+  4: $t4 := 1
+     # live vars: $t4
+     # reaching instruction #5: `t4` @ {4}
+     # refs: []
+     #
+  5: $t3 := infer($t4)
+     # live vars: $t3
+     # reaching instruction #6: `t3` @ {5}
+     # refs: []
+     #
+  6: goto 10
+     # live vars:
+     # reaching instruction #7:
+     # refs: []
+     #
+  7: label L4
+     # live vars:
+     # reaching instruction #8:
+     # refs: []
+     #
+  8: $t5 := 2
+     # live vars: $t5
+     # reaching instruction #9: `t5` @ {8}
+     # refs: []
+     #
+  9: $t3 := infer($t5)
+     # live vars: $t3
+     # reaching instruction #10: `t3` @ {5, 9}
+     # refs: []
+     #
+ 10: label L5
+     # live vars: $t3
+     # reaching instruction #11: `t3` @ {5, 9}
+     # refs: []
+     #
+ 11: goto 22
+     # live vars: $t1
+     # reaching instruction #12:
+     # refs: []
+     #
+ 12: label L1
+     # live vars: $t1
+     # reaching instruction #13:
+     # refs: []
+     #
+ 13: if ($t1) goto 14 else goto 18
+     # live vars:
+     # reaching instruction #14:
+     # refs: []
+     #
+ 14: label L6
+     # live vars:
+     # reaching instruction #15:
+     # refs: []
+     #
+ 15: $t6 := 3
+     # live vars: $t6
+     # reaching instruction #16: `t6` @ {15}
+     # refs: []
+     #
+ 16: $t3 := infer($t6)
+     # live vars: $t3
+     # reaching instruction #17: `t3` @ {16}
+     # refs: []
+     #
+ 17: goto 21
+     # live vars:
+     # reaching instruction #18:
+     # refs: []
+     #
+ 18: label L7
+     # live vars:
+     # reaching instruction #19:
+     # refs: []
+     #
+ 19: $t7 := 4
+     # live vars: $t7
+     # reaching instruction #20: `t7` @ {19}
+     # refs: []
+     #
+ 20: $t3 := infer($t7)
+     # live vars: $t3
+     # reaching instruction #21: `t3` @ {16, 20}
+     # refs: []
+     #
+ 21: label L8
+     # live vars: $t3
+     # reaching instruction #22: `t3` @ {5, 9, 16, 20}
+     # refs: []
+     #
+ 22: label L2
+     # live vars: $t3
+     # reaching instruction #23: `t3` @ {5, 9, 16, 20}
+     # refs: []
+     #
+ 23: $t2 := infer($t3)
+     # live vars: $t2
+     # reaching instruction #24: `t2` @ {23}
+     # refs: []
+     #
+ 24: return $t2
+}
+
+
+[variant baseline]
+fun control_flow::partial_assign($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 0
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 0
+     # live vars: $t0, $t2
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: if ($t0) goto 3 else goto 9
+     # live vars: $t2
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: label L0
+     # live vars:
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  4: $t4 := 1
+     # live vars: $t4
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {1}, `t4` @ {4}
+     # refs: []
+     #
+  5: $t2 := infer($t4)
+     # live vars: $t2
+     # reaching instruction #6: `t2` @ {5}, `t3` @ {1}
+     # refs: []
+     #
+  6: $t5 := 1
+     # live vars: $t2, $t5
+     # reaching instruction #7: `t2` @ {5}, `t3` @ {1}, `t5` @ {6}
+     # refs: []
+     #
+  7: $t3 := infer($t5)
+     # live vars: $t2, $t3
+     # reaching instruction #8: `t2` @ {5}, `t3` @ {7}
+     # refs: []
+     #
+  8: goto 12
+     # live vars: $t2
+     # reaching instruction #9: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  9: label L1
+     # live vars: $t2
+     # reaching instruction #10: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+ 10: $t6 := 2
+     # live vars: $t2, $t6
+     # reaching instruction #11: `t2` @ {0}, `t3` @ {1}, `t6` @ {10}
+     # refs: []
+     #
+ 11: $t3 := infer($t6)
+     # live vars: $t2, $t3
+     # reaching instruction #12: `t2` @ {0, 5}, `t3` @ {7, 11}
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t2, $t3
+     # reaching instruction #13: `t2` @ {0, 5}, `t3` @ {7, 11}
+     # refs: []
+     #
+ 13: $t7 := infer($t2)
+     # live vars: $t3, $t7
+     # reaching instruction #14: `t3` @ {7, 11}, `t7` @ {13}
+     # refs: []
+     #
+ 14: $t1 := +($t7, $t3)
+     # live vars: $t1
+     # reaching instruction #15: `t1` @ {14}, `t3` @ {7, 11}, `t7` @ {13}
+     # refs: []
+     #
+ 15: return $t1
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/control_flow.move
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/control_flow.move
@@ -1,0 +1,66 @@
+module 0x42::control_flow {
+
+    // Test nested if-else: x should have defs from all 4 branches at the end
+    fun nested_if(a: bool, b: bool): u64 {
+        let x;
+        if (a) {
+            if (b) {
+                x = 1;
+            } else {
+                x = 2;
+            }
+        } else {
+            if (b) {
+                x = 3;
+            } else {
+                x = 4;
+            }
+        };
+        x
+    }
+
+    // Test if-else chain: result has defs from all branches
+    fun if_else_chain(n: u64): u64 {
+        let result;
+        if (n == 0) {
+            result = 10;
+        } else if (n == 1) {
+            result = 20;
+        } else if (n == 2) {
+            result = 30;
+        } else {
+            result = 40;
+        };
+        result
+    }
+
+    // Test partial assignment in branches
+    fun partial_assign(cond: bool): u64 {
+        let x = 0;
+        let y = 0;
+        if (cond) {
+            x = 1;
+            y = 1;
+        } else {
+            // only y is assigned, x keeps initial value
+            y = 2;
+        };
+        x + y
+    }
+
+    // Test multiple variables with different branch coverage
+    fun multi_var_branches(a: bool, b: bool): u64 {
+        let x = 0;
+        let y = 0;
+        let z = 0;
+        if (a) {
+            x = 1;
+            if (b) {
+                y = 1;
+            };
+        } else {
+            z = 1;
+        };
+        x + y + z
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/loops.exp
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/loops.exp
@@ -1,0 +1,911 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun loops::loop_with_break($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+  0: $t2 := 1
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := infer($t3)
+  4: $t6 := 10
+  5: $t4 := <($t5, $t6)
+  6: if ($t4) goto 7 else goto 25
+  7: label L2
+  8: if ($t0) goto 9 else goto 14
+  9: label L5
+ 10: $t7 := 99
+ 11: $t2 := infer($t7)
+ 12: goto 29
+ 13: goto 15
+ 14: label L6
+ 15: label L7
+ 16: $t9 := infer($t2)
+ 17: $t10 := 1
+ 18: $t8 := +($t9, $t10)
+ 19: $t2 := infer($t8)
+ 20: $t12 := infer($t3)
+ 21: $t13 := 1
+ 22: $t11 := +($t12, $t13)
+ 23: $t3 := infer($t11)
+ 24: goto 27
+ 25: label L3
+ 26: goto 29
+ 27: label L4
+ 28: goto 2
+ 29: label L1
+ 30: $t1 := infer($t2)
+ 31: return $t1
+}
+
+
+[variant baseline]
+fun loops::loop_with_continue($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+  0: $t2 := 0
+  1: $t3 := 0
+  2: label L0
+  3: $t5 := infer($t3)
+  4: $t6 := 10
+  5: $t4 := <($t5, $t6)
+  6: if ($t4) goto 7 else goto 23
+  7: label L2
+  8: $t8 := infer($t3)
+  9: $t9 := 1
+ 10: $t7 := +($t8, $t9)
+ 11: $t3 := infer($t7)
+ 12: if ($t0) goto 13 else goto 16
+ 13: label L5
+ 14: goto 2
+ 15: goto 17
+ 16: label L6
+ 17: label L7
+ 18: $t11 := infer($t2)
+ 19: $t12 := 1
+ 20: $t10 := +($t11, $t12)
+ 21: $t2 := infer($t10)
+ 22: goto 25
+ 23: label L3
+ 24: goto 27
+ 25: label L4
+ 26: goto 2
+ 27: label L1
+ 28: $t1 := infer($t2)
+ 29: return $t1
+}
+
+
+[variant baseline]
+fun loops::nested_loops(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+  0: $t1 := 0
+  1: $t2 := 0
+  2: label L0
+  3: $t4 := infer($t2)
+  4: $t5 := 3
+  5: $t3 := <($t4, $t5)
+  6: if ($t3) goto 7 else goto 34
+  7: label L2
+  8: $t6 := 0
+  9: label L5
+ 10: $t8 := infer($t6)
+ 11: $t9 := 3
+ 12: $t7 := <($t8, $t9)
+ 13: if ($t7) goto 14 else goto 24
+ 14: label L7
+ 15: $t11 := infer($t1)
+ 16: $t12 := 1
+ 17: $t10 := +($t11, $t12)
+ 18: $t1 := infer($t10)
+ 19: $t14 := infer($t6)
+ 20: $t15 := 1
+ 21: $t13 := +($t14, $t15)
+ 22: $t6 := infer($t13)
+ 23: goto 26
+ 24: label L8
+ 25: goto 28
+ 26: label L9
+ 27: goto 9
+ 28: label L6
+ 29: $t17 := infer($t2)
+ 30: $t18 := 1
+ 31: $t16 := +($t17, $t18)
+ 32: $t2 := infer($t16)
+ 33: goto 36
+ 34: label L3
+ 35: goto 38
+ 36: label L4
+ 37: goto 2
+ 38: label L1
+ 39: $t0 := infer($t1)
+ 40: return $t0
+}
+
+
+[variant baseline]
+fun loops::while_loop(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+  0: $t1 := 0
+  1: $t2 := 0
+  2: label L0
+  3: $t4 := infer($t2)
+  4: $t5 := 10
+  5: $t3 := <($t4, $t5)
+  6: if ($t3) goto 7 else goto 17
+  7: label L2
+  8: $t7 := infer($t1)
+  9: $t8 := 1
+ 10: $t6 := +($t7, $t8)
+ 11: $t1 := infer($t6)
+ 12: $t10 := infer($t2)
+ 13: $t11 := 1
+ 14: $t9 := +($t10, $t11)
+ 15: $t2 := infer($t9)
+ 16: goto 19
+ 17: label L3
+ 18: goto 21
+ 19: label L4
+ 20: goto 2
+ 21: label L1
+ 22: $t0 := infer($t1)
+ 23: return $t0
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun loops::loop_with_break($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 0
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #2: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  2: label L0
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #3: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  3: $t5 := infer($t3)
+     # live vars: $t0, $t2, $t3, $t5
+     # reaching instruction #4: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  4: $t6 := 10
+     # live vars: $t0, $t2, $t3, $t5, $t6
+     # reaching instruction #5: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  5: $t4 := <($t5, $t6)
+     # live vars: $t0, $t2, $t3, $t4
+     # reaching instruction #6: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  6: if ($t4) goto 7 else goto 25
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #7: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  7: label L2
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #8: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  8: if ($t0) goto 9 else goto 14
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #9: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+  9: label L5
+     # live vars:
+     # reaching instruction #10: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 10: $t7 := 99
+     # live vars: $t7
+     # reaching instruction #11: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t7` @ {10}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 11: $t2 := infer($t7)
+     # live vars: $t2
+     # reaching instruction #12: `t2` @ {11}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 12: goto 29
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #13:
+ 13: goto 15
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #14: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 14: label L6
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #15: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 15: label L7
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #16: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 16: $t9 := infer($t2)
+     # live vars: $t0, $t3, $t9
+     # reaching instruction #17: `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 17: $t10 := 1
+     # live vars: $t0, $t3, $t9, $t10
+     # reaching instruction #18: `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 18: $t8 := +($t9, $t10)
+     # live vars: $t0, $t3, $t8
+     # reaching instruction #19: `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {18}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 19: $t2 := infer($t8)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #20: `t2` @ {19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 20: $t12 := infer($t3)
+     # live vars: $t0, $t2, $t12
+     # reaching instruction #21: `t2` @ {19}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 21: $t13 := 1
+     # live vars: $t0, $t2, $t12, $t13
+     # reaching instruction #22: `t2` @ {19}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 22: $t11 := +($t12, $t13)
+     # live vars: $t0, $t2, $t11
+     # reaching instruction #23: `t2` @ {19}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t11` @ {22}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 23: $t3 := infer($t11)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #24: `t2` @ {19}, `t3` @ {23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 24: goto 27
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #25: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 25: label L3
+     # live vars: $t2
+     # reaching instruction #26: `t2` @ {0, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 26: goto 29
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #27: `t2` @ {19}, `t3` @ {23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 27: label L4
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #28: `t2` @ {19}, `t3` @ {23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 28: goto 2
+     # live vars: $t2
+     # reaching instruction #29: `t2` @ {0, 11, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 29: label L1
+     # live vars: $t2
+     # reaching instruction #30: `t2` @ {0, 11, 19}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 30: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #31: `t1` @ {30}, `t3` @ {1, 23}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t9` @ {16}, `t10` @ {17}, `t12` @ {20}, `t13` @ {21}
+     # refs: []
+     #
+ 31: return $t1
+}
+
+
+[variant baseline]
+fun loops::loop_with_continue($t0: bool): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: bool
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 0
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 0
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #2: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  2: label L0
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #3: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  3: $t5 := infer($t3)
+     # live vars: $t0, $t2, $t3, $t5
+     # reaching instruction #4: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  4: $t6 := 10
+     # live vars: $t0, $t2, $t3, $t5, $t6
+     # reaching instruction #5: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  5: $t4 := <($t5, $t6)
+     # live vars: $t0, $t2, $t3, $t4
+     # reaching instruction #6: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  6: if ($t4) goto 7 else goto 23
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #7: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  7: label L2
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #8: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  8: $t8 := infer($t3)
+     # live vars: $t0, $t2, $t8
+     # reaching instruction #9: `t2` @ {0, 21}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+  9: $t9 := 1
+     # live vars: $t0, $t2, $t8, $t9
+     # reaching instruction #10: `t2` @ {0, 21}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 10: $t7 := +($t8, $t9)
+     # live vars: $t0, $t2, $t7
+     # reaching instruction #11: `t2` @ {0, 21}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t7` @ {10}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 11: $t3 := infer($t7)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #12: `t2` @ {0, 21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 12: if ($t0) goto 13 else goto 16
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #13: `t2` @ {0, 21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 13: label L5
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #14: `t2` @ {0, 21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 14: goto 2
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #15:
+ 15: goto 17
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #16: `t2` @ {0, 21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 16: label L6
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #17: `t2` @ {0, 21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 17: label L7
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #18: `t2` @ {0, 21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 18: $t11 := infer($t2)
+     # live vars: $t0, $t3, $t11
+     # reaching instruction #19: `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 19: $t12 := 1
+     # live vars: $t0, $t3, $t11, $t12
+     # reaching instruction #20: `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 20: $t10 := +($t11, $t12)
+     # live vars: $t0, $t3, $t10
+     # reaching instruction #21: `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t10` @ {20}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 21: $t2 := infer($t10)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #22: `t2` @ {21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 22: goto 25
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #23: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 23: label L3
+     # live vars: $t2
+     # reaching instruction #24: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 24: goto 27
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #25: `t2` @ {21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 25: label L4
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #26: `t2` @ {21}, `t3` @ {11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 26: goto 2
+     # live vars: $t2
+     # reaching instruction #27: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 27: label L1
+     # live vars: $t2
+     # reaching instruction #28: `t2` @ {0, 21}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 28: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #29: `t1` @ {28}, `t3` @ {1, 11}, `t4` @ {5}, `t5` @ {3}, `t6` @ {4}, `t8` @ {8}, `t9` @ {9}, `t11` @ {18}, `t12` @ {19}
+     # refs: []
+     #
+ 29: return $t1
+}
+
+
+[variant baseline]
+fun loops::nested_loops(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: bool
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: u64
+     var $t18: u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := 0
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: $t2 := 0
+     # live vars: $t1, $t2
+     # reaching instruction #2: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  2: label L0
+     # live vars: $t1, $t2
+     # reaching instruction #3: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  3: $t4 := infer($t2)
+     # live vars: $t1, $t2, $t4
+     # reaching instruction #4: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  4: $t5 := 3
+     # live vars: $t1, $t2, $t4, $t5
+     # reaching instruction #5: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  5: $t3 := <($t4, $t5)
+     # live vars: $t1, $t2, $t3
+     # reaching instruction #6: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  6: if ($t3) goto 7 else goto 34
+     # live vars: $t1, $t2
+     # reaching instruction #7: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  7: label L2
+     # live vars: $t1, $t2
+     # reaching instruction #8: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  8: $t6 := 0
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #9: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+  9: label L5
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #10: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 10: $t8 := infer($t6)
+     # live vars: $t1, $t2, $t6, $t8
+     # reaching instruction #11: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 11: $t9 := 3
+     # live vars: $t1, $t2, $t6, $t8, $t9
+     # reaching instruction #12: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 12: $t7 := <($t8, $t9)
+     # live vars: $t1, $t2, $t6, $t7
+     # reaching instruction #13: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 13: if ($t7) goto 14 else goto 24
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #14: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 14: label L7
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #15: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 15: $t11 := infer($t1)
+     # live vars: $t2, $t6, $t11
+     # reaching instruction #16: `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 16: $t12 := 1
+     # live vars: $t2, $t6, $t11, $t12
+     # reaching instruction #17: `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 17: $t10 := +($t11, $t12)
+     # live vars: $t2, $t6, $t10
+     # reaching instruction #18: `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t10` @ {17}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 18: $t1 := infer($t10)
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #19: `t1` @ {18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 19: $t14 := infer($t6)
+     # live vars: $t1, $t2, $t14
+     # reaching instruction #20: `t1` @ {18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 20: $t15 := 1
+     # live vars: $t1, $t2, $t14, $t15
+     # reaching instruction #21: `t1` @ {18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 21: $t13 := +($t14, $t15)
+     # live vars: $t1, $t2, $t13
+     # reaching instruction #22: `t1` @ {18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t13` @ {21}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 22: $t6 := infer($t13)
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #23: `t1` @ {18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 23: goto 26
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #24: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 24: label L8
+     # live vars: $t1, $t2
+     # reaching instruction #25: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 25: goto 28
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #26: `t1` @ {18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 26: label L9
+     # live vars: $t1, $t2, $t6
+     # reaching instruction #27: `t1` @ {18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 27: goto 9
+     # live vars: $t1, $t2
+     # reaching instruction #28: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 28: label L6
+     # live vars: $t1, $t2
+     # reaching instruction #29: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 29: $t17 := infer($t2)
+     # live vars: $t1, $t17
+     # reaching instruction #30: `t1` @ {0, 18}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 30: $t18 := 1
+     # live vars: $t1, $t17, $t18
+     # reaching instruction #31: `t1` @ {0, 18}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 31: $t16 := +($t17, $t18)
+     # live vars: $t1, $t16
+     # reaching instruction #32: `t1` @ {0, 18}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t16` @ {31}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 32: $t2 := infer($t16)
+     # live vars: $t1, $t2
+     # reaching instruction #33: `t1` @ {0, 18}, `t2` @ {32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 33: goto 36
+     # live vars: $t1, $t2
+     # reaching instruction #34: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 34: label L3
+     # live vars: $t1
+     # reaching instruction #35: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 35: goto 38
+     # live vars: $t1, $t2
+     # reaching instruction #36: `t1` @ {0, 18}, `t2` @ {32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 36: label L4
+     # live vars: $t1, $t2
+     # reaching instruction #37: `t1` @ {0, 18}, `t2` @ {32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 37: goto 2
+     # live vars: $t1
+     # reaching instruction #38: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 38: label L1
+     # live vars: $t1
+     # reaching instruction #39: `t1` @ {0, 18}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 39: $t0 := infer($t1)
+     # live vars: $t0
+     # reaching instruction #40: `t0` @ {39}, `t2` @ {1, 32}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {8, 22}, `t7` @ {12}, `t8` @ {10}, `t9` @ {11}, `t11` @ {15}, `t12` @ {16}, `t14` @ {19}, `t15` @ {20}, `t17` @ {29}, `t18` @ {30}
+     # refs: []
+     #
+ 40: return $t0
+}
+
+
+[variant baseline]
+fun loops::while_loop(): u64 {
+     var $t0: u64
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     var $t11: u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := 0
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: $t2 := 0
+     # live vars: $t1, $t2
+     # reaching instruction #2: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  2: label L0
+     # live vars: $t1, $t2
+     # reaching instruction #3: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  3: $t4 := infer($t2)
+     # live vars: $t1, $t2, $t4
+     # reaching instruction #4: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  4: $t5 := 10
+     # live vars: $t1, $t2, $t4, $t5
+     # reaching instruction #5: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  5: $t3 := <($t4, $t5)
+     # live vars: $t1, $t2, $t3
+     # reaching instruction #6: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  6: if ($t3) goto 7 else goto 17
+     # live vars: $t1, $t2
+     # reaching instruction #7: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  7: label L2
+     # live vars: $t1, $t2
+     # reaching instruction #8: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  8: $t7 := infer($t1)
+     # live vars: $t2, $t7
+     # reaching instruction #9: `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+  9: $t8 := 1
+     # live vars: $t2, $t7, $t8
+     # reaching instruction #10: `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 10: $t6 := +($t7, $t8)
+     # live vars: $t2, $t6
+     # reaching instruction #11: `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t6` @ {10}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 11: $t1 := infer($t6)
+     # live vars: $t1, $t2
+     # reaching instruction #12: `t1` @ {11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 12: $t10 := infer($t2)
+     # live vars: $t1, $t10
+     # reaching instruction #13: `t1` @ {11}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 13: $t11 := 1
+     # live vars: $t1, $t10, $t11
+     # reaching instruction #14: `t1` @ {11}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 14: $t9 := +($t10, $t11)
+     # live vars: $t1, $t9
+     # reaching instruction #15: `t1` @ {11}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t9` @ {14}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 15: $t2 := infer($t9)
+     # live vars: $t1, $t2
+     # reaching instruction #16: `t1` @ {11}, `t2` @ {15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 16: goto 19
+     # live vars: $t1, $t2
+     # reaching instruction #17: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 17: label L3
+     # live vars: $t1
+     # reaching instruction #18: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 18: goto 21
+     # live vars: $t1, $t2
+     # reaching instruction #19: `t1` @ {11}, `t2` @ {15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 19: label L4
+     # live vars: $t1, $t2
+     # reaching instruction #20: `t1` @ {11}, `t2` @ {15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 20: goto 2
+     # live vars: $t1
+     # reaching instruction #21: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 21: label L1
+     # live vars: $t1
+     # reaching instruction #22: `t1` @ {0, 11}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 22: $t0 := infer($t1)
+     # live vars: $t0
+     # reaching instruction #23: `t0` @ {22}, `t2` @ {1, 15}, `t3` @ {5}, `t4` @ {3}, `t5` @ {4}, `t7` @ {8}, `t8` @ {9}, `t10` @ {12}, `t11` @ {13}
+     # refs: []
+     #
+ 23: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/loops.move
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/loops.move
@@ -1,0 +1,58 @@
+module 0x42::loops {
+
+    // Test reaching defs with a while loop
+    // At loop header, x should have defs from both init and loop body
+    fun while_loop(): u64 {
+        let x = 0;
+        let i = 0;
+        while (i < 10) {
+            x = x + 1;
+            i = i + 1;
+        };
+        x
+    }
+
+    // Test loop with break - x has defs from init, loop body, and break path
+    fun loop_with_break(cond: bool): u64 {
+        let x = 1;
+        let i = 0;
+        while (i < 10) {
+            if (cond) {
+                x = 99;
+                break
+            };
+            x = x + 1;
+            i = i + 1;
+        };
+        x  // x can be 1 (loop never entered), 99 (break), or accumulated value
+    }
+
+    // Test loop with continue
+    fun loop_with_continue(cond: bool): u64 {
+        let x = 0;
+        let i = 0;
+        while (i < 10) {
+            i = i + 1;
+            if (cond) {
+                continue
+            };
+            x = x + 1;
+        };
+        x
+    }
+
+    // Test nested loops
+    fun nested_loops(): u64 {
+        let sum = 0;
+        let i = 0;
+        while (i < 3) {
+            let j = 0;
+            while (j < 3) {
+                sum = sum + 1;
+                j = j + 1;
+            };
+            i = i + 1;
+        };
+        sum
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/references.exp
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/references.exp
@@ -1,0 +1,1420 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun references::call_in_conditional($t0: bool): u64 {
+     var $t1: u64
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut 0x42::references::S
+     var $t6: &0x42::references::S
+     var $t7: &u64
+  0: $t3 := 1
+  1: $t4 := 2
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+  3: if ($t0) goto 4 else goto 8
+  4: label L0
+  5: $t5 := borrow_local($t2)
+  6: references::modify_struct($t5)
+  7: goto 9
+  8: label L1
+  9: label L2
+ 10: $t6 := borrow_local($t2)
+ 11: $t7 := borrow_field<0x42::references::S>.x($t6)
+ 12: $t1 := read_ref($t7)
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun references::call_modify_struct(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut 0x42::references::S
+     var $t5: &0x42::references::S
+     var $t6: &u64
+  0: $t2 := 1
+  1: $t3 := 2
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+  3: $t4 := borrow_local($t1)
+  4: references::modify_struct($t4)
+  5: $t5 := borrow_local($t1)
+  6: $t6 := borrow_field<0x42::references::S>.x($t5)
+  7: $t0 := read_ref($t6)
+  8: return $t0
+}
+
+
+[variant baseline]
+fun references::call_with_immut_ref(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: &0x42::references::S
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &0x42::references::S
+     var $t10: &u64
+  0: $t2 := 1
+  1: $t3 := 2
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+  3: $t5 := borrow_local($t1)
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+  5: $t6 := references::read_ref($t4)
+  6: $t7 := infer($t6)
+  7: $t9 := borrow_local($t1)
+  8: $t10 := borrow_field<0x42::references::S>.y($t9)
+  9: $t8 := read_ref($t10)
+ 10: $t0 := +($t7, $t8)
+ 11: return $t0
+}
+
+
+[variant baseline]
+fun references::call_with_mut_ref(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: &mut 0x42::references::S
+     var $t6: &0x42::references::S
+     var $t7: &u64
+  0: $t2 := 1
+  1: $t3 := 2
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+  3: $t5 := borrow_local($t1)
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+  5: references::modify_ref($t4)
+  6: $t6 := borrow_local($t1)
+  7: $t7 := borrow_field<0x42::references::S>.x($t6)
+  8: $t0 := read_ref($t7)
+  9: return $t0
+}
+
+
+[variant baseline]
+fun references::conditional_borrow($t0: bool): u64 {
+     var $t1: u64
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &u64
+     var $t7: &0x42::references::S
+     var $t8: u64
+     var $t9: &u64
+     var $t10: &0x42::references::S
+     var $t11: u64
+  0: $t3 := 1
+  1: $t4 := 2
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+  3: if ($t0) goto 4 else goto 10
+  4: label L0
+  5: $t7 := borrow_local($t2)
+  6: $t6 := borrow_field<0x42::references::S>.x($t7)
+  7: $t8 := read_ref($t6)
+  8: $t5 := infer($t8)
+  9: goto 15
+ 10: label L1
+ 11: $t10 := borrow_local($t2)
+ 12: $t9 := borrow_field<0x42::references::S>.y($t10)
+ 13: $t11 := read_ref($t9)
+ 14: $t5 := infer($t11)
+ 15: label L2
+ 16: $t1 := infer($t5)
+ 17: return $t1
+}
+
+
+[variant baseline]
+fun references::modify_ref($t0: &mut u64) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: write_ref($t0, $t1)
+  4: return ()
+}
+
+
+[variant baseline]
+fun references::modify_struct($t0: &mut 0x42::references::S) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &mut u64
+  0: $t3 := borrow_field<0x42::references::S>.x($t0)
+  1: $t2 := read_ref($t3)
+  2: $t4 := 10
+  3: $t1 := +($t2, $t4)
+  4: $t5 := borrow_field<0x42::references::S>.x($t0)
+  5: write_ref($t5, $t1)
+  6: return ()
+}
+
+
+[variant baseline]
+fun references::multiple_calls(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: &mut 0x42::references::S
+     var $t6: &mut u64
+     var $t7: &mut 0x42::references::S
+     var $t8: u64
+     var $t9: &0x42::references::S
+     var $t10: &u64
+     var $t11: u64
+     var $t12: &0x42::references::S
+     var $t13: &u64
+  0: $t2 := 1
+  1: $t3 := 2
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+  3: $t5 := borrow_local($t1)
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+  5: references::modify_ref($t4)
+  6: $t7 := borrow_local($t1)
+  7: $t6 := borrow_field<0x42::references::S>.y($t7)
+  8: references::modify_ref($t6)
+  9: $t9 := borrow_local($t1)
+ 10: $t10 := borrow_field<0x42::references::S>.x($t9)
+ 11: $t8 := read_ref($t10)
+ 12: $t12 := borrow_local($t1)
+ 13: $t13 := borrow_field<0x42::references::S>.y($t12)
+ 14: $t11 := read_ref($t13)
+ 15: $t0 := +($t8, $t11)
+ 16: return $t0
+}
+
+
+[variant baseline]
+fun references::multiple_field_borrows(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: &0x42::references::S
+     var $t6: &u64
+     var $t7: &0x42::references::S
+     var $t8: u64
+     var $t9: u64
+  0: $t2 := 1
+  1: $t3 := 2
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+  3: $t5 := borrow_local($t1)
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+  5: $t7 := borrow_local($t1)
+  6: $t6 := borrow_field<0x42::references::S>.y($t7)
+  7: $t8 := read_ref($t4)
+  8: $t9 := read_ref($t6)
+  9: $t0 := +($t8, $t9)
+ 10: return $t0
+}
+
+
+[variant baseline]
+fun references::nested_borrow(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::Outer
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: &u64
+     var $t6: &0x42::references::S
+     var $t7: &0x42::references::Outer
+  0: $t3 := 10
+  1: $t4 := 20
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+  3: $t1 := pack 0x42::references::Outer($t2)
+  4: $t7 := borrow_local($t1)
+  5: $t6 := borrow_field<0x42::references::Outer>.inner($t7)
+  6: $t5 := borrow_field<0x42::references::S>.x($t6)
+  7: $t0 := read_ref($t5)
+  8: return $t0
+}
+
+
+[variant baseline]
+fun references::read_ref($t0: &u64): u64 {
+     var $t1: u64
+  0: $t1 := read_ref($t0)
+  1: return $t1
+}
+
+
+[variant baseline]
+fun references::reassign_ref($t0: bool): u64 {
+     var $t1: u64
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: &u64
+     var $t6: &0x42::references::S
+     var $t7: &u64
+     var $t8: &0x42::references::S
+  0: $t3 := 1
+  1: $t4 := 2
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+  3: $t6 := borrow_local($t2)
+  4: $t5 := borrow_field<0x42::references::S>.x($t6)
+  5: if ($t0) goto 6 else goto 11
+  6: label L0
+  7: $t8 := borrow_local($t2)
+  8: $t7 := borrow_field<0x42::references::S>.y($t8)
+  9: $t5 := infer($t7)
+ 10: goto 12
+ 11: label L1
+ 12: label L2
+ 13: $t1 := read_ref($t5)
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun references::simple_mut_ref(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: &mut 0x42::references::S
+     var $t6: u64
+     var $t7: &0x42::references::S
+     var $t8: &u64
+  0: $t2 := 1
+  1: $t3 := 2
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+  3: $t5 := borrow_local($t1)
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+  5: $t6 := 10
+  6: write_ref($t4, $t6)
+  7: $t7 := borrow_local($t1)
+  8: $t8 := borrow_field<0x42::references::S>.x($t7)
+  9: $t0 := read_ref($t8)
+ 10: return $t0
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun references::call_in_conditional($t0: bool): u64 {
+     var $t1: u64
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: &mut 0x42::references::S
+     var $t6: &0x42::references::S
+     var $t7: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 1
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: $t4 := 2
+     # live vars: $t0, $t3, $t4
+     # reaching instruction #2: `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+     # live vars: $t0, $t2
+     # reaching instruction #3: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  3: if ($t0) goto 4 else goto 8
+     # live vars: $t2
+     # reaching instruction #4: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  4: label L0
+     # live vars: $t2
+     # reaching instruction #5: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  5: $t5 := borrow_local($t2)
+     # live vars: $t2, $t5
+     # reaching instruction #6: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {5}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => (mut) #5 via [local `s`] at line 113
+     #
+  6: references::modify_struct($t5)
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {6}, `t3` @ {0}, `t4` @ {1}, `t5` @ {5}
+     # refs: []
+     #
+  7: goto 9
+     # live vars: $t2
+     # reaching instruction #8: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  8: label L1
+     # live vars: $t2
+     # reaching instruction #9: `t2` @ {2, 6}, `t3` @ {0}, `t4` @ {1}, `t5` @ {5}
+     # refs: []
+     #
+  9: label L2
+     # live vars: $t2
+     # reaching instruction #10: `t2` @ {2, 6}, `t3` @ {0}, `t4` @ {1}, `t5` @ {5}
+     # refs: []
+     #
+ 10: $t6 := borrow_local($t2)
+     # live vars: $t6
+     # reaching instruction #11: `t2` @ {2, 6}, `t3` @ {0}, `t4` @ {1}, `t5` @ {5}, `t6` @ {10}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 115
+     #
+ 11: $t7 := borrow_field<0x42::references::S>.x($t6)
+     # live vars: $t7
+     # reaching instruction #12: `t2` @ {2, 6}, `t3` @ {0}, `t4` @ {1}, `t5` @ {5}, `t6` @ {10}, `t7` @ {11}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 115
+     #
+ 12: $t1 := read_ref($t7)
+     # live vars: $t1
+     # reaching instruction #13: `t1` @ {12}, `t2` @ {2, 6}, `t3` @ {0}, `t4` @ {1}, `t5` @ {5}, `t6` @ {10}, `t7` @ {11}
+     # refs: []
+     #
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun references::call_modify_struct(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut 0x42::references::S
+     var $t5: &0x42::references::S
+     var $t6: &u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 2
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: $t4 := borrow_local($t1)
+     # live vars: $t1, $t4
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `s`] at line 95
+     #
+  4: references::modify_struct($t4)
+     # live vars: $t1
+     # reaching instruction #5: `t1` @ {4}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}
+     # refs: []
+     #
+  5: $t5 := borrow_local($t1)
+     # live vars: $t5
+     # reaching instruction #6: `t1` @ {4}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {5}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`] at line 96
+     #
+  6: $t6 := borrow_field<0x42::references::S>.x($t5)
+     # live vars: $t6
+     # reaching instruction #7: `t1` @ {4}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {5}, `t6` @ {6}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`, field `x`] at line 96
+     #
+  7: $t0 := read_ref($t6)
+     # live vars: $t0
+     # reaching instruction #8: `t0` @ {7}, `t1` @ {4}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {5}, `t6` @ {6}
+     # refs: []
+     #
+  8: return $t0
+}
+
+
+[variant baseline]
+fun references::call_with_immut_ref(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: &0x42::references::S
+     var $t6: u64
+     var $t7: u64
+     var $t8: u64
+     var $t9: &0x42::references::S
+     var $t10: &u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 2
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: $t5 := borrow_local($t1)
+     # live vars: $t1, $t5
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t5` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`] at line 87
+     #
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+     # live vars: $t1, $t4
+     # reaching instruction #5: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 87
+     #
+  5: $t6 := references::read_ref($t4)
+     # live vars: $t1, $t6
+     # reaching instruction #6: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {5}
+     # refs: []
+     #
+  6: $t7 := infer($t6)
+     # live vars: $t1, $t7
+     # reaching instruction #7: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t7` @ {6}
+     # refs: []
+     #
+  7: $t9 := borrow_local($t1)
+     # live vars: $t7, $t9
+     # reaching instruction #8: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t7` @ {6}, `t9` @ {7}
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s`] at line 89
+     #
+  8: $t10 := borrow_field<0x42::references::S>.y($t9)
+     # live vars: $t7, $t10
+     # reaching instruction #9: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t7` @ {6}, `t9` @ {7}, `t10` @ {8}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s`, field `y`] at line 89
+     #
+  9: $t8 := read_ref($t10)
+     # live vars: $t7, $t8
+     # reaching instruction #10: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t7` @ {6}, `t8` @ {9}, `t9` @ {7}, `t10` @ {8}
+     # refs: []
+     #
+ 10: $t0 := +($t7, $t8)
+     # live vars: $t0
+     # reaching instruction #11: `t0` @ {10}, `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t7` @ {6}, `t8` @ {9}, `t9` @ {7}, `t10` @ {8}
+     # refs: []
+     #
+ 11: return $t0
+}
+
+
+[variant baseline]
+fun references::call_with_mut_ref(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: &mut 0x42::references::S
+     var $t6: &0x42::references::S
+     var $t7: &u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 2
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: $t5 := borrow_local($t1)
+     # live vars: $t1, $t5
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t5` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => (mut) #5 via [local `s`] at line 79
+     #
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+     # live vars: $t1, $t4
+     # reaching instruction #5: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `s`, field `x`] at line 79
+     #
+  5: references::modify_ref($t4)
+     # live vars: $t1
+     # reaching instruction #6: `t1` @ {5}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}
+     # refs: []
+     #
+  6: $t6 := borrow_local($t1)
+     # live vars: $t6
+     # reaching instruction #7: `t1` @ {5}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {6}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 81
+     #
+  7: $t7 := borrow_field<0x42::references::S>.x($t6)
+     # live vars: $t7
+     # reaching instruction #8: `t1` @ {5}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {6}, `t7` @ {7}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 81
+     #
+  8: $t0 := read_ref($t7)
+     # live vars: $t0
+     # reaching instruction #9: `t0` @ {8}, `t1` @ {5}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {6}, `t7` @ {7}
+     # refs: []
+     #
+  9: return $t0
+}
+
+
+[variant baseline]
+fun references::conditional_borrow($t0: bool): u64 {
+     var $t1: u64
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     var $t6: &u64
+     var $t7: &0x42::references::S
+     var $t8: u64
+     var $t9: &u64
+     var $t10: &0x42::references::S
+     var $t11: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 1
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: $t4 := 2
+     # live vars: $t0, $t3, $t4
+     # reaching instruction #2: `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+     # live vars: $t0, $t2
+     # reaching instruction #3: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  3: if ($t0) goto 4 else goto 10
+     # live vars: $t2
+     # reaching instruction #4: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  4: label L0
+     # live vars: $t2
+     # reaching instruction #5: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  5: $t7 := borrow_local($t2)
+     # live vars: $t7
+     # reaching instruction #6: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t7` @ {5}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`] at line 29
+     #
+  6: $t6 := borrow_field<0x42::references::S>.x($t7)
+     # live vars: $t6
+     # reaching instruction #7: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t6` @ {6}, `t7` @ {5}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`, field `x`] at line 29
+     #
+  7: $t8 := read_ref($t6)
+     # live vars: $t8
+     # reaching instruction #8: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t6` @ {6}, `t7` @ {5}, `t8` @ {7}
+     # refs: []
+     #
+  8: $t5 := infer($t8)
+     # live vars: $t5
+     # reaching instruction #9: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {8}, `t6` @ {6}, `t7` @ {5}
+     # refs: []
+     #
+  9: goto 15
+     # live vars: $t2
+     # reaching instruction #10: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+ 10: label L1
+     # live vars: $t2
+     # reaching instruction #11: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+ 11: $t10 := borrow_local($t2)
+     # live vars: $t10
+     # reaching instruction #12: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t10` @ {11}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s`] at line 32
+     #
+ 12: $t9 := borrow_field<0x42::references::S>.y($t10)
+     # live vars: $t9
+     # reaching instruction #13: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t9` @ {12}, `t10` @ {11}
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s`, field `y`] at line 32
+     #
+ 13: $t11 := read_ref($t9)
+     # live vars: $t11
+     # reaching instruction #14: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t9` @ {12}, `t10` @ {11}, `t11` @ {13}
+     # refs: []
+     #
+ 14: $t5 := infer($t11)
+     # live vars: $t5
+     # reaching instruction #15: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {8, 14}, `t6` @ {6}, `t7` @ {5}, `t9` @ {12}, `t10` @ {11}
+     # refs: []
+     #
+ 15: label L2
+     # live vars: $t5
+     # reaching instruction #16: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {8, 14}, `t6` @ {6}, `t7` @ {5}, `t9` @ {12}, `t10` @ {11}
+     # refs: []
+     #
+ 16: $t1 := infer($t5)
+     # live vars: $t1
+     # reaching instruction #17: `t1` @ {16}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t6` @ {6}, `t7` @ {5}, `t9` @ {12}, `t10` @ {11}
+     # refs: []
+     #
+ 17: return $t1
+}
+
+
+[variant baseline]
+fun references::modify_ref($t0: &mut u64) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := 1
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t0, $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: write_ref($t0, $t1)
+     # live vars:
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun references::modify_struct($t0: &mut 0x42::references::S) {
+     var $t1: u64
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &mut u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_field<0x42::references::S>.x($t0)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   => #3 via [field `x`] at line 73
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := read_ref($t3)
+     # live vars: $t0, $t2
+     # reaching instruction #2: `t2` @ {1}, `t3` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := 10
+     # live vars: $t0, $t2, $t4
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t1 := +($t2, $t4)
+     # live vars: $t0, $t1
+     # reaching instruction #4: `t1` @ {3}, `t2` @ {1}, `t3` @ {0}, `t4` @ {2}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t5 := borrow_field<0x42::references::S>.x($t0)
+     # live vars: $t1, $t5
+     # reaching instruction #5: `t1` @ {3}, `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: write_ref($t5, $t1)
+     # live vars:
+     # reaching instruction #6: `t1` @ {3}, `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}
+     # refs: []
+     #
+  6: return ()
+}
+
+
+[variant baseline]
+fun references::multiple_calls(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: &mut 0x42::references::S
+     var $t6: &mut u64
+     var $t7: &mut 0x42::references::S
+     var $t8: u64
+     var $t9: &0x42::references::S
+     var $t10: &u64
+     var $t11: u64
+     var $t12: &0x42::references::S
+     var $t13: &u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 2
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: $t5 := borrow_local($t1)
+     # live vars: $t1, $t5
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t5` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => (mut) #5 via [local `s`] at line 102
+     #
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+     # live vars: $t1, $t4
+     # reaching instruction #5: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `s`, field `x`] at line 102
+     #
+  5: references::modify_ref($t4)
+     # live vars: $t1
+     # reaching instruction #6: `t1` @ {5}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}
+     # refs: []
+     #
+  6: $t7 := borrow_local($t1)
+     # live vars: $t1, $t7
+     # reaching instruction #7: `t1` @ {5}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t7` @ {6}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `s`] at line 104
+     #
+  7: $t6 := borrow_field<0x42::references::S>.y($t7)
+     # live vars: $t1, $t6
+     # reaching instruction #8: `t1` @ {5}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => (mut) #6 via [local `s`, field `y`] at line 104
+     #
+  8: references::modify_ref($t6)
+     # live vars: $t1
+     # reaching instruction #9: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}
+     # refs: []
+     #
+  9: $t9 := borrow_local($t1)
+     # live vars: $t1, $t9
+     # reaching instruction #10: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}, `t9` @ {9}
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `s`] at line 106
+     #
+ 10: $t10 := borrow_field<0x42::references::S>.x($t9)
+     # live vars: $t1, $t10
+     # reaching instruction #11: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}, `t9` @ {9}, `t10` @ {10}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `s`, field `x`] at line 106
+     #
+ 11: $t8 := read_ref($t10)
+     # live vars: $t1, $t8
+     # reaching instruction #12: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}, `t8` @ {11}, `t9` @ {9}, `t10` @ {10}
+     # refs: []
+     #
+ 12: $t12 := borrow_local($t1)
+     # live vars: $t8, $t12
+     # reaching instruction #13: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}, `t8` @ {11}, `t9` @ {9}, `t10` @ {10}, `t12` @ {12}
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `s`] at line 106
+     #
+ 13: $t13 := borrow_field<0x42::references::S>.y($t12)
+     # live vars: $t8, $t13
+     # reaching instruction #14: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}, `t8` @ {11}, `t9` @ {9}, `t10` @ {10}, `t12` @ {12}, `t13` @ {13}
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `s`, field `y`] at line 106
+     #
+ 14: $t11 := read_ref($t13)
+     # live vars: $t8, $t11
+     # reaching instruction #15: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}, `t8` @ {11}, `t9` @ {9}, `t10` @ {10}, `t11` @ {14}, `t12` @ {12}, `t13` @ {13}
+     # refs: []
+     #
+ 15: $t0 := +($t8, $t11)
+     # live vars: $t0
+     # reaching instruction #16: `t0` @ {15}, `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {7}, `t7` @ {6}, `t8` @ {11}, `t9` @ {9}, `t10` @ {10}, `t11` @ {14}, `t12` @ {12}, `t13` @ {13}
+     # refs: []
+     #
+ 16: return $t0
+}
+
+
+[variant baseline]
+fun references::multiple_field_borrows(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: &0x42::references::S
+     var $t6: &u64
+     var $t7: &0x42::references::S
+     var $t8: u64
+     var $t9: u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 2
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: $t5 := borrow_local($t1)
+     # live vars: $t1, $t5
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t5` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`] at line 19
+     #
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+     # live vars: $t1, $t4
+     # reaching instruction #5: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 19
+     #
+  5: $t7 := borrow_local($t1)
+     # live vars: $t4, $t7
+     # reaching instruction #6: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t7` @ {5}
+     # refs: [$t4 => #4, $t7 => #7]
+     # #4
+     #   <no edges>
+     # #7
+     #   => #4 via [field `x`] at line 19
+     # #root
+     #   => #7 via [local `s`] at line 20
+     #
+  6: $t6 := borrow_field<0x42::references::S>.y($t7)
+     # live vars: $t4, $t6
+     # reaching instruction #7: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {6}, `t7` @ {5}
+     # refs: [$t4 => #4, $t6 => #6]
+     # #4
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 19
+     #   => #6 via [local `s`, field `y`] at line 20
+     #
+  7: $t8 := read_ref($t4)
+     # live vars: $t6, $t8
+     # reaching instruction #8: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {6}, `t7` @ {5}, `t8` @ {7}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`, field `y`] at line 20
+     #
+  8: $t9 := read_ref($t6)
+     # live vars: $t8, $t9
+     # reaching instruction #9: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {6}, `t7` @ {5}, `t8` @ {7}, `t9` @ {8}
+     # refs: []
+     #
+  9: $t0 := +($t8, $t9)
+     # live vars: $t0
+     # reaching instruction #10: `t0` @ {9}, `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {6}, `t7` @ {5}, `t8` @ {7}, `t9` @ {8}
+     # refs: []
+     #
+ 10: return $t0
+}
+
+
+[variant baseline]
+fun references::nested_borrow(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::Outer
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: &u64
+     var $t6: &0x42::references::S
+     var $t7: &0x42::references::Outer
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 10
+     # live vars: $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: $t4 := 20
+     # live vars: $t3, $t4
+     # reaching instruction #2: `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+     # live vars: $t2
+     # reaching instruction #3: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  3: $t1 := pack 0x42::references::Outer($t2)
+     # live vars: $t1
+     # reaching instruction #4: `t1` @ {3}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  4: $t7 := borrow_local($t1)
+     # live vars: $t7
+     # reaching instruction #5: `t1` @ {3}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t7` @ {4}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `o`] at line 55
+     #
+  5: $t6 := borrow_field<0x42::references::Outer>.inner($t7)
+     # live vars: $t6
+     # reaching instruction #6: `t1` @ {3}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t6` @ {5}, `t7` @ {4}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `o`, field `inner`] at line 55
+     #
+  6: $t5 := borrow_field<0x42::references::S>.x($t6)
+     # live vars: $t5
+     # reaching instruction #7: `t1` @ {3}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {6}, `t6` @ {5}, `t7` @ {4}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `o`, field `inner`, field `x`] at line 55
+     #
+  7: $t0 := read_ref($t5)
+     # live vars: $t0
+     # reaching instruction #8: `t0` @ {7}, `t1` @ {3}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {6}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+  8: return $t0
+}
+
+
+[variant baseline]
+fun references::read_ref($t0: &u64): u64 {
+     var $t1: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := read_ref($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: return $t1
+}
+
+
+[variant baseline]
+fun references::reassign_ref($t0: bool): u64 {
+     var $t1: u64
+     var $t2: 0x42::references::S
+     var $t3: u64
+     var $t4: u64
+     var $t5: &u64
+     var $t6: &0x42::references::S
+     var $t7: &u64
+     var $t8: &0x42::references::S
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := 1
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: $t4 := 2
+     # live vars: $t0, $t3, $t4
+     # reaching instruction #2: `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: $t2 := pack 0x42::references::S($t3, $t4)
+     # live vars: $t0, $t2
+     # reaching instruction #3: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  3: $t6 := borrow_local($t2)
+     # live vars: $t0, $t2, $t6
+     # reaching instruction #4: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t6` @ {3}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 41
+     #
+  4: $t5 := borrow_field<0x42::references::S>.x($t6)
+     # live vars: $t0, $t2, $t5
+     # reaching instruction #5: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4}, `t6` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`, field `x`] at line 41
+     #
+  5: if ($t0) goto 6 else goto 11
+     # live vars: $t2, $t5
+     # reaching instruction #6: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4}, `t6` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`, field `x`] at line 41
+     #
+  6: label L0
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4}, `t6` @ {3}
+     # refs: []
+     #
+  7: $t8 := borrow_local($t2)
+     # live vars: $t8
+     # reaching instruction #8: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4}, `t6` @ {3}, `t8` @ {7}
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `s`] at line 43
+     #
+  8: $t7 := borrow_field<0x42::references::S>.y($t8)
+     # live vars: $t7
+     # reaching instruction #9: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4}, `t6` @ {3}, `t7` @ {8}, `t8` @ {7}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `y`] at line 43
+     #
+  9: $t5 := infer($t7)
+     # live vars: $t5
+     # reaching instruction #10: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {9}, `t6` @ {3}, `t8` @ {7}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`, field `y`] at line 43
+     #
+ 10: goto 12
+     # live vars: $t2, $t5
+     # reaching instruction #11: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4}, `t6` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`, field `x`] at line 41
+     #
+ 11: label L1
+     # live vars: $t5
+     # reaching instruction #12: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4, 9}, `t6` @ {3}, `t8` @ {7}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`, field `x`] at line 41
+     #   => #5 via [local `s`, field `y`] at line 43
+     #
+ 12: label L2
+     # live vars: $t5
+     # reaching instruction #13: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4, 9}, `t6` @ {3}, `t8` @ {7}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `s`, field `x`] at line 41
+     #   => #5 via [local `s`, field `y`] at line 43
+     #
+ 13: $t1 := read_ref($t5)
+     # live vars: $t1
+     # reaching instruction #14: `t1` @ {13}, `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {4, 9}, `t6` @ {3}, `t8` @ {7}
+     # refs: []
+     #
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun references::simple_mut_ref(): u64 {
+     var $t0: u64
+     var $t1: 0x42::references::S
+     var $t2: u64
+     var $t3: u64
+     var $t4: &mut u64
+     var $t5: &mut 0x42::references::S
+     var $t6: u64
+     var $t7: &0x42::references::S
+     var $t8: &u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 1
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 2
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := pack 0x42::references::S($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: $t5 := borrow_local($t1)
+     # live vars: $t1, $t5
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t5` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => (mut) #5 via [local `s`] at line 11
+     #
+  4: $t4 := borrow_field<0x42::references::S>.x($t5)
+     # live vars: $t1, $t4
+     # reaching instruction #5: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `s`, field `x`] at line 11
+     #
+  5: $t6 := 10
+     # live vars: $t1, $t4, $t6
+     # reaching instruction #6: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {5}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `s`, field `x`] at line 11
+     #
+  6: write_ref($t4, $t6)
+     # live vars: $t1
+     # reaching instruction #7: `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {5}
+     # refs: []
+     #
+  7: $t7 := borrow_local($t1)
+     # live vars: $t7
+     # reaching instruction #8: `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {5}, `t7` @ {7}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`] at line 13
+     #
+  8: $t8 := borrow_field<0x42::references::S>.x($t7)
+     # live vars: $t8
+     # reaching instruction #9: `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {5}, `t7` @ {7}, `t8` @ {8}
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `s`, field `x`] at line 13
+     #
+  9: $t0 := read_ref($t8)
+     # live vars: $t0
+     # reaching instruction #10: `t0` @ {9}, `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `t4` @ {4}, `t5` @ {3}, `t6` @ {5}, `t7` @ {7}, `t8` @ {8}
+     # refs: []
+     #
+ 10: return $t0
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/references.move
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/references.move
@@ -1,0 +1,117 @@
+module 0x42::references {
+
+    struct S has drop {
+        x: u64,
+        y: u64,
+    }
+
+    // Test simple mutable borrow and write-back
+    fun simple_mut_ref(): u64 {
+        let s = S { x: 1, y: 2 };
+        let r = &mut s.x;
+        *r = 10;
+        s.x
+    }
+
+    // Test multiple borrows from same struct
+    fun multiple_field_borrows(): u64 {
+        let s = S { x: 1, y: 2 };
+        let rx = &s.x;
+        let ry = &s.y;
+        *rx + *ry
+    }
+
+    // Test borrow in conditional
+    fun conditional_borrow(cond: bool): u64 {
+        let s = S { x: 1, y: 2 };
+        let result;
+        if (cond) {
+            let r = &s.x;
+            result = *r;
+        } else {
+            let r = &s.y;
+            result = *r;
+        };
+        result
+    }
+
+    // Test reassigning a reference
+    fun reassign_ref(cond: bool): u64 {
+        let s = S { x: 1, y: 2 };
+        let r = &s.x;
+        if (cond) {
+            r = &s.y;
+        };
+        *r
+    }
+
+    // Test nested struct borrow
+    struct Outer has drop {
+        inner: S,
+    }
+
+    fun nested_borrow(): u64 {
+        let o = Outer { inner: S { x: 10, y: 20 } };
+        let r = &o.inner.x;
+        *r
+    }
+
+    // ========== Function call tests ==========
+
+    // Helper: modifies value through mutable reference
+    fun modify_ref(r: &mut u64) {
+        *r = *r + 1;
+    }
+
+    // Helper: reads through immutable reference
+    fun read_ref(r: &u64): u64 {
+        *r
+    }
+
+    // Helper: modifies struct field
+    fun modify_struct(s: &mut S) {
+        s.x = s.x + 10;
+    }
+
+    // Test: call with mutable ref should conservatively mark struct as modified
+    fun call_with_mut_ref(): u64 {
+        let s = S { x: 1, y: 2 };
+        let r = &mut s.x;
+        modify_ref(r);  // After this call, s should have new reaching def
+        s.x
+    }
+
+    // Test: call with immutable ref should NOT mark struct as modified
+    fun call_with_immut_ref(): u64 {
+        let s = S { x: 1, y: 2 };
+        let r = &s.x;
+        let val = read_ref(r);  // s should NOT get new reaching def
+        val + s.y
+    }
+
+    // Test: call that modifies struct directly
+    fun call_modify_struct(): u64 {
+        let s = S { x: 1, y: 2 };
+        modify_struct(&mut s);  // s should have new reaching def
+        s.x
+    }
+
+    // Test: multiple calls in sequence
+    fun multiple_calls(): u64 {
+        let s = S { x: 1, y: 2 };
+        let r = &mut s.x;
+        modify_ref(r);      // s gets new def
+        let r2 = &mut s.y;
+        modify_ref(r2);     // s gets another new def
+        s.x + s.y
+    }
+
+    // Test: call in conditional
+    fun call_in_conditional(cond: bool): u64 {
+        let s = S { x: 1, y: 2 };
+        if (cond) {
+            modify_struct(&mut s);  // s gets new def in this branch only
+        };
+        s.x  // s should have defs from both init and the call
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/resources.exp
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/resources.exp
@@ -1,0 +1,1441 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun resources::acquire_counter($t0: address): u64 {
+     var $t1: u64
+     var $t2: 0x42::resources::Counter
+     var $t3: &0x42::resources::Counter
+     var $t4: &u64
+  0: $t2 := move_from<0x42::resources::Counter>($t0)
+  1: $t3 := borrow_local($t2)
+  2: $t4 := borrow_field<0x42::resources::Counter>.value($t3)
+  3: $t1 := read_ref($t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun resources::add_to_counter($t0: &mut 0x42::resources::Counter, $t1: u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: &mut u64
+  0: $t4 := borrow_field<0x42::resources::Counter>.value($t0)
+  1: $t3 := read_ref($t4)
+  2: $t2 := +($t3, $t1)
+  3: $t5 := borrow_field<0x42::resources::Counter>.value($t0)
+  4: write_ref($t5, $t2)
+  5: return ()
+}
+
+
+[variant baseline]
+fun resources::call_nested($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+  1: resources::nested_helper($t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun resources::call_with_immut_ref($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+  1: $t1 := resources::read_value($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun resources::call_with_mut_ref($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: &mut 0x42::resources::Counter
+     var $t3: u64
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+  1: $t2 := infer($t1)
+  2: $t3 := 1
+  3: resources::add_to_counter($t2, $t3)
+  4: return ()
+}
+
+
+[variant baseline]
+fun resources::check_and_read($t0: address): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: &0x42::resources::Counter
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+  0: $t3 := exists<0x42::resources::Counter>($t0)
+  1: if ($t3) goto 2 else goto 8
+  2: label L0
+  3: $t4 := borrow_global<0x42::resources::Counter>($t0)
+  4: $t6 := borrow_field<0x42::resources::Counter>.value($t4)
+  5: $t5 := read_ref($t6)
+  6: $t2 := infer($t5)
+  7: goto 11
+  8: label L1
+  9: $t7 := 0
+ 10: $t2 := infer($t7)
+ 11: label L2
+ 12: $t1 := infer($t2)
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun resources::conditional_acquire($t0: address, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: 0x42::resources::Counter
+     var $t5: u64
+     var $t6: &0x42::resources::Counter
+     var $t7: &u64
+     var $t8: u64
+  0: if ($t1) goto 1 else goto 8
+  1: label L0
+  2: $t4 := move_from<0x42::resources::Counter>($t0)
+  3: $t6 := borrow_local($t4)
+  4: $t7 := borrow_field<0x42::resources::Counter>.value($t6)
+  5: $t5 := read_ref($t7)
+  6: $t3 := infer($t5)
+  7: goto 11
+  8: label L1
+  9: $t8 := 0
+ 10: $t3 := infer($t8)
+ 11: label L2
+ 12: $t2 := infer($t3)
+ 13: return $t2
+}
+
+
+[variant baseline]
+fun resources::conditional_mut_call($t0: address, $t1: bool) {
+     var $t2: &mut 0x42::resources::Counter
+     var $t3: &mut 0x42::resources::Counter
+     var $t4: u64
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+  1: if ($t1) goto 2 else goto 7
+  2: label L0
+  3: $t3 := infer($t2)
+  4: $t4 := 1
+  5: resources::add_to_counter($t3, $t4)
+  6: goto 8
+  7: label L1
+  8: label L2
+  9: return ()
+}
+
+
+[variant baseline]
+fun resources::increment_counter($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &mut u64
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+  1: $t4 := borrow_field<0x42::resources::Counter>.value($t1)
+  2: $t3 := read_ref($t4)
+  3: $t5 := 1
+  4: $t2 := +($t3, $t5)
+  5: $t6 := borrow_field<0x42::resources::Counter>.value($t1)
+  6: write_ref($t6, $t2)
+  7: return ()
+}
+
+
+[variant baseline]
+fun resources::invoke_local_modifier($t0: address) {
+     var $t1: |address|
+  0: $t1 := closure#0 resources::modifier_func()
+  1: invoke($t0, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun resources::invoke_local_reader($t0: address): u64 {
+     var $t1: u64
+     var $t2: |address|u64
+  0: $t2 := closure#0 resources::reader_func()
+  1: $t1 := invoke($t0, $t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun resources::invoke_passed_closure($t0: address, $t1: |address|) {
+  0: invoke($t0, $t1)
+  1: return ()
+}
+
+
+[variant baseline]
+fun resources::invoke_passed_closure_mut_ref($t0: address, $t1: |&mut 0x42::resources::Counter|) {
+     var $t2: &mut 0x42::resources::Counter
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+  1: invoke($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun resources::loop_mut_call($t0: address, $t1: u64) {
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: &mut 0x42::resources::Counter
+     var $t6: &mut 0x42::resources::Counter
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+  0: $t2 := 0
+  1: label L0
+  2: $t4 := infer($t2)
+  3: $t3 := <($t4, $t1)
+  4: if ($t3) goto 5 else goto 15
+  5: label L2
+  6: $t5 := borrow_global<0x42::resources::Counter>($t0)
+  7: $t6 := infer($t5)
+  8: $t7 := 1
+  9: resources::add_to_counter($t6, $t7)
+ 10: $t9 := infer($t2)
+ 11: $t10 := 1
+ 12: $t8 := +($t9, $t10)
+ 13: $t2 := infer($t8)
+ 14: goto 17
+ 15: label L3
+ 16: goto 19
+ 17: label L4
+ 18: goto 1
+ 19: label L1
+ 20: return ()
+}
+
+
+[variant baseline]
+fun resources::modifier_func($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &mut u64
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+  1: $t4 := borrow_field<0x42::resources::Counter>.value($t1)
+  2: $t3 := read_ref($t4)
+  3: $t5 := 1
+  4: $t2 := +($t3, $t5)
+  5: $t6 := borrow_field<0x42::resources::Counter>.value($t1)
+  6: write_ref($t6, $t2)
+  7: return ()
+}
+
+
+[variant baseline]
+fun resources::nested_helper($t0: &mut 0x42::resources::Counter) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: u64
+  0: $t1 := infer($t0)
+  1: $t2 := 10
+  2: resources::add_to_counter($t1, $t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun resources::publish_counter($t0: &signer, $t1: u64) {
+     var $t2: 0x42::resources::Counter
+     var $t3: &signer
+  0: $t2 := pack 0x42::resources::Counter($t1)
+  1: $t3 := infer($t0)
+  2: move_to<0x42::resources::Counter>($t3, $t2)
+  3: return ()
+}
+
+
+[variant baseline]
+fun resources::read_counter($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+     var $t3: &u64
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+  1: $t3 := borrow_field<0x42::resources::Counter>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun resources::read_multiple($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+     var $t3: &0x42::resources::Wallet
+     var $t4: u64
+     var $t5: &u64
+     var $t6: u64
+     var $t7: &u64
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+  1: $t3 := borrow_global<0x42::resources::Wallet>($t0)
+  2: $t5 := borrow_field<0x42::resources::Counter>.value($t2)
+  3: $t4 := read_ref($t5)
+  4: $t7 := borrow_field<0x42::resources::Wallet>.balance($t3)
+  5: $t6 := read_ref($t7)
+  6: $t1 := +($t4, $t6)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun resources::read_value($t0: &0x42::resources::Counter): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x42::resources::Counter>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun resources::reader_func($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+     var $t3: &u64
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+  1: $t3 := borrow_field<0x42::resources::Counter>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun resources::test_pass_modifier_closure($t0: address) {
+     var $t1: address
+     var $t2: |address|
+  0: $t1 := infer($t0)
+  1: $t2 := closure#0 resources::modifier_func()
+  2: resources::invoke_passed_closure($t1, $t2)
+  3: return ()
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun resources::acquire_counter($t0: address): u64 {
+     var $t1: u64
+     var $t2: 0x42::resources::Counter
+     var $t3: &0x42::resources::Counter
+     var $t4: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := move_from<0x42::resources::Counter>($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {0}
+     # refs: []
+     #
+  1: $t3 := borrow_local($t2)
+     # live vars: $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {0}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `c`] at line 21
+     #
+  2: $t4 := borrow_field<0x42::resources::Counter>.value($t3)
+     # live vars: $t4
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}, `t4` @ {2}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {0}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `c`, field `value`] at line 21
+     #
+  3: $t1 := read_ref($t4)
+     # live vars: $t1
+     # reaching instruction #4: `t1` @ {3}, `t2` @ {0}, `t3` @ {1}, `t4` @ {2}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {0}
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun resources::add_to_counter($t0: &mut 0x42::resources::Counter, $t1: u64) {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: &mut u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t4 := borrow_field<0x42::resources::Counter>.value($t0)
+     # live vars: $t0, $t1, $t4
+     # reaching instruction #1: `t4` @ {0}
+     # refs: [$t0 => #0, $t4 => #4]
+     # #0
+     #   => #4 via [field `value`] at line 76
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := read_ref($t4)
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #2: `t3` @ {1}, `t4` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t2 := +($t3, $t1)
+     # live vars: $t0, $t2
+     # reaching instruction #3: `t2` @ {2}, `t3` @ {1}, `t4` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t5 := borrow_field<0x42::resources::Counter>.value($t0)
+     # live vars: $t2, $t5
+     # reaching instruction #4: `t2` @ {2}, `t3` @ {1}, `t4` @ {0}, `t5` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: write_ref($t5, $t2)
+     # live vars:
+     # reaching instruction #5: `t2` @ {2}, `t3` @ {1}, `t4` @ {0}, `t5` @ {3}
+     # refs: []
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+fun resources::call_nested($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 115
+     #
+  1: resources::nested_helper($t1)
+     # live vars:
+     # reaching instruction #2: `t1` @ {0}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {1}
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun resources::call_with_immut_ref($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `resources::Counter`] at line 87
+     #
+  1: $t1 := resources::read_value($t2)
+     # live vars: $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun resources::call_with_mut_ref($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: &mut 0x42::resources::Counter
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 81
+     #
+  1: $t2 := infer($t1)
+     # live vars: $t2
+     # reaching instruction #2: `t2` @ {1}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `resources::Counter`] at line 81
+     #
+  2: $t3 := 1
+     # live vars: $t2, $t3
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {2}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `resources::Counter`] at line 81
+     #
+  3: resources::add_to_counter($t2, $t3)
+     # live vars:
+     # reaching instruction #4: `t2` @ {1}, `t3` @ {2}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {3}
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun resources::check_and_read($t0: address): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: bool
+     var $t4: &0x42::resources::Counter
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := exists<0x42::resources::Counter>($t0)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: []
+     #
+  1: if ($t3) goto 2 else goto 8
+     # live vars: $t0
+     # reaching instruction #2: `t3` @ {0}
+     # refs: []
+     #
+  2: label L0
+     # live vars: $t0
+     # reaching instruction #3: `t3` @ {0}
+     # refs: []
+     #
+  3: $t4 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t4
+     # reaching instruction #4: `t3` @ {0}, `t4` @ {3}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `resources::Counter`] at line 40
+     #
+  4: $t6 := borrow_field<0x42::resources::Counter>.value($t4)
+     # live vars: $t6
+     # reaching instruction #5: `t3` @ {0}, `t4` @ {3}, `t6` @ {4}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `resources::Counter`] at line 41
+     #
+  5: $t5 := read_ref($t6)
+     # live vars: $t5
+     # reaching instruction #6: `t3` @ {0}, `t4` @ {3}, `t5` @ {5}, `t6` @ {4}
+     # refs: []
+     #
+  6: $t2 := infer($t5)
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {6}, `t3` @ {0}, `t4` @ {3}, `t6` @ {4}
+     # refs: []
+     #
+  7: goto 11
+     # live vars: $t0
+     # reaching instruction #8: `t3` @ {0}
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # reaching instruction #9: `t3` @ {0}
+     # refs: []
+     #
+  9: $t7 := 0
+     # live vars: $t7
+     # reaching instruction #10: `t3` @ {0}, `t7` @ {9}
+     # refs: []
+     #
+ 10: $t2 := infer($t7)
+     # live vars: $t2
+     # reaching instruction #11: `t2` @ {6, 10}, `t3` @ {0}, `t4` @ {3}, `t6` @ {4}
+     # refs: []
+     #
+ 11: label L2
+     # live vars: $t2
+     # reaching instruction #12: `t2` @ {6, 10}, `t3` @ {0}, `t4` @ {3}, `t6` @ {4}
+     # refs: []
+     #
+ 12: $t1 := infer($t2)
+     # live vars: $t1
+     # reaching instruction #13: `t1` @ {12}, `t3` @ {0}, `t4` @ {3}, `t6` @ {4}
+     # refs: []
+     #
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun resources::conditional_acquire($t0: address, $t1: bool): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: 0x42::resources::Counter
+     var $t5: u64
+     var $t6: &0x42::resources::Counter
+     var $t7: &u64
+     var $t8: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: if ($t1) goto 1 else goto 8
+     # live vars: $t0
+     # reaching instruction #1:
+     # refs: []
+     #
+  1: label L0
+     # live vars: $t0
+     # reaching instruction #2:
+     # refs: []
+     #
+  2: $t4 := move_from<0x42::resources::Counter>($t0)
+     # live vars: $t4
+     # reaching instruction #3: `t4` @ {2}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: []
+     #
+  3: $t6 := borrow_local($t4)
+     # live vars: $t6
+     # reaching instruction #4: `t4` @ {2}, `t6` @ {3}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `c`] at line 53
+     #
+  4: $t7 := borrow_field<0x42::resources::Counter>.value($t6)
+     # live vars: $t7
+     # reaching instruction #5: `t4` @ {2}, `t6` @ {3}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `c`, field `value`] at line 53
+     #
+  5: $t5 := read_ref($t7)
+     # live vars: $t5
+     # reaching instruction #6: `t4` @ {2}, `t5` @ {5}, `t6` @ {3}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: []
+     #
+  6: $t3 := infer($t5)
+     # live vars: $t3
+     # reaching instruction #7: `t3` @ {6}, `t4` @ {2}, `t6` @ {3}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: []
+     #
+  7: goto 11
+     # live vars: $t0
+     # reaching instruction #8:
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # reaching instruction #9:
+     # refs: []
+     #
+  9: $t8 := 0
+     # live vars: $t8
+     # reaching instruction #10: `t8` @ {9}
+     # refs: []
+     #
+ 10: $t3 := infer($t8)
+     # live vars: $t3
+     # reaching instruction #11: `t3` @ {6, 10}, `t4` @ {2}, `t6` @ {3}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: []
+     #
+ 11: label L2
+     # live vars: $t3
+     # reaching instruction #12: `t3` @ {6, 10}, `t4` @ {2}, `t6` @ {3}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: []
+     #
+ 12: $t2 := infer($t3)
+     # live vars: $t2
+     # reaching instruction #13: `t2` @ {12}, `t4` @ {2}, `t6` @ {3}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: []
+     #
+ 13: return $t2
+}
+
+
+[variant baseline]
+fun resources::conditional_mut_call($t0: address, $t1: bool) {
+     var $t2: &mut 0x42::resources::Counter
+     var $t3: &mut 0x42::resources::Counter
+     var $t4: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t1, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `resources::Counter`] at line 93
+     #
+  1: if ($t1) goto 2 else goto 7
+     # live vars: $t2
+     # reaching instruction #2: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `resources::Counter`] at line 93
+     #
+  2: label L0
+     # live vars: $t2
+     # reaching instruction #3: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `resources::Counter`] at line 93
+     #
+  3: $t3 := infer($t2)
+     # live vars: $t3
+     # reaching instruction #4: `t3` @ {3}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `resources::Counter`] at line 93
+     #
+  4: $t4 := 1
+     # live vars: $t3, $t4
+     # reaching instruction #5: `t3` @ {3}, `t4` @ {4}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `resources::Counter`] at line 93
+     #
+  5: resources::add_to_counter($t3, $t4)
+     # live vars:
+     # reaching instruction #6: `t3` @ {3}, `t4` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {5}
+     # refs: []
+     #
+  6: goto 8
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `resources::Counter`] at line 93
+     #
+  7: label L1
+     # live vars:
+     # reaching instruction #8: `t2` @ {0}, `t3` @ {3}, `t4` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {5}
+     # refs: []
+     #
+  8: label L2
+     # live vars:
+     # reaching instruction #9: `t2` @ {0}, `t3` @ {3}, `t4` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {5}
+     # refs: []
+     #
+  9: return ()
+}
+
+
+[variant baseline]
+fun resources::increment_counter($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &mut u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 32
+     #
+  1: $t4 := borrow_field<0x42::resources::Counter>.value($t1)
+     # live vars: $t1, $t4
+     # reaching instruction #2: `t1` @ {0}, `t4` @ {1}
+     # refs: [$t1 => #1, $t4 => #4]
+     # #1
+     #   => #4 via [field `value`] at line 33
+     # #4
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 32
+     #
+  2: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+     # reaching instruction #3: `t1` @ {0}, `t3` @ {2}, `t4` @ {1}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 32
+     #
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+     # reaching instruction #4: `t1` @ {0}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 32
+     #
+  4: $t2 := +($t3, $t5)
+     # live vars: $t1, $t2
+     # reaching instruction #5: `t1` @ {0}, `t2` @ {4}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 32
+     #
+  5: $t6 := borrow_field<0x42::resources::Counter>.value($t1)
+     # live vars: $t2, $t6
+     # reaching instruction #6: `t1` @ {0}, `t2` @ {4}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}, `t6` @ {5}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> (mut) #6 via [struct `resources::Counter`] at line 33
+     #
+  6: write_ref($t6, $t2)
+     # live vars:
+     # reaching instruction #7: `t1` @ {0}, `t2` @ {4}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}, `t6` @ {5}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {6}
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun resources::invoke_local_modifier($t0: address) {
+     var $t1: |address|
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := closure#0 resources::modifier_func()
+     # live vars: $t0, $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: invoke($t0, $t1)
+     # live vars:
+     # reaching instruction #2: `t1` @ {0}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(134)) }` @ {1}
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun resources::invoke_local_reader($t0: address): u64 {
+     var $t1: u64
+     var $t2: |address|u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := closure#0 resources::reader_func()
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t1 := invoke($t0, $t2)
+     # live vars: $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(134)) }` @ {1}
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun resources::invoke_passed_closure($t0: address, $t1: |address|) {
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: invoke($t0, $t1)
+     # live vars:
+     # reaching instruction #1: `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {0}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(134)) }` @ {0}
+     # refs: []
+     #
+  1: return ()
+}
+
+
+[variant baseline]
+fun resources::invoke_passed_closure_mut_ref($t0: address, $t1: |&mut 0x42::resources::Counter|) {
+     var $t2: &mut 0x42::resources::Counter
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t1, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `resources::Counter`] at line 153
+     #
+  1: invoke($t2, $t1)
+     # live vars:
+     # reaching instruction #2: `t2` @ {0}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(134)) }` @ {1}
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun resources::loop_mut_call($t0: address, $t1: u64) {
+     var $t2: u64
+     var $t3: bool
+     var $t4: u64
+     var $t5: &mut 0x42::resources::Counter
+     var $t6: &mut 0x42::resources::Counter
+     var $t7: u64
+     var $t8: u64
+     var $t9: u64
+     var $t10: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := 0
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #1: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+  1: label L0
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #2: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+  2: $t4 := infer($t2)
+     # live vars: $t0, $t1, $t2, $t4
+     # reaching instruction #3: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+  3: $t3 := <($t4, $t1)
+     # live vars: $t0, $t1, $t2, $t3
+     # reaching instruction #4: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 15
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #5: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+  5: label L2
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #6: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+  6: $t5 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t0, $t1, $t2, $t5
+     # reaching instruction #7: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t5` @ {6}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> (mut) #5 via [struct `resources::Counter`] at line 103
+     #
+  7: $t6 := infer($t5)
+     # live vars: $t0, $t1, $t2, $t6
+     # reaching instruction #8: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> (mut) #6 via [struct `resources::Counter`] at line 103
+     #
+  8: $t7 := 1
+     # live vars: $t0, $t1, $t2, $t6, $t7
+     # reaching instruction #9: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> (mut) #6 via [struct `resources::Counter`] at line 103
+     #
+  9: resources::add_to_counter($t6, $t7)
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #10: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 10: $t9 := infer($t2)
+     # live vars: $t0, $t1, $t9
+     # reaching instruction #11: `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 11: $t10 := 1
+     # live vars: $t0, $t1, $t9, $t10
+     # reaching instruction #12: `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 12: $t8 := +($t9, $t10)
+     # live vars: $t0, $t1, $t8
+     # reaching instruction #13: `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t8` @ {12}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 13: $t2 := infer($t8)
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #14: `t2` @ {13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 14: goto 17
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #15: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 15: label L3
+     # live vars:
+     # reaching instruction #16: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 16: goto 19
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #17: `t2` @ {13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 17: label L4
+     # live vars: $t0, $t1, $t2
+     # reaching instruction #18: `t2` @ {13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 18: goto 1
+     # live vars:
+     # reaching instruction #19: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 19: label L1
+     # live vars:
+     # reaching instruction #20: `t2` @ {0, 13}, `t3` @ {3}, `t4` @ {2}, `t6` @ {7}, `t7` @ {8}, `t9` @ {10}, `t10` @ {11}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {9}
+     # refs: []
+     #
+ 20: return ()
+}
+
+
+[variant baseline]
+fun resources::modifier_func($t0: address) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: u64
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &mut u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 123
+     #
+  1: $t4 := borrow_field<0x42::resources::Counter>.value($t1)
+     # live vars: $t1, $t4
+     # reaching instruction #2: `t1` @ {0}, `t4` @ {1}
+     # refs: [$t1 => #1, $t4 => #4]
+     # #1
+     #   => #4 via [field `value`] at line 124
+     # #4
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 123
+     #
+  2: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+     # reaching instruction #3: `t1` @ {0}, `t3` @ {2}, `t4` @ {1}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 123
+     #
+  3: $t5 := 1
+     # live vars: $t1, $t3, $t5
+     # reaching instruction #4: `t1` @ {0}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 123
+     #
+  4: $t2 := +($t3, $t5)
+     # live vars: $t1, $t2
+     # reaching instruction #5: `t1` @ {0}, `t2` @ {4}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   -> (mut) #1 via [struct `resources::Counter`] at line 123
+     #
+  5: $t6 := borrow_field<0x42::resources::Counter>.value($t1)
+     # live vars: $t2, $t6
+     # reaching instruction #6: `t1` @ {0}, `t2` @ {4}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}, `t6` @ {5}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> (mut) #6 via [struct `resources::Counter`] at line 124
+     #
+  6: write_ref($t6, $t2)
+     # live vars:
+     # reaching instruction #7: `t1` @ {0}, `t2` @ {4}, `t3` @ {2}, `t4` @ {1}, `t5` @ {3}, `t6` @ {5}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {6}
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun resources::nested_helper($t0: &mut 0x42::resources::Counter) {
+     var $t1: &mut 0x42::resources::Counter
+     var $t2: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := 10
+     # live vars: $t1, $t2
+     # reaching instruction #2: `t1` @ {0}, `t2` @ {1}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: resources::add_to_counter($t1, $t2)
+     # live vars:
+     # reaching instruction #3: `t1` @ {0}, `t2` @ {1}
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun resources::publish_counter($t0: &signer, $t1: u64) {
+     var $t2: 0x42::resources::Counter
+     var $t3: &signer
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := pack 0x42::resources::Counter($t1)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := infer($t0)
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: move_to<0x42::resources::Counter>($t3, $t2)
+     # live vars:
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun resources::read_counter($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+     var $t3: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `resources::Counter`] at line 26
+     #
+  1: $t3 := borrow_field<0x42::resources::Counter>.value($t2)
+     # live vars: $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `resources::Counter`] at line 27
+     #
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun resources::read_multiple($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+     var $t3: &0x42::resources::Wallet
+     var $t4: u64
+     var $t5: &u64
+     var $t6: u64
+     var $t7: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `resources::Counter`] at line 62
+     #
+  1: $t3 := borrow_global<0x42::resources::Wallet>($t0)
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t2 => #2, $t3 => #3]
+     # #2
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `resources::Counter`] at line 62
+     #   -> #3 via [struct `resources::Wallet`] at line 63
+     #
+  2: $t5 := borrow_field<0x42::resources::Counter>.value($t2)
+     # live vars: $t3, $t5
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}, `t5` @ {2}
+     # refs: [$t3 => #3, $t5 => #5]
+     # #3
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `resources::Wallet`] at line 63
+     #   -> #5 via [struct `resources::Counter`] at line 64
+     #
+  3: $t4 := read_ref($t5)
+     # live vars: $t3, $t4
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {2}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `resources::Wallet`] at line 63
+     #
+  4: $t7 := borrow_field<0x42::resources::Wallet>.balance($t3)
+     # live vars: $t4, $t7
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {2}, `t7` @ {4}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #7 via [struct `resources::Wallet`] at line 64
+     #
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+     # reaching instruction #6: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+  6: $t1 := +($t4, $t6)
+     # live vars: $t1
+     # reaching instruction #7: `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+  7: return $t1
+}
+
+
+[variant baseline]
+fun resources::read_value($t0: &0x42::resources::Counter): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x42::resources::Counter>.value($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun resources::reader_func($t0: address): u64 {
+     var $t1: u64
+     var $t2: &0x42::resources::Counter
+     var $t3: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::resources::Counter>($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `resources::Counter`] at line 129
+     #
+  1: $t3 := borrow_field<0x42::resources::Counter>.value($t2)
+     # live vars: $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `resources::Counter`] at line 130
+     #
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun resources::test_pass_modifier_closure($t0: address) {
+     var $t1: address
+     var $t2: |address|
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: $t2 := closure#0 resources::modifier_func()
+     # live vars: $t1, $t2
+     # reaching instruction #2: `t1` @ {0}, `t2` @ {1}
+     # refs: []
+     #
+  2: resources::invoke_passed_closure($t1, $t2)
+     # live vars:
+     # reaching instruction #3: `t1` @ {0}, `t2` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(134)) }` @ {2}
+     # refs: []
+     #
+  3: return ()
+}

--- a/third_party/move/move-compiler-v2/tests/reaching-def/resources.move
+++ b/third_party/move/move-compiler-v2/tests/reaching-def/resources.move
@@ -1,0 +1,162 @@
+module 0x42::resources {
+
+    struct Counter has key, drop {
+        value: u64,
+    }
+
+    struct Wallet has key, drop {
+        balance: u64,
+        frozen: bool,
+    }
+
+    // Test move_to - publishing a resource
+    fun publish_counter(account: &signer, initial: u64) {
+        let c = Counter { value: initial };
+        move_to(account, c);
+    }
+
+    // Test move_from - acquiring a resource
+    fun acquire_counter(addr: address): u64 acquires Counter {
+        let c = move_from<Counter>(addr);
+        c.value
+    }
+
+    // Test borrow_global (immutable)
+    fun read_counter(addr: address): u64 acquires Counter {
+        let c = borrow_global<Counter>(addr);
+        c.value
+    }
+
+    // Test borrow_global_mut - modifying resource
+    fun increment_counter(addr: address) acquires Counter {
+        let c = borrow_global_mut<Counter>(addr);
+        c.value = c.value + 1;
+    }
+
+    // Test exists check with conditional borrow
+    fun check_and_read(addr: address): u64 acquires Counter {
+        let result;
+        if (exists<Counter>(addr)) {
+            let c = borrow_global<Counter>(addr);
+            result = c.value;
+        } else {
+            result = 0;
+        };
+        result
+    }
+
+    // Test conditional move_from
+    fun conditional_acquire(addr: address, cond: bool): u64 acquires Counter {
+        let result;
+        if (cond) {
+            let c = move_from<Counter>(addr);
+            result = c.value;
+        } else {
+            result = 0;
+        };
+        result
+    }
+
+    // Test with multiple resource types
+    fun read_multiple(addr: address): u64 acquires Counter, Wallet {
+        let c = borrow_global<Counter>(addr);
+        let w = borrow_global<Wallet>(addr);
+        c.value + w.balance
+    }
+
+    // ========== Function call tests with global resources ==========
+
+    // Helper: reads counter value (immutable ref)
+    fun read_value(c: &Counter): u64 {
+        c.value
+    }
+
+    // Helper: modifies counter (mutable ref)
+    fun add_to_counter(c: &mut Counter, amount: u64) {
+        c.value = c.value + amount;
+    }
+
+    // Test: call with mutable ref should mark global as modified
+    fun call_with_mut_ref(addr: address) acquires Counter {
+        let c = borrow_global_mut<Counter>(addr);
+        add_to_counter(c, 1);
+    }
+
+    // Test: call with immutable ref should NOT mark global as modified
+    fun call_with_immut_ref(addr: address): u64 acquires Counter {
+        let c = borrow_global<Counter>(addr);
+        read_value(c)
+    }
+
+    // Test: conditional call with mutable ref
+    fun conditional_mut_call(addr: address, cond: bool) acquires Counter {
+        let c = borrow_global_mut<Counter>(addr);
+        if (cond) {
+            add_to_counter(c, 1);
+        };
+    }
+
+    // Test: call in loop with mutable ref
+    fun loop_mut_call(addr: address, n: u64) acquires Counter {
+        let i = 0;
+        while (i < n) {
+            let c = borrow_global_mut<Counter>(addr);
+            add_to_counter(c, 1);
+            i = i + 1;
+        };
+    }
+
+    // Test: nested function calls
+    fun nested_helper(c: &mut Counter) {
+        add_to_counter(c, 10);
+    }
+
+    fun call_nested(addr: address) acquires Counter {
+        let c = borrow_global_mut<Counter>(addr);
+        nested_helper(c);
+    }
+
+    // ========== Closure/function value tests ==========
+
+    // Helper that modifies Counter via borrow_global_mut
+    fun modifier_func(addr: address) acquires Counter {
+        let c = borrow_global_mut<Counter>(addr);
+        c.value = c.value + 1;
+    }
+
+    // Helper that only reads Counter
+    fun reader_func(addr: address): u64 acquires Counter {
+        let c = borrow_global<Counter>(addr);
+        c.value
+    }
+
+    // Test: invoke a locally created closure that modifies global
+    // Note: Move's type system doesn't track acquires through function values
+    fun invoke_local_modifier(addr: address) {
+        let f = modifier_func;
+        f(addr);
+    }
+
+    // Test: invoke a locally created closure that only reads global
+    fun invoke_local_reader(addr: address): u64 {
+        let f = reader_func;
+        f(addr)
+    }
+
+    // Test: closure passed as argument - analysis cannot track what it accesses
+    fun invoke_passed_closure(addr: address, f: |address|) {
+        f(addr);
+    }
+
+    // Test: passed closure with mutable ref - should mark global as modified
+    fun invoke_passed_closure_mut_ref(addr: address, f: |&mut Counter|) acquires Counter {
+        let c = borrow_global_mut<Counter>(addr);
+        f(c);
+    }
+
+    // Test: caller passes modifier_func to invoke_passed_closure
+    // This demonstrates the soundness issue: Counter is modified but analysis misses it
+    fun test_pass_modifier_closure(addr: address) {
+        invoke_passed_closure(addr, modifier_func);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -332,6 +332,16 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
             ]),
             ..config()
         },
+        // Reaching definition tests
+        TestConfig {
+            name: "reaching-def",
+            runner: |p| run_test(p, get_config_by_name("reaching-def")),
+            include: vec!["/reaching-def/"],
+            stop_after: StopAfter::FirstBytecodePipeline(Some("ReachingDefProcessor")),
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec![INITIAL_BYTECODE_STAGE, "ReachingDefProcessor"]),
+            ..config().exp(Experiment::REACHING_DEF_ANALYSIS)
+        },
         // Reference safety tests (with optimizations on)
         TestConfig {
             name: "reference-safety",


### PR DESCRIPTION
## Description

This PR adds reaching definition analysis for temporaries and global resources used in a function. It is the first PR on the stack to introduce Common Subexpression Elimination (CSE) for Move.

For each bytecode at `code_offset`, the analysis provides a mapping from each local temporary or global resource to the set of code offsets where they may be defined that can reach `code_offset`:
- `ReachingDefState(code_offset) := Map<Object, Set<CodeOffset>>`
- `Object := Local(temp_index) | Global(struct_id)`

The analysis is over-approximation, producing may-definitions and may-reaches. A result `ReachingDefState(offset_1) := Map<obj1, Set<offset_2, offset_3>>` means that `obj1` is possibly defined at `offset_2` and `offset_3` and the definitions may reach `offset_1`.

================= for temporaries =================
- Definitions of temporaries are created at `Assign`, `Load` instructions, and `Call` instructions with destinations.
- Definitions are killed when the temporary is re-defined, or when it is moved.
- Definitions via dereferences are handled conservatively
    - `WriteRef`: all temporaries potentially pointed to by the reference are killed and re-defined
    - `mut_ref` passed to callees: all temporaries potentially pointed to by the reference are killed and re-defined
    - `mut_ref` passed to invoked closures: all temporaries potentially pointed to by the reference are killed and re-defined

================ for global resources =================
- Definitions of global resources are killed and re-defined at the following instructions:
    - `MoveFrom`
    - `MoveTo`
    - Mutation via dereferencing `mut_ref`, conservatively handled like temporaries

- Callees and invoked closures are handled conservatively:
    - On `Call` to a child function, the child function and its transitively used functions are analyzed to collect the accessed resource structs
    - On `Invoke` of a closure, the functions used transitively by the current function are analyzed to collect the accessed resource structs

Important Note: The analysis only considers global resources that are declared in the same module of the target function

## How Has This Been Tested?
  Test cases were generated by Claude and reviewed by me, covering:                                                                                                                        
                                                                                                                                                                                              
  | Test File | Coverage |                                                                                                                                                                    
  |-----------|----------|                                                                                                                                                                    
  | `basic.move` | Simple assignments, reassignments, moves |                                                                                                                                 
  | `loops.move` | While loops, break, continue, nested loops |                                                                                                                               
  | `control_flow.move` | Nested if-else, if-else chains, partial assignments |                                                                                                               
  | `references.move` | Borrows, field borrows, reference reassignment, function calls with refs |                                                                                            
  | `resources.move` | Global storage operations, function calls with global resource refs |                                                                                                  
  | `abort_assert.move` | Abort paths, assertions, unreachable code |                   

## Type of Change
- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a reaching-definition analysis for Move stackless bytecode and integrates it behind an experiment flag.
> 
> - New `ReachingDefProcessor` (`pipeline/reaching_def_analysis_processor.rs`) producing `ReachingDefAnnotation` (may-analysis over locals and same-module global resources); depends on `LiveVarAnnotation` and `LifetimeAnnotation`
> - Adds experiment `reaching-def-analysis` and optional pipeline stage + formatter registration
> - Extends reference safety with `Object` type and `referenced_objects` helpers to support alias-aware kills/defs
> - Minor pipeline wiring/exports in `lib.rs` and `pipeline/mod.rs`
> - Adds comprehensive tests under `tests/reaching-def` (basic, control_flow, loops, references, abort_assert)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7d641641bec1b2cd716206b74fde786c1e5871eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->