### PR TITLE
[Bug fix]Update quorum_store_config.rs

### DIFF
--- a/config/src/config/quorum_store_config.rs
+++ b/config/src/config/quorum_store_config.rs
@@ -121,9 +121,7 @@ impl Default for QuorumStoreConfig {
             receiver_max_batch_bytes: 1024 * 1024 + BATCH_PADDING_BYTES,
             receiver_max_num_batches: 20,
             receiver_max_total_txns: 2000,
-            receiver_max_total_bytes: 4 * 1024 * 1024
-                + DEFAULT_MAX_NUM_BATCHES
-                + BATCH_PADDING_BYTES,
+            receiver_max_total_bytes: 4 * 1024 * 1024 + DEFAULT_MAX_NUM_BATCHES * BATCH_PADDING_BYTES,
             batch_request_num_peers: 5,
             batch_request_retry_limit: 10,
             batch_request_retry_interval_ms: 500,


### PR DESCRIPTION
Question on `receiver_max_total_bytes`: since we add padding to account for per-batch overhead, should this be calculated as

`4 * 1024 * 1024 + DEFAULT_MAX_NUM_BATCHES * BATCH_PADDING_BYTES`

instead of a simple `+ DEFAULT_MAX_NUM_BATCHES + BATCH_PADDING_BYTES`?

If the current expression is intentional, could you help clarify the rationale? Happy to send a small fix if this is an oversight.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fix default `receiver_max_total_bytes` to multiply per-batch padding by `DEFAULT_MAX_NUM_BATCHES`.
> 
> - **Config**:
>   - Adjust `receiver_max_total_bytes` in `config/src/config/quorum_store_config.rs` to `4 * 1024 * 1024 + DEFAULT_MAX_NUM_BATCHES * BATCH_PADDING_BYTES` to correctly account for per-batch overhead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ed9bd6ad044f1c0a748fc0a9afc1c31e9fb0597. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->