### PR TITLE
update KeylessConfiguration comments

### DIFF
--- a/aptos-move/framework/aptos-framework/sources/keyless_account.move
+++ b/aptos-move/framework/aptos-framework/sources/keyless_account.move
@@ -48,22 +48,89 @@ module aptos_framework::keyless_account {
     struct Configuration has key, store, drop, copy {
         /// An override `aud` for the identity of a recovery service, which will help users recover their keyless accounts
         /// associated with dapps or wallets that have disappeared.
-        /// IMPORTANT: This recovery service **cannot** on its own take over user accounts; a user must first sign in
+        /// IMPORTANT: This recovery service **cannot**, on its own, take over user accounts: a user must first sign in
         /// via OAuth in the recovery service in order to allow it to rotate any of that user's keyless accounts.
+        ///
+        /// Furthermore, the ZKP eventually expires, so there is a limited window within which a malicious recovery
+        /// service could rotate accounts. In the future, we can make this window arbitrarily small by further lowering
+        /// the maximum expiration horizon for ZKPs used for recovery, instead of relying on the `max_exp_horizon_secs`
+        /// value in this resource.
+        ///
+        /// If changed: There is no prover service support yet for recovery mode => ZKPs with override aud's enabled
+        ///   will not be served by the prover service => as long as training wheels are "on," such recovery ZKPs will
+        ///   never arrive on chain.
+        ///   (Once support is implemented in the prover service, in an abundance of caution, the training wheel check
+        ///    should only pass if the override aud in the public statement matches one in this list. Therefore, changes
+        ///    to this value should be picked up automatically by the prover service.)
         override_aud_vals: vector<String>,
+
         /// No transaction can have more than this many keyless signatures.
+        ///
+        /// If changed: Only affects the Aptos validators; prover service not impacted.
         max_signatures_per_txn: u16,
-        /// How far in the future from the JWT issued at time the EPK expiry can be set.
+
+        /// How far in the future from the JWT's issued-at-time can the EPK expiration date be set?
+        /// Specifically, validators enforce that the ZKP's expiration horizon is less than this `max_exp_horizon_secs`
+        /// value.
+        ///
+        /// If changed: Only affects the Aptos validators; prover service not impacted.
         max_exp_horizon_secs: u64,
-        /// The training wheels PK, if training wheels are on
+
+        /// The training wheels PK, if training wheels are on.
+        ///
+        /// If changed: Prover service has to be re-deployed with the associated training wheel SK.
         training_wheels_pubkey: Option<vector<u8>>,
+
         /// The max length of an ephemeral public key supported in our circuit (93 bytes)
+        ///
+        /// Note: Currently, the circuit derives the JWT's nonce field by hashing the EPK as:
+        /// ```
+        /// Poseidon_6(
+        ///   epk_0, epk_1, epk_2,
+        ///   max_commited_epk_bytes,
+        ///   exp_date,
+        ///   epk_blinder
+        /// )
+        /// ```
+        /// and the public inputs hash by hashing the EPK with other inputs as:
+        /// ```
+        /// Poseidon_14(
+        ///   epk_0, epk_1, epk_2,
+        ///   max_commited_epk_bytes,
+        ///   [...]
+        /// )
+        /// ```
+        /// where `max_committed_epk_byte` is passed in as one of the witnesses to the circuit. As a result, (some)
+        /// changes to this field could technically be handled by the same circuit: e.g., if we let the epk_i chunks
+        /// exceed 31 bytes, but no more than 32, then `max_commited_epk_bytes` could now be in (93, 96]. Whether such a
+        /// restricted set of changes is useful remains unclear. Therefore, the verdict will be that...
+        ///
+        /// If changed: (Likely) requires a circuit change because over-decreasing (or increasing) it leads to fewer (or
+        ///   more) EPK chunks. This would break the current way the circuit hashes the nonce and the public inputs.
+        ///   => prover service redeployment.
         max_commited_epk_bytes: u16,
+
         /// The max length of the value of the JWT's `iss` field supported in our circuit (e.g., `"https://accounts.google.com"`)
+        ///
+        /// If changed: Requires a circuit change because the `iss` field value is hashed inside the circuit as
+        ///   `HashBytesToFieldWithLen(MAX_ISS_VALUE_LEN)(iss_value, iss_value_len)` where `MAX_ISS_VALUE_LEN` is a
+        ///   circuit constant hard-coded to `max_iss_val_bytes` (i.e., to 120) => prover service redeployment..
         max_iss_val_bytes: u16,
+
         /// The max length of the JWT field name and value (e.g., `"max_age":"18"`) supported in our circuit
+        ///
+        /// If changed: Requires a circuit change because the extra field key-value pair is hashed inside the circuit as
+        ///   `HashBytesToFieldWithLen(MAX_EXTRA_FIELD_KV_PAIR_LEN)(extra_field, extra_field_len)` where
+        ///   `MAX_EXTRA_FIELD_KV_PAIR_LEN` is a circuit constant hard-coded to `max_extra_field_bytes` (i.e., to 350)
+        ///    => prover service redeployment.
         max_extra_field_bytes: u16,
-        /// The max length of the base64url-encoded JWT header in bytes supported in our circuit
+
+        /// The max length of the base64url-encoded JWT header in bytes supported in our circuit.
+        ///
+        /// If changed: Requires a circuit change because the JWT header is hashed inside the circuit as
+        ///   `HashBytesToFieldWithLen(MAX_B64U_JWT_HEADER_W_DOT_LEN)(b64u_jwt_header_w_dot, b64u_jwt_header_w_dot_len)`
+        ///   where `MAX_B64U_JWT_HEADER_W_DOT_LEN` is a circuit constant hard-coded to `max_jwt_header_b64_bytes`
+        ///   (i.e., to 350) => prover service redeployment.
         max_jwt_header_b64_bytes: u32,
     }
 


### PR DESCRIPTION
## Description

Clarifying which fields in the Keyless `Configuration` resource on-chain will affect the prover service and/or the circuit.

**tl;dr:** The following fields can be updated without impacting the circuit **nor** the prover service:
 - `override_aud_vals`: future prover service will be updated to pick this up automatically
 - `max_signatures_per_txn`
 - `max_exp_horizon_secs`

The following fields, if updated, will require a prover service redeployment, but no circuit change:

 - `training_wheels_pubkey`

The following fields, if updated, will require a circuit change, and thus a setup ceremony, and thus a prover service redeployment:
 - `max_commited_epk_bytes`
 - `max_iss_val_bytes`
 - `max_extra_field_bytes`
 - `max_jwt_header_b64_bytes`

**Note:** Why did we put these on-chain then? To allow changes to the keyless circuit without having to write new Rust Aptos validator logic, AFAICT. 

## How Has This Been Tested?

N/A

## Key Areas to Review

N/A

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [x] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [x] Other (specify): none

## Checklist
- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Clarifies comments and docs for Keyless `Configuration` fields, detailing which changes affect validators, the prover service, or require circuit updates; no logic changes.
> 
> - **Documentation**:
>   - **Move source (`sources/keyless_account.move`)**: Expanded comments on `Configuration` fields (`override_aud_vals`, `max_signatures_per_txn`, `max_exp_horizon_secs`, `training_wheels_pubkey`, `max_commited_epk_bytes`, `max_iss_val_bytes`, `max_extra_field_bytes`, `max_jwt_header_b64_bytes`) to specify validator-only effects vs. prover service redeployments and circuit change requirements.
>   - **Generated docs (`doc/keyless_account.md`)**: Synchronized with the above clarifications and minor wording/punctuation adjustments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13f22e98d8a07889a685f399c008e23987b4f506. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->