### PR TITLE
[hot state] fix counters

### DIFF
--- a/storage/aptosdb/src/state_store/hot_state.rs
+++ b/storage/aptosdb/src/state_store/hot_state.rs
@@ -269,11 +269,11 @@ impl Committer {
             );
 
             debug_assert!(self.validate_lru(shard_id).is_ok());
-
-            COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
-            COUNTER.inc_with_by(&["hot_state_update"], n_update);
-            COUNTER.inc_with_by(&["hot_state_evict"], n_evict);
         }
+
+        COUNTER.inc_with_by(&["hot_state_insert"], n_insert);
+        COUNTER.inc_with_by(&["hot_state_update"], n_update);
+        COUNTER.inc_with_by(&["hot_state_evict"], n_evict);
     }
 
     /// Traverses the entire map and checks if all the pointers are correctly linked.


### PR DESCRIPTION

Should only increment the counters after updating all shards, instead of incrementing them once per shard.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Move `hot_state` insert/update/evict counters to increment once per commit after all shards are processed.
> 
> - **storage/aptosdb**:
>   - In `state_store/hot_state.rs`, move `COUNTER.inc_with_by` for `hot_state_insert`, `hot_state_update`, and `hot_state_evict` outside the per-shard loop to increment once after updating all shards.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 612e4e6ce0677519ae78ff505fa3a7f8f478469c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->