### PR TITLE
[move compiler] [CSE Step 3] add test cases

### DIFF
--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/field_access.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/field_access.move
@@ -1,0 +1,47 @@
+module 0x99::FiledAccess {
+    struct Inner has copy, drop {
+        value: u64,
+    }
+
+    struct Outer has copy, drop {
+        inner: Inner,
+    }
+
+    fun get_value(outer: &Outer): u64 {
+        outer.inner.value
+    }
+
+    fun set_value(outer: &mut Outer, new_value: u64) {
+        outer.inner.value = new_value;
+    }
+
+    fun get_inner_value1(inner: &Inner): u64 {
+        inner.value
+    }
+
+    fun get_inner_value2(inner: &Inner): u64 {
+        inner.value
+    }
+
+    // `arg1.inner.value` cannot be reused due to the mutation between the two accesses
+    fun test_field_access(arg1: Outer, arg2: u64): u64 {
+        let x = arg1.inner.value;
+        arg1.inner.value += 1;
+        x + arg2 + arg1.inner.value
+    }
+
+    // `arg1.inner.value` cannot be reused due to the mutation between the two accesses
+    fun test_field_access_ref(arg1: Outer, arg2: u64): u64 {
+        let x = arg1.inner.value;
+        let ref = &mut arg1.inner.value;
+        *ref += 1;
+        x + arg2 + arg1.inner.value
+    }
+
+    // `set_value(&mut arg1, arg2)` may modify `arg1.inner.value`, so the two calls cannot be reused
+    fun test_field_access_mut_ref(arg1: Outer, arg2: u64): u64 {
+        set_value(&mut arg1, arg2);
+        set_value(&mut arg1, arg2);
+        arg1.inner.value
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/field_access.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/field_access.off.exp
@@ -1,0 +1,123 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FiledAccess
+struct Inner has copy + drop
+  value: u64
+
+struct Outer has copy + drop
+  inner: Inner
+
+// Function definition at index 0
+fun get_inner_value1(l0: &Inner): u64
+    move_loc l0
+    borrow_field Inner, value
+    read_ref
+    ret
+
+// Function definition at index 1
+fun get_inner_value2(l0: &Inner): u64
+    move_loc l0
+    borrow_field Inner, value
+    read_ref
+    ret
+
+// Function definition at index 2
+fun get_value(l0: &Outer): u64
+    move_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    ret
+
+// Function definition at index 3
+fun set_value(l0: &mut Outer, l1: u64)
+    local l2: &mut u64
+    move_loc l0
+    mut_borrow_field Outer, inner
+    mut_borrow_field Inner, value
+    st_loc l2
+    move_loc l1
+    // @5
+    move_loc l2
+    write_ref
+    ret
+
+// Function definition at index 4
+fun test_field_access(l0: Outer, l1: u64): u64
+    local l2: &mut u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    mut_borrow_loc l0
+    // @5
+    mut_borrow_field Outer, inner
+    mut_borrow_field Inner, value
+    st_loc l2
+    copy_loc l2
+    read_ref
+    // @10
+    ld_u64 1
+    add
+    move_loc l2
+    write_ref
+    move_loc l1
+    // @15
+    add
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    // @20
+    add
+    ret
+
+// Function definition at index 5
+fun test_field_access_mut_ref(l0: Outer, l1: u64): u64
+    mut_borrow_loc l0
+    copy_loc l1
+    call set_value
+    mut_borrow_loc l0
+    move_loc l1
+    // @5
+    call set_value
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    // @10
+    ret
+
+// Function definition at index 6
+fun test_field_access_ref(l0: Outer, l1: u64): u64
+    local l2: &mut u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    mut_borrow_loc l0
+    // @5
+    mut_borrow_field Outer, inner
+    mut_borrow_field Inner, value
+    st_loc l2
+    copy_loc l2
+    read_ref
+    // @10
+    ld_u64 1
+    add
+    move_loc l2
+    write_ref
+    move_loc l1
+    // @15
+    add
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    // @20
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/field_access.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/field_access.on.exp
@@ -1,0 +1,7870 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t7 := 1
+  5: $t10 := borrow_local($t0)
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+  8: $t12 := read_ref($t8)
+  9: $t11 := +($t12, $t7)
+ 10: write_ref($t8, $t11)
+ 11: $t14 := infer($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := 1
+  8: $t11 := infer($t7)
+  9: $t13 := read_ref($t11)
+ 10: $t12 := +($t13, $t10)
+ 11: write_ref($t11, $t12)
+ 12: $t15 := infer($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t7 := 1
+  5: $t10 := borrow_local($t0)
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+  8: $t12 := read_ref($t8)
+  9: $t11 := +($t12, $t7)
+ 10: write_ref($t8, $t11)
+ 11: $t14 := infer($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := 1
+  8: $t11 := infer($t7)
+  9: $t13 := read_ref($t11)
+ 10: $t12 := +($t13, $t10)
+ 11: write_ref($t11, $t12)
+ 12: $t15 := infer($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t7 := 1
+  5: $t10 := borrow_local($t0)
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+  8: $t12 := read_ref($t8)
+  9: $t11 := +($t12, $t7)
+ 10: write_ref($t8, $t11)
+ 11: $t14 := infer($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := 1
+  8: $t11 := infer($t7)
+  9: $t13 := read_ref($t11)
+ 10: $t12 := +($t13, $t10)
+ 11: write_ref($t11, $t12)
+ 12: $t15 := infer($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t7 := 1
+     # live vars: $t0, $t1, $t3, $t7
+  5: $t10 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+     # live vars: $t0, $t1, $t3, $t7, $t9
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+     # live vars: $t0, $t1, $t3, $t7, $t8
+  8: $t12 := read_ref($t8)
+     # live vars: $t0, $t1, $t3, $t7, $t8, $t12
+  9: $t11 := +($t12, $t7)
+     # live vars: $t0, $t1, $t3, $t8, $t11
+ 10: write_ref($t8, $t11)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t10
+  8: $t11 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+  9: $t13 := read_ref($t11)
+     # live vars: $t0, $t1, $t3, $t10, $t11, $t13
+ 10: $t12 := +($t13, $t10)
+     # live vars: $t0, $t1, $t3, $t11, $t12
+ 11: write_ref($t11, $t12)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t7 := 1
+     # live vars: $t0, $t1, $t3, $t7
+  5: $t10 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+     # live vars: $t0, $t1, $t3, $t7, $t9
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+     # live vars: $t0, $t1, $t3, $t7, $t8
+  8: $t12 := read_ref($t8)
+     # live vars: $t0, $t1, $t3, $t7, $t8, $t12
+  9: $t11 := +($t12, $t7)
+     # live vars: $t0, $t1, $t3, $t8, $t11
+ 10: write_ref($t8, $t11)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t10
+  8: $t11 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+  9: $t13 := read_ref($t11)
+     # live vars: $t0, $t1, $t3, $t10, $t11, $t13
+ 10: $t12 := +($t13, $t10)
+     # live vars: $t0, $t1, $t3, $t11, $t12
+ 11: write_ref($t11, $t12)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t7 := 1
+     # live vars: $t0, $t1, $t3, $t7
+  5: $t10 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+     # live vars: $t0, $t1, $t3, $t7, $t9
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+     # live vars: $t0, $t1, $t3, $t7, $t8
+  8: $t12 := read_ref($t8)
+     # live vars: $t0, $t1, $t3, $t7, $t8, $t12
+  9: $t11 := +($t12, $t7)
+     # live vars: $t0, $t1, $t3, $t8, $t11
+ 10: write_ref($t8, $t11)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t10
+  8: $t11 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+  9: $t13 := read_ref($t11)
+     # live vars: $t0, $t1, $t3, $t10, $t11, $t13
+ 10: $t12 := +($t13, $t10)
+     # live vars: $t0, $t1, $t3, $t11, $t12
+ 11: write_ref($t11, $t12)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: write_ref($t2, $t1)
+     # live vars:
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 28
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 28
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 28
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t7 := 1
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: []
+     #
+  5: $t10 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`] at line 29
+     #
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+     # live vars: $t0, $t1, $t3, $t7, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`, field `inner`] at line 29
+     #
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+     # live vars: $t0, $t1, $t3, $t7, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  8: $t12 := read_ref($t8)
+     # live vars: $t0, $t1, $t3, $t7, $t8, $t12
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  9: $t11 := +($t12, $t7)
+     # live vars: $t0, $t1, $t3, $t8, $t11
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+ 10: write_ref($t8, $t11)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+     # refs: []
+     #
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+     # refs: []
+     #
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`] at line 30
+     #
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `arg1`, field `inner`] at line 30
+     #
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`, field `inner`, field `value`] at line 30
+     #
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+     # refs: []
+     #
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+     # refs: []
+     #
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => (mut) #3 via [local `arg1`] at line 43
+     #
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `arg1`] at line 44
+     #
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`] at line 45
+     #
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`, field `inner`] at line 45
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`, field `inner`, field `value`] at line 45
+     #
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+     # refs: []
+     #
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 35
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 35
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 35
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 36
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 36
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  7: $t10 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  8: $t11 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => (mut) #11 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  9: $t13 := read_ref($t11)
+     # live vars: $t0, $t1, $t3, $t10, $t11, $t13
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => (mut) #11 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 10: $t12 := +($t13, $t10)
+     # live vars: $t0, $t1, $t3, $t11, $t12
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => (mut) #11 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 11: write_ref($t11, $t12)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+     # refs: []
+     #
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+     # refs: []
+     #
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`] at line 38
+     #
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`, field `inner`] at line 38
+     #
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `arg1`, field `inner`, field `value`] at line 38
+     #
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+     # refs: []
+     #
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+     # refs: []
+     #
+ 19: return $t2
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t1 := read_ref($t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # abort state: {returns}
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # abort state: {returns}
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: write_ref($t2, $t1)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 28
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 28
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 28
+     #
+  3: $t3 := read_ref($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t7 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: []
+     #
+  5: $t10 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`] at line 29
+     #
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`, field `inner`] at line 29
+     #
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  8: $t12 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t8, $t12
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  9: $t11 := +($t12, $t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8, $t11
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+ 10: write_ref($t8, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 11: $t14 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t14
+     # refs: []
+     #
+ 12: $t13 := +($t14, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t13
+     # refs: []
+     #
+ 13: $t17 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`] at line 30
+     #
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `arg1`, field `inner`] at line 30
+     #
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`, field `inner`, field `value`] at line 30
+     #
+ 16: $t15 := read_ref($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t15
+     # refs: []
+     #
+ 17: $t2 := +($t13, $t15)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => (mut) #3 via [local `arg1`] at line 43
+     #
+  1: FiledAccess::set_value($t3, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  2: $t4 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `arg1`] at line 44
+     #
+  3: FiledAccess::set_value($t4, $t1)
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t6 := borrow_local($t0)
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`] at line 45
+     #
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # abort state: {returns}
+     # live vars: $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`, field `inner`] at line 45
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # abort state: {returns}
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`, field `inner`, field `value`] at line 45
+     #
+  7: $t2 := read_ref($t7)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 35
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 35
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 35
+     #
+  3: $t3 := read_ref($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 36
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 36
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  7: $t10 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  8: $t11 := infer($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t10, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => (mut) #11 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  9: $t13 := read_ref($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t10, $t11, $t13
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => (mut) #11 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 10: $t12 := +($t13, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t11, $t12
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => (mut) #11 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 11: write_ref($t11, $t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 12: $t15 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t15
+     # refs: []
+     #
+ 13: $t14 := +($t15, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t14
+     # refs: []
+     #
+ 14: $t18 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`] at line 38
+     #
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`, field `inner`] at line 38
+     #
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `arg1`, field `inner`, field `value`] at line 38
+     #
+ 17: $t16 := read_ref($t19)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t16
+     # refs: []
+     #
+ 18: $t2 := +($t14, $t16)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 19: return $t2
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &mut u64
+     var $t9: &mut 0x99::FiledAccess::Inner
+     var $t10: &mut 0x99::FiledAccess::Outer
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t7 := 1
+  5: $t10 := borrow_local($t0)
+  6: $t9 := borrow_field<0x99::FiledAccess::Outer>.inner($t10)
+  7: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t9)
+  8: $t12 := read_ref($t8)
+  9: $t11 := +($t12, $t7)
+ 10: write_ref($t8, $t11)
+ 11: $t14 := move($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: &mut u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := 1
+  8: $t11 := move($t7)
+  9: $t13 := read_ref($t11)
+ 10: $t12 := +($t13, $t10)
+ 11: write_ref($t11, $t12)
+ 12: $t15 := move($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := infer($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := infer($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := infer($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := infer($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := infer($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := infer($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # flush: $t1
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # flush: $t7, $t10
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # flush: $t10, $t11
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # flush: $t1
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: write_ref($t2, $t1)
+     # live vars:
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 28
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 28
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 28
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 29
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # flush: $t7, $t10
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 29
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+     # refs: []
+     #
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+     # refs: []
+     #
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`] at line 30
+     #
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `arg1`, field `inner`] at line 30
+     #
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`, field `inner`, field `value`] at line 30
+     #
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+     # refs: []
+     #
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+     # refs: []
+     #
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => (mut) #3 via [local `arg1`] at line 43
+     #
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `arg1`] at line 44
+     #
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`] at line 45
+     #
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`, field `inner`] at line 45
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`, field `inner`, field `value`] at line 45
+     #
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+     # refs: []
+     #
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 35
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 35
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 35
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 36
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 36
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # flush: $t10, $t11
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  7: $t10 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+     # refs: []
+     #
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+     # refs: []
+     #
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`] at line 38
+     #
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`, field `inner`] at line 38
+     #
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `arg1`, field `inner`, field `value`] at line 38
+     #
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+     # refs: []
+     #
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+     # refs: []
+     #
+ 19: return $t2
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # flush: $t1
+     # live vars: $t1, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+     # reaching instruction #2: `t2` @ {1}, `t3` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: write_ref($t2, $t1)
+     # live vars:
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {0}
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # reaching instruction #1: `t5` @ {0}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 28
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # reaching instruction #2: `t4` @ {1}, `t5` @ {0}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 28
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # reaching instruction #3: `t4` @ {1}, `t5` @ {0}, `t6` @ {2}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 28
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #4: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+     # reaching instruction #5: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t9` @ {4}
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 29
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # flush: $t7, $t10
+     # live vars: $t0, $t1, $t3, $t8
+     # reaching instruction #6: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 29
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+     # reaching instruction #7: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+     # reaching instruction #8: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t11` @ {7}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+     # reaching instruction #9: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t11` @ {7}, `t12` @ {8}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # reaching instruction #10: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #11: `t0` @ {10}, `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}
+     # refs: []
+     #
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+     # reaching instruction #12: `t0` @ {10}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}, `t14` @ {11}
+     # refs: []
+     #
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+     # reaching instruction #13: `t0` @ {10}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}, `t13` @ {12}, `t14` @ {11}
+     # refs: []
+     #
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+     # reaching instruction #14: `t0` @ {10}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}, `t13` @ {12}, `t14` @ {11}, `t17` @ {13}
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`] at line 30
+     #
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+     # reaching instruction #15: `t0` @ {10}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}, `t13` @ {12}, `t14` @ {11}, `t16` @ {14}, `t17` @ {13}
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `arg1`, field `inner`] at line 30
+     #
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+     # reaching instruction #16: `t0` @ {10}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}, `t13` @ {12}, `t14` @ {11}, `t16` @ {14}, `t17` @ {13}, `t18` @ {15}
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`, field `inner`, field `value`] at line 30
+     #
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+     # reaching instruction #17: `t0` @ {10}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}, `t13` @ {12}, `t14` @ {11}, `t15` @ {16}, `t16` @ {14}, `t17` @ {13}, `t18` @ {15}
+     # refs: []
+     #
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+     # reaching instruction #18: `t0` @ {10}, `t2` @ {17}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}, `t10` @ {9}, `t11` @ {7}, `t12` @ {8}, `t13` @ {12}, `t14` @ {11}, `t15` @ {16}, `t16` @ {14}, `t17` @ {13}, `t18` @ {15}
+     # refs: []
+     #
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => (mut) #3 via [local `arg1`] at line 43
+     #
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+     # reaching instruction #2: `t0` @ {1}, `t3` @ {0}
+     # refs: []
+     #
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+     # reaching instruction #3: `t0` @ {1}, `t3` @ {0}, `t4` @ {2}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `arg1`] at line 44
+     #
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+     # reaching instruction #4: `t0` @ {3}, `t3` @ {0}, `t4` @ {2}
+     # refs: []
+     #
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+     # reaching instruction #5: `t0` @ {3}, `t3` @ {0}, `t4` @ {2}, `t6` @ {4}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`] at line 45
+     #
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+     # reaching instruction #6: `t0` @ {3}, `t3` @ {0}, `t4` @ {2}, `t5` @ {5}, `t6` @ {4}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`, field `inner`] at line 45
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+     # reaching instruction #7: `t0` @ {3}, `t3` @ {0}, `t4` @ {2}, `t5` @ {5}, `t6` @ {4}, `t7` @ {6}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`, field `inner`, field `value`] at line 45
+     #
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+     # reaching instruction #8: `t0` @ {3}, `t2` @ {7}, `t3` @ {0}, `t4` @ {2}, `t5` @ {5}, `t6` @ {4}, `t7` @ {6}
+     # refs: []
+     #
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # reaching instruction #1: `t5` @ {0}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 35
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # reaching instruction #2: `t4` @ {1}, `t5` @ {0}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 35
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # reaching instruction #3: `t4` @ {1}, `t5` @ {0}, `t6` @ {2}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 35
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #4: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+     # reaching instruction #5: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t9` @ {4}
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 36
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+     # reaching instruction #6: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 36
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # flush: $t10, $t11
+     # live vars: $t0, $t1, $t3, $t7
+     # reaching instruction #7: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t7` @ {6}, `t8` @ {5}, `t9` @ {4}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  7: $t10 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10
+     # reaching instruction #8: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+     # reaching instruction #9: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t12` @ {8}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+     # reaching instruction #10: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t12` @ {8}, `t13` @ {9}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+     # reaching instruction #11: `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+     # reaching instruction #12: `t0` @ {11}, `t3` @ {3}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}
+     # refs: []
+     #
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+     # reaching instruction #13: `t0` @ {11}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}, `t15` @ {12}
+     # refs: []
+     #
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+     # reaching instruction #14: `t0` @ {11}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}, `t14` @ {13}, `t15` @ {12}
+     # refs: []
+     #
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+     # reaching instruction #15: `t0` @ {11}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}, `t14` @ {13}, `t15` @ {12}, `t18` @ {14}
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`] at line 38
+     #
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+     # reaching instruction #16: `t0` @ {11}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}, `t14` @ {13}, `t15` @ {12}, `t17` @ {15}, `t18` @ {14}
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`, field `inner`] at line 38
+     #
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+     # reaching instruction #17: `t0` @ {11}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}, `t14` @ {13}, `t15` @ {12}, `t17` @ {15}, `t18` @ {14}, `t19` @ {16}
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `arg1`, field `inner`, field `value`] at line 38
+     #
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+     # reaching instruction #18: `t0` @ {11}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}, `t14` @ {13}, `t15` @ {12}, `t16` @ {17}, `t17` @ {15}, `t18` @ {14}, `t19` @ {16}
+     # refs: []
+     #
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+     # reaching instruction #19: `t0` @ {11}, `t2` @ {18}, `t4` @ {1}, `t5` @ {0}, `t6` @ {2}, `t8` @ {5}, `t9` @ {4}, `t10` @ {7}, `t11` @ {10}, `t12` @ {8}, `t13` @ {9}, `t14` @ {13}, `t15` @ {12}, `t16` @ {17}, `t17` @ {15}, `t18` @ {14}, `t19` @ {16}
+     # refs: []
+     #
+ 19: return $t2
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := infer($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := infer($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := infer($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: write_ref($t2, $t1)
+     # live vars:
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 28
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 28
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 28
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 29
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 29
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 11: $t14 := infer($t3)
+     # live vars: $t0, $t1, $t14
+     # refs: []
+     #
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+     # refs: []
+     #
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`] at line 30
+     #
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `arg1`, field `inner`] at line 30
+     #
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`, field `inner`, field `value`] at line 30
+     #
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+     # refs: []
+     #
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+     # refs: []
+     #
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => (mut) #3 via [local `arg1`] at line 43
+     #
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `arg1`] at line 44
+     #
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`] at line 45
+     #
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`, field `inner`] at line 45
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`, field `inner`, field `value`] at line 45
+     #
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+     # refs: []
+     #
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 35
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 35
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 35
+     #
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 36
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 36
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  7: $t10 := infer($t7)
+     # live vars: $t0, $t1, $t3, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 12: $t15 := infer($t3)
+     # live vars: $t0, $t1, $t15
+     # refs: []
+     #
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+     # refs: []
+     #
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`] at line 38
+     #
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`, field `inner`] at line 38
+     #
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `arg1`, field `inner`, field `value`] at line 38
+     #
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+     # refs: []
+     #
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+     # refs: []
+     #
+ 19: return $t2
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := read_ref($t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # abort state: {returns}
+     # live vars: $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t1 := read_ref($t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # abort state: {returns}
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # abort state: {returns}
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: write_ref($t2, $t1)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 28
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 28
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 28
+     #
+  3: $t3 := read_ref($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 29
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 29
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  7: $t11 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t11
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  8: $t12 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+  9: $t10 := +($t11, $t12)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7, $t10
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 29
+     #
+ 10: write_ref($t7, $t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 11: $t14 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t14
+     # refs: []
+     #
+ 12: $t13 := +($t14, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t13
+     # refs: []
+     #
+ 13: $t17 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`] at line 30
+     #
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t16
+     # refs: [$t16 => #16]
+     # #16
+     #   <no edges>
+     # #root
+     #   => #16 via [local `arg1`, field `inner`] at line 30
+     #
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`, field `inner`, field `value`] at line 30
+     #
+ 16: $t15 := read_ref($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t13, $t15
+     # refs: []
+     #
+ 17: $t2 := +($t13, $t15)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t3 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   => (mut) #3 via [local `arg1`] at line 43
+     #
+  1: FiledAccess::set_value($t3, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  2: $t4 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => (mut) #4 via [local `arg1`] at line 44
+     #
+  3: FiledAccess::set_value($t4, $t1)
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  4: $t6 := borrow_local($t0)
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`] at line 45
+     #
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # abort state: {returns}
+     # live vars: $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`, field `inner`] at line 45
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # abort state: {returns}
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`, field `inner`, field `value`] at line 45
+     #
+  7: $t2 := read_ref($t7)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t5 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   => #5 via [local `arg1`] at line 35
+     #
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `arg1`, field `inner`] at line 35
+     #
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`, field `value`] at line 35
+     #
+  3: $t3 := read_ref($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+  4: $t9 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => (mut) #9 via [local `arg1`] at line 36
+     #
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => (mut) #8 via [local `arg1`, field `inner`] at line 36
+     #
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => (mut) #7 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  7: $t10 := infer($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  8: $t12 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t10, $t12
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+  9: $t13 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 10: $t11 := +($t12, $t13)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3, $t10, $t11
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => (mut) #10 via [local `arg1`, field `inner`, field `value`] at line 36
+     #
+ 11: write_ref($t10, $t11)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t3
+     # refs: []
+     #
+ 12: $t15 := infer($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t15
+     # refs: []
+     #
+ 13: $t14 := +($t15, $t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t14
+     # refs: []
+     #
+ 14: $t18 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t18
+     # refs: [$t18 => #18]
+     # #18
+     #   <no edges>
+     # #root
+     #   => #18 via [local `arg1`] at line 38
+     #
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t17
+     # refs: [$t17 => #17]
+     # #17
+     #   <no edges>
+     # #root
+     #   => #17 via [local `arg1`, field `inner`] at line 38
+     #
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t19
+     # refs: [$t19 => #19]
+     # #19
+     #   <no edges>
+     # #root
+     #   => #19 via [local `arg1`, field `inner`, field `value`] at line 38
+     #
+ 17: $t16 := read_ref($t19)
+     # abort state: {returns,aborts}
+     # live vars: $t14, $t16
+     # refs: []
+     #
+ 18: $t2 := +($t14, $t16)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+ 19: return $t2
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := move($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := move($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := move($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := move($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := move($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := move($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := move($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := move($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := move($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # maybe
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # maybe
+  1: $t1 := read_ref($t2)
+     # maybe
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # maybe
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # maybe
+  1: $t1 := read_ref($t2)
+     # maybe
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # maybe
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # maybe
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # maybe
+  2: $t1 := read_ref($t3)
+     # maybe
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # maybe
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # maybe
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # maybe
+  2: write_ref($t2, $t1)
+     # maybe
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # maybe
+  0: $t5 := borrow_local($t0)
+     # maybe
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # maybe
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # maybe
+  3: $t3 := read_ref($t6)
+     # maybe
+  4: $t9 := borrow_local($t0)
+     # maybe
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # maybe
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # maybe
+  7: $t11 := read_ref($t7)
+     # maybe
+  8: $t12 := 1
+     # maybe
+  9: $t10 := +($t11, $t12)
+     # maybe
+ 10: write_ref($t7, $t10)
+     # maybe
+ 11: $t14 := move($t3)
+     # maybe
+ 12: $t13 := +($t14, $t1)
+     # maybe
+ 13: $t17 := borrow_local($t0)
+     # maybe
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # maybe
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # maybe
+ 16: $t15 := read_ref($t18)
+     # maybe
+ 17: $t2 := +($t13, $t15)
+     # maybe
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # maybe
+  0: $t3 := borrow_local($t0)
+     # maybe
+  1: FiledAccess::set_value($t3, $t1)
+     # maybe
+  2: $t4 := borrow_local($t0)
+     # maybe
+  3: FiledAccess::set_value($t4, $t1)
+     # maybe
+  4: $t6 := borrow_local($t0)
+     # maybe
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # maybe
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # maybe
+  7: $t2 := read_ref($t7)
+     # maybe
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # maybe
+  0: $t5 := borrow_local($t0)
+     # maybe
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # maybe
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # maybe
+  3: $t3 := read_ref($t6)
+     # maybe
+  4: $t9 := borrow_local($t0)
+     # maybe
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # maybe
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # maybe
+  7: $t10 := move($t7)
+     # maybe
+  8: $t12 := read_ref($t10)
+     # maybe
+  9: $t13 := 1
+     # maybe
+ 10: $t11 := +($t12, $t13)
+     # maybe
+ 11: write_ref($t10, $t11)
+     # maybe
+ 12: $t15 := move($t3)
+     # maybe
+ 13: $t14 := +($t15, $t1)
+     # maybe
+ 14: $t18 := borrow_local($t0)
+     # maybe
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # maybe
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # maybe
+ 17: $t16 := read_ref($t19)
+     # maybe
+ 18: $t2 := +($t14, $t16)
+     # maybe
+ 19: return $t2
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := move($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := move($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := move($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := move($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := move($t7)
+     # live vars: $t0, $t1, $t3, $t10
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := move($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t10 := +($t11, $t12)
+ 10: write_ref($t7, $t10)
+ 11: $t14 := move($t3)
+ 12: $t13 := +($t14, $t1)
+ 13: $t17 := borrow_local($t0)
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+ 16: $t15 := read_ref($t18)
+ 17: $t2 := +($t13, $t15)
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t4 := borrow_local($t0)
+  3: FiledAccess::set_value($t4, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t2 := read_ref($t7)
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t10 := move($t7)
+  8: $t12 := read_ref($t10)
+  9: $t13 := 1
+ 10: $t11 := +($t12, $t13)
+ 11: write_ref($t10, $t11)
+ 12: $t15 := move($t3)
+ 13: $t14 := +($t15, $t1)
+ 14: $t18 := borrow_local($t0)
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+ 17: $t16 := read_ref($t19)
+ 18: $t2 := +($t14, $t16)
+ 19: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: &0x99::FiledAccess::Inner
+     var $t17: &0x99::FiledAccess::Outer
+     var $t18: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t10 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t10
+ 10: write_ref($t7, $t10)
+     # live vars: $t0, $t1, $t3
+ 11: $t14 := move($t3)
+     # live vars: $t0, $t1, $t14
+ 12: $t13 := +($t14, $t1)
+     # live vars: $t0, $t13
+ 13: $t17 := borrow_local($t0)
+     # live vars: $t13, $t17
+ 14: $t16 := borrow_field<0x99::FiledAccess::Outer>.inner($t17)
+     # live vars: $t13, $t16
+ 15: $t18 := borrow_field<0x99::FiledAccess::Inner>.value($t16)
+     # live vars: $t13, $t18
+ 16: $t15 := read_ref($t18)
+     # live vars: $t13, $t15
+ 17: $t2 := +($t13, $t15)
+     # live vars: $t2
+ 18: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t4 := borrow_local($t0)
+     # live vars: $t0, $t1, $t4
+  3: FiledAccess::set_value($t4, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t2 := read_ref($t7)
+     # live vars: $t2
+  8: return $t2
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64
+     var $t15: u64
+     var $t16: u64
+     var $t17: &0x99::FiledAccess::Inner
+     var $t18: &0x99::FiledAccess::Outer
+     var $t19: &u64
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t10 := move($t7)
+     # live vars: $t0, $t1, $t3, $t10
+  8: $t12 := read_ref($t10)
+     # live vars: $t0, $t1, $t3, $t10, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t10, $t12, $t13
+ 10: $t11 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t10, $t11
+ 11: write_ref($t10, $t11)
+     # live vars: $t0, $t1, $t3
+ 12: $t15 := move($t3)
+     # live vars: $t0, $t1, $t15
+ 13: $t14 := +($t15, $t1)
+     # live vars: $t0, $t14
+ 14: $t18 := borrow_local($t0)
+     # live vars: $t14, $t18
+ 15: $t17 := borrow_field<0x99::FiledAccess::Outer>.inner($t18)
+     # live vars: $t14, $t17
+ 16: $t19 := borrow_field<0x99::FiledAccess::Inner>.value($t17)
+     # live vars: $t14, $t19
+ 17: $t16 := read_ref($t19)
+     # live vars: $t14, $t16
+ 18: $t2 := +($t14, $t16)
+     # live vars: $t2
+ 19: return $t2
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64 [unused]
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: &0x99::FiledAccess::Inner [unused]
+     var $t17: &0x99::FiledAccess::Outer [unused]
+     var $t18: &u64 [unused]
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t11 := +($t11, $t12)
+ 10: write_ref($t7, $t11)
+ 11: $t3 := move($t3)
+ 12: $t1 := +($t3, $t1)
+ 13: $t5 := borrow_local($t0)
+ 14: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+ 15: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+ 16: $t3 := read_ref($t6)
+ 17: $t1 := +($t1, $t3)
+ 18: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer [unused]
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t3 := borrow_local($t0)
+  3: FiledAccess::set_value($t3, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t1 := read_ref($t7)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: u64 [unused]
+     var $t17: &0x99::FiledAccess::Inner [unused]
+     var $t18: &0x99::FiledAccess::Outer [unused]
+     var $t19: &u64 [unused]
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t7 := move($t7)
+  8: $t12 := read_ref($t7)
+  9: $t13 := 1
+ 10: $t12 := +($t12, $t13)
+ 11: write_ref($t7, $t12)
+ 12: $t3 := move($t3)
+ 13: $t1 := +($t3, $t1)
+ 14: $t5 := borrow_local($t0)
+ 15: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+ 16: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+ 17: $t3 := read_ref($t6)
+ 18: $t1 := +($t1, $t3)
+ 19: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64 [unused]
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: &0x99::FiledAccess::Inner [unused]
+     var $t17: &0x99::FiledAccess::Outer [unused]
+     var $t18: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t11 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+ 10: write_ref($t7, $t11)
+     # live vars: $t0, $t1, $t3
+ 11: $t3 := move($t3)
+     # live vars: $t0, $t1, $t3
+ 12: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+ 13: $t5 := borrow_local($t0)
+     # live vars: $t1, $t5
+ 14: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t1, $t4
+ 15: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t1, $t6
+ 16: $t3 := read_ref($t6)
+     # live vars: $t1, $t3
+ 17: $t1 := +($t1, $t3)
+     # live vars: $t1
+ 18: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer [unused]
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  3: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t1 := read_ref($t7)
+     # live vars: $t1
+  8: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: u64 [unused]
+     var $t17: &0x99::FiledAccess::Inner [unused]
+     var $t18: &0x99::FiledAccess::Outer [unused]
+     var $t19: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t7 := move($t7)
+     # live vars: $t0, $t1, $t3, $t7
+  8: $t12 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t12, $t13
+ 10: $t12 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t7, $t12
+ 11: write_ref($t7, $t12)
+     # live vars: $t0, $t1, $t3
+ 12: $t3 := move($t3)
+     # live vars: $t0, $t1, $t3
+ 13: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+ 14: $t5 := borrow_local($t0)
+     # live vars: $t1, $t5
+ 15: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t1, $t4
+ 16: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t1, $t6
+ 17: $t3 := read_ref($t6)
+     # live vars: $t1, $t3
+ 18: $t1 := +($t1, $t3)
+     # live vars: $t1
+ 19: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+  1: $t1 := read_ref($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+  2: $t1 := read_ref($t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+  2: write_ref($t2, $t1)
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64 [unused]
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: &0x99::FiledAccess::Inner [unused]
+     var $t17: &0x99::FiledAccess::Outer [unused]
+     var $t18: &u64 [unused]
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t11 := read_ref($t7)
+  8: $t12 := 1
+  9: $t11 := +($t11, $t12)
+ 10: write_ref($t7, $t11)
+ 11: $t3 := move($t3)
+ 12: $t1 := +($t3, $t1)
+ 13: $t5 := borrow_local($t0)
+ 14: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+ 15: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+ 16: $t3 := read_ref($t6)
+ 17: $t1 := +($t1, $t3)
+ 18: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer [unused]
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+  0: $t3 := borrow_local($t0)
+  1: FiledAccess::set_value($t3, $t1)
+  2: $t3 := borrow_local($t0)
+  3: FiledAccess::set_value($t3, $t1)
+  4: $t6 := borrow_local($t0)
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+  7: $t1 := read_ref($t7)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: u64 [unused]
+     var $t17: &0x99::FiledAccess::Inner [unused]
+     var $t18: &0x99::FiledAccess::Outer [unused]
+     var $t19: &u64 [unused]
+  0: $t5 := borrow_local($t0)
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+  3: $t3 := read_ref($t6)
+  4: $t9 := borrow_local($t0)
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+  7: $t7 := move($t7)
+  8: $t12 := read_ref($t7)
+  9: $t13 := 1
+ 10: $t12 := +($t12, $t13)
+ 11: write_ref($t7, $t12)
+ 12: $t3 := move($t3)
+ 13: $t1 := +($t3, $t1)
+ 14: $t5 := borrow_local($t0)
+ 15: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+ 16: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+ 17: $t3 := read_ref($t6)
+ 18: $t1 := +($t1, $t3)
+ 19: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64 [unused]
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: &0x99::FiledAccess::Inner [unused]
+     var $t17: &0x99::FiledAccess::Outer [unused]
+     var $t18: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t11 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+ 10: write_ref($t7, $t11)
+     # live vars: $t0, $t1, $t3
+ 11: $t3 := move($t3)
+     # live vars: $t0, $t1, $t3
+ 12: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+ 13: $t5 := borrow_local($t0)
+     # live vars: $t1, $t5
+ 14: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t1, $t4
+ 15: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t1, $t6
+ 16: $t3 := read_ref($t6)
+     # live vars: $t1, $t3
+ 17: $t1 := +($t1, $t3)
+     # live vars: $t1
+ 18: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer [unused]
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  3: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t1 := read_ref($t7)
+     # live vars: $t1
+  8: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: u64 [unused]
+     var $t17: &0x99::FiledAccess::Inner [unused]
+     var $t18: &0x99::FiledAccess::Outer [unused]
+     var $t19: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t7 := move($t7)
+     # live vars: $t0, $t1, $t3, $t7
+  8: $t12 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t12, $t13
+ 10: $t12 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t7, $t12
+ 11: write_ref($t7, $t12)
+     # live vars: $t0, $t1, $t3
+ 12: $t3 := move($t3)
+     # live vars: $t0, $t1, $t3
+ 13: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+ 14: $t5 := borrow_local($t0)
+     # live vars: $t1, $t5
+ 15: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t1, $t4
+ 16: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t1, $t6
+ 17: $t3 := read_ref($t6)
+     # live vars: $t1, $t3
+ 18: $t1 := +($t1, $t3)
+     # live vars: $t1
+ 19: return $t1
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::get_inner_value1($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_inner_value2($t0: &0x99::FiledAccess::Inner): u64 {
+     var $t1: u64
+     var $t2: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t0)
+     # live vars: $t2
+  1: $t1 := read_ref($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::get_value($t0: &0x99::FiledAccess::Outer): u64 {
+     var $t1: u64
+     var $t2: &0x99::FiledAccess::Inner
+     var $t3: &u64
+     # live vars: $t0
+  0: $t2 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # live vars: $t2
+  1: $t3 := borrow_field<0x99::FiledAccess::Inner>.value($t2)
+     # live vars: $t3
+  2: $t1 := read_ref($t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::set_value($t0: &mut 0x99::FiledAccess::Outer, $t1: u64) {
+     var $t2: &mut u64
+     var $t3: &mut 0x99::FiledAccess::Inner
+     # live vars: $t0, $t1
+  0: $t3 := borrow_field<0x99::FiledAccess::Outer>.inner($t0)
+     # flush: $t1
+     # live vars: $t1, $t3
+  1: $t2 := borrow_field<0x99::FiledAccess::Inner>.value($t3)
+     # live vars: $t1, $t2
+  2: write_ref($t2, $t1)
+     # live vars:
+  3: return ()
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: u64 [unused]
+     var $t11: u64
+     var $t12: u64
+     var $t13: u64 [unused]
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: &0x99::FiledAccess::Inner [unused]
+     var $t17: &0x99::FiledAccess::Outer [unused]
+     var $t18: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # flush: $t7, $t11
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t11 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+  8: $t12 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t11, $t12
+  9: $t11 := +($t11, $t12)
+     # live vars: $t0, $t1, $t3, $t7, $t11
+ 10: write_ref($t7, $t11)
+     # live vars: $t0, $t1, $t3
+ 11: $t3 := move($t3)
+     # live vars: $t0, $t1, $t3
+ 12: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+ 13: $t5 := borrow_local($t0)
+     # live vars: $t1, $t5
+ 14: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t1, $t4
+ 15: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t1, $t6
+ 16: $t3 := read_ref($t6)
+     # live vars: $t1, $t3
+ 17: $t1 := +($t1, $t3)
+     # live vars: $t1
+ 18: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_mut_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &mut 0x99::FiledAccess::Outer
+     var $t4: &mut 0x99::FiledAccess::Outer [unused]
+     var $t5: &0x99::FiledAccess::Inner
+     var $t6: &0x99::FiledAccess::Outer
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  1: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0, $t1
+  2: $t3 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3
+  3: FiledAccess::set_value($t3, $t1)
+     # live vars: $t0
+  4: $t6 := borrow_local($t0)
+     # live vars: $t6
+  5: $t5 := borrow_field<0x99::FiledAccess::Outer>.inner($t6)
+     # live vars: $t5
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t5)
+     # live vars: $t7
+  7: $t1 := read_ref($t7)
+     # live vars: $t1
+  8: return $t1
+}
+
+
+[variant baseline]
+fun FiledAccess::test_field_access_ref($t0: 0x99::FiledAccess::Outer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: u64
+     var $t4: &0x99::FiledAccess::Inner
+     var $t5: &0x99::FiledAccess::Outer
+     var $t6: &u64
+     var $t7: &mut u64
+     var $t8: &mut 0x99::FiledAccess::Inner
+     var $t9: &mut 0x99::FiledAccess::Outer
+     var $t10: &mut u64 [unused]
+     var $t11: u64 [unused]
+     var $t12: u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     var $t15: u64 [unused]
+     var $t16: u64 [unused]
+     var $t17: &0x99::FiledAccess::Inner [unused]
+     var $t18: &0x99::FiledAccess::Outer [unused]
+     var $t19: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t5 := borrow_local($t0)
+     # live vars: $t0, $t1, $t5
+  1: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t0, $t1, $t4
+  2: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t0, $t1, $t6
+  3: $t3 := read_ref($t6)
+     # live vars: $t0, $t1, $t3
+  4: $t9 := borrow_local($t0)
+     # live vars: $t0, $t1, $t3, $t9
+  5: $t8 := borrow_field<0x99::FiledAccess::Outer>.inner($t9)
+     # flush: $t12
+     # live vars: $t0, $t1, $t3, $t8
+  6: $t7 := borrow_field<0x99::FiledAccess::Inner>.value($t8)
+     # flush: $t7
+     # live vars: $t0, $t1, $t3, $t7
+  7: $t7 := move($t7)
+     # live vars: $t0, $t1, $t3, $t7
+  8: $t12 := read_ref($t7)
+     # live vars: $t0, $t1, $t3, $t7, $t12
+  9: $t13 := 1
+     # live vars: $t0, $t1, $t3, $t7, $t12, $t13
+ 10: $t12 := +($t12, $t13)
+     # live vars: $t0, $t1, $t3, $t7, $t12
+ 11: write_ref($t7, $t12)
+     # live vars: $t0, $t1, $t3
+ 12: $t3 := move($t3)
+     # live vars: $t0, $t1, $t3
+ 13: $t1 := +($t3, $t1)
+     # live vars: $t0, $t1
+ 14: $t5 := borrow_local($t0)
+     # live vars: $t1, $t5
+ 15: $t4 := borrow_field<0x99::FiledAccess::Outer>.inner($t5)
+     # live vars: $t1, $t4
+ 16: $t6 := borrow_field<0x99::FiledAccess::Inner>.value($t4)
+     # live vars: $t1, $t6
+ 17: $t3 := read_ref($t6)
+     # live vars: $t1, $t3
+ 18: $t1 := +($t1, $t3)
+     # live vars: $t1
+ 19: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FiledAccess
+struct Inner has copy + drop
+  value: u64
+
+struct Outer has copy + drop
+  inner: Inner
+
+// Function definition at index 0
+fun get_inner_value1(l0: &Inner): u64
+    move_loc l0
+    borrow_field Inner, value
+    read_ref
+    ret
+
+// Function definition at index 1
+fun get_inner_value2(l0: &Inner): u64
+    move_loc l0
+    borrow_field Inner, value
+    read_ref
+    ret
+
+// Function definition at index 2
+fun get_value(l0: &Outer): u64
+    move_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    ret
+
+// Function definition at index 3
+fun set_value(l0: &mut Outer, l1: u64)
+    local l2: &mut u64
+    move_loc l0
+    mut_borrow_field Outer, inner
+    mut_borrow_field Inner, value
+    st_loc l2
+    move_loc l1
+    // @5
+    move_loc l2
+    write_ref
+    ret
+
+// Function definition at index 4
+fun test_field_access(l0: Outer, l1: u64): u64
+    local l2: &mut u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    mut_borrow_loc l0
+    // @5
+    mut_borrow_field Outer, inner
+    mut_borrow_field Inner, value
+    st_loc l2
+    copy_loc l2
+    read_ref
+    // @10
+    ld_u64 1
+    add
+    move_loc l2
+    write_ref
+    move_loc l1
+    // @15
+    add
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    // @20
+    add
+    ret
+
+// Function definition at index 5
+fun test_field_access_mut_ref(l0: Outer, l1: u64): u64
+    mut_borrow_loc l0
+    copy_loc l1
+    call set_value
+    mut_borrow_loc l0
+    move_loc l1
+    // @5
+    call set_value
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    // @10
+    ret
+
+// Function definition at index 6
+fun test_field_access_ref(l0: Outer, l1: u64): u64
+    local l2: &mut u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    mut_borrow_loc l0
+    // @5
+    mut_borrow_field Outer, inner
+    mut_borrow_field Inner, value
+    st_loc l2
+    copy_loc l2
+    read_ref
+    // @10
+    ld_u64 1
+    add
+    move_loc l2
+    write_ref
+    move_loc l1
+    // @15
+    add
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    // @20
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/function_call.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/function_call.move
@@ -1,0 +1,31 @@
+module 0x99::FunctionCall {
+
+    struct S has key {
+        val: u64,
+    }
+
+    fun foo_ref(x: &u64): u64 {
+        *x + 1
+    }
+
+    fun foo_mut_ref(x: &mut u64): u64 {
+        *x + 1
+    }
+
+    fun foo_global(account: &signer, x: &u64): u64 {
+        move_to(account, S { val: 42 });
+        *x + 1
+    }
+
+    // `foo_mut_ref(y)` cannot be reused because `ref` is a mutable reference
+    fun bar_mut_ref(y: u64): u64 {
+        let ref = &mut y;
+        foo_mut_ref(ref) + foo_mut_ref(ref)
+    }
+
+    // `foo_global(y)` cannot be reused because `foo_global` access global storage
+    fun bar_global(account: &signer, y: u64): u64 {
+        let ref = &y;
+        foo_global(account, ref) + foo_global(account, ref)
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/function_call.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/function_call.off.exp
@@ -1,0 +1,66 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FunctionCall
+struct S has key
+  val: u64
+
+// Function definition at index 0
+fun bar_global(l0: &signer, l1: u64): u64
+    local l2: &u64
+    borrow_loc l1
+    st_loc l2
+    copy_loc l0
+    copy_loc l2
+    call foo_global
+    // @5
+    move_loc l0
+    move_loc l2
+    call foo_global
+    add
+    ret
+
+// Function definition at index 1
+fun bar_mut_ref(l0: u64): u64
+    local l1: &mut u64
+    mut_borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call foo_mut_ref
+    move_loc l1
+    // @5
+    call foo_mut_ref
+    add
+    ret
+
+// Function definition at index 2
+fun foo_global(l0: &signer, l1: &u64): u64
+    move_loc l0
+    ld_u64 42
+    pack S
+    move_to S
+    move_loc l1
+    // @5
+    read_ref
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 3
+fun foo_mut_ref(l0: &mut u64): u64
+    move_loc l0
+    read_ref
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 4
+fun foo_ref(l0: &u64): u64
+    move_loc l0
+    read_ref
+    ld_u64 1
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/function_call.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/function_call.on.exp
@@ -1,0 +1,3874 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := infer($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := infer($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := infer($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := infer($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := infer($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := infer($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := infer($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := infer($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := infer($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+     # refs: [$t0 => #0, $t3 => #3, $t5 => #5]
+     # #0
+     #   => #5 via [] at line 29
+     # #3
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+     # refs: [$t3 => #3, $t7 => #7]
+     # #3
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+     # refs: []
+     #
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0, $t1 => #1]
+     # #0
+     #   <no edges>
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+     # refs: []
+     #
+  5: $t7 := 1
+     # live vars: $t6, $t7
+     # refs: []
+     #
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+     # refs: []
+     #
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  1: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t5
+     # refs: [$t0 => #0, $t3 => #3, $t5 => #5]
+     # #0
+     #   => #5 via [] at line 29
+     # #3
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t4
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  3: $t7 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t4, $t7
+     # refs: [$t3 => #3, $t7 => #7]
+     # #3
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t6
+     # refs: []
+     #
+  5: $t2 := +($t4, $t6)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  3: $t1 := +($t3, $t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0, $t1 => #1]
+     # #0
+     #   <no edges>
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t5 := 42
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t5
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t4
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t6 := read_ref($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t6
+     # refs: []
+     #
+  5: $t7 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t7
+     # refs: []
+     #
+  6: $t2 := +($t6, $t7)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := infer($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := infer($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := infer($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := infer($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := infer($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := infer($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # flush: $t3
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # flush: $t3
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+     # refs: [$t0 => #0, $t3 => #3, $t5 => #5]
+     # #0
+     #   => #5 via [] at line 29
+     # #3
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+     # refs: [$t3 => #3, $t7 => #7]
+     # #3
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+     # refs: []
+     #
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # flush: $t2
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0, $t1 => #1]
+     # #0
+     #   <no edges>
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+     # refs: []
+     #
+  5: $t7 := 1
+     # live vars: $t6, $t7
+     # refs: []
+     #
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+     # refs: []
+     #
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # flush: $t3
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+     # reaching instruction #2: `t3` @ {0}, `t5` @ {1}
+     # refs: [$t0 => #0, $t3 => #3, $t5 => #5]
+     # #0
+     #   => #5 via [] at line 29
+     # #3
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+     # reaching instruction #3: `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+     # reaching instruction #4: `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `t7` @ {3}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {2}
+     # refs: [$t3 => #3, $t7 => #7]
+     # #3
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+     # reaching instruction #5: `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `t6` @ {4}, `t7` @ {3}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {4}
+     # refs: []
+     #
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+     # reaching instruction #6: `t2` @ {5}, `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `t6` @ {4}, `t7` @ {3}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {4}
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # flush: $t2
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t0` @ {1}, `t2` @ {0}, `t3` @ {1}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+     # reaching instruction #3: `t0` @ {2}, `t2` @ {0}, `t3` @ {1}, `t4` @ {2}
+     # refs: []
+     #
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+     # reaching instruction #4: `t0` @ {2}, `t1` @ {3}, `t2` @ {0}, `t3` @ {1}, `t4` @ {2}
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: [$t0 => #0, $t1 => #1]
+     # #0
+     #   <no edges>
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+     # reaching instruction #2: `t3` @ {0}, `t5` @ {1}
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+     # reaching instruction #3: `t3` @ {0}, `t4` @ {2}, `t5` @ {1}
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+     # reaching instruction #4: `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {3}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+     # reaching instruction #5: `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `t6` @ {4}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {3}
+     # refs: []
+     #
+  5: $t7 := 1
+     # live vars: $t6, $t7
+     # reaching instruction #6: `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `t6` @ {4}, `t7` @ {5}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {3}
+     # refs: []
+     #
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+     # reaching instruction #7: `t2` @ {6}, `t3` @ {0}, `t4` @ {2}, `t5` @ {1}, `t6` @ {4}, `t7` @ {5}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {3}
+     # refs: []
+     #
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: return $t1
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := infer($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := infer($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := infer($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  1: $t5 := infer($t0)
+     # live vars: $t0, $t3, $t5
+     # refs: [$t0 => #0, $t3 => #3, $t5 => #5]
+     # #0
+     #   => #5 via [] at line 29
+     # #3
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  3: $t7 := infer($t0)
+     # live vars: $t3, $t4, $t7
+     # refs: [$t3 => #3, $t7 => #7]
+     # #3
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+     # refs: []
+     #
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0, $t1 => #1]
+     # #0
+     #   <no edges>
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := infer($t0)
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+     # refs: []
+     #
+  5: $t7 := 1
+     # live vars: $t6, $t7
+     # refs: []
+     #
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+     # refs: []
+     #
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  1: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t5
+     # refs: [$t0 => #0, $t3 => #3, $t5 => #5]
+     # #0
+     #   => #5 via [] at line 29
+     # #3
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3, $t4
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  3: $t7 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t4, $t7
+     # refs: [$t3 => #3, $t7 => #7]
+     # #3
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   => #3 via [local `y`] at line 28
+     #
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t6
+     # refs: []
+     #
+  5: $t2 := +($t4, $t6)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   => (mut) #2 via [local `y`] at line 22
+     #
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  3: $t1 := +($t3, $t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0, $t1 => #1]
+     # #0
+     #   <no edges>
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t5 := 42
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t5
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3, $t4
+     # refs: [$t1 => #1, $t3 => #3]
+     # #1
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t6 := read_ref($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t6
+     # refs: []
+     #
+  5: $t7 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t7
+     # refs: []
+     #
+  6: $t2 := +($t6, $t7)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := read_ref($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # maybe
+  0: $t3 := borrow_local($t1)
+     # maybe
+  1: $t5 := copy($t0)
+     # maybe
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # maybe
+  3: $t7 := move($t0)
+     # maybe
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # maybe
+  5: $t2 := +($t4, $t6)
+     # maybe
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # maybe
+  0: $t2 := borrow_local($t0)
+     # maybe
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # maybe
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # maybe
+  3: $t1 := +($t3, $t4)
+     # maybe
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # maybe
+  0: $t3 := move($t0)
+     # maybe
+  1: $t5 := 42
+     # maybe
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # maybe
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # maybe
+  4: $t6 := read_ref($t1)
+     # maybe
+  5: $t7 := 1
+     # maybe
+  6: $t2 := +($t6, $t7)
+     # maybe
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # maybe
+  0: $t2 := read_ref($t0)
+     # maybe
+  1: $t3 := 1
+     # maybe
+  2: $t1 := +($t2, $t3)
+     # maybe
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # maybe
+  0: $t2 := read_ref($t0)
+     # maybe
+  1: $t3 := 1
+     # maybe
+  2: $t1 := +($t2, $t3)
+     # maybe
+  3: return $t1
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := copy($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := move($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := move($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t7 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+  5: $t2 := +($t4, $t6)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t1 := +($t3, $t4)
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+  4: $t6 := read_ref($t1)
+  5: $t7 := 1
+  6: $t2 := +($t6, $t7)
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := copy($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t7 := move($t0)
+     # live vars: $t3, $t4, $t7
+  4: $t6 := FunctionCall::foo_global($t7, $t3)
+     # live vars: $t4, $t6
+  5: $t2 := +($t4, $t6)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t1 := +($t3, $t4)
+     # live vars: $t1
+  4: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64
+     var $t3: &signer
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := move($t0)
+     # live vars: $t1, $t3
+  1: $t5 := 42
+     # live vars: $t1, $t3, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t1, $t3, $t4
+  3: move_to<0x99::FunctionCall::S>($t3, $t4)
+     # live vars: $t1
+  4: $t6 := read_ref($t1)
+     # live vars: $t6
+  5: $t7 := 1
+     # live vars: $t6, $t7
+  6: $t2 := +($t6, $t7)
+     # live vars: $t2
+  7: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer [unused]
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t0 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t0, $t3)
+  5: $t4 := +($t4, $t6)
+  6: return $t4
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t3 := +($t3, $t4)
+  4: return $t3
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &signer [unused]
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+  0: $t0 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t0, $t4)
+  4: $t5 := read_ref($t1)
+  5: $t7 := 1
+  6: $t5 := +($t5, $t7)
+  7: return $t5
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t2 := +($t2, $t3)
+  3: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t2 := +($t2, $t3)
+  3: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer [unused]
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := copy($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t0 := move($t0)
+     # live vars: $t0, $t3, $t4
+  4: $t6 := FunctionCall::foo_global($t0, $t3)
+     # live vars: $t4, $t6
+  5: $t4 := +($t4, $t6)
+     # live vars: $t4
+  6: return $t4
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t3 := +($t3, $t4)
+     # live vars: $t3
+  4: return $t3
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &signer [unused]
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t5 := 42
+     # live vars: $t0, $t1, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t0, $t1, $t4
+  3: move_to<0x99::FunctionCall::S>($t0, $t4)
+     # live vars: $t1
+  4: $t5 := read_ref($t1)
+     # live vars: $t5
+  5: $t7 := 1
+     # live vars: $t5, $t7
+  6: $t5 := +($t5, $t7)
+     # live vars: $t5
+  7: return $t5
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer [unused]
+  0: $t3 := borrow_local($t1)
+  1: $t5 := copy($t0)
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+  3: $t0 := move($t0)
+  4: $t6 := FunctionCall::foo_global($t0, $t3)
+  5: $t4 := +($t4, $t6)
+  6: return $t4
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+  0: $t2 := borrow_local($t0)
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+  3: $t3 := +($t3, $t4)
+  4: return $t3
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &signer [unused]
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+  0: $t0 := move($t0)
+  1: $t5 := 42
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+  3: move_to<0x99::FunctionCall::S>($t0, $t4)
+  4: $t5 := read_ref($t1)
+  5: $t7 := 1
+  6: $t5 := +($t5, $t7)
+  7: return $t5
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t2 := +($t2, $t3)
+  3: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := read_ref($t0)
+  1: $t3 := 1
+  2: $t2 := +($t2, $t3)
+  3: return $t2
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer [unused]
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := copy($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t0 := move($t0)
+     # live vars: $t0, $t3, $t4
+  4: $t6 := FunctionCall::foo_global($t0, $t3)
+     # live vars: $t4, $t6
+  5: $t4 := +($t4, $t6)
+     # live vars: $t4
+  6: return $t4
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t3 := +($t3, $t4)
+     # live vars: $t3
+  4: return $t3
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &signer [unused]
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t5 := 42
+     # live vars: $t0, $t1, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t0, $t1, $t4
+  3: move_to<0x99::FunctionCall::S>($t0, $t4)
+     # live vars: $t1
+  4: $t5 := read_ref($t1)
+     # live vars: $t5
+  5: $t7 := 1
+     # live vars: $t5, $t7
+  6: $t5 := +($t5, $t7)
+     # live vars: $t5
+  7: return $t5
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_global($t0: &signer, $t1: u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &u64
+     var $t4: u64
+     var $t5: &signer
+     var $t6: u64
+     var $t7: &signer [unused]
+     # flush: $t3
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t5 := copy($t0)
+     # live vars: $t0, $t3, $t5
+  2: $t4 := FunctionCall::foo_global($t5, $t3)
+     # live vars: $t0, $t3, $t4
+  3: $t0 := move($t0)
+     # live vars: $t0, $t3, $t4
+  4: $t6 := FunctionCall::foo_global($t0, $t3)
+     # live vars: $t4, $t6
+  5: $t4 := +($t4, $t6)
+     # live vars: $t4
+  6: return $t4
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_mut_ref($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: &mut u64
+     var $t3: u64
+     var $t4: u64
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := borrow_local($t0)
+     # live vars: $t2
+  1: $t3 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t2, $t3
+  2: $t4 := FunctionCall::foo_mut_ref($t2)
+     # live vars: $t3, $t4
+  3: $t3 := +($t3, $t4)
+     # live vars: $t3
+  4: return $t3
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_global($t0: &signer, $t1: &u64): u64 {
+     var $t2: u64 [unused]
+     var $t3: &signer [unused]
+     var $t4: 0x99::FunctionCall::S
+     var $t5: u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t0 := move($t0)
+     # live vars: $t0, $t1
+  1: $t5 := 42
+     # live vars: $t0, $t1, $t5
+  2: $t4 := pack 0x99::FunctionCall::S($t5)
+     # live vars: $t0, $t1, $t4
+  3: move_to<0x99::FunctionCall::S>($t0, $t4)
+     # live vars: $t1
+  4: $t5 := read_ref($t1)
+     # live vars: $t5
+  5: $t7 := 1
+     # live vars: $t5, $t7
+  6: $t5 := +($t5, $t7)
+     # live vars: $t5
+  7: return $t5
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_mut_ref($t0: &mut u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_ref($t0: &u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := read_ref($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t2 := +($t2, $t3)
+     # live vars: $t2
+  3: return $t2
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FunctionCall
+struct S has key
+  val: u64
+
+// Function definition at index 0
+fun bar_global(l0: &signer, l1: u64): u64
+    local l2: &u64
+    borrow_loc l1
+    st_loc l2
+    copy_loc l0
+    copy_loc l2
+    call foo_global
+    // @5
+    move_loc l0
+    move_loc l2
+    call foo_global
+    add
+    ret
+
+// Function definition at index 1
+fun bar_mut_ref(l0: u64): u64
+    local l1: &mut u64
+    mut_borrow_loc l0
+    st_loc l1
+    copy_loc l1
+    call foo_mut_ref
+    move_loc l1
+    // @5
+    call foo_mut_ref
+    add
+    ret
+
+// Function definition at index 2
+fun foo_global(l0: &signer, l1: &u64): u64
+    move_loc l0
+    ld_u64 42
+    pack S
+    move_to S
+    move_loc l1
+    // @5
+    read_ref
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 3
+fun foo_mut_ref(l0: &mut u64): u64
+    move_loc l0
+    read_ref
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 4
+fun foo_ref(l0: &u64): u64
+    move_loc l0
+    read_ref
+    ld_u64 1
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/global_access.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/global_access.move
@@ -1,0 +1,68 @@
+module 0x99::GlobalAccess {
+    use std::signer;
+    use std::vector;
+
+    struct S has key, drop {
+        val: u64,
+    }
+
+    struct S1 has key, drop {
+        val: u64,
+    }
+
+    fun move_to_S(account: &signer) {
+        move_to<S>(account, S { val: 42 } )
+    }
+
+    fun move_from_S(account: &signer) {
+        move_from<S>(signer::address_of(account));
+    }
+
+    fun mutable_borrow_S(account: &signer) {
+        *borrow_global_mut<S>(signer::address_of(account)) = S { val: 100  };
+    }
+
+    fun dummy_func(): vector<u8> {
+        vector::empty<u8>()
+    }
+
+    // `borrow_global<S>(addr).val` cannot be reused
+    // because `move_to_S` may modify the global storage
+    fun test_global_borrow_v1(account: &signer): u64 {
+        let addr = signer::address_of(account);
+        let r1 = borrow_global<S>(addr);
+        move_to_S(account);
+        let r2 = borrow_global<S>(addr);
+        r1.val + r2.val
+    }
+
+    // `exists<S>(addr)` cannot be reused
+    // because `move_to_S` may modify the global storage
+    fun test_existence_check_v1(account: &signer): bool {
+        let addr = signer::address_of(account);
+        let b1 = exists<S>(addr);
+        move_to_S(account);
+        let b2 = exists<S>(addr);
+        b1 && b2
+    }
+
+    // `exists<S>(addr)` cannot be reused
+    // because `move_from_S` may modify the global storage
+    fun test_existence_check_v2(account: &signer): bool {
+        let addr = signer::address_of(account);
+        let b1 = exists<S>(addr);
+        move_from_S(account);
+        let b2 = exists<S>(addr);
+        b1 && b2
+    }
+
+    // `exists<S>(addr)` cannot be reused
+    // because `move_to_S` may modify the global storage
+    fun test_existence_check_v3(account: &signer): bool {
+        let addr = signer::address_of(account);
+        let b1 = exists<S>(addr);
+        mutable_borrow_S(account);
+        let b2 = exists<S>(addr);
+        b1 && b2
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/global_access.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/global_access.off.exp
@@ -1,0 +1,136 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::GlobalAccess
+use 0x1::signer
+struct S has drop + key
+  val: u64
+
+struct S1 has drop + key
+  val: u64
+
+// Function definition at index 0
+fun dummy_func(): vector<u8>
+    vec_pack <u8>, 0
+    ret
+
+// Function definition at index 1
+fun move_from_S(l0: &signer) acquires S
+    move_loc l0
+    call signer::address_of
+    move_from S
+    pop
+    ret
+
+// Function definition at index 2
+fun move_to_S(l0: &signer)
+    move_loc l0
+    ld_u64 42
+    pack S
+    move_to S
+    ret
+
+// Function definition at index 3
+fun mutable_borrow_S(l0: &signer) acquires S
+    ld_u64 100
+    pack S
+    move_loc l0
+    call signer::address_of
+    mut_borrow_global S
+    // @5
+    write_ref
+    ret
+
+// Function definition at index 4
+fun test_existence_check_v1(l0: &signer): bool
+    local l1: address
+    local l2: bool
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    exists S
+    // @5
+    move_loc l0
+    call move_to_S
+    move_loc l1
+    exists S
+    st_loc l2
+    // @10
+    br_false l0
+    move_loc l2
+    ret
+l0: ld_false
+    ret
+
+// Function definition at index 5
+fun test_existence_check_v2(l0: &signer): bool acquires S
+    local l1: address
+    local l2: bool
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    exists S
+    // @5
+    move_loc l0
+    call move_from_S
+    move_loc l1
+    exists S
+    st_loc l2
+    // @10
+    br_false l0
+    move_loc l2
+    ret
+l0: ld_false
+    ret
+
+// Function definition at index 6
+fun test_existence_check_v3(l0: &signer): bool acquires S
+    local l1: address
+    local l2: bool
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    exists S
+    // @5
+    move_loc l0
+    call mutable_borrow_S
+    move_loc l1
+    exists S
+    st_loc l2
+    // @10
+    br_false l0
+    move_loc l2
+    ret
+l0: ld_false
+    ret
+
+// Function definition at index 7
+fun test_global_borrow_v1(l0: &signer): u64 acquires S
+    local l1: address
+    local l2: &S
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    borrow_global S
+    // @5
+    move_loc l0
+    call move_to_S
+    move_loc l1
+    borrow_global S
+    st_loc l2
+    // @10
+    borrow_field S, val
+    read_ref
+    move_loc l2
+    borrow_field S, val
+    read_ref
+    // @15
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/global_access.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/not-optimized/global_access.on.exp
@@ -1,0 +1,7110 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := infer($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := infer($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := infer($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := 42
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := 100
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+     # refs: []
+     #
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `GlobalAccess::S`] at line 22
+     #
+  4: write_ref($t3, $t1)
+     # live vars:
+     # refs: []
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: [$t3 => #3, $t4 => #4]
+     # #3
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4, $t6 => #6]
+     # #4
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #   -> #6 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 36
+     #
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # refs: []
+     #
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := 42
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := 100
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t4
+     # refs: []
+     #
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # abort state: {returns}
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `GlobalAccess::S`] at line 22
+     #
+  4: write_ref($t3, $t1)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # abort state: {returns}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_from_S($t0)
+     # abort state: {returns}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # abort state: {returns}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t4
+     # refs: [$t3 => #3, $t4 => #4]
+     # #3
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4, $t6 => #6]
+     # #4
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #   -> #6 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t5 := read_ref($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t5
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 36
+     #
+  7: $t7 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t7
+     # refs: []
+     #
+  8: $t1 := +($t5, $t7)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := infer($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := infer($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # flush: $t1
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # flush: $t1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # flush: $t1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # flush: $t1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # flush: $t1
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := 42
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := 100
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+     # refs: []
+     #
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `GlobalAccess::S`] at line 22
+     #
+  4: write_ref($t3, $t1)
+     # live vars:
+     # refs: []
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # flush: $t1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_from_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # flush: $t1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # flush: $t1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # flush: $t2
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: [$t3 => #3, $t4 => #4]
+     # #3
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4, $t6 => #6]
+     # #4
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #   -> #6 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 36
+     #
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # refs: []
+     #
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # reaching instruction #1: `t0` @ {0}
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # flush: $t1
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {1}
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := 42
+     # live vars: $t1, $t3
+     # reaching instruction #2: `t1` @ {0}, `t3` @ {1}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+     # reaching instruction #3: `t1` @ {0}, `t2` @ {2}, `t3` @ {1}
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+     # reaching instruction #4: `t1` @ {0}, `t2` @ {2}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {3}
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := 100
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+     # reaching instruction #3: `t1` @ {1}, `t2` @ {0}, `t4` @ {2}
+     # refs: []
+     #
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+     # reaching instruction #4: `t1` @ {1}, `t2` @ {0}, `t3` @ {3}, `t4` @ {2}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `GlobalAccess::S`] at line 22
+     #
+  4: write_ref($t3, $t1)
+     # live vars:
+     # reaching instruction #5: `t1` @ {1}, `t2` @ {0}, `t3` @ {3}, `t4` @ {2}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {4}
+     # refs: []
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+     # reaching instruction #6: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # reaching instruction #7: `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # reaching instruction #8: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  8: label L1
+     # flush: $t1
+     # live vars:
+     # reaching instruction #9: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # reaching instruction #10: `t1` @ {6, 9}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # reaching instruction #11: `t1` @ {6, 9}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_from_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+     # reaching instruction #6: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # reaching instruction #7: `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # reaching instruction #8: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  8: label L1
+     # flush: $t1
+     # live vars:
+     # reaching instruction #9: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # reaching instruction #10: `t1` @ {6, 9}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # reaching instruction #11: `t1` @ {6, 9}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  5: label L0
+     # flush: $t1
+     # live vars: $t4
+     # reaching instruction #6: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # reaching instruction #7: `t1` @ {6}, `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # reaching instruction #8: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  8: label L1
+     # flush: $t1
+     # live vars:
+     # reaching instruction #9: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # reaching instruction #10: `t1` @ {6, 9}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # reaching instruction #11: `t1` @ {6, 9}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # flush: $t2
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+     # reaching instruction #3: `t2` @ {0}, `t3` @ {1}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: [$t3 => #3, $t4 => #4]
+     # #3
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+     # reaching instruction #5: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t6` @ {4}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: [$t4 => #4, $t6 => #6]
+     # #4
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #   -> #6 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+     # reaching instruction #6: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {5}, `t6` @ {4}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+     # reaching instruction #7: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {5}, `t6` @ {4}, `t8` @ {6}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 36
+     #
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # reaching instruction #8: `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {5}, `t6` @ {4}, `t7` @ {7}, `t8` @ {6}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+     # reaching instruction #9: `t1` @ {8}, `t2` @ {0}, `t3` @ {1}, `t4` @ {3}, `t5` @ {5}, `t6` @ {4}, `t7` @ {7}, `t8` @ {6}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(140)) }` @ {2}
+     # refs: []
+     #
+  9: return $t1
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := infer($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := infer($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := infer($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := infer($t4)
+     # live vars: $t1
+  7: goto 10
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: label L2
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := 42
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := 100
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+     # refs: []
+     #
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `GlobalAccess::S`] at line 22
+     #
+  4: write_ref($t3, $t1)
+     # live vars:
+     # refs: []
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+     # refs: [$t3 => #3, $t4 => #4]
+     # #3
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4, $t6 => #6]
+     # #4
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #   -> #6 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 36
+     #
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # refs: []
+     #
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t1 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := 42
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t3
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2
+     # refs: [$t1 => #1]
+     # #1
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := 100
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t4 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t4
+     # refs: []
+     #
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # abort state: {returns}
+     # live vars: $t1, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> (mut) #3 via [struct `GlobalAccess::S`] at line 22
+     #
+  4: write_ref($t3, $t1)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # abort state: {returns}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::move_from_S($t0)
+     # abort state: {returns}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # abort state: {returns}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns}
+     # live vars: $t3, $t4
+     # refs: []
+     #
+  4: if ($t3) goto 5 else goto 8
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  5: label L0
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  6: $t1 := infer($t4)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  7: goto 10
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  8: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  9: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  2: GlobalAccess::move_to_S($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: [$t3 => #3]
+     # #3
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t3, $t4
+     # refs: [$t3 => #3, $t4 => #4]
+     # #3
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #3 via [struct `GlobalAccess::S`] at line 33
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4, $t6 => #6]
+     # #4
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #   -> #6 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t5 := read_ref($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t5
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 35
+     #
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 36
+     #
+  7: $t7 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t7
+     # refs: []
+     #
+  8: $t1 := +($t5, $t7)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: goto 10
+  8: label L1
+  9: $t1 := false
+ 10: label L2
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # maybe
+  0: $t0 := vector::empty<u8>()
+     # maybe
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # maybe
+  0: $t2 := signer::address_of($t0)
+     # maybe
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # maybe
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # maybe
+  0: $t1 := move($t0)
+     # maybe
+  1: $t3 := 42
+     # maybe
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # maybe
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # maybe
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # maybe
+  0: $t2 := 100
+     # maybe
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # maybe
+  2: $t4 := signer::address_of($t0)
+     # maybe
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # maybe
+  4: write_ref($t3, $t1)
+     # maybe
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # maybe
+  0: $t2 := signer::address_of($t0)
+     # maybe
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # maybe
+  2: GlobalAccess::move_to_S($t0)
+     # maybe
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # maybe
+  4: if ($t3) goto 5 else goto 8
+     # maybe
+  5: label L0
+     # maybe
+  6: $t1 := move($t4)
+     # maybe
+  7: return $t1
+     # maybe
+  8: label L1
+     # maybe
+  9: $t1 := false
+     # maybe
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # maybe
+  0: $t2 := signer::address_of($t0)
+     # maybe
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # maybe
+  2: GlobalAccess::move_from_S($t0)
+     # maybe
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # maybe
+  4: if ($t3) goto 5 else goto 8
+     # maybe
+  5: label L0
+     # maybe
+  6: $t1 := move($t4)
+     # maybe
+  7: return $t1
+     # maybe
+  8: label L1
+     # maybe
+  9: $t1 := false
+     # maybe
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # maybe
+  0: $t2 := signer::address_of($t0)
+     # maybe
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # maybe
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # maybe
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # maybe
+  4: if ($t3) goto 5 else goto 8
+     # maybe
+  5: label L0
+     # maybe
+  6: $t1 := move($t4)
+     # maybe
+  7: return $t1
+     # maybe
+  8: label L1
+     # maybe
+  9: $t1 := false
+     # maybe
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # maybe
+  0: $t2 := signer::address_of($t0)
+     # maybe
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # maybe
+  2: GlobalAccess::move_to_S($t0)
+     # maybe
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # maybe
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # maybe
+  5: $t5 := read_ref($t6)
+     # maybe
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # maybe
+  7: $t7 := read_ref($t8)
+     # maybe
+  8: $t1 := +($t5, $t7)
+     # maybe
+  9: return $t1
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := move($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := move($t4)
+     # live vars: $t1
+  7: return $t1
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := move($t4)
+     # live vars: $t1
+  7: return $t1
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := move($t4)
+     # live vars: $t1
+  7: return $t1
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t1 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t1 := move($t4)
+  7: return $t1
+  8: label L1
+  9: $t1 := false
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t8)
+  8: $t1 := +($t5, $t7)
+  9: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t1 := move($t0)
+     # live vars: $t1
+  1: $t3 := 42
+     # live vars: $t1, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t1, $t2
+  3: move_to<0x99::GlobalAccess::S>($t1, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := move($t4)
+     # live vars: $t1
+  7: return $t1
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := move($t4)
+     # live vars: $t1
+  7: return $t1
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t1 := move($t4)
+     # live vars: $t1
+  7: return $t1
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t1 := false
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t8
+  7: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  8: $t1 := +($t5, $t7)
+     # live vars: $t1
+  9: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer [unused]
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t0 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t0, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t3 := move($t4)
+  7: return $t3
+  8: label L1
+  9: $t3 := false
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t3 := move($t4)
+  7: return $t3
+  8: label L1
+  9: $t3 := false
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t3 := move($t4)
+  7: return $t3
+  8: label L1
+  9: $t3 := false
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64 [unused]
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t6)
+  8: $t5 := +($t5, $t7)
+  9: return $t5
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer [unused]
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t3 := 42
+     # live vars: $t0, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t0, $t2
+  3: move_to<0x99::GlobalAccess::S>($t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64 [unused]
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t6
+  7: $t7 := read_ref($t6)
+     # live vars: $t5, $t7
+  8: $t5 := +($t5, $t7)
+     # live vars: $t5
+  9: return $t5
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer [unused]
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+  0: $t0 := move($t0)
+  1: $t3 := 42
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+  3: move_to<0x99::GlobalAccess::S>($t0, $t2)
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+  0: $t2 := 100
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+  2: $t4 := signer::address_of($t0)
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+  4: write_ref($t3, $t1)
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t3 := move($t4)
+  7: return $t3
+  8: label L1
+  9: $t3 := false
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_from_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t3 := move($t4)
+  7: return $t3
+  8: label L1
+  9: $t3 := false
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::mutable_borrow_S($t0)
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+  4: if ($t3) goto 5 else goto 8
+  5: label L0
+  6: $t3 := move($t4)
+  7: return $t3
+  8: label L1
+  9: $t3 := false
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64 [unused]
+  0: $t2 := signer::address_of($t0)
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+  2: GlobalAccess::move_to_S($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+  5: $t5 := read_ref($t6)
+  6: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t7 := read_ref($t6)
+  8: $t5 := +($t5, $t7)
+  9: return $t5
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer [unused]
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t3 := 42
+     # live vars: $t0, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t0, $t2
+  3: move_to<0x99::GlobalAccess::S>($t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64 [unused]
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t6
+  7: $t7 := read_ref($t6)
+     # live vars: $t5, $t7
+  8: $t5 := +($t5, $t7)
+     # live vars: $t5
+  9: return $t5
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # flush: $t1
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S>($t2)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_to_S($t0: &signer) {
+     var $t1: &signer [unused]
+     var $t2: 0x99::GlobalAccess::S
+     var $t3: u64
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t3 := 42
+     # live vars: $t0, $t3
+  2: $t2 := pack 0x99::GlobalAccess::S($t3)
+     # live vars: $t0, $t2
+  3: move_to<0x99::GlobalAccess::S>($t0, $t2)
+     # live vars:
+  4: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::mutable_borrow_S($t0: &signer) {
+     var $t1: 0x99::GlobalAccess::S
+     var $t2: u64
+     var $t3: &mut 0x99::GlobalAccess::S
+     var $t4: address
+     # live vars: $t0
+  0: $t2 := 100
+     # live vars: $t0, $t2
+  1: $t1 := pack 0x99::GlobalAccess::S($t2)
+     # live vars: $t0, $t1
+  2: $t4 := signer::address_of($t0)
+     # live vars: $t1, $t4
+  3: $t3 := borrow_global<0x99::GlobalAccess::S>($t4)
+     # live vars: $t1, $t3
+  4: write_ref($t3, $t1)
+     # live vars:
+  5: return ()
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v1($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v2($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_from_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check_v3($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: address
+     var $t3: bool
+     var $t4: bool
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::mutable_borrow_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := exists<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: if ($t3) goto 5 else goto 8
+     # live vars: $t4
+  5: label L0
+     # live vars: $t4
+  6: $t3 := move($t4)
+     # live vars: $t3
+  7: return $t3
+     # live vars: $t4
+  8: label L1
+     # live vars:
+  9: $t3 := false
+     # live vars: $t3
+ 10: return $t3
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v1($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: address
+     var $t3: &0x99::GlobalAccess::S
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: u64
+     var $t6: &u64
+     var $t7: u64
+     var $t8: &u64 [unused]
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t0, $t2
+  1: $t3 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t0, $t2, $t3
+  2: GlobalAccess::move_to_S($t0)
+     # flush: $t4
+     # live vars: $t2, $t3
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t2)
+     # live vars: $t3, $t4
+  4: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t3)
+     # live vars: $t4, $t6
+  5: $t5 := read_ref($t6)
+     # live vars: $t4, $t5
+  6: $t6 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t5, $t6
+  7: $t7 := read_ref($t6)
+     # live vars: $t5, $t7
+  8: $t5 := +($t5, $t7)
+     # live vars: $t5
+  9: return $t5
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::GlobalAccess
+use 0x1::signer
+struct S has drop + key
+  val: u64
+
+struct S1 has drop + key
+  val: u64
+
+// Function definition at index 0
+fun dummy_func(): vector<u8>
+    vec_pack <u8>, 0
+    ret
+
+// Function definition at index 1
+fun move_from_S(l0: &signer) acquires S
+    move_loc l0
+    call signer::address_of
+    move_from S
+    pop
+    ret
+
+// Function definition at index 2
+fun move_to_S(l0: &signer)
+    move_loc l0
+    ld_u64 42
+    pack S
+    move_to S
+    ret
+
+// Function definition at index 3
+fun mutable_borrow_S(l0: &signer) acquires S
+    ld_u64 100
+    pack S
+    move_loc l0
+    call signer::address_of
+    mut_borrow_global S
+    // @5
+    write_ref
+    ret
+
+// Function definition at index 4
+fun test_existence_check_v1(l0: &signer): bool
+    local l1: address
+    local l2: bool
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    exists S
+    // @5
+    move_loc l0
+    call move_to_S
+    move_loc l1
+    exists S
+    st_loc l2
+    // @10
+    br_false l0
+    move_loc l2
+    ret
+l0: ld_false
+    ret
+
+// Function definition at index 5
+fun test_existence_check_v2(l0: &signer): bool acquires S
+    local l1: address
+    local l2: bool
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    exists S
+    // @5
+    move_loc l0
+    call move_from_S
+    move_loc l1
+    exists S
+    st_loc l2
+    // @10
+    br_false l0
+    move_loc l2
+    ret
+l0: ld_false
+    ret
+
+// Function definition at index 6
+fun test_existence_check_v3(l0: &signer): bool acquires S
+    local l1: address
+    local l2: bool
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    exists S
+    // @5
+    move_loc l0
+    call mutable_borrow_S
+    move_loc l1
+    exists S
+    st_loc l2
+    // @10
+    br_false l0
+    move_loc l2
+    ret
+l0: ld_false
+    ret
+
+// Function definition at index 7
+fun test_global_borrow_v1(l0: &signer): u64 acquires S
+    local l1: address
+    local l2: &S
+    copy_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    borrow_global S
+    // @5
+    move_loc l0
+    call move_to_S
+    move_loc l1
+    borrow_global S
+    st_loc l2
+    // @10
+    borrow_field S, val
+    read_ref
+    move_loc l2
+    borrow_field S, val
+    read_ref
+    // @15
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access.off.exp
@@ -1,0 +1,39 @@
+
+Diagnostics:
+warning: Unused value of parameter `arg2`. Consider removing the parameter, or prefixing with an underscore (e.g., `_arg2`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access.move:16:40
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                        ^^^^
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FiledAccess
+struct Inner has copy + drop
+  value: u64
+
+struct Outer has copy + drop
+  inner: Inner
+
+// Function definition at index 0
+fun test_field_access(l0: Outer, l1: u64, l2: u64, l3: u64): u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    move_loc l2
+    // @5
+    move_loc l3
+    add
+    add
+    borrow_loc l0
+    borrow_field Outer, inner
+    // @10
+    borrow_field Inner, value
+    read_ref
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access.on.exp
@@ -1,0 +1,176 @@
+
+Diagnostics:
+warning: Unused value of parameter `arg2`. Consider removing the parameter, or prefixing with an underscore (e.g., `_arg2`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access.move:16:40
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                        ^^^^
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &0x99::FiledAccess::Inner
+     var $t8: &0x99::FiledAccess::Outer
+     var $t9: &u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &0x99::FiledAccess::Inner
+     var $t14: &0x99::FiledAccess::Outer
+     var $t15: &u64
+     # live vars: $t0, $t1, $t2, $t3
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t8 := borrow_local($t0)
+     # live vars: $t0, $t2, $t3, $t8
+     # reaching instruction #1: `t8` @ {0}
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `arg1`] at line 17
+     #
+  1: $t7 := borrow_field<0x99::FiledAccess::Outer>.inner($t8)
+     # live vars: $t0, $t2, $t3, $t7
+     # reaching instruction #2: `t7` @ {1}, `t8` @ {0}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`, field `inner`] at line 17
+     #
+  2: $t9 := borrow_field<0x99::FiledAccess::Inner>.value($t7)
+     # live vars: $t0, $t2, $t3, $t9
+     # reaching instruction #3: `t7` @ {1}, `t8` @ {0}, `t9` @ {2}
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   => #9 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  3: $t6 := read_ref($t9)
+     # live vars: $t0, $t2, $t3, $t6
+     # reaching instruction #4: `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}
+     # refs: []
+     #
+  4: $t11 := infer($t2)
+     # live vars: $t0, $t3, $t6, $t11
+     # reaching instruction #5: `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t11` @ {4}
+     # refs: []
+     #
+  5: $t10 := +($t11, $t3)
+     # live vars: $t0, $t6, $t10
+     # reaching instruction #6: `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t10` @ {5}, `t11` @ {4}
+     # refs: []
+     #
+  6: $t5 := +($t6, $t10)
+     # live vars: $t0, $t5
+     # reaching instruction #7: `t5` @ {6}, `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t10` @ {5}, `t11` @ {4}
+     # refs: []
+     #
+  7: $t14 := borrow_local($t0)
+     # live vars: $t5, $t14
+     # reaching instruction #8: `t5` @ {6}, `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t10` @ {5}, `t11` @ {4}, `t14` @ {7}
+     # refs: [$t14 => #14]
+     # #14
+     #   <no edges>
+     # #root
+     #   => #14 via [local `arg1`] at line 17
+     #
+  8: $t13 := borrow_field<0x99::FiledAccess::Outer>.inner($t14)
+     # live vars: $t5, $t13
+     # reaching instruction #9: `t5` @ {6}, `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t10` @ {5}, `t11` @ {4}, `t13` @ {8}, `t14` @ {7}
+     # refs: [$t13 => #13]
+     # #13
+     #   <no edges>
+     # #root
+     #   => #13 via [local `arg1`, field `inner`] at line 17
+     #
+  9: $t15 := borrow_field<0x99::FiledAccess::Inner>.value($t13)
+     # live vars: $t5, $t15
+     # reaching instruction #10: `t5` @ {6}, `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t10` @ {5}, `t11` @ {4}, `t13` @ {8}, `t14` @ {7}, `t15` @ {9}
+     # refs: [$t15 => #15]
+     # #15
+     #   <no edges>
+     # #root
+     #   => #15 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+ 10: $t12 := read_ref($t15)
+     # live vars: $t5, $t12
+     # reaching instruction #11: `t5` @ {6}, `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t10` @ {5}, `t11` @ {4}, `t12` @ {10}, `t13` @ {8}, `t14` @ {7}, `t15` @ {9}
+     # refs: []
+     #
+ 11: $t4 := +($t5, $t12)
+     # live vars: $t4
+     # reaching instruction #12: `t4` @ {11}, `t5` @ {6}, `t6` @ {3}, `t7` @ {1}, `t8` @ {0}, `t9` @ {2}, `t10` @ {5}, `t11` @ {4}, `t12` @ {10}, `t13` @ {8}, `t14` @ {7}, `t15` @ {9}
+     # refs: []
+     #
+ 12: return $t4
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: u64
+     var $t7: &0x99::FiledAccess::Inner
+     var $t8: &0x99::FiledAccess::Outer
+     var $t9: &u64
+     var $t10: u64
+     var $t11: u64
+     var $t12: u64
+     var $t13: &0x99::FiledAccess::Inner [unused]
+     var $t14: &0x99::FiledAccess::Outer [unused]
+     var $t15: &u64 [unused]
+  0: $t8 := borrow_local($t0)
+  1: $t7 := borrow_field<0x99::FiledAccess::Outer>.inner($t8)
+  2: $t9 := borrow_field<0x99::FiledAccess::Inner>.value($t7)
+  3: $t6 := read_ref($t9)
+  4: $t6 := dup($t6)
+  5: $t11 := infer($t2)
+  6: $t10 := +($t11, $t3)
+  7: $t5 := +($t6, $t10)
+  8: $t12 := infer($t6)
+  9: $t4 := +($t5, $t12)
+ 10: return $t4
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FiledAccess
+struct Inner has copy + drop
+  value: u64
+
+struct Outer has copy + drop
+  inner: Inner
+
+// Function definition at index 0
+fun test_field_access(l0: Outer, l1: u64, l2: u64, l3: u64): u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    st_loc l1
+    // @5
+    move_loc l2
+    move_loc l3
+    add
+    st_loc l2
+    copy_loc l1
+    // @10
+    move_loc l2
+    add
+    move_loc l1
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access_1.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access_1.move
@@ -1,0 +1,19 @@
+module 0x99::FiledAccess {
+    struct Inner has copy, drop {
+        value: u64,
+    }
+
+    struct Outer has copy, drop {
+        inner: Inner,
+    }
+
+    // `arg1.inner` can be reused
+    // perf_gain: removed 1 `borrow_loc` + 2 `borrow_field`
+    // new_cost:
+    // - `st_loc` to flush `arg1.inner`
+    // - `copy_loc` of `arg1.inner` twice respectively for
+    //    its original use and the new use
+    fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+        arg1.inner.value + arg1.inner.value
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access_1.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access_1.off.exp
@@ -1,0 +1,46 @@
+
+Diagnostics:
+warning: Unused value of parameter `arg2`. Consider removing the parameter, or prefixing with an underscore (e.g., `_arg2`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access_1.move:16:40
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                        ^^^^
+
+warning: Unused value of parameter `x`. Consider removing the parameter, or prefixing with an underscore (e.g., `_x`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access_1.move:16:51
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                                   ^
+
+warning: Unused value of parameter `y`. Consider removing the parameter, or prefixing with an underscore (e.g., `_y`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access_1.move:16:59
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                                           ^
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FiledAccess
+struct Inner has copy + drop
+  value: u64
+
+struct Outer has copy + drop
+  inner: Inner
+
+// Function definition at index 0
+fun test_field_access(l0: Outer, l1: u64, l2: u64, l3: u64): u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    borrow_loc l0
+    // @5
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access_1.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/field_access_1.on.exp
@@ -1,0 +1,1235 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t11 := borrow_local($t0)
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+  7: $t9 := read_ref($t12)
+  8: $t4 := +($t5, $t9)
+  9: return $t4
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t11 := borrow_local($t0)
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+  7: $t9 := read_ref($t12)
+  8: $t4 := +($t5, $t9)
+  9: return $t4
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t11 := borrow_local($t0)
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+  7: $t9 := read_ref($t12)
+  8: $t4 := +($t5, $t9)
+  9: return $t4
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+  9: return $t4
+}
+
+
+Diagnostics:
+warning: Unused value of parameter `arg2`. Consider removing the parameter, or prefixing with an underscore (e.g., `_arg2`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access_1.move:16:40
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                        ^^^^
+
+warning: Unused value of parameter `x`. Consider removing the parameter, or prefixing with an underscore (e.g., `_x`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access_1.move:16:51
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                                   ^
+
+warning: Unused value of parameter `y`. Consider removing the parameter, or prefixing with an underscore (e.g., `_y`), or binding to `_`
+   ┌─ tests/common-subexp-elimination/optimized/field_access_1.move:16:59
+   │
+16 │     fun test_field_access(arg1: Outer, arg2: u64, x: u64, y: u64): u64 {
+   │                                                           ^
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+  9: return $t4
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+  9: return $t4
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+     # refs: []
+     #
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`] at line 17
+     #
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`] at line 17
+     #
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => #11 via [local `arg1`] at line 17
+     #
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `arg1`, field `inner`] at line 17
+     #
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+     # refs: []
+     #
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+     # refs: []
+     #
+  9: return $t4
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t3
+     # refs: []
+     #
+  0: $t7 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`] at line 17
+     #
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`] at line 17
+     #
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  3: $t5 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  4: $t11 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => #11 via [local `arg1`] at line 17
+     #
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `arg1`, field `inner`] at line 17
+     #
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  7: $t9 := read_ref($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t9
+     # refs: []
+     #
+  8: $t4 := +($t5, $t9)
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  9: return $t4
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t11 := borrow_local($t0)
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+  7: $t9 := read_ref($t12)
+  8: $t4 := +($t5, $t9)
+  9: return $t4
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t11 := borrow_local($t0)
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+  7: $t9 := read_ref($t12)
+  8: $t4 := +($t5, $t9)
+  9: return $t4
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t11 := borrow_local($t0)
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+  7: $t9 := read_ref($t12)
+  8: $t4 := +($t5, $t9)
+  9: return $t4
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+  9: return $t4
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+  9: return $t4
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+     # refs: []
+     #
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`] at line 17
+     #
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`] at line 17
+     #
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => #11 via [local `arg1`] at line 17
+     #
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `arg1`, field `inner`] at line 17
+     #
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+     # refs: []
+     #
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+     # refs: []
+     #
+  9: return $t4
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner
+     var $t11: &0x99::FiledAccess::Outer
+     var $t12: &u64
+     # live vars: $t0, $t1, $t2, $t3
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t7 := borrow_local($t0)
+     # live vars: $t0, $t7
+     # reaching instruction #1: `t7` @ {0}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`] at line 17
+     #
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t0, $t6
+     # reaching instruction #2: `t6` @ {1}, `t7` @ {0}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`] at line 17
+     #
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t0, $t8
+     # reaching instruction #3: `t6` @ {1}, `t7` @ {0}, `t8` @ {2}
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  3: $t5 := read_ref($t8)
+     # live vars: $t0, $t5
+     # reaching instruction #4: `t5` @ {3}, `t6` @ {1}, `t7` @ {0}, `t8` @ {2}
+     # refs: []
+     #
+  4: $t11 := borrow_local($t0)
+     # live vars: $t5, $t11
+     # reaching instruction #5: `t5` @ {3}, `t6` @ {1}, `t7` @ {0}, `t8` @ {2}, `t11` @ {4}
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   => #11 via [local `arg1`] at line 17
+     #
+  5: $t10 := borrow_field<0x99::FiledAccess::Outer>.inner($t11)
+     # live vars: $t5, $t10
+     # reaching instruction #6: `t5` @ {3}, `t6` @ {1}, `t7` @ {0}, `t8` @ {2}, `t10` @ {5}, `t11` @ {4}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   => #10 via [local `arg1`, field `inner`] at line 17
+     #
+  6: $t12 := borrow_field<0x99::FiledAccess::Inner>.value($t10)
+     # live vars: $t5, $t12
+     # reaching instruction #7: `t5` @ {3}, `t6` @ {1}, `t7` @ {0}, `t8` @ {2}, `t10` @ {5}, `t11` @ {4}, `t12` @ {6}
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   => #12 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  7: $t9 := read_ref($t12)
+     # live vars: $t5, $t9
+     # reaching instruction #8: `t5` @ {3}, `t6` @ {1}, `t7` @ {0}, `t8` @ {2}, `t9` @ {7}, `t10` @ {5}, `t11` @ {4}, `t12` @ {6}
+     # refs: []
+     #
+  8: $t4 := +($t5, $t9)
+     # live vars: $t4
+     # reaching instruction #9: `t4` @ {8}, `t5` @ {3}, `t6` @ {1}, `t7` @ {0}, `t8` @ {2}, `t9` @ {7}, `t10` @ {5}, `t11` @ {4}, `t12` @ {6}
+     # refs: []
+     #
+  9: return $t4
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t5 := dup($t5)
+  5: $t9 := dup($t5)
+  6: $t4 := +($t5, $t9)
+  7: return $t4
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t5
+  4: $t5 := dup($t5)
+     # live vars: $t5
+  5: $t9 := dup($t5)
+     # live vars: $t5, $t9
+  6: $t4 := +($t5, $t9)
+     # live vars: $t4
+  7: return $t4
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+     # refs: []
+     #
+  0: $t7 := borrow_local($t0)
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`] at line 17
+     #
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`] at line 17
+     #
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  3: $t5 := read_ref($t8)
+     # live vars: $t5
+     # refs: []
+     #
+  4: $t5 := dup($t5)
+     # live vars: $t5
+     # refs: []
+     #
+  5: $t9 := dup($t5)
+     # live vars: $t5, $t9
+     # refs: []
+     #
+  6: $t4 := +($t5, $t9)
+     # live vars: $t4
+     # refs: []
+     #
+  7: return $t4
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1, $t2, $t3
+     # refs: []
+     #
+  0: $t7 := borrow_local($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `arg1`] at line 17
+     #
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `arg1`, field `inner`] at line 17
+     #
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   => #8 via [local `arg1`, field `inner`, field `value`] at line 17
+     #
+  3: $t5 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t5
+     # refs: []
+     #
+  4: $t5 := dup($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t5
+     # refs: []
+     #
+  5: $t9 := dup($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t9
+     # refs: []
+     #
+  6: $t4 := +($t5, $t9)
+     # abort state: {returns}
+     # live vars: $t4
+     # refs: []
+     #
+  7: return $t4
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t5 := dup($t5)
+  5: $t9 := dup($t5)
+  6: $t4 := +($t5, $t9)
+  7: return $t4
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t5 := dup($t5)
+  5: $t9 := dup($t5)
+  6: $t4 := +($t5, $t9)
+  7: return $t4
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t5 := dup($t5)
+  5: $t9 := dup($t5)
+  6: $t4 := +($t5, $t9)
+  7: return $t4
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # maybe
+  0: $t7 := borrow_local($t0)
+     # maybe
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # maybe
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # maybe
+  3: $t5 := read_ref($t8)
+     # maybe
+  4: $t5 := dup($t5)
+     # maybe
+  5: $t9 := dup($t5)
+     # maybe
+  6: $t4 := +($t5, $t9)
+     # maybe
+  7: return $t4
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t5 := dup($t5)
+  5: $t9 := dup($t5)
+  6: $t4 := +($t5, $t9)
+  7: return $t4
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t5
+  4: $t5 := dup($t5)
+     # live vars: $t5
+  5: $t9 := dup($t5)
+     # live vars: $t5, $t9
+  6: $t4 := +($t5, $t9)
+     # live vars: $t4
+  7: return $t4
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t5 := read_ref($t8)
+  4: $t5 := dup($t5)
+  5: $t9 := dup($t5)
+  6: $t4 := +($t5, $t9)
+  7: return $t4
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64
+     var $t5: u64
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t8
+  3: $t5 := read_ref($t8)
+     # live vars: $t5
+  4: $t5 := dup($t5)
+     # live vars: $t5
+  5: $t9 := dup($t5)
+     # live vars: $t5, $t9
+  6: $t4 := +($t5, $t9)
+     # live vars: $t4
+  7: return $t4
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64 [unused]
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t1 := read_ref($t8)
+  4: $t1 := dup($t1)
+  5: $t2 := dup($t1)
+  6: $t1 := +($t1, $t2)
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64 [unused]
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t8
+  3: $t1 := read_ref($t8)
+     # live vars: $t1
+  4: $t1 := dup($t1)
+     # live vars: $t1
+  5: $t2 := dup($t1)
+     # live vars: $t1, $t2
+  6: $t1 := +($t1, $t2)
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64 [unused]
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+  0: $t7 := borrow_local($t0)
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+  3: $t1 := read_ref($t8)
+  4: $t1 := dup($t1)
+  5: $t2 := dup($t1)
+  6: $t1 := +($t1, $t2)
+  7: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64 [unused]
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # live vars: $t8
+  3: $t1 := read_ref($t8)
+     # live vars: $t1
+  4: $t1 := dup($t1)
+     # live vars: $t1
+  5: $t2 := dup($t1)
+     # live vars: $t1, $t2
+  6: $t1 := +($t1, $t2)
+     # live vars: $t1
+  7: return $t1
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FiledAccess::test_field_access($t0: 0x99::FiledAccess::Outer, $t1: u64, $t2: u64, $t3: u64): u64 {
+     var $t4: u64 [unused]
+     var $t5: u64 [unused]
+     var $t6: &0x99::FiledAccess::Inner
+     var $t7: &0x99::FiledAccess::Outer
+     var $t8: &u64
+     var $t9: u64 [unused]
+     var $t10: &0x99::FiledAccess::Inner [unused]
+     var $t11: &0x99::FiledAccess::Outer [unused]
+     var $t12: &u64 [unused]
+     # live vars: $t0, $t1, $t2, $t3
+  0: $t7 := borrow_local($t0)
+     # live vars: $t7
+  1: $t6 := borrow_field<0x99::FiledAccess::Outer>.inner($t7)
+     # live vars: $t6
+  2: $t8 := borrow_field<0x99::FiledAccess::Inner>.value($t6)
+     # flush: $t1
+     # live vars: $t8
+  3: $t1 := read_ref($t8)
+     # flush: $t1
+     # live vars: $t1
+  4: $t1 := dup($t1)
+     # live vars: $t1
+  5: $t2 := dup($t1)
+     # live vars: $t1, $t2
+  6: $t1 := +($t1, $t2)
+     # live vars: $t1
+  7: return $t1
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FiledAccess
+struct Inner has copy + drop
+  value: u64
+
+struct Outer has copy + drop
+  inner: Inner
+
+// Function definition at index 0
+fun test_field_access(l0: Outer, l1: u64, l2: u64, l3: u64): u64
+    borrow_loc l0
+    borrow_field Outer, inner
+    borrow_field Inner, value
+    read_ref
+    st_loc l1
+    // @5
+    copy_loc l1
+    copy_loc l1
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/function_call.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/function_call.move
@@ -1,0 +1,29 @@
+module 0x99::FunctionCall {
+    use std::vector;
+    use std::bit_vector;
+
+    fun foo(x: u64): u64 {
+        x + 1
+    }
+
+    fun foo_vec(): vector<u8> {
+        vector::empty<u8>()
+    }
+
+    // `foo(y)` can be reused
+    // perf_gain: 1 function call eliminated
+    // new_cost:
+    // - None
+    fun bar_optimal(y: u64): u64 {
+        let temp = foo(y);
+        temp + foo(y) + temp
+    }
+
+    // `foo_vec()` can be reused
+    // perf_gain: 1 function call eliminated
+    // new_cost: none
+    fun bar_vec(): vector<u8> {
+        foo_vec();
+        foo_vec()
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/function_call.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/function_call.off.exp
@@ -1,0 +1,48 @@
+
+Diagnostics:
+warning: unused alias
+  ┌─ tests/common-subexp-elimination/optimized/function_call.move:3:14
+  │
+3 │     use std::bit_vector;
+  │              ^^^^^^^^^^ Unused 'use' of alias 'bit_vector'. Consider removing it
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FunctionCall
+// Function definition at index 0
+fun bar_optimal(l0: u64): u64
+    local l1: u64
+    copy_loc l0
+    call foo
+    st_loc l1
+    copy_loc l1
+    move_loc l0
+    // @5
+    call foo
+    add
+    move_loc l1
+    add
+    ret
+
+// Function definition at index 1
+fun bar_vec(): vector<u8>
+    call foo_vec
+    pop
+    call foo_vec
+    ret
+
+// Function definition at index 2
+fun foo(l0: u64): u64
+    move_loc l0
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 3
+fun foo_vec(): vector<u8>
+    vec_pack <u8>, 0
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/function_call.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/function_call.on.exp
@@ -1,0 +1,2045 @@
+
+Diagnostics:
+warning: unused alias
+  ┌─ tests/common-subexp-elimination/optimized/function_call.move:3:14
+  │
+3 │     use std::bit_vector;
+  │              ^^^^^^^^^^ Unused 'use' of alias 'bit_vector'. Consider removing it
+
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := infer($t2)
+  2: $t5 := FunctionCall::foo($t0)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := FunctionCall::foo_vec()
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := infer($t2)
+  2: $t5 := FunctionCall::foo($t0)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := FunctionCall::foo_vec()
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := infer($t2)
+  2: $t5 := FunctionCall::foo($t0)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := FunctionCall::foo_vec()
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+     # refs: []
+     #
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+     # refs: []
+     #
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+     # refs: []
+     #
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+     # refs: []
+     #
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+     # refs: []
+     #
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := FunctionCall::foo($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  1: $t4 := infer($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t4
+     # refs: []
+     #
+  2: $t5 := FunctionCall::foo($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4, $t5
+     # refs: []
+     #
+  3: $t3 := +($t4, $t5)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  4: $t1 := +($t3, $t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := FunctionCall::foo_vec()
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  1: $t0 := FunctionCall::foo_vec()
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := copy($t2)
+  2: $t5 := FunctionCall::foo($t0)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := FunctionCall::foo_vec()
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := infer($t2)
+  2: $t5 := FunctionCall::foo($t0)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := FunctionCall::foo_vec()
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := infer($t2)
+  2: $t5 := FunctionCall::foo($t0)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := FunctionCall::foo_vec()
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # flush: $t2
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # flush: $t1
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # flush: $t2
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+     # refs: []
+     #
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+     # refs: []
+     #
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+     # refs: []
+     #
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # flush: $t1
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+     # refs: []
+     #
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+     # refs: []
+     #
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # flush: $t2
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t4 := infer($t2)
+     # live vars: $t0, $t2, $t4
+     # reaching instruction #2: `t2` @ {0}, `t4` @ {1}
+     # refs: []
+     #
+  2: $t5 := FunctionCall::foo($t0)
+     # live vars: $t2, $t4, $t5
+     # reaching instruction #3: `t2` @ {0}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+     # reaching instruction #4: `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+     # reaching instruction #5: `t1` @ {4}, `t2` @ {0}, `t3` @ {3}, `t4` @ {1}, `t5` @ {2}
+     # refs: []
+     #
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # flush: $t1
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars:
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: $t0 := FunctionCall::foo_vec()
+     # live vars: $t0
+     # reaching instruction #2: `t0` @ {1}, `t1` @ {0}
+     # refs: []
+     #
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # reaching instruction #2: `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t2` @ {0}, `t3` @ {1}
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # reaching instruction #1: `t0` @ {0}
+     # refs: []
+     #
+  1: return $t0
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := infer($t2)
+  2: $t5 := infer($t2)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := infer($t1)
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := infer($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t2
+  1: $t4 := infer($t2)
+     # live vars: $t2, $t4
+  2: $t5 := infer($t2)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars: $t1
+  1: $t0 := infer($t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := infer($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t4 := infer($t2)
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  2: $t5 := infer($t2)
+     # live vars: $t2, $t4, $t5
+     # refs: []
+     #
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+     # refs: []
+     #
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := infer($t1)
+     # live vars: $t0
+     # refs: []
+     #
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := FunctionCall::foo($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t4 := infer($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: []
+     #
+  2: $t5 := infer($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4, $t5
+     # refs: []
+     #
+  3: $t3 := +($t4, $t5)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  4: $t1 := +($t3, $t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := FunctionCall::foo_vec()
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := infer($t1)
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t2 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t3 := 1
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  2: $t1 := +($t2, $t3)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := copy($t2)
+  2: $t5 := copy($t2)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := move($t1)
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := copy($t2)
+  2: $t5 := copy($t2)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := move($t1)
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := copy($t2)
+  2: $t5 := copy($t2)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := move($t1)
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # maybe
+  0: $t2 := FunctionCall::foo($t0)
+     # maybe
+  1: $t4 := copy($t2)
+     # maybe
+  2: $t5 := copy($t2)
+     # maybe
+  3: $t3 := +($t4, $t5)
+     # maybe
+  4: $t1 := +($t3, $t2)
+     # maybe
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # maybe
+  0: $t1 := FunctionCall::foo_vec()
+     # maybe
+  1: $t0 := move($t1)
+     # maybe
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # maybe
+  0: $t2 := move($t0)
+     # maybe
+  1: $t3 := 1
+     # maybe
+  2: $t1 := +($t2, $t3)
+     # maybe
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # maybe
+  0: $t0 := vector::empty<u8>()
+     # maybe
+  1: return $t0
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := copy($t2)
+  2: $t5 := copy($t2)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := move($t1)
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t2
+  1: $t4 := copy($t2)
+     # live vars: $t2, $t4
+  2: $t5 := copy($t2)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars: $t1
+  1: $t0 := move($t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := move($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+  0: $t2 := FunctionCall::foo($t0)
+  1: $t4 := copy($t2)
+  2: $t5 := copy($t2)
+  3: $t3 := +($t4, $t5)
+  4: $t1 := +($t3, $t2)
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t0 := move($t1)
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+  0: $t2 := move($t0)
+  1: $t3 := 1
+  2: $t1 := +($t2, $t3)
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t2 := FunctionCall::foo($t0)
+     # live vars: $t2
+  1: $t4 := copy($t2)
+     # live vars: $t2, $t4
+  2: $t5 := copy($t2)
+     # live vars: $t2, $t4, $t5
+  3: $t3 := +($t4, $t5)
+     # live vars: $t2, $t3
+  4: $t1 := +($t3, $t2)
+     # live vars: $t1
+  5: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8>
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars: $t1
+  1: $t0 := move($t1)
+     # live vars: $t0
+  2: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64
+     var $t2: u64
+     var $t3: u64
+     # live vars: $t0
+  0: $t2 := move($t0)
+     # live vars: $t2
+  1: $t3 := 1
+     # live vars: $t2, $t3
+  2: $t1 := +($t2, $t3)
+     # live vars: $t1
+  3: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64
+  0: $t0 := FunctionCall::foo($t0)
+  1: $t4 := copy($t0)
+  2: $t5 := copy($t0)
+  3: $t4 := +($t4, $t5)
+  4: $t0 := +($t4, $t0)
+  5: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8> [unused]
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: $t1 := move($t1)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+  0: $t0 := move($t0)
+  1: $t3 := 1
+  2: $t0 := +($t0, $t3)
+  3: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t0 := FunctionCall::foo($t0)
+     # live vars: $t0
+  1: $t4 := copy($t0)
+     # live vars: $t0, $t4
+  2: $t5 := copy($t0)
+     # live vars: $t0, $t4, $t5
+  3: $t4 := +($t4, $t5)
+     # live vars: $t0, $t4
+  4: $t0 := +($t4, $t0)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8> [unused]
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars: $t1
+  1: $t1 := move($t1)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t3 := 1
+     # live vars: $t0, $t3
+  2: $t0 := +($t0, $t3)
+     # live vars: $t0
+  3: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64
+  0: $t0 := FunctionCall::foo($t0)
+  1: $t4 := copy($t0)
+  2: $t5 := copy($t0)
+  3: $t4 := +($t4, $t5)
+  4: $t0 := +($t4, $t0)
+  5: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8> [unused]
+     var $t1: vector<u8>
+  0: $t1 := FunctionCall::foo_vec()
+  1: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+  0: $t0 := move($t0)
+  1: $t3 := 1
+  2: $t0 := +($t0, $t3)
+  3: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t0 := FunctionCall::foo($t0)
+     # live vars: $t0
+  1: $t4 := copy($t0)
+     # live vars: $t0, $t4
+  2: $t5 := copy($t0)
+     # live vars: $t0, $t4, $t5
+  3: $t4 := +($t4, $t5)
+     # live vars: $t0, $t4
+  4: $t0 := +($t4, $t0)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8> [unused]
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t3 := 1
+     # live vars: $t0, $t3
+  2: $t0 := +($t0, $t3)
+     # live vars: $t0
+  3: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun FunctionCall::bar_optimal($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64 [unused]
+     var $t4: u64
+     var $t5: u64
+     # flush: $t0
+     # live vars: $t0
+  0: $t0 := FunctionCall::foo($t0)
+     # live vars: $t0
+  1: $t4 := copy($t0)
+     # live vars: $t0, $t4
+  2: $t5 := copy($t0)
+     # live vars: $t0, $t4, $t5
+  3: $t4 := +($t4, $t5)
+     # live vars: $t0, $t4
+  4: $t0 := +($t4, $t0)
+     # live vars: $t0
+  5: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::bar_vec(): vector<u8> {
+     var $t0: vector<u8> [unused]
+     var $t1: vector<u8>
+     # live vars:
+  0: $t1 := FunctionCall::foo_vec()
+     # live vars: $t1
+  1: return $t1
+}
+
+
+[variant baseline]
+fun FunctionCall::foo($t0: u64): u64 {
+     var $t1: u64 [unused]
+     var $t2: u64 [unused]
+     var $t3: u64
+     # live vars: $t0
+  0: $t0 := move($t0)
+     # live vars: $t0
+  1: $t3 := 1
+     # live vars: $t0, $t3
+  2: $t0 := +($t0, $t3)
+     # live vars: $t0
+  3: return $t0
+}
+
+
+[variant baseline]
+fun FunctionCall::foo_vec(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::FunctionCall
+// Function definition at index 0
+fun bar_optimal(l0: u64): u64
+    move_loc l0
+    call foo
+    st_loc l0
+    copy_loc l0
+    copy_loc l0
+    // @5
+    add
+    move_loc l0
+    add
+    ret
+
+// Function definition at index 1
+fun bar_vec(): vector<u8>
+    call foo_vec
+    ret
+
+// Function definition at index 2
+fun foo(l0: u64): u64
+    move_loc l0
+    ld_u64 1
+    add
+    ret
+
+// Function definition at index 3
+fun foo_vec(): vector<u8>
+    vec_pack <u8>, 0
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/global_access.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/global_access.move
@@ -1,0 +1,72 @@
+module 0x99::GlobalAccess {
+    use std::signer;
+    use std::vector;
+
+    struct S has key {
+        val: u64,
+    }
+
+    struct S1 has key, drop {
+        val: u64,
+    }
+
+    fun move_from_S1(account: &signer): S1 {
+        move_from<S1>(signer::address_of(account))
+    }
+
+    fun dummy_func(): vector<u8> {
+        vector::empty<u8>()
+    }
+
+    // `r1.val` can be reused
+    // perf_gain: 1 call to `address_of` + 1 `borrow_global` + 1 `borrow_field` + 1 `readref` eliminated (counted as 6 bytecodes in total)
+    // new_cost:
+    // - `r1.val` flushed and copied twice
+    // - the result of `r2.val` needs to be adjust on stack (one st_loc and one move_loc, counted as 2 bytecodes)
+    // - total 6 bytecodes added
+    fun test_global_borrow(account: &signer): u64 {
+        let r1 = borrow_global<S>(signer::address_of(account));
+        let r2 = borrow_global<S>(signer::address_of(account));
+        r1.val + r2.val
+    }
+
+    // `r1.val` can be reused
+    // performance gain same as `test_global_borrow`
+    fun test_global_borrow_v2(account: &signer): u64 {
+        let r1 = borrow_global<S>(signer::address_of(account));
+        move_from<S1>(signer::address_of(account));
+        let r2 = borrow_global<S>(signer::address_of(account));
+        r1.val + r2.val
+    }
+
+    // `r1.val` can be reused
+    // performance gain same as `test_global_borrow`
+    fun test_global_borrow_v3(account: &signer): u64 {
+        let r1 = borrow_global<S>(signer::address_of(account));
+        move_from_S1(account);
+        let r2 = borrow_global<S>(signer::address_of(account));
+        r1.val + r2.val
+    }
+
+    // `r1.val` can be reused
+    // performance gain same as `test_global_borrow`
+    fun test_global_borrow_v4(account: &signer): u64 {
+        let r1 = borrow_global<S>(signer::address_of(account));
+        dummy_func();
+        let r2 = borrow_global<S>(signer::address_of(account));
+        r1.val + r2.val
+    }
+
+    // `signer::address_of(account)` and `exists<S>(signer::address_of(account))` can be reused
+    // perf_gain: two calls to `address_of` + one call to `exists` eliminated (counted as 9 bytecodes in total)
+    // new_cost:
+    // - result of `address_of` flushed and copied three times (counted as 4 bytecodes in total)
+    // - result of first `exists` copied twice (counted as 3 bytecode in total)
+    // - `b2` needs to be adjusted on stack (one st_loc and one move_loc, counted as 2 bytecodes)
+    fun test_existence_check(account: &signer): bool {
+        let b1 = exists<S>(signer::address_of(account));
+        borrow_global<S>(signer::address_of(account));
+        let b2 = exists<S>(signer::address_of(account));
+        b1 && b2
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/global_access.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/global_access.off.exp
@@ -1,0 +1,141 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::GlobalAccess
+use 0x1::signer
+struct S has key
+  val: u64
+
+struct S1 has drop + key
+  val: u64
+
+// Function definition at index 0
+fun dummy_func(): vector<u8>
+    vec_pack <u8>, 0
+    ret
+
+// Function definition at index 1
+fun move_from_S1(l0: &signer): S1 acquires S1
+    move_loc l0
+    call signer::address_of
+    move_from S1
+    ret
+
+// Function definition at index 2
+fun test_existence_check(l0: &signer): bool acquires S
+    local l1: &S
+    local l2: bool
+    copy_loc l0
+    call signer::address_of
+    exists S
+    copy_loc l0
+    call signer::address_of
+    // @5
+    borrow_global S
+    pop
+    move_loc l0
+    call signer::address_of
+    exists S
+    // @10
+    st_loc l2
+    br_false l0
+    move_loc l2
+    ret
+l0: ld_false
+    // @15
+    ret
+
+// Function definition at index 3
+fun test_global_borrow(l0: &signer): u64 acquires S
+    local l1: &S
+    copy_loc l0
+    call signer::address_of
+    borrow_global S
+    move_loc l0
+    call signer::address_of
+    // @5
+    borrow_global S
+    st_loc l1
+    borrow_field S, val
+    read_ref
+    move_loc l1
+    // @10
+    borrow_field S, val
+    read_ref
+    add
+    ret
+
+// Function definition at index 4
+fun test_global_borrow_v2(l0: &signer): u64 acquires S, S1
+    local l1: &S
+    copy_loc l0
+    call signer::address_of
+    borrow_global S
+    copy_loc l0
+    call signer::address_of
+    // @5
+    move_from S1
+    pop
+    move_loc l0
+    call signer::address_of
+    borrow_global S
+    // @10
+    st_loc l1
+    borrow_field S, val
+    read_ref
+    move_loc l1
+    borrow_field S, val
+    // @15
+    read_ref
+    add
+    ret
+
+// Function definition at index 5
+fun test_global_borrow_v3(l0: &signer): u64 acquires S, S1
+    local l1: &S
+    copy_loc l0
+    call signer::address_of
+    borrow_global S
+    copy_loc l0
+    call move_from_S1
+    // @5
+    pop
+    move_loc l0
+    call signer::address_of
+    borrow_global S
+    st_loc l1
+    // @10
+    borrow_field S, val
+    read_ref
+    move_loc l1
+    borrow_field S, val
+    read_ref
+    // @15
+    add
+    ret
+
+// Function definition at index 6
+fun test_global_borrow_v4(l0: &signer): u64 acquires S
+    local l1: &S
+    copy_loc l0
+    call signer::address_of
+    borrow_global S
+    call dummy_func
+    pop
+    // @5
+    move_loc l0
+    call signer::address_of
+    borrow_global S
+    st_loc l1
+    borrow_field S, val
+    // @10
+    read_ref
+    move_loc l1
+    borrow_field S, val
+    read_ref
+    add
+    // @15
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/global_access.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/global_access.on.exp
@@ -1,0 +1,7828 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+  6: if ($t2) goto 7 else goto 10
+  7: label L0
+  8: $t1 := infer($t6)
+  9: goto 12
+ 10: label L1
+ 11: $t1 := false
+ 12: label L2
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  5: $t6 := read_ref($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t8 := read_ref($t9)
+  8: $t1 := +($t6, $t8)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  7: $t8 := read_ref($t9)
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+  9: $t10 := read_ref($t11)
+ 10: $t1 := +($t8, $t10)
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+  6: if ($t2) goto 7 else goto 10
+  7: label L0
+  8: $t1 := infer($t6)
+  9: goto 12
+ 10: label L1
+ 11: $t1 := false
+ 12: label L2
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  5: $t6 := read_ref($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t8 := read_ref($t9)
+  8: $t1 := +($t6, $t8)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  7: $t8 := read_ref($t9)
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+  9: $t10 := read_ref($t11)
+ 10: $t1 := +($t8, $t10)
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+  6: if ($t2) goto 7 else goto 10
+  7: label L0
+  8: $t1 := infer($t6)
+  9: goto 12
+ 10: label L1
+ 11: $t1 := false
+ 12: label L2
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  5: $t6 := read_ref($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t8 := read_ref($t9)
+  8: $t1 := +($t6, $t8)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  7: $t8 := read_ref($t9)
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+  9: $t10 := read_ref($t11)
+ 10: $t1 := +($t8, $t10)
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+  7: label L0
+     # live vars: $t6
+  8: $t1 := infer($t6)
+     # live vars: $t1
+  9: goto 12
+     # live vars: $t6
+ 10: label L1
+     # live vars:
+ 11: $t1 := false
+     # live vars: $t1
+ 12: label L2
+     # live vars: $t1
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+  7: label L0
+     # live vars: $t6
+  8: $t1 := infer($t6)
+     # live vars: $t1
+  9: goto 12
+     # live vars: $t6
+ 10: label L1
+     # live vars:
+ 11: $t1 := false
+     # live vars: $t1
+ 12: label L2
+     # live vars: $t1
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+  7: label L0
+     # live vars: $t6
+  8: $t1 := infer($t6)
+     # live vars: $t1
+  9: goto 12
+     # live vars: $t6
+ 10: label L1
+     # live vars:
+ 11: $t1 := false
+     # live vars: $t1
+ 12: label L2
+     # live vars: $t1
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+     # refs: []
+     #
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+     # refs: []
+     #
+  7: label L0
+     # live vars: $t6
+     # refs: []
+     #
+  8: $t1 := infer($t6)
+     # live vars: $t1
+     # refs: []
+     #
+  9: goto 12
+     # live vars: $t6
+     # refs: []
+     #
+ 10: label L1
+     # live vars:
+     # refs: []
+     #
+ 11: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+     # refs: [$t2 => #2, $t4 => #4]
+     # #2
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+     # refs: [$t4 => #4, $t7 => #7]
+     # #4
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #   -> #7 via [struct `GlobalAccess::S`] at line 30
+     #
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #9 via [struct `GlobalAccess::S`] at line 30
+     #
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+     # refs: []
+     #
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2, $t6 => #6]
+     # #2
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+     # refs: [$t6 => #6, $t9 => #9]
+     # #6
+     #   <no edges>
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #   -> #9 via [struct `GlobalAccess::S`] at line 39
+     #
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   -> #11 via [struct `GlobalAccess::S`] at line 39
+     #
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+     # refs: []
+     #
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #   -> #8 via [struct `GlobalAccess::S`] at line 48
+     #
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 48
+     #
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #   -> #8 via [struct `GlobalAccess::S`] at line 57
+     #
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 57
+     #
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t5 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t5
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := signer::address_of($t0)
+     # abort state: {returns}
+     # live vars: $t2, $t7
+     # refs: []
+     #
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # abort state: {returns}
+     # live vars: $t2, $t6
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 10
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: []
+     #
+  7: label L0
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: []
+     #
+  8: $t1 := infer($t6)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  9: goto 12
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: []
+     #
+ 10: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 11: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 12: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  2: $t5 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t4
+     # refs: [$t2 => #2, $t4 => #4]
+     # #2
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t7
+     # refs: [$t4 => #4, $t7 => #7]
+     # #4
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #   -> #7 via [struct `GlobalAccess::S`] at line 30
+     #
+  5: $t6 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #9 via [struct `GlobalAccess::S`] at line 30
+     #
+  7: $t8 := read_ref($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t8
+     # refs: []
+     #
+  8: $t1 := +($t6, $t8)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  2: $t5 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2, $t5
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  4: $t7 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t7
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2, $t6 => #6]
+     # #2
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t9
+     # refs: [$t6 => #6, $t9 => #9]
+     # #6
+     #   <no edges>
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #   -> #9 via [struct `GlobalAccess::S`] at line 39
+     #
+  7: $t8 := read_ref($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t8
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t8, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   -> #11 via [struct `GlobalAccess::S`] at line 39
+     #
+  9: $t10 := read_ref($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t8, $t10
+     # refs: []
+     #
+ 10: $t1 := +($t8, $t10)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  3: $t6 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t8
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #   -> #8 via [struct `GlobalAccess::S`] at line 48
+     #
+  6: $t7 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 48
+     #
+  8: $t9 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  2: $t4 := GlobalAccess::dummy_func()
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  3: $t6 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t8
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #   -> #8 via [struct `GlobalAccess::S`] at line 57
+     #
+  6: $t7 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 57
+     #
+  8: $t9 := read_ref($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: drop($t4)
+  5: $t7 := signer::address_of($t0)
+  6: $t6 := exists<0x99::GlobalAccess::S>($t7)
+  7: if ($t2) goto 8 else goto 11
+  8: label L0
+  9: $t1 := move($t6)
+ 10: goto 13
+ 11: label L1
+ 12: $t1 := false
+ 13: label L2
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  5: $t6 := read_ref($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t8 := read_ref($t9)
+  8: $t1 := +($t6, $t8)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  7: $t8 := read_ref($t9)
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+  9: $t10 := read_ref($t11)
+ 10: $t1 := +($t8, $t10)
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+  6: if ($t2) goto 7 else goto 10
+  7: label L0
+  8: $t1 := infer($t6)
+  9: goto 12
+ 10: label L1
+ 11: $t1 := false
+ 12: label L2
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  5: $t6 := read_ref($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t8 := read_ref($t9)
+  8: $t1 := +($t6, $t8)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  7: $t8 := read_ref($t9)
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+  9: $t10 := read_ref($t11)
+ 10: $t1 := +($t8, $t10)
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+  6: if ($t2) goto 7 else goto 10
+  7: label L0
+  8: $t1 := infer($t6)
+  9: goto 12
+ 10: label L1
+ 11: $t1 := false
+ 12: label L2
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  5: $t6 := read_ref($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+  7: $t8 := read_ref($t9)
+  8: $t1 := +($t6, $t8)
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t5 := signer::address_of($t0)
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  4: $t7 := signer::address_of($t0)
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  7: $t8 := read_ref($t9)
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+  9: $t10 := read_ref($t11)
+ 10: $t1 := +($t8, $t10)
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t6 := signer::address_of($t0)
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t7 := read_ref($t8)
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+  8: $t9 := read_ref($t10)
+  9: $t1 := +($t7, $t9)
+ 10: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+  7: label L0
+     # live vars: $t6
+  8: $t1 := infer($t6)
+     # live vars: $t1
+  9: goto 12
+     # live vars: $t6
+ 10: label L1
+     # live vars:
+ 11: $t1 := false
+     # live vars: $t1
+ 12: label L2
+     # live vars: $t1
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # live vars: $t0, $t2, $t5
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # live vars: $t2, $t7
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t0, $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # flush: $t6
+     # live vars: $t2, $t7
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+  7: label L0
+     # flush: $t1
+     # live vars: $t6
+  8: $t1 := infer($t6)
+     # live vars: $t1
+  9: goto 12
+     # live vars: $t6
+ 10: label L1
+     # flush: $t1
+     # live vars:
+ 11: $t1 := false
+     # live vars: $t1
+ 12: label L2
+     # live vars: $t1
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t2, $t5
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t0, $t2, $t5
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+  4: $t7 := signer::address_of($t0)
+     # flush: $t6
+     # live vars: $t2, $t7
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # flush: $t5
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+  3: $t6 := signer::address_of($t0)
+     # flush: $t5
+     # live vars: $t2, $t6
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+ 10: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t0, $t2, $t5
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := signer::address_of($t0)
+     # flush: $t6
+     # live vars: $t2, $t7
+     # refs: []
+     #
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+     # refs: []
+     #
+  7: label L0
+     # flush: $t1
+     # live vars: $t6
+     # refs: []
+     #
+  8: $t1 := infer($t6)
+     # live vars: $t1
+     # refs: []
+     #
+  9: goto 12
+     # live vars: $t6
+     # refs: []
+     #
+ 10: label L1
+     # flush: $t1
+     # live vars:
+     # refs: []
+     #
+ 11: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+     # refs: [$t2 => #2, $t4 => #4]
+     # #2
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+     # refs: [$t4 => #4, $t7 => #7]
+     # #4
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #   -> #7 via [struct `GlobalAccess::S`] at line 30
+     #
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #9 via [struct `GlobalAccess::S`] at line 30
+     #
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+     # refs: []
+     #
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+     # refs: []
+     #
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t0, $t2, $t5
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  4: $t7 := signer::address_of($t0)
+     # flush: $t6
+     # live vars: $t2, $t7
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2, $t6 => #6]
+     # #2
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+     # refs: [$t6 => #6, $t9 => #9]
+     # #6
+     #   <no edges>
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #   -> #9 via [struct `GlobalAccess::S`] at line 39
+     #
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   -> #11 via [struct `GlobalAccess::S`] at line 39
+     #
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+     # refs: []
+     #
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  3: $t6 := signer::address_of($t0)
+     # flush: $t5
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #   -> #8 via [struct `GlobalAccess::S`] at line 48
+     #
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 48
+     #
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  3: $t6 := signer::address_of($t0)
+     # flush: $t5
+     # live vars: $t2, $t6
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #   -> #8 via [struct `GlobalAccess::S`] at line 57
+     #
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 57
+     #
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # reaching instruction #1: `t0` @ {0}
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+     # reaching instruction #2: `t1` @ {1}, `t2` @ {0}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {1}
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # reaching instruction #2: `t2` @ {1}, `t3` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t0, $t2, $t5
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {0}, `t5` @ {2}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t0, $t2
+     # reaching instruction #4: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := signer::address_of($t0)
+     # flush: $t6
+     # live vars: $t2, $t7
+     # reaching instruction #5: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t7` @ {4}
+     # refs: []
+     #
+  5: $t6 := exists<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+     # reaching instruction #6: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 10
+     # live vars: $t6
+     # reaching instruction #7: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+  7: label L0
+     # flush: $t1
+     # live vars: $t6
+     # reaching instruction #8: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+  8: $t1 := infer($t6)
+     # live vars: $t1
+     # reaching instruction #9: `t1` @ {8}, `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t7` @ {4}
+     # refs: []
+     #
+  9: goto 12
+     # live vars: $t6
+     # reaching instruction #10: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+ 10: label L1
+     # flush: $t1
+     # live vars:
+     # reaching instruction #11: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+ 11: $t1 := false
+     # live vars: $t1
+     # reaching instruction #12: `t1` @ {8, 11}, `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t1
+     # reaching instruction #13: `t1` @ {8, 11}, `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+ 13: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # reaching instruction #2: `t2` @ {1}, `t3` @ {0}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t2, $t5
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {0}, `t5` @ {2}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  3: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+     # reaching instruction #4: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}
+     # refs: [$t2 => #2, $t4 => #4]
+     # #2
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  4: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t4, $t7
+     # reaching instruction #5: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t7` @ {4}
+     # refs: [$t4 => #4, $t7 => #7]
+     # #4
+     #   <no edges>
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #   -> #7 via [struct `GlobalAccess::S`] at line 30
+     #
+  5: $t6 := read_ref($t7)
+     # live vars: $t4, $t6
+     # reaching instruction #6: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `GlobalAccess::S`] at line 29
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t4)
+     # live vars: $t6, $t9
+     # reaching instruction #7: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t9` @ {6}
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #9 via [struct `GlobalAccess::S`] at line 30
+     #
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+     # reaching instruction #8: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t8` @ {7}, `t9` @ {6}
+     # refs: []
+     #
+  8: $t1 := +($t6, $t8)
+     # live vars: $t1
+     # reaching instruction #9: `t1` @ {8}, `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t8` @ {7}, `t9` @ {6}
+     # refs: []
+     #
+  9: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S
+     var $t7: address
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # reaching instruction #2: `t2` @ {1}, `t3` @ {0}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  2: $t5 := signer::address_of($t0)
+     # flush: $t4
+     # live vars: $t0, $t2, $t5
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {0}, `t5` @ {2}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  3: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t0, $t2
+     # reaching instruction #4: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  4: $t7 := signer::address_of($t0)
+     # flush: $t6
+     # live vars: $t2, $t7
+     # reaching instruction #5: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t6 := borrow_global<0x99::GlobalAccess::S>($t7)
+     # live vars: $t2, $t6
+     # reaching instruction #6: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: [$t2 => #2, $t6 => #6]
+     # #2
+     #   <no edges>
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  6: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t6, $t9
+     # reaching instruction #7: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t9` @ {6}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: [$t6 => #6, $t9 => #9]
+     # #6
+     #   <no edges>
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #   -> #9 via [struct `GlobalAccess::S`] at line 39
+     #
+  7: $t8 := read_ref($t9)
+     # live vars: $t6, $t8
+     # reaching instruction #8: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t8` @ {7}, `t9` @ {6}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   -> #6 via [struct `GlobalAccess::S`] at line 38
+     #
+  8: $t11 := borrow_field<0x99::GlobalAccess::S>.val($t6)
+     # live vars: $t8, $t11
+     # reaching instruction #9: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t8` @ {7}, `t9` @ {6}, `t11` @ {8}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: [$t11 => #11]
+     # #11
+     #   <no edges>
+     # #root
+     #   -> #11 via [struct `GlobalAccess::S`] at line 39
+     #
+  9: $t10 := read_ref($t11)
+     # live vars: $t8, $t10
+     # reaching instruction #10: `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t8` @ {7}, `t9` @ {6}, `t10` @ {9}, `t11` @ {8}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: []
+     #
+ 10: $t1 := +($t8, $t10)
+     # live vars: $t1
+     # reaching instruction #11: `t1` @ {10}, `t2` @ {1}, `t3` @ {0}, `t4` @ {3}, `t5` @ {2}, `t6` @ {5}, `t7` @ {4}, `t8` @ {7}, `t9` @ {6}, `t10` @ {9}, `t11` @ {8}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {3}
+     # refs: []
+     #
+ 11: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t0, $t2
+     # reaching instruction #2: `t2` @ {1}, `t3` @ {0}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t0, $t2
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  3: $t6 := signer::address_of($t0)
+     # flush: $t5
+     # live vars: $t2, $t6
+     # reaching instruction #4: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t6` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+     # reaching instruction #5: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+     # reaching instruction #6: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t8` @ {5}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #   -> #8 via [struct `GlobalAccess::S`] at line 48
+     #
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # reaching instruction #7: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 47
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+     # reaching instruction #8: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}, `t10` @ {7}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 48
+     #
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+     # reaching instruction #9: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}, `t9` @ {8}, `t10` @ {7}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # reaching instruction #10: `t1` @ {9}, `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}, `t9` @ {8}, `t10` @ {7}, `Struct QualifiedId { module_id: ModuleId(2), id: StructId(Symbol(141)) }` @ {2}
+     # refs: []
+     #
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S
+     var $t6: address
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t0, $t2
+     # reaching instruction #2: `t2` @ {1}, `t3` @ {0}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t0, $t2
+     # reaching instruction #3: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  3: $t6 := signer::address_of($t0)
+     # flush: $t5
+     # live vars: $t2, $t6
+     # reaching instruction #4: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t6` @ {3}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  4: $t5 := borrow_global<0x99::GlobalAccess::S>($t6)
+     # live vars: $t2, $t5
+     # reaching instruction #5: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}
+     # refs: [$t2 => #2, $t5 => #5]
+     # #2
+     #   <no edges>
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  5: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t5, $t8
+     # reaching instruction #6: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t8` @ {5}
+     # refs: [$t5 => #5, $t8 => #8]
+     # #5
+     #   <no edges>
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #   -> #8 via [struct `GlobalAccess::S`] at line 57
+     #
+  6: $t7 := read_ref($t8)
+     # live vars: $t5, $t7
+     # reaching instruction #7: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   -> #5 via [struct `GlobalAccess::S`] at line 56
+     #
+  7: $t10 := borrow_field<0x99::GlobalAccess::S>.val($t5)
+     # live vars: $t7, $t10
+     # reaching instruction #8: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}, `t10` @ {7}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `GlobalAccess::S`] at line 57
+     #
+  8: $t9 := read_ref($t10)
+     # live vars: $t7, $t9
+     # reaching instruction #9: `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}, `t9` @ {8}, `t10` @ {7}
+     # refs: []
+     #
+  9: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # reaching instruction #10: `t1` @ {9}, `t2` @ {1}, `t3` @ {0}, `t4` @ {2}, `t5` @ {4}, `t6` @ {3}, `t7` @ {6}, `t8` @ {5}, `t9` @ {8}, `t10` @ {7}
+     # refs: []
+     #
+ 10: return $t1
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t5 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  6: $t6 := dup($t2)
+  7: if ($t2) goto 8 else goto 11
+  8: label L0
+  9: $t1 := infer($t6)
+ 10: goto 13
+ 11: label L1
+ 12: $t1 := false
+ 13: label L2
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t1 := +($t6, $t8)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t5 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t1 := +($t8, $t10)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t2 := dup($t2)
+     # live vars: $t2, $t3
+  4: $t5 := dup($t3)
+     # live vars: $t2, $t5
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2
+  6: $t6 := dup($t2)
+     # live vars: $t2, $t6
+  7: if ($t2) goto 8 else goto 11
+     # live vars: $t6
+  8: label L0
+     # live vars: $t6
+  9: $t1 := infer($t6)
+     # live vars: $t1
+ 10: goto 13
+     # live vars: $t6
+ 11: label L1
+     # live vars:
+ 12: $t1 := false
+     # live vars: $t1
+ 13: label L2
+     # live vars: $t1
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t7
+  3: $t6 := read_ref($t7)
+     # live vars: $t6
+  4: $t6 := dup($t6)
+     # live vars: $t6
+  5: $t8 := dup($t6)
+     # live vars: $t6, $t8
+  6: $t1 := +($t6, $t8)
+     # live vars: $t1
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t5 := dup($t3)
+     # live vars: $t2, $t5
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t2
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t9
+  6: $t8 := read_ref($t9)
+     # live vars: $t8
+  7: $t8 := dup($t8)
+     # live vars: $t8
+  8: $t10 := dup($t8)
+     # live vars: $t8, $t10
+  9: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+  8: return $t1
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t3 := dup($t3)
+     # live vars: $t3
+     # refs: []
+     #
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t2 := dup($t2)
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  4: $t5 := dup($t3)
+     # live vars: $t2, $t5
+     # refs: []
+     #
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2
+     # refs: []
+     #
+  6: $t6 := dup($t2)
+     # live vars: $t2, $t6
+     # refs: []
+     #
+  7: if ($t2) goto 8 else goto 11
+     # live vars: $t6
+     # refs: []
+     #
+  8: label L0
+     # live vars: $t6
+     # refs: []
+     #
+  9: $t1 := infer($t6)
+     # live vars: $t1
+     # refs: []
+     #
+ 10: goto 13
+     # live vars: $t6
+     # refs: []
+     #
+ 11: label L1
+     # live vars:
+     # refs: []
+     #
+ 12: $t1 := false
+     # live vars: $t1
+     # refs: []
+     #
+ 13: label L2
+     # live vars: $t1
+     # refs: []
+     #
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #7 via [struct `GlobalAccess::S`] at line 30
+     #
+  3: $t6 := read_ref($t7)
+     # live vars: $t6
+     # refs: []
+     #
+  4: $t6 := dup($t6)
+     # live vars: $t6
+     # refs: []
+     #
+  5: $t8 := dup($t6)
+     # live vars: $t6, $t8
+     # refs: []
+     #
+  6: $t1 := +($t6, $t8)
+     # live vars: $t1
+     # refs: []
+     #
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t3 := dup($t3)
+     # live vars: $t3
+     # refs: []
+     #
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  3: $t5 := dup($t3)
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #9 via [struct `GlobalAccess::S`] at line 39
+     #
+  6: $t8 := read_ref($t9)
+     # live vars: $t8
+     # refs: []
+     #
+  7: $t8 := dup($t8)
+     # live vars: $t8
+     # refs: []
+     #
+  8: $t10 := dup($t8)
+     # live vars: $t8, $t10
+     # refs: []
+     #
+  9: $t1 := +($t8, $t10)
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 48
+     #
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+     # refs: []
+     #
+  5: $t7 := dup($t7)
+     # live vars: $t7
+     # refs: []
+     #
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # refs: []
+     #
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 57
+     #
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+     # refs: []
+     #
+  5: $t7 := dup($t7)
+     # live vars: $t7
+     # refs: []
+     #
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+     # refs: []
+     #
+  8: return $t1
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t0 := vector::empty<u8>()
+     # abort state: {returns}
+     # live vars: $t0
+     # refs: []
+     #
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t2 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: []
+     #
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t3 := dup($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t3
+     # refs: []
+     #
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  3: $t2 := dup($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: []
+     #
+  4: $t5 := dup($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5
+     # refs: []
+     #
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  6: $t6 := dup($t2)
+     # abort state: {returns}
+     # live vars: $t2, $t6
+     # refs: []
+     #
+  7: if ($t2) goto 8 else goto 11
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: []
+     #
+  8: label L0
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: []
+     #
+  9: $t1 := infer($t6)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: goto 13
+     # abort state: {returns}
+     # live vars: $t6
+     # refs: []
+     #
+ 11: label L1
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 12: $t1 := false
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 13: label L2
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 28
+     #
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   -> #7 via [struct `GlobalAccess::S`] at line 30
+     #
+  3: $t6 := read_ref($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t6
+     # refs: []
+     #
+  4: $t6 := dup($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t6
+     # refs: []
+     #
+  5: $t8 := dup($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t6, $t8
+     # refs: []
+     #
+  6: $t1 := +($t6, $t8)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t3 := dup($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t3
+     # refs: []
+     #
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t3
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  3: $t5 := dup($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 36
+     #
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t9
+     # refs: [$t9 => #9]
+     # #9
+     #   <no edges>
+     # #root
+     #   -> #9 via [struct `GlobalAccess::S`] at line 39
+     #
+  6: $t8 := read_ref($t9)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # refs: []
+     #
+  7: $t8 := dup($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # refs: []
+     #
+  8: $t10 := dup($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t8, $t10
+     # refs: []
+     #
+  9: $t1 := +($t8, $t10)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0, $t2 => #2]
+     # #0
+     #   <no edges>
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 45
+     #
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 48
+     #
+  4: $t7 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t7
+     # refs: []
+     #
+  5: $t7 := dup($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t7
+     # refs: []
+     #
+  6: $t9 := dup($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  7: $t1 := +($t7, $t9)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := signer::address_of($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t3
+     # refs: []
+     #
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  2: $t4 := GlobalAccess::dummy_func()
+     # abort state: {returns,aborts}
+     # live vars: $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> #2 via [struct `GlobalAccess::S`] at line 54
+     #
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # refs: [$t8 => #8]
+     # #8
+     #   <no edges>
+     # #root
+     #   -> #8 via [struct `GlobalAccess::S`] at line 57
+     #
+  4: $t7 := read_ref($t8)
+     # abort state: {returns,aborts}
+     # live vars: $t7
+     # refs: []
+     #
+  5: $t7 := dup($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t7
+     # refs: []
+     #
+  6: $t9 := dup($t7)
+     # abort state: {returns,aborts}
+     # live vars: $t7, $t9
+     # refs: []
+     #
+  7: $t1 := +($t7, $t9)
+     # abort state: {returns}
+     # live vars: $t1
+     # refs: []
+     #
+  8: return $t1
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t5 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  6: drop($t4)
+  7: $t6 := dup($t2)
+  8: if ($t2) goto 9 else goto 12
+  9: label L0
+ 10: $t1 := move($t6)
+ 11: goto 14
+ 12: label L1
+ 13: $t1 := false
+ 14: label L2
+ 15: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t1 := +($t6, $t8)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t5 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t1 := +($t8, $t10)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t5 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  6: drop($t4)
+  7: $t6 := dup($t2)
+  8: if ($t2) goto 9 else goto 12
+  9: label L0
+ 10: $t1 := move($t6)
+ 11: return $t1
+ 12: label L1
+ 13: $t1 := false
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t1 := +($t6, $t8)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t5 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t1 := +($t8, $t10)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t5 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  6: drop($t4)
+  7: $t6 := dup($t2)
+  8: if ($t2) goto 9 else goto 12
+  9: label L0
+ 10: $t1 := move($t6)
+ 11: return $t1
+ 12: label L1
+ 13: $t1 := false
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t1 := +($t6, $t8)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t5 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t1 := +($t8, $t10)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # maybe
+  0: $t0 := vector::empty<u8>()
+     # maybe
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # maybe
+  0: $t2 := signer::address_of($t0)
+     # maybe
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # maybe
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+     # maybe
+  0: $t3 := signer::address_of($t0)
+     # maybe
+  1: $t3 := dup($t3)
+     # maybe
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # maybe
+  3: $t2 := dup($t2)
+     # maybe
+  4: $t5 := dup($t3)
+     # maybe
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # maybe
+  6: drop($t4)
+     # maybe
+  7: $t6 := dup($t2)
+     # maybe
+  8: if ($t2) goto 9 else goto 12
+     # maybe
+  9: label L0
+     # maybe
+ 10: $t1 := move($t6)
+     # maybe
+ 11: return $t1
+     # maybe
+ 12: label L1
+     # maybe
+ 13: $t1 := false
+     # maybe
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # maybe
+  0: $t3 := signer::address_of($t0)
+     # maybe
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # maybe
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # maybe
+  3: $t6 := read_ref($t7)
+     # maybe
+  4: $t6 := dup($t6)
+     # maybe
+  5: $t8 := dup($t6)
+     # maybe
+  6: $t1 := +($t6, $t8)
+     # maybe
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # maybe
+  0: $t3 := signer::address_of($t0)
+     # maybe
+  1: $t3 := dup($t3)
+     # maybe
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # maybe
+  3: $t5 := dup($t3)
+     # maybe
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # maybe
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # maybe
+  6: $t8 := read_ref($t9)
+     # maybe
+  7: $t8 := dup($t8)
+     # maybe
+  8: $t10 := dup($t8)
+     # maybe
+  9: $t1 := +($t8, $t10)
+     # maybe
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # maybe
+  0: $t3 := signer::address_of($t0)
+     # maybe
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # maybe
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # maybe
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # maybe
+  4: $t7 := read_ref($t8)
+     # maybe
+  5: $t7 := dup($t7)
+     # maybe
+  6: $t9 := dup($t7)
+     # maybe
+  7: $t1 := +($t7, $t9)
+     # maybe
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # maybe
+  0: $t3 := signer::address_of($t0)
+     # maybe
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # maybe
+  2: $t4 := GlobalAccess::dummy_func()
+     # maybe
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # maybe
+  4: $t7 := read_ref($t8)
+     # maybe
+  5: $t7 := dup($t7)
+     # maybe
+  6: $t9 := dup($t7)
+     # maybe
+  7: $t1 := +($t7, $t9)
+     # maybe
+  8: return $t1
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t5 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  6: drop($t4)
+  7: $t6 := dup($t2)
+  8: if ($t2) goto 9 else goto 12
+  9: label L0
+ 10: $t1 := move($t6)
+ 11: return $t1
+ 12: label L1
+ 13: $t1 := false
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t1 := +($t6, $t8)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t5 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t1 := +($t8, $t10)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t2 := dup($t2)
+     # live vars: $t2, $t3
+  4: $t5 := dup($t3)
+     # live vars: $t2, $t5
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+  6: drop($t4)
+     # live vars: $t2
+  7: $t6 := dup($t2)
+     # live vars: $t2, $t6
+  8: if ($t2) goto 9 else goto 12
+     # live vars: $t6
+  9: label L0
+     # live vars: $t6
+ 10: $t1 := move($t6)
+     # live vars: $t1
+ 11: return $t1
+     # live vars: $t6
+ 12: label L1
+     # live vars:
+ 13: $t1 := false
+     # live vars: $t1
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t7
+  3: $t6 := read_ref($t7)
+     # live vars: $t6
+  4: $t6 := dup($t6)
+     # live vars: $t6
+  5: $t8 := dup($t6)
+     # live vars: $t6, $t8
+  6: $t1 := +($t6, $t8)
+     # live vars: $t1
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t5 := dup($t3)
+     # live vars: $t2, $t5
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t2
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t9
+  6: $t8 := read_ref($t9)
+     # live vars: $t8
+  7: $t8 := dup($t8)
+     # live vars: $t8
+  8: $t10 := dup($t8)
+     # live vars: $t8, $t10
+  9: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+  8: return $t1
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t5 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+  6: drop($t4)
+  7: $t6 := dup($t2)
+  8: if ($t2) goto 9 else goto 12
+  9: label L0
+ 10: $t1 := move($t6)
+ 11: return $t1
+ 12: label L1
+ 13: $t1 := false
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t1 := +($t6, $t8)
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t5 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t1 := +($t8, $t10)
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t1 := +($t7, $t9)
+  8: return $t1
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address
+     var $t6: bool
+     var $t7: address [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t2 := dup($t2)
+     # live vars: $t2, $t3
+  4: $t5 := dup($t3)
+     # live vars: $t2, $t5
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t5)
+     # live vars: $t2, $t4
+  6: drop($t4)
+     # live vars: $t2
+  7: $t6 := dup($t2)
+     # live vars: $t2, $t6
+  8: if ($t2) goto 9 else goto 12
+     # live vars: $t6
+  9: label L0
+     # live vars: $t6
+ 10: $t1 := move($t6)
+     # live vars: $t1
+ 11: return $t1
+     # live vars: $t6
+ 12: label L1
+     # live vars:
+ 13: $t1 := false
+     # live vars: $t1
+ 14: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t7
+  3: $t6 := read_ref($t7)
+     # live vars: $t6
+  4: $t6 := dup($t6)
+     # live vars: $t6
+  5: $t8 := dup($t6)
+     # live vars: $t6, $t8
+  6: $t1 := +($t6, $t8)
+     # live vars: $t1
+  7: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t5 := dup($t3)
+     # live vars: $t2, $t5
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t5)
+     # live vars: $t2
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t9
+  6: $t8 := read_ref($t9)
+     # live vars: $t8
+  7: $t8 := dup($t8)
+     # live vars: $t8
+  8: $t10 := dup($t8)
+     # live vars: $t8, $t10
+  9: $t1 := +($t8, $t10)
+     # live vars: $t1
+ 10: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+  8: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t1 := +($t7, $t9)
+     # live vars: $t1
+  8: return $t1
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address [unused]
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t3 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t3)
+  6: drop($t4)
+  7: $t6 := dup($t2)
+  8: if ($t2) goto 9 else goto 12
+  9: label L0
+ 10: $t2 := move($t6)
+ 11: return $t2
+ 12: label L1
+ 13: $t2 := false
+ 14: return $t2
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t6 := +($t6, $t8)
+  7: return $t6
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address [unused]
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t3 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t3)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t8 := +($t8, $t10)
+ 10: return $t8
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t7 := +($t7, $t9)
+  8: return $t7
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t7 := +($t7, $t9)
+  8: return $t7
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address [unused]
+     var $t6: bool
+     var $t7: address [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t2 := dup($t2)
+     # live vars: $t2, $t3
+  4: $t3 := dup($t3)
+     # live vars: $t2, $t3
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t4
+  6: drop($t4)
+     # live vars: $t2
+  7: $t6 := dup($t2)
+     # live vars: $t2, $t6
+  8: if ($t2) goto 9 else goto 12
+     # live vars: $t6
+  9: label L0
+     # live vars: $t6
+ 10: $t2 := move($t6)
+     # live vars: $t2
+ 11: return $t2
+     # live vars: $t6
+ 12: label L1
+     # live vars:
+ 13: $t2 := false
+     # live vars: $t2
+ 14: return $t2
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t7
+  3: $t6 := read_ref($t7)
+     # live vars: $t6
+  4: $t6 := dup($t6)
+     # live vars: $t6
+  5: $t8 := dup($t6)
+     # live vars: $t6, $t8
+  6: $t6 := +($t6, $t8)
+     # live vars: $t6
+  7: return $t6
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address [unused]
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t3 := dup($t3)
+     # live vars: $t2, $t3
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t3)
+     # live vars: $t2
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t9
+  6: $t8 := read_ref($t9)
+     # live vars: $t8
+  7: $t8 := dup($t8)
+     # live vars: $t8
+  8: $t10 := dup($t8)
+     # live vars: $t8, $t10
+  9: $t8 := +($t8, $t10)
+     # live vars: $t8
+ 10: return $t8
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t7 := +($t7, $t9)
+     # live vars: $t7
+  8: return $t7
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t7 := +($t7, $t9)
+     # live vars: $t7
+  8: return $t7
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+  0: $t0 := vector::empty<u8>()
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+  0: $t2 := signer::address_of($t0)
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address [unused]
+     var $t6: bool
+     var $t7: address [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+  3: $t2 := dup($t2)
+  4: $t3 := dup($t3)
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t3)
+  6: drop($t4)
+  7: $t6 := dup($t2)
+  8: if ($t2) goto 9 else goto 12
+  9: label L0
+ 10: $t2 := move($t6)
+ 11: return $t2
+ 12: label L1
+ 13: $t2 := false
+ 14: return $t2
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  3: $t6 := read_ref($t7)
+  4: $t6 := dup($t6)
+  5: $t8 := dup($t6)
+  6: $t6 := +($t6, $t8)
+  7: return $t6
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address [unused]
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t3 := dup($t3)
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  3: $t3 := dup($t3)
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t3)
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  6: $t8 := read_ref($t9)
+  7: $t8 := dup($t8)
+  8: $t10 := dup($t8)
+  9: $t8 := +($t8, $t10)
+ 10: return $t8
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t7 := +($t7, $t9)
+  8: return $t7
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+  0: $t3 := signer::address_of($t0)
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+  2: $t4 := GlobalAccess::dummy_func()
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+  4: $t7 := read_ref($t8)
+  5: $t7 := dup($t7)
+  6: $t9 := dup($t7)
+  7: $t7 := +($t7, $t9)
+  8: return $t7
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address [unused]
+     var $t6: bool
+     var $t7: address [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t2 := dup($t2)
+     # live vars: $t2, $t3
+  4: $t3 := dup($t3)
+     # live vars: $t2, $t3
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t4
+  6: drop($t4)
+     # live vars: $t2
+  7: $t6 := dup($t2)
+     # live vars: $t2, $t6
+  8: if ($t2) goto 9 else goto 12
+     # live vars: $t6
+  9: label L0
+     # live vars: $t6
+ 10: $t2 := move($t6)
+     # live vars: $t2
+ 11: return $t2
+     # live vars: $t6
+ 12: label L1
+     # live vars:
+ 13: $t2 := false
+     # live vars: $t2
+ 14: return $t2
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t7
+  3: $t6 := read_ref($t7)
+     # live vars: $t6
+  4: $t6 := dup($t6)
+     # live vars: $t6
+  5: $t8 := dup($t6)
+     # live vars: $t6, $t8
+  6: $t6 := +($t6, $t8)
+     # live vars: $t6
+  7: return $t6
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address [unused]
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t3 := dup($t3)
+     # live vars: $t2, $t3
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t3)
+     # live vars: $t2
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t9
+  6: $t8 := read_ref($t9)
+     # live vars: $t8
+  7: $t8 := dup($t8)
+     # live vars: $t8
+  8: $t10 := dup($t8)
+     # live vars: $t8, $t10
+  9: $t8 := +($t8, $t10)
+     # live vars: $t8
+ 10: return $t8
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t7 := +($t7, $t9)
+     # live vars: $t7
+  8: return $t7
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t7 := +($t7, $t9)
+     # live vars: $t7
+  8: return $t7
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun GlobalAccess::dummy_func(): vector<u8> {
+     var $t0: vector<u8>
+     # live vars:
+  0: $t0 := vector::empty<u8>()
+     # live vars: $t0
+  1: return $t0
+}
+
+
+[variant baseline]
+fun GlobalAccess::move_from_S1($t0: &signer): 0x99::GlobalAccess::S1 {
+     var $t1: 0x99::GlobalAccess::S1
+     var $t2: address
+     # live vars: $t0
+  0: $t2 := signer::address_of($t0)
+     # live vars: $t2
+  1: $t1 := move_from<0x99::GlobalAccess::S1>($t2)
+     # live vars: $t1
+  2: return $t1
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_existence_check($t0: &signer): bool {
+     var $t1: bool [unused]
+     var $t2: bool
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S
+     var $t5: address [unused]
+     var $t6: bool
+     var $t7: address [unused]
+     # flush: $t3
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # flush: $t3
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # flush: $t2
+     # live vars: $t3
+  2: $t2 := exists<0x99::GlobalAccess::S>($t3)
+     # flush: $t2
+     # live vars: $t2, $t3
+  3: $t2 := dup($t2)
+     # live vars: $t2, $t3
+  4: $t3 := dup($t3)
+     # live vars: $t2, $t3
+  5: $t4 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t4
+  6: drop($t4)
+     # flush: $t6
+     # live vars: $t2
+  7: $t6 := dup($t2)
+     # live vars: $t2, $t6
+  8: if ($t2) goto 9 else goto 12
+     # live vars: $t6
+  9: label L0
+     # live vars: $t6
+ 10: $t2 := move($t6)
+     # live vars: $t2
+ 11: return $t2
+     # live vars: $t6
+ 12: label L1
+     # live vars:
+ 13: $t2 := false
+     # live vars: $t2
+ 14: return $t2
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: &0x99::GlobalAccess::S [unused]
+     var $t5: address [unused]
+     var $t6: u64
+     var $t7: &u64
+     var $t8: u64
+     var $t9: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2
+  2: $t7 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # flush: $t6
+     # live vars: $t7
+  3: $t6 := read_ref($t7)
+     # flush: $t6
+     # live vars: $t6
+  4: $t6 := dup($t6)
+     # live vars: $t6
+  5: $t8 := dup($t6)
+     # live vars: $t6, $t8
+  6: $t6 := +($t6, $t8)
+     # live vars: $t6
+  7: return $t6
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v2($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: address [unused]
+     var $t6: &0x99::GlobalAccess::S [unused]
+     var $t7: address [unused]
+     var $t8: u64
+     var $t9: &u64
+     var $t10: u64
+     var $t11: &u64 [unused]
+     # flush: $t3
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # flush: $t3
+     # live vars: $t3
+  1: $t3 := dup($t3)
+     # live vars: $t3
+  2: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # live vars: $t2, $t3
+  3: $t3 := dup($t3)
+     # flush: $t4
+     # live vars: $t2, $t3
+  4: $t4 := move_from<0x99::GlobalAccess::S1>($t3)
+     # live vars: $t2
+  5: $t9 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # flush: $t8
+     # live vars: $t9
+  6: $t8 := read_ref($t9)
+     # flush: $t8
+     # live vars: $t8
+  7: $t8 := dup($t8)
+     # live vars: $t8
+  8: $t10 := dup($t8)
+     # live vars: $t8, $t10
+  9: $t8 := +($t8, $t10)
+     # live vars: $t8
+ 10: return $t8
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v3($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: 0x99::GlobalAccess::S1
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t0, $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t0, $t2
+  2: $t4 := GlobalAccess::move_from_S1($t0)
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # flush: $t7
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # flush: $t7
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t7 := +($t7, $t9)
+     # live vars: $t7
+  8: return $t7
+}
+
+
+[variant baseline]
+fun GlobalAccess::test_global_borrow_v4($t0: &signer): u64 {
+     var $t1: u64 [unused]
+     var $t2: &0x99::GlobalAccess::S
+     var $t3: address
+     var $t4: vector<u8>
+     var $t5: &0x99::GlobalAccess::S [unused]
+     var $t6: address [unused]
+     var $t7: u64
+     var $t8: &u64
+     var $t9: u64
+     var $t10: &u64 [unused]
+     # live vars: $t0
+  0: $t3 := signer::address_of($t0)
+     # live vars: $t3
+  1: $t2 := borrow_global<0x99::GlobalAccess::S>($t3)
+     # flush: $t4
+     # live vars: $t2
+  2: $t4 := GlobalAccess::dummy_func()
+     # live vars: $t2
+  3: $t8 := borrow_field<0x99::GlobalAccess::S>.val($t2)
+     # flush: $t7
+     # live vars: $t8
+  4: $t7 := read_ref($t8)
+     # flush: $t7
+     # live vars: $t7
+  5: $t7 := dup($t7)
+     # live vars: $t7
+  6: $t9 := dup($t7)
+     # live vars: $t7, $t9
+  7: $t7 := +($t7, $t9)
+     # live vars: $t7
+  8: return $t7
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x99::GlobalAccess
+use 0x1::signer
+struct S has key
+  val: u64
+
+struct S1 has drop + key
+  val: u64
+
+// Function definition at index 0
+fun dummy_func(): vector<u8>
+    vec_pack <u8>, 0
+    ret
+
+// Function definition at index 1
+fun move_from_S1(l0: &signer): S1 acquires S1
+    move_loc l0
+    call signer::address_of
+    move_from S1
+    ret
+
+// Function definition at index 2
+fun test_existence_check(l0: &signer): bool acquires S
+    local l1: address
+    local l2: bool
+    local l3: &S
+    local l4: bool
+    move_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    exists S
+    // @5
+    st_loc l2
+    copy_loc l2
+    copy_loc l1
+    borrow_global S
+    pop
+    // @10
+    copy_loc l2
+    st_loc l4
+    br_false l0
+    move_loc l4
+    ret
+    // @15
+l0: ld_false
+    ret
+
+// Function definition at index 3
+fun test_global_borrow(l0: &signer): u64 acquires S
+    local l1: u64
+    move_loc l0
+    call signer::address_of
+    borrow_global S
+    borrow_field S, val
+    read_ref
+    // @5
+    st_loc l1
+    copy_loc l1
+    copy_loc l1
+    add
+    ret
+
+// Function definition at index 4
+fun test_global_borrow_v2(l0: &signer): u64 acquires S, S1
+    local l1: address
+    local l2: u64
+    move_loc l0
+    call signer::address_of
+    st_loc l1
+    copy_loc l1
+    borrow_global S
+    // @5
+    copy_loc l1
+    move_from S1
+    pop
+    borrow_field S, val
+    read_ref
+    // @10
+    st_loc l2
+    copy_loc l2
+    copy_loc l2
+    add
+    ret
+
+// Function definition at index 5
+fun test_global_borrow_v3(l0: &signer): u64 acquires S, S1
+    local l1: u64
+    copy_loc l0
+    call signer::address_of
+    borrow_global S
+    move_loc l0
+    call move_from_S1
+    // @5
+    pop
+    borrow_field S, val
+    read_ref
+    st_loc l1
+    copy_loc l1
+    // @10
+    copy_loc l1
+    add
+    ret
+
+// Function definition at index 6
+fun test_global_borrow_v4(l0: &signer): u64 acquires S
+    local l1: u64
+    move_loc l0
+    call signer::address_of
+    borrow_global S
+    call dummy_func
+    pop
+    // @5
+    borrow_field S, val
+    read_ref
+    st_loc l1
+    copy_loc l1
+    copy_loc l1
+    // @10
+    add
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired.move
@@ -1,0 +1,28 @@
+//# publish
+module 0x42::test {
+
+    struct W has key, store, drop, copy {
+        x: u64
+    }
+
+    fun greater(self: &W, s: W): bool {
+        self.x > s.x
+    }
+
+    fun merge(self: &mut W, s: W) {
+        self.x += s.x;
+    }
+
+    fun foo_2(account: address, w: W) acquires W {
+        W[account].merge(w)
+    }
+
+    fun test_receiver() acquires W {
+        let w = W {
+            x: 3
+        };
+        assert!(!W[@0x1].greater(w), 0);
+        foo_2(@0x1, w);
+        assert!(W[@0x1].x == 5, 0);
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired.off.exp
@@ -1,0 +1,81 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::test
+struct W has copy + drop + store + key
+  x: u64
+
+// Function definition at index 0
+fun foo_2(l0: address, l1: W) acquires W
+    move_loc l0
+    mut_borrow_global W
+    move_loc l1
+    call merge
+    ret
+
+// Function definition at index 1
+fun greater(l0: &W, l1: W): bool
+    move_loc l0
+    borrow_field W, x
+    read_ref
+    borrow_loc l1
+    borrow_field W, x
+    // @5
+    read_ref
+    gt
+    ret
+
+// Function definition at index 2
+fun merge(l0: &mut W, l1: W)
+    local l2: u64
+    local l3: &mut u64
+    borrow_loc l1
+    borrow_field W, x
+    read_ref
+    st_loc l2
+    move_loc l0
+    // @5
+    mut_borrow_field W, x
+    st_loc l3
+    copy_loc l3
+    read_ref
+    move_loc l2
+    // @10
+    add
+    move_loc l3
+    write_ref
+    ret
+
+// Function definition at index 3
+fun test_receiver() acquires W
+    local l0: W
+    ld_u64 3
+    pack W
+    st_loc l0
+    ld_const<address> 1
+    borrow_global W
+    // @5
+    copy_loc l0
+    call greater
+    br_true l0
+    ld_const<address> 1
+    move_loc l0
+    // @10
+    call foo_2
+    ld_const<address> 1
+    borrow_global W
+    borrow_field W, x
+    read_ref
+    // @15
+    ld_u64 5
+    eq
+    br_false l1
+    ret
+l1: ld_u64 0
+    // @20
+    abort
+l0: ld_u64 0
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired.on.exp
@@ -1,0 +1,5028 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: goto 12
+     # live vars: $t0
+  9: label L1
+     # live vars:
+ 10: $t6 := 0
+     # live vars: $t6
+ 11: abort($t6)
+     # live vars: $t0
+ 12: label L2
+     # live vars: $t0
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+ 15: $t11 := 0x1
+     # live vars: $t11
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+ 22: label L3
+     # live vars:
+ 23: goto 27
+     # live vars:
+ 24: label L4
+     # live vars:
+ 25: $t14 := 0
+     # live vars: $t14
+ 26: abort($t14)
+     # live vars:
+ 27: label L5
+     # live vars:
+ 28: return ()
+}
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: goto 12
+     # live vars: $t0
+  9: label L1
+     # live vars:
+ 10: $t6 := 0
+     # live vars: $t6
+ 11: abort($t6)
+     # live vars: $t0
+ 12: label L2
+     # live vars: $t0
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+ 15: $t11 := 0x1
+     # live vars: $t11
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+ 22: label L3
+     # live vars:
+ 23: goto 27
+     # live vars:
+ 24: label L4
+     # live vars:
+ 25: $t14 := 0
+     # live vars: $t14
+ 26: abort($t14)
+     # live vars:
+ 27: label L5
+     # live vars:
+ 28: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: goto 12
+     # live vars: $t0
+  9: label L1
+     # live vars:
+ 10: $t6 := 0
+     # live vars: $t6
+ 11: abort($t6)
+     # live vars: $t0
+ 12: label L2
+     # live vars: $t0
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+ 15: $t11 := 0x1
+     # live vars: $t11
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+ 22: label L3
+     # live vars:
+ 23: goto 27
+     # live vars:
+ 24: label L4
+     # live vars:
+ 25: $t14 := 0
+     # live vars: $t14
+ 26: abort($t14)
+     # live vars:
+ 27: label L5
+     # live vars:
+ 28: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `test::W`] at line 17
+     #
+  1: test::merge($t2, $t1)
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 9
+     #
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 9
+     #
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `s`] at line 13
+     #
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+     # refs: [$t0 => #0, $t4 => #4]
+     # #0
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 13
+     #
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  6: write_ref($t5, $t6)
+     # live vars:
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := 3
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+     # refs: []
+     #
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `test::W`] at line 24
+     #
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+     # refs: []
+     #
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L0
+     # live vars: $t0
+     # refs: []
+     #
+  8: goto 12
+     # live vars: $t0
+     # refs: []
+     #
+  9: label L1
+     # live vars:
+     # refs: []
+     #
+ 10: $t6 := 0
+     # live vars: $t6
+     # refs: []
+     #
+ 11: abort($t6)
+     # live vars: $t0
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t0
+     # refs: []
+     #
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+     # refs: []
+     #
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+     # refs: []
+     #
+ 15: $t11 := 0x1
+     # live vars: $t11
+     # refs: []
+     #
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `test::W`] at line 26
+     #
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   -> #12 via [struct `test::W`] at line 26
+     #
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+     # refs: []
+     #
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+     # refs: []
+     #
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+     # refs: []
+     #
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+     # refs: []
+     #
+ 22: label L3
+     # live vars:
+     # refs: []
+     #
+ 23: goto 27
+     # live vars:
+     # refs: []
+     #
+ 24: label L4
+     # live vars:
+     # refs: []
+     #
+ 25: $t14 := 0
+     # live vars: $t14
+     # refs: []
+     #
+ 26: abort($t14)
+     # live vars:
+     # refs: []
+     #
+ 27: label L5
+     # live vars:
+     # refs: []
+     #
+ 28: return ()
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `test::W`] at line 17
+     #
+  1: test::merge($t2, $t1)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # abort state: {returns}
+     # live vars: $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := read_ref($t4)
+     # abort state: {returns}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  2: $t6 := borrow_local($t1)
+     # abort state: {returns}
+     # live vars: $t3, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 9
+     #
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # abort state: {returns}
+     # live vars: $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 9
+     #
+  4: $t5 := read_ref($t7)
+     # abort state: {returns}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  5: $t2 := >($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `s`] at line 13
+     #
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: [$t0 => #0, $t4 => #4]
+     # #0
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 13
+     #
+  2: $t2 := read_ref($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := read_ref($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: $t6 := +($t7, $t2)
+     # abort state: {returns}
+     # live vars: $t5, $t6
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  6: write_ref($t5, $t6)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := pack 0x42::test::W($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  2: $t5 := 0x1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `test::W`] at line 24
+     #
+  4: $t3 := test::greater($t4, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+  5: $t2 := !($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 9
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  8: goto 12
+     # abort state: {aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  9: label L1
+     # abort state: {aborts}
+     # live vars:
+     # refs: []
+     #
+ 10: $t6 := 0
+     # abort state: {aborts}
+     # live vars: $t6
+     # refs: []
+     #
+ 11: abort($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 12: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 13: $t7 := 0x1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t7
+     # refs: []
+     #
+ 14: test::foo_2($t7, $t0)
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+ 15: $t11 := 0x1
+     # abort state: {returns,aborts}
+     # live vars: $t11
+     # refs: []
+     #
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `test::W`] at line 26
+     #
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   -> #12 via [struct `test::W`] at line 26
+     #
+ 18: $t9 := read_ref($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t9
+     # refs: []
+     #
+ 19: $t13 := 5
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13
+     # refs: []
+     #
+ 20: $t8 := ==($t9, $t13)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # refs: []
+     #
+ 21: if ($t8) goto 22 else goto 24
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 22: label L3
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 23: goto 27
+     # abort state: {aborts}
+     # live vars:
+     # refs: []
+     #
+ 24: label L4
+     # abort state: {aborts}
+     # live vars:
+     # refs: []
+     #
+ 25: $t14 := 0
+     # abort state: {aborts}
+     # live vars: $t14
+     # refs: []
+     #
+ 26: abort($t14)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 27: label L5
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 28: return ()
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: goto 12
+     # live vars: $t0
+  9: label L1
+     # live vars:
+ 10: $t6 := 0
+     # live vars: $t6
+ 11: abort($t6)
+     # live vars: $t0
+ 12: label L2
+     # live vars: $t0
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+ 15: $t11 := 0x1
+     # live vars: $t11
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+ 22: label L3
+     # live vars:
+ 23: goto 27
+     # live vars:
+ 24: label L4
+     # live vars:
+ 25: $t14 := 0
+     # live vars: $t14
+ 26: abort($t14)
+     # live vars:
+ 27: label L5
+     # live vars:
+ 28: return ()
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # flush: $t2
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # flush: $t5, $t6
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # flush: $t0
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: goto 12
+     # live vars: $t0
+  9: label L1
+     # live vars:
+ 10: $t6 := 0
+     # live vars: $t6
+ 11: abort($t6)
+     # live vars: $t0
+ 12: label L2
+     # live vars: $t0
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+ 15: $t11 := 0x1
+     # live vars: $t11
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+ 22: label L3
+     # live vars:
+ 23: goto 27
+     # live vars:
+ 24: label L4
+     # live vars:
+ 25: $t14 := 0
+     # live vars: $t14
+ 26: abort($t14)
+     # live vars:
+ 27: label L5
+     # live vars:
+ 28: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `test::W`] at line 17
+     #
+  1: test::merge($t2, $t1)
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 9
+     #
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 9
+     #
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `s`] at line 13
+     #
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # flush: $t2
+     # live vars: $t0, $t4
+     # refs: [$t0 => #0, $t4 => #4]
+     # #0
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 13
+     #
+  2: $t2 := read_ref($t4)
+     # flush: $t5, $t6
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  6: write_ref($t5, $t6)
+     # live vars:
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := 3
+     # flush: $t0
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+     # refs: []
+     #
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `test::W`] at line 24
+     #
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+     # refs: []
+     #
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L0
+     # live vars: $t0
+     # refs: []
+     #
+  8: goto 12
+     # live vars: $t0
+     # refs: []
+     #
+  9: label L1
+     # live vars:
+     # refs: []
+     #
+ 10: $t6 := 0
+     # live vars: $t6
+     # refs: []
+     #
+ 11: abort($t6)
+     # live vars: $t0
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t0
+     # refs: []
+     #
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+     # refs: []
+     #
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+     # refs: []
+     #
+ 15: $t11 := 0x1
+     # live vars: $t11
+     # refs: []
+     #
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `test::W`] at line 26
+     #
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   -> #12 via [struct `test::W`] at line 26
+     #
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+     # refs: []
+     #
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+     # refs: []
+     #
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+     # refs: []
+     #
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+     # refs: []
+     #
+ 22: label L3
+     # live vars:
+     # refs: []
+     #
+ 23: goto 27
+     # live vars:
+     # refs: []
+     #
+ 24: label L4
+     # live vars:
+     # refs: []
+     #
+ 25: $t14 := 0
+     # live vars: $t14
+     # refs: []
+     #
+ 26: abort($t14)
+     # live vars:
+     # refs: []
+     #
+ 27: label L5
+     # live vars:
+     # refs: []
+     #
+ 28: return ()
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+     # reaching instruction #1: `t2` @ {0}
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `test::W`] at line 17
+     #
+  1: test::merge($t2, $t1)
+     # live vars:
+     # reaching instruction #2: `t2` @ {0}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {1}
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+     # reaching instruction #1: `t4` @ {0}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+     # reaching instruction #2: `t3` @ {1}, `t4` @ {0}
+     # refs: []
+     #
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+     # reaching instruction #3: `t3` @ {1}, `t4` @ {0}, `t6` @ {2}
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 9
+     #
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+     # reaching instruction #4: `t3` @ {1}, `t4` @ {0}, `t6` @ {2}, `t7` @ {3}
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 9
+     #
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+     # reaching instruction #5: `t3` @ {1}, `t4` @ {0}, `t5` @ {4}, `t6` @ {2}, `t7` @ {3}
+     # refs: []
+     #
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+     # reaching instruction #6: `t2` @ {5}, `t3` @ {1}, `t4` @ {0}, `t5` @ {4}, `t6` @ {2}, `t7` @ {3}
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # reaching instruction #0:
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # reaching instruction #1: `t3` @ {0}
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `s`] at line 13
+     #
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # flush: $t2
+     # live vars: $t0, $t4
+     # reaching instruction #2: `t3` @ {0}, `t4` @ {1}
+     # refs: [$t0 => #0, $t4 => #4]
+     # #0
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 13
+     #
+  2: $t2 := read_ref($t4)
+     # flush: $t5, $t6
+     # live vars: $t0, $t2
+     # reaching instruction #3: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+     # reaching instruction #4: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {3}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+     # reaching instruction #5: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {3}, `t7` @ {4}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+     # reaching instruction #6: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {3}, `t6` @ {5}, `t7` @ {4}
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  6: write_ref($t5, $t6)
+     # live vars:
+     # reaching instruction #7: `t2` @ {2}, `t3` @ {0}, `t4` @ {1}, `t5` @ {3}, `t6` @ {5}, `t7` @ {4}
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t1 := 3
+     # flush: $t0
+     # live vars: $t1
+     # reaching instruction #1: `t1` @ {0}
+     # refs: []
+     #
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+     # reaching instruction #2: `t0` @ {1}, `t1` @ {0}
+     # refs: []
+     #
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+     # reaching instruction #3: `t0` @ {1}, `t1` @ {0}, `t5` @ {2}
+     # refs: []
+     #
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+     # reaching instruction #4: `t0` @ {1}, `t1` @ {0}, `t4` @ {3}, `t5` @ {2}
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `test::W`] at line 24
+     #
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+     # reaching instruction #5: `t0` @ {1}, `t1` @ {0}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+     # reaching instruction #6: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+     # reaching instruction #7: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+  7: label L0
+     # live vars: $t0
+     # reaching instruction #8: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+  8: goto 12
+     # live vars: $t0
+     # reaching instruction #9: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+  9: label L1
+     # live vars:
+     # reaching instruction #10: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+ 10: $t6 := 0
+     # live vars: $t6
+     # reaching instruction #11: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t6` @ {10}
+     # refs: []
+     #
+ 11: abort($t6)
+     # live vars: $t0
+     # reaching instruction #12: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t0
+     # reaching instruction #13: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}
+     # refs: []
+     #
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+     # reaching instruction #14: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}
+     # refs: []
+     #
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+     # reaching instruction #15: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 15: $t11 := 0x1
+     # live vars: $t11
+     # reaching instruction #16: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t11` @ {15}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+     # reaching instruction #17: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t10` @ {16}, `t11` @ {15}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `test::W`] at line 26
+     #
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+     # reaching instruction #18: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   -> #12 via [struct `test::W`] at line 26
+     #
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+     # reaching instruction #19: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+     # reaching instruction #20: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+     # reaching instruction #21: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+     # reaching instruction #22: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 22: label L3
+     # live vars:
+     # reaching instruction #23: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 23: goto 27
+     # live vars:
+     # reaching instruction #24: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 24: label L4
+     # live vars:
+     # reaching instruction #25: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 25: $t14 := 0
+     # live vars: $t14
+     # reaching instruction #26: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `t14` @ {25}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 26: abort($t14)
+     # live vars:
+     # reaching instruction #27: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 27: label L5
+     # live vars:
+     # reaching instruction #28: `t0` @ {1}, `t1` @ {0}, `t2` @ {5}, `t3` @ {4}, `t4` @ {3}, `t5` @ {2}, `t7` @ {13}, `t8` @ {20}, `t9` @ {18}, `t10` @ {16}, `t11` @ {15}, `t12` @ {17}, `t13` @ {19}, `Struct QualifiedId { module_id: ModuleId(1), id: StructId(Symbol(133)) }` @ {14}
+     # refs: []
+     #
+ 28: return ()
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: goto 12
+     # live vars: $t0
+  9: label L1
+     # live vars:
+ 10: $t6 := 0
+     # live vars: $t6
+ 11: abort($t6)
+     # live vars: $t0
+ 12: label L2
+     # live vars: $t0
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+ 15: $t11 := 0x1
+     # live vars: $t11
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+ 22: label L3
+     # live vars:
+ 23: goto 27
+     # live vars:
+ 24: label L4
+     # live vars:
+ 25: $t14 := 0
+     # live vars: $t14
+ 26: abort($t14)
+     # live vars:
+ 27: label L5
+     # live vars:
+ 28: return ()
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `test::W`] at line 17
+     #
+  1: test::merge($t2, $t1)
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 9
+     #
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 9
+     #
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `s`] at line 13
+     #
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+     # refs: [$t0 => #0, $t4 => #4]
+     # #0
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 13
+     #
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  6: write_ref($t5, $t6)
+     # live vars:
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := 3
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+     # refs: []
+     #
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `test::W`] at line 24
+     #
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+     # refs: []
+     #
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 9
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L0
+     # live vars: $t0
+     # refs: []
+     #
+  8: goto 12
+     # live vars: $t0
+     # refs: []
+     #
+  9: label L1
+     # live vars:
+     # refs: []
+     #
+ 10: $t6 := 0
+     # live vars: $t6
+     # refs: []
+     #
+ 11: abort($t6)
+     # live vars: $t0
+     # refs: []
+     #
+ 12: label L2
+     # live vars: $t0
+     # refs: []
+     #
+ 13: $t7 := 0x1
+     # live vars: $t0, $t7
+     # refs: []
+     #
+ 14: test::foo_2($t7, $t0)
+     # live vars:
+     # refs: []
+     #
+ 15: $t11 := 0x1
+     # live vars: $t11
+     # refs: []
+     #
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `test::W`] at line 26
+     #
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   -> #12 via [struct `test::W`] at line 26
+     #
+ 18: $t9 := read_ref($t12)
+     # live vars: $t9
+     # refs: []
+     #
+ 19: $t13 := 5
+     # live vars: $t9, $t13
+     # refs: []
+     #
+ 20: $t8 := ==($t9, $t13)
+     # live vars: $t8
+     # refs: []
+     #
+ 21: if ($t8) goto 22 else goto 24
+     # live vars:
+     # refs: []
+     #
+ 22: label L3
+     # live vars:
+     # refs: []
+     #
+ 23: goto 27
+     # live vars:
+     # refs: []
+     #
+ 24: label L4
+     # live vars:
+     # refs: []
+     #
+ 25: $t14 := 0
+     # live vars: $t14
+     # refs: []
+     #
+ 26: abort($t14)
+     # live vars:
+     # refs: []
+     #
+ 27: label L5
+     # live vars:
+     # refs: []
+     #
+ 28: return ()
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: []
+     #
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2
+     # refs: [$t2 => #2]
+     # #2
+     #   <no edges>
+     # #root
+     #   -> (mut) #2 via [struct `test::W`] at line 17
+     #
+  1: test::merge($t2, $t1)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # abort state: {returns}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # abort state: {returns}
+     # live vars: $t1, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  1: $t3 := read_ref($t4)
+     # abort state: {returns}
+     # live vars: $t1, $t3
+     # refs: []
+     #
+  2: $t6 := borrow_local($t1)
+     # abort state: {returns}
+     # live vars: $t3, $t6
+     # refs: [$t6 => #6]
+     # #6
+     #   <no edges>
+     # #root
+     #   => #6 via [local `s`] at line 9
+     #
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # abort state: {returns}
+     # live vars: $t3, $t7
+     # refs: [$t7 => #7]
+     # #7
+     #   <no edges>
+     # #root
+     #   => #7 via [local `s`, field `x`] at line 9
+     #
+  4: $t5 := read_ref($t7)
+     # abort state: {returns}
+     # live vars: $t3, $t5
+     # refs: []
+     #
+  5: $t2 := >($t3, $t5)
+     # abort state: {returns}
+     # live vars: $t2
+     # refs: []
+     #
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t1
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  0: $t3 := borrow_local($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: [$t0 => #0, $t3 => #3]
+     # #0
+     #   <no edges>
+     # #3
+     #   <no edges>
+     # #root
+     #   => #3 via [local `s`] at line 13
+     #
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: [$t0 => #0, $t4 => #4]
+     # #0
+     #   <no edges>
+     # #4
+     #   <no edges>
+     # #root
+     #   => #4 via [local `s`, field `x`] at line 13
+     #
+  2: $t2 := read_ref($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: [$t0 => #0]
+     # #0
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  4: $t7 := read_ref($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t2, $t5, $t7
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  5: $t6 := +($t7, $t2)
+     # abort state: {returns}
+     # live vars: $t5, $t6
+     # refs: [$t5 => #5]
+     # #5
+     #   <no edges>
+     # #root
+     #   <no edges>
+     #
+  6: write_ref($t5, $t6)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+  0: $t1 := 3
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: []
+     #
+  1: $t0 := pack 0x42::test::W($t1)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  2: $t5 := 0x1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t4
+     # refs: [$t4 => #4]
+     # #4
+     #   <no edges>
+     # #root
+     #   -> #4 via [struct `test::W`] at line 24
+     #
+  4: $t3 := test::greater($t4, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t3
+     # refs: []
+     #
+  5: $t2 := !($t3)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t2
+     # refs: []
+     #
+  6: if ($t2) goto 7 else goto 9
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  7: label L0
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  8: goto 12
+     # abort state: {aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  9: label L1
+     # abort state: {aborts}
+     # live vars:
+     # refs: []
+     #
+ 10: $t6 := 0
+     # abort state: {aborts}
+     # live vars: $t6
+     # refs: []
+     #
+ 11: abort($t6)
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 12: label L2
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+ 13: $t7 := 0x1
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t7
+     # refs: []
+     #
+ 14: test::foo_2($t7, $t0)
+     # abort state: {returns,aborts}
+     # live vars:
+     # refs: []
+     #
+ 15: $t11 := 0x1
+     # abort state: {returns,aborts}
+     # live vars: $t11
+     # refs: []
+     #
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+     # abort state: {returns,aborts}
+     # live vars: $t10
+     # refs: [$t10 => #10]
+     # #10
+     #   <no edges>
+     # #root
+     #   -> #10 via [struct `test::W`] at line 26
+     #
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # abort state: {returns,aborts}
+     # live vars: $t12
+     # refs: [$t12 => #12]
+     # #12
+     #   <no edges>
+     # #root
+     #   -> #12 via [struct `test::W`] at line 26
+     #
+ 18: $t9 := read_ref($t12)
+     # abort state: {returns,aborts}
+     # live vars: $t9
+     # refs: []
+     #
+ 19: $t13 := 5
+     # abort state: {returns,aborts}
+     # live vars: $t9, $t13
+     # refs: []
+     #
+ 20: $t8 := ==($t9, $t13)
+     # abort state: {returns,aborts}
+     # live vars: $t8
+     # refs: []
+     #
+ 21: if ($t8) goto 22 else goto 24
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 22: label L3
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 23: goto 27
+     # abort state: {aborts}
+     # live vars:
+     # refs: []
+     #
+ 24: label L4
+     # abort state: {aborts}
+     # live vars:
+     # refs: []
+     #
+ 25: $t14 := 0
+     # abort state: {aborts}
+     # live vars: $t14
+     # refs: []
+     #
+ 26: abort($t14)
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 27: label L5
+     # abort state: {returns}
+     # live vars:
+     # refs: []
+     #
+ 28: return ()
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 9
+  7: label L0
+  8: goto 12
+  9: label L1
+ 10: $t6 := 0
+ 11: abort($t6)
+ 12: label L2
+ 13: $t7 := 0x1
+ 14: test::foo_2($t7, $t0)
+ 15: $t11 := 0x1
+ 16: $t10 := borrow_global<0x42::test::W>($t11)
+ 17: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 18: $t9 := read_ref($t12)
+ 19: $t13 := 5
+ 20: $t8 := ==($t9, $t13)
+ 21: if ($t8) goto 22 else goto 24
+ 22: label L3
+ 23: goto 27
+ 24: label L4
+ 25: $t14 := 0
+ 26: abort($t14)
+ 27: label L5
+ 28: return ()
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 22
+  7: label L0
+  8: $t7 := 0x1
+  9: test::foo_2($t7, $t0)
+ 10: $t11 := 0x1
+ 11: $t10 := borrow_global<0x42::test::W>($t11)
+ 12: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 13: $t9 := read_ref($t12)
+ 14: $t13 := 5
+ 15: $t8 := ==($t9, $t13)
+ 16: if ($t8) goto 17 else goto 19
+ 17: label L3
+ 18: return ()
+ 19: label L4
+ 20: $t14 := 0
+ 21: abort($t14)
+ 22: label L1
+ 23: $t6 := 0
+ 24: abort($t6)
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 22
+  7: label L0
+  8: $t7 := 0x1
+  9: test::foo_2($t7, $t0)
+ 10: $t11 := 0x1
+ 11: $t10 := borrow_global<0x42::test::W>($t11)
+ 12: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 13: $t9 := read_ref($t12)
+ 14: $t13 := 5
+ 15: $t8 := ==($t9, $t13)
+ 16: if ($t8) goto 17 else goto 19
+ 17: label L3
+ 18: return ()
+ 19: label L4
+ 20: $t14 := 0
+ 21: abort($t14)
+ 22: label L1
+ 23: $t6 := 0
+ 24: abort($t6)
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # maybe
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # maybe
+  1: test::merge($t2, $t1)
+     # maybe
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # maybe
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # maybe
+  1: $t3 := read_ref($t4)
+     # maybe
+  2: $t6 := borrow_local($t1)
+     # maybe
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # maybe
+  4: $t5 := read_ref($t7)
+     # maybe
+  5: $t2 := >($t3, $t5)
+     # maybe
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # maybe
+  0: $t3 := borrow_local($t1)
+     # maybe
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # maybe
+  2: $t2 := read_ref($t4)
+     # maybe
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # maybe
+  4: $t7 := read_ref($t5)
+     # maybe
+  5: $t6 := +($t7, $t2)
+     # maybe
+  6: write_ref($t5, $t6)
+     # maybe
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # maybe
+  0: $t1 := 3
+     # maybe
+  1: $t0 := pack 0x42::test::W($t1)
+     # maybe
+  2: $t5 := 0x1
+     # maybe
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # maybe
+  4: $t3 := test::greater($t4, $t0)
+     # maybe
+  5: $t2 := !($t3)
+     # maybe
+  6: if ($t2) goto 7 else goto 22
+     # maybe
+  7: label L0
+     # maybe
+  8: $t7 := 0x1
+     # maybe
+  9: test::foo_2($t7, $t0)
+     # maybe
+ 10: $t11 := 0x1
+     # maybe
+ 11: $t10 := borrow_global<0x42::test::W>($t11)
+     # maybe
+ 12: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # maybe
+ 13: $t9 := read_ref($t12)
+     # maybe
+ 14: $t13 := 5
+     # maybe
+ 15: $t8 := ==($t9, $t13)
+     # maybe
+ 16: if ($t8) goto 17 else goto 19
+     # maybe
+ 17: label L3
+     # maybe
+ 18: return ()
+     # maybe
+ 19: label L4
+     # maybe
+ 20: $t14 := 0
+     # maybe
+ 21: abort($t14)
+     # maybe
+ 22: label L1
+     # maybe
+ 23: $t6 := 0
+     # maybe
+ 24: abort($t6)
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 22
+  7: label L0
+  8: $t7 := 0x1
+  9: test::foo_2($t7, $t0)
+ 10: $t11 := 0x1
+ 11: $t10 := borrow_global<0x42::test::W>($t11)
+ 12: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 13: $t9 := read_ref($t12)
+ 14: $t13 := 5
+ 15: $t8 := ==($t9, $t13)
+ 16: if ($t8) goto 17 else goto 19
+ 17: label L3
+ 18: return ()
+ 19: label L4
+ 20: $t14 := 0
+ 21: abort($t14)
+ 22: label L1
+ 23: $t6 := 0
+ 24: abort($t6)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 22
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: $t7 := 0x1
+     # live vars: $t0, $t7
+  9: test::foo_2($t7, $t0)
+     # live vars:
+ 10: $t11 := 0x1
+     # live vars: $t11
+ 11: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 12: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 13: $t9 := read_ref($t12)
+     # live vars: $t9
+ 14: $t13 := 5
+     # live vars: $t9, $t13
+ 15: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 16: if ($t8) goto 17 else goto 19
+     # live vars:
+ 17: label L3
+     # live vars:
+ 18: return ()
+     # live vars:
+ 19: label L4
+     # live vars:
+ 20: $t14 := 0
+     # live vars: $t14
+ 21: abort($t14)
+     # live vars: $t0
+ 22: label L1
+     # live vars:
+ 23: $t6 := 0
+     # live vars: $t6
+ 24: abort($t6)
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t6 := borrow_local($t1)
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+  4: $t5 := read_ref($t7)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t6 := +($t7, $t2)
+  6: write_ref($t5, $t6)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t2 := !($t3)
+  6: if ($t2) goto 7 else goto 22
+  7: label L0
+  8: $t7 := 0x1
+  9: test::foo_2($t7, $t0)
+ 10: $t11 := 0x1
+ 11: $t10 := borrow_global<0x42::test::W>($t11)
+ 12: $t12 := borrow_field<0x42::test::W>.x($t10)
+ 13: $t9 := read_ref($t12)
+ 14: $t13 := 5
+ 15: $t8 := ==($t9, $t13)
+ 16: if ($t8) goto 17 else goto 19
+ 17: label L3
+ 18: return ()
+ 19: label L4
+ 20: $t14 := 0
+ 21: abort($t14)
+ 22: label L1
+ 23: $t6 := 0
+ 24: abort($t6)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W
+     var $t7: &u64
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t6 := borrow_local($t1)
+     # live vars: $t3, $t6
+  3: $t7 := borrow_field<0x42::test::W>.x($t6)
+     # live vars: $t3, $t7
+  4: $t5 := read_ref($t7)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t6 := +($t7, $t2)
+     # live vars: $t5, $t6
+  6: write_ref($t5, $t6)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64
+     var $t7: address
+     var $t8: bool
+     var $t9: u64
+     var $t10: &0x42::test::W
+     var $t11: address
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t2 := !($t3)
+     # live vars: $t0, $t2
+  6: if ($t2) goto 7 else goto 22
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: $t7 := 0x1
+     # live vars: $t0, $t7
+  9: test::foo_2($t7, $t0)
+     # live vars:
+ 10: $t11 := 0x1
+     # live vars: $t11
+ 11: $t10 := borrow_global<0x42::test::W>($t11)
+     # live vars: $t10
+ 12: $t12 := borrow_field<0x42::test::W>.x($t10)
+     # live vars: $t12
+ 13: $t9 := read_ref($t12)
+     # live vars: $t9
+ 14: $t13 := 5
+     # live vars: $t9, $t13
+ 15: $t8 := ==($t9, $t13)
+     # live vars: $t8
+ 16: if ($t8) goto 17 else goto 19
+     # live vars:
+ 17: label L3
+     # live vars:
+ 18: return ()
+     # live vars:
+ 19: label L4
+     # live vars:
+ 20: $t14 := 0
+     # live vars: $t14
+ 21: abort($t14)
+     # live vars: $t0
+ 22: label L1
+     # live vars:
+ 23: $t6 := 0
+     # live vars: $t6
+ 24: abort($t6)
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W [unused]
+     var $t7: &u64 [unused]
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t0 := borrow_local($t1)
+  3: $t4 := borrow_field<0x42::test::W>.x($t0)
+  4: $t5 := read_ref($t4)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64 [unused]
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t2 := +($t7, $t2)
+  6: write_ref($t5, $t2)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool [unused]
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64 [unused]
+     var $t7: address [unused]
+     var $t8: bool [unused]
+     var $t9: u64 [unused]
+     var $t10: &0x42::test::W [unused]
+     var $t11: address [unused]
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64 [unused]
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t3 := !($t3)
+  6: if ($t3) goto 7 else goto 22
+  7: label L0
+  8: $t5 := 0x1
+  9: test::foo_2($t5, $t0)
+ 10: $t5 := 0x1
+ 11: $t4 := borrow_global<0x42::test::W>($t5)
+ 12: $t12 := borrow_field<0x42::test::W>.x($t4)
+ 13: $t1 := read_ref($t12)
+ 14: $t13 := 5
+ 15: $t3 := ==($t1, $t13)
+ 16: if ($t3) goto 17 else goto 19
+ 17: label L3
+ 18: return ()
+ 19: label L4
+ 20: $t1 := 0
+ 21: abort($t1)
+ 22: label L1
+ 23: $t1 := 0
+ 24: abort($t1)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W [unused]
+     var $t7: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t0 := borrow_local($t1)
+     # live vars: $t0, $t3
+  3: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t3, $t4
+  4: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t2 := +($t7, $t2)
+     # live vars: $t2, $t5
+  6: write_ref($t5, $t2)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool [unused]
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64 [unused]
+     var $t7: address [unused]
+     var $t8: bool [unused]
+     var $t9: u64 [unused]
+     var $t10: &0x42::test::W [unused]
+     var $t11: address [unused]
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t3 := !($t3)
+     # live vars: $t0, $t3
+  6: if ($t3) goto 7 else goto 22
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: $t5 := 0x1
+     # live vars: $t0, $t5
+  9: test::foo_2($t5, $t0)
+     # live vars:
+ 10: $t5 := 0x1
+     # live vars: $t5
+ 11: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t4
+ 12: $t12 := borrow_field<0x42::test::W>.x($t4)
+     # live vars: $t12
+ 13: $t1 := read_ref($t12)
+     # live vars: $t1
+ 14: $t13 := 5
+     # live vars: $t1, $t13
+ 15: $t3 := ==($t1, $t13)
+     # live vars: $t3
+ 16: if ($t3) goto 17 else goto 19
+     # live vars:
+ 17: label L3
+     # live vars:
+ 18: return ()
+     # live vars:
+ 19: label L4
+     # live vars:
+ 20: $t1 := 0
+     # live vars: $t1
+ 21: abort($t1)
+     # live vars: $t0
+ 22: label L1
+     # live vars:
+ 23: $t1 := 0
+     # live vars: $t1
+ 24: abort($t1)
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+  1: test::merge($t2, $t1)
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W [unused]
+     var $t7: &u64 [unused]
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+  1: $t3 := read_ref($t4)
+  2: $t0 := borrow_local($t1)
+  3: $t4 := borrow_field<0x42::test::W>.x($t0)
+  4: $t5 := read_ref($t4)
+  5: $t2 := >($t3, $t5)
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64 [unused]
+     var $t7: u64
+  0: $t3 := borrow_local($t1)
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+  2: $t2 := read_ref($t4)
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+  4: $t7 := read_ref($t5)
+  5: $t2 := +($t7, $t2)
+  6: write_ref($t5, $t2)
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool [unused]
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64 [unused]
+     var $t7: address [unused]
+     var $t8: bool [unused]
+     var $t9: u64 [unused]
+     var $t10: &0x42::test::W [unused]
+     var $t11: address [unused]
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64 [unused]
+  0: $t1 := 3
+  1: $t0 := pack 0x42::test::W($t1)
+  2: $t5 := 0x1
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+  4: $t3 := test::greater($t4, $t0)
+  5: $t3 := !($t3)
+  6: if ($t3) goto 7 else goto 22
+  7: label L0
+  8: $t5 := 0x1
+  9: test::foo_2($t5, $t0)
+ 10: $t5 := 0x1
+ 11: $t4 := borrow_global<0x42::test::W>($t5)
+ 12: $t12 := borrow_field<0x42::test::W>.x($t4)
+ 13: $t1 := read_ref($t12)
+ 14: $t13 := 5
+ 15: $t3 := ==($t1, $t13)
+ 16: if ($t3) goto 17 else goto 19
+ 17: label L3
+ 18: return ()
+ 19: label L4
+ 20: $t1 := 0
+ 21: abort($t1)
+ 22: label L1
+ 23: $t1 := 0
+ 24: abort($t1)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W [unused]
+     var $t7: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t0 := borrow_local($t1)
+     # live vars: $t0, $t3
+  3: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t3, $t4
+  4: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t2 := +($t7, $t2)
+     # live vars: $t2, $t5
+  6: write_ref($t5, $t2)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool [unused]
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64 [unused]
+     var $t7: address [unused]
+     var $t8: bool [unused]
+     var $t9: u64 [unused]
+     var $t10: &0x42::test::W [unused]
+     var $t11: address [unused]
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     # live vars:
+  0: $t1 := 3
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t3 := !($t3)
+     # live vars: $t0, $t3
+  6: if ($t3) goto 7 else goto 22
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: $t5 := 0x1
+     # live vars: $t0, $t5
+  9: test::foo_2($t5, $t0)
+     # live vars:
+ 10: $t5 := 0x1
+     # live vars: $t5
+ 11: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t4
+ 12: $t12 := borrow_field<0x42::test::W>.x($t4)
+     # live vars: $t12
+ 13: $t1 := read_ref($t12)
+     # live vars: $t1
+ 14: $t13 := 5
+     # live vars: $t1, $t13
+ 15: $t3 := ==($t1, $t13)
+     # live vars: $t3
+ 16: if ($t3) goto 17 else goto 19
+     # live vars:
+ 17: label L3
+     # live vars:
+ 18: return ()
+     # live vars:
+ 19: label L4
+     # live vars:
+ 20: $t1 := 0
+     # live vars: $t1
+ 21: abort($t1)
+     # live vars: $t0
+ 22: label L1
+     # live vars:
+ 23: $t1 := 0
+     # live vars: $t1
+ 24: abort($t1)
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun test::foo_2($t0: address, $t1: 0x42::test::W) {
+     var $t2: &mut 0x42::test::W
+     # live vars: $t0, $t1
+  0: $t2 := borrow_global<0x42::test::W>($t0)
+     # live vars: $t1, $t2
+  1: test::merge($t2, $t1)
+     # live vars:
+  2: return ()
+}
+
+
+[variant baseline]
+fun test::greater($t0: &0x42::test::W, $t1: 0x42::test::W): bool {
+     var $t2: bool
+     var $t3: u64
+     var $t4: &u64
+     var $t5: u64
+     var $t6: &0x42::test::W [unused]
+     var $t7: &u64 [unused]
+     # live vars: $t0, $t1
+  0: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t1, $t4
+  1: $t3 := read_ref($t4)
+     # live vars: $t1, $t3
+  2: $t0 := borrow_local($t1)
+     # live vars: $t0, $t3
+  3: $t4 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t3, $t4
+  4: $t5 := read_ref($t4)
+     # live vars: $t3, $t5
+  5: $t2 := >($t3, $t5)
+     # live vars: $t2
+  6: return $t2
+}
+
+
+[variant baseline]
+fun test::merge($t0: &mut 0x42::test::W, $t1: 0x42::test::W) {
+     var $t2: u64
+     var $t3: &0x42::test::W
+     var $t4: &u64
+     var $t5: &mut u64
+     var $t6: u64 [unused]
+     var $t7: u64
+     # live vars: $t0, $t1
+  0: $t3 := borrow_local($t1)
+     # live vars: $t0, $t3
+  1: $t4 := borrow_field<0x42::test::W>.x($t3)
+     # flush: $t2
+     # live vars: $t0, $t4
+  2: $t2 := read_ref($t4)
+     # flush: $t2, $t5
+     # live vars: $t0, $t2
+  3: $t5 := borrow_field<0x42::test::W>.x($t0)
+     # live vars: $t2, $t5
+  4: $t7 := read_ref($t5)
+     # live vars: $t2, $t5, $t7
+  5: $t2 := +($t7, $t2)
+     # live vars: $t2, $t5
+  6: write_ref($t5, $t2)
+     # live vars:
+  7: return ()
+}
+
+
+[variant baseline]
+fun test::test_receiver() {
+     var $t0: 0x42::test::W
+     var $t1: u64
+     var $t2: bool [unused]
+     var $t3: bool
+     var $t4: &0x42::test::W
+     var $t5: address
+     var $t6: u64 [unused]
+     var $t7: address [unused]
+     var $t8: bool [unused]
+     var $t9: u64 [unused]
+     var $t10: &0x42::test::W [unused]
+     var $t11: address [unused]
+     var $t12: &u64
+     var $t13: u64
+     var $t14: u64 [unused]
+     # live vars:
+  0: $t1 := 3
+     # flush: $t0
+     # live vars: $t1
+  1: $t0 := pack 0x42::test::W($t1)
+     # live vars: $t0
+  2: $t5 := 0x1
+     # live vars: $t0, $t5
+  3: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t0, $t4
+  4: $t3 := test::greater($t4, $t0)
+     # live vars: $t0, $t3
+  5: $t3 := !($t3)
+     # live vars: $t0, $t3
+  6: if ($t3) goto 7 else goto 22
+     # live vars: $t0
+  7: label L0
+     # live vars: $t0
+  8: $t5 := 0x1
+     # live vars: $t0, $t5
+  9: test::foo_2($t5, $t0)
+     # live vars:
+ 10: $t5 := 0x1
+     # live vars: $t5
+ 11: $t4 := borrow_global<0x42::test::W>($t5)
+     # live vars: $t4
+ 12: $t12 := borrow_field<0x42::test::W>.x($t4)
+     # live vars: $t12
+ 13: $t1 := read_ref($t12)
+     # live vars: $t1
+ 14: $t13 := 5
+     # live vars: $t1, $t13
+ 15: $t3 := ==($t1, $t13)
+     # live vars: $t3
+ 16: if ($t3) goto 17 else goto 19
+     # live vars:
+ 17: label L3
+     # live vars:
+ 18: return ()
+     # live vars:
+ 19: label L4
+     # live vars:
+ 20: $t1 := 0
+     # live vars: $t1
+ 21: abort($t1)
+     # live vars: $t0
+ 22: label L1
+     # live vars:
+ 23: $t1 := 0
+     # live vars: $t1
+ 24: abort($t1)
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0x42::test
+struct W has copy + drop + store + key
+  x: u64
+
+// Function definition at index 0
+fun foo_2(l0: address, l1: W) acquires W
+    move_loc l0
+    mut_borrow_global W
+    move_loc l1
+    call merge
+    ret
+
+// Function definition at index 1
+fun greater(l0: &W, l1: W): bool
+    move_loc l0
+    borrow_field W, x
+    read_ref
+    borrow_loc l1
+    borrow_field W, x
+    // @5
+    read_ref
+    gt
+    ret
+
+// Function definition at index 2
+fun merge(l0: &mut W, l1: W)
+    local l2: u64
+    local l3: &mut u64
+    borrow_loc l1
+    borrow_field W, x
+    read_ref
+    st_loc l2
+    move_loc l0
+    // @5
+    mut_borrow_field W, x
+    st_loc l3
+    copy_loc l3
+    read_ref
+    move_loc l2
+    // @10
+    add
+    move_loc l3
+    write_ref
+    ret
+
+// Function definition at index 3
+fun test_receiver() acquires W
+    local l0: W
+    ld_u64 3
+    pack W
+    st_loc l0
+    ld_const<address> 1
+    borrow_global W
+    // @5
+    copy_loc l0
+    call greater
+    br_true l0
+    ld_const<address> 1
+    move_loc l0
+    // @10
+    call foo_2
+    ld_const<address> 1
+    borrow_global W
+    borrow_field W, x
+    read_ref
+    // @15
+    ld_u64 5
+    eq
+    br_false l1
+    ret
+l1: ld_u64 0
+    // @20
+    abort
+l0: ld_u64 0
+    abort
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired_case.move
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired_case.move
@@ -1,0 +1,7 @@
+module 0xc0ffee::m {
+    use std::option;
+    fun test(x: u64): (u64, option::Option<u64>, option::Option<u64>) {
+        let y = x * x;
+        (y, option::none(), option::none())
+    }
+}

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired_case.off.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired_case.off.exp
@@ -1,0 +1,17 @@
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+use 0x1::option
+// Function definition at index 0
+fun test(l0: u64): (u64, option::Option<u64>, option::Option<u64>)
+    copy_loc l0
+    move_loc l0
+    mul
+    call option::none<u64>
+    call option::none<u64>
+    // @5
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired_case.on.exp
+++ b/third_party/move/move-compiler-v2/tests/common-subexp-elimination/optimized/wired_case.on.exp
@@ -1,0 +1,795 @@
+============ bytecode before first stackless bytecode pipeline ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := infer($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := infer($t4)
+  3: $t2 := option::none<u64>()
+  4: $t3 := option::none<u64>()
+  5: return ($t1, $t2, $t3)
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := infer($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := infer($t4)
+  3: $t2 := option::none<u64>()
+  4: $t3 := option::none<u64>()
+  5: return ($t1, $t2, $t3)
+}
+
+============ after uninitialized_use_checker: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := infer($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := infer($t4)
+  3: $t2 := option::none<u64>()
+  4: $t3 := option::none<u64>()
+  5: return ($t1, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := infer($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+  5: return ($t1, $t2, $t3)
+}
+
+============ after UnusedAssignmentChecker: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := infer($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+  5: return ($t1, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := infer($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+  5: return ($t1, $t2, $t3)
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+     # refs: []
+     #
+  2: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+     # refs: []
+     #
+  5: return ($t1, $t2, $t3)
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  1: $t4 := *($t5, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t4
+     # refs: []
+     #
+  2: $t1 := infer($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: []
+     #
+  3: $t2 := option::none<u64>()
+     # abort state: {returns,aborts}
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  4: $t3 := option::none<u64>()
+     # abort state: {returns}
+     # live vars: $t1, $t2, $t3
+     # refs: []
+     #
+  5: return ($t1, $t2, $t3)
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := move($t4)
+  3: $t2 := option::none<u64>()
+  4: $t3 := option::none<u64>()
+  5: return ($t1, $t2, $t3)
+}
+
+============ bytecode before second stackless bytecode pipeline ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := infer($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := infer($t4)
+  3: $t2 := option::none<u64>()
+  4: $t3 := option::none<u64>()
+  5: return ($t1, $t2, $t3)
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := infer($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := infer($t4)
+  3: $t2 := option::none<u64>()
+  4: $t3 := option::none<u64>()
+  5: return ($t1, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := infer($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+  5: return ($t1, $t2, $t3)
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := infer($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+  5: return ($t1, $t2, $t3)
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+     # refs: []
+     #
+  2: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+     # refs: []
+     #
+  5: return ($t1, $t2, $t3)
+}
+
+============ after ReachingDefProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # reaching instruction #0:
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+     # reaching instruction #1: `t5` @ {0}
+     # refs: []
+     #
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+     # reaching instruction #2: `t4` @ {1}, `t5` @ {0}
+     # refs: []
+     #
+  2: $t1 := infer($t4)
+     # live vars: $t1
+     # reaching instruction #3: `t1` @ {2}, `t5` @ {0}
+     # refs: []
+     #
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+     # reaching instruction #4: `t1` @ {2}, `t2` @ {3}, `t5` @ {0}
+     # refs: []
+     #
+  4: $t3 := option::none<u64>()
+     # live vars: $t1, $t2, $t3
+     # reaching instruction #5: `t1` @ {2}, `t2` @ {3}, `t3` @ {4}, `t5` @ {0}
+     # refs: []
+     #
+  5: return ($t1, $t2, $t3)
+}
+
+============ after CommonSubexpElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := infer($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := infer($t4)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t1, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := infer($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t2 := dup($t2)
+     # live vars: $t1, $t2
+  5: $t3 := dup($t2)
+     # live vars: $t1, $t2, $t3
+  6: return ($t1, $t2, $t3)
+}
+
+============ after ReferenceSafetyProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+     # refs: []
+     #
+  2: $t1 := infer($t4)
+     # live vars: $t1
+     # refs: []
+     #
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  4: $t2 := dup($t2)
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  5: $t3 := dup($t2)
+     # live vars: $t1, $t2, $t3
+     # refs: []
+     #
+  6: return ($t1, $t2, $t3)
+}
+
+============ after AbortAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # abort state: {returns,aborts}
+     # live vars: $t0
+     # refs: []
+     #
+  0: $t5 := infer($t0)
+     # abort state: {returns,aborts}
+     # live vars: $t0, $t5
+     # refs: []
+     #
+  1: $t4 := *($t5, $t0)
+     # abort state: {returns,aborts}
+     # live vars: $t4
+     # refs: []
+     #
+  2: $t1 := infer($t4)
+     # abort state: {returns,aborts}
+     # live vars: $t1
+     # refs: []
+     #
+  3: $t2 := option::none<u64>()
+     # abort state: {returns}
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  4: $t2 := dup($t2)
+     # abort state: {returns}
+     # live vars: $t1, $t2
+     # refs: []
+     #
+  5: $t3 := dup($t2)
+     # abort state: {returns}
+     # live vars: $t1, $t2, $t3
+     # refs: []
+     #
+  6: return ($t1, $t2, $t3)
+}
+
+============ after AbilityProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := move($t4)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t1, $t2, $t3)
+}
+
+============ after ControlFlowGraphSimplifier: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := move($t4)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t1, $t2, $t3)
+}
+
+============ after SplitCriticalEdgesProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := move($t4)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t1, $t2, $t3)
+}
+
+============ after UnreachableCodeProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # maybe
+  0: $t5 := copy($t0)
+     # maybe
+  1: $t4 := *($t5, $t0)
+     # maybe
+  2: $t1 := move($t4)
+     # maybe
+  3: $t2 := option::none<u64>()
+     # maybe
+  4: $t2 := dup($t2)
+     # maybe
+  5: $t3 := dup($t2)
+     # maybe
+  6: return ($t1, $t2, $t3)
+}
+
+============ after UnreachableCodeRemover: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := move($t4)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t1, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := move($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t2 := dup($t2)
+     # live vars: $t1, $t2
+  5: $t3 := dup($t2)
+     # live vars: $t1, $t2, $t3
+  6: return ($t1, $t2, $t3)
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t4 := *($t5, $t0)
+  2: $t1 := move($t4)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t1, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t5
+  1: $t4 := *($t5, $t0)
+     # live vars: $t4
+  2: $t1 := move($t4)
+     # live vars: $t1
+  3: $t2 := option::none<u64>()
+     # live vars: $t1, $t2
+  4: $t2 := dup($t2)
+     # live vars: $t1, $t2
+  5: $t3 := dup($t2)
+     # live vars: $t1, $t2, $t3
+  6: return ($t1, $t2, $t3)
+}
+
+============ after VariableCoalescingTransformer: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64 [unused]
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t0 := *($t5, $t0)
+  2: $t0 := move($t0)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t0, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64 [unused]
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64 [unused]
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t5
+  1: $t0 := *($t5, $t0)
+     # live vars: $t0
+  2: $t0 := move($t0)
+     # live vars: $t0
+  3: $t2 := option::none<u64>()
+     # live vars: $t0, $t2
+  4: $t2 := dup($t2)
+     # live vars: $t0, $t2
+  5: $t3 := dup($t2)
+     # live vars: $t0, $t2, $t3
+  6: return ($t0, $t2, $t3)
+}
+
+============ after DeadStoreElimination: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64 [unused]
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64 [unused]
+     var $t5: u64
+  0: $t5 := copy($t0)
+  1: $t0 := *($t5, $t0)
+  2: $t0 := move($t0)
+  3: $t2 := option::none<u64>()
+  4: $t2 := dup($t2)
+  5: $t3 := dup($t2)
+  6: return ($t0, $t2, $t3)
+}
+
+============ after LiveVarAnalysisProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64 [unused]
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64 [unused]
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t5
+  1: $t0 := *($t5, $t0)
+     # live vars: $t0
+  2: $t0 := move($t0)
+     # live vars: $t0
+  3: $t2 := option::none<u64>()
+     # live vars: $t0, $t2
+  4: $t2 := dup($t2)
+     # live vars: $t0, $t2
+  5: $t3 := dup($t2)
+     # live vars: $t0, $t2, $t3
+  6: return ($t0, $t2, $t3)
+}
+
+============ after FlushWritesProcessor: ================
+
+[variant baseline]
+fun m::test($t0: u64): (u64, 0x1::option::Option<u64>, 0x1::option::Option<u64>) {
+     var $t1: u64 [unused]
+     var $t2: 0x1::option::Option<u64>
+     var $t3: 0x1::option::Option<u64>
+     var $t4: u64 [unused]
+     var $t5: u64
+     # live vars: $t0
+  0: $t5 := copy($t0)
+     # live vars: $t0, $t5
+  1: $t0 := *($t5, $t0)
+     # live vars: $t0
+  2: $t0 := move($t0)
+     # flush: $t2
+     # live vars: $t0
+  3: $t2 := option::none<u64>()
+     # flush: $t2
+     # live vars: $t0, $t2
+  4: $t2 := dup($t2)
+     # live vars: $t0, $t2
+  5: $t3 := dup($t2)
+     # live vars: $t0, $t2, $t3
+  6: return ($t0, $t2, $t3)
+}
+
+
+============ disassembled file-format ==================
+// Bytecode version v9
+module 0xc0ffee::m
+use 0x1::option
+// Function definition at index 0
+fun test(l0: u64): (u64, option::Option<u64>, option::Option<u64>)
+    local l1: option::Option<u64>
+    copy_loc l0
+    move_loc l0
+    mul
+    call option::none<u64>
+    st_loc l1
+    // @5
+    copy_loc l1
+    copy_loc l1
+    ret
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/testsuite.rs
+++ b/third_party/move/move-compiler-v2/tests/testsuite.rs
@@ -469,6 +469,24 @@ const TEST_CONFIGS: Lazy<BTreeMap<&str, TestConfig>> = Lazy::new(|| {
                 // For testing
                 .exp(Experiment::VARIABLE_COALESCING_ANNOTATE)
         },
+        // Common exbpression elimination tests
+        TestConfig {
+            name: "common-subexp-elim-on",
+            runner: |p| run_test(p, get_config_by_name("common-subexp-elim-on")),
+            include: vec!["/common-subexp-elimination/"],
+            exp_suffix: Some("on.exp"),
+            dump_bytecode: DumpLevel::AllStages,
+            ..config().exp(Experiment::COMMON_SUBEXP_ELIMINATION)
+        },
+        TestConfig {
+            name: "common-subexp-elim-off",
+            runner: |p| run_test(p, get_config_by_name("common-subexp-elim-off")),
+            include: vec!["/common-subexp-elimination/"],
+            exp_suffix: Some("off.exp"),
+            dump_bytecode: DumpLevel::AllStages,
+            dump_bytecode_filter: Some(vec![FILE_FORMAT_STAGE]),
+            ..config().exp_off(Experiment::COMMON_SUBEXP_ELIMINATION)
+        },
         // Flush writes processor tests
         TestConfig {
             name: "flush-writes-on",


### PR DESCRIPTION
## Description

This PR adds test cases for the newly introduced Common Subexpression Elimination (CSE) optimization. It consists of two groups of tests
- optimized: test cases that are expected to be optimized
- not-optimized: test cases that are expected to be not optimized

This is the third PR on the stack to introduce CSE.

## How Has This Been Tested?
This PR adds test cases.

#### Expected results
- For `optimized`: `*.on.exp` should show optimized results in file format bytecode, compared to `*.off.exp`.
- For `not-optimized`: `*.on.exp` should be identical to `*.off.exp` in file format bytecode.

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [x] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new CSE "not-optimized" tests to validate no common subexpression reuse when state may change between accesses.
> 
> - Introduces `field_access.move` with `Inner/Outer` structs and helpers; adds `field_access.off.exp` and exhaustive `field_access.on.exp` to assert identical file-format bytecode despite nested field reads, mutations, and mutable refs.
> - Adds `function_call.move` and `function_call.off.exp` to confirm calls taking mutable refs or touching global state (`foo_mut_ref`, `foo_global`) are not CSE-optimized (`bar_mut_ref`, `bar_global`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ce9c82171283e15a6b974fc2c1bfe82adbd4d16c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->