### PR TITLE
[telemetry] support custom contracts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -157,3 +157,11 @@ third_party/move/tools/move-package-resolver/cache
 
 # ignore batch encryption benchmark results
 crates/aptos-batch-encryption/benchmark_results
+
+# Telemetry service E2E test generated files
+# Test data directory (created at runtime)
+test-data/
+
+# Any test keys
+**/*.key
+**/*.pub

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4457,9 +4457,11 @@ dependencies = [
  "claims",
  "clap 4.5.21",
  "debug-ignore",
+ "ed25519-dalek 1.0.1",
  "flate2",
  "futures",
  "gcp-bigquery-client",
+ "hex",
  "httpmock",
  "jsonwebtoken 8.3.0",
  "once_cell",
@@ -4476,6 +4478,7 @@ dependencies = [
  "tokio",
  "tracing",
  "url",
+ "urlencoding",
  "uuid 1.11.0",
  "warp",
 ]
@@ -17999,6 +18002,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba323866e5d033818e3240feeb9f7db2c4296674e4d9e16b97b7bf8f490434e8"
 dependencies = [
  "pin-utils",
+]
+
+[[package]]
+name = "telemetry-test-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "aptos-crypto",
+ "aptos-telemetry-service",
+ "aptos-types",
+ "chrono",
+ "clap 4.5.21",
+ "flate2",
+ "hex",
+ "rand 0.7.3",
+ "reqwest 0.11.23",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber 0.3.18",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,7 @@ members = [
     "crates/aptos-system-utils",
     "crates/aptos-telemetry",
     "crates/aptos-telemetry-service",
+    "crates/aptos-telemetry-service/e2e-test/test-client",
     "crates/aptos-temppath",
     "crates/aptos-time-service",
     "crates/aptos-transaction-filters",

--- a/crates/aptos-telemetry-service/Cargo.toml
+++ b/crates/aptos-telemetry-service/Cargo.toml
@@ -12,6 +12,9 @@ publish = { workspace = true }
 repository = { workspace = true }
 rust-version = { workspace = true }
 
+[features]
+bigquery_integration_tests = []
+
 [dependencies]
 anyhow = { workspace = true }
 aptos-config = { workspace = true }
@@ -47,9 +50,9 @@ url = { workspace = true }
 uuid = { workspace = true }
 warp = { workspace = true }
 
-[features]
-bigquery_integration_tests = []
-
 [dev-dependencies]
 claims = { workspace = true }
+ed25519-dalek = { workspace = true }
+hex = { workspace = true }
 httpmock = { workspace = true }
+urlencoding = "2.1"

--- a/crates/aptos-telemetry-service/e2e-test/cleanup.sh
+++ b/crates/aptos-telemetry-service/e2e-test/cleanup.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Cleanup script for E2E test environment
+# Stops all services and optionally removes data
+
+set -e
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TEST_DIR="$SCRIPT_DIR/test-data"
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}E2E Test Environment Cleanup${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Stop Docker services
+echo -e "${YELLOW}[1/3]${NC} Stopping Docker services..."
+cd "$SCRIPT_DIR"
+docker-compose down
+echo -e "${GREEN}✓ Docker services stopped${NC}"
+echo ""
+
+# Stop aptos-node
+echo -e "${YELLOW}[2/3]${NC} Stopping Aptos node..."
+if [ -f "$TEST_DIR/node.pid" ]; then
+    NODE_PID=$(cat "$TEST_DIR/node.pid")
+    if ps -p $NODE_PID > /dev/null 2>&1; then
+        kill $NODE_PID
+        echo -e "${GREEN}✓ Aptos node stopped (PID: $NODE_PID)${NC}"
+    else
+        echo -e "${YELLOW}Node process not running${NC}"
+    fi
+    rm "$TEST_DIR/node.pid"
+else
+    # Try to find and kill any aptos-node process on port 8080
+    if lsof -Pi :8080 -sTCP:LISTEN -t >/dev/null 2>&1; then
+        kill $(lsof -t -i:8080) 2>/dev/null || true
+        echo -e "${GREEN}✓ Stopped process on port 8080${NC}"
+    else
+        echo -e "${YELLOW}No node process found${NC}"
+    fi
+fi
+echo ""
+
+# Ask about data removal
+echo -e "${YELLOW}[3/3]${NC} Data cleanup..."
+read -p "Remove test data directory? (y/N) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    rm -rf "$TEST_DIR"
+    echo -e "${GREEN}✓ Test data removed${NC}"
+else
+    echo -e "${YELLOW}Test data preserved at: $TEST_DIR${NC}"
+fi
+
+read -p "Remove Docker volumes? (y/N) " -n 1 -r
+echo
+if [[ $REPLY =~ ^[Yy]$ ]]; then
+    cd "$SCRIPT_DIR"
+    docker-compose down -v
+    echo -e "${GREEN}✓ Docker volumes removed${NC}"
+else
+    echo -e "${YELLOW}Docker volumes preserved${NC}"
+fi
+
+echo ""
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}✓ Cleanup Complete${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+

--- a/crates/aptos-telemetry-service/e2e-test/docker-compose.yaml
+++ b/crates/aptos-telemetry-service/e2e-test/docker-compose.yaml
@@ -1,0 +1,72 @@
+# Docker Compose setup for E2E testing of Aptos Telemetry Service
+# Runs VictoriaMetrics and Loki locally for telemetry data ingestion testing
+version: '3.8'
+
+services:
+  # VictoriaMetrics - Time-series database for metrics
+  victoria-metrics:
+    image: victoriametrics/victoria-metrics:latest
+    container_name: telemetry-victoria-metrics
+    ports:
+      - "8428:8428"  # HTTP API for ingestion and queries
+    volumes:
+      - victoria-data:/victoria-metrics-data
+    command:
+      - '--storageDataPath=/victoria-metrics-data'
+      - '--httpListenAddr=:8428'
+      - '--retentionPeriod=30d'  # Keep data for 30 days
+      - '--selfScrapeInterval=10s'  # Self-monitoring interval
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:8428/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Loki - Log aggregation system
+  loki:
+    image: grafana/loki:3.0.0
+    container_name: telemetry-loki
+    ports:
+      - "3100:3100"  # HTTP API for ingestion and queries
+    volumes:
+      - ./loki-config.yaml:/etc/loki/local-config.yaml
+      - loki-data:/loki
+    command: -config.file=/etc/loki/local-config.yaml
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3100/ready"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+
+  # Grafana - Visualization (optional, for debugging)
+  grafana:
+    image: grafana/grafana:latest
+    container_name: telemetry-grafana
+    ports:
+      - "3000:3000"  # Web UI
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./grafana-datasources.yaml:/etc/grafana/provisioning/datasources/datasources.yaml
+    environment:
+      - GF_AUTH_ANONYMOUS_ENABLED=true
+      - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+    restart: unless-stopped
+    depends_on:
+      - victoria-metrics
+      - loki
+
+volumes:
+  victoria-data:
+    driver: local
+  loki-data:
+    driver: local
+  grafana-data:
+    driver: local
+
+networks:
+  default:
+    name: telemetry-network
+

--- a/crates/aptos-telemetry-service/e2e-test/grafana-datasources.yaml
+++ b/crates/aptos-telemetry-service/e2e-test/grafana-datasources.yaml
@@ -1,0 +1,27 @@
+# Grafana datasources for E2E testing
+# Auto-configures VictoriaMetrics and Loki datasources
+
+apiVersion: 1
+
+datasources:
+  # VictoriaMetrics (Prometheus-compatible) datasource
+  - name: VictoriaMetrics
+    type: prometheus
+    access: proxy
+    url: http://victoria-metrics:8428
+    isDefault: true
+    jsonData:
+      httpMethod: POST
+      timeInterval: 10s
+    editable: true
+
+  # Loki datasource
+  - name: Loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    jsonData:
+      maxLines: 1000
+      timeout: 60
+    editable: true
+

--- a/crates/aptos-telemetry-service/e2e-test/loki-config.yaml
+++ b/crates/aptos-telemetry-service/e2e-test/loki-config.yaml
@@ -1,0 +1,44 @@
+# Loki configuration for local E2E testing - MINIMAL
+
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2020-10-24
+      store: boltdb-shipper
+      object_store: filesystem
+      schema: v11
+      index:
+        prefix: index_
+        period: 24h
+
+storage_config:
+  boltdb_shipper:
+    active_index_directory: /loki/boltdb-shipper-active
+    cache_location: /loki/boltdb-shipper-cache
+  filesystem:
+    directory: /loki/chunks
+
+limits_config:
+  allow_structured_metadata: false
+  reject_old_samples: false
+  ingestion_rate_mb: 100
+  ingestion_burst_size_mb: 200
+
+compactor:
+  working_directory: /loki/compactor
+

--- a/crates/aptos-telemetry-service/e2e-test/move/Move.toml
+++ b/crates/aptos-telemetry-service/e2e-test/move/Move.toml
@@ -1,0 +1,15 @@
+[package]
+name = "TelemetryRegistry"
+version = "1.0.0"
+authors = ["Aptos Labs"]
+
+[addresses]
+telemetry_deployer = "_"
+
+[dependencies.AptosFramework]
+git = "https://github.com/aptos-labs/aptos-framework.git"
+rev = "devnet"
+subdir = "aptos-framework"
+
+[dev-dependencies]
+

--- a/crates/aptos-telemetry-service/e2e-test/move/sources/telemetry_registry.move
+++ b/crates/aptos-telemetry-service/e2e-test/move/sources/telemetry_registry.move
@@ -1,0 +1,161 @@
+/// Test module for Telemetry Service E2E testing
+/// Implements a simple allowlist registry for custom contract authentication
+///
+/// This contract allows a single admin to manage a list of authorized addresses
+/// that can authenticate with the telemetry service.
+module telemetry_deployer::telemetry_registry {
+    use std::signer;
+    use std::vector;
+    use aptos_framework::event;
+
+    /// Error codes
+    const ENOT_AUTHORIZED: u64 = 1;
+    const EALREADY_REGISTERED: u64 = 2;
+    const ENOT_FOUND: u64 = 3;
+
+    /// Member information stored on-chain
+    struct Member has copy, drop, store {
+        address: address,
+        ip_address: vector<u8>,  // String representation like "127.0.0.1"
+        port: vector<u8>,         // String representation like "8080"
+        bls_public_key: vector<u8>,  // Hex-encoded BLS key
+        failure_domain: vector<u8>,  // e.g., "dc_us_east"
+    }
+
+    /// Registry resource storing all authorized members
+    struct Registry has key {
+        admin: address,
+        members: vector<Member>,
+    }
+
+    // Event emitted when a member is added
+    #[event]
+    struct MemberAddedEvent has drop, store {
+        address: address,
+        timestamp: u64,
+    }
+
+    // Event emitted when a member is removed
+    #[event]
+    struct MemberRemovedEvent has drop, store {
+        address: address,
+        timestamp: u64,
+    }
+
+    /// Initialize the registry (called once by the deployer)
+    public entry fun initialize(account: &signer) {
+        let account_addr = signer::address_of(account);
+
+        // Only allow initialization once
+        assert!(!exists<Registry>(account_addr), EALREADY_REGISTERED);
+
+        move_to(account, Registry {
+            admin: account_addr,
+            members: vector::empty(),
+        });
+    }
+
+    /// Add a new member to the registry (admin only)
+    public entry fun add_member(
+        admin: &signer,
+        member_address: address,
+        ip_address: vector<u8>,
+        port: vector<u8>,
+        bls_public_key: vector<u8>,
+        failure_domain: vector<u8>,
+    ) acquires Registry {
+        let registry = borrow_global_mut<Registry>(signer::address_of(admin));
+
+        // Verify admin
+        assert!(signer::address_of(admin) == registry.admin, ENOT_AUTHORIZED);
+
+        // Check if member already exists
+        let i = 0;
+        let len = vector::length(&registry.members);
+        while (i < len) {
+            let member = vector::borrow(&registry.members, i);
+            assert!(member.address != member_address, EALREADY_REGISTERED);
+            i = i + 1;
+        };
+
+        // Add new member
+        let member = Member {
+            address: member_address,
+            ip_address,
+            port,
+            bls_public_key,
+            failure_domain,
+        };
+        vector::push_back(&mut registry.members, member);
+
+        // Emit event
+        event::emit(MemberAddedEvent {
+            address: member_address,
+            timestamp: aptos_framework::timestamp::now_seconds(),
+        });
+    }
+
+    /// Remove a member from the registry (admin only)
+    public entry fun remove_member(
+        admin: &signer,
+        member_address: address,
+    ) acquires Registry {
+        let registry = borrow_global_mut<Registry>(signer::address_of(admin));
+
+        // Verify admin
+        assert!(signer::address_of(admin) == registry.admin, ENOT_AUTHORIZED);
+
+        // Find and remove member
+        let i = 0;
+        let len = vector::length(&registry.members);
+        let found = false;
+        while (i < len) {
+            let member = vector::borrow(&registry.members, i);
+            if (member.address == member_address) {
+                vector::remove(&mut registry.members, i);
+                found = true;
+                break
+            };
+            i = i + 1;
+        };
+
+        assert!(found, ENOT_FOUND);
+
+        // Emit event
+        event::emit(MemberRemovedEvent {
+            address: member_address,
+            timestamp: aptos_framework::timestamp::now_seconds(),
+        });
+    }
+
+    // View function to get all members (used by telemetry service)
+    // Returns vector of Member structs containing address, ip, port, etc.
+    #[view]
+    public fun get_all_members(registry_address: address): vector<Member> acquires Registry {
+        let registry = borrow_global<Registry>(registry_address);
+        *&registry.members  // Return a copy of the members vector
+    }
+
+    // View function to check if an address is authorized
+    #[view]
+    public fun is_member(registry_address: address, member_address: address): bool acquires Registry {
+        let registry = borrow_global<Registry>(registry_address);
+        let i = 0;
+        let len = vector::length(&registry.members);
+        while (i < len) {
+            let member = vector::borrow(&registry.members, i);
+            if (member.address == member_address) {
+                return true
+            };
+            i = i + 1;
+        };
+        false
+    }
+
+    // View function to get member count
+    #[view]
+    public fun member_count(registry_address: address): u64 acquires Registry {
+        let registry = borrow_global<Registry>(registry_address);
+        vector::length(&registry.members)
+    }
+}

--- a/crates/aptos-telemetry-service/e2e-test/setup.sh
+++ b/crates/aptos-telemetry-service/e2e-test/setup.sh
@@ -1,0 +1,304 @@
+#!/bin/bash
+# E2E Test Setup Script
+# Sets up local test environment for Aptos Telemetry Service with custom contract authentication
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Directories
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+TEST_DIR="$SCRIPT_DIR/test-data"
+MOVE_DIR="$SCRIPT_DIR/move"
+
+echo -e "${BLUE}========================================${NC}"
+echo -e "${BLUE}Aptos Telemetry Service E2E Test Setup${NC}"
+echo -e "${BLUE}========================================${NC}"
+echo ""
+
+# Step 1: Check prerequisites
+echo -e "${YELLOW}[1/7]${NC} Checking prerequisites..."
+
+if ! command -v docker &> /dev/null; then
+    echo -e "${RED}Error: Docker is not installed${NC}"
+    echo "Please install Docker: https://docs.docker.com/get-docker/"
+    exit 1
+fi
+
+if ! command -v docker-compose &> /dev/null && ! docker compose version &> /dev/null; then
+    echo -e "${RED}Error: Docker Compose is not installed${NC}"
+    echo "Please install Docker Compose: https://docs.docker.com/compose/install/"
+    exit 1
+fi
+
+if ! command -v cargo &> /dev/null; then
+    echo -e "${RED}Error: Cargo is not installed${NC}"
+    echo "Please install Rust: https://rustup.rs/"
+    exit 1
+fi
+
+# Check if aptos CLI is available
+if ! command -v aptos &> /dev/null; then
+    echo -e "${YELLOW}Warning: Aptos CLI not found in PATH${NC}"
+    echo "Attempting to use cargo to run aptos CLI..."
+    APTOS_CMD="cargo run -p aptos --"
+else
+    APTOS_CMD="aptos"
+fi
+
+echo -e "${GREEN}✓ All prerequisites met${NC}"
+echo ""
+
+# Step 2: Start Docker services (VictoriaMetrics, Loki, Grafana)
+echo -e "${YELLOW}[2/7]${NC} Starting Docker services (VictoriaMetrics, Loki, Grafana)..."
+cd "$SCRIPT_DIR"
+docker-compose up -d
+
+# Wait for services to be healthy
+echo "Waiting for services to be ready..."
+sleep 5
+
+# Check VictoriaMetrics health
+for i in {1..30}; do
+    if curl -s http://localhost:8428/health > /dev/null; then
+        echo -e "${GREEN}✓ VictoriaMetrics is ready${NC}"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo -e "${RED}Error: VictoriaMetrics failed to start${NC}"
+        docker-compose logs victoria-metrics
+        exit 1
+    fi
+    sleep 1
+done
+
+# Check Loki health
+for i in {1..30}; do
+    if curl -s http://localhost:3100/ready > /dev/null; then
+        echo -e "${GREEN}✓ Loki is ready${NC}"
+        break
+    fi
+    if [ $i -eq 30 ]; then
+        echo -e "${RED}Error: Loki failed to start${NC}"
+        docker-compose logs loki
+        exit 1
+    fi
+    sleep 1
+done
+
+echo -e "${GREEN}✓ All Docker services started${NC}"
+echo ""
+
+# Step 3: Create test directory and start aptos-node in test mode
+echo -e "${YELLOW}[3/7]${NC} Starting Aptos test node..."
+mkdir -p "$TEST_DIR"
+
+# Kill any existing aptos-node process on port 8080
+if lsof -Pi :8080 -sTCP:LISTEN -t >/dev/null 2>&1; then
+    echo "Killing existing process on port 8080..."
+    kill $(lsof -t -i:8080) 2>/dev/null || true
+    sleep 2
+fi
+
+# Start aptos-node in test mode in the background
+export TELEMETRY_SERVICE_URL=http://localhost:8082
+cd "$PROJECT_ROOT/../.."  # Navigate to aptos-core root
+echo "Starting aptos local testnet..."
+nohup $APTOS_CMD node run-local-testnet --faucet-port 8081 --force-restart --assume-yes --test-dir "$TEST_DIR" --no-txn-stream --skip-metadata-apply > "$TEST_DIR/node.log" 2>&1 &
+NODE_PID=$!
+echo $NODE_PID > "$TEST_DIR/node.pid"
+
+# Wait for node to be ready
+echo "Waiting for node to be ready (this may take a minute)..."
+for i in {1..60}; do
+    if curl -s http://localhost:8080/v1/-/healthy > /dev/null 2>&1; then
+        echo -e "${GREEN}✓ Aptos node is ready${NC}"
+        break
+    fi
+    if [ $i -eq 60 ]; then
+        echo -e "${RED}Error: Aptos node failed to start${NC}"
+        echo "Check logs at: $TEST_DIR/node.log"
+        cat "$TEST_DIR/node.log"
+        exit 1
+    fi
+    sleep 5
+done
+
+sleep 30
+
+# Get the chain ID (should be 4 for testnet by default)
+CHAIN_ID=$(curl -s http://localhost:8080/v1 | grep -o '"chain_id":[0-9]*' | cut -d':' -f2 || echo "4")
+echo "Node chain ID: $CHAIN_ID"
+echo ""
+
+# Step 4: Create test accounts (while still in test-data directory)
+echo -e "${YELLOW}[4/7]${NC} Creating test accounts..."
+cd "$TEST_DIR"
+
+# Create deployer account profile
+echo "Creating deployer account..."
+$APTOS_CMD key generate --output-file $TEST_DIR/deployer.key --key-type ed25519
+DEPLOYER_KEY_HEX="0x$(cat $TEST_DIR/deployer.key)" # USE FOR TEST ONLY
+$APTOS_CMD init --profile telemetry-service-e2e-test --network local --assume-yes --private-key "$DEPLOYER_KEY_HEX" 2>&1 | tee init.log || true
+DEPLOYER_ADDRESS=$(yq e '.profiles.telemetry-service-e2e-test.account' "$TEST_DIR/.aptos/config.yaml" | tr -d '"' || echo "")
+echo "Deployer account address: $DEPLOYER_ADDRESS"
+
+# Create test member account profile
+echo "Creating test member account..."
+$APTOS_CMD key generate --output-file $TEST_DIR/test-member.key --key-type ed25519
+TEST_ACCOUNT_KEY_HEX="0x$(cat $TEST_DIR/test-member.key)" # USE FOR TEST ONLY
+$APTOS_CMD init --profile telemetry-service-e2e-test-member --network local --assume-yes --private-key "$TEST_ACCOUNT_KEY_HEX" 2>&1 | tee -a init.log || true
+TEST_ACCOUNT_ADDRESS=$(yq e '.profiles.telemetry-service-e2e-test-member.account' "$TEST_DIR/.aptos/config.yaml" | tr -d '"' || echo "")
+echo "Test member account address: $TEST_ACCOUNT_ADDRESS"
+
+# Copy config file to move dir for consistency
+mkdir -p "$MOVE_DIR/.aptos"
+cp "$TEST_DIR/.aptos/config.yaml" "$MOVE_DIR/.aptos/config.yaml"
+
+echo -e "${GREEN}✓ Test accounts created${NC}"
+echo ""
+
+# Step 5: Deploy the Move contract
+echo -e "${YELLOW}[5/7]${NC} Deploying Move contract..."
+cd "$MOVE_DIR"
+
+# Create a temporary Move.toml with the correct address
+sed "s/telemetry_deployer = \"_\"/telemetry_deployer = \"$DEPLOYER_ADDRESS\"/" Move.toml > Move.toml.tmp
+mv Move.toml.tmp Move.toml
+
+echo "Compiling Move contract..."
+$APTOS_CMD move compile --named-addresses telemetry_deployer=$DEPLOYER_ADDRESS --dev --skip-checks-on-test-code --language-version 2.3
+
+echo "Publishing Move contract..."
+$APTOS_CMD move publish \
+    --profile telemetry-service-e2e-test \
+    --named-addresses telemetry_deployer=$DEPLOYER_ADDRESS \
+    --assume-yes \
+    --url http://localhost:8080
+
+echo "Initializing registry..."
+$APTOS_CMD move run \
+    --profile telemetry-service-e2e-test \
+    --function-id ${DEPLOYER_ADDRESS}::telemetry_registry::initialize \
+    --assume-yes \
+    --url http://localhost:8080
+
+echo -e "${GREEN}✓ Contract deployed and initialized at $DEPLOYER_ADDRESS${NC}"
+echo ""
+
+# Step 6: Add test member to the registry
+echo -e "${YELLOW}[6/7]${NC} Adding test member to registry..."
+
+$APTOS_CMD move run \
+    --profile telemetry-service-e2e-test \
+    --function-id ${DEPLOYER_ADDRESS}::telemetry_registry::add_member \
+    --args address:$TEST_ACCOUNT_ADDRESS string:"127.0.0.1" string:"9000" string:"0xtest123" string:"dc_local" \
+    --assume-yes \
+    --url http://localhost:8080
+
+echo -e "${GREEN}✓ Test member added to registry${NC}"
+echo ""
+
+# Step 7: Set up environment variables
+echo -e "${YELLOW}[7/7]${NC} Setting up environment variables..."
+
+# Generate x25519 private key for SERVER_PRIVATE_KEY (32 bytes hex encoded)
+SERVER_PRIVATE_KEY=$(openssl rand -hex 32)
+
+# Create dummy GCP credentials file for local testing (BigQuery won't actually be used)
+cat > "$TEST_DIR/dummy-gcp-credentials.json" << 'GCPEOF'
+{
+  "type": "service_account",
+  "project_id": "local-test",
+  "private_key_id": "dummy",
+  "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIBOgIBAAJBALRiMLAHHLOflX0lPJj+D2Sc2wfBxAFmX93u5gWJ0xgqPr3v9y5d\ndkJP3CJG3F3r3d3s4F5hXq3A4p5yZ2r3XM0CAwEAAQJANLr8FxlMg3xbYPsS3fE3\nN7E9rEDBIh8bKL+RYSQ3ZhB3X2Gxf4qLX5p1X5E5X5K5X5L5X5M5X5N5X5O5X5P5\nQQIhAORD3X2Z5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5AiEAyF3X5X5X5X\n5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5UCIQCe3X5X5X5X5X5X5X5X5X5X5X5X5X\n5X5X5X5X5X5X5QIgW3X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5UCIBt3\nX5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5X5U=\n-----END RSA PRIVATE KEY-----\n",
+  "client_email": "dummy@local-test.iam.gserviceaccount.com",
+  "client_id": "000000000000000000000",
+  "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+  "token_uri": "https://oauth2.googleapis.com/token"
+}
+GCPEOF
+
+# Create .env file
+cat > "$TEST_DIR/.env" << EOF
+# E2E Test Environment Variables
+# Generated by setup.sh
+
+# Server private key for telemetry service (x25519, hex encoded)
+SERVER_PRIVATE_KEY=$SERVER_PRIVATE_KEY
+
+# GCP credentials (dummy for local testing - BigQuery not used)
+GOOGLE_APPLICATION_CREDENTIALS=$TEST_DIR/dummy-gcp-credentials.json
+
+# Contract deployer account
+DEPLOYER_ADDRESS=$DEPLOYER_ADDRESS
+DEPLOYER_KEY_HEX=$DEPLOYER_KEY_HEX
+
+# Test account for authentication
+TEST_ACCOUNT_ADDRESS=$TEST_ACCOUNT_ADDRESS
+TEST_ACCOUNT_KEY_HEX=$TEST_ACCOUNT_KEY_HEX
+TEST_CONTRACT_ADDRESS=$DEPLOYER_ADDRESS
+
+# Chain ID
+CHAIN_ID=$CHAIN_ID
+
+# Metrics keys (empty for local testing - no auth)
+TEST_METRICS_KEYS={"local":""}
+
+# Loki token (empty for local testing - no auth)
+TEST_LOKI_TOKEN=
+
+# Service endpoints (telemetry on 8082, faucet on 8081)
+TELEMETRY_SERVICE_URL=http://localhost:8082
+FAUCET_URL=http://localhost:8081
+NODE_REST_API=http://localhost:8080
+VICTORIA_METRICS_URL=http://localhost:8428
+LOKI_URL=http://localhost:3100
+GRAFANA_URL=http://localhost:3000
+EOF
+
+echo -e "${GREEN}✓ Environment file created at $TEST_DIR/.env${NC}"
+echo ""
+
+# Summary and next steps
+echo -e "${GREEN}========================================${NC}"
+echo -e "${GREEN}✓ E2E Test Setup Complete!${NC}"
+echo -e "${GREEN}========================================${NC}"
+echo ""
+echo -e "${BLUE}Services Running:${NC}"
+echo "  • Aptos Node:        http://localhost:8080 (PID: $NODE_PID)"
+echo "  • Faucet:            http://localhost:8081"
+echo "  • VictoriaMetrics:   http://localhost:8428"
+echo "  • Loki:              http://localhost:3100"
+echo "  • Grafana:           http://localhost:3000 (admin/admin)"
+echo ""
+echo -e "${BLUE}Test Data:${NC}"
+echo "  • Test directory:    $TEST_DIR"
+echo "  • Contract address:  $DEPLOYER_ADDRESS"
+echo "  • Test account:      $TEST_ACCOUNT_ADDRESS"
+echo "  • Environment file:  $TEST_DIR/.env"
+echo ""
+echo -e "${BLUE}Next Steps:${NC}"
+echo "  1. Start the telemetry service:"
+echo "     cd $PROJECT_ROOT"
+echo "     source $TEST_DIR/.env"
+echo "     cargo run --release -- -f $SCRIPT_DIR/telemetry-config.yaml"
+echo ""
+echo "  2. Run the E2E test:"
+echo "     cd $SCRIPT_DIR"
+echo "     ./run-test.sh"
+echo ""
+echo "  3. View telemetry data in Grafana:"
+echo "     Open http://localhost:3000 in your browser"
+echo ""
+echo -e "${YELLOW}To stop all services:${NC}"
+echo "  cd $SCRIPT_DIR"
+echo "  ./cleanup.sh"
+echo ""
+

--- a/crates/aptos-telemetry-service/e2e-test/telemetry-config.yaml
+++ b/crates/aptos-telemetry-service/e2e-test/telemetry-config.yaml
@@ -1,0 +1,94 @@
+# Aptos Telemetry Service E2E Test Configuration
+# This config is used for local end-to-end testing with aptos-node --test
+
+address: "0.0.0.0:8082"
+
+# Short allowlist cache TTL for testing (default is 300 seconds)
+allowlist_cache_ttl_secs: 10
+
+# Required Aptos node config (not used for custom contracts, but must be present)
+trusted_full_node_addresses:
+  mainnet: "https://api.mainnet.aptoslabs.com"
+  testnet: "https://api.testnet.aptoslabs.com"
+  devnet: "https://api.devnet.aptoslabs.com"
+update_interval: 300
+pfn_allowlist: {}
+log_env_map: {}
+peer_identities: {}
+
+# Required BigQuery config (placeholder - not used in local testing)
+custom_event_config:
+  project_id: "local-test"
+  dataset_id: "telemetry_events"
+  table_id: "custom_events"
+
+# ========================================================================
+# CUSTOM CONTRACT CONFIGURATION FOR E2E TESTING
+# ========================================================================
+custom_contract_configs:
+  # Test contract configuration
+  - name: "e2e_test_contract"
+    
+    on_chain_auth:
+      # Chain ID where the contract is deployed (4 = local testnet)
+      chain_id: 4
+      
+      # Use view function method (recommended)
+      method: viewfunction
+      
+      # Contract function to call - will be substituted with deployed address
+      # Format: ${CONTRACT_ADDRESS}::telemetry_registry::get_all_members
+      resource_path: "${TEST_CONTRACT_ADDRESS}::telemetry_registry::get_all_members"
+      
+      # Arguments to pass to the view function
+      # get_all_members(registry_address: address) - pass the registry address
+      view_function_args:
+        - "${TEST_CONTRACT_ADDRESS}"
+      
+      # Extract address field from returned Member structs
+      # The Move contract returns vector<Member> where Member has an 'address' field
+      address_list_field: "[0].address"
+      
+      # REST API URL - points to local test node
+      rest_api_url: "http://127.0.0.1:8080"
+      
+      # Custom node type for JWT claims
+      node_type_name: "TelemetryTestNode"
+    
+    # Metrics sink - local VictoriaMetrics
+    metrics_sinks:
+      endpoint_urls:
+        local: "http://127.0.0.1:8428/api/v1/import/prometheus"
+      # No auth required for local testing
+      keys_env_var: "TEST_METRICS_KEYS"
+    
+    # Logs sink - local Loki
+    logs_sink:
+      endpoint_url: "http://127.0.0.1:3100/loki/api/v1/push"
+      # No auth required for local testing
+      key_env_var: "TEST_LOKI_TOKEN"
+      backend_type: loki
+
+# Standard telemetry endpoints (required but not used in custom contract testing)
+metrics_endpoints_config:
+  telemetry_service_metrics:
+    endpoint_urls:
+      local: "http://127.0.0.1:8428/api/v1/import/prometheus"
+    keys_env_var: "TEST_METRICS_KEYS"
+  ingest_metrics:
+    endpoint_urls: {}
+    keys_env_var: "TEST_METRICS_KEYS"
+  untrusted_ingest_metrics:
+    endpoint_urls: {}
+    keys_env_var: "TEST_METRICS_KEYS"
+
+humio_ingest_config:
+  known_logs_endpoint:
+    endpoint_url: "http://127.0.0.1:3100/loki/api/v1/push"
+    key_env_var: "TEST_LOKI_TOKEN"
+    backend_type: loki
+  unknown_logs_endpoint:
+    endpoint_url: "http://127.0.0.1:3100/loki/api/v1/push"
+    key_env_var: "TEST_LOKI_TOKEN"
+    backend_type: loki
+

--- a/crates/aptos-telemetry-service/e2e-test/test-client/Cargo.toml
+++ b/crates/aptos-telemetry-service/e2e-test/test-client/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "telemetry-test-client"
+version = "0.1.0"
+edition = "2021"
+description = "Test client for Aptos Telemetry Service custom contract endpoints"
+license = { workspace = true }
+publish = false
+
+[[bin]]
+name = "telemetry-test-client"
+path = "src/main.rs"
+
+[dependencies]
+# Aptos dependencies
+# NOTE: fuzzing feature enables sign_arbitrary_message for signing raw challenge bytes
+aptos-crypto = { workspace = true, features = ["fuzzing"] }
+aptos-telemetry-service = { workspace = true }
+aptos-types = { workspace = true }
+
+# Workspace dependencies
+anyhow = { workspace = true }
+chrono = { workspace = true }
+clap = { workspace = true }
+flate2 = { workspace = true }
+hex = { workspace = true }
+rand = { workspace = true }
+reqwest = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+

--- a/crates/aptos-telemetry-service/e2e-test/test-client/README.md
+++ b/crates/aptos-telemetry-service/e2e-test/test-client/README.md
@@ -1,0 +1,127 @@
+# Telemetry Test Client
+
+A CLI tool to test the Aptos Telemetry Service custom contract endpoints.
+
+## Building
+
+```bash
+cd /path/to/aptos-core
+cargo build -p telemetry-test-client
+```
+
+## Usage
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `TELEMETRY_SERVICE_URL` | Base URL of the telemetry service | `http://localhost:8082` |
+| `CONTRACT_NAME` | Custom contract name to use | `e2e_test_contract` |
+| `PRIVATE_KEY_HEX` | Private key for signing (hex, with or without 0x) | Random |
+| `CHAIN_ID` | Chain ID | `4` |
+
+### Commands
+
+#### Authenticate Only
+```bash
+# Get a JWT token
+cargo run -p telemetry-test-client -- auth
+
+# With specific key
+cargo run -p telemetry-test-client -- -p 0x1234...abcd auth
+```
+
+#### Send Metrics
+```bash
+# Send sample metrics
+cargo run -p telemetry-test-client -- metrics
+
+# Send metrics from file
+cargo run -p telemetry-test-client -- metrics -f /path/to/metrics.prom
+
+# Custom sample metric
+cargo run -p telemetry-test-client -- metrics --metric-name my_metric --metric-value 100
+```
+
+#### Send Logs
+```bash
+# Send sample logs
+cargo run -p telemetry-test-client -- logs
+
+# Send logs from file (JSON array of strings)
+cargo run -p telemetry-test-client -- logs -f /path/to/logs.json
+
+# Custom sample logs
+cargo run -p telemetry-test-client -- logs --message "Hello World" --count 5
+```
+
+#### Send Custom Events
+```bash
+# Send sample events
+cargo run -p telemetry-test-client -- events
+
+# Send events from file (TelemetryDump JSON format)
+cargo run -p telemetry-test-client -- events -f /path/to/events.json
+
+# Custom event name
+cargo run -p telemetry-test-client -- events --event-name MY_CUSTOM_EVENT
+```
+
+#### Send All Data Types
+```bash
+# Send all types once
+cargo run -p telemetry-test-client -- all
+
+# Send all types with 10 iterations, 2 second delay
+cargo run -p telemetry-test-client -- all -i 10 -d 2
+```
+
+### Full Example with E2E Test Setup
+
+```bash
+# Source the test environment
+source /path/to/aptos-core/crates/aptos-telemetry-service/e2e-test/test-data/.env
+
+# Run with the test account key
+cargo run -p telemetry-test-client -- \
+    -u http://localhost:8082 \
+    -c e2e_test_contract \
+    -p $TEST_ACCOUNT_KEY_HEX \
+    --chain-id 4 \
+    all -i 5 -d 1
+```
+
+## File Formats
+
+### Metrics File (Prometheus format)
+```
+# HELP my_metric A sample metric
+# TYPE my_metric gauge
+my_metric{label="value"} 42.0 1701234567890
+```
+
+### Logs File (JSON array)
+```json
+[
+  "{\"level\":\"INFO\",\"message\":\"Log 1\"}",
+  "{\"level\":\"WARN\",\"message\":\"Log 2\"}"
+]
+```
+
+### Events File (TelemetryDump format)
+```json
+{
+  "client_id": "my-client",
+  "user_id": "0x123...",
+  "timestamp_micros": "1701234567890000",
+  "events": [
+    {
+      "name": "MY_EVENT",
+      "params": {
+        "key1": "value1"
+      }
+    }
+  ]
+}
+```
+

--- a/crates/aptos-telemetry-service/e2e-test/test-client/src/main.rs
+++ b/crates/aptos-telemetry-service/e2e-test/test-client/src/main.rs
@@ -1,0 +1,581 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Telemetry Service Test Client
+//!
+//! A CLI tool to test the telemetry service custom contract endpoints.
+//! Sends logs, metrics, and custom events to a telemetry service instance.
+
+use anyhow::{anyhow, Result};
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature},
+    traits::{SigningKey, Uniform},
+};
+use aptos_telemetry_service::types::telemetry::{TelemetryDump, TelemetryEvent};
+use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
+use clap::{Parser, Subcommand};
+use flate2::{write::GzEncoder, Compression};
+use reqwest::{header::CONTENT_ENCODING, Client};
+use serde::{Deserialize, Serialize};
+use std::{
+    collections::BTreeMap,
+    fs,
+    io::Write,
+    path::PathBuf,
+    time::{SystemTime, UNIX_EPOCH},
+};
+use tracing::{debug, info, warn};
+
+/// Telemetry Service Test Client
+#[derive(Parser, Debug)]
+#[clap(name = "telemetry-test-client", version, about)]
+struct Args {
+    /// Base URL of the telemetry service
+    #[clap(
+        short,
+        long,
+        env = "TELEMETRY_SERVICE_URL",
+        default_value = "http://localhost:8082"
+    )]
+    url: String,
+
+    /// Contract name to use for custom contract endpoints
+    #[clap(
+        short,
+        long,
+        env = "CONTRACT_NAME",
+        default_value = "e2e_test_contract"
+    )]
+    contract_name: String,
+
+    /// Private key hex (without 0x prefix) for signing auth requests
+    /// If not provided, generates a random key
+    #[clap(short, long, env = "PRIVATE_KEY_HEX")]
+    private_key: Option<String>,
+
+    /// Chain ID
+    #[clap(long, env = "CHAIN_ID", default_value = "4")]
+    chain_id: u8,
+
+    #[clap(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+enum Commands {
+    /// Authenticate and get a JWT token
+    Auth,
+
+    /// Send metrics to the telemetry service
+    Metrics {
+        /// Path to a file containing Prometheus-format metrics
+        /// If not provided, sends sample metrics
+        #[clap(short, long)]
+        file: Option<PathBuf>,
+
+        /// Sample metric name (used when no file provided)
+        #[clap(long, default_value = "test_metric")]
+        metric_name: String,
+
+        /// Sample metric value (used when no file provided)
+        #[clap(long, default_value = "42")]
+        metric_value: f64,
+    },
+
+    /// Send logs to the telemetry service
+    Logs {
+        /// Path to a file containing JSON logs (array of strings)
+        /// If not provided, sends sample logs
+        #[clap(short, long)]
+        file: Option<PathBuf>,
+
+        /// Sample log message (used when no file provided)
+        #[clap(long, default_value = "Test log message from telemetry-test-client")]
+        message: String,
+
+        /// Number of sample logs to send (used when no file provided)
+        #[clap(long, default_value = "3")]
+        count: usize,
+    },
+
+    /// Send custom events to the telemetry service
+    Events {
+        /// Path to a file containing JSON events (TelemetryDump format)
+        /// If not provided, sends sample events
+        #[clap(short, long)]
+        file: Option<PathBuf>,
+
+        /// Sample event name (used when no file provided)
+        #[clap(long, default_value = "TEST_EVENT")]
+        event_name: String,
+    },
+
+    /// Send all types of data (auth + metrics + logs + events)
+    All {
+        /// Number of iterations
+        #[clap(short, long, default_value = "1")]
+        iterations: usize,
+
+        /// Delay between iterations in seconds
+        #[clap(short, long, default_value = "1")]
+        delay: u64,
+    },
+}
+
+/// Challenge request for custom contracts
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChallengeRequest {
+    pub address: AccountAddress,
+    pub chain_id: ChainId,
+}
+
+/// Challenge response from server
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct ChallengeResponse {
+    pub challenge: String,
+    pub expires_at: u64,
+}
+
+/// Authentication request for custom contracts
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CustomAuthRequest {
+    pub address: AccountAddress,
+    pub chain_id: ChainId,
+    pub challenge: String,
+    pub signature: Vec<u8>,
+    pub public_key: Vec<u8>,
+}
+
+/// Authentication response
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CustomAuthResponse {
+    pub token: String,
+}
+
+/// Test client for telemetry service
+struct TelemetryTestClient {
+    client: Client,
+    base_url: String,
+    contract_name: String,
+    private_key: Ed25519PrivateKey,
+    address: AccountAddress,
+    chain_id: ChainId,
+    token: Option<String>,
+}
+
+impl TelemetryTestClient {
+    fn new(
+        base_url: String,
+        contract_name: String,
+        private_key_hex: Option<String>,
+        chain_id: u8,
+    ) -> Result<Self> {
+        // Parse or generate private key using aptos-crypto
+        let private_key = match private_key_hex {
+            Some(hex_str) => {
+                let hex_str = hex_str.strip_prefix("0x").unwrap_or(&hex_str);
+                let bytes = hex::decode(hex_str)?;
+                Ed25519PrivateKey::try_from(&bytes[..])
+                    .map_err(|e| anyhow!("Invalid private key: {:?}", e))?
+            },
+            None => {
+                info!("No private key provided, generating random key");
+                let mut rng = rand::rngs::OsRng;
+                Ed25519PrivateKey::generate(&mut rng)
+            },
+        };
+
+        // Derive address from public key
+        let public_key: Ed25519PublicKey = (&private_key).into();
+        let address = aptos_types::account_address::from_public_key(&public_key);
+
+        info!("Using address: {}", address);
+        info!("Public key: {}", hex::encode(public_key.to_bytes()));
+
+        Ok(Self {
+            client: Client::new(),
+            base_url,
+            contract_name,
+            private_key,
+            address,
+            chain_id: ChainId::new(chain_id),
+            token: None,
+        })
+    }
+
+    /// Build API path
+    fn build_path(&self, path: &str) -> String {
+        format!("{}/api/v1/{}", self.base_url, path)
+    }
+
+    /// Authenticate and get JWT token using 2-step challenge-response flow
+    async fn authenticate(&mut self) -> Result<String> {
+        info!("Authenticating with telemetry service...");
+
+        // Step 1: Request challenge from server
+        info!("Requesting challenge from server...");
+        let challenge_request = ChallengeRequest {
+            address: self.address,
+            chain_id: self.chain_id,
+        };
+
+        let challenge_url = self.build_path(&format!(
+            "custom-contract/{}/auth-challenge",
+            self.contract_name
+        ));
+        let challenge_response = self
+            .client
+            .post(&challenge_url)
+            .json(&challenge_request)
+            .send()
+            .await?;
+
+        if !challenge_response.status().is_success() {
+            let status = challenge_response.status();
+            let body = challenge_response.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "Challenge request failed with status {}: {}",
+                status,
+                body
+            ));
+        }
+
+        let challenge_resp: ChallengeResponse = challenge_response.json().await?;
+        debug!(
+            "Received challenge: {} (expires at {})",
+            challenge_resp.challenge, challenge_resp.expires_at
+        );
+
+        // Step 2: Sign the server-issued challenge using aptos-crypto
+        let signature: Ed25519Signature = self
+            .private_key
+            .sign_arbitrary_message(challenge_resp.challenge.as_bytes());
+
+        // Step 3: Send auth request with signed challenge
+        let public_key: Ed25519PublicKey = (&self.private_key).into();
+        let auth_request = CustomAuthRequest {
+            address: self.address,
+            chain_id: self.chain_id,
+            challenge: challenge_resp.challenge,
+            signature: signature.to_bytes().to_vec(),
+            public_key: public_key.to_bytes().to_vec(),
+        };
+
+        debug!("Auth request: {:?}", auth_request);
+
+        let auth_url = self.build_path(&format!("custom-contract/{}/auth", self.contract_name));
+        let response = self
+            .client
+            .post(&auth_url)
+            .json(&auth_request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!("Auth failed with status {}: {}", status, body));
+        }
+
+        let auth_response: CustomAuthResponse = response.json().await?;
+        self.token = Some(auth_response.token.clone());
+
+        info!("Authentication successful!");
+        debug!("JWT token: {}", auth_response.token);
+
+        Ok(auth_response.token)
+    }
+
+    /// Ensure we have a valid token
+    async fn ensure_authenticated(&mut self) -> Result<String> {
+        match &self.token {
+            Some(token) => Ok(token.clone()),
+            None => self.authenticate().await,
+        }
+    }
+
+    /// Send metrics to the telemetry service
+    async fn send_metrics(&mut self, metrics: &str) -> Result<()> {
+        let token = self.ensure_authenticated().await?;
+
+        info!("Sending metrics ({} bytes)...", metrics.len());
+        debug!("Metrics content:\n{}", metrics);
+
+        // Gzip compress the metrics
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(metrics.as_bytes())?;
+        let compressed = encoder.finish()?;
+
+        let url = self.build_path(&format!(
+            "custom-contract/{}/ingest/metrics",
+            self.contract_name
+        ));
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&token)
+            .header(CONTENT_ENCODING, "gzip")
+            .body(compressed)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "Metrics send failed with status {}: {}",
+                status,
+                body
+            ));
+        }
+
+        info!("Metrics sent successfully!");
+        Ok(())
+    }
+
+    /// Send logs to the telemetry service
+    async fn send_logs(&mut self, logs: Vec<String>) -> Result<()> {
+        let token = self.ensure_authenticated().await?;
+
+        info!("Sending {} logs...", logs.len());
+        debug!("Logs: {:?}", logs);
+
+        // Serialize to JSON and gzip compress
+        let json = serde_json::to_string(&logs)?;
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+        encoder.write_all(json.as_bytes())?;
+        let compressed = encoder.finish()?;
+
+        let url = self.build_path(&format!(
+            "custom-contract/{}/ingest/logs",
+            self.contract_name
+        ));
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&token)
+            .header(CONTENT_ENCODING, "gzip")
+            .body(compressed)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!("Logs send failed with status {}: {}", status, body));
+        }
+
+        info!("Logs sent successfully!");
+        Ok(())
+    }
+
+    /// Send custom events to the telemetry service
+    async fn send_events(&mut self, events: Vec<TelemetryEvent>) -> Result<()> {
+        let token = self.ensure_authenticated().await?;
+
+        info!("Sending {} custom events...", events.len());
+        debug!("Events: {:?}", events);
+
+        let telemetry_dump = TelemetryDump {
+            client_id: format!("test-client-{}", self.address),
+            user_id: self.address.to_string(),
+            timestamp_micros: SystemTime::now()
+                .duration_since(UNIX_EPOCH)?
+                .as_micros()
+                .to_string(),
+            events,
+        };
+
+        let url = self.build_path(&format!(
+            "custom-contract/{}/ingest/custom-event",
+            self.contract_name
+        ));
+        let response = self
+            .client
+            .post(&url)
+            .bearer_auth(&token)
+            .json(&telemetry_dump)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            return Err(anyhow!(
+                "Events send failed with status {}: {}",
+                status,
+                body
+            ));
+        }
+
+        info!("Custom events sent successfully!");
+        Ok(())
+    }
+}
+
+/// Generate sample Prometheus metrics
+fn generate_sample_metrics(name: &str, value: f64) -> String {
+    let timestamp = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_millis();
+
+    format!(
+        r#"# HELP {name} A test metric from telemetry-test-client
+# TYPE {name} gauge
+{name}{{source="test_client",environment="e2e_test"}} {value} {timestamp}
+"#,
+        name = name,
+        value = value,
+        timestamp = timestamp
+    )
+}
+
+/// Generate sample logs
+fn generate_sample_logs(message: &str, count: usize) -> Vec<String> {
+    (0..count)
+        .map(|i| {
+            serde_json::json!({
+                "level": "INFO",
+                "message": format!("{} [{}]", message, i),
+                "timestamp": chrono::Utc::now().to_rfc3339(),
+                "source": "telemetry-test-client",
+                "iteration": i
+            })
+            .to_string()
+        })
+        .collect()
+}
+
+/// Generate sample events
+fn generate_sample_events(event_name: &str) -> Vec<TelemetryEvent> {
+    let mut params = BTreeMap::new();
+    params.insert("source".to_string(), "telemetry-test-client".to_string());
+    params.insert("timestamp".to_string(), chrono::Utc::now().to_rfc3339());
+    params.insert("test_key".to_string(), "test_value".to_string());
+
+    vec![TelemetryEvent {
+        name: event_name.to_string(),
+        params,
+    }]
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::from_default_env()
+                .add_directive("telemetry_test_client=info".parse()?),
+        )
+        .init();
+
+    let args = Args::parse();
+
+    info!("Telemetry Test Client");
+    info!("URL: {}", args.url);
+    info!("Contract: {}", args.contract_name);
+    info!("Chain ID: {}", args.chain_id);
+
+    let mut client = TelemetryTestClient::new(
+        args.url,
+        args.contract_name,
+        args.private_key,
+        args.chain_id,
+    )?;
+
+    match args.command {
+        Commands::Auth => {
+            let token = client.authenticate().await?;
+            println!("JWT Token: {}", token);
+        },
+
+        Commands::Metrics {
+            file,
+            metric_name,
+            metric_value,
+        } => {
+            let metrics = match file {
+                Some(path) => {
+                    info!("Reading metrics from file: {:?}", path);
+                    fs::read_to_string(path)?
+                },
+                None => {
+                    info!("Generating sample metrics");
+                    generate_sample_metrics(&metric_name, metric_value)
+                },
+            };
+            client.send_metrics(&metrics).await?;
+        },
+
+        Commands::Logs {
+            file,
+            message,
+            count,
+        } => {
+            let logs = match file {
+                Some(path) => {
+                    info!("Reading logs from file: {:?}", path);
+                    serde_json::from_str(&fs::read_to_string(path)?)?
+                },
+                None => {
+                    info!("Generating sample logs");
+                    generate_sample_logs(&message, count)
+                },
+            };
+            client.send_logs(logs).await?;
+        },
+
+        Commands::Events { file, event_name } => {
+            let events = match file {
+                Some(path) => {
+                    info!("Reading events from file: {:?}", path);
+                    let dump: TelemetryDump = serde_json::from_str(&fs::read_to_string(path)?)?;
+                    dump.events
+                },
+                None => {
+                    info!("Generating sample events");
+                    generate_sample_events(&event_name)
+                },
+            };
+            client.send_events(events).await?;
+        },
+
+        Commands::All { iterations, delay } => {
+            for i in 0..iterations {
+                info!("=== Iteration {}/{} ===", i + 1, iterations);
+
+                // Authenticate (will reuse token after first iteration)
+                if i == 0 {
+                    client.authenticate().await?;
+                }
+
+                // Send metrics
+                let metrics = generate_sample_metrics("test_iteration_metric", i as f64);
+                if let Err(e) = client.send_metrics(&metrics).await {
+                    warn!("Failed to send metrics: {}", e);
+                }
+
+                // Send logs
+                let logs = generate_sample_logs(&format!("Iteration {} log", i), 2);
+                if let Err(e) = client.send_logs(logs).await {
+                    warn!("Failed to send logs: {}", e);
+                }
+
+                // Send events
+                let events = generate_sample_events(&format!("TEST_EVENT_ITER_{}", i));
+                if let Err(e) = client.send_events(events).await {
+                    warn!("Failed to send events: {}", e);
+                }
+
+                if i < iterations - 1 {
+                    info!("Waiting {} seconds before next iteration...", delay);
+                    tokio::time::sleep(tokio::time::Duration::from_secs(delay)).await;
+                }
+            }
+        },
+    }
+
+    info!("Done!");
+    Ok(())
+}

