### PR TITLE
Revert "Add support for configuring node txn stream worker count and channel size"

### DIFF
--- a/config/src/config/indexer_grpc_config.rs
+++ b/config/src/config/indexer_grpc_config.rs
@@ -14,18 +14,10 @@ use std::{
 };
 
 // Useful indexer defaults
+const DEFAULT_PROCESSOR_TASK_COUNT: u16 = 20;
 const DEFAULT_PROCESSOR_BATCH_SIZE: u16 = 1000;
 const DEFAULT_OUTPUT_BATCH_SIZE: u16 = 100;
-const DEFAULT_TRANSACTION_CHANNEL_SIZE: usize = 35;
 pub const DEFAULT_GRPC_STREAM_PORT: u16 = 50051;
-
-pub fn get_default_processor_task_count(use_data_service_interface: bool) -> u16 {
-    if use_data_service_interface {
-        1
-    } else {
-        20
-    }
-}
 
 #[derive(Clone, Deserialize, PartialEq, Eq, Serialize)]
 #[serde(default, deny_unknown_fields)]
@@ -42,16 +34,13 @@ pub struct IndexerGrpcConfig {
     pub address: SocketAddr,
 
     /// Number of processor tasks to fan out
-    pub processor_task_count: Option<u16>,
+    pub processor_task_count: u16,
 
     /// Number of transactions each processor will process
     pub processor_batch_size: u16,
 
     /// Number of transactions returned in a single stream response
     pub output_batch_size: u16,
-
-    /// Size of the transaction channel buffer for streaming.
-    pub transaction_channel_size: usize,
 }
 
 impl Debug for IndexerGrpcConfig {
@@ -66,7 +55,6 @@ impl Debug for IndexerGrpcConfig {
             .field("processor_task_count", &self.processor_task_count)
             .field("processor_batch_size", &self.processor_batch_size)
             .field("output_batch_size", &self.output_batch_size)
-            .field("transaction_channel_size", &self.transaction_channel_size)
             .finish()
     }
 }
@@ -83,10 +71,9 @@ impl Default for IndexerGrpcConfig {
                 Ipv4Addr::new(0, 0, 0, 0),
                 DEFAULT_GRPC_STREAM_PORT,
             )),
-            processor_task_count: None,
+            processor_task_count: DEFAULT_PROCESSOR_TASK_COUNT,
             processor_batch_size: DEFAULT_PROCESSOR_BATCH_SIZE,
             output_batch_size: DEFAULT_OUTPUT_BATCH_SIZE,
-            transaction_channel_size: DEFAULT_TRANSACTION_CHANNEL_SIZE,
         }
     }
 }

--- a/config/src/config/override_node_config.rs
+++ b/config/src/config/override_node_config.rs
@@ -67,7 +67,6 @@ fn diff_override_config_yaml(
                 Ok(Some(override_config))
             }
         },
