### PR TITLE
[vm] Make layout caches enabled by default

### DIFF
--- a/config/src/config/execution_config.rs
+++ b/config/src/config/execution_config.rs
@@ -89,8 +89,8 @@ impl Default for ExecutionConfig {
             processed_transactions_detailed_counters: false,
             genesis_waypoint: None,
             blockstm_v2_enabled: false,
+            layout_caches_enabled: true,
             // TODO: consider setting to be true by default.
-            layout_caches_enabled: false,
             async_runtime_checks: false,
         }
     }

--- a/testsuite/forge-cli/src/suites/realistic_environment.rs
+++ b/testsuite/forge-cli/src/suites/realistic_environment.rs
@@ -330,7 +330,6 @@ pub(crate) fn realistic_env_graceful_overload(duration: Duration) -> ForgeConfig
         .with_validator_override_node_config_fn(Arc::new(|config, _| {
             config.execution.processed_transactions_detailed_counters = true;
             // TODO(georgemitenkov): remove once features are added to default config.
-            config.execution.layout_caches_enabled = true;
             config.execution.async_runtime_checks = true;
         }))
         .with_genesis_helm_config_fn(Arc::new(|helm_values| {
@@ -466,7 +465,6 @@ pub(crate) fn realistic_env_max_load_test(
                 .consensus_observer
                 .observer_fallback_sync_lag_threshold_ms = 45_000; // 45 seconds
                                                                    // TODO(georgemitenkov): remove once features are added to default config.
-            config.execution.layout_caches_enabled = true;
             config.execution.async_runtime_checks = true;
         }))
         // First start higher gas-fee traffic, to not cause issues with TxnEmitter setup - account creation
@@ -525,7 +523,6 @@ pub(crate) fn realistic_network_tuned_for_throughput_test() -> ForgeConfig {
                 }
 
                 // TODO(georgemitenkov): remove once features are added to default config.
-                config.execution.layout_caches_enabled = true;
                 config.execution.async_runtime_checks = true;
             }))
             .with_genesis_helm_config_fn(Arc::new(move |helm_values| {


### PR DESCRIPTION
## Description

Layout caches should be used as default.

## How Has This Been Tested?
<!--
- Please ensure that the functionality introduced by this change is well tested and verified to work as expected.
- Ensure tests cover both happy and unhappy paths.
- List and link relevant tests.
-->

## Key Areas to Review
<!--
- Identify any critical parts of the code that require special attention or understanding. Explain why these parts are crucial to the functionality or architecture of the project.
- Point out any areas where complex logic has been implemented. Provide a brief explanation of the logic and your approach to make it easier for reviewers to follow.
- Highlight any areas where you are particularly concerned or unsure about the code's impact on the change. This can include potential performance or security issues, or compatibility with existing features.
-->

## Type of Change
- [ ] New feature
- [ ] Bug fix
- [ ] Breaking change
- [ ] Performance improvement
- [ ] Refactoring
- [ ] Dependency update
- [ ] Documentation update
- [ ] Tests

## Which Components or Systems Does This Change Impact?
- [ ] Validator Node
- [ ] Full Node (API, Indexer, etc.)
- [ ] Move/Aptos Virtual Machine
- [ ] Aptos Framework
- [ ] Aptos CLI/SDK
- [ ] Developer Infrastructure
- [ ] Move Compiler
- [ ] Other (specify)

## Checklist
- [ ] I have read and followed the [CONTRIBUTING](https://github.com/aptos-labs/aptos-core/blob/main/CONTRIBUTING.md) doc
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I identified and added all stakeholders and component owners affected by this change as reviewers
- [ ] I tested both happy and unhappy path of the functionality
- [ ] I have made corresponding changes to the documentation

<!-- Thank you for your contribution! -->