--- a/crates/aptos-telemetry-service/src/allowlist_cache.rs
+++ b/crates/aptos-telemetry-service/src/allowlist_cache.rs
@@ -1,0 +1,352 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Allowlist cache for custom contract authentication.
+//!
+//! Uses a background refresh pattern (like validator_cache) to keep allowlists fresh.
+//! A single background task periodically fetches allowlists for all configured contracts,
+//! eliminating thundering herd issues and ensuring low-latency cache lookups.
+
+use crate::{
+    custom_contract_auth::{fetch_addresses_via_resource, fetch_addresses_via_view_function},
+    debug, error,
+    metrics::{
+        AllowlistCacheOp, ALLOWLIST_CACHE_ENTRIES, ALLOWLIST_CACHE_LAST_UPDATE_TIMESTAMP,
+        ALLOWLIST_CACHE_OPERATIONS, ALLOWLIST_CACHE_SIZE, ALLOWLIST_CACHE_UPDATE_FAILED_COUNT,
+        ALLOWLIST_CACHE_UPDATE_SUCCESS_COUNT,
+    },
+    CustomContractConfig, OnChainAuthMethod,
+};
+use aptos_infallible::RwLock;
+use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+use tokio::time;
+
+/// Allowlist data stored in the cache
+#[derive(Clone, Debug)]
+struct CachedAllowlist {
+    addresses: HashSet<AccountAddress>,
+}
+
+impl CachedAllowlist {
+    fn new(addresses: HashSet<AccountAddress>) -> Self {
+        Self { addresses }
+    }
+
+    fn contains(&self, address: &AccountAddress) -> bool {
+        self.addresses.contains(address)
+    }
+}
+
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+struct CacheKey {
+    contract_name: String,
+    chain_id: ChainId,
+}
+
+/// Simple cache for allowlist data. Updated by AllowlistCacheUpdater.
+#[derive(Clone, Default)]
+pub struct AllowlistCache {
+    cache: Arc<RwLock<HashMap<CacheKey, CachedAllowlist>>>,
+}
+
+impl AllowlistCache {
+    pub fn new() -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Check if an address is in the cached allowlist.
+    /// Returns `Some(true)` if address is allowed, `Some(false)` if not allowed,
+    /// or `None` if no cache entry exists.
+    pub fn check_address(
+        &self,
+        contract_name: &str,
+        chain_id: &ChainId,
+        address: &AccountAddress,
+    ) -> Option<bool> {
+        let key = CacheKey {
+            contract_name: contract_name.to_string(),
+            chain_id: *chain_id,
+        };
+
+        let chain_id_str = chain_id.to_string();
+        let cache = self.cache.read();
+        if let Some(cached) = cache.get(&key) {
+            let is_allowed = cached.contains(address);
+            ALLOWLIST_CACHE_OPERATIONS
+                .with_label_values(&[contract_name, &chain_id_str, AllowlistCacheOp::Hit.as_str()])
+                .inc();
+            Some(is_allowed)
+        } else {
+            ALLOWLIST_CACHE_OPERATIONS
+                .with_label_values(&[
+                    contract_name,
+                    &chain_id_str,
+                    AllowlistCacheOp::Miss.as_str(),
+                ])
+                .inc();
+            None
+        }
+    }
+
+    /// Update the cache with a new allowlist (called by AllowlistCacheUpdater)
+    pub fn update(&self, contract_name: &str, chain_id: &ChainId, addresses: Vec<AccountAddress>) {
+        let key = CacheKey {
+            contract_name: contract_name.to_string(),
+            chain_id: *chain_id,
+        };
+
+        let address_count = addresses.len();
+        let cached = CachedAllowlist::new(addresses.into_iter().collect());
+
+        let chain_id_str = chain_id.to_string();
+        let mut cache = self.cache.write();
+        cache.insert(key, cached);
+
+        // Record update operation and update metrics
+        ALLOWLIST_CACHE_OPERATIONS
+            .with_label_values(&[
+                contract_name,
+                &chain_id_str,
+                AllowlistCacheOp::Update.as_str(),
+            ])
+            .inc();
+
+        // Update timestamp for this contract/chain (unix seconds for staleness alerting)
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        ALLOWLIST_CACHE_LAST_UPDATE_TIMESTAMP
+            .with_label_values(&[contract_name, &chain_id_str])
+            .set(now_unix as i64);
+
+        // Update size metrics
+        ALLOWLIST_CACHE_SIZE
+            .with_label_values(&[contract_name, &chain_id_str])
+            .set(address_count as i64);
+        ALLOWLIST_CACHE_ENTRIES.set(cache.len() as i64);
+    }
+
+    /// Get cache statistics
+    #[allow(dead_code)]
+    pub fn stats(&self) -> CacheStats {
+        let cache = self.cache.read();
+        CacheStats {
+            total_entries: cache.len(),
+        }
+    }
+}
+
+/// Cache statistics
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct CacheStats {
+    pub total_entries: usize,
+}
+
+/// Background updater for allowlist cache (similar to PeerSetCacheUpdater).
+/// Periodically fetches allowlists for all configured custom contracts.
+#[derive(Clone)]
+pub struct AllowlistCacheUpdater {
+    cache: AllowlistCache,
+    contracts: Arc<Vec<CustomContractConfig>>,
+    update_interval: Duration,
+}
+
+impl AllowlistCacheUpdater {
+    pub fn new(
+        cache: AllowlistCache,
+        contracts: Vec<CustomContractConfig>,
+        update_interval: Duration,
+    ) -> Self {
+        Self {
+            cache,
+            contracts: Arc::new(contracts),
+            update_interval,
+        }
+    }
+
+    /// Start the background update loop.
+    /// Spawns a tokio task that runs until the process exits.
+    pub fn run(self) {
+        let mut interval = time::interval(self.update_interval);
+        tokio::spawn(async move {
+            // Do initial update immediately
+            self.update().await;
+            loop {
+                interval.tick().await;
+                self.update().await;
+            }
+        });
+    }
+
+    /// Update allowlists for all configured contracts
+    async fn update(&self) {
+        for contract in self.contracts.iter() {
+            match self.update_contract(contract).await {
+                Ok(count) => {
+                    ALLOWLIST_CACHE_UPDATE_SUCCESS_COUNT
+                        .with_label_values(&[&contract.name])
+                        .inc();
+                    debug!(
+                        "allowlist cache update successful for contract '{}': {} addresses",
+                        contract.name, count
+                    );
+                },
+                Err(err) => {
+                    // Log error but don't clear cache - stale data is better than no data
+                    // The ALLOWLIST_CACHE_LAST_UPDATE_TIMESTAMP metric will show staleness
+                    // Operators should alert on: now() - last_update_timestamp > threshold
+                    ALLOWLIST_CACHE_UPDATE_FAILED_COUNT
+                        .with_label_values(&[&contract.name, err.error_type()])
+                        .inc();
+                    error!(
+                        "allowlist cache update failed for contract '{}': {:?} (using stale cache)",
+                        contract.name, err
+                    );
+                },
+            }
+        }
+    }
+
+    /// Update allowlist for a single contract
+    async fn update_contract(
+        &self,
+        contract: &CustomContractConfig,
+    ) -> Result<usize, AllowlistUpdateError> {
+        let config = &contract.on_chain_auth;
+        let chain_id = ChainId::new(config.chain_id);
+
+        // Resolve the resource/function path (with env var substitution)
+        let path = config
+            .resolve_resource_path()
+            .map_err(AllowlistUpdateError::ConfigError)?;
+
+        // Resolve view function arguments (with env var substitution)
+        let view_args = config
+            .resolve_view_function_args()
+            .map_err(AllowlistUpdateError::ConfigError)?;
+
+        // Get REST URL
+        let rest_url = config.rest_api_url.clone().ok_or_else(|| {
+            AllowlistUpdateError::ConfigError("No REST URL configured".to_string())
+        })?;
+
+        // Fetch address list based on method
+        let addresses = match config.method {
+            OnChainAuthMethod::ViewFunction => fetch_addresses_via_view_function(
+                &rest_url,
+                &path,
+                &view_args,
+                &config.address_list_field,
+            )
+            .await
+            .map_err(|e| AllowlistUpdateError::FetchError(e.to_string()))?,
+            OnChainAuthMethod::Resource => {
+                fetch_addresses_via_resource(&rest_url, &path, &config.address_list_field)
+                    .await
+                    .map_err(|e| AllowlistUpdateError::FetchError(e.to_string()))?
+            },
+        };
+
+        let count = addresses.len();
+        self.cache.update(&contract.name, &chain_id, addresses);
+        Ok(count)
+    }
+}
+
+/// Errors that can occur during allowlist update
+#[derive(Debug)]
+pub enum AllowlistUpdateError {
+    ConfigError(String),
+    FetchError(String),
+}
+
+impl AllowlistUpdateError {
+    /// Get error type as string for metrics labels
+    pub fn error_type(&self) -> &'static str {
+        match self {
+            AllowlistUpdateError::ConfigError(_) => "config_error",
+            AllowlistUpdateError::FetchError(_) => "fetch_error",
+        }
+    }
+}
+
+impl std::fmt::Display for AllowlistUpdateError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AllowlistUpdateError::ConfigError(s) => write!(f, "config error: {}", s),
+            AllowlistUpdateError::FetchError(s) => write!(f, "fetch error: {}", s),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_basic_operations() {
+        let cache = AllowlistCache::new();
+        let contract_name = "test_contract";
+        let chain_id = ChainId::new(1);
+        let addr1 = AccountAddress::from_hex_literal("0x1").unwrap();
+        let addr2 = AccountAddress::from_hex_literal("0x2").unwrap();
+
+        // Initially not cached
+        assert_eq!(cache.check_address(contract_name, &chain_id, &addr1), None);
+
+        // Update cache
+        cache.update(contract_name, &chain_id, vec![addr1]);
+
+        // Should be cached and found
+        assert_eq!(
+            cache.check_address(contract_name, &chain_id, &addr1),
+            Some(true)
+        );
+
+        // Different address should not be found
+        assert_eq!(
+            cache.check_address(contract_name, &chain_id, &addr2),
+            Some(false)
+        );
+    }
+
+    #[test]
+    fn test_cache_per_contract_and_chain() {
+        let cache = AllowlistCache::new();
+        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+
+        // Different contracts
+        cache.update("contract1", &ChainId::new(1), vec![addr]);
+        cache.update("contract2", &ChainId::new(1), vec![]);
+
+        assert_eq!(
+            cache.check_address("contract1", &ChainId::new(1), &addr),
+            Some(true)
+        );
+        assert_eq!(
+            cache.check_address("contract2", &ChainId::new(1), &addr),
+            Some(false)
+        );
+
+        // Different chains
+        cache.update("contract1", &ChainId::new(2), vec![]);
+
+        assert_eq!(
+            cache.check_address("contract1", &ChainId::new(1), &addr),
+            Some(true)
+        );
+        assert_eq!(
+            cache.check_address("contract1", &ChainId::new(2), &addr),
+            Some(false)
+        );
+    }
+}

