### PR TITLE
Linter fix bug in boolean expression equality

### DIFF
--- a/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.exp
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.exp
@@ -1,0 +1,28 @@
+
+Diagnostics:
+warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:19:9
+   │
+19 │         exists<A>(@0xc0ffee) && exists<A>(@0xc0ffee)
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:23:9
+   │
+23 │         borrow_global<A>(@0xc0ffee).0 && borrow_global<A>(@0xc0ffee).0
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.
+
+warning: [lint] This boolean expression can be simplified using idempotence (`a && a` is equivalent to `a`).
+   ┌─ tests/model_ast_lints/exists_bool_equality.move:27:9
+   │
+27 │         move_from<A>(@0xc0ffee).0 && move_from<A>(@0xc0ffee).0
+   │         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   │
+   = To suppress this warning, annotate the function/module with the attribute `#[lint::skip(simpler_bool_expression)]`.
+   = For more information, see https://aptos.dev/en/build/smart-contracts/linter#simpler_bool_expression.

--- a/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.move
+++ b/third_party/move/tools/move-linter/tests/model_ast_lints/exists_bool_equality.move
@@ -1,0 +1,29 @@
+module 0xc0ffee::m {
+    struct A(bool) has key, drop;
+    struct B(bool) has key, drop;
+
+
+    public fun no_warn_1(): bool {
+        exists<A>(@0xc0ffee) && exists<B>(@0xc0ffee)
+    }
+
+    public fun no_warn_2(): bool {
+        borrow_global<A>(@0xc0ffee).0 && borrow_global<B>(@0xc0ffee).0
+    }
+
+    public fun no_warn_3(): bool {
+        move_from<A>(@0xc0ffee).0 && move_from<B>(@0xc0ffee).0
+    }
+
+    public fun warn_1(): bool {
+        exists<A>(@0xc0ffee) && exists<A>(@0xc0ffee)
+    }
+
+    public fun warn_2(): bool {
+        borrow_global<A>(@0xc0ffee).0 && borrow_global<A>(@0xc0ffee).0
+    }
+
+    public fun warn_3(): bool {
+        move_from<A>(@0xc0ffee).0 && move_from<A>(@0xc0ffee).0
+    }
+}


### PR DESCRIPTION
## Description

Linter complained that code below was redundant and the same as `a && a`: 
```exists<A> && exists<B>```

Clearly, that is not the case. Turns out the lint check also had to consider node instantiations in this case.

This PR contains the corresponding fix.

## How Has This Been Tested?

- Added new test cases
- Existing tests have no changes

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Linter

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Fixes boolean expression equality in the linter by comparing `exists<T>` instantiations via `GlobalEnv`, preventing false positives (e.g., `exists<A> && exists<B>`), and adds targeted tests.
> 
> - **Linter (simpler_bool_expression)**:
>   - Enhance `is_expression_equal` to accept `GlobalEnv` and compare node instantiations for `exists<T>` via new `exists_instantiation_equal`.
>   - Propagate `env` through absorption, idempotence, contradiction/tautology, and distributive checks.
>   - Avoids equating different `exists<T>` calls, preventing false positives like `exists<A> && exists<B>`.
> - **Tests**:
>   - Add `tests/model_ast_lints/exists_bool_equality.move` with `no_warn_*` and `warn_*` cases and corresponding `.exp` output.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4c42ea2183ca76520e681aa3a9f676f0d1b0fe51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->