### PR TITLE
[License] Adopt innovation license header 3/n

### DIFF
--- a/crates/aptos-admin-service/src/lib.rs
+++ b/crates/aptos-admin-service/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod server;
 

--- a/crates/aptos-admin-service/src/server/consensus/mod.rs
+++ b/crates/aptos-admin-service/src/server/consensus/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{bail, Error};
 use aptos_consensus::{

--- a/crates/aptos-admin-service/src/server/malloc.rs
+++ b/crates/aptos-admin-service/src/server/malloc.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_system_utils::utils::{reply_with, reply_with_status};
 use hyper::{Body, Response, StatusCode};

--- a/crates/aptos-admin-service/src/server/mempool/mod.rs
+++ b/crates/aptos-admin-service/src/server/mempool/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_logger::info;
 use aptos_mempool::{MempoolClientRequest, MempoolClientSender};

--- a/crates/aptos-admin-service/src/server/mod.rs
+++ b/crates/aptos-admin-service/src/server/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_config::config::{AdminServiceConfig, AuthenticationConfig, NodeConfig};
 use aptos_consensus::{

--- a/crates/aptos-api-tester/src/consts.rs
+++ b/crates/aptos-api-tester/src/consts.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils::NetworkName;
 use once_cell::sync::Lazy;

--- a/crates/aptos-api-tester/src/counters.rs
+++ b/crates/aptos-api-tester/src/counters.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use once_cell::sync::Lazy;
 use prometheus::{register_histogram_vec, Histogram, HistogramVec};

--- a/crates/aptos-api-tester/src/macros.rs
+++ b/crates/aptos-api-tester/src/macros.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_export]
 macro_rules! time_fn {

--- a/crates/aptos-api-tester/src/main.rs
+++ b/crates/aptos-api-tester/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/aptos-api-tester/src/persistent_check.rs
+++ b/crates/aptos-api-tester/src/persistent_check.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // Persistent checking is a mechanism to increase tolerancy to eventual consistency issues. In our
 // earlier tests we have observed that parallel runs of the flows returned higher failure rates

--- a/crates/aptos-api-tester/src/strings.rs
+++ b/crates/aptos-api-tester/src/strings.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // Fail messages
 

--- a/crates/aptos-api-tester/src/tests/coin_transfer.rs
+++ b/crates/aptos-api-tester/src/tests/coin_transfer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     consts::FUND_AMOUNT,

--- a/crates/aptos-api-tester/src/tests/mod.rs
+++ b/crates/aptos-api-tester/src/tests/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod coin_transfer;
 pub mod new_account;

--- a/crates/aptos-api-tester/src/tests/new_account.rs
+++ b/crates/aptos-api-tester/src/tests/new_account.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     consts::FUND_AMOUNT,

--- a/crates/aptos-api-tester/src/tests/publish_module.rs
+++ b/crates/aptos-api-tester/src/tests/publish_module.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     consts::FUND_AMOUNT,

--- a/crates/aptos-api-tester/src/tests/tokenv1_transfer.rs
+++ b/crates/aptos-api-tester/src/tests/tokenv1_transfer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     consts::FUND_AMOUNT,

--- a/crates/aptos-api-tester/src/tests/view_function.rs
+++ b/crates/aptos-api-tester/src/tests/view_function.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     consts::FUND_AMOUNT,

--- a/crates/aptos-api-tester/src/tokenv1_client.rs
+++ b/crates/aptos-api-tester/src/tokenv1_client.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // TODO: this should be part of the SDK
 

--- a/crates/aptos-api-tester/src/utils.rs
+++ b/crates/aptos-api-tester/src/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     consts::{

--- a/crates/aptos-bcs-utils/src/lib.rs
+++ b/crates/aptos-bcs-utils/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::bail;
 

--- a/crates/aptos-build-info/build.rs
+++ b/crates/aptos-build-info/build.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 fn main() -> shadow_rs::SdResult<()> {
     // CARGO_CFG env vars don't make it to the program at runtime, so we

--- a/crates/aptos-build-info/src/lib.rs
+++ b/crates/aptos-build-info/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use shadow_rs::{is_release, shadow};
 use std::collections::BTreeMap;

--- a/crates/aptos-cli-common/src/lib.rs
+++ b/crates/aptos-cli-common/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// A style for the CLI that closely resembles the Clap v3 color scheme
 pub fn aptos_cli_style() -> clap::builder::Styles {

--- a/crates/aptos-collections/src/bounded_vec_deque.rs
+++ b/crates/aptos-collections/src/bounded_vec_deque.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use std::collections::{
     vec_deque::{IntoIter, Iter},

--- a/crates/aptos-collections/src/lib.rs
+++ b/crates/aptos-collections/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod bounded_vec_deque;
 

--- a/crates/aptos-compression/src/client.rs
+++ b/crates/aptos-compression/src/client.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// A simple enum for identifying clients of the compression crate. This
 /// allows us to provide a runtime breakdown of compression metrics for

--- a/crates/aptos-compression/src/lib.rs
+++ b/crates/aptos-compression/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     client::CompressionClient,

--- a/crates/aptos-compression/src/metrics.rs
+++ b/crates/aptos-compression/src/metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::client::CompressionClient;
 use aptos_metrics_core::{

--- a/crates/aptos-compression/src/tests.rs
+++ b/crates/aptos-compression/src/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::CompressionClient;
 use aptos_crypto::{ed25519::Ed25519PrivateKey, hash::HashValue, PrivateKey, SigningKey, Uniform};

--- a/crates/aptos-crypto/benches/ark_bls12_381.rs
+++ b/crates/aptos-crypto/benches/ark_bls12_381.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_use]
 extern crate criterion;

--- a/crates/aptos-crypto/benches/ark_bn254.rs
+++ b/crates/aptos-crypto/benches/ark_bn254.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_use]
 extern crate criterion;

--- a/crates/aptos-crypto/benches/ark_groth16.rs
+++ b/crates/aptos-crypto/benches/ark_groth16.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 extern crate criterion;
 
 use ark_bn254::Bn254;

--- a/crates/aptos-crypto/benches/ark_rand.rs
+++ b/crates/aptos-crypto/benches/ark_rand.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::arkworks::random::{sample_field_element, scalar_from_uniform_be_bytes};
 use ark_ff::PrimeField;

--- a/crates/aptos-crypto/benches/bench_utils.rs
+++ b/crates/aptos-crypto/benches/bench_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use ark_ff::{BigInteger256, Field};
 use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};

--- a/crates/aptos-crypto/benches/bls12381.rs
+++ b/crates/aptos-crypto/benches/bls12381.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_use]
 extern crate criterion;

--- a/crates/aptos-crypto/benches/bulletproofs.rs
+++ b/crates/aptos-crypto/benches/bulletproofs.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_use]
 extern crate criterion;

--- a/crates/aptos-crypto/benches/hash.rs
+++ b/crates/aptos-crypto/benches/hash.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_use]
 extern crate criterion;

--- a/crates/aptos-crypto/benches/random.rs
+++ b/crates/aptos-crypto/benches/random.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::arkworks::random::{
     unsafe_random_point, unsafe_random_point_slow, unsafe_random_points, unsafe_random_points_slow,

--- a/crates/aptos-crypto/benches/ristretto255.rs
+++ b/crates/aptos-crypto/benches/ristretto255.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_use]
 extern crate criterion;

--- a/crates/aptos-crypto/benches/secp256k1.rs
+++ b/crates/aptos-crypto/benches/secp256k1.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[macro_use]
 extern crate criterion;

--- a/crates/aptos-crypto/src/arkworks/differentiate.rs
+++ b/crates/aptos-crypto/src/arkworks/differentiate.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module defines a trait `DifferentiableFn` for differentiable functions (like polynomials),
 //! and provides an implementation for `DensePolynomial` from the arkworks library.

--- a/crates/aptos-crypto/src/arkworks/hashing.rs
+++ b/crates/aptos-crypto/src/arkworks/hashing.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Provides an "unsafe" hash-to-curve implementation for elliptic curve affine points.
 

--- a/crates/aptos-crypto/src/arkworks/mod.rs
+++ b/crates/aptos-crypto/src/arkworks/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides some helper functions for arkworks.
 

--- a/crates/aptos-crypto/src/arkworks/random.rs
+++ b/crates/aptos-crypto/src/arkworks/random.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides functions to sample random elements from cryptographic
 //! structures such as prime fields and elliptic curve groups; `arkworks` can

--- a/crates/aptos-crypto/src/arkworks/scrape.rs
+++ b/crates/aptos-crypto/src/arkworks/scrape.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides a mechanism to check whether a set of polynomial evaluations
 //! corresponds to a polynomial of bounded degree. It implements the dual code word

--- a/crates/aptos-crypto/src/arkworks/serialization.rs
+++ b/crates/aptos-crypto/src/arkworks/serialization.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Copied from https://github.com/arkworks-rs/algebra/issues/178#issuecomment-1413219278
 

--- a/crates/aptos-crypto/src/arkworks/shamir.rs
+++ b/crates/aptos-crypto/src/arkworks/shamir.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Contains a version of shamir secret sharing and `ThresholdConfig` for arkworks
 

--- a/crates/aptos-crypto/src/arkworks/vanishing_poly.rs
+++ b/crates/aptos-crypto/src/arkworks/vanishing_poly.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Auxiliary function for Lagrange interpolation
 

--- a/crates/aptos-crypto/src/arkworks/weighted_sum.rs
+++ b/crates/aptos-crypto/src/arkworks/weighted_sum.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Weighted sum utilities for scalars and elliptic curve points.
 

--- a/crates/aptos-crypto/src/asymmetric_encryption/elgamal_curve25519_aes256_gcm.rs
+++ b/crates/aptos-crypto/src/asymmetric_encryption/elgamal_curve25519_aes256_gcm.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     asymmetric_encryption::AsymmetricEncryption,

--- a/crates/aptos-crypto/src/asymmetric_encryption/mod.rs
+++ b/crates/aptos-crypto/src/asymmetric_encryption/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides asymmetric encryption traits and instances.
 

--- a/crates/aptos-crypto/src/bls12381/bls12381_keys.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_keys.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides APIs for private keys and public keys used in Boneh-Lynn-Shacham (BLS)
 //! aggregate signatures (including individual signatures and multisignatures) implemented on top of

--- a/crates/aptos-crypto/src/bls12381/bls12381_pop.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_pop.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides APIs for _proofs-of-possesion (PoPs)_ used to prevent _rogue-key attacks_,
 //! both for multisignatures and aggregate signatures.

--- a/crates/aptos-crypto/src/bls12381/bls12381_sigs.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_sigs.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides APIs for aggregating and verifying Boneh-Lynn-Shacham (BLS) aggregate
 //! signatures (including individual signatures and multisignatures), implemented on top of

--- a/crates/aptos-crypto/src/bls12381/bls12381_validatable.rs
+++ b/crates/aptos-crypto/src/bls12381/bls12381_validatable.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module implements the Validate trait for BLS12-381 public keys, which enables library users
 //! to make sure public keys used for verifying normal (non-aggregated) signatures lie in the prime-order

--- a/crates/aptos-crypto/src/bls12381/mod.rs
+++ b/crates/aptos-crypto/src/bls12381/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides APIs for Boneh-Lynn-Shacham (BLS) aggregate signatures, including
 //! normal (non-aggregated) signatures and multisignatures, on top of Barreto-Lynn-Scott BLS12-381

--- a/crates/aptos-crypto/src/blstrs/evaluation_domain.rs
+++ b/crates/aptos-crypto/src/blstrs/evaluation_domain.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Evaluation domains and batched evaluation domains for radix-2 FFTs over the BLS12-381 scalar field.
 

--- a/crates/aptos-crypto/src/blstrs/fft.rs
+++ b/crates/aptos-crypto/src/blstrs/fft.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Fast Fourier Transform (FFT) utilities over the BLS12-381 scalar field.
 

--- a/crates/aptos-crypto/src/blstrs/lagrange.rs
+++ b/crates/aptos-crypto/src/blstrs/lagrange.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Utilities for computing Lagrange coefficients and related polynomials over FFT evaluation domains.
 

--- a/crates/aptos-crypto/src/blstrs/mod.rs
+++ b/crates/aptos-crypto/src/blstrs/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Utilities and helpers for working with BLS12-381 primitives used in Aptos.
 

--- a/crates/aptos-crypto/src/blstrs/polynomials.rs
+++ b/crates/aptos-crypto/src/blstrs/polynomials.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Polynomial utilities and threshold secret sharing for BLSTRS-based cryptography.
 

--- a/crates/aptos-crypto/src/blstrs/random.rs
+++ b/crates/aptos-crypto/src/blstrs/random.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Utilities for generating random scalars and elliptic curve points for BLS12-381.
 

--- a/crates/aptos-crypto/src/blstrs/scalar_secret_key.rs
+++ b/crates/aptos-crypto/src/blstrs/scalar_secret_key.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Implements unweighted threshold secret reconstruction for BLSTRS scalars.
 

--- a/crates/aptos-crypto/src/blstrs/threshold_config.rs
+++ b/crates/aptos-crypto/src/blstrs/threshold_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Threshold secret sharing configuration for BLSTRS-based PVSS.
 

--- a/crates/aptos-crypto/src/bulletproofs/mod.rs
+++ b/crates/aptos-crypto/src/bulletproofs/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! For now, this module stores some constants related to our implementation of Bulletproofs as a
 //! Move API.

--- a/crates/aptos-crypto/src/constant_time/mod.rs
+++ b/crates/aptos-crypto/src/constant_time/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides implementations of "dudect" statistical tests to check some of our code
 //! is constant-time (e.g., like scalar multiplication).

--- a/crates/aptos-crypto/src/ed25519/ed25519_keys.rs
+++ b/crates/aptos-crypto/src/ed25519/ed25519_keys.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This file implements traits for Ed25519 private keys and public keys.
 

--- a/crates/aptos-crypto/src/ed25519/ed25519_sigs.rs
+++ b/crates/aptos-crypto/src/ed25519/ed25519_sigs.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This file implements traits for Ed25519 signatures.
 

--- a/crates/aptos-crypto/src/ed25519/mod.rs
+++ b/crates/aptos-crypto/src/ed25519/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides an API for the PureEdDSA signature scheme over the Ed25519 twisted
 //! Edwards curve as defined in [RFC8032](https://tools.ietf.org/html/rfc8032).

--- a/crates/aptos-crypto/src/elgamal/curve25519.rs
+++ b/crates/aptos-crypto/src/elgamal/curve25519.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::elgamal::ElGamalFriendlyGroup;
 use rand_core::{CryptoRng, RngCore};

--- a/crates/aptos-crypto/src/elgamal/mod.rs
+++ b/crates/aptos-crypto/src/elgamal/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides ElGamal generic constructions and concrete schemes.
 

--- a/crates/aptos-crypto/src/encoding_type.rs
+++ b/crates/aptos-crypto/src/encoding_type.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides utility for reading and writing crypto keys
 //! in different formats used by the blockchain.

--- a/crates/aptos-crypto/src/input_secret.rs
+++ b/crates/aptos-crypto/src/input_secret.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Input secrets for the PVSS (Publicly Verifiable Secret Sharing) dealing protocol.
 

--- a/crates/aptos-crypto/src/player.rs
+++ b/crates/aptos-crypto/src/player.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Defines a struct to represents a participant (player) in a protocol.
 

--- a/crates/aptos-crypto/src/poseidon_bn254/keyless.rs
+++ b/crates/aptos-crypto/src/poseidon_bn254/keyless.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Implements keyless-specific domain-separated hash functions from Poseidon scalar hashing.
 use crate::{

--- a/crates/aptos-crypto/src/secp256k1_ecdsa.rs
+++ b/crates/aptos-crypto/src/secp256k1_ecdsa.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This module provides APIs for private keys and public keys used in Secp256k1 ecdsa.
 

--- a/crates/aptos-crypto/src/secp256r1_ecdsa/mod.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 //! This module provides an API for the ECDSA signature scheme over the NIST-P256 curve as defined in [NIST SP 800-186](https://csrc.nist.gov/publications/detail/sp/800-186/final).
 //! NIST-P256 is also known as Secp256r1 or Prime256v1.
 //!

--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_keys.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_keys.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This file implements traits for Secp256r1 ECDSA private keys and public keys.
 

--- a/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
+++ b/crates/aptos-crypto/src/secp256r1_ecdsa/secp256r1_ecdsa_sigs.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This file implements traits for ECDSA signatures over Secp256r1.
 

--- a/crates/aptos-crypto/src/unit_tests/arkworks_upgrade.rs
+++ b/crates/aptos-crypto/src/unit_tests/arkworks_upgrade.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use ark_bls12_381::{Bls12_381 as Bls12_381New, G1Projective as G1New, G2Projective as G2New};
 use ark_bls12_381_old::{Bls12_381 as Bls12_381Old, G1Projective as G1Old, G2Projective as G2Old};

--- a/crates/aptos-crypto/src/unit_tests/bcs_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/bcs_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     ed25519::{

--- a/crates/aptos-crypto/src/unit_tests/bls12381_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/bls12381_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     bls12381,

--- a/crates/aptos-crypto/src/unit_tests/bulletproofs_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/bulletproofs_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::bulletproofs::MAX_RANGE_BITS;
 use bulletproofs::{BulletproofGens, PedersenGens, RangeProof};

--- a/crates/aptos-crypto/src/unit_tests/compat_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/compat_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::compat;
 use digest::Digest;

--- a/crates/aptos-crypto/src/unit_tests/compilation/cross_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/compilation/cross_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey},

--- a/crates/aptos-crypto/src/unit_tests/compilation/cross_test_trait_obj.rs
+++ b/crates/aptos-crypto/src/unit_tests/compilation/cross_test_trait_obj.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::traits::*;
 

--- a/crates/aptos-crypto/src/unit_tests/compilation/cross_test_trait_obj_pub.rs
+++ b/crates/aptos-crypto/src/unit_tests/compilation/cross_test_trait_obj_pub.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::traits::*;
 

--- a/crates/aptos-crypto/src/unit_tests/compilation/cross_test_trait_obj_sig.rs
+++ b/crates/aptos-crypto/src/unit_tests/compilation/cross_test_trait_obj_sig.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::traits::*;
 

--- a/crates/aptos-crypto/src/unit_tests/compilation/small_kdf.rs
+++ b/crates/aptos-crypto/src/unit_tests/compilation/small_kdf.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 fn main() {
     // Test for ripemd160, output_length < 256

--- a/crates/aptos-crypto/src/unit_tests/constant_time_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/constant_time_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::constant_time;
 use dudect_bencher::ctbench::{run_bench, BenchName};

--- a/crates/aptos-crypto/src/unit_tests/cross_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/cross_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is necessary for the derive macros which rely on being used in a
 // context where the crypto crate is external

--- a/crates/aptos-crypto/src/unit_tests/cryptohasher.rs
+++ b/crates/aptos-crypto/src/unit_tests/cryptohasher.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Test file for the procedural macros CryptoHasher and BCSCryptoHash.
 

--- a/crates/aptos-crypto/src/unit_tests/ed25519_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/ed25519_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::redundant_clone)] // Required to work around prop_assert_eq! limitations
 

--- a/crates/aptos-crypto/src/unit_tests/hash_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/hash_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::hash::*;
 use bitvec::prelude::*;

--- a/crates/aptos-crypto/src/unit_tests/hkdf_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/hkdf_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{compat::Sha3_256, hkdf::*};
 use sha2::{Sha256, Sha512};

--- a/crates/aptos-crypto/src/unit_tests/mod.rs
+++ b/crates/aptos-crypto/src/unit_tests/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[cfg(feature = "arkworks-upgrade-compat-test")]
 mod arkworks_upgrade;

--- a/crates/aptos-crypto/src/unit_tests/multi_ed25519_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/multi_ed25519_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     ed25519::{Ed25519PrivateKey, Ed25519PublicKey, ED25519_PUBLIC_KEY_LENGTH},

--- a/crates/aptos-crypto/src/unit_tests/noise_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/noise_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     noise::{handshake_init_msg_len, handshake_resp_msg_len, NoiseConfig, MAX_SIZE_NOISE_MSG},

--- a/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256k1_ecdsa_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     secp256k1_ecdsa::{self, PrivateKey, PublicKey},

--- a/crates/aptos-crypto/src/unit_tests/secp256r1_ecdsa_test.rs
+++ b/crates/aptos-crypto/src/unit_tests/secp256r1_ecdsa_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::redundant_clone)] // Required to work around prop_assert_eq! limitations
 

