### PR TITLE
[move compiler] fix issue #17211

### DIFF
--- a/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
+++ b/third_party/move/move-compiler-v2/tests/bytecode-generator/globals.exp
@@ -38,7 +38,7 @@ module 0x42::globals {
         exists<R>(a)
     }
     fun publish(s: &signer) {
-        move_to<R>(R{f: 1}, s);
+        move_to<R>(s, R{f: 1});
     }
     fun read(a: address): u64
         acquires R

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/acquires/acquires_inferred.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/acquires/acquires_inferred.exp
@@ -34,7 +34,7 @@ module 0x42::acquires_inferred {
         exists<R>(a)
     }
     fun publish(s: &signer) {
-        move_to<R>(R{f: 1}, s);
+        move_to<R>(s, R{f: 1});
     }
     fun read(a: address): u64 {
         let r = borrow_global<R>(a);

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_1.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_1.exp
@@ -58,6 +58,6 @@ module 0x99::m {
     fun init_module(account: &signer) {
         let v = 0x1::option::none<u64>();
         let f: ||0x1::option::Option<u64> has copy + drop + store = || id(v);
-        move_to<FunctionStore>(FunctionStore{f: f}, account);
+        move_to<FunctionStore>(account, FunctionStore{f: f});
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_4.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_4.exp
@@ -64,6 +64,6 @@ module 0x99::m {
     fun init_module(account: &signer) {
         let v = Store<0x1::option::Option<u64>>{o: 0x1::option::none<u64>()};
         let f: ||0x1::option::Option<u64> has copy + drop + store = || id<0x1::option::Option<u64>>(v);
-        move_to<FunctionStore>(FunctionStore{f: f}, account);
+        move_to<FunctionStore>(account, FunctionStore{f: f});
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_5_no_warning.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/capturing_option_5_no_warning.exp
@@ -50,6 +50,6 @@ module 0x99::m {
     fun init_module(account: &signer) {
         let v: |0x1::option::Option<u64>|u64 has copy + drop + store = |arg0| id2(arg0);
         let f: ||u64 has copy + drop + store = || id(v);
-        move_to<FunctionStore>(FunctionStore{f: f}, account);
+        move_to<FunctionStore>(account, FunctionStore{f: f});
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/storable/generic_func.exp
+++ b/third_party/move/move-compiler-v2/tests/checking-lang-v2.2/lambda/storable/generic_func.exp
@@ -85,7 +85,7 @@ module 0x42::mod2 {
         exists<Registry<F>>(addr)
     }
     public fun save_item<F: copy + store>(owner: &signer, f: F) {
-        move_to<Registry<F>>(Registry<F>{func: f}, owner);
+        move_to<Registry<F>>(owner, Registry<F>{func: f});
     }
 }
 module 0x42::mod3 {
@@ -108,7 +108,7 @@ module 0x42::mod3 {
         let f2: |address|bool has copy + drop + store = |arg0| 0x42::mod2::item_exists<MyStruct2>(arg0);
         let addr = 0x1::signer::address_of(&owner);
         0x42::mod2::save_item<MyStruct1>(&owner, struct1);
-        move_to<MyStruct1>(struct1, &owner);
+        move_to<MyStruct1>(&owner, struct1);
         if (use_1) {
             0x42::mod2::save_item<|address|bool has copy + drop + store>(&owner, f1);
         } else {

--- a/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_param_op_abilities.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/abilities/v1/phantom_param_op_abilities.exp
@@ -80,7 +80,7 @@ module 0x42::M {
         (copy x, x)
     }
     fun f5(s: &signer, x: HasKey<NoAbilities, u64>) {
-        move_to<HasKey<NoAbilities, u64>>(x, s);
+        move_to<HasKey<NoAbilities, u64>>(s, x);
     }
     fun f6(): HasKey<NoAbilities, u64>
         acquires HasKey

--- a/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_one_type_argument.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/naming/global_builtin_one_type_argument.exp
@@ -33,7 +33,7 @@ module 0x8675309::M {
         acquires R
     {
         let _ = exists<R>(@0x0);
-        let () = move_to<R>(R{}, account);
+        let () = move_to<R>(account, R{});
         let _ = borrow_global<R>(@0x0);
         let _ = borrow_global_mut<R>(@0x0);
         let R{} = move_from<R>(@0x0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/assign_tuple_wg.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/assign_tuple_wg.exp
@@ -39,6 +39,6 @@ module 0xc0ffee::dummy2 {
         value: u64,
     }
     fun tuple_assignments(s: &signer, state: State) {
-        let () = move_to<State>(state, s);
+        let () = move_to<State>(s, state);
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/dummy_field.exp
@@ -59,6 +59,6 @@ module 0x42::test {
     }
     public entry fun test4(s: &signer) {
         let r = T{};
-        move_to<T>(r, s);
+        move_to<T>(s, r);
     }
 }

--- a/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/global_builtins.exp
@@ -53,7 +53,7 @@ module 0x8675309::M {
         acquires R
     {
         let _ = exists<R>(@0x0);
-        let () = move_to<R>(R{}, a);
+        let () = move_to<R>(a, R{});
         let _ = borrow_global<R>(@0x0);
         let _ = borrow_global_mut<R>(@0x0);
         let R{} = move_from<R>(@0x0);
@@ -62,7 +62,7 @@ module 0x8675309::M {
         acquires R
     {
         let _ = exists<R>(@0x0);
-        let () = move_to<R>(R{}, a);
+        let () = move_to<R>(a, R{});
         let _ = borrow_global<R>(@0x0);
         let _ = borrow_global_mut<R>(@0x0);
         let R{} = move_from<R>(@0x0);

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/multi_pool_money_market_token.exp
@@ -361,7 +361,7 @@ module 0x3::OneToOneMarket {
     fun accept<AssetType: copy + drop + store>(account: &signer, init: Token::Coin<AssetType>) {
         let sender = 0x1::signer::address_of(account);
         if (!exists<Pool<AssetType>>(sender)) () else abort 42;
-        move_to<Pool<AssetType>>(Pool<AssetType>{coin: init}, account)
+        move_to<Pool<AssetType>>(account, Pool<AssetType>{coin: init})
     }
     fun borrowed_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address): u64
         acquires BorrowRecord
@@ -395,13 +395,13 @@ module 0x3::OneToOneMarket {
     public fun register_price<In: copy + drop + store, Out: copy + drop + store>(account: &signer, initial_in: Token::Coin<In>, initial_out: Token::Coin<Out>, price: u64) {
         accept<In>(account, initial_in);
         accept<Out>(account, initial_out);
-        move_to<Price<In, Out>>(Price<In,Out>{price: price}, account)
+        move_to<Price<In, Out>>(account, Price<In,Out>{price: price})
     }
     fun update_borrow_record<In: copy + drop + store, Out: copy + drop + store>(account: &signer, pool_owner: address, amount: u64)
         acquires BorrowRecord
     {
         let sender = 0x1::signer::address_of(account);
-        if (!exists<BorrowRecord<In, Out>>(sender)) move_to<BorrowRecord<In, Out>>(BorrowRecord<In,Out>{record: Map::empty<address,u64>()}, account);
+        if (!exists<BorrowRecord<In, Out>>(sender)) move_to<BorrowRecord<In, Out>>(account, BorrowRecord<In,Out>{record: Map::empty<address,u64>()});
         let record = &mut borrow_global_mut<BorrowRecord<In, Out>>(sender).record;
         if (Map::contains_key<address,u64>(/*freeze*/record, &pool_owner)) {
             let old_amount = Map::remove<address,u64>(/*freeze*/record, &pool_owner);
@@ -413,7 +413,7 @@ module 0x3::OneToOneMarket {
         acquires DepositRecord
     {
         let sender = 0x1::signer::address_of(account);
-        if (!exists<DepositRecord<In, Out>>(sender)) move_to<DepositRecord<In, Out>>(DepositRecord<In,Out>{record: Map::empty<address,u64>()}, account);
+        if (!exists<DepositRecord<In, Out>>(sender)) move_to<DepositRecord<In, Out>>(account, DepositRecord<In,Out>{record: Map::empty<address,u64>()});
         let record = &mut borrow_global_mut<DepositRecord<In, Out>>(sender).record;
         if (Map::contains_key<address,u64>(/*freeze*/record, &pool_owner)) {
             let old_amount = Map::remove<address,u64>(/*freeze*/record, &pool_owner);
@@ -432,7 +432,7 @@ module 0x70dd::ToddNickels {
     }
     public fun init(account: &signer) {
         if (0x1::signer::address_of(account) == @0x70dd) () else abort 42;
-        move_to<Wallet>(Wallet{nickels: Token::create<T>(T{}, 0)}, account)
+        move_to<Wallet>(account, Wallet{nickels: Token::create<T>(T{}, 0)})
     }
     public fun destroy(c: Token::Coin<T>)
         acquires Wallet

--- a/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.exp
+++ b/third_party/move/move-compiler-v2/tests/checking/typing/v1-examples/simple_money_market_token.exp
@@ -291,7 +291,7 @@ module 0x70dd::ToddNickels {
     }
     public fun init(account: &signer) {
         if (0x1::signer::address_of(account) == @0x70dd) () else abort 42;
-        move_to<Wallet>(Wallet{nickels: Token::create<T>(T{}, 0)}, account)
+        move_to<Wallet>(account, Wallet{nickels: Token::create<T>(T{}, 0)})
     }
     public fun destroy(c: Token::Coin<T>)
         acquires Wallet
@@ -337,7 +337,7 @@ module 0xb055::OneToOneMarket {
     fun accept<AssetType: copy + drop + store>(account: &signer, init: Token::Coin<AssetType>) {
         let sender = 0x1::signer::address_of(account);
         if (!exists<Pool<AssetType>>(sender)) () else abort 42;
-        move_to<Pool<AssetType>>(Pool<AssetType>{coin: init}, account)
+        move_to<Pool<AssetType>>(account, Pool<AssetType>{coin: init})
     }
     fun borrowed_amount<In: copy + drop + store, Out: copy + drop + store>(account: &signer): u64
         acquires BorrowRecord
@@ -371,13 +371,13 @@ module 0xb055::OneToOneMarket {
         if (sender == @0xb055) () else abort 42;
         accept<In>(account, initial_in);
         accept<Out>(account, initial_out);
-        move_to<Price<In, Out>>(Price<In,Out>{price: price}, account)
+        move_to<Price<In, Out>>(account, Price<In,Out>{price: price})
     }
     fun update_borrow_record<In: copy + drop + store, Out: copy + drop + store>(account: &signer, amount: u64)
         acquires BorrowRecord
     {
         let sender = 0x1::signer::address_of(account);
-        if (!exists<BorrowRecord<In, Out>>(sender)) move_to<BorrowRecord<In, Out>>(BorrowRecord<In,Out>{record: 0}, account);
+        if (!exists<BorrowRecord<In, Out>>(sender)) move_to<BorrowRecord<In, Out>>(account, BorrowRecord<In,Out>{record: 0});
         let record = &mut borrow_global_mut<BorrowRecord<In, Out>>(sender).record;
         *record = *record + amount
     }
@@ -385,7 +385,7 @@ module 0xb055::OneToOneMarket {
         acquires DepositRecord
     {
         let sender = 0x1::signer::address_of(account);
-        if (!exists<DepositRecord<In, Out>>(sender)) move_to<DepositRecord<In, Out>>(DepositRecord<In,Out>{record: 0}, account);
+        if (!exists<DepositRecord<In, Out>>(sender)) move_to<DepositRecord<In, Out>>(account, DepositRecord<In,Out>{record: 0});
         let record = &mut borrow_global_mut<DepositRecord<In, Out>>(sender).record;
         *record = *record + amount
     }

--- a/third_party/move/move-compiler-v2/tests/integers/signed/valid_ref_source.exp
+++ b/third_party/move/move-compiler-v2/tests/integers/signed/valid_ref_source.exp
@@ -98,7 +98,7 @@ module 0x42::valid_ref_resource {
     }
     fun test_move_to(account: &signer, addr: address) {
         let s1 = S1{x: 1, y: -1i64, z: -2i128};
-        if (!exists<S1>(addr)) move_to<S1>(s1, account)
+        if (!exists<S1>(addr)) move_to<S1>(account, s1)
     }
 }
 

--- a/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
+++ b/third_party/move/move-model/bytecode/src/stackless_bytecode_generator.rs
@@ -1612,7 +1612,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                         vec![],
                     ),
                     vec![],
-                    vec![value_operand_index, signer_operand_index],
+                    vec![signer_operand_index, value_operand_index],
                 ));
             },
 
@@ -1629,7 +1629,7 @@ impl<'a> StacklessBytecodeGenerator<'a> {
                         self.get_type_params(struct_instantiation.type_parameters),
                     ),
                     vec![],
-                    vec![value_operand_index, signer_operand_index],
+                    vec![signer_operand_index, value_operand_index],
                 ));
             },
 

--- a/third_party/move/move-model/bytecode/tests/from_move/smoke_test.exp
+++ b/third_party/move/move-model/bytecode/tests/from_move/smoke_test.exp
@@ -144,7 +144,7 @@ fun SmokeTest::create_resource($t0|sender: &signer) {
   0: $t1 := move($t0)
   1: $t2 := 1
   2: $t3 := pack 0x42::SmokeTest::R($t2)
-  3: move_to<0x42::SmokeTest::R>($t3, $t1)
+  3: move_to<0x42::SmokeTest::R>($t1, $t3)
   4: return ()
 }
 
@@ -157,7 +157,7 @@ fun SmokeTest::create_resoure_generic($t0|sender: &signer) {
   0: $t1 := move($t0)
   1: $t2 := 1
   2: $t3 := pack 0x42::SmokeTest::G<u64>($t2)
-  3: move_to<0x42::SmokeTest::G<u64>>($t3, $t1)
+  3: move_to<0x42::SmokeTest::G<u64>>($t1, $t3)
   4: return ()
 }
 
@@ -215,7 +215,7 @@ fun SmokeTest::move_from_addr_to_sender($t0|sender: &signer, $t1|a: address) {
   4: $t6 := move($t0)
   5: $t7 := move($t2)
   6: $t8 := pack 0x42::SmokeTest::R($t7)
-  7: move_to<0x42::SmokeTest::R>($t8, $t6)
+  7: move_to<0x42::SmokeTest::R>($t6, $t8)
   8: return ()
 }
 

--- a/third_party/move/move-model/bytecode/tests/reaching_def/basic_test.exp
+++ b/third_party/move/move-model/bytecode/tests/reaching_def/basic_test.exp
@@ -34,7 +34,7 @@ fun ReachingDefTest::create_resource($t0|sender: &signer) {
   3: $t1 := $t4
   4: $t5 := move($t0)
   5: $t6 := move($t1)
-  6: move_to<0x42::ReachingDefTest::R>($t6, $t5)
+  6: move_to<0x42::ReachingDefTest::R>($t5, $t6)
   7: return ()
 }
 
@@ -74,6 +74,6 @@ fun ReachingDefTest::create_resource($t0|sender: &signer) {
   3: $t1 := $t4
   4: $t5 := move($t0)
   5: $t6 := move($t4)
-  6: move_to<0x42::ReachingDefTest::R>($t4, $t0)
+  6: move_to<0x42::ReachingDefTest::R>($t0, $t4)
   7: return ()
 }

--- a/third_party/move/move-model/bytecode/tests/usage_analysis/test.exp
+++ b/third_party/move/move-model/bytecode/tests/usage_analysis/test.exp
@@ -40,7 +40,7 @@ public fun Test::publish<#0>($t0|signer: &signer, $t1|x: 0x123::Test::A<#0, u8>)
      var $t3: 0x123::Test::A<#0, u8>
   0: $t2 := move($t0)
   1: $t3 := move($t1)
-  2: move_to<0x123::Test::A<#0, u8>>($t3, $t2)
+  2: move_to<0x123::Test::A<#0, u8>>($t2, $t3)
   3: return ()
 }
 
@@ -120,7 +120,7 @@ public fun Test::publish<#0>($t0|signer: &signer, $t1|x: 0x123::Test::A<#0, u8>)
      var $t3: 0x123::Test::A<#0, u8>
   0: $t2 := move($t0)
   1: $t3 := move($t1)
-  2: move_to<0x123::Test::A<#0, u8>>($t3, $t2)
+  2: move_to<0x123::Test::A<#0, u8>>($t2, $t3)
   3: return ()
 }
 

--- a/third_party/move/move-model/src/sourcifier.rs
+++ b/third_party/move/move-model/src/sourcifier.rs
@@ -1034,13 +1034,6 @@ impl<'a> ExpSourcifier<'a> {
         })
     }
 
-    fn print_rev_exp_list(&self, open: &str, close: &str, exps: &[Exp]) {
-        self.parent
-            .print_list(open, ", ", close, exps.iter().rev(), |e| {
-                self.print_exp(Prio::General, false, e)
-            })
-    }
-
     fn print_call(&self, context_prio: Priority, id: NodeId, oper: &Operation, args: &[Exp]) {
         match oper {
             Operation::MoveFunction(mid, fid) => {
@@ -1247,7 +1240,7 @@ impl<'a> ExpSourcifier<'a> {
             Operation::MoveTo => self.parenthesize(context_prio, Prio::Postfix, || {
                 emit!(self.wr(), "move_to");
                 self.print_node_inst(id);
-                self.print_rev_exp_list("(", ")", args)
+                self.print_exp_list("(", ")", args)
             }),
             Operation::MoveFrom => self.parenthesize(context_prio, Prio::Postfix, || {
                 emit!(self.wr(), "move_from");

--- a/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
+++ b/third_party/move/move-prover/boogie-backend/src/bytecode_translator.rs
@@ -2406,8 +2406,8 @@ impl FunctionTranslator<'_> {
                             &mid.qualified_inst(*sid, inst),
                             &None,
                         );
-                        let value_str = str_local(srcs[0]);
-                        let signer_str = str_local(srcs[1]);
+                        let signer_str = str_local(srcs[0]);
+                        let value_str = str_local(srcs[1]);
                         emitln!(
                             writer,
                             "if ($ResourceExists({}, {}->$addr)) {{",

--- a/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
+++ b/third_party/move/move-prover/bytecode-pipeline/src/spec_instrumentation.rs
@@ -411,7 +411,7 @@ impl<'a> Instrumenter<'a> {
                 );
             },
             Call(id, _, MoveTo(mid, sid, targs), srcs, _) => {
-                let addr_exp = self.builder.mk_temporary(srcs[1]);
+                let addr_exp = self.builder.mk_temporary(srcs[0]);
                 self.generate_modifies_check(
                     PropKind::Assert,
                     spec,

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/disable_in_body.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/disable_in_body.exp
@@ -8,7 +8,7 @@ fun DisableInv::foo($t0|s: &signer) {
   0: $t1 := move($t0)
   1: $t2 := false
   2: $t3 := pack 0x1::DisableInv::R2($t2)
-  3: move_to<0x1::DisableInv::R2>($t3, $t1)
+  3: move_to<0x1::DisableInv::R2>($t1, $t3)
   4: return ()
 }
 
@@ -21,7 +21,7 @@ fun DisableInv::foo($t0|s: signer) {
      var $t3: num
   0: $t1 := false
   1: $t2 := pack 0x1::DisableInv::R2($t1)
-  2: move_to<0x1::DisableInv::R2>($t2, $t0) on_abort goto 5 with $t3
+  2: move_to<0x1::DisableInv::R2>($t0, $t2) on_abort goto 5 with $t3
   3: label L1
   4: return ()
   5: label L2
@@ -39,7 +39,7 @@ DisableInv::foo: [
       ]
     ]
   }
-  2: move_to<0x1::DisableInv::R2>($t2, $t0) on_abort goto L2 with $t3 {}
+  2: move_to<0x1::DisableInv::R2>($t0, $t2) on_abort goto L2 with $t3 {}
   exitpoint {
     assert @0 = [
       <> -> [

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/mutual_inst.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_analysis/mutual_inst.exp
@@ -12,7 +12,7 @@ public fun S::publish_u64_bool($t0|account: signer, $t1|x: u64, $t2|y: bool) {
   2: $t5 := move($t2)
   3: $t6 := 0
   4: $t7 := pack 0x2::S::Storage<u64, bool>($t4, $t5, $t6)
-  5: move_to<0x2::S::Storage<u64, bool>>($t7, $t3)
+  5: move_to<0x2::S::Storage<u64, bool>>($t3, $t7)
   6: return ()
 }
 
@@ -29,7 +29,7 @@ public fun S::publish_u64_y<#0>($t0|account: signer, $t1|x: u64, $t2|y: #0) {
   2: $t5 := move($t2)
   3: $t6 := 1
   4: $t7 := pack 0x2::S::Storage<u64, #0>($t4, $t5, $t6)
-  5: move_to<0x2::S::Storage<u64, #0>>($t7, $t3)
+  5: move_to<0x2::S::Storage<u64, #0>>($t3, $t7)
   6: return ()
 }
 
@@ -46,7 +46,7 @@ public fun S::publish_x_bool<#0>($t0|account: signer, $t1|x: #0, $t2|y: bool) {
   2: $t5 := move($t2)
   3: $t6 := 2
   4: $t7 := pack 0x2::S::Storage<#0, bool>($t4, $t5, $t6)
-  5: move_to<0x2::S::Storage<#0, bool>>($t7, $t3)
+  5: move_to<0x2::S::Storage<#0, bool>>($t3, $t7)
   6: return ()
 }
 
@@ -63,7 +63,7 @@ public fun S::publish_x_y<#0, #1>($t0|account: signer, $t1|x: #0, $t2|y: #1) {
   2: $t5 := move($t2)
   3: $t6 := 3
   4: $t7 := pack 0x2::S::Storage<#0, #1>($t4, $t5, $t6)
-  5: move_to<0x2::S::Storage<#0, #1>>($t7, $t3)
+  5: move_to<0x2::S::Storage<#0, #1>>($t3, $t7)
   6: return ()
 }
 
@@ -96,7 +96,7 @@ public fun S::publish_u64_bool($t0|account: signer, $t1|x: u64, $t2|y: bool) {
      var $t5: num
   0: $t3 := 0
   1: $t4 := pack 0x2::S::Storage<u64, bool>($t1, $t2, $t3)
-  2: move_to<0x2::S::Storage<u64, bool>>($t4, $t0) on_abort goto 5 with $t5
+  2: move_to<0x2::S::Storage<u64, bool>>($t0, $t4) on_abort goto 5 with $t5
   3: label L1
   4: return ()
   5: label L2
@@ -111,7 +111,7 @@ public fun S::publish_u64_y<#0>($t0|account: signer, $t1|x: u64, $t2|y: #0) {
      var $t5: num
   0: $t3 := 1
   1: $t4 := pack 0x2::S::Storage<u64, #0>($t1, $t2, $t3)
-  2: move_to<0x2::S::Storage<u64, #0>>($t4, $t0) on_abort goto 5 with $t5
+  2: move_to<0x2::S::Storage<u64, #0>>($t0, $t4) on_abort goto 5 with $t5
   3: label L1
   4: return ()
   5: label L2
@@ -126,7 +126,7 @@ public fun S::publish_x_bool<#0>($t0|account: signer, $t1|x: #0, $t2|y: bool) {
      var $t5: num
   0: $t3 := 2
   1: $t4 := pack 0x2::S::Storage<#0, bool>($t1, $t2, $t3)
-  2: move_to<0x2::S::Storage<#0, bool>>($t4, $t0) on_abort goto 5 with $t5
+  2: move_to<0x2::S::Storage<#0, bool>>($t0, $t4) on_abort goto 5 with $t5
   3: label L1
   4: return ()
   5: label L2
@@ -141,7 +141,7 @@ public fun S::publish_x_y<#0, #1>($t0|account: signer, $t1|x: #0, $t2|y: #1) {
      var $t5: num
   0: $t3 := 3
   1: $t4 := pack 0x2::S::Storage<#0, #1>($t1, $t2, $t3)
-  2: move_to<0x2::S::Storage<#0, #1>>($t4, $t0) on_abort goto 5 with $t5
+  2: move_to<0x2::S::Storage<#0, #1>>($t0, $t4) on_abort goto 5 with $t5
   3: label L1
   4: return ()
   5: label L2
@@ -156,7 +156,7 @@ public fun S::publish_x_y<#0, #1>($t0|account: signer, $t1|x: #0, $t2|y: #1) {
      var $t5: num
   0: $t3 := 3
   1: $t4 := pack 0x2::S::Storage<#0, #1>($t1, $t2, $t3)
-  2: move_to<0x2::S::Storage<#0, #1>>($t4, $t0) on_abort goto 5 with $t5
+  2: move_to<0x2::S::Storage<#0, #1>>($t0, $t4) on_abort goto 5 with $t5
   3: label L1
   4: return ()
   5: label L2
@@ -209,7 +209,7 @@ S::publish_u64_bool: [
       ]
     ]
   }
-  2: move_to<0x2::S::Storage<u64, bool>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<0x2::S::Storage<u64, bool>>($t0, $t4) on_abort goto L2 with $t5 {
     assert @0 = [
       <> -> [
         <>
@@ -256,7 +256,7 @@ S::publish_u64_y: [
       ]
     ]
   }
-  2: move_to<0x2::S::Storage<u64, #0>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<0x2::S::Storage<u64, #0>>($t0, $t4) on_abort goto L2 with $t5 {
     assert @0 = [
       <bool> -> [
         <>
@@ -303,7 +303,7 @@ S::publish_x_bool: [
       ]
     ]
   }
-  2: move_to<0x2::S::Storage<#0, bool>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<0x2::S::Storage<#0, bool>>($t0, $t4) on_abort goto L2 with $t5 {
     assert @0 = [
       <u64> -> [
         <>
@@ -350,7 +350,7 @@ S::publish_x_y: [
       ]
     ]
   }
-  2: move_to<0x2::S::Storage<#0, #1>>($t4, $t0) on_abort goto L2 with $t5 {
+  2: move_to<0x2::S::Storage<#0, #1>>($t0, $t4) on_abort goto L2 with $t5 {
     assert @0 = [
       <u64, bool> -> [
         <>

--- a/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/move.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/global_invariant_instrumentation/move.exp
@@ -8,7 +8,7 @@ public fun Test::publish($t0|s: &signer) {
   0: $t1 := move($t0)
   1: $t2 := 1
   2: $t3 := pack 0x42::Test::R($t2)
-  3: move_to<0x42::Test::R>($t3, $t1)
+  3: move_to<0x42::Test::R>($t1, $t3)
   4: return ()
 }
 
@@ -33,7 +33,7 @@ public fun Test::publish($t0|s: signer) {
   0: assume forall a: address: TypeDomain<address>(): Gt(select Test::R.x<0x42::Test::R>(global<0x42::Test::R>(a)), 0)
   1: $t1 := 1
   2: $t2 := pack 0x42::Test::R($t1)
-  3: move_to<0x42::Test::R>($t2, $t0) on_abort goto 7 with $t3
+  3: move_to<0x42::Test::R>($t0, $t2) on_abort goto 7 with $t3
      # global invariant at tests/global_invariant_instrumentation/move.move:7:9+57
      # VC: global memory invariant does not hold at tests/global_invariant_instrumentation/move.move:7:9+57
   4: assert forall a: address: TypeDomain<address>(): Gt(select Test::R.x<0x42::Test::R>(global<0x42::Test::R>(a)), 0)

--- a/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/modifies.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/spec_instrumentation/modifies.exp
@@ -73,7 +73,7 @@ public fun B::move_to_test_incorrect($t0|account: &signer, $t1|addr2: address) {
   3: $t6 := move($t0)
   4: $t7 := 2
   5: $t8 := pack 0x0::B::T($t7)
-  6: move_to<0x0::B::T>($t8, $t6)
+  6: move_to<0x0::B::T>($t6, $t8)
   7: $t9 := move($t1)
   8: $t10 := A::read_at($t9)
   9: $t3 := $t10
@@ -278,7 +278,7 @@ public fun B::move_to_test_incorrect($t0|account: signer, $t1|addr2: address) {
  12: $t8 := pack 0x0::B::T($t7)
      # VC: caller does not have permission to modify `B::T` at given address at tests/spec_instrumentation/modifies.move:52:9+28
  13: assert CanModify<0x0::B::T>($t0)
- 14: move_to<0x0::B::T>($t8, $t0) on_abort goto 28 with $t6
+ 14: move_to<0x0::B::T>($t0, $t8) on_abort goto 28 with $t6
  15: $t9 := opaque begin: A::read_at($t1)
  16: assume Identical($t10, Not(exists<0x0::A::S>($t1)))
  17: if ($t10) goto 18 else goto 21

--- a/third_party/move/move-prover/bytecode-pipeline/tests/verification_analysis/inv_relevance.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/verification_analysis/inv_relevance.exp
@@ -8,7 +8,7 @@ fun InvRelevance::inner<#0>($t0|s: &signer, $t1|t: #0) {
   0: $t2 := move($t0)
   1: $t3 := move($t1)
   2: $t4 := pack 0x2::InvRelevance::R<#0>($t3)
-  3: move_to<0x2::InvRelevance::R<#0>>($t4, $t2)
+  3: move_to<0x2::InvRelevance::R<#0>>($t2, $t4)
   4: return ()
 }
 
@@ -51,7 +51,7 @@ public fun InvRelevance::outer_u64($t0|s: &signer, $t1|t: u64) {
 fun InvRelevance::inner<#0>($t0|s: signer, $t1|t: #0) {
      var $t2: 0x2::InvRelevance::R<#0>
   0: $t2 := pack 0x2::InvRelevance::R<#0>($t1)
-  1: move_to<0x2::InvRelevance::R<#0>>($t2, $t0)
+  1: move_to<0x2::InvRelevance::R<#0>>($t0, $t2)
   2: return ()
 }
 

--- a/third_party/move/move-prover/bytecode-pipeline/tests/verification_analysis/inv_suspension.exp
+++ b/third_party/move/move-prover/bytecode-pipeline/tests/verification_analysis/inv_suspension.exp
@@ -8,7 +8,7 @@ fun InvRelevance::inner<#0>($t0|s: &signer, $t1|t: #0) {
   0: $t2 := move($t0)
   1: $t3 := move($t1)
   2: $t4 := pack 0x2::InvRelevance::R<#0>($t3)
-  3: move_to<0x2::InvRelevance::R<#0>>($t4, $t2)
+  3: move_to<0x2::InvRelevance::R<#0>>($t2, $t4)
   4: return ()
 }
 
@@ -51,7 +51,7 @@ public fun InvRelevance::outer_u64($t0|s: &signer, $t1|t: u64) {
 fun InvRelevance::inner<#0>($t0|s: signer, $t1|t: #0) {
      var $t2: 0x2::InvRelevance::R<#0>
   0: $t2 := pack 0x2::InvRelevance::R<#0>($t1)
-  1: move_to<0x2::InvRelevance::R<#0>>($t2, $t0)
+  1: move_to<0x2::InvRelevance::R<#0>>($t0, $t2)
   2: return ()
 }
 


### PR DESCRIPTION
## Description

When reversing file format bytecode to stackless bytecode, the generator puts the arguments of `move_to` in wrong order. Specifically, the order should be `(addr, value)` while it was put as `(value, addr)`. This PR fixes this minor issue.

Components affected by the issue include the decompiler and the prover translator. Both are fixed by this PR.

Close #17211

## How Has This Been Tested?

- Many existing decompiler and prover test cases involve `move_to`. The PR maintains their results.

## Type of Change

- [ ] New feature
- [x] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [x] Move Compiler
- [ ] Other (specify)