### PR TITLE
[gas profiler] track peak memory usage

### DIFF
--- a/aptos-move/aptos-gas-meter/src/lib.rs
+++ b/aptos-move/aptos-gas-meter/src/lib.rs
@@ -10,4 +10,4 @@ mod traits;
 
 pub use algebra::StandardGasAlgebra;
 pub use meter::StandardGasMeter;
-pub use traits::{AptosGasMeter, CacheValueSizes, GasAlgebra};
+pub use traits::{AptosGasMeter, CacheValueSizes, GasAlgebra, PeakMemoryUsage};

--- a/aptos-move/aptos-gas-meter/src/traits.rs
+++ b/aptos-move/aptos-gas-meter/src/traits.rs
@@ -284,3 +284,7 @@ pub trait CacheValueSizes: AptosGasMeter {
         heap_size: AbstractValueSize,
     ) -> PartialVMResult<()>;
 }
+
+pub trait PeakMemoryUsage {
+    fn peak_memory_usage(&self) -> AbstractValueSize;
+}

--- a/aptos-move/aptos-gas-profiling/src/log.rs
+++ b/aptos-move/aptos-gas-profiling/src/log.rs
@@ -2,7 +2,7 @@
 // Licensed pursuant to the Innovation-Enabling Source Code License, available at https://github.com/aptos-labs/aptos-core/blob/main/LICENSE
 
 use crate::render::Render;
-use aptos_gas_algebra::{Fee, GasScalingFactor, InternalGas, NumBytes};
+use aptos_gas_algebra::{AbstractValueSize, Fee, GasScalingFactor, InternalGas, NumBytes};
 use aptos_types::state_store::state_key::StateKey;
 use move_binary_format::{file_format::CodeOffset, file_format_common::Opcodes};
 use move_core_types::{
@@ -159,6 +159,7 @@ pub struct TransactionGasLog {
     pub exec_io: ExecutionAndIOCosts,
     pub storage: StorageFees,
     pub num_txns: usize,
+    pub peak_memory_usage: AbstractValueSize,
 }
 pub struct GasEventIter<'a> {
     stack: SmallVec<[(&'a CallFrame, usize); 16]>,
@@ -296,7 +297,7 @@ impl ExecutionAndIOCosts {
             panic!(
                 "Execution & IO costs do not add up. Check if the gas meter & the gas profiler have been implemented correctly. From gas meter: {}. Calculated: {}.",
                 self.total, total
-            )
+            );
         }
     }
 }

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -6,7 +6,7 @@ use crate::log::{
     FrameName, StorageFees, TransactionGasLog, WriteOpType, WriteStorage, WriteTransient,
 };
 use aptos_gas_algebra::{Fee, FeePerGasUnit, InternalGas, NumArgs, NumBytes, NumTypeNodes};
-use aptos_gas_meter::{AptosGasMeter, GasAlgebra};
+use aptos_gas_meter::{AptosGasMeter, GasAlgebra, PeakMemoryUsage};
 use aptos_gas_schedule::gas_feature_versions::RELEASE_V1_30;
 use aptos_types::{
     contract_event::ContractEvent, state_store::state_key::StateKey, write_set::WriteOpSize,
@@ -702,9 +702,9 @@ where
     }
 
     fn charge_keyless(&mut self) -> VMResult<()> {
-        let (_cost, res) = self.delegate_charge(|base| base.charge_keyless());
+        let (cost, res) = self.delegate_charge(|base| base.charge_keyless());
 
-        // TODO: add keyless
+        self.keyless_cost = Some(cost);
 
         res
     }
@@ -712,7 +712,7 @@ where
 
 impl<G> GasProfiler<G>
 where
-    G: AptosGasMeter,
+    G: AptosGasMeter + PeakMemoryUsage,
 {
     pub fn finish(mut self) -> TransactionGasLog {
         while self.frames.len() > 1 {
@@ -748,6 +748,7 @@ where
             exec_io,
             storage,
             num_txns: 1,
+            peak_memory_usage: self.base.peak_memory_usage(),
         }
     }
 }

--- a/aptos-move/aptos-gas-profiling/src/report.rs
+++ b/aptos-move/aptos-gas-profiling/src/report.rs
@@ -326,6 +326,12 @@ impl TransactionGasLog {
             );
         }
 
+        // Memory usage
+        data.insert(
+            "peak-memory-usage".to_string(),
+            Value::String(format!("{}", self.peak_memory_usage)),
+        );
+
         // Execution trace
         let mut tree = self.exec_io.to_erased(true).tree;
         tree.include_child_costs();