--- a/crates/aptos-telemetry-service/src/challenge_cache.rs
+++ b/crates/aptos-telemetry-service/src/challenge_cache.rs
@@ -1,0 +1,476 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Challenge cache for secure challenge-response authentication.
+//!
+//! This cache stores server-issued challenges to prevent:
+//! - Replay attacks (same challenge cannot be used twice)
+//! - Bypass attacks (clients cannot use self-generated challenges)
+
+use crate::metrics::{
+    ChallengeCacheOp, CHALLENGE_CACHE_KEYS, CHALLENGE_CACHE_LAST_STORE_TIMESTAMP,
+    CHALLENGE_CACHE_OPERATIONS, CHALLENGE_CACHE_SIZE,
+};
+use aptos_infallible::RwLock;
+use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+};
+
+/// Default TTL for challenges (5 minutes)
+const CHALLENGE_CACHE_TTL: Duration = Duration::from_secs(300);
+
+/// Maximum number of pending challenges per address to prevent memory exhaustion
+const MAX_CHALLENGES_PER_ADDRESS: usize = 5;
+
+/// A cached challenge with expiration metadata
+#[derive(Clone, Debug)]
+struct CachedChallenge {
+    /// The challenge string
+    challenge: String,
+    /// When this challenge expires (absolute time)
+    expires_at: Instant,
+}
+
+impl CachedChallenge {
+    fn new(challenge: String, ttl: Duration) -> Self {
+        Self {
+            challenge,
+            expires_at: Instant::now() + ttl,
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        Instant::now() >= self.expires_at
+    }
+}
+
+/// Key for the challenge cache: (contract_name, chain_id, address)
+#[derive(Clone, Debug, Hash, Eq, PartialEq)]
+struct CacheKey {
+    contract_name: String,
+    chain_id: ChainId,
+    address: AccountAddress,
+}
+
+/// Thread-safe cache for server-issued challenges
+#[derive(Clone)]
+pub struct ChallengeCache {
+    /// Map from cache key to list of pending challenges for that key
+    cache: Arc<RwLock<HashMap<CacheKey, Vec<CachedChallenge>>>>,
+    /// TTL for challenges
+    ttl: Duration,
+}
+
+impl ChallengeCache {
+    /// Create a new challenge cache with default TTL
+    pub fn new() -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            ttl: CHALLENGE_CACHE_TTL,
+        }
+    }
+
+    /// Create a new challenge cache with custom TTL
+    #[cfg(test)]
+    pub fn with_ttl(ttl: Duration) -> Self {
+        Self {
+            cache: Arc::new(RwLock::new(HashMap::new())),
+            ttl,
+        }
+    }
+
+    /// Store a newly issued challenge
+    ///
+    /// Returns the expiration timestamp (unix seconds) for the challenge
+    pub fn store_challenge(
+        &self,
+        contract_name: &str,
+        chain_id: &ChainId,
+        address: &AccountAddress,
+        challenge: String,
+    ) -> u64 {
+        let key = CacheKey {
+            contract_name: contract_name.to_string(),
+            chain_id: *chain_id,
+            address: *address,
+        };
+
+        let cached = CachedChallenge::new(challenge, self.ttl);
+        let now_unix = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let expires_at_unix = now_unix + self.ttl.as_secs();
+
+        let mut cache = self.cache.write();
+        let challenges = cache.entry(key).or_default();
+
+        // Remove expired challenges
+        challenges.retain(|c| !c.is_expired());
+
+        // Limit the number of pending challenges per address
+        let evicted = challenges.len() >= MAX_CHALLENGES_PER_ADDRESS;
+        if evicted {
+            // Remove the oldest challenge
+            challenges.remove(0);
+            CHALLENGE_CACHE_OPERATIONS
+                .with_label_values(&[contract_name, ChallengeCacheOp::Evicted.as_str()])
+                .inc();
+        }
+
+        challenges.push(cached);
+
+        // Update metrics: record store operation and update gauges
+        CHALLENGE_CACHE_OPERATIONS
+            .with_label_values(&[contract_name, ChallengeCacheOp::Store.as_str()])
+            .inc();
+        CHALLENGE_CACHE_LAST_STORE_TIMESTAMP
+            .with_label_values(&[contract_name])
+            .set(now_unix as i64);
+
+        // Update size metrics per contract (count challenges for this contract only)
+        let contract_challenges: usize = cache
+            .iter()
+            .filter(|(k, _)| k.contract_name == contract_name)
+            .map(|(_, v)| v.len())
+            .sum();
+        let contract_keys: usize = cache
+            .iter()
+            .filter(|(k, _)| k.contract_name == contract_name)
+            .count();
+        CHALLENGE_CACHE_SIZE
+            .with_label_values(&[contract_name])
+            .set(contract_challenges as i64);
+        CHALLENGE_CACHE_KEYS
+            .with_label_values(&[contract_name])
+            .set(contract_keys as i64);
+
+        expires_at_unix
+    }
+
+    /// Verify and consume a challenge
+    ///
+    /// Returns Ok(()) if the challenge was valid and has been consumed.
+    /// Returns Err with a message if the challenge is invalid or expired.
+    ///
+    /// IMPORTANT: This method consumes the challenge on success, preventing replay.
+    pub fn verify_and_consume(
+        &self,
+        contract_name: &str,
+        chain_id: &ChainId,
+        address: &AccountAddress,
+        challenge: &str,
+    ) -> Result<(), ChallengeError> {
+        let key = CacheKey {
+            contract_name: contract_name.to_string(),
+            chain_id: *chain_id,
+            address: *address,
+        };
+
+        let mut cache = self.cache.write();
+
+        // Get the challenges for this key
+        let challenges = match cache.get_mut(&key) {
+            Some(c) => c,
+            None => {
+                CHALLENGE_CACHE_OPERATIONS
+                    .with_label_values(&[contract_name, ChallengeCacheOp::VerifyNotFound.as_str()])
+                    .inc();
+                return Err(ChallengeError::NotFound);
+            },
+        };
+
+        // Remove expired challenges first
+        challenges.retain(|c| !c.is_expired());
+
+        // Find the matching challenge
+        let idx = match challenges.iter().position(|c| c.challenge == challenge) {
+            Some(i) => i,
+            None => {
+                CHALLENGE_CACHE_OPERATIONS
+                    .with_label_values(&[contract_name, ChallengeCacheOp::VerifyNotFound.as_str()])
+                    .inc();
+                return Err(ChallengeError::NotFound);
+            },
+        };
+
+        // Check if expired (shouldn't happen after retain, but double-check)
+        if challenges[idx].is_expired() {
+            challenges.remove(idx);
+            CHALLENGE_CACHE_OPERATIONS
+                .with_label_values(&[contract_name, ChallengeCacheOp::VerifyExpired.as_str()])
+                .inc();
+            Self::update_size_metrics(&cache, contract_name);
+            return Err(ChallengeError::Expired);
+        }
+
+        // Remove the challenge (consume it) to prevent replay
+        challenges.remove(idx);
+
+        // Clean up empty entries
+        if challenges.is_empty() {
+            cache.remove(&key);
+        }
+
+        // Record successful verification
+        CHALLENGE_CACHE_OPERATIONS
+            .with_label_values(&[contract_name, ChallengeCacheOp::VerifySuccess.as_str()])
+            .inc();
+        Self::update_size_metrics(&cache, contract_name);
+
+        Ok(())
+    }
+
+    /// Helper to update size metrics after cache mutations (per contract)
+    fn update_size_metrics(cache: &HashMap<CacheKey, Vec<CachedChallenge>>, contract_name: &str) {
+        let contract_challenges: usize = cache
+            .iter()
+            .filter(|(k, _)| k.contract_name == contract_name)
+            .map(|(_, v)| v.len())
+            .sum();
+        let contract_keys: usize = cache
+            .iter()
+            .filter(|(k, _)| k.contract_name == contract_name)
+            .count();
+        CHALLENGE_CACHE_SIZE
+            .with_label_values(&[contract_name])
+            .set(contract_challenges as i64);
+        CHALLENGE_CACHE_KEYS
+            .with_label_values(&[contract_name])
+            .set(contract_keys as i64);
+    }
+
+    /// Clean up all expired challenges from the cache
+    #[allow(dead_code)]
+    pub fn cleanup_expired(&self) {
+        let mut cache = self.cache.write();
+        // Remove expired challenges within each entry
+        for challenges in cache.values_mut() {
+            challenges.retain(|c| !c.is_expired());
+        }
+        // Remove empty entries
+        cache.retain(|_, v| !v.is_empty());
+    }
+
+    /// Get cache statistics
+    #[allow(dead_code)]
+    pub fn stats(&self) -> CacheStats {
+        let cache = self.cache.read();
+        let mut total_challenges = 0;
+        let mut expired_challenges = 0;
+
+        for challenges in cache.values() {
+            for c in challenges {
+                total_challenges += 1;
+                if c.is_expired() {
+                    expired_challenges += 1;
+                }
+            }
+        }
+
+        CacheStats {
+            total_keys: cache.len(),
+            total_challenges,
+            active_challenges: total_challenges - expired_challenges,
+            expired_challenges,
+        }
+    }
+}
+
+impl Default for ChallengeCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Error type for challenge verification
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ChallengeError {
+    /// Challenge was not found (never issued or already consumed)
+    NotFound,
+    /// Challenge has expired
+    Expired,
+}
+
+impl std::fmt::Display for ChallengeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ChallengeError::NotFound => {
+                write!(f, "challenge not found (not issued or already used)")
+            },
+            ChallengeError::Expired => write!(f, "challenge has expired"),
+        }
+    }
+}
+
+impl std::error::Error for ChallengeError {}
+
+/// Cache statistics
+#[derive(Debug, Clone)]
+#[allow(dead_code)]
+pub struct CacheStats {
+    pub total_keys: usize,
+    pub total_challenges: usize,
+    pub active_challenges: usize,
+    pub expired_challenges: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+
+    #[test]
+    fn test_store_and_verify_challenge() {
+        let cache = ChallengeCache::new();
+        let contract = "test_contract";
+        let chain_id = ChainId::new(1);
+        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+        let challenge = "test-challenge-123";
+
+        // Store challenge
+        cache.store_challenge(contract, &chain_id, &addr, challenge.to_string());
+
+        // Verify and consume should succeed
+        assert!(cache
+            .verify_and_consume(contract, &chain_id, &addr, challenge)
+            .is_ok());
+
+        // Second verify should fail (challenge consumed)
+        assert_eq!(
+            cache.verify_and_consume(contract, &chain_id, &addr, challenge),
+            Err(ChallengeError::NotFound)
+        );
+    }
+
+    #[test]
+    fn test_challenge_not_found() {
+        let cache = ChallengeCache::new();
+        let contract = "test_contract";
+        let chain_id = ChainId::new(1);
+        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+
+        // Verify non-existent challenge
+        assert_eq!(
+            cache.verify_and_consume(contract, &chain_id, &addr, "fake-challenge"),
+            Err(ChallengeError::NotFound)
+        );
+    }
+
+    #[test]
+    fn test_wrong_challenge() {
+        let cache = ChallengeCache::new();
+        let contract = "test_contract";
+        let chain_id = ChainId::new(1);
+        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+
+        // Store one challenge
+        cache.store_challenge(contract, &chain_id, &addr, "real-challenge".to_string());
+
+        // Verify different challenge should fail
+        assert_eq!(
+            cache.verify_and_consume(contract, &chain_id, &addr, "fake-challenge"),
+            Err(ChallengeError::NotFound)
+        );
+
+        // Original challenge should still be valid
+        assert!(cache
+            .verify_and_consume(contract, &chain_id, &addr, "real-challenge")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_challenge_expiration() {
+        let cache = ChallengeCache::with_ttl(Duration::from_millis(50));
+        let contract = "test_contract";
+        let chain_id = ChainId::new(1);
+        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+        let challenge = "expiring-challenge";
+
+        // Store challenge
+        cache.store_challenge(contract, &chain_id, &addr, challenge.to_string());
+
+        // Wait for expiration
+        sleep(Duration::from_millis(100));
+
+        // Should fail due to expiration
+        assert_eq!(
+            cache.verify_and_consume(contract, &chain_id, &addr, challenge),
+            Err(ChallengeError::NotFound) // NotFound because expired challenges are removed
+        );
+    }
+
+    #[test]
+    fn test_different_contracts_isolated() {
+        let cache = ChallengeCache::new();
+        let chain_id = ChainId::new(1);
+        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+        let challenge = "shared-challenge";
+
+        // Store for contract1
+        cache.store_challenge("contract1", &chain_id, &addr, challenge.to_string());
+
+        // Verify for contract2 should fail
+        assert_eq!(
+            cache.verify_and_consume("contract2", &chain_id, &addr, challenge),
+            Err(ChallengeError::NotFound)
+        );
+
+        // Verify for contract1 should succeed
+        assert!(cache
+            .verify_and_consume("contract1", &chain_id, &addr, challenge)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_different_addresses_isolated() {
+        let cache = ChallengeCache::new();
+        let contract = "test_contract";
+        let chain_id = ChainId::new(1);
+        let addr1 = AccountAddress::from_hex_literal("0x1").unwrap();
+        let addr2 = AccountAddress::from_hex_literal("0x2").unwrap();
+        let challenge = "shared-challenge";
+
+        // Store for addr1
+        cache.store_challenge(contract, &chain_id, &addr1, challenge.to_string());
+
+        // Verify for addr2 should fail
+        assert_eq!(
+            cache.verify_and_consume(contract, &chain_id, &addr2, challenge),
+            Err(ChallengeError::NotFound)
+        );
+
+        // Verify for addr1 should succeed
+        assert!(cache
+            .verify_and_consume(contract, &chain_id, &addr1, challenge)
+            .is_ok());
+    }
+
+    #[test]
+    fn test_max_challenges_per_address() {
+        let cache = ChallengeCache::new();
+        let contract = "test_contract";
+        let chain_id = ChainId::new(1);
+        let addr = AccountAddress::from_hex_literal("0x1").unwrap();
+
+        // Store more than MAX_CHALLENGES_PER_ADDRESS challenges
+        for i in 0..=MAX_CHALLENGES_PER_ADDRESS {
+            cache.store_challenge(contract, &chain_id, &addr, format!("challenge-{}", i));
+        }
+
+        // First challenge should have been evicted
+        assert_eq!(
+            cache.verify_and_consume(contract, &chain_id, &addr, "challenge-0"),
+            Err(ChallengeError::NotFound)
+        );
+
+        // Last challenge should still be valid
+        let last_challenge = format!("challenge-{}", MAX_CHALLENGES_PER_ADDRESS);
+        assert!(cache
+            .verify_and_consume(contract, &chain_id, &addr, &last_challenge)
+            .is_ok());
+    }
+}

--- a/crates/aptos-telemetry-service/src/clients/loki.rs
+++ b/crates/aptos-telemetry-service/src/clients/loki.rs
@@ -1,0 +1,168 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+//! Loki log ingestion client
+//!
+//! This client sends logs to Grafana Loki using the push API.
+//! Format: https://grafana.com/docs/loki/latest/api/#push-log-entries-to-loki
+
+use anyhow::anyhow;
+use debug_ignore::DebugIgnore;
+use reqwest::{Client as ReqwestClient, Url};
+use reqwest_middleware::{ClientBuilder, ClientWithMiddleware};
+use reqwest_retry::{policies::ExponentialBackoff, RetryTransientMiddleware};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// Loki push request format
+#[derive(Debug, Serialize, Deserialize)]
+struct LokiPushRequest {
+    streams: Vec<LokiStream>,
+}
+
+/// A single log stream with labels
+#[derive(Debug, Serialize, Deserialize)]
+struct LokiStream {
+    /// Label set for this stream (e.g., {"job": "aptos", "peer_id": "0x123"})
+    stream: HashMap<String, String>,
+    /// Log entries as [timestamp_ns, log_line] pairs
+    values: Vec<[String; 2]>,
+}
+
+#[derive(Clone, Debug)]
+pub struct LokiIngestClient {
+    inner: DebugIgnore<ClientWithMiddleware>,
+    base_url: Url,
+    auth_token: Option<String>,
+}
+
+impl LokiIngestClient {
+    /// Create a new Loki ingest client
+    ///
+    /// # Arguments
+    /// * `base_url` - Base URL of Loki (e.g., http://loki:3100)
+    /// * `auth_token` - Optional bearer token for authentication
+    pub fn new(base_url: Url, auth_token: Option<String>) -> Self {
+        let retry_policy = ExponentialBackoff::builder().build_with_max_retries(3);
+        let inner = ClientBuilder::new(ReqwestClient::new())
+            .with(RetryTransientMiddleware::new_with_policy(retry_policy))
+            .build();
+        Self {
+            inner: DebugIgnore(inner),
+            base_url,
+            auth_token,
+        }
+    }
+
+    /// Ingest log messages with labels
+    ///
+    /// # Arguments
+    /// * `messages` - Vector of log message strings
+    /// * `labels` - Labels to attach to the log stream (e.g., peer_id, node_type, etc.)
+    pub async fn ingest_logs(
+        &self,
+        messages: Vec<String>,
+        labels: HashMap<String, String>,
+    ) -> Result<reqwest::Response, anyhow::Error> {
+        // Get current timestamp in nanoseconds
+        let now_ns = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| anyhow!("failed to get timestamp: {}", e))?
+            .as_nanos()
+            .to_string();
+
+        // Convert messages to Loki format: [[timestamp_ns, log_line], ...]
+        let values: Vec<[String; 2]> = messages
+            .into_iter()
+            .map(|msg| [now_ns.clone(), msg])
+            .collect();
+
+        let stream = LokiStream {
+            stream: labels,
+            values,
+        };
+
+        let request = LokiPushRequest {
+            streams: vec![stream],
+        };
+
+        let json_body = serde_json::to_string(&request)
+            .map_err(|e| anyhow!("unable to serialize json: {}", e))?;
+
+        let mut req = self
+            .inner
+            .0
+            .post(self.base_url.join("/loki/api/v1/push")?)
+            .header("Content-Type", "application/json")
+            .body(json_body);
+
+        // Add authentication if provided
+        if let Some(token) = &self.auth_token {
+            req = req.bearer_auth(token);
+        }
+
+        req.send()
+            .await
+            .map_err(|e| anyhow!("failed to post logs to Loki: {}", e))
+    }
+
+    /// Ingest logs from an unstructured log format (for compatibility)
+    ///
+    /// This converts the Humio UnstructuredLog format to Loki format
+    pub async fn ingest_unstructured_log(
+        &self,
+        unstructured_log: crate::types::humio::UnstructuredLog,
+    ) -> Result<reqwest::Response, anyhow::Error> {
+        // Combine fields and tags into a single label set
+        let mut labels = HashMap::new();
+
+        // Add all fields as labels
+        for (key, value) in unstructured_log.fields {
+            labels.insert(key, value);
+        }
+
+        // Add all tags as labels
+        for (key, value) in unstructured_log.tags {
+            labels.insert(key, value);
+        }
+
+        // Add a default job label if not present
+        labels
+            .entry("job".to_string())
+            .or_insert_with(|| "aptos-telemetry".to_string());
+
+        self.ingest_logs(unstructured_log.messages, labels).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_loki_request_format() {
+        let mut labels = HashMap::new();
+        labels.insert("peer_id".to_string(), "0x123".to_string());
+        labels.insert("node_type".to_string(), "storage_provider".to_string());
+
+        let stream = LokiStream {
+            stream: labels,
+            values: vec![
+                ["1234567890000000000".to_string(), "log line 1".to_string()],
+                ["1234567890000000001".to_string(), "log line 2".to_string()],
+            ],
+        };
+
+        let request = LokiPushRequest {
+            streams: vec![stream],
+        };
+
+        let json = serde_json::to_string_pretty(&request).unwrap();
+        println!("Loki request format:\n{}", json);
+
+        // Verify it serializes correctly
+        assert!(json.contains("streams"));
+        assert!(json.contains("peer_id"));
+        assert!(json.contains("log line 1"));
+    }
+}

--- a/crates/aptos-telemetry-service/src/clients/mod.rs
+++ b/crates/aptos-telemetry-service/src/clients/mod.rs
@@ -2,6 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 pub mod humio;
+pub mod loki;
 
 pub mod victoria_metrics_api {
 

--- a/crates/aptos-telemetry-service/src/custom_contract_auth.rs
+++ b/crates/aptos-telemetry-service/src/custom_contract_auth.rs
@@ -1,0 +1,672 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+/// Custom contract authentication via on-chain allowlist verification.
+///
+/// Flow: Challenge request → Sign challenge → Verify signature + on-chain allowlist → JWT token
+use crate::{
+    context::Context,
+    debug, error,
+    errors::{ServiceError, ServiceErrorCode},
+    jwt_auth::create_jwt_token,
+    metrics::{record_custom_contract_error, CustomContractEndpoint, CustomContractErrorType},
+    types::common::NodeType,
+    warn,
+};
+use anyhow::{anyhow, Result};
+use aptos_crypto::{
+    ed25519::{Ed25519PublicKey, Ed25519Signature},
+    CryptoMaterialError, Signature,
+};
+use aptos_rest_client::Client as RestClient;
+use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
+use reqwest::header::AUTHORIZATION;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+use warp::{filters::BoxedFilter, reject, reply, Filter, Rejection, Reply};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChallengeRequest {
+    pub address: AccountAddress,
+    pub chain_id: ChainId,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChallengeResponse {
+    pub challenge: String,
+    pub expires_at: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomAuthRequest {
+    pub address: AccountAddress,
+    /// Chain ID
+    pub chain_id: ChainId,
+    /// The challenge that was signed
+    pub challenge: String,
+    /// Ed25519 signature over the challenge
+    pub signature: Vec<u8>,
+    /// Ed25519 public key used for signing (32 bytes)
+    pub public_key: Vec<u8>,
+}
+
+/// Authentication response with JWT token
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CustomAuthResponse {
+    /// JWT token for authenticated requests
+    pub token: String,
+}
+
+/// Get authentication challenge endpoint
+pub fn auth_challenge(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("custom-contract" / String / "auth-challenge")
+        .and(warp::post())
+        .and(context.filter())
+        .and(warp::body::json())
+        .and_then(handle_auth_challenge)
+        .boxed()
+}
+
+/// Handle authentication challenge request
+async fn handle_auth_challenge(
+    contract_name: String,
+    context: Context,
+    body: ChallengeRequest,
+) -> Result<impl Reply, Rejection> {
+    debug!(
+        "received custom contract '{}' auth challenge request: {:?}",
+        contract_name, body
+    );
+
+    // Verify the contract exists before issuing a challenge
+    if context.get_custom_contract(&contract_name).is_none() {
+        warn!("custom contract '{}' not configured", contract_name);
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::AuthChallenge,
+            CustomContractErrorType::ContractNotConfigured,
+        );
+        return Err(reject::custom(ServiceError::forbidden(
+            ServiceErrorCode::CustomContractAuthError(
+                format!("custom contract '{}' not configured", contract_name),
+                body.chain_id,
+            ),
+        )));
+    }
+
+    // Generate random challenge nonce
+    let challenge = Uuid::new_v4().to_string();
+
+    // Store the challenge in the cache and get the expiration timestamp
+    let expires_at = context.challenge_cache().store_challenge(
+        &contract_name,
+        &body.chain_id,
+        &body.address,
+        challenge.clone(),
+    );
+
+    let response = ChallengeResponse {
+        challenge,
+        expires_at,
+    };
+
+    Ok(reply::json(&response))
+}
+
+/// Custom contract authentication endpoint
+pub fn auth(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("custom-contract" / String / "auth")
+        .and(warp::post())
+        .and(context.filter())
+        .and(warp::body::json())
+        .and_then(handle_auth)
+        .boxed()
+}
+
+/// Handle custom contract authentication request
+async fn handle_auth(
+    contract_name: String,
+    context: Context,
+    body: CustomAuthRequest,
+) -> Result<impl Reply, Rejection> {
+    debug!(
+        "received custom contract '{}' auth request for address: {}",
+        contract_name, body.address
+    );
+
+    // Get the custom contract instance
+    let instance = context.get_custom_contract(&contract_name).ok_or_else(|| {
+        warn!("custom contract '{}' not configured", contract_name);
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::Auth,
+            CustomContractErrorType::ContractNotConfigured,
+        );
+        reject::custom(ServiceError::forbidden(
+            ServiceErrorCode::CustomContractAuthError(
+                format!("custom contract '{}' not configured", contract_name),
+                body.chain_id,
+            ),
+        ))
+    })?;
+
+    // Verify and consume the challenge BEFORE signature verification
+    // This prevents replay attacks and ensures the challenge was issued by this server
+    context
+        .challenge_cache()
+        .verify_and_consume(
+            &contract_name,
+            &body.chain_id,
+            &body.address,
+            &body.challenge,
+        )
+        .map_err(|e| {
+            warn!(
+                "challenge verification failed for address {}: {}",
+                body.address, e
+            );
+            record_custom_contract_error(
+                &contract_name,
+                CustomContractEndpoint::Auth,
+                CustomContractErrorType::ChallengeFailed,
+            );
+            reject::custom(ServiceError::bad_request(
+                ServiceErrorCode::CustomContractAuthError(
+                    format!("invalid or expired challenge: {}", e),
+                    body.chain_id,
+                ),
+            ))
+        })?;
+
+    // Verify the signature over the challenge
+    verify_signature(&body).map_err(|e| {
+        warn!("signature verification failed: {}", e);
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::Auth,
+            CustomContractErrorType::SignatureInvalid,
+        );
+        reject::custom(ServiceError::bad_request(
+            ServiceErrorCode::CustomContractAuthError(e.to_string(), body.chain_id),
+        ))
+    })?;
+
+    // Verify the address is in the AllowList list on-chain (with caching)
+    verify_custom_contract(
+        &context,
+        &contract_name,
+        &instance.config,
+        &body.address,
+        &body.chain_id,
+    )
+    .await
+    .map_err(|e| {
+        warn!("custom contract verification failed: {}", e);
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::Auth,
+            CustomContractErrorType::NotInAllowlist,
+        );
+        reject::custom(ServiceError::forbidden(
+            ServiceErrorCode::CustomContractAuthError(e.to_string(), body.chain_id),
+        ))
+    })?;
+
+    // Create JWT token for the custom contract client
+    // IMPORTANT: Store the contract_name in JWT (not node_type_name) for auth verification
+    // This prevents cross-contract token reuse attacks where a user authenticated for
+    // contract_A could use their JWT to inject data into contract_B's sinks
+    let run_uuid = Uuid::new_v4();
+    let token = create_jwt_token(
+        context.jwt_service(),
+        body.chain_id,
+        body.address,                            // Use address as PeerId
+        NodeType::Custom(contract_name.clone()), // contract_name for auth, not display label
+        0,                                       // epoch not relevant for custom contract clients
+        run_uuid,
+    )
+    .map_err(|e| {
+        error!("unable to create jwt token: {}", e);
+        reject::custom(ServiceError::internal(
+            ServiceErrorCode::CustomContractAuthError(e.to_string(), body.chain_id),
+        ))
+    })?;
+
+    Ok(reply::json(&CustomAuthResponse { token }))
+}
+
+/// Verify the Ed25519 signature over the challenge
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) fn verify_signature(request: &CustomAuthRequest) -> Result<()> {
+    // Parse the public key
+    if request.public_key.len() != 32 {
+        return Err(anyhow!(
+            "invalid public key length: expected 32 bytes, got {}",
+            request.public_key.len()
+        ));
+    }
+
+    let public_key = Ed25519PublicKey::try_from(&request.public_key[..])
+        .map_err(|e: CryptoMaterialError| anyhow!("invalid public key: {}", e))?;
+
+    // Verify the public key matches the address
+    let derived_address = aptos_types::account_address::from_public_key(&public_key);
+    if derived_address != request.address {
+        return Err(anyhow!(
+            "public key does not match address: expected {}, got {}",
+            request.address,
+            derived_address
+        ));
+    }
+
+    // Parse the signature
+    let signature = Ed25519Signature::try_from(&request.signature[..])
+        .map_err(|e: CryptoMaterialError| anyhow!("invalid signature: {}", e))?;
+
+    // Verify the signature over the challenge
+    signature
+        .verify_arbitrary_msg(request.challenge.as_bytes(), &public_key)
+        .map_err(|e| anyhow!("signature verification failed: {}", e))?;
+
+    Ok(())
+}
+
+/// Verify that the address is registered in an on-chain allowlist.
+///
+/// Uses a simple cache lookup - the cache is kept fresh by AllowlistCacheUpdater
+/// running in the background (similar to PeerSetCacheUpdater for validators).
+///
+/// Returns Ok if address is in allowlist, Err otherwise.
+async fn verify_custom_contract(
+    context: &Context,
+    contract_name: &str,
+    _config: &crate::OnChainAuthConfig,
+    address: &AccountAddress,
+    chain_id: &ChainId,
+) -> Result<()> {
+    let cache = context.allowlist_cache();
+
+    match cache.check_address(contract_name, chain_id, address) {
+        Some(true) => {
+            debug!(
+                "address {} is in allowlist for contract '{}' chain {}",
+                address, contract_name, chain_id
+            );
+            Ok(())
+        },
+        Some(false) => {
+            debug!(
+                "address {} is NOT in allowlist for contract '{}' chain {}",
+                address, contract_name, chain_id
+            );
+            Err(anyhow!(
+                "address {} is not in the allowlist for contract '{}'",
+                address,
+                contract_name
+            ))
+        },
+        None => {
+            // Cache miss - this shouldn't happen in normal operation since
+            // AllowlistCacheUpdater populates the cache before requests arrive.
+            // This could occur if:
+            // 1. Service just started and updater hasn't run yet
+            // 2. Contract was just added to config
+            // 3. Cache was cleared
+            warn!(
+                "allowlist cache miss for contract '{}' chain {} - updater may not have run yet",
+                contract_name, chain_id
+            );
+            Err(anyhow!(
+                "allowlist not available for contract '{}' (cache miss)",
+                contract_name
+            ))
+        },
+    }
+}
+
+/// Fetch addresses using view function (recommended)
+/// Crate-public for cache pre-warming at startup.
+pub(crate) async fn fetch_addresses_via_view_function(
+    rest_url: &reqwest::Url,
+    function_path: &str,
+    function_args: &[String],
+    address_field: &str,
+) -> Result<Vec<AccountAddress>> {
+    use aptos_rest_client::aptos_api_types::{EntryFunctionId, ViewRequest};
+    use std::str::FromStr;
+
+    // Parse the function path into an EntryFunctionId
+    let function_id = EntryFunctionId::from_str(function_path)
+        .map_err(|e| anyhow!("invalid function path '{}': {}", function_path, e))?;
+
+    // Convert string args to JSON values for the view request
+    let arguments: Vec<serde_json::Value> = function_args
+        .iter()
+        .map(|arg| serde_json::Value::String(arg.clone()))
+        .collect();
+
+    // Create the view request
+    let view_request = ViewRequest {
+        function: function_id,
+        type_arguments: vec![],
+        arguments,
+    };
+
+    // Use the REST client to call the view function
+    let client = RestClient::new(rest_url.clone());
+    let response = client.view(&view_request, None).await.map_err(|e| {
+        // Provide user-friendly error messages for common failures
+        let error_msg = format!("{}", e);
+        if error_msg.contains("404") || error_msg.contains("not found") {
+            anyhow!(
+                "view function '{}' does not exist or account not found on chain",
+                function_path
+            )
+        } else if error_msg.contains("403") || error_msg.contains("Forbidden") {
+            anyhow!(
+                "access denied when calling view function '{}' - check API credentials",
+                function_path
+            )
+        } else if error_msg.contains("500") || error_msg.contains("Internal Server Error") {
+            anyhow!(
+                "blockchain node error when calling view function '{}': {}",
+                function_path,
+                error_msg
+            )
+        } else {
+            anyhow!(
+                "failed to call view function '{}': {}",
+                function_path,
+                error_msg
+            )
+        }
+    })?;
+
+    // The response is a Vec<serde_json::Value>, we need to extract addresses
+    let result = response.inner();
+
+    // Check if result is empty
+    if result.is_empty() {
+        return Err(anyhow!(
+            "view function '{}' returned empty result - function may not exist or returned no data",
+            function_path
+        ));
+    }
+
+    // For view functions that return a list of objects/addresses,
+    // the result is typically wrapped in an array
+    let result_json = serde_json::to_value(result)
+        .map_err(|e| anyhow!("failed to convert view result to JSON: {}", e))?;
+
+    // Extract addresses from result
+    extract_address_list(&result_json, address_field)
+}
+
+/// Fetch addresses using get_account_resource (legacy)
+/// Crate-public for cache pre-warming at startup.
+pub(crate) async fn fetch_addresses_via_resource(
+    rest_url: &reqwest::Url,
+    resource_path: &str,
+    address_field: &str,
+) -> Result<Vec<AccountAddress>> {
+    // Parse resource path: "0x123::module::Resource"
+    let parts: Vec<&str> = resource_path.split("::").collect();
+    if parts.len() != 3 {
+        return Err(anyhow!(
+            "invalid resource path format, expected '0xADDRESS::module::Resource', got '{}'",
+            resource_path
+        ));
+    }
+
+    let resource_address = AccountAddress::from_hex_literal(parts[0])
+        .map_err(|e| anyhow!("invalid address in resource path '{}': {}", parts[0], e))?;
+    let resource_type = format!(
+        "{}::{}::{}",
+        resource_address.to_hex_literal(),
+        parts[1],
+        parts[2]
+    );
+
+    let client = RestClient::new(rest_url.clone());
+
+    // Fetch the resource from on-chain
+    let response = client
+        .get_account_resource(resource_address, &resource_type)
+        .await
+        .map_err(|e| {
+            // Provide user-friendly error messages for common failures
+            let error_msg = format!("{}", e);
+            if error_msg.contains("404") || error_msg.contains("not found") {
+                anyhow!(
+                    "resource '{}' does not exist at address {} or account not found on chain",
+                    resource_type,
+                    resource_address
+                )
+            } else if error_msg.contains("403") || error_msg.contains("Forbidden") {
+                anyhow!(
+                    "access denied when fetching resource '{}' - check API credentials",
+                    resource_type
+                )
+            } else if error_msg.contains("500") || error_msg.contains("Internal Server Error") {
+                anyhow!(
+                    "blockchain node error when fetching resource '{}': {}",
+                    resource_type,
+                    error_msg
+                )
+            } else {
+                anyhow!(
+                    "failed to fetch resource '{}': {}",
+                    resource_type,
+                    error_msg
+                )
+            }
+        })?;
+
+    let resource = response
+        .into_inner()
+        .ok_or_else(|| {
+            anyhow!(
+                "resource '{}' not found at address {} - the resource type may not exist or account may not have this resource",
+                resource_type, resource_address
+            )
+        })?;
+
+    // Extract the address list from the specified field path
+    extract_address_list(&resource.data, address_field)
+        .map_err(|e| {
+            anyhow!(
+                "failed to extract addresses from resource '{}' using field path '{}': {} - check that the field exists and contains valid address data",
+                resource_type, address_field, e
+            )
+        })
+}
+
+/// Extract a list of addresses from a JSON value using a field path
+/// Supports:
+/// - "providers" - simple field
+/// - "data.providers" - nested path
+/// - "[0].address" - array at root, extract address field from each object
+/// - "" or "." - root is the array
+fn extract_address_list(json: &serde_json::Value, field_path: &str) -> Result<Vec<AccountAddress>> {
+    // Handle special case for array iteration syntax: "[0].field"
+    if field_path.starts_with("[0].") || field_path.starts_with("[].") {
+        let field_in_object = field_path.split('.').nth(1).unwrap_or("address");
+        return extract_addresses_from_array_of_objects(json, field_in_object);
+    }
+
+    // Handle empty or root path
+    if field_path.is_empty() || field_path == "." {
+        return extract_addresses_from_value(json);
+    }
+
+    // Navigate the field path
+    let mut current = json;
+    for field in field_path.split('.') {
+        if field.is_empty() {
+            continue;
+        }
+        current = current
+            .get(field)
+            .ok_or_else(|| anyhow!("field '{}' not found in path '{}'", field, field_path))?;
+    }
+
+    extract_addresses_from_value(current)
+}
+
+/// Extract addresses from a JSON value (array or single)
+#[cfg_attr(test, allow(dead_code))]
+pub(crate) fn extract_addresses_from_value(
+    json: &serde_json::Value,
+) -> Result<Vec<AccountAddress>> {
+    // The value should be an array of addresses
+    let array = json
+        .as_array()
+        .ok_or_else(|| anyhow!("expected an array, got {:?}", json))?;
+
+    // Parse each element as an address (either string or object with address field)
+    let mut addresses = Vec::new();
+    for (i, item) in array.iter().enumerate() {
+        let addr = if let Some(addr_str) = item.as_str() {
+            // Direct string address
+            AccountAddress::from_hex_literal(addr_str)
+                .map_err(|e| anyhow!("invalid address at index {}: {}", i, e))?
+        } else if let Some(obj) = item.as_object() {
+            // Object with 'address' or 'account' field
+            let addr_str = obj
+                .get("address")
+                .or_else(|| obj.get("account"))
+                .and_then(|v| v.as_str())
+                .ok_or_else(|| anyhow!("address not found in object at index {}", i))?;
+            AccountAddress::from_hex_literal(addr_str)
+                .map_err(|e| anyhow!("invalid address at index {}: {}", i, e))?
+        } else {
+            return Err(anyhow!("invalid address format at index {}", i));
+        };
+        addresses.push(addr);
+    }
+
+    Ok(addresses)
+}
+
+/// Extract addresses from an array of objects, pulling specific field from each
+fn extract_addresses_from_array_of_objects(
+    json: &serde_json::Value,
+    address_field: &str,
+) -> Result<Vec<AccountAddress>> {
+    let outer_array = json
+        .as_array()
+        .ok_or_else(|| anyhow!("expected an array at root"))?;
+
+    // View function results are wrapped: [[{...}]] - first element is the actual return value
+    // If the first element is also an array, unwrap it
+    let array = if outer_array.len() == 1 {
+        if let Some(inner) = outer_array.first().and_then(|v| v.as_array()) {
+            inner
+        } else {
+            outer_array
+        }
+    } else {
+        outer_array
+    };
+
+    let mut addresses = Vec::new();
+    for (i, item) in array.iter().enumerate() {
+        let obj = item
+            .as_object()
+            .ok_or_else(|| anyhow!("expected object at index {}, got {:?}", i, item))?;
+        let addr_str = obj
+            .get(address_field)
+            .and_then(|v| v.as_str())
+            .ok_or_else(|| {
+                anyhow!(
+                    "field '{}' not found in object at index {}",
+                    address_field,
+                    i
+                )
+            })?;
+        let addr = AccountAddress::from_hex_literal(addr_str)
+            .map_err(|e| anyhow!("invalid address at index {}: {}", i, e))?;
+        addresses.push(addr);
+    }
+
+    Ok(addresses)
+}
+
+/// Get the REST API URL for a given chain
+#[allow(dead_code)]
+fn get_rest_url_for_chain(chain_id: &ChainId) -> Result<reqwest::Url> {
+    // Check environment variable first
+    let env_var = format!("APTOS_REST_URL_CHAIN_{}", chain_id.id());
+    if let Ok(url) = std::env::var(&env_var) {
+        return reqwest::Url::parse(&url).map_err(|e| anyhow!("invalid URL in {}: {}", env_var, e));
+    }
+
+    // Default URLs for known chains
+    let url_str = match chain_id.id() {
+        1 => "https://api.mainnet.aptoslabs.com/v1",
+        2 => "https://api.testnet.aptoslabs.com/v1",
+        _ => {
+            return Err(anyhow!(
+                "unknown chain_id {}, set {} environment variable",
+                chain_id.id(),
+                env_var
+            ))
+        },
+    };
+
+    reqwest::Url::parse(url_str).map_err(|e| anyhow!("invalid default URL: {}", e))
+}
+
+/// Authorization filter for custom contract authenticated requests.
+/// Returns (contract_name, peer_id, chain_id) from JWT claims.
+/// The contract_name is extracted from NodeType::Custom(contract_name) and should be
+/// verified against the URL path to prevent cross-contract token reuse.
+pub fn with_custom_contract_auth(
+    context: Context,
+) -> impl Filter<Extract = ((String, aptos_types::PeerId, ChainId),), Error = Rejection> + Clone {
+    warp::header::optional(AUTHORIZATION.as_str())
+        .and_then(crate::jwt_auth::jwt_from_header)
+        .and(warp::any().map(move || context.clone()))
+        .and_then(authorize_custom_contract_jwt)
+}
+
+/// Authorize a custom contract JWT token.
+/// Returns (contract_name, peer_id, chain_id) from claims for use in data ingestion.
+/// The contract_name is stored in NodeType::Custom(contract_name) to prevent
+/// cross-contract token reuse attacks.
+async fn authorize_custom_contract_jwt(
+    token: String,
+    context: Context,
+) -> Result<(String, aptos_types::PeerId, ChainId), Rejection> {
+    use crate::types::auth::Claims;
+
+    let claims = context
+        .jwt_service()
+        .decode::<Claims>(&token)
+        .map_err(|e| {
+            debug!("jwt decode error: {}", e);
+            reject::custom(ServiceError::unauthorized(
+                ServiceErrorCode::CustomContractAuthError(
+                    "invalid token".to_string(),
+                    ChainId::test(),
+                ),
+            ))
+        })?
+        .claims;
+
+    // Extract and verify the contract_name from NodeType::Custom
+    // This prevents cross-contract token reuse attacks
+    let jwt_contract_name = match &claims.node_type {
+        NodeType::Custom(name) => name.clone(),
+        _ => {
+            return Err(reject::custom(ServiceError::forbidden(
+                ServiceErrorCode::CustomContractAuthError(
+                    "token is not for a custom contract client".to_string(),
+                    claims.chain_id,
+                ),
+            )));
+        },
+    };
+
+    Ok((jwt_contract_name, claims.peer_id, claims.chain_id))
+}

--- a/crates/aptos-telemetry-service/src/custom_contract_ingest.rs
+++ b/crates/aptos-telemetry-service/src/custom_contract_ingest.rs
@@ -1,0 +1,447 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+/// Storage Provider Data Ingestion
+///
+/// This module handles data ingestion from authenticated storage providers.
+/// The data flows to separate sinks configured specifically for storage providers
+/// to avoid mixing with node telemetry data.
+use crate::{
+    clients::humio::{PEER_ID_FIELD_NAME, PEER_ROLE_TAG_NAME},
+    context::Context,
+    custom_contract_auth::with_custom_contract_auth,
+    debug, error,
+    errors::{CustomEventIngestError, LogIngestError, ServiceError, ServiceErrorCode},
+    metrics::{record_custom_contract_error, CustomContractEndpoint, CustomContractErrorType},
+    types::{
+        common::EventIdentity, common::NodeType, humio::UnstructuredLog, telemetry::TelemetryDump,
+    },
+};
+use aptos_types::{chain_id::ChainId, PeerId};
+use flate2::read::GzDecoder;
+use gcp_bigquery_client::model::table_data_insert_all_request::TableDataInsertAllRequest;
+use std::{collections::HashMap, io::Read};
+use uuid::Uuid;
+use warp::{filters::BoxedFilter, hyper::body::Bytes, reject, reply, Filter, Rejection, Reply};
+
+/// Custom contract metrics ingest endpoint
+pub fn metrics_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("custom-contract" / String / "ingest" / "metrics")
+        .and(warp::post())
+        .and(context.clone().filter())
+        .and(with_custom_contract_auth(context.clone()))
+        .and(warp::header::optional("content-encoding"))
+        .and(warp::body::bytes())
+        .and_then(handle_metrics_ingest)
+        .boxed()
+}
+
+/// Handle custom contract metrics ingestion
+async fn handle_metrics_ingest(
+    contract_name: String,
+    context: Context,
+    (jwt_contract_name, peer_id, chain_id): (String, PeerId, ChainId),
+    content_encoding: Option<String>,
+    body: Bytes,
+) -> Result<impl Reply, Rejection> {
+    // Verify the JWT was issued for this specific contract (prevents cross-contract token reuse)
+    if jwt_contract_name != contract_name {
+        error!(
+            "contract name mismatch: JWT issued for '{}', request for '{}'",
+            jwt_contract_name, contract_name
+        );
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::MetricsIngest,
+            CustomContractErrorType::TokenMismatch,
+        );
+        return Err(reject::custom(ServiceError::forbidden(
+            ServiceErrorCode::CustomContractAuthError(
+                format!(
+                    "token issued for '{}' cannot be used for '{}'",
+                    jwt_contract_name, contract_name
+                ),
+                chain_id,
+            ),
+        )));
+    }
+
+    debug!(
+        "received custom contract '{}' metrics from peer_id: {}, chain_id: {}, body length: {}",
+        contract_name,
+        peer_id,
+        chain_id,
+        body.len()
+    );
+
+    // Get the custom contract instance
+    let instance = context.get_custom_contract(&contract_name).ok_or_else(|| {
+        error!("custom contract '{}' not configured", contract_name);
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::MetricsIngest,
+            CustomContractErrorType::ContractNotConfigured,
+        );
+        reject::custom(ServiceError::internal(
+            LogIngestError::IngestionError.into(),
+        ))
+    })?;
+
+    // Get the metrics clients for this contract
+    let metrics_client = &instance.metrics_clients;
+
+    // Prepare extra labels for metrics - include contract name and node_type_name from config
+    // Format: name=value (no quotes - Victoria Metrics extra_label format)
+    let node_type = &instance.config.node_type_name;
+    let extra_labels = vec![
+        format!("peer_id={}", peer_id),
+        format!("node_type={}", node_type),
+        format!("contract_name={}", contract_name),
+    ];
+
+    // Determine encoding
+    let encoding = content_encoding.unwrap_or_else(|| "identity".to_string());
+
+    // Send metrics to all configured sinks for this custom contract
+    for (name, client) in metrics_client {
+        debug!(
+            "forwarding custom contract '{}' metrics to sink: {}",
+            contract_name, name
+        );
+        if let Err(e) = client
+            .post_prometheus_metrics(body.clone(), extra_labels.clone(), encoding.clone())
+            .await
+        {
+            debug!("failed to forward metrics to {}: {}", name, e);
+        }
+    }
+
+    Ok(reply::reply())
+}
+
+/// Custom contract logs ingest endpoint
+pub fn log_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("custom-contract" / String / "ingest" / "logs")
+        .and(warp::post())
+        .and(context.clone().filter())
+        .and(with_custom_contract_auth(context.clone()))
+        .and(warp::header::optional("content-encoding"))
+        .and(warp::body::bytes())
+        .and_then(handle_log_ingest)
+        .boxed()
+}
+
+/// Handle custom contract log ingestion
+async fn handle_log_ingest(
+    contract_name: String,
+    context: Context,
+    (jwt_contract_name, peer_id, chain_id): (String, PeerId, ChainId),
+    content_encoding: Option<String>,
+    body: Bytes,
+) -> Result<impl Reply, Rejection> {
+    // Verify the JWT was issued for this specific contract (prevents cross-contract token reuse)
+    if jwt_contract_name != contract_name {
+        error!(
+            "contract name mismatch: JWT issued for '{}', request for '{}'",
+            jwt_contract_name, contract_name
+        );
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::LogsIngest,
+            CustomContractErrorType::TokenMismatch,
+        );
+        return Err(reject::custom(ServiceError::forbidden(
+            ServiceErrorCode::CustomContractAuthError(
+                format!(
+                    "token issued for '{}' cannot be used for '{}'",
+                    jwt_contract_name, contract_name
+                ),
+                chain_id,
+            ),
+        )));
+    }
+
+    debug!(
+        "received custom contract '{}' logs from peer_id: {}, chain_id: {}, body length: {}",
+        contract_name,
+        peer_id,
+        chain_id,
+        body.len()
+    );
+
+    // Decode the body if gzip encoded
+    let log_data = if content_encoding.as_deref() == Some("gzip") {
+        let mut decoder = GzDecoder::new(&body[..]);
+        let mut decompressed = Vec::new();
+        decoder.read_to_end(&mut decompressed).map_err(|_| {
+            record_custom_contract_error(
+                &contract_name,
+                CustomContractEndpoint::LogsIngest,
+                CustomContractErrorType::InvalidPayload,
+            );
+            reject::custom(ServiceError::bad_request(
+                LogIngestError::UnexpectedContentEncoding.into(),
+            ))
+        })?;
+        decompressed
+    } else {
+        body.to_vec()
+    };
+
+    // Parse the log batch
+    let log_batch: Vec<String> = serde_json::from_slice(&log_data).map_err(|_| {
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::LogsIngest,
+            CustomContractErrorType::InvalidPayload,
+        );
+        reject::custom(ServiceError::bad_request(
+            LogIngestError::UnexpectedPayloadBody.into(),
+        ))
+    })?;
+
+    debug!(
+        "custom contract '{}' log batch size: {} from peer_id: {}",
+        contract_name,
+        log_batch.len(),
+        peer_id
+    );
+
+    // Get the custom contract instance
+    let instance = context.get_custom_contract(&contract_name).ok_or_else(|| {
+        error!("custom contract '{}' not configured", contract_name);
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::LogsIngest,
+            CustomContractErrorType::ContractNotConfigured,
+        );
+        reject::custom(ServiceError::internal(
+            LogIngestError::IngestionError.into(),
+        ))
+    })?;
+
+    // Get the log client for this contract
+    let log_client = instance.logs_client.as_ref().ok_or_else(|| {
+        debug!(
+            "custom contract '{}' log client not configured",
+            contract_name
+        );
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::LogsIngest,
+            CustomContractErrorType::IngestionFailed,
+        );
+        reject::custom(ServiceError::internal(
+            LogIngestError::IngestionError.into(),
+        ))
+    })?;
+
+    // Prepare unstructured log with custom contract metadata
+    let mut fields = HashMap::new();
+    fields.insert(PEER_ID_FIELD_NAME.into(), peer_id.to_string());
+
+    // Get the node type from the contract instance config
+    let node_type = NodeType::Custom(instance.config.node_type_name.clone());
+
+    let mut tags = HashMap::new();
+    tags.insert(PEER_ROLE_TAG_NAME.into(), node_type.as_str());
+    tags.insert("contract_name".into(), contract_name.clone());
+
+    let unstructured_log = UnstructuredLog {
+        fields,
+        tags,
+        messages: log_batch,
+    };
+
+    // Forward logs to the custom contract-specific sink
+    log_client
+        .ingest_unstructured_log(unstructured_log)
+        .await
+        .map_err(|e| {
+            debug!(
+                "failed to ingest custom contract '{}' logs: {}",
+                contract_name, e
+            );
+            record_custom_contract_error(
+                &contract_name,
+                CustomContractEndpoint::LogsIngest,
+                CustomContractErrorType::IngestionFailed,
+            );
+            reject::custom(ServiceError::internal(
+                LogIngestError::IngestionError.into(),
+            ))
+        })?;
+
+    Ok(reply::reply())
+}
+
+/// Custom contract custom event ingest endpoint
+pub fn custom_event_ingest(context: Context) -> BoxedFilter<(impl Reply,)> {
+    warp::path!("custom-contract" / String / "ingest" / "custom-event")
+        .and(warp::post())
+        .and(context.clone().filter())
+        .and(with_custom_contract_auth(context.clone()))
+        .and(warp::body::json())
+        .and_then(handle_custom_event_ingest)
+        .boxed()
+}
+
+/// Handle custom contract custom event ingestion
+async fn handle_custom_event_ingest(
+    contract_name: String,
+    context: Context,
+    (jwt_contract_name, peer_id, chain_id): (String, PeerId, ChainId),
+    body: TelemetryDump,
+) -> Result<impl Reply, Rejection> {
+    // Verify the JWT was issued for this specific contract (prevents cross-contract token reuse)
+    if jwt_contract_name != contract_name {
+        error!(
+            "contract name mismatch: JWT issued for '{}', request for '{}'",
+            jwt_contract_name, contract_name
+        );
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::EventsIngest,
+            CustomContractErrorType::TokenMismatch,
+        );
+        return Err(reject::custom(ServiceError::forbidden(
+            ServiceErrorCode::CustomContractAuthError(
+                format!(
+                    "token issued for '{}' cannot be used for '{}'",
+                    jwt_contract_name, contract_name
+                ),
+                chain_id,
+            ),
+        )));
+    }
+
+    debug!(
+        "received custom contract '{}' custom event from peer_id: {}, chain_id: {}, events: {}",
+        contract_name,
+        peer_id,
+        chain_id,
+        body.events.len()
+    );
+
+    // Validate the user_id matches the peer_id
+    if body.user_id != peer_id.to_string() {
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::EventsIngest,
+            CustomContractErrorType::InvalidPayload,
+        );
+        return Err(reject::custom(ServiceError::bad_request(
+            CustomEventIngestError::InvalidEvent(body.user_id.clone(), peer_id).into(),
+        )));
+    }
+
+    // Validate there are events
+    if body.events.is_empty() {
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::EventsIngest,
+            CustomContractErrorType::InvalidPayload,
+        );
+        return Err(reject::custom(ServiceError::bad_request(
+            CustomEventIngestError::EmptyPayload.into(),
+        )));
+    }
+
+    // Parse timestamp
+    let event_timestamp: u64 = body.timestamp_micros.parse().map_err(|_| {
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::EventsIngest,
+            CustomContractErrorType::InvalidPayload,
+        );
+        reject::custom(ServiceError::bad_request(
+            CustomEventIngestError::InvalidTimestamp(body.timestamp_micros.clone()).into(),
+        ))
+    })?;
+
+    // Get the custom contract instance
+    let instance = context.get_custom_contract(&contract_name).ok_or_else(|| {
+        error!("custom contract '{}' not configured", contract_name);
+        record_custom_contract_error(
+            &contract_name,
+            CustomContractEndpoint::EventsIngest,
+            CustomContractErrorType::ContractNotConfigured,
+        );
+        reject::custom(ServiceError::internal(
+            CustomEventIngestError::EmptyPayload.into(),
+        ))
+    })?;
+
+    // Get the BigQuery client for this custom contract
+    if let Some(bq_client) = &instance.bigquery_client {
+        use crate::types::telemetry::BigQueryRow;
+
+        // Get the node type from the contract instance config
+        let node_type = NodeType::Custom(instance.config.node_type_name.clone());
+
+        // Create event identity for custom contract client using chain_id from JWT claims
+        let event_identity = EventIdentity {
+            peer_id,
+            chain_id,
+            role_type: node_type,
+            epoch: 0,
+            uuid: Uuid::new_v4(),
+        };
+
+        // Convert events to BigQuery rows and build insert request
+        let mut insert_request = TableDataInsertAllRequest::new();
+
+        for event in body.events {
+            // Add contract_name to event params
+            let mut event_params: Vec<serde_json::Value> = event
+                .params
+                .into_iter()
+                .map(|(key, value)| {
+                    serde_json::json!({
+                        "key": key,
+                        "value": {"string_value": value}
+                    })
+                })
+                .collect();
+            // Append contract_name as an additional parameter
+            event_params.push(serde_json::json!({
+                "key": "contract_name",
+                "value": {"string_value": contract_name.clone()}
+            }));
+
+            let row = BigQueryRow {
+                event_identity: event_identity.clone(),
+                event_name: event.name,
+                event_timestamp,
+                event_params,
+            };
+
+            insert_request.add_row(None, &row).map_err(|e| {
+                error!("unable to create BigQuery row: {}", e);
+                record_custom_contract_error(
+                    &contract_name,
+                    CustomContractEndpoint::EventsIngest,
+                    CustomContractErrorType::IngestionFailed,
+                );
+                reject::custom(ServiceError::internal(
+                    CustomEventIngestError::from(e).into(),
+                ))
+            })?;
+        }
+
+        // Insert into BigQuery
+        bq_client.insert_all(insert_request).await.map_err(|e| {
+            error!("BigQuery insert failed: {}", e);
+            record_custom_contract_error(
+                &contract_name,
+                CustomContractEndpoint::EventsIngest,
+                CustomContractErrorType::IngestionFailed,
+            );
+            reject::custom(ServiceError::internal(
+                CustomEventIngestError::from(e).into(),
+            ))
+        })?;
+    }
+
+    Ok(reply::reply())
+}

