### PR TITLE
[License] Adopt innovation license header 9/n

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,8 +22,6 @@ repos:
         args:
           - --license-filepath
           - devtools/assets/innovation_license_header.txt
-          - --license-filepath
-          - devtools/assets/shared_license_header.txt
           - --comment-style
           - //
       - id: insert-license


### PR DESCRIPTION
## Description
This PR removes the shared license from the pre-commit allowlist.

## Testing Plan
Existing test infrastructure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates pre-commit to only accept the innovation license header for non-third_party `.rs` files by removing the shared license from the allowlist.
> 
> - **Pre-commit config (`.pre-commit-config.yaml`)**:
>   - For `insert-license` on non-`third_party` Rust files, removed `devtools/assets/shared_license_header.txt` from `--license-filepath` args, leaving only `innovation_license_header.txt`.
>   - No changes to the `insert-license` hook for `third_party` Rust files.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b86788798e2ead36d7d662908d8596a7a428ba5e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->