### PR TITLE
[API] Add support for encrypted transaction filtering.

### DIFF
--- a/crates/aptos-transaction-filters/src/tests/transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/tests/transaction_filter.rs
@@ -141,6 +141,28 @@ fn test_all_filter() {
 }
 
 #[test]
+fn test_encrypted_transaction_filter() {
+    // Create a filter that only allows encrypted transactions
+    let transactions = utils::create_encrypted_and_plaintext_transactions();
+    let filter = TransactionFilter::empty()
+        .add_encrypted_transaction_filter(true)
+        .add_all_filter(false);
+
+    // Verify that the filter returns only encrypted transactions (txn 0, 1 and 2)
+    let filtered_transactions = filter.filter_transactions(transactions.clone());
+    assert_eq!(filtered_transactions, transactions[0..3].to_vec());
+
+    // Create a filter that denies encrypted transactions
+    let filter = TransactionFilter::empty()
+        .add_encrypted_transaction_filter(false)
+        .add_all_filter(true);
+
+    // Verify that the filter returns only plaintext transactions (txn 3 onwards)
+    let filtered_transactions = filter.filter_transactions(transactions.clone());
+    assert_eq!(filtered_transactions, transactions[3..].to_vec());
+}
+
+#[test]
 fn test_empty_filter() {
     for use_new_txn_payload_format in [false, true] {
         // Create an empty filter

--- a/crates/aptos-transaction-filters/src/tests/transaction_filter_config.rs
+++ b/crates/aptos-transaction-filters/src/tests/transaction_filter_config.rs
@@ -118,3 +118,28 @@ fn test_transaction_filter_config_multiple_matchers() {
         assert_eq!(filtered_transactions, transactions[4..].to_vec());
     }
 }
+
+#[test]
+fn test_transaction_filter_config_multiple_matchers_encrypted() {
+    // Create a set of transactions (encrypted and plaintext)
+    let transactions = utils::create_encrypted_and_plaintext_transactions();
+
+    // Create a filter that denies encrypted transactions from the first transaction sender only
+    let transaction_filter_string = format!(
+        r#"
+            transaction_rules:
+                - Deny:
+                    - EncryptedTransaction
+                    - Sender: "{}"
+                - Allow:
+                    - All
+          "#,
+        transactions[0].sender().to_standard_string()
+    );
+    let transaction_filter =
+        serde_yaml::from_str::<TransactionFilter>(&transaction_filter_string).unwrap();
+
+    // Verify that the first transaction is denied
+    let filtered_transactions = transaction_filter.filter_transactions(transactions.clone());
+    assert_eq!(filtered_transactions, transactions[1..].to_vec());
+}

--- a/crates/aptos-transaction-filters/src/transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/transaction_filter.rs
@@ -101,6 +101,12 @@ impl TransactionFilter {
         self.add_multiple_matchers_filter(allow, vec![transaction_matcher])
     }
 
+    /// Adds an encrypted transaction matcher to the filter
+    pub fn add_encrypted_transaction_filter(self, allow: bool) -> Self {
+        let transaction_matcher = TransactionMatcher::EncryptedTransaction;
+        self.add_multiple_matchers_filter(allow, vec![transaction_matcher])
+    }
+
     /// Adds an entry function matcher to the filter
     pub fn add_entry_function_filter(
         self,
@@ -170,6 +176,7 @@ pub enum TransactionMatcher {
     EntryFunction(AccountAddress, String, String), // Matches any transaction that calls a specific entry function in a module
     AccountAddress(AccountAddress), // Matches any transaction that involves a specific account address
     PublicKey(AnyPublicKey),        // Matches any transaction that involves a specific public key
+    EncryptedTransaction,           // Matches any encrypted transaction
 }
 
 impl TransactionMatcher {
@@ -196,6 +203,9 @@ impl TransactionMatcher {
             },
             TransactionMatcher::PublicKey(public_key) => {
                 matches_transaction_authenticator_public_key(signed_transaction, public_key)
+            },
+            TransactionMatcher::EncryptedTransaction => {
+                matches_encrypted_transaction(signed_transaction)
             },
         }
     }
@@ -311,6 +321,11 @@ fn matches_any_public_key_address(any_public_key: &AnyPublicKey, address: &Accou
             public_key.jwk_addr == *address
         },
     }
+}
+
+/// Returns true iff the transaction is an encrypted transaction
+fn matches_encrypted_transaction(signed_transaction: &SignedTransaction) -> bool {
+    signed_transaction.payload().is_encrypted_variant()
 }
 
 /// Returns true iff the transaction's entry function matches the given account address, module name, and function name


### PR DESCRIPTION
## Description
This PR extends the API-based transaction filter to support encrypted transaction payloads.

## Testing Plan
New and existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces an `EncryptedTransaction` matcher and helper to filter encrypted payloads, with accompanying tests and utilities to generate encrypted and mixed transactions.
> 
> - **Filters**:
>   - Add `TransactionMatcher::EncryptedTransaction` and `add_encrypted_transaction_filter()` in `crates/aptos-transaction-filters/src/transaction_filter.rs`.
>   - Implement encrypted detection via `matches_encrypted_transaction()` using `payload().is_encrypted_variant()`.
> - **Tests**:
>   - Add `test_encrypted_transaction_filter` in `tests/transaction_filter.rs`.
>   - Add config test `test_transaction_filter_config_multiple_matchers_encrypted` in `tests/transaction_filter_config.rs`.
> - **Test Utilities**:
>   - Add generators for encrypted transactions and mixed sets (`create_encrypted_*`, `create_encrypted_and_plaintext_transactions`) in `tests/utils.rs` (covering encrypted, failed decryption, and decrypted states).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 34f58e10e912355554e8baa34a70d976a0b16059. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->