### PR TITLE
[pool_u64] make deduct shares function public

### DIFF
--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64.md
@@ -683,7 +683,7 @@ Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 Directly deduct <code>shareholder</code>'s number of shares in <code>self</code> and return the number of remaining shares.
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
 </code></pre>
 
 
@@ -692,7 +692,7 @@ Directly deduct <code>shareholder</code>'s number of shares in <code>self</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64 {
     <b>assert</b>!(self.<a href="pool_u64.md#0x1_pool_u64_contains">contains</a>(shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
     <b>assert</b>!(self.<a href="pool_u64.md#0x1_pool_u64_shares">shares</a>(shareholder) &gt;= num_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64.md#0x1_pool_u64_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
 
@@ -1157,7 +1157,7 @@ Return the number of coins <code>shares</code> are worth in <code>self</code> wi
 ### Function `deduct_shares`
 
 
-<pre><code><b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64.md#0x1_pool_u64_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64.md#0x1_pool_u64_Pool">pool_u64::Pool</a>, shareholder: <b>address</b>, num_shares: u64): u64
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
+++ b/aptos-move/framework/aptos-stdlib/doc/pool_u64_unbound.md
@@ -645,7 +645,7 @@ Transfer shares from <code>shareholder_1</code> to <code>shareholder_2</code>.
 Directly deduct <code>shareholder</code>'s number of shares in <code>self</code> and return the number of remaining shares.
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
 </code></pre>
 
 
@@ -654,7 +654,7 @@ Directly deduct <code>shareholder</code>'s number of shares in <code>self</code>
 <summary>Implementation</summary>
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128 {
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128 {
     <b>assert</b>!(self.<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_contains">contains</a>(shareholder), <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_ESHAREHOLDER_NOT_FOUND">ESHAREHOLDER_NOT_FOUND</a>));
     <b>assert</b>!(self.<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_shares">shares</a>(shareholder) &gt;= num_shares, <a href="../../move-stdlib/doc/error.md#0x1_error_invalid_argument">error::invalid_argument</a>(<a href="pool_u64_unbound.md#0x1_pool_u64_unbound_EINSUFFICIENT_SHARES">EINSUFFICIENT_SHARES</a>));
 
@@ -1141,7 +1141,7 @@ Return the number of coins <code>shares</code> are worth in <code>pool</code> wi
 ### Function `deduct_shares`
 
 
-<pre><code><b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
+<pre><code><b>public</b> <b>fun</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_deduct_shares">deduct_shares</a>(self: &<b>mut</b> <a href="pool_u64_unbound.md#0x1_pool_u64_unbound_Pool">pool_u64_unbound::Pool</a>, shareholder: <b>address</b>, num_shares: u128): u128
 </code></pre>
 
 

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64.move
@@ -199,7 +199,7 @@ module aptos_std::pool_u64 {
     }
 
     /// Directly deduct `shareholder`'s number of shares in `self` and return the number of remaining shares.
-    fun deduct_shares(self: &mut Pool, shareholder: address, num_shares: u64): u64 {
+    public fun deduct_shares(self: &mut Pool, shareholder: address, num_shares: u64): u64 {
         assert!(self.contains(shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
         assert!(self.shares(shareholder) >= num_shares, error::invalid_argument(EINSUFFICIENT_SHARES));
 

--- a/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
+++ b/aptos-move/framework/aptos-stdlib/sources/pool_u64_unbound.move
@@ -184,7 +184,7 @@ module aptos_std::pool_u64_unbound {
     }
 
     /// Directly deduct `shareholder`'s number of shares in `self` and return the number of remaining shares.
-    fun deduct_shares(self: &mut Pool, shareholder: address, num_shares: u128): u128 {
+    public fun deduct_shares(self: &mut Pool, shareholder: address, num_shares: u128): u128 {
         assert!(self.contains(shareholder), error::invalid_argument(ESHAREHOLDER_NOT_FOUND));
         assert!(self.shares(shareholder) >= num_shares, error::invalid_argument(EINSUFFICIENT_SHARES));
 


### PR DESCRIPTION
## Description
It's useful sometimes, so it makes sense to make it public.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes `deduct_shares` public in both `0x1::pool_u64` (u64) and `0x1::pool_u64_unbound` (u128) modules and updates docs/specs accordingly.
> 
> - **Aptos stdlib (Move)**:
>   - **API change**: `deduct_shares` is now `public fun` in `sources/pool_u64.move` and `sources/pool_u64_unbound.move`.
>     - Affects: `0x1::pool_u64::deduct_shares(address, u64) -> u64`, `0x1::pool_u64_unbound::deduct_shares(address, u128) -> u128`.
>   - **Docs/Specs**: Reflect public visibility in `doc/pool_u64.md` and `doc/pool_u64_unbound.md`, including specification sections.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a6930419a301659a623b2a277e26498a3567c6db. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->