### PR TITLE
Revert "adding params to the stack trace inside gas-profiler (#18283)"

### DIFF
--- a/aptos-move/aptos-gas-profiling/src/aggregate.rs
+++ b/aptos-move/aptos-gas-profiling/src/aggregate.rs
@@ -90,7 +90,6 @@ impl ExecutionAndIOCosts {
                     fn_name,
                     ty_args,
                     cost,
-                    ..
                 } => insert_or_add(
                     &mut ops,
                     format!(

--- a/aptos-move/aptos-gas-profiling/src/erased.rs
+++ b/aptos-move/aptos-gas-profiling/src/erased.rs
@@ -140,11 +140,10 @@ impl ExecutionGasEvent {
                 module_id,
                 fn_name,
                 ty_args,
-                args,
                 cost,
             } => Node::new(
                 format!(
-                    "{}({})",
+                    "{}",
                     Render(&(
                         module_id,
                         fn_name.as_ident_str(),
@@ -153,8 +152,7 @@ impl ExecutionGasEvent {
                         } else {
                             &[]
                         }
-                    )),
-                    args.join(", ")
+                    ))
                 ),
                 *cost,
             ),
@@ -178,7 +176,7 @@ impl CallFrame {
                 ty_args,
             } => {
                 format!(
-                    "{}({})",
+                    "{}",
                     Render(&(
                         module_id,
                         name.as_ident_str(),
@@ -187,8 +185,7 @@ impl CallFrame {
                         } else {
                             &[]
                         }
-                    )),
-                    self.args.join(", ")
+                    ))
                 )
             },
         };