-        (_, serde_yaml::Value::Null) => Ok(Some(override_config)),
         (_, _) => bail!(
             "base does not match override: {:?}, {:?}",
             override_config,

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/fullnode_data_service.rs
@@ -50,6 +50,7 @@ type FullnodeResponseStream =
 // Default Values
 pub const DEFAULT_NUM_RETRIES: usize = 3;
 pub const RETRY_TIME_MILLIS: u64 = 100;
+const TRANSACTION_CHANNEL_SIZE: usize = 35;
 const DEFAULT_EMIT_SIZE: usize = 1000;
 const SERVICE_TYPE: &str = "indexer_fullnode";
 
@@ -77,7 +78,6 @@ impl FullnodeData for FullnodeDataService {
         let processor_task_count = self.service_context.processor_task_count;
         let processor_batch_size = self.service_context.processor_batch_size;
         let output_batch_size = self.service_context.output_batch_size;
-        let transaction_channel_size = self.service_context.transaction_channel_size;
         let ending_version = if let Some(count) = r.transactions_count {
             starting_version.saturating_add(count)
         } else {
@@ -88,8 +88,8 @@ impl FullnodeData for FullnodeDataService {
         let context = self.service_context.context.clone();
         let ledger_chain_id = context.chain_id().id();
 
-        // Creates a channel to send the stream to the client.
-        let (tx, rx) = mpsc::channel(transaction_channel_size);
+        // Creates a channel to send the stream to the client
+        let (tx, rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
 
         // Creates a moving average to track tps
         let mut ma = MovingAverage::new(10_000);
@@ -159,7 +159,7 @@ impl FullnodeData for FullnodeDataService {
                     Some(max_version),
                     ledger_chain_id,
                 );
-                let channel_size = transaction_channel_size - tx.capacity();
+                let channel_size = TRANSACTION_CHANNEL_SIZE - tx.capacity();
                 CHANNEL_SIZE
                     .with_label_values(&["2"])
                     .set(channel_size as i64);

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/lib.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/lib.rs
@@ -17,7 +17,6 @@ pub struct ServiceContext {
     pub processor_task_count: u16,
     pub processor_batch_size: u16,
     pub output_batch_size: u16,
-    pub transaction_channel_size: usize,
 }
 
 #[cfg(test)]

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/localnet_data_service.rs
@@ -16,6 +16,7 @@ use tonic::{Request, Response, Status};
 // Default Values
 pub const DEFAULT_NUM_RETRIES: usize = 3;
 pub const RETRY_TIME_MILLIS: u64 = 100;
+const TRANSACTION_CHANNEL_SIZE: usize = 35;
 
 type TransactionResponseStream =
     Pin<Box<dyn Stream<Item = Result<TransactionsResponse, Status>> + Send>>;
@@ -24,9 +25,8 @@ pub struct LocalnetDataService {
     pub service_context: ServiceContext,
 }
 
-/// Exposes a transaction stream on the node that matches the interface exposed by the
-/// full production data service.
-///
+/// External service on the fullnode is for testing/local development only.
+/// Performance is not optimized, e.g., single-threaded.
 /// NOTE: code is duplicated from fullnode_data_service.rs with some minor changes.
 #[tonic::async_trait]
 impl RawData for LocalnetDataService {
@@ -48,23 +48,23 @@ impl RawData for LocalnetDataService {
         } else {
             u64::MAX
         };
-        let processor_task_count = self.service_context.processor_task_count;
         let processor_batch_size = self.service_context.processor_batch_size;
         let output_batch_size = self.service_context.output_batch_size;
-        let transaction_channel_size = self.service_context.transaction_channel_size;
         let ledger_chain_id = context.chain_id().id();
         let transactions_count = r.transactions_count;
-        // Creates a channel to send the stream to the client.
-        let (tx, mut rx) = mpsc::channel(transaction_channel_size);
-        let (external_service_tx, external_service_rx) = mpsc::channel(transaction_channel_size);
+        // Creates a channel to send the stream to the client
+        let (tx, mut rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
+        let (external_service_tx, external_service_rx) = mpsc::channel(TRANSACTION_CHANNEL_SIZE);
 
         tokio::spawn(async move {
-            // Initialize the coordinator that tracks starting version and processes transactions.
+            // Initialize the coordinator that tracks starting version and processes transactions
             let mut coordinator = IndexerStreamCoordinator::new(
                 context,
                 starting_version,
                 ending_version,
-                processor_task_count,
+                // Performance is not important for raw data, and to make sure data is in order,
+                // single thread is used.
+                1,
                 processor_batch_size,
                 output_batch_size,
                 tx.clone(),

--- a/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
+++ b/ecosystem/indexer-grpc/indexer-grpc-fullnode/src/runtime.rs
@@ -6,7 +6,7 @@ use crate::{
     ServiceContext,
 };
 use aptos_api::context::Context;
-use aptos_config::config::{get_default_processor_task_count, NodeConfig};
+use aptos_config::config::NodeConfig;
 use aptos_logger::info;
 use aptos_mempool::MempoolClientSender;
 use aptos_protos::{
@@ -51,13 +51,9 @@ pub fn bootstrap(
 
     let address = node_config.indexer_grpc.address;
     let use_data_service_interface = node_config.indexer_grpc.use_data_service_interface;
-    let processor_task_count = node_config
-        .indexer_grpc
-        .processor_task_count
-        .unwrap_or_else(|| get_default_processor_task_count(use_data_service_interface));
+    let processor_task_count = node_config.indexer_grpc.processor_task_count;
     let processor_batch_size = node_config.indexer_grpc.processor_batch_size;
     let output_batch_size = node_config.indexer_grpc.output_batch_size;
-    let transaction_channel_size = node_config.indexer_grpc.transaction_channel_size;
 
     runtime.spawn(async move {
         let context = Arc::new(Context::new(
@@ -72,7 +68,6 @@ pub fn bootstrap(
             processor_task_count,
             processor_batch_size,
             output_batch_size,
-            transaction_channel_size,
         };
         // If we are here, we know indexer grpc is enabled.
         let server = FullnodeDataService {


### PR DESCRIPTION
Reverts aptos-labs/aptos-core#18028

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Drops configurable transaction channel size and makes `processor_task_count` a non-optional field with a fixed default, updating services/runtime and tightening override diffing.
> 
> - **Config**:
>   - `IndexerGrpcConfig`: `processor_task_count` changed from `Option<u16>` to `u16` with default `20`; removed `transaction_channel_size` and `get_default_processor_task_count()`.
>   - `override_node_config`: removed special-case handling for `(_, Null)` in `diff_override_config_yaml` (stricter type matching).
> - **Indexer Fullnode Services**:
>   - Use fixed `TRANSACTION_CHANNEL_SIZE = 35` for streams; stop reading channel size from config.
>   - `ServiceContext` no longer includes `transaction_channel_size`.
>   - Localnet service explicitly uses single-threaded processing (sets processor tasks to `1`).
> - **Runtime**:
>   - No longer derives processor tasks via helper; passes `processor_task_count` directly; removes channel size wiring.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70ef71a9bdad2413275e0dc872fc7cfca8ac2b9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->