--- a/crates/aptos-telemetry-service/src/errors.rs
+++ b/crates/aptos-telemetry-service/src/errors.rs
@@ -133,6 +133,8 @@ pub(crate) enum ServiceErrorCode {
     LogIngestError(#[from] LogIngestError),
     #[error("metrics ingest error: {0}")]
     MetricsIngestError(#[from] MetricsIngestError),
+    #[error("custom contract authentication error: {0}")]
+    CustomContractAuthError(String, ChainId),
 }
 
 #[derive(Debug)]

--- a/crates/aptos-telemetry-service/src/index.rs
+++ b/crates/aptos-telemetry-service/src/index.rs
@@ -5,7 +5,7 @@ use crate::{
     auth,
     constants::GCP_CLOUD_TRACE_CONTEXT_HEADER,
     context::Context,
-    custom_event, debug,
+    custom_contract_auth, custom_contract_ingest, custom_event, debug,
     errors::ServiceError,
     log_ingest,
     metrics::SERVICE_ERROR_COUNTS,
@@ -35,7 +35,13 @@ pub fn routes(
             .or(custom_event::custom_event_ingest(context.clone()))
             .or(prometheus_push_metrics::metrics_ingest(context.clone()))
             .or(log_ingest::log_ingest(context.clone()))
-            .or(remote_config::telemetry_log_env(context)),
+            .or(remote_config::telemetry_log_env(context.clone()))
+            // custom contract auth endpoints
+            .or(custom_contract_auth::auth_challenge(context.clone()))
+            .or(custom_contract_auth::auth(context.clone()))
+            .or(custom_contract_ingest::metrics_ingest(context.clone()))
+            .or(custom_contract_ingest::log_ingest(context.clone()))
+            .or(custom_contract_ingest::custom_event_ingest(context)),
     );
 
     v1_api

--- a/crates/aptos-telemetry-service/src/lib.rs
+++ b/crates/aptos-telemetry-service/src/lib.rs
@@ -2,7 +2,8 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::{
-    clients::{big_query, humio, victoria_metrics_api::Client as MetricsClient},
+    allowlist_cache::AllowlistCacheUpdater,
+    clients::{big_query, victoria_metrics_api::Client as MetricsClient},
     context::{ClientTuple, Context, JsonWebTokenService, LogIngestClients, PeerStoreTuple},
     index::routes,
     metrics::PrometheusExporter,
@@ -30,10 +31,14 @@ use std::{
 use types::common::ChainCommonName;
 use warp::{Filter, Reply};
 
+mod allowlist_cache;
 mod auth;
+mod challenge_cache;
 mod clients;
 mod constants;
 mod context;
+mod custom_contract_auth;
+mod custom_contract_ingest;
 mod custom_event;
 mod errors;
 mod gcp_logger;
@@ -75,20 +80,38 @@ impl AptosTelemetryServiceArgs {
         )
         .expect("unable to form x25519::Private key from environment variable SERVER_PRIVATE_KEY");
 
-        let bigquery_client = BigQueryClient::from_service_account_key_file(
-            env::var("GOOGLE_APPLICATION_CREDENTIALS")
-                .expect("environment variable GOOGLE_APPLICATION_CREDENTIALS must be set")
-                .as_str(),
-        )
-        .await
-        .expect("Failed to create BigQuery client");
+        // BigQuery is optional - skip if GOOGLE_APPLICATION_CREDENTIALS not set or invalid
+        let bigquery_client: Option<BigQueryClient> =
+            match env::var("GOOGLE_APPLICATION_CREDENTIALS") {
+                Ok(creds_path) if !creds_path.is_empty() && creds_path != "/dev/null" => {
+                    match BigQueryClient::from_service_account_key_file(&creds_path).await {
+                        Ok(client) => {
+                            info!("BigQuery client initialized successfully");
+                            Some(client)
+                        },
+                        Err(e) => {
+                            warn!(
+                                "Failed to create BigQuery client (BigQuery features disabled): {}",
+                                e
+                            );
+                            None
+                        },
+                    }
+                },
+                _ => {
+                    warn!("GOOGLE_APPLICATION_CREDENTIALS not set - BigQuery features disabled");
+                    None
+                },
+            };
 
-        let bigquery_table_client = big_query::TableWriteClient::new(
-            bigquery_client.clone(),
-            config.custom_event_config.project_id.clone(),
-            config.custom_event_config.dataset_id.clone(),
-            config.custom_event_config.table_id.clone(),
-        );
+        let bigquery_table_client = bigquery_client.as_ref().map(|client| {
+            big_query::TableWriteClient::new(
+                client.clone(),
+                config.custom_event_config.project_id.clone(),
+                config.custom_event_config.dataset_id.clone(),
+                config.custom_event_config.table_id.clone(),
+            )
+        });
 
         let metrics_clients: GroupedMetricsClients = config.metrics_endpoints_config.clone().into();
 
@@ -100,6 +123,43 @@ impl AptosTelemetryServiceArgs {
             .unwrap();
 
         let log_ingest_clients: LogIngestClients = config.humio_ingest_config.clone().into();
+
+        // Setup custom contract clients from new config format
+        let custom_contract_clients = if !config.custom_contract_configs.is_empty() {
+            let mut instances = HashMap::new();
+
+            for cc_config in &config.custom_contract_configs {
+                let metrics_clients = cc_config
+                    .metrics_sinks
+                    .as_ref()
+                    .map(|s| s.make_clients())
+                    .unwrap_or_default();
+
+                let logs_client = cc_config.logs_sink.as_ref().map(|s| s.make_client());
+
+                let cc_bigquery_client = cc_config.events_sink.as_ref().and_then(|ec| {
+                    bigquery_client.as_ref().map(|client| {
+                        big_query::TableWriteClient::new(
+                            client.clone(),
+                            ec.project_id.clone(),
+                            ec.dataset_id.clone(),
+                            ec.table_id.clone(),
+                        )
+                    })
+                });
+
+                instances.insert(cc_config.name.clone(), context::CustomContractInstance {
+                    config: cc_config.on_chain_auth.clone(),
+                    metrics_clients,
+                    logs_client,
+                    bigquery_client: cc_bigquery_client,
+                });
+            }
+
+            Some(context::CustomContractClients { instances })
+        } else {
+            None
+        };
 
         let jwt_service = JsonWebTokenService::from_base64_secret(
             env::var("JWT_SIGNING_KEY")
@@ -120,9 +180,10 @@ impl AptosTelemetryServiceArgs {
                 public_fullnodes,
             ),
             ClientTuple::new(
-                Some(bigquery_table_client),
+                bigquery_table_client,
                 Some(metrics_clients),
                 Some(log_ingest_clients),
+                custom_contract_clients,
             ),
             jwt_service,
             config.log_env_map.clone(),
@@ -138,13 +199,34 @@ impl AptosTelemetryServiceArgs {
         )
         .run();
 
-        if let Err(err) =
-            PeerLocationUpdater::new(bigquery_client.clone(), peer_locations.clone()).run()
-        {
-            error!("Failed to start PeerLocationUpdater: {:?}", err);
+        // PeerLocationUpdater requires BigQuery - only start if available
+        if let Some(bq_client) = bigquery_client.as_ref() {
+            if let Err(err) =
+                PeerLocationUpdater::new(bq_client.clone(), peer_locations.clone()).run()
+            {
+                error!("Failed to start PeerLocationUpdater: {:?}", err);
+            }
+        } else {
+            warn!("PeerLocationUpdater disabled - BigQuery client not available");
         }
 
         PrometheusExporter::new(telemetry_metrics_client).run();
+
+        // Start AllowlistCacheUpdater for custom contracts (like PeerSetCacheUpdater)
+        // This keeps the allowlist cache fresh in the background
+        if !config.custom_contract_configs.is_empty() {
+            info!(
+                "Starting AllowlistCacheUpdater for {} custom contracts (interval: {}s)",
+                config.custom_contract_configs.len(),
+                config.allowlist_cache_ttl_secs
+            );
+            AllowlistCacheUpdater::new(
+                context.allowlist_cache().clone(),
+                config.custom_contract_configs.clone(),
+                Duration::from_secs(config.allowlist_cache_ttl_secs),
+            )
+            .run();
+        }
 
         Self::serve(&config, routes(context)).await;
     }
@@ -219,7 +301,7 @@ impl MetricsEndpoint {
 }
 
 /// Metrics endpoints configuration for metrics from
-/// different datasources.
+/// different datasources (node telemetry only)
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct MetricsEndpointsConfig {
@@ -239,12 +321,193 @@ impl MetricsEndpointsConfig {
     }
 }
 
+/// Log backend type
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum LogBackendType {
+    #[default]
+    Humio,
+    Loki,
+}
+
+/// Authentication method for on-chain verification
+#[derive(Clone, Debug, Default, Deserialize, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum OnChainAuthMethod {
+    /// Use get_account_resource API (legacy)
+    Resource,
+    /// Use view function API (recommended)
+    #[default]
+    ViewFunction,
+}
+
+/// Default node type name for custom contract auth
+fn default_node_type_name() -> String {
+    "custom".to_string()
+}
+
+/// Configuration for on-chain contract-based authentication
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct OnChainAuthConfig {
+    /// Chain ID where the contract is deployed.
+    /// Used for cache keying and pre-warming at startup.
+    /// If not specified, defaults to 1 (mainnet).
+    #[serde(default = "default_chain_id")]
+    pub chain_id: u8,
+
+    /// Authentication method (resource or view_function)
+    #[serde(default)]
+    pub method: OnChainAuthMethod,
+
+    /// For ViewFunction method: full function path (e.g., "0x123::module::get_members")
+    /// For Resource method: full resource path (e.g., "0x123::module::ResourceName")
+    /// Can use environment variable substitution with ${ENV_VAR} syntax
+    pub resource_path: String,
+
+    /// Arguments to pass to the view function (only used with ViewFunction method)
+    /// Each argument is a string that will be passed as-is to the view function
+    /// Can use environment variable substitution with ${ENV_VAR} syntax
+    /// Example: ["0x1234...", "100"]
+    #[serde(default)]
+    pub view_function_args: Vec<String>,
+
+    /// JSON path to the list of addresses in the response/resource
+    /// Examples: "providers", "members", "data.allowlist", "[0].address"
+    pub address_list_field: String,
+
+    /// Optional: chain-specific REST API URL
+    /// If not provided, uses default URLs or APTOS_REST_URL_CHAIN_<id> env var
+    #[serde(default)]
+    pub rest_api_url: Option<Url>,
+
+    /// Custom node type name for authenticated clients
+    /// Examples: "ShelbyStorageProvider", "CustomStorageNode", "DataProvider"
+    /// Defaults to "custom" if not specified
+    #[serde(default = "default_node_type_name")]
+    pub node_type_name: String,
+}
+
+/// Default chain ID (mainnet)
+fn default_chain_id() -> u8 {
+    1
+}
+
+/// Metrics sink configuration (subset of MetricsEndpoint)
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct MetricsSinkConfig {
+    /// Map of sink name to endpoint URL
+    pub endpoint_urls: HashMap<String, String>,
+    /// Environment variable containing JSON map of sink names to auth keys
+    #[serde(default)]
+    pub keys_env_var: Option<String>,
+}
+
+impl MetricsSinkConfig {
+    /// Convert to MetricsClient instances
+    pub fn make_clients(&self) -> HashMap<String, MetricsClient> {
+        let keys: HashMap<String, String> = self
+            .keys_env_var
+            .as_ref()
+            .and_then(|env_var| std::env::var(env_var).ok())
+            .and_then(|json_str| serde_json::from_str(&json_str).ok())
+            .unwrap_or_default();
+
+        self.endpoint_urls
+            .iter()
+            .map(|(name, url)| {
+                let secret: clients::victoria_metrics_api::AuthToken = keys
+                    .get(name)
+                    .map(|k| clients::victoria_metrics_api::AuthToken::Bearer(k.clone()))
+                    .unwrap_or_else(|| {
+                        clients::victoria_metrics_api::AuthToken::Bearer("".to_string())
+                    });
+                let parsed_url = Url::parse(url).expect("valid URL in metrics sink config");
+                (name.clone(), MetricsClient::new(parsed_url, secret))
+            })
+            .collect()
+    }
+}
+
+/// Custom contract configuration - consolidates auth and all data sinks
+#[derive(Clone, Debug, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct CustomContractConfig {
+    /// Unique identifier for this custom contract configuration
+    /// Used in routing and logging
+    pub name: String,
+
+    /// On-chain authentication configuration
+    pub on_chain_auth: OnChainAuthConfig,
+
+    /// Metrics sinks for this custom contract (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metrics_sinks: Option<MetricsSinkConfig>,
+
+    /// Log sink for this custom contract (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub logs_sink: Option<LogIngestEndpoint>,
+
+    /// BigQuery events sink for this custom contract (optional)
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub events_sink: Option<CustomEventConfig>,
+}
+
+impl OnChainAuthConfig {
+    /// Resolve environment variables in a string (${ENV_VAR} syntax)
+    ///
+    /// Note: Only substitutes patterns from the original string. If an env var's
+    /// value contains ${VAR} patterns, they are NOT recursively substituted.
+    /// This prevents infinite loops from self-referential (FOO=abc${FOO}def)
+    /// or cyclical (FOO=${BAR}, BAR=${FOO}) environment variables.
+    fn resolve_env_vars(input: &str) -> Result<String, String> {
+        let mut resolved = input.to_string();
+        let mut search_start = 0;
+
+        // Find and replace ${ENV_VAR} patterns, advancing past each substitution
+        while let Some(rel_start) = resolved[search_start..].find("${") {
+            let start = search_start + rel_start;
+            if let Some(rel_end) = resolved[start..].find('}') {
+                let end = start + rel_end;
+                let env_var = &resolved[start + 2..end];
+                let value = std::env::var(env_var)
+                    .map_err(|_| format!("Environment variable {} not set", env_var))?;
+                let value_len = value.len();
+                resolved = format!("{}{}{}", &resolved[..start], value, &resolved[end + 1..]);
+                // Continue searching after the substituted value to avoid infinite loops
+                search_start = start + value_len;
+            } else {
+                return Err("Malformed environment variable substitution".to_string());
+            }
+        }
+
+        Ok(resolved)
+    }
+
+    /// Resolve environment variables in the resource path
+    pub fn resolve_resource_path(&self) -> Result<String, String> {
+        Self::resolve_env_vars(&self.resource_path)
+    }
+
+    /// Resolve environment variables in view function arguments
+    pub fn resolve_view_function_args(&self) -> Result<Vec<String>, String> {
+        self.view_function_args
+            .iter()
+            .map(|arg| Self::resolve_env_vars(arg))
+            .collect()
+    }
+}
+
 /// A single log ingest endpoint config
 #[derive(Clone, Debug, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct LogIngestEndpoint {
     pub endpoint_url: Url,
     pub key_env_var: String,
+    /// Log backend type (humio or loki). Defaults to humio for compatibility.
+    #[serde(default)]
+    pub backend_type: LogBackendType,
 }
 
 impl LogIngestEndpoint {
@@ -253,18 +516,36 @@ impl LogIngestEndpoint {
         Self {
             endpoint_url: Url::parse("test://test").unwrap(),
             key_env_var: "".into(),
+            backend_type: LogBackendType::Humio,
         }
     }
 
-    fn make_client(&self) -> humio::IngestClient {
-        let secret = env::var(&self.key_env_var).unwrap_or_else(|_| {
-            panic!(
-                "environment variable {} must be set.",
-                self.key_env_var.clone()
-            )
-        });
+    fn make_client(&self) -> context::LogIngestClient {
+        use crate::clients::{humio, loki};
 
-        humio::IngestClient::new(self.endpoint_url.clone(), secret)
+        let secret = env::var(&self.key_env_var).ok(); // Make optional for Loki
+
+        match self.backend_type {
+            LogBackendType::Humio => {
+                let token = secret.unwrap_or_else(|| {
+                    panic!(
+                        "environment variable {} must be set for Humio backend.",
+                        self.key_env_var.clone()
+                    )
+                });
+                context::LogIngestClient::Humio(humio::IngestClient::new(
+                    self.endpoint_url.clone(),
+                    token,
+                ))
+            },
+            LogBackendType::Loki => {
+                // Loki auth token is optional
+                context::LogIngestClient::Loki(loki::LokiIngestClient::new(
+                    self.endpoint_url.clone(),
+                    secret,
+                ))
+            },
+        }
     }
 }
 
@@ -277,6 +558,7 @@ pub struct LogIngestConfig {
     // Log endpoint for unknown nodes
     pub unknown_logs_endpoint: LogIngestEndpoint,
     // Blacklisted peers from log ingestion
+    #[serde(default)]
     pub blacklist_peers: Option<HashSet<PeerId>>,
 }
 impl LogIngestConfig {
@@ -310,6 +592,21 @@ pub struct TelemetryServiceConfig {
     pub peer_identities: HashMap<ChainId, HashMap<PeerId, String>>,
 
     pub metrics_endpoints_config: MetricsEndpointsConfig,
+
+    /// Custom contract configurations (optional)
+    /// Each entry defines authentication and data sinks for a different custom contract client type
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub custom_contract_configs: Vec<CustomContractConfig>,
+
+    /// Allowlist cache TTL in seconds (optional)
+    /// Controls how long on-chain allowlist data is cached before re-fetching
+    /// Default: 300 seconds (5 minutes). Set lower for testing (e.g., 10 seconds)
+    #[serde(default = "default_allowlist_cache_ttl_secs")]
+    pub allowlist_cache_ttl_secs: u64,
+}
+
+fn default_allowlist_cache_ttl_secs() -> u64 {
+    300 // 5 minutes default
 }
 
 impl TelemetryServiceConfig {
@@ -352,4 +649,79 @@ pub struct CustomEventConfig {
 fn verify_tool() {
     use clap::CommandFactory;
     AptosTelemetryServiceArgs::command().debug_assert()
+}
+
+#[cfg(test)]
+mod resolve_env_vars_tests {
+    use super::OnChainAuthConfig;
+
+    // SAFETY: These tests modify environment variables which is inherently unsafe
+    // in multi-threaded contexts. Tests should be run with --test-threads=1 or
+    // use unique variable names to avoid conflicts.
+
+    #[test]
+    fn test_basic_substitution() {
+        // SAFETY: Test-only env var modification with unique name
+        unsafe { std::env::set_var("TEST_VAR_BASIC", "hello") };
+        let result = OnChainAuthConfig::resolve_env_vars("prefix_${TEST_VAR_BASIC}_suffix");
+        assert_eq!(result.unwrap(), "prefix_hello_suffix");
+        unsafe { std::env::remove_var("TEST_VAR_BASIC") };
+    }
+
+    #[test]
+    fn test_multiple_substitutions() {
+        // SAFETY: Test-only env var modification with unique names
+        unsafe { std::env::set_var("TEST_VAR_A", "aaa") };
+        unsafe { std::env::set_var("TEST_VAR_B", "bbb") };
+        let result = OnChainAuthConfig::resolve_env_vars("${TEST_VAR_A}_${TEST_VAR_B}");
+        assert_eq!(result.unwrap(), "aaa_bbb");
+        unsafe { std::env::remove_var("TEST_VAR_A") };
+        unsafe { std::env::remove_var("TEST_VAR_B") };
+    }
+
+    #[test]
+    fn test_self_referential_no_infinite_loop() {
+        // Set env var whose value contains ${VAR} pattern - should NOT be recursively expanded
+        // SAFETY: Test-only env var modification with unique name
+        unsafe { std::env::set_var("TEST_SELF_REF", "value_with_${TEST_SELF_REF}_inside") };
+        let result = OnChainAuthConfig::resolve_env_vars("${TEST_SELF_REF}");
+        // The inner ${TEST_SELF_REF} should NOT be substituted (prevents infinite loop)
+        assert_eq!(result.unwrap(), "value_with_${TEST_SELF_REF}_inside");
+        unsafe { std::env::remove_var("TEST_SELF_REF") };
+    }
+
+    #[test]
+    fn test_cyclical_no_infinite_loop() {
+        // Set up cyclical references: FOO -> ${BAR}, BAR -> ${FOO}
+        // SAFETY: Test-only env var modification with unique names
+        unsafe { std::env::set_var("TEST_CYCLE_FOO", "${TEST_CYCLE_BAR}") };
+        unsafe { std::env::set_var("TEST_CYCLE_BAR", "${TEST_CYCLE_FOO}") };
+        let result = OnChainAuthConfig::resolve_env_vars("${TEST_CYCLE_FOO}");
+        // Should substitute once and stop - the value ${TEST_CYCLE_BAR} is NOT expanded
+        assert_eq!(result.unwrap(), "${TEST_CYCLE_BAR}");
+        unsafe { std::env::remove_var("TEST_CYCLE_FOO") };
+        unsafe { std::env::remove_var("TEST_CYCLE_BAR") };
+    }
+
+    #[test]
+    fn test_missing_env_var() {
+        let result = OnChainAuthConfig::resolve_env_vars("${NONEXISTENT_VAR_12345}");
+        assert!(result.is_err());
+        assert!(result
+            .unwrap_err()
+            .contains("NONEXISTENT_VAR_12345 not set"));
+    }
+
+    #[test]
+    fn test_malformed_pattern() {
+        let result = OnChainAuthConfig::resolve_env_vars("${UNCLOSED");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Malformed"));
+    }
+
+    #[test]
+    fn test_no_substitution_needed() {
+        let result = OnChainAuthConfig::resolve_env_vars("plain_string");
+        assert_eq!(result.unwrap(), "plain_string");
+    }
 }

--- a/crates/aptos-telemetry-service/src/tests/custom_contract_auth_test.rs
+++ b/crates/aptos-telemetry-service/src/tests/custom_contract_auth_test.rs
@@ -1,0 +1,1007 @@
+// Copyright (c) Aptos Foundation
+// Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
+
+use crate::{
+    tests::test_context::new_test_context_with_auth, OnChainAuthConfig, OnChainAuthMethod,
+};
+use aptos_crypto::{
+    ed25519::{Ed25519PrivateKey, Ed25519Signature},
+    PrivateKey, Uniform,
+};
+use aptos_types::{account_address, account_address::AccountAddress, chain_id::ChainId};
+use httpmock::prelude::*;
+use rand::SeedableRng;
+use serde_json::json;
+
+/// Helper function to sign arbitrary bytes in tests
+fn sign_bytes(private_key: &Ed25519PrivateKey, message: &[u8]) -> Ed25519Signature {
+    use ed25519_dalek::Signer;
+    // Use ed25519_dalek v1.x directly for signing in tests
+    let secret_bytes: &[u8; 32] = &private_key.to_bytes();
+    let dalek_secret = ed25519_dalek::SecretKey::from_bytes(secret_bytes).unwrap();
+    let dalek_public = ed25519_dalek::PublicKey::from(&dalek_secret);
+    let dalek_keypair = ed25519_dalek::Keypair {
+        secret: dalek_secret,
+        public: dalek_public,
+    };
+    let dalek_signature = dalek_keypair.sign(message);
+    Ed25519Signature::try_from(dalek_signature.to_bytes().as_ref()).unwrap()
+}
+
+/// Test authentication flow with mocked view function
+#[tokio::test]
+async fn test_custom_contract_auth_with_view_function() {
+    let server = MockServer::start();
+
+    // Generate a keypair for the client
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    // Use a valid test contract address
+    let contract_address = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    // Mock the view function response (REST client uses /v1/view)
+    // Note: We match on path only since REST client serializes the body differently
+    let _view_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/view");
+        then.status(200)
+            .header("X-Aptos-Chain-Id", "21")
+            .header("X-Aptos-Ledger-Version", "1000")
+            .header("X-Aptos-Ledger-TimestampUsec", "1234567890000000")
+            .header("X-Aptos-Epoch", "1")
+            .header("X-Aptos-Ledger-Oldest-Version", "0")
+            .header("X-Aptos-Block-Height", "100")
+            .header("X-Aptos-Oldest-Block-Height", "0")
+            .json_body(json!([
+                {
+                    "address": address.to_hex_literal(),
+                    "bls_public_key": "0xabc123",
+                    "failure_domain": "dc_test",
+                    "ip_address": "127.0.0.1",
+                    "port": "8080"
+                }
+            ]));
+    });
+
+    // Create config and context
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: format!("{}::registry::get_members", contract_address),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "TestNode".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+
+    // Auth endpoints now require contract name in path
+    let contract_name = "test_contract";
+
+    // Pre-populate the allowlist cache (since tests don't run background updater)
+    context.populate_allowlist_cache(contract_name, chain_id, vec![address]);
+
+    // Step 1: Request challenge
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    assert!(challenge_resp.get("challenge").is_some());
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+
+    // Step 2: Sign challenge
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    // Step 3: Authenticate
+    let auth_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    // Should succeed
+    assert!(auth_resp.get("token").is_some());
+    // Note: view_mock is not asserted because cache is pre-populated directly
+}
+
+/// Test authentication with resource method (legacy)
+/// Ignored because mocking the full Aptos REST API response headers is complex
+#[tokio::test]
+async fn test_custom_contract_auth_with_resource() {
+    let server = MockServer::start();
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    // Use a valid test contract address
+    let contract_address = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    // Mock the resource endpoint with required Aptos API headers
+    let _resource_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path_contains("accounts")
+            .path_contains("resource");
+        then.status(200)
+            .header("X-Aptos-Chain-Id", "21")
+            .header("X-Aptos-Ledger-Version", "1000")
+            .header("X-Aptos-Ledger-TimestampUsec", "1234567890")
+            .header("X-Aptos-Epoch", "1")
+            .header("X-Aptos-Ledger-Oldest-Version", "0")
+            .header("X-Aptos-Block-Height", "100")
+            .header("X-Aptos-Oldest-Block-Height", "0")
+            .json_body(json!({
+                "type": format!("{}::registry::Members", contract_address),
+                "data": {
+                    "members": [address.to_hex_literal()]
+                }
+            }));
+    });
+
+    // Create config and context
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::Resource,
+        resource_path: format!("{}::registry::Members", contract_address),
+        view_function_args: vec![],
+        address_list_field: "members".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "TestNode".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+
+    // Auth endpoints now require contract name in path
+    let contract_name = "test_contract";
+
+    // Pre-populate the allowlist cache (since tests don't run background updater)
+    context.populate_allowlist_cache(contract_name, chain_id, vec![address]);
+
+    // Get challenge
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    // Authenticate
+    let auth_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert!(auth_resp.get("token").is_some());
+    // Note: resource_mock is not asserted because cache is pre-populated directly
+}
+
+/// Test authentication failure when address not in allowlist
+#[tokio::test]
+async fn test_custom_contract_auth_address_not_in_allowlist() {
+    let server = MockServer::start();
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    // Use a valid test contract address
+    let contract_address = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    // Mock view function returning different addresses (not used since cache is pre-populated)
+    let _view_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/view");
+        then.status(200).json_body(json!([
+            {
+                "address": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+                "port": "8080"
+            }
+        ]));
+    });
+
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: format!("{}::registry::get_members", contract_address),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "TestNode".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+
+    // Auth endpoints now require contract name in path
+    let contract_name = "test_contract";
+
+    // Pre-populate the allowlist cache with a DIFFERENT address (not the requesting address)
+    let other_address = AccountAddress::from_hex_literal(
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+    )
+    .unwrap();
+    context.populate_allowlist_cache(contract_name, chain_id, vec![other_address]);
+
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    // This should fail
+    let auth_resp = context
+        .expect_status_code(403)
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert!(auth_resp.get("code").is_some());
+    assert_eq!(auth_resp["code"], 403);
+    // Mock not used - cache is pre-populated directly
+}
+
+/// Test signature verification with wrong signature
+#[tokio::test]
+async fn test_custom_contract_auth_invalid_signature() {
+    // Need a minimal config to create the contract instance
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "0x1::test::get_members".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: None,
+        node_type_name: "custom".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+
+    // Auth endpoints now require contract name in path
+    let contract_name = "test_contract";
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+
+    // Sign wrong message
+    let wrong_message = "wrong challenge";
+    let signature = sign_bytes(&private_key, wrong_message.as_bytes());
+
+    // This should fail before even checking on-chain
+    let auth_resp = context
+        .expect_status_code(400)
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert_eq!(auth_resp["code"], 400);
+}
+
+/// Test with Shelby-style response format
+#[tokio::test]
+async fn test_custom_contract_auth_shelby_format() {
+    let server = MockServer::start();
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    // Mock Shelby's get_all_storage_providers response format
+    let _view_mock = server.mock(|when, then| {
+        when.method(POST)
+            .path("/v1/view");
+        then.status(200)
+            .header("X-Aptos-Chain-Id", "21")
+            .header("X-Aptos-Ledger-Version", "1000")
+            .header("X-Aptos-Ledger-TimestampUsec", "1234567890000000")
+            .header("X-Aptos-Epoch", "1")
+            .header("X-Aptos-Ledger-Oldest-Version", "0")
+            .header("X-Aptos-Block-Height", "100")
+            .header("X-Aptos-Oldest-Block-Height", "0")
+            .json_body(json!([
+                {
+                    "address": address.to_hex_literal(),
+                    "bls_public_key": "0xb9aef025aa84f215d7ce94f830a3ffe2dc13fbae9a7abcf7b6c17e36441eb2ae757e7a4e6c8e8dd192e214de6a19829e",
+                    "failure_domain": "dc_us_east",
+                    "ip_address": "172.16.0.3",
+                    "port": "39431"
+                },
+                {
+                    "address": "0xe608a3e95269e1f54fdd2ee3112616d590fc021f1bb00c86ab8b663dd862d71a",
+                    "bls_public_key": "0xac4bb211f707f2448728f3ddd8a8b850e28525a63ddd31aa70ced8bbbef21b81e738c71b3e4643adaf19fc225acbf528",
+                    "failure_domain": "dc_us_west",
+                    "ip_address": "172.16.0.5",
+                    "port": "39431"
+                }
+            ]));
+    });
+
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "0xc63d6a5efb0080a6029403131715bd4971e1149f7cc099aac69bb0069b3ddbf5::global_metadata::get_all_storage_providers".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "ShelbyStorageProvider".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+
+    // Auth endpoints now require contract name in path
+    let contract_name = "test_contract";
+
+    // Pre-populate the allowlist cache (since tests don't run background updater)
+    context.populate_allowlist_cache(contract_name, chain_id, vec![address]);
+
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    let auth_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert!(auth_resp.get("token").is_some());
+
+    // Verify the JWT contains correct claims
+    let token = auth_resp["token"].as_str().unwrap();
+    assert!(!token.is_empty());
+    // Note: view_mock is not asserted because cache is pre-populated directly
+}
+
+/// Unit test for OnChainAuthConfig environment variable substitution
+#[test]
+fn test_on_chain_auth_config_env_substitution() {
+    use std::sync::Mutex;
+
+    // Use a mutex to prevent race conditions in env var setting
+    static ENV_MUTEX: Mutex<()> = Mutex::new(());
+    let _guard = ENV_MUTEX.lock().unwrap();
+
+    unsafe {
+        std::env::set_var("TEST_CONTRACT", "0x123");
+    }
+
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "${TEST_CONTRACT}::module::function".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: None,
+        node_type_name: "custom".to_string(),
+    };
+
+    let resolved = config.resolve_resource_path().unwrap();
+    assert_eq!(resolved, "0x123::module::function");
+
+    unsafe {
+        std::env::remove_var("TEST_CONTRACT");
+    }
+}
+
+/// Test extract_address_list with different formats
+#[test]
+fn test_extract_address_list_formats() {
+    use crate::custom_contract_auth::extract_addresses_from_value;
+
+    // Test with array of strings
+    let json1 = json!([
+        "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+        "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890"
+    ]);
+    let addrs1 = extract_addresses_from_value(&json1).unwrap();
+    assert_eq!(addrs1.len(), 2);
+
+    // Test with array of objects
+    let json2 = json!([
+        {"address": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef", "port": "8080"},
+        {"address": "0xabcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890", "port": "9090"}
+    ]);
+    let addrs2 = extract_addresses_from_value(&json2).unwrap();
+    assert_eq!(addrs2.len(), 2);
+}
+
+/// Test graceful failure when view function doesn't exist
+#[tokio::test]
+async fn test_custom_contract_auth_function_not_found() {
+    let server = MockServer::start();
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    let contract_address = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    // Mock 404 response for non-existent function (not used since cache is checked first)
+    let _view_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/view");
+        then.status(404).json_body(json!({
+            "message": "Module not found",
+            "error_code": "module_not_found",
+            "vm_error_code": 404
+        }));
+    });
+
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: format!("{}::nonexistent::get_members", contract_address),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "TestNode".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+    let contract_name = "test_contract";
+
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    // Should fail with 403 because cache is not populated (background updater would fail to fetch)
+    // In the new push model, we return "cache miss" when allowlist isn't available
+    let auth_resp = context
+        .expect_status_code(403)
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert_eq!(auth_resp["code"], 403);
+    // With background refresh model, cache miss returns allowlist not available
+    let message = auth_resp["message"].as_str().unwrap();
+    assert!(
+        message.contains("allowlist not available") || message.contains("cache miss"),
+        "unexpected error message: {}",
+        message
+    );
+}
+
+/// Test replay attack prevention - same challenge cannot be used twice
+#[tokio::test]
+async fn test_custom_contract_auth_replay_attack_prevented() {
+    let server = MockServer::start();
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    let contract_address = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    // Mock view function to return the address
+    let _view_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/view");
+        then.status(200)
+            .header("X-Aptos-Chain-Id", "21")
+            .header("X-Aptos-Ledger-Version", "1000")
+            .header("X-Aptos-Ledger-TimestampUsec", "1234567890000000")
+            .header("X-Aptos-Epoch", "1")
+            .header("X-Aptos-Ledger-Oldest-Version", "0")
+            .header("X-Aptos-Block-Height", "100")
+            .header("X-Aptos-Oldest-Block-Height", "0")
+            .json_body(json!([
+                {
+                    "address": address.to_hex_literal(),
+                    "port": "8080"
+                }
+            ]));
+    });
+
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: format!("{}::registry::get_members", contract_address),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "TestNode".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+    let contract_name = "test_contract";
+
+    // Pre-populate the allowlist cache (since tests don't run background updater)
+    context.populate_allowlist_cache(contract_name, chain_id, vec![address]);
+
+    // Get a challenge
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    // First auth should succeed
+    let auth_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert!(auth_resp.get("token").is_some());
+
+    // Second auth with same challenge should fail (replay attack)
+    let replay_resp = context
+        .expect_status_code(400)
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert_eq!(replay_resp["code"], 400);
+    let message = replay_resp["message"].as_str().unwrap();
+    assert!(message.contains("challenge") || message.contains("expired"));
+}
+
+/// Test bypass attack prevention - client-generated challenge doesn't work
+#[tokio::test]
+async fn test_custom_contract_auth_bypass_attack_prevented() {
+    // Need a minimal config to create the contract instance
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "0x1::test::get_members".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: None,
+        node_type_name: "custom".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+    let contract_name = "test_contract";
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    // Create a self-generated challenge (bypass attack)
+    let fake_challenge = "self-generated-challenge-12345";
+    let signature = sign_bytes(&private_key, fake_challenge.as_bytes());
+
+    // Auth with fake challenge should fail
+    let auth_resp = context
+        .expect_status_code(400)
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": fake_challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert_eq!(auth_resp["code"], 400);
+    let message = auth_resp["message"].as_str().unwrap();
+    assert!(
+        message.contains("challenge")
+            || message.contains("not found")
+            || message.contains("issued")
+    );
+}
+
+/// Test that challenge for one address cannot be used by another address
+#[tokio::test]
+async fn test_custom_contract_auth_challenge_address_isolation() {
+    // Need a minimal config to create the contract instance
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "0x1::test::get_members".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: None,
+        node_type_name: "custom".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+    let contract_name = "test_contract";
+
+    // Generate two different keypairs
+    let private_key1 = Ed25519PrivateKey::generate_for_testing();
+    let public_key1 = private_key1.public_key();
+    let address1 = account_address::from_public_key(&public_key1);
+
+    // Generate a second keypair (deterministically different)
+    let mut rng = ::rand::rngs::StdRng::from_seed([1u8; 32]);
+    let private_key2 = Ed25519PrivateKey::generate(&mut rng);
+    let public_key2 = private_key2.public_key();
+    let address2 = account_address::from_public_key(&public_key2);
+
+    let chain_id = ChainId::new(21);
+
+    // Request challenge for address1
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address1.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+
+    // Sign the challenge with address2's key
+    let signature = sign_bytes(&private_key2, challenge.as_bytes());
+
+    // Try to use address1's challenge with address2 - should fail
+    let auth_resp = context
+        .expect_status_code(400)
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address2.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key2.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert_eq!(auth_resp["code"], 400);
+}
+
+/// Test that challenge for unconfigured contract is rejected
+#[tokio::test]
+async fn test_custom_contract_auth_challenge_unconfigured_contract() {
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "0x1::test::get_members".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: None,
+        node_type_name: "custom".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    // Request challenge for non-existent contract - should fail
+    let challenge_resp = context
+        .expect_status_code(403)
+        .post(
+            "/api/v1/custom-contract/nonexistent_contract/auth-challenge",
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    assert_eq!(challenge_resp["code"], 403);
+    let message = challenge_resp["message"].as_str().unwrap();
+    assert!(message.contains("not configured"));
+}
+
+/// Test cross-contract token reuse attack is prevented
+/// A user authenticated for contract_A should NOT be able to use their JWT
+/// to inject data into contract_B's endpoints
+#[tokio::test]
+async fn test_cross_contract_token_reuse_prevented() {
+    use crate::tests::test_context::new_test_context_with_multiple_contracts;
+
+    let server = MockServer::start();
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    // Mock view function to return the test address for both contracts
+    let _view_mock = server.mock(|when, then| {
+        when.method(POST).path("/v1/view");
+        then.status(200)
+            .header("X-Aptos-Chain-Id", "21")
+            .header("X-Aptos-Ledger-Version", "1000")
+            .header("X-Aptos-Ledger-TimestampUsec", "1234567890000000")
+            .header("X-Aptos-Epoch", "1")
+            .header("X-Aptos-Ledger-Oldest-Version", "0")
+            .header("X-Aptos-Block-Height", "100")
+            .header("X-Aptos-Oldest-Block-Height", "0")
+            .json_body(json!([
+                {
+                    "address": address.to_hex_literal(),
+                    "port": "8080"
+                }
+            ]));
+    });
+
+    // Create two contracts with different names
+    let config_a = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "0x1::registry::get_members".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "ContractANode".to_string(),
+    };
+
+    let config_b = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::ViewFunction,
+        resource_path: "0x1::registry::get_members".to_string(),
+        view_function_args: vec![],
+        address_list_field: "[0].address".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "ContractBNode".to_string(),
+    };
+
+    let context = new_test_context_with_multiple_contracts(Some(vec![
+        ("contract_a".to_string(), config_a),
+        ("contract_b".to_string(), config_b),
+    ]))
+    .await;
+
+    // Pre-populate the allowlist cache for both contracts
+    context.populate_allowlist_cache("contract_a", chain_id, vec![address]);
+    context.populate_allowlist_cache("contract_b", chain_id, vec![address]);
+
+    // Authenticate for contract_a
+    let challenge_resp = context
+        .post(
+            "/api/v1/custom-contract/contract_a/auth-challenge",
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    let auth_resp = context
+        .post(
+            "/api/v1/custom-contract/contract_a/auth",
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    // Should get a valid token for contract_a
+    assert!(auth_resp.get("token").is_some());
+    let token_for_contract_a = auth_resp["token"].as_str().unwrap();
+
+    // Try to use contract_a's token on contract_b's metrics endpoint - should fail
+    let metrics_resp = context
+        .with_bearer_auth(token_for_contract_a.to_string())
+        .expect_status_code(403)
+        .reply(
+            warp::test::request()
+                .header("Authorization", format!("Bearer {}", token_for_contract_a))
+                .method("POST")
+                .path("/api/v1/custom-contract/contract_b/ingest/metrics")
+                .body("test_metric{label=\"value\"} 42"),
+        )
+        .await;
+
+    // Verify the request was rejected (cross-contract token reuse blocked)
+    assert_eq!(metrics_resp.status(), 403);
+}
+
+/// Test graceful failure when resource doesn't exist (legacy method)
+#[tokio::test]
+async fn test_custom_contract_auth_resource_not_found() {
+    let server = MockServer::start();
+
+    let private_key = Ed25519PrivateKey::generate_for_testing();
+    let public_key = private_key.public_key();
+    let address = account_address::from_public_key(&public_key);
+    let chain_id = ChainId::new(21);
+
+    let contract_address = "0x0000000000000000000000000000000000000000000000000000000000000001";
+
+    // Mock 404 response for non-existent resource (not used since cache is checked first)
+    let _resource_mock = server.mock(|when, then| {
+        when.method(GET)
+            .path_contains("accounts")
+            .path_contains("resource");
+        then.status(404)
+            .header("X-Aptos-Chain-Id", "21")
+            .header("X-Aptos-Ledger-Version", "1000")
+            .header("X-Aptos-Ledger-TimestampUsec", "1234567890000000")
+            .header("X-Aptos-Epoch", "1")
+            .header("X-Aptos-Ledger-Oldest-Version", "0")
+            .header("X-Aptos-Block-Height", "100")
+            .header("X-Aptos-Oldest-Block-Height", "0")
+            .json_body(json!({
+                "message": "Resource not found",
+                "error_code": "resource_not_found"
+            }));
+    });
+
+    let config = OnChainAuthConfig {
+        chain_id: 21, // test chain
+        method: OnChainAuthMethod::Resource,
+        resource_path: format!("{}::nonexistent::Members", contract_address),
+        view_function_args: vec![],
+        address_list_field: "members".to_string(),
+        rest_api_url: Some(server.base_url().parse().unwrap()),
+        node_type_name: "TestNode".to_string(),
+    };
+
+    let context = new_test_context_with_auth(Some(config)).await;
+    let contract_name = "test_contract";
+
+    let challenge_resp = context
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth-challenge", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id
+            }),
+        )
+        .await;
+
+    let challenge = challenge_resp["challenge"].as_str().unwrap();
+    let signature = sign_bytes(&private_key, challenge.as_bytes());
+
+    // Should fail with 403 because cache is not populated (background updater would fail to fetch)
+    // In the new push model, we return "cache miss" when allowlist isn't available
+    let auth_resp = context
+        .expect_status_code(403)
+        .post(
+            &format!("/api/v1/custom-contract/{}/auth", contract_name),
+            json!({
+                "address": address.to_hex_literal(),
+                "chain_id": chain_id,
+                "challenge": challenge,
+                "signature": signature.to_bytes().to_vec(),
+                "public_key": public_key.to_bytes().to_vec()
+            }),
+        )
+        .await;
+
+    assert_eq!(auth_resp["code"], 403);
+    // With background refresh model, cache miss returns allowlist not available
+    let message = auth_resp["message"].as_str().unwrap();
+    assert!(
+        message.contains("allowlist not available") || message.contains("cache miss"),
+        "unexpected error message: {}",
+        message
+    );
+    // Note: resource_mock is not asserted because verify_custom_contract only checks cache
+}

