### PR TITLE
[compiler-v2] Fix spurious compiler warning in inline functions

### DIFF
--- a/third_party/move/move-compiler-v2/src/env_pipeline/ast_simplifier.rs
+++ b/third_party/move/move-compiler-v2/src/env_pipeline/ast_simplifier.rs
@@ -1113,8 +1113,8 @@ impl ExpRewriterFunctions for SimplifierRewriter<'_> {
                 },
                 _ => None,
             } {
-                if !self.after_inlining_optimization {
-                    let loc = self.env().get_node_loc(eliminated_id);
+                let loc = self.env().get_node_loc(eliminated_id);
+                if !self.after_inlining_optimization && !loc.is_inlined() {
                     let cond_loc = self.env().get_node_loc(cond.node_id());
                     self.env().diag_with_labels(
                         Severity::Warning,
@@ -1152,8 +1152,8 @@ impl ExpRewriterFunctions for SimplifierRewriter<'_> {
             let side_effecting_elts_refs = siter
                 .filter(|exp|
                         if exp.as_ref().is_ok_to_remove_from_code() {
-                            if !self.after_inlining_optimization {
-                                let loc = self.env().get_node_loc(exp.node_id());
+                            let loc = self.env().get_node_loc(exp.node_id());
+                            if !self.after_inlining_optimization && !loc.is_inlined() {
                                 self.env().diag(
                                     Severity::Warning,
                                     &loc,

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/inlining_spurious_warning.exp
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/inlining_spurious_warning.exp
@@ -1,0 +1,76 @@
+// -- Model dump before first bytecode pipeline
+module 0x123::a {
+    public fun bar() {
+        {
+          let (x: bool): (bool) = Tuple(false);
+          if Not(x) {
+            if Eq<u64>(1, 1) {
+              Tuple()
+            } else {
+              Abort(14566554180833181696)
+            };
+            Tuple()
+          } else {
+            Tuple()
+          }
+        };
+        Tuple()
+    }
+    private inline fun foo(x: bool) {
+        if Not(x) {
+          if Eq<u64>(1, 1) {
+            Tuple()
+          } else {
+            Abort(14566554180833181696)
+          };
+          Tuple()
+        } else {
+          Tuple()
+        }
+    }
+} // end 0x123::a
+
+// -- Sourcified model before first bytecode pipeline
+module 0x123::a {
+    public fun bar() {
+        {
+            let (x) = (false);
+            if (!x) {
+                if (1 == 1) () else abort 14566554180833181696;
+            }
+        };
+    }
+    inline fun foo(x: bool) {
+        if (!x) {
+            if (1 == 1) () else abort 14566554180833181696;
+        }
+    }
+}
+
+// -- Model dump before second bytecode pipeline
+module 0x123::a {
+    public fun bar() {
+        if true {
+          Tuple()
+        } else {
+          Abort(14566554180833181696)
+        };
+        Tuple();
+        Tuple()
+    }
+    private inline fun foo(x: bool) {
+        if Not(x) {
+          if true {
+            Tuple()
+          } else {
+            Abort(14566554180833181696)
+          };
+          Tuple()
+        } else {
+          Tuple()
+        }
+    }
+} // end 0x123::a
+
+
+============ bytecode verification succeeded ========

--- a/third_party/move/move-compiler-v2/tests/simplifier-elimination/inlining_spurious_warning.move
+++ b/third_party/move/move-compiler-v2/tests/simplifier-elimination/inlining_spurious_warning.move
@@ -1,0 +1,11 @@
+module 0x123::a {
+    inline fun foo(x: bool) {
+        if (!x) {
+            assert!(1 == 1);
+        }
+    }
+
+    public fun bar() {
+        foo(false);
+    }
+}


### PR DESCRIPTION
## Description

When `--optimize=extra` is on, certain additional optimizations run. On `inline` functions, this can cause spurious compiler warnings that are not actionable to the user.

Closes #18310.

In this PR, we disable such warnings when being reported on inlined locations.

## How Has This Been Tested?

- Added a new test which showed the spurious warning before, but does not any longer.

## Type of Change
- [x] Bug fix

## Which Components or Systems Does This Change Impact?
- [x] Move Compiler

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Suppresses dead-code elimination warnings on inlined locations and adds a regression test.
> 
> - **Compiler (AST Simplifier)**:
>   - Gate dead-code warnings in `rewrite_if_else` and `rewrite_sequence` by checking `!loc.is_inlined()` in addition to `!after_inlining_optimization` to avoid warnings on inlined code.
> - **Tests**:
>   - Add `tests/simplifier-elimination/inlining_spurious_warning.{move,exp}` verifying no spurious warnings after inlining.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d2633c4e7a9b63aabba50dbd66c84e1da9808eec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->