--- a/aptos-move/aptos-gas-profiling/src/flamegraph.rs
+++ b/aptos-move/aptos-gas-profiling/src/flamegraph.rs
@@ -138,7 +138,6 @@ impl ExecutionAndIOCosts {
                             fn_name,
                             ty_args,
                             cost,
-                            ..
                         } => self.lines.push(
                             format!(
                                 "{};{}",

--- a/aptos-move/aptos-gas-profiling/src/log.rs
+++ b/aptos-move/aptos-gas-profiling/src/log.rs
@@ -30,7 +30,6 @@ pub enum ExecutionGasEvent {
         module_id: ModuleId,
         fn_name: Identifier,
         ty_args: Vec<TypeTag>,
-        args: Vec<String>,
         cost: InternalGas,
     },
     LoadResource {
@@ -61,7 +60,6 @@ pub enum FrameName {
 #[derive(Debug, Clone)]
 pub struct CallFrame {
     pub name: FrameName,
-    pub args: Vec<String>,
     pub events: Vec<ExecutionGasEvent>,
     /// Accumulates gas charged by native functions. For frames of non-native functions, kept as 0.
     pub native_gas: InternalGas,
@@ -192,19 +190,13 @@ impl<'a> Iterator for GasEventIter<'a> {
 }
 
 impl CallFrame {
-    pub fn new_function(
-        module_id: ModuleId,
-        name: Identifier,
-        ty_args: Vec<TypeTag>,
-        args: Vec<String>,
-    ) -> Self {
+    pub fn new_function(module_id: ModuleId, name: Identifier, ty_args: Vec<TypeTag>) -> Self {
         Self {
             name: FrameName::Function {
                 module_id,
                 name,
                 ty_args,
             },
-            args,
             events: vec![],
             native_gas: 0.into(),
         }
@@ -213,7 +205,6 @@ impl CallFrame {
     pub fn new_script() -> Self {
         Self {
             name: FrameName::Script,
-            args: vec![],
             events: vec![],
             native_gas: 0.into(),
         }
@@ -222,7 +213,6 @@ impl CallFrame {
     pub fn new_transaction_batch() -> Self {
         Self {
             name: FrameName::TransactionBatch,
-            args: vec![],
             events: vec![],
             native_gas: 0.into(),
         }

--- a/aptos-move/aptos-gas-profiling/src/profiler.rs
+++ b/aptos-move/aptos-gas-profiling/src/profiler.rs
@@ -115,12 +115,7 @@ impl<G> GasProfiler<G> {
             intrinsic_cost: None,
             keyless_cost: None,
             dependencies: vec![],
-            frames: vec![CallFrame::new_function(
-                module_id,
-                func_name,
-                ty_args,
-                vec![],
-            )],
+            frames: vec![CallFrame::new_function(module_id, func_name, ty_args)],
             transaction_transient: None,
             events_transient: vec![],
             write_set_transient: vec![],
@@ -417,7 +412,6 @@ where
             module_id,
             fn_name: name,
             ty_args,
-            args: frame.args,
             cost,
         });
 
@@ -481,12 +475,6 @@ where
         args: impl ExactSizeIterator<Item = impl ValueView> + Clone,
         num_locals: NumArgs,
     ) -> PartialVMResult<()> {
-        // Capture arguments
-        let arg_strings = args
-            .clone()
-            .map(|arg| format!("{:?}", arg))
-            .collect::<Vec<_>>();
-
         let (cost, res) =
             self.delegate_charge(|base| base.charge_call(module_id, func_name, args, num_locals));
 
@@ -495,7 +483,6 @@ where
             module_id.clone(),
             Identifier::new(func_name).unwrap(),
             vec![],
-            arg_strings,
         ));
 
         res
@@ -514,12 +501,6 @@ where
             .map(|ty| ty.to_type_tag())
             .collect::<Vec<_>>();
 
-        // Capture arguments
-        let arg_strings = args
-            .clone()
-            .map(|arg| format!("{:?}", arg))
-            .collect::<Vec<_>>();
-
         let (cost, res) = self.delegate_charge(|base| {
             base.charge_call_generic(module_id, func_name, ty_args, args, num_locals)
         });
@@ -529,7 +510,6 @@ where
             module_id.clone(),
             Identifier::new(func_name).unwrap(),
             ty_tags,
-            arg_strings,
         ));
 
         res

--- a/aptos-move/aptos-gas-profiling/src/unique_stack.rs
+++ b/aptos-move/aptos-gas-profiling/src/unique_stack.rs
@@ -163,7 +163,6 @@ impl UniqueStackFoldedCallFrame {
                     fn_name,
                     ty_args,
                     cost,
-                    ..
                 } => (
                     InstructionKey::CallNative {
                         module_id,
@@ -205,7 +204,6 @@ impl UniqueStackFoldedCallFrame {
                     module_id,
                     fn_name,
                     ty_args,
-                    args: vec![],
                     cost,
                 },
                 InstructionKey::LoadResource { addr, ty } => {
@@ -228,7 +226,6 @@ impl UniqueStackFoldedCallFrame {
         events.reverse();
         CallFrame {
             name,
-            args: vec![],
             events,
             native_gas: self.self_gas,
         }

--- a/third_party/move/move-vm/types/src/values/values_impl.rs
+++ b/third_party/move/move-vm/types/src/values/values_impl.rs
@@ -5537,7 +5537,6 @@ impl Struct {
 impl Vector {
     #[cfg_attr(feature = "force-inline", inline(always))]
     pub fn elem_views(&self) -> impl ExactSizeIterator<Item = impl ValueView + '_> + Clone {
-        #[derive(Debug)]
         struct ElemView<'b> {
             container: &'b Container,
             idx: usize,
@@ -5560,7 +5559,6 @@ impl Vector {
 
 impl Reference {
     pub fn value_view(&self) -> impl ValueView + '_ {
-        #[derive(Debug)]
         struct ValueBehindRef<'b>(&'b ReferenceImpl);
 
         impl ValueView for ValueBehindRef<'_> {
@@ -5582,7 +5580,6 @@ impl GlobalValue {
     pub fn view(&self) -> Option<impl ValueView + '_> {
         use GlobalValueImpl as G;
 
-        #[derive(Debug)]
         struct Wrapper<'b>(&'b Rc<RefCell<Vec<Value>>>);
 
         impl ValueView for Wrapper<'_> {

--- a/third_party/move/move-vm/types/src/views.rs
+++ b/third_party/move/move-vm/types/src/views.rs
@@ -21,7 +21,7 @@ pub trait TypeView {
 ///
 /// This is used to expose certain info to clients (e.g. the gas meter),
 /// usually in a lazily evaluated fashion.
-pub trait ValueView: std::fmt::Debug {
+pub trait ValueView {
     fn visit(&self, visitor: &mut impl ValueVisitor) -> PartialVMResult<()>;
 
     /// Returns the abstract memory size of the value.


### PR DESCRIPTION
This reverts https://github.com/aptos-labs/aptos-core/pull/18283, which was a nice idea but needed more polishing to avoid causing issues to the usability of the tool. 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes capturing/printing of function arguments from gas profiler traces and flamegraphs, and drops the Debug bound from ValueView.
> 
> - **Gas Profiler/Tracing**:
>   - Remove argument collection/storage from `ExecutionGasEvent::CallNative` and `CallFrame`.
>   - Stop rendering/capturing args in erased tree (`erased.rs`), aggregation (`aggregate.rs`), and flamegraph output (`flamegraph.rs`).
>   - Update profiler call sites to no longer collect `arg_strings` for `charge_call[_generic]` and native calls.
>   - Adjust unique stack folding to omit args in instruction keys/events.
> - **Types/Traits**:
>   - Drop `Debug` bound from `third_party/move` `ValueView` and remove unnecessary `Debug` derives on internal view wrappers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b333079cb0920fbe6358a5f8c9948bf7827dd8bd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->