--- a/aptos-move/aptos-gas-profiling/src/unique_stack.rs
+++ b/aptos-move/aptos-gas-profiling/src/unique_stack.rs
@@ -50,6 +50,7 @@ impl TransactionGasLog {
             exec_io: self.exec_io.combine(&other.exec_io),
             storage: self.storage.combine(&other.storage),
             num_txns: self.num_txns + other.num_txns,
+            peak_memory_usage: self.peak_memory_usage.max(other.peak_memory_usage),
         }
     }
 }

--- a/aptos-move/aptos-gas-profiling/templates/index.html
+++ b/aptos-move/aptos-gas-profiling/templates/index.html
@@ -130,7 +130,7 @@
         {{else}}
         (No operations to show.)
         {{/if}}
-        <br/>
+        <br />
         {{#if methods}}
         <table>
             <tr>
@@ -151,7 +151,7 @@
         {{else}}
         (No methods to show.)
         {{/if}}
-        <br/>
+        <br />
         {{#if methods_self}}
         <table>
             <tr>
@@ -300,6 +300,13 @@
         {{else}}
         (No events to show.)
         {{/if}}
+    </section>
+
+    <section>
+        <h2>Memory Usage</h2>
+        Peak memory usage during transaction execution: {{peak-memory-usage}}.<br><br>
+
+        Note: This is measured in abstract value size, which does not map 1:1 to bytes.
     </section>
 
     <section>

--- a/aptos-move/aptos-memory-usage-tracker/src/lib.rs
+++ b/aptos-move/aptos-memory-usage-tracker/src/lib.rs
@@ -4,7 +4,7 @@
 use aptos_gas_algebra::{
     AbstractValueSize, Fee, FeePerGasUnit, InternalGas, NumArgs, NumBytes, NumTypeNodes,
 };
-use aptos_gas_meter::{AptosGasMeter, CacheValueSizes};
+use aptos_gas_meter::{AptosGasMeter, CacheValueSizes, PeakMemoryUsage};
 use aptos_types::{
     account_config::CORE_CODE_ADDRESS, contract_event::ContractEvent,
     state_store::state_key::StateKey, write_set::WriteOpSize,
@@ -22,41 +22,38 @@ use move_vm_types::{
     views::{TypeView, ValueView},
 };
 
-/// Special gas meter implementation that tracks the VM's memory usage based on the operations
-/// executed.
-///
-/// Must be composed with a base gas meter.
-pub struct MemoryTrackedGasMeter<G> {
-    base: G,
-
-    memory_quota: AbstractValueSize,
-    should_leak_memory_for_native: bool,
+pub trait MemoryAlgebra {
+    fn new(memory_quota: AbstractValueSize, feature_version: u64) -> Self;
+    fn use_heap_memory(&mut self, amount: AbstractValueSize) -> PartialVMResult<()>;
+    fn release_heap_memory(&mut self, amount: AbstractValueSize);
+    fn current_memory_usage(&self) -> AbstractValueSize;
 }
 
-impl<G> MemoryTrackedGasMeter<G>
-where
-    G: AptosGasMeter + CacheValueSizes,
-{
-    pub fn new(base: G) -> Self {
-        let memory_quota = base.vm_gas_params().txn.memory_quota;
+pub struct StandardMemoryAlgebra {
+    initial_memory_quota: AbstractValueSize,
+    remaining_memory_quota: AbstractValueSize,
+    feature_version: u64,
+}
 
+impl MemoryAlgebra for StandardMemoryAlgebra {
+    fn new(memory_quota: AbstractValueSize, feature_version: u64) -> Self {
         Self {
-            base,
-            memory_quota,
-            should_leak_memory_for_native: false,
+            initial_memory_quota: memory_quota,
+            remaining_memory_quota: memory_quota,
+            feature_version,
         }
     }
 
     #[inline]
     fn use_heap_memory(&mut self, amount: AbstractValueSize) -> PartialVMResult<()> {
-        if self.feature_version() >= 3 {
-            match self.memory_quota.checked_sub(amount) {
+        if self.feature_version >= 3 {
+            match self.remaining_memory_quota.checked_sub(amount) {
                 Some(remaining_quota) => {
-                    self.memory_quota = remaining_quota;
+                    self.remaining_memory_quota = remaining_quota;
                     Ok(())
                 },
                 None => {
-                    self.memory_quota = 0.into();
+                    self.remaining_memory_quota = 0.into();
                     Err(PartialVMError::new(StatusCode::MEMORY_LIMIT_EXCEEDED))
                 },
             }
@@ -67,9 +64,109 @@ where
 
     #[inline]
     fn release_heap_memory(&mut self, amount: AbstractValueSize) {
-        if self.feature_version() >= 3 {
-            self.memory_quota += amount;
+        if self.feature_version >= 3 {
+            self.remaining_memory_quota += amount;
         }
+    }
+
+    #[inline]
+    fn current_memory_usage(&self) -> AbstractValueSize {
+        match self
+            .initial_memory_quota
+            .checked_sub(self.remaining_memory_quota)
+        {
+            Some(usage) => usage,
+            None => AbstractValueSize::zero(),
+            // Note: It's possible for the available memory quota to rise above the initial quota
+            //       under rare circumstances (e.g. values not being tracked initially).
+            //       In such cases, just treat the usage as 0.
+        }
+    }
+}
+
+pub struct ExtendedMemoryAlgebra {
+    base: StandardMemoryAlgebra,
+    peak_memory_usage: AbstractValueSize,
+}
+
+impl ExtendedMemoryAlgebra {
+    #[inline]
+    fn update_peak_memory_usage(&mut self) {
+        self.peak_memory_usage = self.base.current_memory_usage().max(self.peak_memory_usage);
+    }
+}
+
+impl MemoryAlgebra for ExtendedMemoryAlgebra {
+    fn new(memory_quota: AbstractValueSize, feature_version: u64) -> Self {
+        Self {
+            base: StandardMemoryAlgebra::new(memory_quota, feature_version),
+            peak_memory_usage: AbstractValueSize::zero(),
+        }
+    }
+
+    #[inline]
+    fn use_heap_memory(&mut self, amount: AbstractValueSize) -> PartialVMResult<()> {
+        let res = self.base.use_heap_memory(amount);
+        self.update_peak_memory_usage();
+        res
+    }
+
+    #[inline]
+    fn release_heap_memory(&mut self, amount: AbstractValueSize) {
+        self.base.release_heap_memory(amount);
+        self.update_peak_memory_usage();
+    }
+
+    #[inline]
+    fn current_memory_usage(&self) -> AbstractValueSize {
+        self.base.current_memory_usage()
+    }
+}
+
+/// Special gas meter implementation that tracks the VM's memory usage based on the operations
+/// executed.
+///
+/// Must be composed with a base gas meter.
+pub struct MemoryTrackedGasMeterImpl<G, A> {
+    base: G,
+
+    algebra: A,
+    should_leak_memory_for_native: bool,
+}
+
+pub type MemoryTrackedGasMeter<G> = MemoryTrackedGasMeterImpl<G, StandardMemoryAlgebra>;
+pub type ExtendedMemoryTrackedGasMeter<G> = MemoryTrackedGasMeterImpl<G, ExtendedMemoryAlgebra>;
+
+impl<G> PeakMemoryUsage for ExtendedMemoryTrackedGasMeter<G> {
+    fn peak_memory_usage(&self) -> AbstractValueSize {
+        self.algebra.peak_memory_usage
+    }
+}
+
+impl<G, A> MemoryTrackedGasMeterImpl<G, A>
+where
+    G: AptosGasMeter + CacheValueSizes,
+    A: MemoryAlgebra,
+{
+    pub fn new(base: G) -> Self {
+        let memory_quota = base.vm_gas_params().txn.memory_quota;
+        let feature_version = base.feature_version();
+
+        Self {
+            base,
+            algebra: A::new(memory_quota, feature_version),
+            should_leak_memory_for_native: false,
+        }
+    }
+
+    #[inline]
+    fn use_heap_memory(&mut self, amount: AbstractValueSize) -> PartialVMResult<()> {
+        self.algebra.use_heap_memory(amount)
+    }
+
+    #[inline]
+    fn release_heap_memory(&mut self, amount: AbstractValueSize) {
+        self.algebra.release_heap_memory(amount);
     }
 }
 
@@ -96,18 +193,20 @@ macro_rules! delegate_mut {
     };
 }
 
-impl<G> DependencyGasMeter for MemoryTrackedGasMeter<G>
+impl<G, A> DependencyGasMeter for MemoryTrackedGasMeterImpl<G, A>
 where
     G: AptosGasMeter,
+    A: MemoryAlgebra,
 {
     delegate_mut! {
         fn charge_dependency(&mut self, kind: DependencyKind, addr: &AccountAddress, name: &IdentStr, size: NumBytes) -> PartialVMResult<()>;
     }
 }
 
-impl<G> NativeGasMeter for MemoryTrackedGasMeter<G>
+impl<G, A> NativeGasMeter for MemoryTrackedGasMeterImpl<G, A>
 where
     G: AptosGasMeter + CacheValueSizes,
+    A: MemoryAlgebra,
 {
     delegate! {
         fn legacy_gas_budget_in_native_context(&self) -> InternalGas;
@@ -123,9 +222,10 @@ where
     }
 }
 
-impl<G> GasMeter for MemoryTrackedGasMeter<G>
+impl<G, A> GasMeter for MemoryTrackedGasMeterImpl<G, A>
 where
     G: AptosGasMeter + CacheValueSizes,
+    A: MemoryAlgebra,
 {
     delegate_mut! {
         fn charge_simple_instr(&mut self, instr: SimpleInstruction) -> PartialVMResult<()>;
@@ -540,9 +640,10 @@ where
     }
 }
 
-impl<G> CacheValueSizes for MemoryTrackedGasMeter<G>
+impl<G, A> CacheValueSizes for MemoryTrackedGasMeterImpl<G, A>
 where
     G: AptosGasMeter + CacheValueSizes,
+    A: MemoryAlgebra,
 {
     #[inline]
     fn charge_read_ref_cached(
@@ -567,9 +668,10 @@ where
     }
 }
 
-impl<G> AptosGasMeter for MemoryTrackedGasMeter<G>
+impl<G, A> AptosGasMeter for MemoryTrackedGasMeterImpl<G, A>
 where
     G: AptosGasMeter + CacheValueSizes,
+    A: MemoryAlgebra,
 {
     type Algebra = G::Algebra;
 

--- a/aptos-move/aptos-vm/src/aptos_vm.rs
+++ b/aptos-move/aptos-vm/src/aptos_vm.rs
@@ -6,7 +6,7 @@ use crate::{
     counters::*,
     data_cache::{AsMoveResolver, StorageAdapter},
     errors::{discarded_output, expect_only_successful_execution},
-    gas::{check_gas, make_prod_gas_meter, ProdGasMeter},
+    gas::{check_gas, make_prod_gas_meter, make_prod_gas_meter_impl},
     keyless_validation,
     move_vm_ext::{
         session::{
@@ -40,13 +40,14 @@ use aptos_block_executor::{
 use aptos_crypto::HashValue;
 use aptos_framework::natives::code::PublishRequest;
 use aptos_gas_algebra::{Gas, GasQuantity, NumBytes, Octa};
-use aptos_gas_meter::{AptosGasMeter, GasAlgebra};
+use aptos_gas_meter::{AptosGasMeter, GasAlgebra, StandardGasAlgebra, StandardGasMeter};
 use aptos_gas_schedule::{
     gas_feature_versions,
     gas_feature_versions::{RELEASE_V1_10, RELEASE_V1_27, RELEASE_V1_38},
     AptosGasParameters, VMGasParameters,
 };
 use aptos_logger::{enabled, prelude::*, Level};
+use aptos_memory_usage_tracker::{MemoryAlgebra, MemoryTrackedGasMeterImpl};
 use aptos_metrics_core::IntCounterVecHelper;
 #[cfg(any(test, feature = "testing"))]
 use aptos_types::state_store::StateViewId;
@@ -2180,7 +2181,7 @@ impl AptosVM {
     ///
     /// This can be useful for off-chain applications that wants to perform additional
     /// measurements or analysis while preserving the production gas behavior.
-    pub fn execute_user_transaction_with_modified_gas_meter<'a, G, F>(
+    pub fn execute_user_transaction_with_modified_gas_meter<'a, G, M, F>(
         &self,
         resolver: &'a impl AptosMoveResolver,
         code_storage: &'a (impl AptosCodeStorage + BlockSynchronizationKillSwitch),
@@ -2190,8 +2191,14 @@ impl AptosVM {
         auxiliary_info: &AuxiliaryInfo,
     ) -> Result<(VMStatus, VMOutput, G), VMStatus>
     where
-        F: FnOnce(ProdGasMeter<'a, NoopBlockSynchronizationKillSwitch>) -> G,
+        F: FnOnce(
+            MemoryTrackedGasMeterImpl<
+                StandardGasMeter<StandardGasAlgebra<'a, NoopBlockSynchronizationKillSwitch>>,
+                M,
+            >,
+        ) -> G,
         G: AptosGasMeter,
+        M: MemoryAlgebra,
     {
         self.execute_user_transaction_with_custom_gas_meter(
             resolver,
@@ -2204,7 +2211,7 @@ impl AptosVM {
              is_approved_gov_script,
              meter_balance,
              _maybe_block_synchronization_kill_switch| {
-                modify_gas_meter(make_prod_gas_meter(
+                modify_gas_meter(make_prod_gas_meter_impl::<_, M>(
                     gas_feature_version,
                     vm_gas_params,
                     storage_gas_params,

--- a/aptos-move/aptos-vm/src/gas.rs
+++ b/aptos-move/aptos-vm/src/gas.rs
@@ -9,7 +9,9 @@ use aptos_gas_schedule::{
     VMGasParameters,
 };
 use aptos_logger::{enabled, Level};
-use aptos_memory_usage_tracker::MemoryTrackedGasMeter;
+use aptos_memory_usage_tracker::{
+    MemoryAlgebra, MemoryTrackedGasMeter, MemoryTrackedGasMeterImpl, StandardMemoryAlgebra,
+};
 use aptos_types::on_chain_config::Features;
 use aptos_vm_logging::{log_schema::AdapterLogSchema, speculative_log, speculative_warn};
 use aptos_vm_types::{
@@ -36,7 +38,25 @@ pub fn make_prod_gas_meter<T: BlockSynchronizationKillSwitch>(
     meter_balance: Gas,
     block_synchronization_kill_switch: &T,
 ) -> ProdGasMeter<'_, T> {
-    MemoryTrackedGasMeter::new(StandardGasMeter::new(StandardGasAlgebra::new(
+    make_prod_gas_meter_impl::<T, StandardMemoryAlgebra>(
+        gas_feature_version,
+        vm_gas_params,
+        storage_gas_params,
+        is_approved_gov_script,
+        meter_balance,
+        block_synchronization_kill_switch,
+    )
+}
+
+pub fn make_prod_gas_meter_impl<T: BlockSynchronizationKillSwitch, M: MemoryAlgebra>(
+    gas_feature_version: u64,
+    vm_gas_params: VMGasParameters,
+    storage_gas_params: StorageGasParameters,
+    is_approved_gov_script: bool,
+    meter_balance: Gas,
+    block_synchronization_kill_switch: &T,
+) -> MemoryTrackedGasMeterImpl<StandardGasMeter<StandardGasAlgebra<'_, T>>, M> {
+    MemoryTrackedGasMeterImpl::new(StandardGasMeter::new(StandardGasAlgebra::new(
         gas_feature_version,
         vm_gas_params,
         storage_gas_params,


### PR DESCRIPTION
This adds to the gas profiler the ability to record peak memory usage, which is shown as an additional section in the gas report.
<img width="415" height="97" alt="Screenshot 2025-12-11 040538" src="https://github.com/user-attachments/assets/99e1b2d7-e23c-411d-95e7-bc83d378d47d" />

Note that the implementation may seem more complicated than some might expect, but this is to ensure 
1. There is no overhead in production 
2. There are no changes to the current memory semantics
3. Memory usage gets recorded accurately

I'll see if I can clean it up a bit more.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds peak memory usage tracking to gas profiler/report via a new trait and extended memory tracker, and wires it through VM; also records keyless intrinsic cost.
> 
> - **Profiling/Reporting**:
>   - Add `peak_memory_usage: AbstractValueSize` to `TransactionGasLog`; render new "Memory Usage" section in report templates and JSON (`peak-memory-usage`).
>   - Ensure execution/IO `keyless_cost` is recorded.
> - **Memory Tracking**:
>   - Introduce `MemoryAlgebra` with `StandardMemoryAlgebra` and `ExtendedMemoryAlgebra` (tracks peaks).
>   - Generalize `MemoryTrackedGasMeter` to `MemoryTrackedGasMeterImpl<G, A>`; add aliases and implement `PeakMemoryUsage` for extended variant.
> - **Gas Meter Traits**:
>   - Add `PeakMemoryUsage` trait and export from `aptos-gas-meter`.
> - **VM Integration**:
>   - Make `make_prod_gas_meter_impl` generic over memory algebra; update VM paths to use it and support customizing the memory algebra in `execute_user_transaction_with_modified_gas_meter`.
> - **Aggregation**:
>   - When combining logs, propagate max of `peak_memory_usage`.
> - **Misc**:
>   - Minor formatting fixes in HTML and consistency checks punctuation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7025fac52e45ee3cf3f5c224b8f957a8f26a3199. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->