--- a/crates/aptos-telemetry-service/src/tests/mod.rs
+++ b/crates/aptos-telemetry-service/src/tests/mod.rs
@@ -2,5 +2,6 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 mod auth_test;
+mod custom_contract_auth_test;
 mod custom_event;
 pub(crate) mod test_context;

--- a/crates/aptos-telemetry-service/src/tests/test_context.rs
+++ b/crates/aptos-telemetry-service/src/tests/test_context.rs
@@ -8,6 +8,7 @@ use crate::{
 use aptos_crypto::{x25519, Uniform};
 use aptos_infallible::RwLock;
 use aptos_rest_client::aptos_api_types::mime_types;
+use aptos_types::{account_address::AccountAddress, chain_id::ChainId};
 use rand::SeedableRng;
 use reqwest::header::AUTHORIZATION;
 use serde_json::Value;
@@ -18,8 +19,39 @@ use warp::{
 };
 
 pub async fn new_test_context() -> TestContext {
+    new_test_context_with_auth(None).await
+}
+
+pub async fn new_test_context_with_auth(
+    on_chain_auth_config: Option<crate::OnChainAuthConfig>,
+) -> TestContext {
+    // Wrap in a vec with default contract name
+    let configs = on_chain_auth_config.map(|cfg| vec![("test_contract".to_string(), cfg)]);
+    new_test_context_with_multiple_contracts(configs).await
+}
+
+/// Create test context with multiple custom contracts (for cross-contract testing)
+pub async fn new_test_context_with_multiple_contracts(
+    contract_configs: Option<Vec<(String, crate::OnChainAuthConfig)>>,
+) -> TestContext {
     let mut rng = ::rand::rngs::StdRng::from_seed([0u8; 32]);
     let server_private_key = x25519::PrivateKey::generate(&mut rng);
+
+    // Convert to multi-contract format
+    let custom_contract_configs = contract_configs
+        .map(|configs| {
+            configs
+                .into_iter()
+                .map(|(name, auth_config)| crate::CustomContractConfig {
+                    name,
+                    on_chain_auth: auth_config,
+                    metrics_sinks: None,
+                    logs_sink: None,
+                    events_sink: None,
+                })
+                .collect()
+        })
+        .unwrap_or_default();
 
     let config = TelemetryServiceConfig {
         address: format!("{}:{}", "127.0.0.1", 80).parse().unwrap(),
@@ -37,17 +69,43 @@ pub async fn new_test_context() -> TestContext {
         peer_identities: HashMap::new(),
         metrics_endpoints_config: MetricsEndpointsConfig::default_for_test(),
         humio_ingest_config: LogIngestConfig::default_for_test(),
+        custom_contract_configs,
+        allowlist_cache_ttl_secs: 10, // Short TTL for testing
     };
 
     let peers = PeerStoreTuple::default();
     let jwt_service = JsonWebTokenService::from_base64_secret(&base64::encode("jwt_secret_key"));
 
+    // Build custom contract clients if configured
+    let custom_contract_clients = if !config.custom_contract_configs.is_empty() {
+        let mut instances = HashMap::new();
+        for cc_config in &config.custom_contract_configs {
+            instances.insert(
+                cc_config.name.clone(),
+                crate::context::CustomContractInstance {
+                    config: cc_config.on_chain_auth.clone(),
+                    metrics_clients: HashMap::new(),
+                    logs_client: None,
+                    bigquery_client: None,
+                },
+            );
+        }
+        Some(crate::context::CustomContractClients { instances })
+    } else {
+        None
+    };
+
     TestContext::new(
-        config,
+        config.clone(),
         Context::new(
             server_private_key,
             peers,
-            ClientTuple::new(None, Some(GroupedMetricsClients::new_empty()), None),
+            ClientTuple::new(
+                None,
+                Some(GroupedMetricsClients::new_empty()),
+                None,
+                custom_contract_clients,
+            ),
             jwt_service,
             HashMap::new(),
             HashMap::new(),
@@ -73,6 +131,19 @@ impl TestContext {
             inner: context,
             bearer_token: "".into(),
         }
+    }
+
+    /// Pre-populate the allowlist cache with test addresses.
+    /// This is needed because tests don't run the AllowlistCacheUpdater background task.
+    pub fn populate_allowlist_cache(
+        &self,
+        contract_name: &str,
+        chain_id: ChainId,
+        addresses: Vec<AccountAddress>,
+    ) {
+        self.inner
+            .allowlist_cache()
+            .update(contract_name, &chain_id, addresses);
     }
 
     pub fn expect_status_code(&self, status_code: u16) -> Self {

--- a/crates/aptos-telemetry-service/src/types/mod.rs
+++ b/crates/aptos-telemetry-service/src/types/mod.rs
@@ -39,7 +39,7 @@ pub mod common {
         }
     }
 
-    #[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
+    #[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
     pub enum NodeType {
         Validator,
         ValidatorFullNode,
@@ -47,17 +47,22 @@ pub mod common {
         Unknown,
         UnknownValidator,
         UnknownFullNode,
+        /// Custom node type with a user-defined name (e.g., "ShelbyStorageProvider")
+        Custom(String),
     }
 
     impl NodeType {
-        pub fn as_str(self) -> &'static str {
+        /// Get the string representation of the node type
+        /// For Custom types, returns "custom({name})" to prevent ambiguity with built-in types
+        pub fn as_str(&self) -> String {
             match self {
-                NodeType::Validator => "validator",
-                NodeType::ValidatorFullNode => "validator_fullnode",
-                NodeType::PublicFullNode => "public_fullnode",
-                NodeType::Unknown => "unknown_peer",
-                NodeType::UnknownValidator => "unknown_validator",
-                NodeType::UnknownFullNode => "unknown_fullnode",
+                NodeType::Validator => "validator".to_string(),
+                NodeType::ValidatorFullNode => "validator_fullnode".to_string(),
+                NodeType::PublicFullNode => "public_fullnode".to_string(),
+                NodeType::Unknown => "unknown_peer".to_string(),
+                NodeType::UnknownValidator => "unknown_validator".to_string(),
+                NodeType::UnknownFullNode => "unknown_fullnode".to_string(),
+                NodeType::Custom(name) => format!("custom({})", name),
             }
         }
     }

--- a/crates/aptos-telemetry-service/src/validator_cache.rs
+++ b/crates/aptos-telemetry-service/src/validator_cache.rs
@@ -4,7 +4,10 @@
 use crate::{
     debug, error,
     errors::ValidatorCacheUpdateError,
-    metrics::{VALIDATOR_SET_UPDATE_FAILED_COUNT, VALIDATOR_SET_UPDATE_SUCCESS_COUNT},
+    metrics::{
+        ValidatorCachePeerType, VALIDATOR_CACHE_LAST_UPDATE_TIMESTAMP, VALIDATOR_CACHE_SIZE,
+        VALIDATOR_SET_UPDATE_FAILED_COUNT, VALIDATOR_SET_UPDATE_SUCCESS_COUNT,
+    },
     types::common::{ChainCommonName, EpochedPeerStore},
 };
 use aptos_config::config::{Peer, PeerRole, PeerSet};
@@ -13,7 +16,11 @@ use aptos_rest_client::Response;
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS, chain_id::ChainId, on_chain_config::ValidatorSet, PeerId,
 };
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{
+    collections::HashMap,
+    sync::Arc,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
 use tokio::time;
 use url::Url;
 
@@ -147,18 +154,31 @@ impl PeerSetCacheUpdater {
             chain_name, chain_id, state.epoch, validator_peers
         );
 
-        let result = if validator_peers.is_empty() && vfn_peers.is_empty() {
+        // Capture counts before moving into cache
+        let validator_count = validator_peers.len();
+        let vfn_count = vfn_peers.len();
+        let has_validators = !validator_peers.is_empty();
+        let has_vfns = !vfn_peers.is_empty();
+
+        let result = if !has_validators && !has_vfns {
             Err(ValidatorCacheUpdateError::BothPeerSetEmpty)
-        } else if validator_peers.is_empty() {
+        } else if !has_validators {
             Err(ValidatorCacheUpdateError::ValidatorSetEmpty)
-        } else if vfn_peers.is_empty() {
+        } else if !has_vfns {
             Err(ValidatorCacheUpdateError::VfnSetEmpty)
         } else {
             Ok(())
         };
 
-        if !validator_peers.is_empty() {
+        // Update validator cache and record metrics
+        let chain_id_str = chain_id.to_string();
+        if has_validators {
             validator_cache.insert(chain_id, (state.epoch, validator_peers));
+
+            // Record cache size for validators
+            VALIDATOR_CACHE_SIZE
+                .with_label_values(&[&chain_id_str, ValidatorCachePeerType::Validator.as_str()])
+                .set(validator_count as i64);
         }
 
         debug!(
@@ -166,8 +186,28 @@ impl PeerSetCacheUpdater {
             chain_name, chain_id, state.epoch, vfn_peers
         );
 
-        if !vfn_peers.is_empty() {
+        if has_vfns {
             vfn_cache.insert(chain_id, (state.epoch, vfn_peers));
+
+            // Record cache size for VFNs
+            VALIDATOR_CACHE_SIZE
+                .with_label_values(&[
+                    &chain_id_str,
+                    ValidatorCachePeerType::ValidatorFullnode.as_str(),
+                ])
+                .set(vfn_count as i64);
+        }
+
+        // Record last update timestamp for staleness alerting (even on partial success)
+        // Alert on: now() - this_timestamp > threshold
+        if has_validators || has_vfns {
+            let now_unix = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs();
+            VALIDATOR_CACHE_LAST_UPDATE_TIMESTAMP
+                .with_label_values(&[&chain_id_str])
+                .set(now_unix as i64);
         }
 
         result


### PR DESCRIPTION
## Description

<!-- Please include a summary of the change, including which issue it fixes or what feature it adds. Include relevant motivation, context and documentation as appropriate. List dependencies that are required for this change, if any. -->

Extend the telemetry service to be able to authenticate against members specified in a smart contract. This is useful for use cases like Shelby, where StorageProviders each have an address onchain. This works by:

1. Telemetry service either fetch onchain resources or call a view function to maintain a cache of authenticated peers.
2. Clients prove their membership in that cache by signing an auth challenge `custom-contract/{contract_name}/auth`
3. Clients receive a JWT that lets them push logs, metrics, and custom events (bigquery) `custom-contract/{contract_name}/ingest/{metrics,logs,custom-event}`

Also:

- Add a new Loki sink for logs, as an alternative for Humio. The config now requires `LogIngestClient` as oppose to strictly a `humio::IngestClient`
- Some config refactoring. Should be all backwards compatible.
    - Make the allowlist cache ttl tunable for testing purposes
    - Make BigQuery optional, to make completely local testing possible

## How Has This Been Tested?

<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

New tests. Including a new semi-automated e2e test for the custom contract auth, which:

1. Spins up Metrics (VictoriaMetrics), Logs (Loki) sinks as well as Grafana
2. Spins up an aptos localnet
3. Publishes a test contract which includes an allowlist of members identified by address
4. Creates accounts and initializes the contract

Then using `aptos-telemetry-service/e2e-test/test-client`, which serves also as a reference implementation of the new custom contract auth, publish some data after proving ownership of the address in the onchain allowlist:

```
cargo run -p telemetry-test-client -- -p $TEST_PRIVATE_KEY <metrics|logs>
```

###  

### Initialize & inspect via view function

Telemetry service under the hood has the ability to call view functions and gather addresses. We can manually inspect the onchain state after adding a single member: `0xa820dde0cbc0a87ee24751bce56d25b55026255d8350e2aad494dfc76f067419`

Add the member by calling the function

```
$ TEST_ACCOUNT_ADDRESS=0xabd2fae01258e099a1f3cd98fbc04f80a84cdc4753373a86afdae0a040b928bf
$ $APTOS_CMD move run \
    --profile telemetry-service-e2e-test \
    --function-id ${DEPLOYER_ADDRESS}::telemetry_registry::add_member \
    --args address:$TEST_ACCOUNT_ADDRESS string:"127.0.0.1" string:"9000" string:"0xtest123" string:"dc_local" \
    --assume-yes \
    --url http://localhost:8080
```

Call view function like this to confirm it's onchain

```
{"function":"0xabd2fae01258e099a1f3cd98fbc04f80a84cdc4753373a86afdae0a040b928bf::telemetry_registry::get_all_members","type_arguments":[],"arguments":["abd2fae01258e099a1f3cd98fbc04f80a84cdc4753373a86afdae0a040b928bf"]}
```

```
[
    [
        {
            "address": "0xa820dde0cbc0a87ee24751bce56d25b55026255d8350e2aad494dfc76f067419",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        }
    ]
]
```

This confirms that we

### Run the telemetry service

The config reads from env var where the contract is published which we'll use for custom contract auth:

```
$ TEST_CONTRACT_ADDRESS=0xabd2fae01258e099a1f3cd98fbc04f80a84cdc4753373a86afdae0a040b928bf
$ cargo run -- -f telemetry-config.yaml 
...
```

### Sending and verifying metrics

Send metrics via the test client:

```
$ cargo run -p telemetry-test-client -- -p $TEST_PRIVATE_KEY metrics
warning: Patch `ark-bls12-381 v0.5.0-alpha.0 (https://github.com/aptos-labs/algebra?branch=fix-fft-parallelism-cutoff#2cacd5ef)` was not used in the crate graph.
Patch `ark-bn254 v0.5.0-alpha.0 (https://github.com/aptos-labs/algebra?branch=fix-fft-parallelism-cutoff#2cacd5ef)` was not used in the crate graph.
Check that the patched package version and available features are compatible
with the dependency requirements. If the patch has a different version from
what is locked in the Cargo.lock file, run `cargo update` to use the new
version. This may also occur with an optional dependency that is not enabled.
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.16s
     Running `target/debug/telemetry-test-client -p 0xe615723fec28759155ad68714f92b28533e4e2cd9757ce09131367b3cd4ae93c metrics`
2025-12-03T23:41:28.603922Z  INFO telemetry_test_client: Telemetry Test Client
2025-12-03T23:41:28.604003Z  INFO telemetry_test_client: URL: http://localhost:8082
2025-12-03T23:41:28.604008Z  INFO telemetry_test_client: Contract: e2e_test_contract
2025-12-03T23:41:28.604012Z  INFO telemetry_test_client: Chain ID: 4
2025-12-03T23:41:28.604393Z  INFO telemetry_test_client: Using address: 0xa820dde0cbc0a87ee24751bce56d25b55026255d8350e2aad494dfc76f067419
2025-12-03T23:41:28.604425Z  INFO telemetry_test_client: Public key: ab207449111cbf18b41aec78d2f7e4b8a22eaf05e007f98d1afcd7bbaef1a55c
2025-12-03T23:41:28.616338Z  INFO telemetry_test_client: Generating sample metrics
2025-12-03T23:41:28.616475Z  INFO telemetry_test_client: Authenticating with telemetry service...
2025-12-03T23:41:28.622332Z  INFO telemetry_test_client: Authentication successful!
2025-12-03T23:41:28.622353Z  INFO telemetry_test_client: Sending metrics (159 bytes)...
2025-12-03T23:41:28.627554Z  INFO telemetry_test_client: Metrics sent successfully!
2025-12-03T23:41:28.627606Z  INFO telemetry_test_client: Done!
```

Note in the example below:

- the `node_type` label comes from the server side, where it gets mapped to the `custom_contract_configs[0].on_chain_auth.node_type_name` config
- the `peer_id` label comes from the address allowed onchain

![image.png](https://app.graphite.com/user-attachments/assets/80f3ecb2-1978-4002-be1d-58a64e05ea92.png)

### Getting  logs

Same as metrics. We can see in the `peer_role` label that the right address appears

![image.png](https://app.graphite.com/user-attachments/assets/a62d8346-0c3e-45b7-92f7-323b3a6a9daa.png)

This time we can look at the telemetry service server logs which show success after auth

```
2025-12-03T23:42:48.218542Z [tokio-runtime-worker] INFO /Users/rustielin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/warp-0.3.6/src/filters/trace.rs {"message":"finished processing with success","request.method":"POST","request.path":"/api/v1/custom-contract/e2e_test_contract/auth","request.trace_id":"","status":"200"}
2025-12-03T23:42:48.220090Z [tokio-runtime-worker] INFO /Users/rustielin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/warp-0.3.6/src/filters/trace.rs {"message":"processing request","request.method":"POST","request.path":"/api/v1/custom-contract/e2e_test_contract/ingest/logs","request.trace_id":""}
2025-12-03T23:42:48.251782Z [tokio-runtime-worker] INFO /Users/rustielin/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/warp-0.3.6/src/filters/trace.rs {"message":"finished processing with success","request.method":"POST","request.path":"/api/v1/custom-contract/e2e_test_contract/ingest/logs","request.trace_id":"","status":"200"}
```

### Do it all again with more addresses allowed

Generate some new keys, and add their addresses as members to the test contract

```
[
    [
        {
            "address": "0xa820dde0cbc0a87ee24751bce56d25b55026255d8350e2aad494dfc76f067419",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0xc210eea17fd0b8f24080609c70647afbf24f8caa86744cc24d0a2b1981255188",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0x472480b520b4d47711e9f1385a0e5138ffa88dcbb6c79d988eb42958a6af3df4",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0xf81fb43d1434e86e48b794e6195bfb7df6b903f45489935ba91b3a213af0bdc1",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0x1d78627dc51c634e12a06bcd3029a17a8311bcfec954b8e35037a9c5ecb7ee63",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0xe278913082941b17ce1fe3938cdf8995658ad4e58246a45f4f16a3dc895ae4b8",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0x81a076fc1c8149ae0ae236fc8aa27bb4a101597eb5401e8b552470fe656b052c",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0x184b1214abd4b952071e483d59b78de5b057bfdf0084fc3f086bfe314d32d3e1",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0xc9e51c4bebfaf04a1788167ee1993ed5f0f551f15c22c91a5bb8fd6bb464223b",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0x399df027f94196b93349028e13652887e93c833d3ad3c47577f5967e3f7fdca",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        },
        {
            "address": "0xf0c13f74be06b72cb2f203021f2ce78db866ca3b007d338583b808da5db4fe11",
            "bls_public_key": "0x307874657374313233",
            "failure_domain": "0x64635f6c6f63616c",
            "ip_address": "0x3132372e302e302e31",
            "port": "0x39303030"
        }
    ]
]
```

More logs!!!

```
for i in `seq 1 10`; do cargo run -p telemetry-test-client -- -p $(cat test-member-$i.key) logs; done
```

![image.png](https://app.graphite.com/user-attachments/assets/05932988-c219-4715-ab7f-044fa98b13e6.png)

More metrics!!!

```
for i in `seq 1 10`; do cargo run -p telemetry-test-client -- -p $(cat test-member-$i.key) metrics; done
```

![image.png](https://app.graphite.com/user-attachments/assets/4079f652-71f9-414b-9f85-354b2fd872fa.png)

## Key Areas to Review

<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [x] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?

- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [x] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist

- [x] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I identified and added all stakeholders and component owners affected by this change as reviewers
- [x] I tested both happy and unhappy path of the functionality
- [x] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add custom contract-based auth and per-contract ingestion (metrics/logs/events) with on-chain allowlist caching, challenge-response, Loki support, config refactors, and full E2E test client/setup.
> 
> - **Telemetry Service (core)**:
>   - Add custom contract auth flow and endpoints: `custom-contract/{name}/auth-challenge`, `.../auth`, and `.../ingest/{metrics,logs,custom-event}`.
>   - Implement `ChallengeCache` (prevents replay/bypass) and `AllowlistCache` with background updater (view function or resource fetch).
>   - Enforce per-contract JWTs to prevent cross-contract token reuse.
> - **Config & Types**:
>   - New `custom_contract_configs` with `on_chain_auth`, per-contract `metrics_sinks`, `logs_sink`, optional `events_sink`.
>   - Add `allowlist_cache_ttl_secs`, make BigQuery optional, support env var substitution in paths/args.
>   - Extend `NodeType` with `Custom(String)`.
> - **Clients/Sinks**:
>   - Introduce Loki log client and generic `LogIngestClient` (Humio or Loki).
> - **Metrics/Observability**:
>   - Add cache metrics: challenge/allowlist sizes, ops, last-update timestamps; enhance validator cache metrics.
> - **Tests & E2E**:
>   - New integration/unit tests for custom contract auth and caches.
>   - Add `telemetry-test-client` CLI and E2E harness: Docker Compose (VictoriaMetrics, Loki, Grafana), Move test contract, setup/cleanup scripts, sample config.
> - **Misc**:
>   - Update `.gitignore` for E2E artifacts and test keys.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 52b94db5270ac67a1ec81aa8a528748e9bb226fd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->