--- a/crates/aptos-crypto/src/utils.rs
+++ b/crates/aptos-crypto/src/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Utility functions for general-purpose operations.
 //! Currently contains only a `powers()` function for computing sequential powers of a base element.

--- a/crates/aptos-crypto/src/weighted_config.rs
+++ b/crates/aptos-crypto/src/weighted_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Weighted threshold secret sharing configuration for BLSTRS-based PVSS.
 

--- a/crates/aptos-debugger/src/lib.rs
+++ b/crates/aptos-debugger/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::Result;
 use clap::Parser;

--- a/crates/aptos-debugger/src/main.rs
+++ b/crates/aptos-debugger/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::Result;
 use aptos_debugger::Cmd;

--- a/crates/aptos-dkg/benches/bsgs.rs
+++ b/crates/aptos-dkg/benches/bsgs.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_dkg::dlog::{bsgs, table};
 use ark_ec::{pairing::Pairing, CurveGroup, PrimeGroup};

--- a/crates/aptos-dkg/benches/crypto.rs
+++ b/crates/aptos-dkg/benches/crypto.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::useless_conversion)]
 

--- a/crates/aptos-dkg/benches/lagrange.rs
+++ b/crates/aptos-dkg/benches/lagrange.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_dkg::algebra::{
     evaluation_domain::BatchEvaluationDomain, lagrange::lagrange_coefficients,

--- a/crates/aptos-dkg/benches/pvss.rs
+++ b/crates/aptos-dkg/benches/pvss.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::needless_borrow)]

--- a/crates/aptos-dkg/benches/weighted_vuf.rs
+++ b/crates/aptos-dkg/benches/weighted_vuf.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::needless_range_loop)]
 #![allow(clippy::ptr_arg)]

--- a/crates/aptos-dkg/src/dlog/bsgs.rs
+++ b/crates/aptos-dkg/src/dlog/bsgs.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use ark_ec::CurveGroup;
 use std::collections::HashMap;

--- a/crates/aptos-dkg/src/dlog/mod.rs
+++ b/crates/aptos-dkg/src/dlog/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod bsgs;
 pub mod table;

--- a/crates/aptos-dkg/src/dlog/table.rs
+++ b/crates/aptos-dkg/src/dlog/table.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use ark_ec::CurveGroup;
 use std::collections::HashMap;

--- a/crates/aptos-dkg/src/fiat_shamir.rs
+++ b/crates/aptos-dkg/src/fiat_shamir.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! For what it's worth, I don't understand why the `merlin` library wants the user to first define
 //! a trait with their 'append' operations and then implement that trait on `merlin::Transcript`.

--- a/crates/aptos-dkg/src/lib.rs
+++ b/crates/aptos-dkg/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::redundant_static_lifetimes)]
 #![allow(clippy::needless_return)]

--- a/crates/aptos-dkg/src/pcs/mod.rs
+++ b/crates/aptos-dkg/src/pcs/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod univariate_hiding_kzg;
 pub mod univariate_kzg;

--- a/crates/aptos-dkg/src/pcs/univariate_hiding_kzg.rs
+++ b/crates/aptos-dkg/src/pcs/univariate_hiding_kzg.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     algebra::polynomials,

