### PR TITLE
[Pre-Commit] Remove shared license from pre-commit allowlist.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,6 @@ repos:
         args:
           - --license-filepath
           - devtools/assets/innovation_license_header.txt
-          - --license-filepath
-          - devtools/assets/shared_license_header.txt
           - --comment-style
           - //
       - id: insert-license


### PR DESCRIPTION
## Description
This PR removes the shared license from the pre-commit allowlist for non-third party files.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes the shared license from the insert-license allowlist for non-third_party `.rs` files in `.pre-commit-config.yaml`.
> 
> - **Pre-commit config (`.pre-commit-config.yaml`)**:
>   - For `insert-license` on non-`third_party` `.rs` files, remove `devtools/assets/shared_license_header.txt`, leaving only `innovation_license_header.txt` with `//` comment style.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5321052dcf90ea3ad211baaf367657b49350d339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->