--- a/crates/aptos-dkg/src/pcs/univariate_kzg.rs
+++ b/crates/aptos-dkg/src/pcs/univariate_kzg.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::sigma_protocol::{
     homomorphism,

--- a/crates/aptos-dkg/src/pvss/chunky/chunked_elgamal.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/chunked_elgamal.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     sigma_protocol,

--- a/crates/aptos-dkg/src/pvss/chunky/chunks.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/chunks.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use ark_ff::{BigInteger, PrimeField};
 

--- a/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/hkzg_chunked_elgamal.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     pcs::univariate_hiding_kzg,

--- a/crates/aptos-dkg/src/pvss/chunky/input_secret.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/input_secret.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{pvss::chunky::public_parameters::PublicParameters, traits::Convert, Scalar};
 use aptos_crypto::{arkworks, Uniform};

--- a/crates/aptos-dkg/src/pvss/chunky/keys.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/keys.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{pvss::chunky::chunked_elgamal, traits, Scalar};
 use aptos_crypto::{

--- a/crates/aptos-dkg/src/pvss/chunky/mod.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod chunked_elgamal;
 mod chunks;

--- a/crates/aptos-dkg/src/pvss/chunky/public_parameters.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/public_parameters.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This submodule implements the *public parameters* for this "chunked_elgamal_field" PVSS scheme.
 

--- a/crates/aptos-dkg/src/pvss/chunky/transcript.rs
+++ b/crates/aptos-dkg/src/pvss/chunky/transcript.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     dlog::bsgs,

--- a/crates/aptos-dkg/src/pvss/contribution.rs
+++ b/crates/aptos-dkg/src/pvss/contribution.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     pvss::{schnorr, Player},

--- a/crates/aptos-dkg/src/pvss/das/enc.rs
+++ b/crates/aptos-dkg/src/pvss/das/enc.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::pvss::{
     encryption_dlog::g1::{DecryptPrivKey, EncryptPubKey},

--- a/crates/aptos-dkg/src/pvss/das/input_secret.rs
+++ b/crates/aptos-dkg/src/pvss/das/input_secret.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::pvss::{
     das, dealt_pub_key::g2::DealtPubKey, dealt_secret_key::g1::DealtSecretKey,

--- a/crates/aptos-dkg/src/pvss/das/mod.rs
+++ b/crates/aptos-dkg/src/pvss/das/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod enc;
 mod input_secret;

--- a/crates/aptos-dkg/src/pvss/das/public_parameters.rs
+++ b/crates/aptos-dkg/src/pvss/das/public_parameters.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This submodule implements the *public parameters* for this PVSS scheme.
 

--- a/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/unweighted_protocol.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     algebra::polynomials::{get_nonzero_powers_of_tau, shamir_secret_share},

--- a/crates/aptos-dkg/src/pvss/das/weighted_protocol.rs
+++ b/crates/aptos-dkg/src/pvss/das/weighted_protocol.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     algebra::polynomials::shamir_secret_share,

--- a/crates/aptos-dkg/src/pvss/dealt_pub_key.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_pub_key.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 macro_rules! dealt_pub_key_impl {
     ($GT_PROJ_NUM_BYTES:ident, $gt_proj_from_bytes:ident, $GTProjective:ident) => {

--- a/crates/aptos-dkg/src/pvss/dealt_pub_key_share.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_pub_key_share.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // NOTE: I don't think we need this DealtPubKey[Share] anymore, since we never implement any traits
 // on it, unlike the DealtSecretKey[Share]. We will keep it in case we want to implement the

--- a/crates/aptos-dkg/src/pvss/dealt_secret_key.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_secret_key.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 macro_rules! dealt_secret_key_impl {
     (

--- a/crates/aptos-dkg/src/pvss/dealt_secret_key_share.rs
+++ b/crates/aptos-dkg/src/pvss/dealt_secret_key_share.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 macro_rules! dealt_secret_key_share_impl {
     ($GTProjective:ident, $gt:ident) => {

--- a/crates/aptos-dkg/src/pvss/encryption_dlog.rs
+++ b/crates/aptos-dkg/src/pvss/encryption_dlog.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// Implements public parameters $h \in G$ for a simple DLOG-based encryption scheme.
 macro_rules! encryption_dlog_pp_impl {

--- a/crates/aptos-dkg/src/pvss/encryption_elgamal.rs
+++ b/crates/aptos-dkg/src/pvss/encryption_elgamal.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// Implements public parameters $(h, g) \in G$ for an ElGamal encryption scheme where $h$
 /// is the message base and $g$ is the PK base.

--- a/crates/aptos-dkg/src/pvss/insecure_field/mod.rs
+++ b/crates/aptos-dkg/src/pvss/insecure_field/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod transcript;
 

--- a/crates/aptos-dkg/src/pvss/insecure_field/transcript.rs
+++ b/crates/aptos-dkg/src/pvss/insecure_field/transcript.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     algebra::polynomials::shamir_secret_share,

--- a/crates/aptos-dkg/src/pvss/low_degree_test.rs
+++ b/crates/aptos-dkg/src/pvss/low_degree_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// Low-degree test from the SCRAPE paper that checks whether $n$ evaluations encode a degree $\le t-1$
 /// polynomial.

--- a/crates/aptos-dkg/src/pvss/mod.rs
+++ b/crates/aptos-dkg/src/pvss/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod chunky;
 mod contribution;

--- a/crates/aptos-dkg/src/pvss/schnorr.rs
+++ b/crates/aptos-dkg/src/pvss/schnorr.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils::{hash_to_scalar, HasMultiExp};
 use anyhow::bail;

--- a/crates/aptos-dkg/src/pvss/test_utils.rs
+++ b/crates/aptos-dkg/src/pvss/test_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::pvss::{
     traits::{

--- a/crates/aptos-dkg/src/pvss/traits/mod.rs
+++ b/crates/aptos-dkg/src/pvss/traits/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod transcript;
 

--- a/crates/aptos-dkg/src/pvss/traits/transcript.rs
+++ b/crates/aptos-dkg/src/pvss/traits/transcript.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! # Traits for authenticated PVSS transcripts
 //!

--- a/crates/aptos-dkg/src/pvss/weighted/generic_weighting.rs
+++ b/crates/aptos-dkg/src/pvss/weighted/generic_weighting.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// A generic transformation from an unweighted PVSS to a weighted PVSS.
 ///

--- a/crates/aptos-dkg/src/pvss/weighted/mod.rs
+++ b/crates/aptos-dkg/src/pvss/weighted/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod generic_weighting;
 

--- a/crates/aptos-dkg/src/sigma_protocol/homomorphism/fixed_base_msms.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/homomorphism/fixed_base_msms.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     sigma_protocol,

--- a/crates/aptos-dkg/src/sigma_protocol/homomorphism/mod.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/homomorphism/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use ark_serialize::{
     CanonicalDeserialize, CanonicalSerialize, Compress, SerializationError, Write,

--- a/crates/aptos-dkg/src/sigma_protocol/homomorphism/tuple.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/homomorphism/tuple.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     sigma_protocol,

--- a/crates/aptos-dkg/src/sigma_protocol/mod.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub use traits::{Proof, Statement, Trait, Witness};
 

--- a/crates/aptos-dkg/src/sigma_protocol/traits.rs
+++ b/crates/aptos-dkg/src/sigma_protocol/traits.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     fiat_shamir,

--- a/crates/aptos-dkg/src/utils/mod.rs
+++ b/crates/aptos-dkg/src/utils/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils::{
     parallel_multi_pairing::parallel_multi_pairing_slice, random::random_scalar_from_uniform_bytes,

--- a/crates/aptos-dkg/src/utils/parallel_multi_pairing.rs
+++ b/crates/aptos-dkg/src/utils/parallel_multi_pairing.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use blst::blst_fp12;
 use blstrs::{Fp12, G1Affine, G2Affine, Gt};

--- a/crates/aptos-dkg/src/utils/random.rs
+++ b/crates/aptos-dkg/src/utils/random.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::blstrs::{
     biguint_to_scalar, G1_PROJ_NUM_BYTES, G2_PROJ_NUM_BYTES, SCALAR_FIELD_ORDER, SCALAR_NUM_BYTES,

--- a/crates/aptos-dkg/src/weighted_vuf/bls/mod.rs
+++ b/crates/aptos-dkg/src/weighted_vuf/bls/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     algebra::{lagrange::lagrange_coefficients, polynomials::get_powers_of_tau},

--- a/crates/aptos-dkg/src/weighted_vuf/mod.rs
+++ b/crates/aptos-dkg/src/weighted_vuf/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod bls;
 pub mod pinkas;

--- a/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs
+++ b/crates/aptos-dkg/src/weighted_vuf/pinkas/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     algebra::{lagrange::lagrange_coefficients, polynomials::get_powers_of_tau},

--- a/crates/aptos-dkg/src/weighted_vuf/traits.rs
+++ b/crates/aptos-dkg/src/weighted_vuf/traits.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Notes: Unlike PVSS, we do NOT want to use a generic unweighted-to-weighted VUF transformation,
 //! since we have a more optimized transformation for some VRF schemes (e.g., BLS and [GJM+21e]).

--- a/crates/aptos-dkg/tests/accumulator.rs
+++ b/crates/aptos-dkg/tests/accumulator.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::blstrs::random_scalar;
 use aptos_dkg::{

--- a/crates/aptos-dkg/tests/crypto.rs
+++ b/crates/aptos-dkg/tests/crypto.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::blstrs::{multi_pairing, random_scalar};
 use aptos_dkg::{

--- a/crates/aptos-dkg/tests/dkg.rs
+++ b/crates/aptos-dkg/tests/dkg.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::{blstrs::random_scalar, hash::CryptoHash, traits::SecretSharingConfig as _};
 use aptos_dkg::pvss::{

--- a/crates/aptos-dkg/tests/fft.rs
+++ b/crates/aptos-dkg/tests/fft.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::needless_range_loop)]
 

--- a/crates/aptos-dkg/tests/pvss.rs
+++ b/crates/aptos-dkg/tests/pvss.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::needless_borrow)]
 #![allow(clippy::ptr_arg)]

--- a/crates/aptos-dkg/tests/secret_sharing_config.rs
+++ b/crates/aptos-dkg/tests/secret_sharing_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::needless_borrow)]

--- a/crates/aptos-dkg/tests/weighted_vuf.rs
+++ b/crates/aptos-dkg/tests/weighted_vuf.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(clippy::ptr_arg)]
 #![allow(clippy::needless_borrow)]

--- a/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
+++ b/crates/aptos-drop-helper/src/async_concurrent_dropper.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     metrics::{GAUGE, TIMER},

--- a/crates/aptos-drop-helper/src/async_drop_queue.rs
+++ b/crates/aptos-drop-helper/src/async_drop_queue.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::metrics::TIMER;
 use aptos_infallible::Mutex;

--- a/crates/aptos-drop-helper/src/lib.rs
+++ b/crates/aptos-drop-helper/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::async_concurrent_dropper::AsyncConcurrentDropper;
 use once_cell::sync::Lazy;

--- a/crates/aptos-drop-helper/src/metrics.rs
+++ b/crates/aptos-drop-helper/src/metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_metrics_core::{
     exponential_buckets, register_histogram_vec, register_int_gauge_vec, HistogramVec, IntGaugeVec,

--- a/crates/aptos-enum-conversion-derive/src/lib.rs
+++ b/crates/aptos-enum-conversion-derive/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use proc_macro::TokenStream;
 use quote::quote;

--- a/crates/aptos-enum-conversion-derive/tests/cases/multiple_fields.rs
+++ b/crates/aptos-enum-conversion-derive/tests/cases/multiple_fields.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_enum_conversion_derive::EnumConversion;
 

--- a/crates/aptos-enum-conversion-derive/tests/cases/no_fields.rs
+++ b/crates/aptos-enum-conversion-derive/tests/cases/no_fields.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_enum_conversion_derive::EnumConversion;
 

--- a/crates/aptos-enum-conversion-derive/tests/conversion_tests.rs
+++ b/crates/aptos-enum-conversion-derive/tests/conversion_tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_enum_conversion_derive::EnumConversion;
 

--- a/crates/aptos-faucet/cli/src/main.rs
+++ b/crates/aptos-faucet/cli/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{Context, Result};
 use aptos_faucet_core::funder::{

--- a/crates/aptos-faucet/core/src/build.rs
+++ b/crates/aptos-faucet/core/src/build.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 fn main() {
     println!("cargo:rerun-if-changed=../doc/.version");

--- a/crates/aptos-faucet/core/src/bypasser/auth_token.rs
+++ b/crates/aptos-faucet/core/src/bypasser/auth_token.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::BypasserTrait;
 use crate::{

--- a/crates/aptos-faucet/core/src/bypasser/ip_allowlist.rs
+++ b/crates/aptos-faucet/core/src/bypasser/ip_allowlist.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::BypasserTrait;
 use crate::{

--- a/crates/aptos-faucet/core/src/bypasser/mod.rs
+++ b/crates/aptos-faucet/core/src/bypasser/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod auth_token;
 mod ip_allowlist;

--- a/crates/aptos-faucet/core/src/checkers/auth_token.rs
+++ b/crates/aptos-faucet/core/src/checkers/auth_token.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{CheckerData, CheckerTrait};
 use crate::{

--- a/crates/aptos-faucet/core/src/checkers/google_captcha.rs
+++ b/crates/aptos-faucet/core/src/checkers/google_captcha.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{CheckerData, CheckerTrait};
 use crate::endpoints::{AptosTapError, AptosTapErrorCode, RejectionReason, RejectionReasonCode};

--- a/crates/aptos-faucet/core/src/checkers/ip_blocklist.rs
+++ b/crates/aptos-faucet/core/src/checkers/ip_blocklist.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{CheckerData, CheckerTrait};
 use crate::{

--- a/crates/aptos-faucet/core/src/checkers/magic_header.rs
+++ b/crates/aptos-faucet/core/src/checkers/magic_header.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{CheckerData, CheckerTrait};
 use crate::endpoints::{AptosTapError, RejectionReason, RejectionReasonCode};

--- a/crates/aptos-faucet/core/src/checkers/memory_ratelimit.rs
+++ b/crates/aptos-faucet/core/src/checkers/memory_ratelimit.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{CheckerData, CheckerTrait, CompleteData};
 use crate::{

--- a/crates/aptos-faucet/core/src/checkers/mod.rs
+++ b/crates/aptos-faucet/core/src/checkers/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod auth_token;
 mod google_captcha;

--- a/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
+++ b/crates/aptos-faucet/core/src/checkers/redis_ratelimit.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{CheckerData, CheckerTrait, CompleteData};
 use crate::{

--- a/crates/aptos-faucet/core/src/checkers/referer_blocklist.rs
+++ b/crates/aptos-faucet/core/src/checkers/referer_blocklist.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{CheckerData, CheckerTrait};
 use crate::{

--- a/crates/aptos-faucet/core/src/checkers/tap_captcha.rs
+++ b/crates/aptos-faucet/core/src/checkers/tap_captcha.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Warning: This could be attacked and cause the server to OOM because we
 //! don't throw out captchas info if it has been sitting there for too long /

--- a/crates/aptos-faucet/core/src/common/ip_range_manager.rs
+++ b/crates/aptos-faucet/core/src/common/ip_range_manager.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{bail, Context, Result};
 use ipnet::{Ipv4Net, Ipv6Net};

--- a/crates/aptos-faucet/core/src/common/list_manager.rs
+++ b/crates/aptos-faucet/core/src/common/list_manager.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};

--- a/crates/aptos-faucet/core/src/common/mod.rs
+++ b/crates/aptos-faucet/core/src/common/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod ip_range_manager;
 mod list_manager;

--- a/crates/aptos-faucet/core/src/endpoints/api.rs
+++ b/crates/aptos-faucet/core/src/endpoints/api.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{basic::BasicApi, fund::FundApi, CaptchaApi};
 use poem_openapi::{ContactObject, LicenseObject, OpenApiService};

--- a/crates/aptos-faucet/core/src/endpoints/basic.rs
+++ b/crates/aptos-faucet/core/src/endpoints/basic.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::ApiTags;
 use crate::funder::{Funder, FunderTrait};

--- a/crates/aptos-faucet/core/src/endpoints/captcha.rs
+++ b/crates/aptos-faucet/core/src/endpoints/captcha.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This API is for the in-house TapCaptchaChecker, it doesn't do anything for
 //! the GoogleCaptchaChecker.

--- a/crates/aptos-faucet/core/src/endpoints/error_converter.rs
+++ b/crates/aptos-faucet/core/src/endpoints/error_converter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::errors::AptosTapErrorResponse;
 use crate::endpoints::{AptosTapError, AptosTapErrorCode};

--- a/crates/aptos-faucet/core/src/endpoints/errors.rs
+++ b/crates/aptos-faucet/core/src/endpoints/errors.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::middleware::bump_rejection_reason_counters;
 use once_cell::sync::OnceCell;

--- a/crates/aptos-faucet/core/src/endpoints/fund.rs
+++ b/crates/aptos-faucet/core/src/endpoints/fund.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
     errors::{AptosTapError, AptosTapErrorResponse},

--- a/crates/aptos-faucet/core/src/endpoints/mod.rs
+++ b/crates/aptos-faucet/core/src/endpoints/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod api;
 mod basic;

--- a/crates/aptos-faucet/core/src/firebase_jwt.rs
+++ b/crates/aptos-faucet/core/src/firebase_jwt.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::endpoints::{AptosTapError, AptosTapErrorCode};
 use anyhow::Result;

--- a/crates/aptos-faucet/core/src/funder/fake.rs
+++ b/crates/aptos-faucet/core/src/funder/fake.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::FunderTrait;
 use crate::endpoints::AptosTapError;

--- a/crates/aptos-faucet/core/src/funder/mod.rs
+++ b/crates/aptos-faucet/core/src/funder/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod common;
 mod fake;

--- a/crates/aptos-faucet/core/src/funder/transfer.rs
+++ b/crates/aptos-faucet/core/src/funder/transfer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
     common::{

--- a/crates/aptos-faucet/core/src/helpers.rs
+++ b/crates/aptos-faucet/core/src/helpers.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_sdk::{crypto::HashValue, types::transaction::SignedTransaction};
 use std::time::{SystemTime, UNIX_EPOCH};

--- a/crates/aptos-faucet/core/src/lib.rs
+++ b/crates/aptos-faucet/core/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod bypasser;
 pub mod checkers;

--- a/crates/aptos-faucet/core/src/middleware/log.rs
+++ b/crates/aptos-faucet/core/src/middleware/log.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::metrics::{HISTOGRAM, RESPONSE_STATUS};
 use aptos_logger::{

--- a/crates/aptos-faucet/core/src/middleware/metrics.rs
+++ b/crates/aptos-faucet/core/src/middleware/metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::endpoints::RejectionReason;
 use aptos_metrics_core::{

--- a/crates/aptos-faucet/core/src/middleware/mod.rs
+++ b/crates/aptos-faucet/core/src/middleware/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod log;
 mod metrics;

--- a/crates/aptos-faucet/core/src/server/generate_openapi.rs
+++ b/crates/aptos-faucet/core/src/server/generate_openapi.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     checkers::CaptchaManager,

--- a/crates/aptos-faucet/core/src/server/mod.rs
+++ b/crates/aptos-faucet/core/src/server/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod generate_openapi;
 mod run;

--- a/crates/aptos-faucet/core/src/server/run.rs
+++ b/crates/aptos-faucet/core/src/server/run.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::server_args::ServerConfig;
 use crate::{

--- a/crates/aptos-faucet/core/src/server/server_args.rs
+++ b/crates/aptos-faucet/core/src/server/server_args.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/aptos-faucet/core/src/server/validate_config.rs
+++ b/crates/aptos-faucet/core/src/server/validate_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::run::RunConfig;
 use anyhow::{Context, Result};

--- a/crates/aptos-faucet/metrics-server/src/config.rs
+++ b/crates/aptos-faucet/metrics-server/src/config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use serde::{Deserialize, Serialize};
 

--- a/crates/aptos-faucet/metrics-server/src/gather_metrics.rs
+++ b/crates/aptos-faucet/metrics-server/src/gather_metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_logger::prelude::*;
 use aptos_metrics_core::{register_int_counter_vec, IntCounterVec};

--- a/crates/aptos-faucet/metrics-server/src/lib.rs
+++ b/crates/aptos-faucet/metrics-server/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/aptos-faucet/metrics-server/src/server.rs
+++ b/crates/aptos-faucet/metrics-server/src/server.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     gather_metrics::{gather_metrics, NUM_METRICS},

--- a/crates/aptos-faucet/service/src/main.rs
+++ b/crates/aptos-faucet/service/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::Result;
 use aptos_faucet_core::server::Server;

--- a/crates/aptos-genesis/src/builder.rs
+++ b/crates/aptos-genesis/src/builder.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     config::ValidatorConfiguration,

--- a/crates/aptos-genesis/src/config.rs
+++ b/crates/aptos-genesis/src/config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_config::config::HANDSHAKE_VERSION;
 use aptos_crypto::{bls12381, ed25519::Ed25519PublicKey, x25519};

--- a/crates/aptos-genesis/src/keys.rs
+++ b/crates/aptos-genesis/src/keys.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_config::{config::IdentityBlob, keys::ConfigKey};
 use aptos_crypto::{

--- a/crates/aptos-genesis/src/lib.rs
+++ b/crates/aptos-genesis/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/aptos-genesis/src/mainnet.rs
+++ b/crates/aptos-genesis/src/mainnet.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{builder::GenesisConfiguration, config::ValidatorConfiguration};
 use aptos_config::config::{

--- a/crates/aptos-genesis/src/test_utils.rs
+++ b/crates/aptos-genesis/src/test_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::builder::InitGenesisConfigFn;
 use aptos_config::config::{IdentityBlob, NodeConfig};

--- a/crates/aptos-in-memory-cache/src/caches/mod.rs
+++ b/crates/aptos-in-memory-cache/src/caches/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod sync_mutex;
 

--- a/crates/aptos-in-memory-cache/src/caches/sync_mutex.rs
+++ b/crates/aptos-in-memory-cache/src/caches/sync_mutex.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{SizedCache, SizedCacheEntry};
 use parking_lot::Mutex;

--- a/crates/aptos-in-memory-cache/src/lib.rs
+++ b/crates/aptos-in-memory-cache/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use std::hash::Hash;
 

--- a/crates/aptos-in-memory-cache/tests/common/mod.rs
+++ b/crates/aptos-in-memory-cache/tests/common/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_in_memory_cache::{Cache, SizedCache};
 use get_size::GetSize;

--- a/crates/aptos-in-memory-cache/tests/tests.rs
+++ b/crates/aptos-in-memory-cache/tests/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_in_memory_cache::Cache;
 use common::{NotATransaction, TestCache};

--- a/crates/aptos-inspection-service/src/inspection_client.rs
+++ b/crates/aptos-inspection-service/src/inspection_client.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::Result;
 use reqwest::Url;

--- a/crates/aptos-inspection-service/src/lib.rs
+++ b/crates/aptos-inspection-service/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod inspection_client;
 pub mod server;

--- a/crates/aptos-inspection-service/src/server/configuration.rs
+++ b/crates/aptos-inspection-service/src/server/configuration.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::server::utils::CONTENT_TYPE_TEXT;
 use aptos_config::config::NodeConfig;

--- a/crates/aptos-inspection-service/src/server/identity_information.rs
+++ b/crates/aptos-inspection-service/src/server/identity_information.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::server::utils::CONTENT_TYPE_TEXT;
 use aptos_config::config::NodeConfig;

--- a/crates/aptos-inspection-service/src/server/index.rs
+++ b/crates/aptos-inspection-service/src/server/index.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     server::utils::CONTENT_TYPE_TEXT, CONFIGURATION_PATH, CONSENSUS_HEALTH_CHECK_PATH,

--- a/crates/aptos-inspection-service/src/server/json_encoder.rs
+++ b/crates/aptos-inspection-service/src/server/json_encoder.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils::CONTENT_TYPE_JSON;
 use aptos_logger::error;

--- a/crates/aptos-inspection-service/src/server/metrics.rs
+++ b/crates/aptos-inspection-service/src/server/metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::server::{
     json_encoder::JsonEncoder,

--- a/crates/aptos-inspection-service/src/server/mod.rs
+++ b/crates/aptos-inspection-service/src/server/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::server::utils::CONTENT_TYPE_TEXT;
 use aptos_config::config::NodeConfig;

--- a/crates/aptos-inspection-service/src/server/peer_information.rs
+++ b/crates/aptos-inspection-service/src/server/peer_information.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::server::utils::CONTENT_TYPE_TEXT;
 use aptos_config::{

--- a/crates/aptos-inspection-service/src/server/system_information.rs
+++ b/crates/aptos-inspection-service/src/server/system_information.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::server::utils::{CONTENT_TYPE_JSON, CONTENT_TYPE_TEXT};
 use aptos_build_info::build_information;

--- a/crates/aptos-inspection-service/src/server/tests.rs
+++ b/crates/aptos-inspection-service/src/server/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     server::{

--- a/crates/aptos-inspection-service/src/server/utils.rs
+++ b/crates/aptos-inspection-service/src/server/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_logger::{error, warn};
 use aptos_metrics_core::{register_int_counter_vec, IntCounterVec};

--- a/crates/aptos-jwk-consensus/src/counters.rs
+++ b/crates/aptos-jwk-consensus/src/counters.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_metrics_core::{register_histogram_vec, register_int_gauge, HistogramVec, IntGauge};
 use once_cell::sync::Lazy;

--- a/crates/aptos-jwk-consensus/src/epoch_manager.rs
+++ b/crates/aptos-jwk-consensus/src/epoch_manager.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     jwk_manager::IssuerLevelConsensusManager,

--- a/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     jwk_observer::JWKObserver,

--- a/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     jwk_manager::{

--- a/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_manager_per_key.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     jwk_observer::JWKObserver,

--- a/crates/aptos-jwk-consensus/src/jwk_observer.rs
+++ b/crates/aptos-jwk-consensus/src/jwk_observer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::counters::OBSERVATION_SECONDS;
 use anyhow::{anyhow, Result};

--- a/crates/aptos-jwk-consensus/src/lib.rs
+++ b/crates/aptos-jwk-consensus/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     epoch_manager::EpochManager,

--- a/crates/aptos-jwk-consensus/src/network.rs
+++ b/crates/aptos-jwk-consensus/src/network.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     network_interface::{JWKConsensusNetworkClient, RPC},

--- a/crates/aptos-jwk-consensus/src/network_interface.rs
+++ b/crates/aptos-jwk-consensus/src/network_interface.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::types::JWKConsensusMsg;
 use aptos_config::network_id::{NetworkId, PeerNetworkId};

--- a/crates/aptos-jwk-consensus/src/observation_aggregation/mod.rs
+++ b/crates/aptos-jwk-consensus/src/observation_aggregation/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     mode::TConsensusMode,

--- a/crates/aptos-jwk-consensus/src/observation_aggregation/tests.rs
+++ b/crates/aptos-jwk-consensus/src/observation_aggregation/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     mode::per_issuer::PerIssuerMode,

--- a/crates/aptos-jwk-consensus/src/types.rs
+++ b/crates/aptos-jwk-consensus/src/types.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::bls12381::Signature;
 use aptos_enum_conversion_derive::EnumConversion;

--- a/crates/aptos-jwk-consensus/src/update_certifier.rs
+++ b/crates/aptos-jwk-consensus/src/update_certifier.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     mode::TConsensusMode, observation_aggregation::ObservationAggregationState,

--- a/crates/aptos-keygen/src/lib.rs
+++ b/crates/aptos-keygen/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::{
     bls12381,

--- a/crates/aptos-keygen/src/main.rs
+++ b/crates/aptos-keygen/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::ValidCryptoMaterialStringExt;
 use aptos_keygen::KeyGen;

--- a/crates/aptos-ledger/src/lib.rs
+++ b/crates/aptos-ledger/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! # aptos-ledger
 //!

--- a/crates/aptos-logger/src/telemetry_log_writer.rs
+++ b/crates/aptos-logger/src/telemetry_log_writer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::counters::{APTOS_LOG_INGEST_WRITER_DISCONNECTED, APTOS_LOG_INGEST_WRITER_FULL};
 use futures::channel;

--- a/crates/aptos-metrics-core/src/avg_counter.rs
+++ b/crates/aptos-metrics-core/src/avg_counter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use prometheus::{register_histogram, register_histogram_vec, Histogram, HistogramVec};
 

--- a/crates/aptos-metrics-core/src/const_metric.rs
+++ b/crates/aptos-metrics-core/src/const_metric.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{anyhow, Result};
 use prometheus::{

--- a/crates/aptos-metrics-core/src/op_counters.rs
+++ b/crates/aptos-metrics-core/src/op_counters.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! `OpCounters` is a collection of convenience methods to add arbitrary counters to modules.
 //! For now, it supports Int-Counters, Int-Gauges, and Histogram.

--- a/crates/aptos-metrics-core/src/thread_local.rs
+++ b/crates/aptos-metrics-core/src/thread_local.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod __private {
     pub use once_cell::sync::Lazy;

--- a/crates/aptos-network-checker/src/args.rs
+++ b/crates/aptos-network-checker/src/args.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{bail, Context, Result};
 use aptos_config::network_id::NetworkId;

--- a/crates/aptos-network-checker/src/check_endpoint.rs
+++ b/crates/aptos-network-checker/src/check_endpoint.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::args::CheckEndpointArgs;
 use anyhow::{bail, Context, Result};

--- a/crates/aptos-network-checker/src/lib.rs
+++ b/crates/aptos-network-checker/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod args;
 pub mod check_endpoint;

--- a/crates/aptos-node-identity/src/lib.rs
+++ b/crates/aptos-node-identity/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{format_err, Result};
 use aptos_types::{chain_id::ChainId, PeerId};

--- a/crates/aptos-openapi/src/helpers.rs
+++ b/crates/aptos-openapi/src/helpers.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! In order to use a type with poem-openapi, it must implement a certain set
 //! of traits, depending on the context in which you want to use the type.

--- a/crates/aptos-openapi/src/lib.rs
+++ b/crates/aptos-openapi/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod helpers;
 

--- a/crates/aptos-profiler/src/cpu_profiler.rs
+++ b/crates/aptos-profiler/src/cpu_profiler.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     utils::{convert_svg_to_string, create_file_with_parents},

--- a/crates/aptos-profiler/src/lib.rs
+++ b/crates/aptos-profiler/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{cpu_profiler::CpuProfiler, memory_profiler::MemProfiler};
 use anyhow::Result;

--- a/crates/aptos-profiler/src/memory_profiler.rs
+++ b/crates/aptos-profiler/src/memory_profiler.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{utils::convert_svg_to_string, MemProfilerConfig, Profiler};
 #[cfg(unix)]

--- a/crates/aptos-profiler/src/utils.rs
+++ b/crates/aptos-profiler/src/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::Result;
 use std::{fs, fs::File, path::Path};

--- a/crates/aptos-push-metrics/src/lib.rs
+++ b/crates/aptos-push-metrics/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/aptos-rest-client/examples/account/main.rs
+++ b/crates/aptos-rest-client/examples/account/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{Context, Result};
 use aptos_logger::{debug, info};

--- a/crates/aptos-rest-client/src/aptos.rs
+++ b/crates/aptos-rest-client/src/aptos.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_api_types::U64;
 use serde::{Deserialize, Serialize};

--- a/crates/aptos-rest-client/src/client_builder.rs
+++ b/crates/aptos-rest-client/src/client_builder.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     get_version_path_with_base, Client, DEFAULT_VERSION_PATH_BASE, X_APTOS_SDK_HEADER_VALUE,

--- a/crates/aptos-rest-client/src/error.rs
+++ b/crates/aptos-rest-client/src/error.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::State;
 use aptos_api_types::AptosError;

--- a/crates/aptos-rest-client/src/response.rs
+++ b/crates/aptos-rest-client/src/response.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::state::State;
 

--- a/crates/aptos-rest-client/src/state.rs
+++ b/crates/aptos-rest-client/src/state.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_api_types::{
     X_APTOS_BLOCK_HEIGHT, X_APTOS_CHAIN_ID, X_APTOS_CURSOR, X_APTOS_EPOCH,

--- a/crates/aptos-rosetta-cli/src/account.rs
+++ b/crates/aptos-rosetta-cli/src/account.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::{format_output, BlockArgs, NetworkArgs, UrlArgs};
 use aptos_rosetta::{

--- a/crates/aptos-rosetta-cli/src/block.rs
+++ b/crates/aptos-rosetta-cli/src/block.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::{format_output, BlockArgs, NetworkArgs, UrlArgs};
 use aptos_rosetta::types::{BlockRequest, BlockRequestMetadata, BlockResponse};

--- a/crates/aptos-rosetta-cli/src/common.rs
+++ b/crates/aptos-rosetta-cli/src/common.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{account, block, construction, network};
 use aptos_rosetta::{

--- a/crates/aptos-rosetta-cli/src/construction.rs
+++ b/crates/aptos-rosetta-cli/src/construction.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::{format_output, NetworkArgs, UrlArgs};
 use aptos::common::types::{EncodingOptions, PrivateKeyInputOptions, ProfileOptions};

--- a/crates/aptos-rosetta-cli/src/main.rs
+++ b/crates/aptos-rosetta-cli/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Aptos Rosetta CLI
 //!

--- a/crates/aptos-rosetta-cli/src/network.rs
+++ b/crates/aptos-rosetta-cli/src/network.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::{format_output, NetworkArgs, UrlArgs};
 use aptos_rosetta::types::{NetworkListResponse, NetworkOptionsResponse, NetworkStatusResponse};

--- a/crates/aptos-rosetta/src/account.rs
+++ b/crates/aptos-rosetta/src/account.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Rosetta Account API
 //!

--- a/crates/aptos-rosetta/src/block.rs
+++ b/crates/aptos-rosetta/src/block.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos-rosetta/src/client.rs
+++ b/crates/aptos-rosetta/src/client.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::native_coin,

--- a/crates/aptos-rosetta/src/common.rs
+++ b/crates/aptos-rosetta/src/common.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     error::{ApiError, ApiResult},

--- a/crates/aptos-rosetta/src/construction.rs
+++ b/crates/aptos-rosetta/src/construction.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Construction APIs
 //!

--- a/crates/aptos-rosetta/src/error.rs
+++ b/crates/aptos-rosetta/src/error.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{types, types::ErrorDetails};
 use aptos_rest_client::{aptos_api_types::AptosErrorCode, error::RestError};

--- a/crates/aptos-rosetta/src/lib.rs
+++ b/crates/aptos-rosetta/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Aptos Rosetta API
 //!

--- a/crates/aptos-rosetta/src/main.rs
+++ b/crates/aptos-rosetta/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Runs the Rosetta server directly.
 

--- a/crates/aptos-rosetta/src/network.rs
+++ b/crates/aptos-rosetta/src/network.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{check_network, handle_request, with_context, with_empty_request},

--- a/crates/aptos-rosetta/src/types/identifiers.rs
+++ b/crates/aptos-rosetta/src/types/identifiers.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Identifiers for the Rosetta spec
 //!

--- a/crates/aptos-rosetta/src/types/misc.rs
+++ b/crates/aptos-rosetta/src/types/misc.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     account::view,

--- a/crates/aptos-rosetta/src/types/mod.rs
+++ b/crates/aptos-rosetta/src/types/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod identifiers;
 mod misc;

--- a/crates/aptos-rosetta/src/types/move_types.rs
+++ b/crates/aptos-rosetta/src/types/move_types.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Types and identifiers for parsing Move pub structs and types
 

--- a/crates/aptos-rosetta/src/types/objects.rs
+++ b/crates/aptos-rosetta/src/types/objects.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Objects of the Rosetta spec
 //!

--- a/crates/aptos-rosetta/src/types/requests.rs
+++ b/crates/aptos-rosetta/src/types/requests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     types::{

--- a/crates/aptos-runtimes/src/lib.rs
+++ b/crates/aptos-runtimes/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use rayon::{ThreadPool, ThreadPoolBuilder};
 use std::sync::atomic::{AtomicUsize, Ordering};

--- a/crates/aptos-speculative-state-helper/src/lib.rs
+++ b/crates/aptos-speculative-state-helper/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! This crate is designed to help with tracking events and state that might be speculative in
 //! nature due to speculative execution of transactions (e.g. by BlockSTM parallel executor, but

--- a/crates/aptos-speculative-state-helper/src/tests/logging.rs
+++ b/crates/aptos-speculative-state-helper/src/tests/logging.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{SpeculativeEvent, SpeculativeEvents};
 use claims::{assert_err, assert_ok};

--- a/crates/aptos-speculative-state-helper/src/tests/mod.rs
+++ b/crates/aptos-speculative-state-helper/src/tests/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{SpeculativeEvent, SpeculativeEvents};
 use claims::{assert_err, assert_ok};

--- a/crates/aptos-speculative-state-helper/src/tests/proptests.rs
+++ b/crates/aptos-speculative-state-helper/src/tests/proptests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{SpeculativeCounter, SpeculativeEvent, SpeculativeEvents};
 use claims::{assert_err, assert_ok};

--- a/crates/aptos-system-utils/src/lib.rs
+++ b/crates/aptos-system-utils/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[cfg(target_os = "linux")]
 pub mod profiling;

--- a/crates/aptos-system-utils/src/profiling.rs
+++ b/crates/aptos-system-utils/src/profiling.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils::{reply_with, reply_with_status};
 use anyhow::{anyhow, ensure};

--- a/crates/aptos-system-utils/src/thread_dump.rs
+++ b/crates/aptos-system-utils/src/thread_dump.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils::{reply_with, reply_with_status};
 use anyhow::{ensure, Error};

--- a/crates/aptos-system-utils/src/utils.rs
+++ b/crates/aptos-system-utils/src/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![allow(unused)]
 

--- a/crates/aptos-telemetry-service/src/auth.rs
+++ b/crates/aptos-telemetry-service/src/auth.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     context::Context,

--- a/crates/aptos-telemetry-service/src/clients/humio.rs
+++ b/crates/aptos-telemetry-service/src/clients/humio.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::types::humio::UnstructuredLog;
 use anyhow::anyhow;

--- a/crates/aptos-telemetry-service/src/clients/mod.rs
+++ b/crates/aptos-telemetry-service/src/clients/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod humio;
 

--- a/crates/aptos-telemetry-service/src/constants.rs
+++ b/crates/aptos-telemetry-service/src/constants.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// The maximum content length to accept in the http body.
 pub const MAX_CONTENT_LENGTH: u64 = 1024 * 1024;

--- a/crates/aptos-telemetry-service/src/context.rs
+++ b/crates/aptos-telemetry-service/src/context.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     clients::{big_query::TableWriteClient, humio, victoria_metrics_api::Client as MetricsClient},

--- a/crates/aptos-telemetry-service/src/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/custom_event.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     auth::with_auth,

--- a/crates/aptos-telemetry-service/src/errors.rs
+++ b/crates/aptos-telemetry-service/src/errors.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::noise::NoiseError;
 use aptos_rest_client::error::RestError;

--- a/crates/aptos-telemetry-service/src/gcp_logger.rs
+++ b/crates/aptos-telemetry-service/src/gcp_logger.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::constants::GCP_SERVICE_PROJECT_ID_ENV;
 use std::env;

--- a/crates/aptos-telemetry-service/src/index.rs
+++ b/crates/aptos-telemetry-service/src/index.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     auth,

--- a/crates/aptos-telemetry-service/src/jwt_auth.rs
+++ b/crates/aptos-telemetry-service/src/jwt_auth.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     context::{Context, JsonWebTokenService},

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     clients::{big_query, humio, victoria_metrics_api::Client as MetricsClient},

--- a/crates/aptos-telemetry-service/src/log_ingest.rs
+++ b/crates/aptos-telemetry-service/src/log_ingest.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     auth::with_auth,

--- a/crates/aptos-telemetry-service/src/main.rs
+++ b/crates/aptos-telemetry-service/src/main.rs
@@ -1,7 +1,7 @@
 #![forbid(unsafe_code)]
 
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_telemetry_service::AptosTelemetryServiceArgs;
 use clap::Parser;

--- a/crates/aptos-telemetry-service/src/metrics.rs
+++ b/crates/aptos-telemetry-service/src/metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     clients::victoria_metrics_api,

--- a/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
+++ b/crates/aptos-telemetry-service/src/prometheus_push_metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     auth::with_auth,

--- a/crates/aptos-telemetry-service/src/remote_config.rs
+++ b/crates/aptos-telemetry-service/src/remote_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     auth::with_auth,

--- a/crates/aptos-telemetry-service/src/tests/auth_test.rs
+++ b/crates/aptos-telemetry-service/src/tests/auth_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     context::JsonWebTokenService,

--- a/crates/aptos-telemetry-service/src/tests/custom_event.rs
+++ b/crates/aptos-telemetry-service/src/tests/custom_event.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::test_context::new_test_context;
 use crate::{

--- a/crates/aptos-telemetry-service/src/tests/mod.rs
+++ b/crates/aptos-telemetry-service/src/tests/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod auth_test;
 mod custom_event;

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     context::{ClientTuple, Context, GroupedMetricsClients, JsonWebTokenService, PeerStoreTuple},

--- a/crates/aptos-telemetry-service/src/types/auth.rs
+++ b/crates/aptos-telemetry-service/src/types/auth.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::common::NodeType;
 use aptos_config::config::RoleType;

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod auth;
 pub mod telemetry;

--- a/crates/aptos-telemetry-service/src/types/telemetry.rs
+++ b/crates/aptos-telemetry-service/src/types/telemetry.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::types::common::EventIdentity;
 use serde::{Deserialize, Serialize};

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     debug, error,

--- a/crates/aptos-telemetry/src/cli_metrics.rs
+++ b/crates/aptos-telemetry/src/cli_metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{service, utils};
 use aptos_logger::debug;

--- a/crates/aptos-telemetry/src/constants.rs
+++ b/crates/aptos-telemetry/src/constants.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 /// A collection of constants and default values for configuring telemetry components
 

--- a/crates/aptos-telemetry/src/core_metrics.rs
+++ b/crates/aptos-telemetry/src/core_metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{utils, utils::sum_all_histogram_counts};
 use aptos_config::config::NodeConfig;

--- a/crates/aptos-telemetry/src/lib.rs
+++ b/crates/aptos-telemetry/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod constants;
 mod core_metrics;

--- a/crates/aptos-telemetry/src/metrics.rs
+++ b/crates/aptos-telemetry/src/metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_metrics_core::{
     register_int_counter, register_int_counter_vec, IntCounter, IntCounterVec,

--- a/crates/aptos-telemetry/src/network_metrics.rs
+++ b/crates/aptos-telemetry/src/network_metrics.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils;
 use aptos_telemetry_service::types::telemetry::TelemetryEvent;

--- a/crates/aptos-telemetry/src/sender.rs
+++ b/crates/aptos-telemetry/src/sender.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::metrics::{self, increment_log_ingest_failures_by, increment_log_ingest_successes_by};
 use anyhow::{anyhow, Error, Result};

--- a/crates/aptos-telemetry/src/service.rs
+++ b/crates/aptos-telemetry/src/service.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     constants::*, core_metrics::create_core_metric_telemetry_event, metrics,

--- a/crates/aptos-telemetry/src/system_information.rs
+++ b/crates/aptos-telemetry/src/system_information.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::utils;
 use aptos_infallible::Mutex;

--- a/crates/aptos-telemetry/src/telemetry_log_sender.rs
+++ b/crates/aptos-telemetry/src/telemetry_log_sender.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{metrics::increment_log_ingest_too_large_by, sender::TelemetrySender};
 use aptos_logger::{prelude::*, telemetry_log_writer::TelemetryLog};

--- a/crates/aptos-telemetry/src/utils.rs
+++ b/crates/aptos-telemetry/src/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/aptos-transaction-filters/src/batch_transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/batch_transaction_filter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::transaction_filter::TransactionMatcher;
 use aptos_crypto::HashValue;

--- a/crates/aptos-transaction-filters/src/block_transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/block_transaction_filter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::transaction_filter::TransactionMatcher;
 use aptos_crypto::HashValue;

--- a/crates/aptos-transaction-filters/src/lib.rs
+++ b/crates/aptos-transaction-filters/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/aptos-transaction-filters/src/tests/batch_transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/tests/batch_transaction_filter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     batch_transaction_filter::{BatchMatcher, BatchTransactionFilter, BatchTransactionMatcher},

--- a/crates/aptos-transaction-filters/src/tests/batch_transaction_filter_config.rs
+++ b/crates/aptos-transaction-filters/src/tests/batch_transaction_filter_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{batch_transaction_filter::BatchTransactionFilter, tests::utils};
 use aptos_types::{quorum_store::BatchId, PeerId};

--- a/crates/aptos-transaction-filters/src/tests/block_transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/tests/block_transaction_filter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     block_transaction_filter::{BlockMatcher, BlockTransactionFilter, BlockTransactionMatcher},

--- a/crates/aptos-transaction-filters/src/tests/block_transaction_filter_config.rs
+++ b/crates/aptos-transaction-filters/src/tests/block_transaction_filter_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{block_transaction_filter::BlockTransactionFilter, tests::utils};
 use aptos_crypto::HashValue;

--- a/crates/aptos-transaction-filters/src/tests/mod.rs
+++ b/crates/aptos-transaction-filters/src/tests/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod batch_transaction_filter;
 mod batch_transaction_filter_config;

--- a/crates/aptos-transaction-filters/src/tests/transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/tests/transaction_filter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     tests::utils,

--- a/crates/aptos-transaction-filters/src/tests/transaction_filter_config.rs
+++ b/crates/aptos-transaction-filters/src/tests/transaction_filter_config.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{tests::utils, transaction_filter::TransactionFilter};
 

--- a/crates/aptos-transaction-filters/src/tests/utils.rs
+++ b/crates/aptos-transaction-filters/src/tests/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::tests::utils;
 use aptos_crypto::{

--- a/crates/aptos-transaction-filters/src/transaction_filter.rs
+++ b/crates/aptos-transaction-filters/src/transaction_filter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_crypto::{ed25519::Ed25519PublicKey, HashValue};
 use aptos_types::transaction::{

--- a/crates/aptos/build.rs
+++ b/crates/aptos/build.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 fn main() -> shadow_rs::SdResult<()> {
     shadow_rs::new()

--- a/crates/aptos/src/account/balance.rs
+++ b/crates/aptos/src/account/balance.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{
     CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, ProfileOptions, RestOptions,

--- a/crates/aptos/src/account/create.rs
+++ b/crates/aptos/src/account/create.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions, TransactionSummary};
 use aptos_cached_packages::aptos_stdlib;

--- a/crates/aptos/src/account/create_resource_account.rs
+++ b/crates/aptos/src/account/create_resource_account.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     account::derive_resource_account::ResourceAccountSeed,

--- a/crates/aptos/src/account/derive_resource_account.rs
+++ b/crates/aptos/src/account/derive_resource_account.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{CliCommand, CliError, CliTypedResult};
 use aptos_sdk::rest_client::aptos_api_types::HexEncodedBytes;

--- a/crates/aptos/src/account/fund.rs
+++ b/crates/aptos/src/account/fund.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     account::create::DEFAULT_FUNDED_COINS,

--- a/crates/aptos/src/account/key_rotation.rs
+++ b/crates/aptos/src/account/key_rotation.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{
     account_address_from_auth_key, account_address_from_public_key, AuthenticationKeyInputOptions,

--- a/crates/aptos/src/account/list.rs
+++ b/crates/aptos/src/account/list.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{
     CliCommand, CliConfig, CliError, CliTypedResult, ConfigSearchMode, ProfileOptions, RestOptions,

--- a/crates/aptos/src/account/mod.rs
+++ b/crates/aptos/src/account/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{CliCommand, CliResult};
 use clap::Subcommand;

--- a/crates/aptos/src/account/multisig_account.rs
+++ b/crates/aptos/src/account/multisig_account.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::{
     types::{

--- a/crates/aptos/src/account/transfer.rs
+++ b/crates/aptos/src/account/transfer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{CliCommand, CliTypedResult, TransactionOptions};
 use aptos_cached_packages::aptos_stdlib;

--- a/crates/aptos/src/common/init.rs
+++ b/crates/aptos/src/common/init.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::types::FaucetOptions;
 use crate::{

--- a/crates/aptos/src/common/local_simulation.rs
+++ b/crates/aptos/src/common/local_simulation.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::{CliError, CliTypedResult};
 use aptos_crypto::HashValue;

--- a/crates/aptos/src/common/mod.rs
+++ b/crates/aptos/src/common/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod init;
 pub mod local_simulation;

--- a/crates/aptos/src/common/transactions.rs
+++ b/crates/aptos/src/common/transactions.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::{
     local_simulation,

--- a/crates/aptos/src/common/types.rs
+++ b/crates/aptos/src/common/types.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::utils::{explorer_transaction_link, fund_account, strip_private_key_prefix};
 use crate::{

--- a/crates/aptos/src/common/utils.rs
+++ b/crates/aptos/src/common/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/config/mod.rs
+++ b/crates/aptos/src/config/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/genesis/git.rs
+++ b/crates/aptos/src/genesis/git.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/genesis/keys.rs
+++ b/crates/aptos/src/genesis/keys.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/genesis/mod.rs
+++ b/crates/aptos/src/genesis/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod git;
 pub mod keys;

--- a/crates/aptos/src/genesis/tests.rs
+++ b/crates/aptos/src/genesis/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/genesis/tools.rs
+++ b/crates/aptos/src/genesis/tools.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/governance/delegation_pool.rs
+++ b/crates/aptos/src/governance/delegation_pool.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::governance::{utils::*, *};
 use clap::Subcommand;

--- a/crates/aptos/src/governance/mod.rs
+++ b/crates/aptos/src/governance/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod delegation_pool;
 pub mod utils;

--- a/crates/aptos/src/governance/utils.rs
+++ b/crates/aptos/src/governance/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{governance::*, *};
 use aptos_types::on_chain_config::FeatureFlag;

--- a/crates/aptos/src/lib.rs
+++ b/crates/aptos/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![deny(unsafe_code)]
 

--- a/crates/aptos/src/main.rs
+++ b/crates/aptos/src/main.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Aptos is a one stop tool for operations, debugging, and other operations with the blockchain
 

--- a/crates/aptos/src/move_tool/aptos_debug_natives.rs
+++ b/crates/aptos/src/move_tool/aptos_debug_natives.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_framework::extended_checks;
 use aptos_gas_schedule::{MiscGasParameters, NativeGasParameters, LATEST_GAS_FEATURE_VERSION};

--- a/crates/aptos/src/move_tool/bytecode.rs
+++ b/crates/aptos/src/move_tool/bytecode.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/move_tool/coverage.rs
+++ b/crates/aptos/src/move_tool/coverage.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageOptions},

--- a/crates/aptos/src/move_tool/lint.rs
+++ b/crates/aptos/src/move_tool/lint.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::types::{AccountAddressWrapper, CliCommand, CliTypedResult, MovePackageOptions},

--- a/crates/aptos/src/move_tool/manifest.rs
+++ b/crates/aptos/src/move_tool/manifest.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::common::types::load_manifest_account_arg;
 use aptos_types::account_address::AccountAddress;

--- a/crates/aptos/src/move_tool/mod.rs
+++ b/crates/aptos/src/move_tool/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     account::derive_resource_account::ResourceAccountSeed,

--- a/crates/aptos/src/move_tool/package_hooks.rs
+++ b/crates/aptos/src/move_tool/package_hooks.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{common::types::load_account_arg, move_tool::CachedPackageRegistry};
 use aptos_framework::UPGRADE_POLICY_CUSTOM_FIELD;

--- a/crates/aptos/src/move_tool/show.rs
+++ b/crates/aptos/src/move_tool/show.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::IncludedArtifactsArgs;
 use crate::common::types::{CliCommand, CliError, CliResult, CliTypedResult, MovePackageOptions};

--- a/crates/aptos/src/move_tool/stored_package.rs
+++ b/crates/aptos/src/move_tool/stored_package.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::bail;
 use aptos_framework::{

--- a/crates/aptos/src/node/analyze/analyze_validators.rs
+++ b/crates/aptos/src/node/analyze/analyze_validators.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::fetch_metadata::ValidatorInfo;
 use anyhow::Result;

--- a/crates/aptos/src/node/analyze/fetch_metadata.rs
+++ b/crates/aptos/src/node/analyze/fetch_metadata.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{anyhow, Result};
 use aptos_rest_client::{

--- a/crates/aptos/src/node/analyze/mod.rs
+++ b/crates/aptos/src/node/analyze/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod analyze_validators;
 pub mod fetch_metadata;

--- a/crates/aptos/src/node/local_testnet/docker.rs
+++ b/crates/aptos/src/node/local_testnet/docker.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::traits::ShutdownStep;
 use anyhow::{Context, Result};

--- a/crates/aptos/src/node/local_testnet/faucet.rs
+++ b/crates/aptos/src/node/local_testnet/faucet.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use anyhow::Result;

--- a/crates/aptos/src/node/local_testnet/health_checker.rs
+++ b/crates/aptos/src/node/local_testnet/health_checker.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::indexer_api::confirm_metadata_applied;
 use anyhow::{anyhow, Context, Result};

--- a/crates/aptos/src/node/local_testnet/indexer_api.rs
+++ b/crates/aptos/src/node/local_testnet/indexer_api.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
     docker::{

--- a/crates/aptos/src/node/local_testnet/logging.rs
+++ b/crates/aptos/src/node/local_testnet/logging.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use dashmap::DashMap;
 use std::{

--- a/crates/aptos/src/node/local_testnet/mod.rs
+++ b/crates/aptos/src/node/local_testnet/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod logging;
 mod postgres;

--- a/crates/aptos/src/node/local_testnet/node.rs
+++ b/crates/aptos/src/node/local_testnet/node.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use crate::node::local_testnet::utils::socket_addr_to_url;

--- a/crates/aptos/src/node/local_testnet/postgres.rs
+++ b/crates/aptos/src/node/local_testnet/postgres.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
     docker::{

--- a/crates/aptos/src/node/local_testnet/processors.rs
+++ b/crates/aptos/src/node/local_testnet/processors.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use anyhow::{bail, Context, Result};

--- a/crates/aptos/src/node/local_testnet/ready_server.rs
+++ b/crates/aptos/src/node/local_testnet/ready_server.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{health_checker::HealthChecker, traits::ServiceManager, RunLocalnet};
 use anyhow::Result;

--- a/crates/aptos/src/node/local_testnet/traits.rs
+++ b/crates/aptos/src/node/local_testnet/traits.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::health_checker::HealthChecker;
 use anyhow::{Context, Result};

--- a/crates/aptos/src/node/local_testnet/utils.rs
+++ b/crates/aptos/src/node/local_testnet/utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::Result;
 use reqwest::Url;

--- a/crates/aptos/src/node/mod.rs
+++ b/crates/aptos/src/node/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod analyze;
 pub mod local_testnet;

--- a/crates/aptos/src/op/key.rs
+++ b/crates/aptos/src/op/key.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/op/mod.rs
+++ b/crates/aptos/src/op/mod.rs
@@ -1,4 +1,4 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod key;

--- a/crates/aptos/src/stake/mod.rs
+++ b/crates/aptos/src/stake/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     common::{

--- a/crates/aptos/src/test/mod.rs
+++ b/crates/aptos/src/test/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     account::{

--- a/crates/aptos/src/test/tests.rs
+++ b/crates/aptos/src/test/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     move_tool::{ArgWithType, FunctionArgType},

--- a/crates/aptos/src/update/aptos.rs
+++ b/crates/aptos/src/update/aptos.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // Out of the box the self_update crate assumes that you have releases named a
 // specific way with the crate name, version, and target triple in a specific

--- a/crates/aptos/src/update/helpers.rs
+++ b/crates/aptos/src/update/helpers.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use std::path::PathBuf;
 

--- a/crates/aptos/src/update/mod.rs
+++ b/crates/aptos/src/update/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // Note: We make use of the self_update crate, but as you can see in the case of
 // Revela, this can also be used to install / update other binaries.

--- a/crates/aptos/src/update/move_mutation_test.rs
+++ b/crates/aptos/src/update/move_mutation_test.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{update_binary, BinaryUpdater, UpdateRequiredInfo};
 use crate::{

--- a/crates/aptos/src/update/movefmt.rs
+++ b/crates/aptos/src/update/movefmt.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{update_binary, BinaryUpdater, UpdateRequiredInfo};
 use crate::{

--- a/crates/aptos/src/update/prover_dependencies.rs
+++ b/crates/aptos/src/update/prover_dependencies.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     cli_build_information,

--- a/crates/aptos/src/update/prover_dependency_installer.rs
+++ b/crates/aptos/src/update/prover_dependency_installer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{BinaryUpdater, UpdateRequiredInfo};
 use crate::update::{

--- a/crates/aptos/src/update/revela.rs
+++ b/crates/aptos/src/update/revela.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{update_binary, BinaryUpdater, UpdateRequiredInfo};
 use crate::{

--- a/crates/aptos/src/update/tool.rs
+++ b/crates/aptos/src/update/tool.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{aptos::AptosUpdateTool, revela::RevelaUpdateTool};
 use crate::{

--- a/crates/aptos/src/update/update_helper.rs
+++ b/crates/aptos/src/update/update_helper.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     cli_build_information,

--- a/crates/bounded-executor/src/concurrent_stream.rs
+++ b/crates/bounded-executor/src/concurrent_stream.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::BoundedExecutor;
 use futures::{

--- a/crates/bounded-executor/src/executor.rs
+++ b/crates/bounded-executor/src/executor.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! A bounded tokio [`Handle`]. Only a bounded number of tasks can run
 //! concurrently when spawned through this executor, defined by the initial

--- a/crates/indexer/src/counters.rs
+++ b/crates/indexer/src/counters.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_metrics_core::{
     register_int_counter, register_int_counter_vec, register_int_gauge_vec, IntCounter,

--- a/crates/indexer/src/database.rs
+++ b/crates/indexer/src/database.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 //! Database-related functions
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/indexer/errors.rs
+++ b/crates/indexer/src/indexer/errors.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::Error;
 

--- a/crates/indexer/src/indexer/fetcher.rs
+++ b/crates/indexer/src/indexer/fetcher.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::counters::{FETCHED_TRANSACTION, UNABLE_TO_FETCH_TRANSACTION};
 use aptos_api::Context;

--- a/crates/indexer/src/indexer/mod.rs
+++ b/crates/indexer/src/indexer/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod errors;
 pub mod fetcher;

--- a/crates/indexer/src/indexer/processing_result.rs
+++ b/crates/indexer/src/indexer/processing_result.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #[derive(Debug)]
 pub struct ProcessingResult {

--- a/crates/indexer/src/indexer/tailer.rs
+++ b/crates/indexer/src/indexer/tailer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{
     database::{execute_with_better_error, PgDbPool},
     indexer::{

--- a/crates/indexer/src/indexer/transaction_processor.rs
+++ b/crates/indexer/src/indexer/transaction_processor.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     counters::{

--- a/crates/indexer/src/lib.rs
+++ b/crates/indexer/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // Increase recursion limit for `serde_json::json!` macro parsing
 #![recursion_limit = "256"]

--- a/crates/indexer/src/models/block_metadata_transactions.rs
+++ b/crates/indexer/src/models/block_metadata_transactions.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/coin_models/account_transactions.rs
+++ b/crates/indexer/src/models/coin_models/account_transactions.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/coin_models/coin_activities.rs
+++ b/crates/indexer/src/models/coin_models/coin_activities.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/coin_models/coin_balances.rs
+++ b/crates/indexer/src/models/coin_models/coin_balances.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/coin_models/coin_infos.rs
+++ b/crates/indexer/src/models/coin_models/coin_infos.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/coin_models/coin_supply.rs
+++ b/crates/indexer/src/models/coin_models/coin_supply.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/coin_models/coin_utils.rs
+++ b/crates/indexer/src/models/coin_models/coin_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/coin_models/mod.rs
+++ b/crates/indexer/src/models/coin_models/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod account_transactions;
 pub mod coin_activities;

--- a/crates/indexer/src/models/coin_models/v2_fungible_asset_utils.rs
+++ b/crates/indexer/src/models/coin_models/v2_fungible_asset_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/events.rs
+++ b/crates/indexer/src/models/events.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use super::transactions::TransactionQuery;
 use crate::{models::transactions::Transaction, schema::events, util::standardize_address};

--- a/crates/indexer/src/models/ledger_info.rs
+++ b/crates/indexer/src/models/ledger_info.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{database::PgPoolConnection, schema::ledger_infos};
 use diesel::{OptionalExtension, QueryDsl, RunQueryDsl};

--- a/crates/indexer/src/models/mod.rs
+++ b/crates/indexer/src/models/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod block_metadata_transactions;
 pub mod coin_models;

--- a/crates/indexer/src/models/move_modules.rs
+++ b/crates/indexer/src/models/move_modules.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{models::transactions::Transaction, schema::move_modules, util::standardize_address};
 use aptos_api_types::{DeleteModule, MoveModule as APIMoveModule, MoveModuleBytecode, WriteModule};

--- a/crates/indexer/src/models/move_resources.rs
+++ b/crates/indexer/src/models/move_resources.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{models::transactions::Transaction, schema::move_resources, util::standardize_address};
 use anyhow::{Context, Result};

--- a/crates/indexer/src/models/move_tables.rs
+++ b/crates/indexer/src/models/move_tables.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{
     models::transactions::Transaction,

--- a/crates/indexer/src/models/processor_status.rs
+++ b/crates/indexer/src/models/processor_status.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{database::PgPoolConnection, schema::processor_status};
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, RunQueryDsl};

--- a/crates/indexer/src/models/processor_statuses.rs
+++ b/crates/indexer/src/models/processor_statuses.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use crate::{indexer::errors::TransactionProcessingError, schema::processor_statuses};
 use field_count::FieldCount;

--- a/crates/indexer/src/models/property_map.rs
+++ b/crates/indexer/src/models/property_map.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::util;
 use serde::{Deserialize, Serialize};

--- a/crates/indexer/src/models/signatures.rs
+++ b/crates/indexer/src/models/signatures.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 
 use crate::{models::transactions::Transaction, schema::signatures, util::standardize_address};

--- a/crates/indexer/src/models/stake_models/delegator_activities.rs
+++ b/crates/indexer/src/models/stake_models/delegator_activities.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/stake_models/delegator_balances.rs
+++ b/crates/indexer/src/models/stake_models/delegator_balances.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/stake_models/delegator_pools.rs
+++ b/crates/indexer/src/models/stake_models/delegator_pools.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/stake_models/mod.rs
+++ b/crates/indexer/src/models/stake_models/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod delegator_activities;
 pub mod delegator_balances;

--- a/crates/indexer/src/models/stake_models/proposal_votes.rs
+++ b/crates/indexer/src/models/stake_models/proposal_votes.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/stake_models/stake_utils.rs
+++ b/crates/indexer/src/models/stake_models/stake_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::models::{move_resources::MoveResource, token_models::token_utils::Table};
 use anyhow::{Context, Result};

--- a/crates/indexer/src/models/stake_models/staking_pool_voter.rs
+++ b/crates/indexer/src/models/stake_models/staking_pool_voter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/ans_lookup.rs
+++ b/crates/indexer/src/models/token_models/ans_lookup.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/collection_datas.rs
+++ b/crates/indexer/src/models/token_models/collection_datas.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/mod.rs
+++ b/crates/indexer/src/models/token_models/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod ans_lookup;
 pub mod collection_datas;

--- a/crates/indexer/src/models/token_models/nft_points.rs
+++ b/crates/indexer/src/models/token_models/nft_points.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/token_activities.rs
+++ b/crates/indexer/src/models/token_models/token_activities.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/token_claims.rs
+++ b/crates/indexer/src/models/token_models/token_claims.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/token_datas.rs
+++ b/crates/indexer/src/models/token_models/token_datas.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/token_ownerships.rs
+++ b/crates/indexer/src/models/token_models/token_ownerships.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/token_utils.rs
+++ b/crates/indexer/src/models/token_models/token_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/tokens.rs
+++ b/crates/indexer/src/models/token_models/tokens.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/v2_collections.rs
+++ b/crates/indexer/src/models/token_models/v2_collections.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/v2_token_activities.rs
+++ b/crates/indexer/src/models/token_models/v2_token_activities.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/v2_token_datas.rs
+++ b/crates/indexer/src/models/token_models/v2_token_datas.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/v2_token_metadata.rs
+++ b/crates/indexer/src/models/token_models/v2_token_metadata.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/v2_token_ownerships.rs
+++ b/crates/indexer/src/models/token_models/v2_token_ownerships.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/token_models/v2_token_utils.rs
+++ b/crates/indexer/src/models/token_models/v2_token_utils.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/transactions.rs
+++ b/crates/indexer/src/models/transactions.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/user_transactions.rs
+++ b/crates/indexer/src/models/user_transactions.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/v2_objects.rs
+++ b/crates/indexer/src/models/v2_objects.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This is required because a diesel macro makes clippy sad
 #![allow(clippy::extra_unused_lifetimes)]

--- a/crates/indexer/src/models/write_set_changes.rs
+++ b/crates/indexer/src/models/write_set_changes.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(clippy::extra_unused_lifetimes)]
 use super::{
     move_modules::MoveModule,

--- a/crates/indexer/src/processors/coin_processor.rs
+++ b/crates/indexer/src/processors/coin_processor.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     database::{

--- a/crates/indexer/src/processors/default_processor.rs
+++ b/crates/indexer/src/processors/default_processor.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     database::{

--- a/crates/indexer/src/processors/mod.rs
+++ b/crates/indexer/src/processors/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod coin_processor;
 pub mod default_processor;

--- a/crates/indexer/src/processors/stake_processor.rs
+++ b/crates/indexer/src/processors/stake_processor.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     database::{

--- a/crates/indexer/src/processors/token_processor.rs
+++ b/crates/indexer/src/processors/token_processor.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     database::{

--- a/crates/indexer/src/runtime.rs
+++ b/crates/indexer/src/runtime.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     database::new_db_pool,

--- a/crates/indexer/src/schema.rs
+++ b/crates/indexer/src/schema.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // @generated automatically by Diesel CLI.
 

--- a/crates/indexer/src/util.rs
+++ b/crates/indexer/src/util.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::models::property_map::{PropertyMap, TokenObjectPropertyMap};
 use aptos_api_types::Address;

--- a/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/basic_node_info_collector.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::collectors::common::NAMESPACE;
 use aptos_infallible::Mutex;

--- a/crates/node-resource-metrics/src/collectors/common.rs
+++ b/crates/node-resource-metrics/src/collectors/common.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_metrics_core::{exponential_buckets, HistogramVec};
 use once_cell::sync::Lazy;

--- a/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/cpu_metrics_collector.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::common::NAMESPACE;
 use crate::collectors::common::MeasureLatency;

--- a/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/disk_metrics_collector.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::common::NAMESPACE;
 use crate::collectors::common::MeasureLatency;

--- a/crates/node-resource-metrics/src/collectors/linux_collectors.rs
+++ b/crates/node-resource-metrics/src/collectors/linux_collectors.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::common::NAMESPACE;
 use crate::collectors::common::MeasureLatency;

--- a/crates/node-resource-metrics/src/collectors/loadavg_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/loadavg_collector.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::collectors::common::{MeasureLatency, NAMESPACE};
 use aptos_metrics_core::const_metric::ConstMetric;

--- a/crates/node-resource-metrics/src/collectors/memory_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/memory_metrics_collector.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::collectors::common::{MeasureLatency, NAMESPACE};
 use aptos_infallible::Mutex;

--- a/crates/node-resource-metrics/src/collectors/mod.rs
+++ b/crates/node-resource-metrics/src/collectors/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod basic_node_info_collector;
 mod common;

--- a/crates/node-resource-metrics/src/collectors/network_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/network_metrics_collector.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::common::NAMESPACE;
 use crate::collectors::common::MeasureLatency;

--- a/crates/node-resource-metrics/src/collectors/process_metrics_collector.rs
+++ b/crates/node-resource-metrics/src/collectors/process_metrics_collector.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::collectors::common::{MeasureLatency, NAMESPACE};
 use aptos_infallible::Mutex;

--- a/crates/node-resource-metrics/src/lib.rs
+++ b/crates/node-resource-metrics/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::collectors::BasicNodeInfoCollector;
 use aptos_infallible::Mutex;

--- a/crates/reliable-broadcast/src/lib.rs
+++ b/crates/reliable-broadcast/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_bounded_executor::BoundedExecutor;
 use aptos_consensus_types::common::Author;

--- a/crates/reliable-broadcast/src/tests.rs
+++ b/crates/reliable-broadcast/src/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{BroadcastStatus, RBMessage, RBNetworkSender, ReliableBroadcast};
 use anyhow::bail;

--- a/crates/transaction-emitter-lib/src/args.rs
+++ b/crates/transaction-emitter-lib/src/args.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{bail, format_err, Result};
 use aptos_config::keys::ConfigKey;

--- a/crates/transaction-emitter-lib/src/cluster.rs
+++ b/crates/transaction-emitter-lib/src/cluster.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{emitter::load_specific_account, instance::Instance, ClusterArgs};
 use anyhow::{anyhow, bail, format_err, Result};

--- a/crates/transaction-emitter-lib/src/emitter/account_minter.rs
+++ b/crates/transaction-emitter-lib/src/emitter/account_minter.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{
     local_account_generator::LocalAccountGenerator, parse_seed,

--- a/crates/transaction-emitter-lib/src/emitter/local_account_generator.rs
+++ b/crates/transaction-emitter-lib/src/emitter/local_account_generator.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use aptos_crypto::ed25519::Ed25519PrivateKey;
 use aptos_sdk::types::{
     AccountKey, EphemeralKeyPair, EphemeralPrivateKey, KeylessAccount, LocalAccount,

--- a/crates/transaction-emitter-lib/src/emitter/mod.rs
+++ b/crates/transaction-emitter-lib/src/emitter/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod account_minter;
 pub mod local_account_generator;

--- a/crates/transaction-emitter-lib/src/emitter/stats.rs
+++ b/crates/transaction-emitter-lib/src/emitter/stats.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use std::{
     fmt,

--- a/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
+++ b/crates/transaction-emitter-lib/src/emitter/submission_worker.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     emitter::{

--- a/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
+++ b/crates/transaction-emitter-lib/src/emitter/transaction_executor.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::FETCH_ACCOUNT_RETRY_POLICY;
 use anyhow::{Context, Result};

--- a/crates/transaction-emitter-lib/src/instance.rs
+++ b/crates/transaction-emitter-lib/src/instance.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_rest_client::{aptos_api_types, AptosBaseUrl, Client as RestClient};
 use reqwest::Url;

--- a/crates/transaction-emitter-lib/src/lib.rs
+++ b/crates/transaction-emitter-lib/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/transaction-emitter-lib/src/wrappers.rs
+++ b/crates/transaction-emitter-lib/src/wrappers.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     args::{ClusterArgs, EmitArgs},

--- a/crates/transaction-emitter/src/diag.rs
+++ b/crates/transaction-emitter/src/diag.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{bail, format_err, Result};
 use aptos_sdk::transaction_builder::TransactionFactory;

--- a/crates/transaction-generator-lib/src/account_generator.rs
+++ b/crates/transaction-generator-lib/src/account_generator.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{
     create_account_transaction, ObjectPool, TransactionGenerator, TransactionGeneratorCreator,
 };

--- a/crates/transaction-generator-lib/src/accounts_pool_wrapper.rs
+++ b/crates/transaction-generator-lib/src/accounts_pool_wrapper.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{ObjectPool, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};

--- a/crates/transaction-generator-lib/src/batch_transfer.rs
+++ b/crates/transaction-generator-lib/src/batch_transfer.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{ObjectPool, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::{

--- a/crates/transaction-generator-lib/src/bounded_batch_wrapper.rs
+++ b/crates/transaction-generator-lib/src/bounded_batch_wrapper.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};

--- a/crates/transaction-generator-lib/src/call_custom_modules.rs
+++ b/crates/transaction-generator-lib/src/call_custom_modules.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::{publishing::publish_util::Package, ReliableTransactionSubmitter};
 use crate::{

--- a/crates/transaction-generator-lib/src/entry_points.rs
+++ b/crates/transaction-generator-lib/src/entry_points.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     call_custom_modules::{TransactionGeneratorWorker, UserModuleTransactionGenerator},

--- a/crates/transaction-generator-lib/src/lib.rs
+++ b/crates/transaction-generator-lib/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/transaction-generator-lib/src/p2p_transaction_generator.rs
+++ b/crates/transaction-generator-lib/src/p2p_transaction_generator.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{ObjectPool, TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::{
     move_types::account_address::AccountAddress,

--- a/crates/transaction-generator-lib/src/publish_modules.rs
+++ b/crates/transaction-generator-lib/src/publish_modules.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{
     publishing::publish_util::PackageHandler, TransactionGenerator, TransactionGeneratorCreator,
 };

--- a/crates/transaction-generator-lib/src/publishing/mod.rs
+++ b/crates/transaction-generator-lib/src/publishing/mod.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod entry_point_trait;
 pub mod prebuild_packages;

--- a/crates/transaction-generator-lib/src/publishing/prebuild_packages.rs
+++ b/crates/transaction-generator-lib/src/publishing/prebuild_packages.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use anyhow::{anyhow, bail};
 use aptos_framework::{natives::code::PackageMetadata, BuildOptions, BuiltPackage};
@@ -125,8 +125,8 @@ pub fn create_prebuilt_packages_bundle(
 
     // Step 2: generate implementation to access prebuilt packages.
     let code = r#"
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This file was generated. Do not modify!
 //

--- a/crates/transaction-generator-lib/src/publishing/publish_util.rs
+++ b/crates/transaction-generator-lib/src/publishing/publish_util.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use super::entry_point_trait::PreBuiltPackages;
 use aptos_framework::{

--- a/crates/transaction-generator-lib/src/transaction_mix_generator.rs
+++ b/crates/transaction-generator-lib/src/transaction_mix_generator.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 use crate::{TransactionGenerator, TransactionGeneratorCreator};
 use aptos_sdk::types::{transaction::SignedTransaction, LocalAccount};
 use rand::{rngs::StdRng, Rng, SeedableRng};

--- a/crates/transaction-generator-lib/src/workflow_delegator.rs
+++ b/crates/transaction-generator-lib/src/workflow_delegator.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     account_generator::AccountGeneratorCreator,

--- a/crates/transaction-workloads-lib/src/args.rs
+++ b/crates/transaction-workloads-lib/src/args.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
     move_workloads::{FibonacciFunctionType, LoopType, PreBuiltPackagesImpl},

--- a/crates/transaction-workloads-lib/src/lib.rs
+++ b/crates/transaction-workloads-lib/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 #![forbid(unsafe_code)]
 

--- a/crates/transaction-workloads-lib/src/move_workloads.rs
+++ b/crates/transaction-workloads-lib/src/move_workloads.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 #![allow(unused)]
 
 pub use super::prebuilt_packages::PreBuiltPackagesImpl;

--- a/crates/transaction-workloads-lib/src/prebuilt_packages.rs
+++ b/crates/transaction-workloads-lib/src/prebuilt_packages.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 // This file was generated. Do not modify!
 //

--- a/crates/validator-transaction-pool/src/lib.rs
+++ b/crates/validator-transaction-pool/src/lib.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use aptos_channels::aptos_channel;
 use aptos_crypto::{hash::CryptoHash, HashValue};

--- a/crates/validator-transaction-pool/src/tests.rs
+++ b/crates/validator-transaction-pool/src/tests.rs
@@ -1,5 +1,5 @@
-// Copyright © Aptos Foundation
-// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{TransactionFilter, VTxnPoolState};
 use aptos_channels::{aptos_channel, message_queues::QueueStyle};


### PR DESCRIPTION
## Description
This PR adopts the innovation license header for the `crates` directory.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates license headers in the `crates` directory to the Innovation-Enabling Source Code License with no functional code changes.
> 
> - **Licensing**:
>   - Replace Apache-2.0 SPDX headers with Innovation-Enabling Source Code License headers across numerous files in `crates/*` (no code or behavior changes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a349ae3848dfde82376650f9cdffc1c140ff87db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->